### PR TITLE
bugfix/assertion-result-issue  fixed the issue related to assertions …

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -169,14 +169,14 @@ const registerNetworkIpc = (mainWindow, watcher, lastOpenedCollections) => {
 
       // run assertions
       const assertions = get(request, 'assertions');
-        const assertRuntime = new AssertRuntime();
-        const results = assertRuntime.runAssertions(assertions, request, response, envVars, collectionVariables, collectionPath);
+      const assertRuntime = new AssertRuntime();
+      const results = assertRuntime.runAssertions(assertions, request, response, envVars, collectionVariables, collectionPath);
 
-        mainWindow.webContents.send('main:assertion-results', {
-          results: results,
-          itemUid: item.uid,
-          collectionUid
-        });
+      mainWindow.webContents.send('main:assertion-results', {
+        results: results,
+        itemUid: item.uid,
+        collectionUid
+      });
 
       // run tests
       const testFile = get(item, 'request.tests');

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -169,7 +169,6 @@ const registerNetworkIpc = (mainWindow, watcher, lastOpenedCollections) => {
 
       // run assertions
       const assertions = get(request, 'assertions');
-      if(assertions && assertions.length) {
         const assertRuntime = new AssertRuntime();
         const results = assertRuntime.runAssertions(assertions, request, response, envVars, collectionVariables, collectionPath);
 
@@ -178,7 +177,6 @@ const registerNetworkIpc = (mainWindow, watcher, lastOpenedCollections) => {
           itemUid: item.uid,
           collectionUid
         });
-      }
 
       // run tests
       const testFile = get(item, 'request.tests');


### PR DESCRIPTION
**Which issue ticket is this pull request for, and is the ticket now complete?**
https://github.com/usebruno/bruno/issues/**121** (Complete)

**Briefly describe your change.**
**Issue** : Assertions are still displayed in the Tests tab after deletion
**After Fix**: When we delete the assertion in the request tab, it is getting deleted in the Tests result tab too.

**What parts of the application are affected by your change?**
Tests result tab

**How did you test your change? If relevant, which role(s) and/or customer configuration(s) did you use?**
Created a request
Add assertions in Assert tab.
Save and execute request.
Assert results should display in Tests tab.

Now delete assertions using the garbage bin button.
Save and execute request.
Assert results are not displayed in Tests tab.