### PR TITLE
Adds fallback when no environments are defined

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionProperties/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionProperties/index.js
@@ -35,7 +35,7 @@ const CollectionProperties = ({ collection, onClose }) => {
           </tr>
           <tr className="">
             <td className="py-2 px-2 text-right">Environments&nbsp;:</td>
-            <td className="py-2 px-2">{collection.environments.length}</td>
+            <td className="py-2 px-2">{collection.environments?.length || 0}</td>
           </tr>
           <tr className="">
             <td className="py-2 px-2 text-right">Requests&nbsp;:</td>


### PR DESCRIPTION
This adds a fallback for when a user has no environment defined. Otherwise, there's a bug where the `environments.length` can't be computed and causes the screen to blank.