### PR TITLE
check response type for ResponsePane CodeEditor

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
@@ -35,7 +35,7 @@ const EnvironmentSelector = ({ collection }) => {
           toast.success(`No Environments are active now`);
         }
       })
-      .catch((err) => console.log(err) && toast.error('An error occured while selecting the environment'));
+      .catch((err) => console.log(err) && toast.error('An error occurred while selecting the environment'));
   };
 
   return (
@@ -64,7 +64,7 @@ const EnvironmentSelector = ({ collection }) => {
             }}
           >
             <IconDatabaseOff size={18} strokeWidth={1.5} />
-            <span className='ml-2'>No Environment</span>
+            <span className="ml-2">No Environment</span>
           </div>
           <div className="dropdown-item border-top" onClick={() => setOpenSettingsModal(true)}>
             <div className="pr-2 text-gray-600">

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -6,14 +6,12 @@ import { sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 
 import StyledWrapper from './StyledWrapper';
 
-const QueryResult = ({ item, collection, value, width, disableRunEventListener }) => {
-  const {
-    storedTheme
-  } = useTheme();
+const QueryResult = ({ item, collection, value, width, disableRunEventListener, mode }) => {
+  const { storedTheme } = useTheme();
   const dispatch = useDispatch();
 
   const onRun = () => {
-    if(disableRunEventListener) {
+    if (disableRunEventListener) {
       return;
     }
     dispatch(sendRequest(item, collection.uid));
@@ -22,7 +20,7 @@ const QueryResult = ({ item, collection, value, width, disableRunEventListener }
   return (
     <StyledWrapper className="px-3 w-full" style={{ maxWidth: width }}>
       <div className="h-full">
-        <CodeEditor collection={collection} theme={storedTheme} onRun={onRun} value={value || ''} readOnly />
+        <CodeEditor collection={collection} theme={storedTheme} onRun={onRun} value={value || ''} mode={mode} readOnly />
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -2,9 +2,13 @@ const { get, each, filter } = require('lodash');
 
 const prepareRequest = (request) => {
   const headers = {};
+  let contentTypeDefined = false;
   each(request.headers, (h) => {
     if (h.enabled) {
       headers[h.name] = h.value;
+      if (h.name.toLowerCase() === 'content-type') {
+        contentTypeDefined = true;
+      }
     }
   });
 
@@ -17,7 +21,9 @@ const prepareRequest = (request) => {
   request.body = request.body || {};
 
   if (request.body.mode === 'json') {
-    axiosRequest.headers['content-type'] = 'application/json';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'application/json';
+    }
     try {
       axiosRequest.data = JSON.parse(request.body.json);
     } catch (ex) {
@@ -26,12 +32,16 @@ const prepareRequest = (request) => {
   }
 
   if (request.body.mode === 'text') {
-    axiosRequest.headers['content-type'] = 'text/plain';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'text/plain';
+    }
     axiosRequest.data = request.body.text;
   }
 
   if (request.body.mode === 'xml') {
-    axiosRequest.headers['content-type'] = 'text/xml';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'text/xml';
+    }
     axiosRequest.data = request.body.xml;
   }
 
@@ -56,7 +66,9 @@ const prepareRequest = (request) => {
       query: get(request, 'body.graphql.query'),
       variables: JSON.parse(get(request, 'body.graphql.variables') || '{}')
     };
-    axiosRequest.headers['content-type'] = 'application/json';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'application/json';
+    }
     axiosRequest.data = graphqlQuery;
   }
 

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -2,9 +2,13 @@ const { get, each, filter } = require('lodash');
 
 const prepareRequest = (request) => {
   const headers = {};
+  let contentTypeDefined = false;
   each(request.headers, (h) => {
     if (h.enabled) {
       headers[h.name] = h.value;
+      if (h.name.toLowerCase() === 'content-type') {
+        contentTypeDefined = true;
+      }
     }
   });
 
@@ -15,7 +19,9 @@ const prepareRequest = (request) => {
   };
 
   if (request.body.mode === 'json') {
-    axiosRequest.headers['content-type'] = 'application/json';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'application/json';
+    }
     try {
       axiosRequest.data = JSON.parse(request.body.json);
     } catch (ex) {
@@ -24,12 +30,16 @@ const prepareRequest = (request) => {
   }
 
   if (request.body.mode === 'text') {
-    axiosRequest.headers['content-type'] = 'text/plain';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'text/plain';
+    }
     axiosRequest.data = request.body.text;
   }
 
   if (request.body.mode === 'xml') {
-    axiosRequest.headers['content-type'] = 'text/xml';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'text/xml';
+    }
     axiosRequest.data = request.body.xml;
   }
 
@@ -54,7 +64,9 @@ const prepareRequest = (request) => {
       query: get(request, 'body.graphql.query'),
       variables: JSON.parse(get(request, 'body.graphql.variables') || '{}')
     };
-    axiosRequest.headers['content-type'] = 'application/json';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'application/json';
+    }
     axiosRequest.data = graphqlQuery;
   }
 


### PR DESCRIPTION
Hi,

currently XML was presented in the response Pane surrounded by quotation marks and so the CodeEditor could not highlight the XML.
I added a check for the response type to check if the result is a JSON. Only then Stringify the JSON.
Before the `JSON.stringify` ran on XML too and added the quotations marks.

second change:
set the request header `content-type` only if it is not set by the user in the header variables.

BR
Mirko