### PR TITLE
Removed redundant instructions in docs

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -23,25 +23,7 @@ You would need [Node v14.x or the latest LTS version](https://nodejs.org/en/) an
 
 ### Lets start coding
 
-```bash
-# clone and cd into bruno
-# use Node 14.x, Npm 8.x
-
-# Install deps (note that we use npm workspaces)
-npm i
-
-# run next app
-npm run dev:web
-
-# run electron app
-# neededonly if you want to test changes related to electron app
-# please note that both web and electron use the same code
-# if it works in web, then it should also work in electron
-npm run dev:electron
-
-# open in browser
-open http://localhost:3000
-```
+Please reference [development.md](docs/development.md) for instructions on running the local development environment.
 
 ### Raising Pull Request
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,10 +18,10 @@ npm i --legacy-peer-deps
 npm run build:graphql-docs
 
 # run next app (terminal 1)
-npm run dev --workspace=packages/bruno-app
+npm run dev:web
 
 # run electron app (terminal 2)
-npm run dev --workspace=packages/bruno-electron
+npm run dev:electron
 ```
 
 ### Troubleshooting
@@ -35,6 +35,6 @@ You might encounter a `Unsupported platform` error when you run `npm install`. T
 npm test --workspace=packages/bruno-schema
 
 # bruno-lang
-npm test --workspace=packages/bruno-schema
+npm test --workspace=packages/bruno-lang
 
 ```


### PR DESCRIPTION
1. Replaced section in `contributing.md` with link to `development.md` 
2. Updated `development.md` to use npm scripts; fixed reference to `bruno-lang` tests