### PR TITLE
Fixed unhandled exception on collection search Re #106

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -55,12 +55,6 @@ const Collection = ({ collection, searchText }) => {
     dispatch(collectionClicked(collection.uid));
   };
 
-  if (searchText && searchText.length) {
-    if (!doesCollectionHaveItemsMatchingSearchText(collection, searchText)) {
-      return null;
-    }
-  }
-
   const handleExportClick = () => {
     const collectionCopy = cloneDeep(collection);
     exportCollection(transformCollectionToSaveToIdb(collectionCopy));


### PR DESCRIPTION
Removed code related to no collections / requests matching the collection search term.

I tried a few different return values (`return false`, `return collection.item`) - TBH I don't understand the object model being used (yet)... so please feel free to decline / amend my commit.