### PR TITLE
chore: improve the cli doc to avoid misunderstandings 

### DIFF
--- a/packages/bruno-cli/readme.md
+++ b/packages/bruno-cli/readme.md
@@ -21,7 +21,7 @@ This command will run all the requests in your collection. You can also run a si
 bru run request.bru
 ```
 
-Or run all requests in a folder:
+Or run all requests in a collection's subfolder:
 ```bash
 bru run folder
 ```


### PR DESCRIPTION
As part of a poc for testing on our CI, I'm exploring Bruno's cli.

Based on this excerpt from the documentation:
```
Or run all requests in a folder:

`bru run folder`
```


I tried to run the following command:
`bru run apps/backend/requests`

where `apps/backend/requests` is the collection root folder. I got the following error:
`You can run only at the root of a collection`


Thinking I typed the command wrong, I tried several commands before realizing that the command is only valid for the sub-folders of a collection.

I therefore propose a change in the document in order to clarify this point for newcomers