### PR TITLE
Set default theme to the user's browser theme

### DIFF
--- a/packages/bruno-app/src/providers/Theme/index.js
+++ b/packages/bruno-app/src/providers/Theme/index.js
@@ -6,7 +6,8 @@ import { ThemeProvider as SCThemeProvider } from 'styled-components';
 
 export const ThemeContext = createContext();
 export const ThemeProvider = (props) => {
-  const [storedTheme, setStoredTheme] = useLocalStorage('bruno.theme', 'light');
+  const isBrowserThemeLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+  const [storedTheme, setStoredTheme] = useLocalStorage('bruno.theme', isBrowserThemeLight ? 'light' : 'dark');
 
   const theme = themes[storedTheme];
   const themeOptions = Object.keys(themes);


### PR DESCRIPTION
Set the default theme to the user's preferred browser theme.

[Browser support](https://caniuse.com/prefers-color-scheme) for `prefers-color-scheme`.

**Note**: There is a [known issue](https://bugs.chromium.org/p/chromium/issues/detail?id=998903) with Chrome in Linux which causes the `prefers-color-scheme` to always detect light mode.