### PR TITLE
Add chai-http to enable to.be.json assertions Re #132

### DIFF
--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -18,6 +18,7 @@
     "@usebruno/schema": "0.3.1",
     "axios": "^0.26.0",
     "chai": "^4.3.7",
+    "chai-http": "^4.3.0",
     "chokidar": "^3.5.3",
     "dotenv": "^16.0.3",
     "electron-is-dev": "^2.0.0",

--- a/packages/bruno-js/src/runtime/assert-runtime.js
+++ b/packages/bruno-js/src/runtime/assert-runtime.js
@@ -6,6 +6,7 @@ const BrunoRequest = require('../bruno-request');
 const { evaluateJsTemplateLiteral, evaluateJsExpression, createResponseParser } = require('../utils');
 
 const { expect } = chai;
+const chaiHttp = require('chai-http');
 
 /**
  * Assertion operators
@@ -92,7 +93,7 @@ const evaluateRhsOperand = (rhsOperand, operator, context) => {
     return;
   }
 
-  // gracefulle allyow both a,b as well as [a, b]
+  // gracefully allow both a,b as well as [a, b]
   if(operator === 'in' || operator === 'notIn') {
     if(rhsOperand.startsWith('[') && rhsOperand.endsWith(']')) {
       rhsOperand = rhsOperand.substring(1, rhsOperand.length - 1);
@@ -225,6 +226,7 @@ class AssertRuntime {
             expect(lhs).to.be.false;
             break;
           case 'isJson':
+            chai.use(chaiHttp);
             expect(lhs).to.be.json;
             break;
           case 'isNumber':


### PR DESCRIPTION
Proposed fix for #132 uses `chai-http` to enable the `.to.be.json` assertion.