### PR TITLE
Proposed adjustment to terminology on requests

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/useGraphqlSchema.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/useGraphqlSchema.js
@@ -32,7 +32,7 @@ const useGraphqlSchema = (endpoint, environment) => {
           setSchema(buildClientSchema(s.data));
           setIsLoading(false);
           localStorage.setItem(localStorageKey, JSON.stringify(s.data));
-          toast.success('Graphql Schema loaded successfully');
+          toast.success('GraphQL Schema loaded successfully');
         } else {
           return Promise.reject(new Error('An error occurred while introspecting schema'));
         }
@@ -40,7 +40,7 @@ const useGraphqlSchema = (endpoint, environment) => {
       .catch((err) => {
         setIsLoading(false);
         setError(err);
-        toast.error('Error occured while loading Graphql Schema');
+        toast.error('Error occured while loading GraphQL Schema');
       });
   };
 

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -52,7 +52,7 @@ const RequestBodyMode = ({ item, collection }) => {
               onModeChange('formUrlEncoded');
             }}
           >
-            Form Url Encoded
+            Form URL Encoded
           </div>
           <div className="label-item font-medium">Raw</div>
           <div

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -102,7 +102,7 @@ const NewRequest = ({ collection, item, isEphermal, onClose }) => {
                 checked={formik.values.requestType === 'http-request'}
               />
               <label htmlFor="http-request" className="ml-1 cursor-pointer select-none">
-                REST
+                HTTP
               </label>
 
               <input

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -102,7 +102,7 @@ const NewRequest = ({ collection, item, isEphermal, onClose }) => {
                 checked={formik.values.requestType === 'http-request'}
               />
               <label htmlFor="http-request" className="ml-1 cursor-pointer select-none">
-                Http
+                REST
               </label>
 
               <input
@@ -118,7 +118,7 @@ const NewRequest = ({ collection, item, isEphermal, onClose }) => {
                 checked={formik.values.requestType === 'graphql-request'}
               />
               <label htmlFor="graphql-request" className="ml-1 cursor-pointer select-none">
-                Graphql
+                GraphQL
               </label>
             </div>
           </div>
@@ -145,7 +145,7 @@ const NewRequest = ({ collection, item, isEphermal, onClose }) => {
 
           <div className="mt-4">
             <label htmlFor="request-url" className="block font-semibold">
-              Url
+              URL
             </label>
 
             <div className="flex items-center mt-2 ">

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -433,7 +433,7 @@ export const humanizeRequestBodyMode = (mode) => {
       break;
     }
     case 'formUrlEncoded': {
-      label = 'Form Url Encoded';
+      label = 'Form URL Encoded';
       break;
     }
     case 'multipartForm': {


### PR DESCRIPTION
I propose the following UI terminology changes relating to the new request dialog:

1. `Http` --> `REST`
2. `Graphql` --> `GraphQL`
3. `Form Url Encoded` --> `Form URL Encoded`