### PR TITLE
Issue #203 Add about-window to help menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@faker-js/faker": "^7.6.0",
     "@jest/globals": "^29.2.0",
     "@playwright/test": "^1.27.1",
+    "about-window": "^1.15.2",
     "husky": "^8.0.3",
     "jest": "^29.2.0",
     "pretty-quick": "^3.1.3",

--- a/packages/bruno-electron/src/app/menu-template.js
+++ b/packages/bruno-electron/src/app/menu-template.js
@@ -1,4 +1,6 @@
 const { ipcMain } = require('electron');
+const openAboutWindow = require('about-window').default;
+const { join } = require('path');
 
 const template = [
   {
@@ -42,7 +44,18 @@ const template = [
   },
   {
     role: 'help',
-    submenu: [{ label: 'Learn More' }]
+    submenu: [
+      {
+        label: 'About Bruno',
+        click: () =>
+          openAboutWindow({
+            icon_path: join(__dirname, '../../resources/icons/png/128x128.png'),
+            homepage: 'https://www.usebruno.com/',
+            package_json_dir: join(__dirname, '../..')
+          })
+      },
+      { label: 'Learn More' }
+    ]
   }
 ];
 


### PR DESCRIPTION
Add `about-window` module to add a basic about window to bruno so that the user knows what version is currently installed.