### PR TITLE
filter shortcut for scalar properties

### DIFF
--- a/packages/bruno-query/readme.md
+++ b/packages/bruno-query/readme.md
@@ -18,6 +18,10 @@ Array filtering [?] with corresponding filter function
 ```js
 get(data, '..items[?].amount', i => i.amount > 20) 
 ```
+Array filtering [?] with simple object predicate, same as (i => i.id === 2 && i.amount === 20)
+```js
+get(data, '..items[?]', { id: 2, amount: 20 }) 
+```
 Array mapping [?] with corresponding mapper function
 ```js
 get(data, '..items[?].amount', i => i.amount + 10) 

--- a/packages/bruno-query/tests/index.spec.ts
+++ b/packages/bruno-query/tests/index.spec.ts
@@ -22,7 +22,7 @@ const data = {
           { id: 4, amount: 40 }
         ]
       }
-    ]
+    ],
   },
 };
 
@@ -48,11 +48,13 @@ describe("get", () => {
   // filter and map
   it.each([
     ["..items[?].amount", [40], (i: any) => i.amount > 30],              // [?] filter
+    ["..items[?].amount", [40], { id: 4, amount: 40 }],                  // object filter
+    ["..items[?].amount", undefined, { id: 5, amount: 40 }],
     ["..items..amount[?][0]", 40, (amt: number) => amt > 30],
     ["..items..amount[0][?]", undefined, (amt: number) => amt > 30],     // filter on single value
     ["..items..amount[?]", [11, 21, 31, 41], (amt: number) => amt + 1],  // [?] mapper
     ["..items..amount[0][?]", 11, (amt: number) => amt + 1],             // [?] map on single value
-  ])("%s should be %j %s", (expr, result, filter) => {
+  ])("%s should be %j for %s", (expr, result, filter) => {
     expect(get(data, expr, filter)).toEqual(result);
   });
 


### PR DESCRIPTION
Filter shortcut for scalar properties
```js
get(data, '..items[?]', { id: 2, amount: 20 })
```
instead of
```js
get(data, '..items[?]', i => i.id === 2 && i.amount === 20)
```
