### PR TITLE
Proposed addition of CMD+W hotkey Re #128

### DIFF
--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -10,6 +10,7 @@ import NewRequest from 'components/Sidebar/NewRequest';
 import BrunoSupport from 'components/BrunoSupport';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { findCollectionByUid, findItemInCollection } from 'utils/collections';
+import { closeTabs } from 'providers/ReduxStore/slices/tabs';
 
 export const HotkeysContext = React.createContext();
 
@@ -143,6 +144,23 @@ export const HotkeysProvider = (props) => {
       Mousetrap.unbind(['command+h', 'ctrl+h']);
     };
   }, [setShowNewRequestModal]);
+
+  // close tab hotkey
+  useEffect(() => {
+    Mousetrap.bind(['command+w', 'ctrl+w'], (e) => {
+      dispatch(
+        closeTabs({
+          tabUids: [activeTabUid]
+        })
+      );
+
+      return false; // this stops the event bubbling
+    });
+
+    return () => {
+      Mousetrap.unbind(['command+w', 'ctrl+w']);
+    };
+  }, [activeTabUid, tabs, collections, setShowNewRequestModal]);
 
   return (
     <HotkeysContext.Provider {...props} value="hotkey">

--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -160,7 +160,7 @@ export const HotkeysProvider = (props) => {
     return () => {
       Mousetrap.unbind(['command+w', 'ctrl+w']);
     };
-  }, [activeTabUid, tabs, collections, setShowNewRequestModal]);
+  }, [activeTabUid]);
 
   return (
     <HotkeysContext.Provider {...props} value="hotkey">


### PR DESCRIPTION
This commit adds a CMD+W hotkey (see #128 for details).

Please point me in the right direction if more error handling is required.

Caveat:  closing a tab with unsaved changes is consistent with the app behaviour when clicking the `x` to close the tab.