### PR TITLE
support custom cacert file

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -53,7 +53,8 @@ const runSingleRequest = async function (filename, bruJson, collectionPath, coll
       });
     }
     else {
-      const cacert = options['cacert'];
+      const cacertArray = [options['cacert'], process.env.SSL_CERT_FILE, process.env.NODE_EXTRA_CA_CERTS];
+      const cacertFile = cacertArray.find(el => el);
       if (cacert && cacert.length > 1) {
         try {
           caCrt = fs.readFileSync(cacert)

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -47,24 +47,27 @@ const runSingleRequest = async function (filename, bruJson, collectionPath, coll
 
     const options = getOptions();
     const insecure = get(options, 'insecure', false);
+    const httpsAgentRequestFields = {};
     if(insecure) {
-      request.httpsAgent = new https.Agent({
-        rejectUnauthorized: false
-      });
+      httpsAgentRequestFields['rejectUnauthorized'] = false;
     }
     else {
       const cacertArray = [options['cacert'], process.env.SSL_CERT_FILE, process.env.NODE_EXTRA_CA_CERTS];
-      const cacertFile = cacertArray.find(el => el);
+      const cacert = cacertArray.find(el => el);
       if (cacert && cacert.length > 1) {
         try {
-          caCrt = fs.readFileSync(cacert)
-          request.httpsAgent = new https.Agent({
-            ca: caCrt
-          });
+          caCrt = fs.readFileSync(cacert);
+          httpsAgentRequestFields['ca'] = caCrt;
         } catch(err) {
           console.log('Error reading CA cert file:' + cacert, err);
         }
       }
+    }
+
+    if (Object.keys(httpsAgentRequestFields).length > 0) {
+      request.httpsAgent = new https.Agent({
+        ...httpsAgentRequestFields
+      });
     }
 
     // stringify the request url encoded params

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -54,7 +54,7 @@ const runSingleRequest = async function (filename, bruJson, collectionPath, coll
     else {
       const cacertArray = [options['cacert'], process.env.SSL_CERT_FILE, process.env.NODE_EXTRA_CA_CERTS];
       const cacert = cacertArray.find(el => el);
-      if (cacert && cacert.length > 1) {
+      if(cacert && cacert.length > 1) {
         try {
           caCrt = fs.readFileSync(cacert);
           httpsAgentRequestFields['ca'] = caCrt;
@@ -64,7 +64,7 @@ const runSingleRequest = async function (filename, bruJson, collectionPath, coll
       }
     }
 
-    if (Object.keys(httpsAgentRequestFields).length > 0) {
+    if(Object.keys(httpsAgentRequestFields).length > 0) {
       request.httpsAgent = new https.Agent({
         ...httpsAgentRequestFields
       });

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -154,6 +154,21 @@ const registerNetworkIpc = (mainWindow, watcher, lastOpenedCollections) => {
           rejectUnauthorized: false
         });
       }
+      else {
+        const cacertArray = [preferences['cacert'], process.env.SSL_CERT_FILE, process.env.NODE_EXTRA_CA_CERTS];
+        cacertFile = cacertArray.find(el => el);
+        if (cacertFile && cacertFile.length > 1) {
+          try {
+            const fs = require('fs');
+            caCrt = fs.readFileSync(cacertFile)
+            request.httpsAgent = new https.Agent({
+              ca: caCrt
+            });
+          } catch(err) {
+            console.log('Error reading CA cert file:' + cacertFile, err);
+          }
+        }
+      }
 
       const response = await axios(request);
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -155,7 +155,7 @@ const registerNetworkIpc = (mainWindow, watcher, lastOpenedCollections) => {
       else {
         const cacertArray = [preferences['cacert'], process.env.SSL_CERT_FILE, process.env.NODE_EXTRA_CA_CERTS];
         cacertFile = cacertArray.find(el => el);
-        if (cacertFile && cacertFile.length > 1) {
+        if(cacertFile && cacertFile.length > 1) {
           try {
             const fs = require('fs');
             caCrt = fs.readFileSync(cacertFile);
@@ -166,7 +166,7 @@ const registerNetworkIpc = (mainWindow, watcher, lastOpenedCollections) => {
         }
       }
 
-      if (Object.keys(httpsAgentRequestFields).length > 0) {
+      if(Object.keys(httpsAgentRequestFields).length > 0) {
         request.httpsAgent = new https.Agent({
           ...httpsAgentRequestFields
         });


### PR DESCRIPTION
Add custom cacert file support in electron app. Process environment variables SSL_CERT_FILE or NODE_EXTRA_CA_CERTS can be used. The 'cacert' preference can also be used, but I have not added a way to set it. I was thinking maybe a file dialog in the preferences.

Added ability to use SSL_CERT_FILE or NODE_EXTRA_CA_CERTS process environment variables in the cli in addition to the 'cacert' command line option.

This should address the problem in issue #117.