### PR TITLE
#192 implement fallback to search body language by header 'content-type'

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -91,7 +91,10 @@ const importPostmanV2CollectionItem = (brunoParent, item) => {
           }
 
           if (bodyMode === 'raw') {
-            const language = get(i, 'request.body.options.raw.language');
+            let language = get(i, 'request.body.options.raw.language');
+            if (!language) {
+              language = searchLanguageByHeader(i.request.header);
+            }
             if (language === 'json') {
               brunoRequestItem.request.body.mode = 'json';
               brunoRequestItem.request.body.json = i.request.body.raw;
@@ -129,6 +132,21 @@ const importPostmanV2CollectionItem = (brunoParent, item) => {
       }
     }
   });
+};
+
+const searchLanguageByHeader = (headers) => {
+  let contentType;
+  each(headers, (header) => {
+    if (header.key.toLowerCase() === 'content-type' && !header.disabled) {
+      if (typeof header.value == 'string' && /^[\w\-]+\/([\w\-]+\+)?json/.test(header.value)) {
+        contentType = 'json';
+      } else if (typeof header.value == 'string' && /^[\w\-]+\/([\w\-]+\+)?xml/.test(header.value)) {
+        contentType = 'xml';
+      }
+      return false;
+    }
+  });
+  return contentType;
 };
 
 const importPostmanV2Collection = (collection) => {


### PR DESCRIPTION
Hallo @helloanoop,

While importing postman collections it can happen, that the language of a raw body is missing (problem of postman export)
I have implemented a fallback to search body language by header 'content-type'.

Can you please merge the fix?
It is possible to get a new release 0.14.1 with my fixes of the last days?

Postman is not usable anymore in my company, because we are not allowed to use postman accounts, because of data privacy. (All data is stored anywhere in the world.)
And we are working strong with XML.

Thanks
Mirko