### PR TITLE
Correct the tab order on the CreateCollection modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -84,7 +84,6 @@ const CreateCollection = ({ onClose }) => {
             id="collection-folder-name"
             type="text"
             name="collectionFolderName"
-            ref={inputRef}
             className="block textbox mt-2 w-full"
             onChange={formik.handleChange}
             autoComplete="off"


### PR DESCRIPTION
collectionFolderName `inputRef` was overriding the `inputRef` on collectionName