### PR TITLE
Handle failed requests and reduce duplication

### DIFF
--- a/packages/bruno-cli/examples/report.json
+++ b/packages/bruno-cli/examples/report.json
@@ -1,8 +1,11 @@
 {
   "summary": {
+    "totalRequests": 10,
+    "passedRequests": 10,
+    "failedRequests": 0,
     "totalAssertions": 4,
-    "passedAssertions": 4,
-    "failedAssertions": 0,
+    "passedAssertions": 0,
+    "failedAssertions": 4,
     "totalTests": 0,
     "passedTests": 0,
     "failedTests": 0
@@ -11,53 +14,33 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:8080/test/v4",
+        "url": "http://localhost:3000/test/v4",
         "headers": {}
       },
       "response": {
-        "status": 200,
-        "statusText": "OK",
+        "status": 404,
+        "statusText": "Not Found",
         "headers": {
           "x-powered-by": "Express",
-          "content-type": "application/json; charset=utf-8",
-          "content-length": "497",
-          "etag": "W/\"1f1-08gGpUcq2NTnMCVT5AuXxQ0DzGE\"",
-          "date": "Mon, 25 Sep 2023 21:43:02 GMT",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "146",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
           "connection": "close"
         },
-        "data": {
-          "path": "/test/v4",
-          "headers": {
-            "accept": "application/json, text/plain, */*",
-            "user-agent": "axios/1.5.0",
-            "accept-encoding": "gzip, compress, deflate, br",
-            "host": "localhost:8080",
-            "connection": "close"
-          },
-          "method": "GET",
-          "body": "",
-          "fresh": false,
-          "hostname": "localhost",
-          "ip": "",
-          "ips": [],
-          "protocol": "http",
-          "query": {},
-          "subdomains": [],
-          "xhr": false,
-          "os": {
-            "hostname": "05512cb2102c"
-          },
-          "connection": {}
-        }
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /test/v4</pre>\n</body>\n</html>\n"
       },
+      "error": null,
       "assertionResults": [
         {
-          "uid": "mTrKBl5YU6jiAVG-phKT4",
+          "uid": "oidgfXLiyD8Jv0NBAHUHF",
           "lhsExpr": "res.status",
           "rhsExpr": "200",
           "rhsOperand": "200",
           "operator": "eq",
-          "status": "pass"
+          "status": "fail",
+          "error": "expected 404 to equal 200"
         }
       ],
       "testResults": []
@@ -65,53 +48,33 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:8080/test/v2",
+        "url": "http://localhost:3000/test/v2",
         "headers": {}
       },
       "response": {
-        "status": 200,
-        "statusText": "OK",
+        "status": 404,
+        "statusText": "Not Found",
         "headers": {
           "x-powered-by": "Express",
-          "content-type": "application/json; charset=utf-8",
-          "content-length": "497",
-          "etag": "W/\"1f1-lMqxZgVOJiQXjF5yk3AFEU8O9Ro\"",
-          "date": "Mon, 25 Sep 2023 21:43:02 GMT",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "146",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
           "connection": "close"
         },
-        "data": {
-          "path": "/test/v2",
-          "headers": {
-            "accept": "application/json, text/plain, */*",
-            "user-agent": "axios/1.5.0",
-            "accept-encoding": "gzip, compress, deflate, br",
-            "host": "localhost:8080",
-            "connection": "close"
-          },
-          "method": "GET",
-          "body": "",
-          "fresh": false,
-          "hostname": "localhost",
-          "ip": "",
-          "ips": [],
-          "protocol": "http",
-          "query": {},
-          "subdomains": [],
-          "xhr": false,
-          "os": {
-            "hostname": "05512cb2102c"
-          },
-          "connection": {}
-        }
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /test/v2</pre>\n</body>\n</html>\n"
       },
+      "error": null,
       "assertionResults": [
         {
-          "uid": "XsjjGx9cjt5t8tE_t69ZB",
+          "uid": "IgliYuHd9wKp6JNyqyHFK",
           "lhsExpr": "res.status",
           "rhsExpr": "200",
           "rhsOperand": "200",
           "operator": "eq",
-          "status": "pass"
+          "status": "fail",
+          "error": "expected 404 to equal 200"
         }
       ],
       "testResults": []
@@ -119,53 +82,33 @@
     {
       "request": {
         "method": "GET",
-        "url": "http://localhost:8080/test/v3",
+        "url": "http://localhost:3000/test/v3",
         "headers": {}
       },
       "response": {
-        "status": 200,
-        "statusText": "OK",
+        "status": 404,
+        "statusText": "Not Found",
         "headers": {
           "x-powered-by": "Express",
-          "content-type": "application/json; charset=utf-8",
-          "content-length": "497",
-          "etag": "W/\"1f1-tSiYu0/vWz3r+NYRCaed0aW1waw\"",
-          "date": "Mon, 25 Sep 2023 21:43:02 GMT",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "146",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
           "connection": "close"
         },
-        "data": {
-          "path": "/test/v3",
-          "headers": {
-            "accept": "application/json, text/plain, */*",
-            "user-agent": "axios/1.5.0",
-            "accept-encoding": "gzip, compress, deflate, br",
-            "host": "localhost:8080",
-            "connection": "close"
-          },
-          "method": "GET",
-          "body": "",
-          "fresh": false,
-          "hostname": "localhost",
-          "ip": "",
-          "ips": [],
-          "protocol": "http",
-          "query": {},
-          "subdomains": [],
-          "xhr": false,
-          "os": {
-            "hostname": "05512cb2102c"
-          },
-          "connection": {}
-        }
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /test/v3</pre>\n</body>\n</html>\n"
       },
+      "error": null,
       "assertionResults": [
         {
-          "uid": "i_8MmDMtJA9YfvB_FrW15",
+          "uid": "u-3sRebrCyuUbZOkwS0z8",
           "lhsExpr": "res.status",
           "rhsExpr": "200",
           "rhsOperand": "200",
           "operator": "eq",
-          "status": "pass"
+          "status": "fail",
+          "error": "expected 404 to equal 200"
         }
       ],
       "testResults": []
@@ -173,7 +116,7 @@
     {
       "request": {
         "method": "POST",
-        "url": "http://localhost:8080/test/v1",
+        "url": "http://localhost:3000/test/v1",
         "headers": {
           "content-type": "application/json"
         },
@@ -182,56 +125,200 @@
         }
       },
       "response": {
+        "status": 404,
+        "statusText": "Not Found",
+        "headers": {
+          "x-powered-by": "Express",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "147",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
+          "connection": "close"
+        },
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot POST /test/v1</pre>\n</body>\n</html>\n"
+      },
+      "error": null,
+      "assertionResults": [
+        {
+          "uid": "PpKLK6I38I5_ibw4lZqLb",
+          "lhsExpr": "res.status",
+          "rhsExpr": "eq 200",
+          "rhsOperand": "200",
+          "operator": "eq",
+          "status": "fail",
+          "error": "expected 404 to equal 200"
+        }
+      ],
+      "testResults": []
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3000/test",
+        "headers": {}
+      },
+      "response": {
+        "status": 404,
+        "statusText": "Not Found",
+        "headers": {
+          "x-powered-by": "Express",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "144",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
+          "connection": "close"
+        },
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot POST /test</pre>\n</body>\n</html>\n"
+      },
+      "error": null,
+      "assertionResults": [],
+      "testResults": []
+    },
+    {
+      "request": {
+        "method": "HEAD",
+        "url": "http://localhost:3000/",
+        "headers": {}
+      },
+      "response": {
         "status": 200,
         "statusText": "OK",
         "headers": {
           "x-powered-by": "Express",
-          "content-type": "application/json; charset=utf-8",
-          "content-length": "623",
-          "etag": "W/\"26f-ku5QGz4p9f02u79vJIve7JH3QYM\"",
-          "date": "Mon, 25 Sep 2023 21:43:02 GMT",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "12",
+          "etag": "W/\"c-Lve95gjOVATpfV8EL5X4nxwjKHE\"",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
           "connection": "close"
         },
+        "data": ""
+      },
+      "error": null,
+      "assertionResults": [],
+      "testResults": []
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3000",
+        "headers": {}
+      },
+      "response": {
+        "status": 404,
+        "statusText": "Not Found",
+        "headers": {
+          "x-powered-by": "Express",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "140",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
+          "connection": "close"
+        },
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot POST /</pre>\n</body>\n</html>\n"
+      },
+      "error": null,
+      "assertionResults": [],
+      "testResults": []
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3000/",
+        "headers": {
+          "content-type": "multipart/form-data; boundary=--------------------------897965859410704836065858"
+        },
         "data": {
-          "path": "/test/v1",
-          "headers": {
-            "accept": "application/json, text/plain, */*",
-            "content-type": "application/json",
-            "user-agent": "axios/1.5.0",
-            "content-length": "16",
-            "accept-encoding": "gzip, compress, deflate, br",
-            "host": "localhost:8080",
-            "connection": "close"
-          },
-          "method": "POST",
-          "body": "{\"test\":\"hello\"}",
-          "fresh": false,
-          "hostname": "localhost",
-          "ip": "",
-          "ips": [],
-          "protocol": "http",
-          "query": {},
-          "subdomains": [],
-          "xhr": false,
-          "os": {
-            "hostname": "05512cb2102c"
-          },
-          "connection": {},
-          "json": {
-            "test": "hello"
-          }
+          "_overheadLength": 103,
+          "_valueLength": 3,
+          "_valuesToMeasure": [],
+          "writable": false,
+          "readable": true,
+          "dataSize": 0,
+          "maxDataSize": 2097152,
+          "pauseStreams": true,
+          "_released": true,
+          "_streams": [],
+          "_currentStream": null,
+          "_insideLoop": false,
+          "_pendingNext": false,
+          "_boundary": "--------------------------897965859410704836065858",
+          "_events": {},
+          "_eventsCount": 3
         }
       },
-      "assertionResults": [
-        {
-          "uid": "hNBSF_GBdSTFHNiyCcOn9",
-          "lhsExpr": "res.status",
-          "rhsExpr": "200",
-          "rhsOperand": "200",
-          "operator": "eq",
-          "status": "pass"
-        }
-      ],
+      "response": {
+        "status": 404,
+        "statusText": "Not Found",
+        "headers": {
+          "x-powered-by": "Express",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "140",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
+          "connection": "close"
+        },
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot POST /</pre>\n</body>\n</html>\n"
+      },
+      "error": null,
+      "assertionResults": [],
+      "testResults": []
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3000/",
+        "headers": {
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        "data": "a=b&c=d"
+      },
+      "response": {
+        "status": 404,
+        "statusText": "Not Found",
+        "headers": {
+          "x-powered-by": "Express",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "140",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
+          "connection": "close"
+        },
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot POST /</pre>\n</body>\n</html>\n"
+      },
+      "error": null,
+      "assertionResults": [],
+      "testResults": []
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "http://localhost:3000/test",
+        "headers": {
+          "content-type": "text/xml"
+        },
+        "data": "<xml>\n  <test>1</test>\n</xml>"
+      },
+      "response": {
+        "status": 404,
+        "statusText": "Not Found",
+        "headers": {
+          "x-powered-by": "Express",
+          "content-security-policy": "default-src 'none'",
+          "x-content-type-options": "nosniff",
+          "content-type": "text/html; charset=utf-8",
+          "content-length": "144",
+          "date": "Fri, 29 Sep 2023 00:37:50 GMT",
+          "connection": "close"
+        },
+        "data": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot POST /test</pre>\n</body>\n</html>\n"
+      },
+      "error": null,
+      "assertionResults": [],
       "testResults": []
     }
   ]

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -12,16 +12,55 @@ const { dotenvToJson } = require('@usebruno/lang');
 const command = 'run [filename]';
 const desc = 'Run a request';
 
-const printRunSummary = (assertionResults, testResults) => {
-  // display assertion results and test results summary
-  const totalAssertions = assertionResults.length;
-  const passedAssertions = assertionResults.filter((result) => result.status === 'pass').length;
-  const failedAssertions = totalAssertions - passedAssertions;
+const printRunSummary = (results) => {
+  let totalRequests = 0;
+  let passedRequests = 0;
+  let failedRequests = 0;
+  let totalAssertions = 0;
+  let passedAssertions = 0;
+  let failedAssertions = 0;
+  let totalTests = 0;
+  let passedTests = 0;
+  let failedTests = 0;
 
-  const totalTests = testResults.length;
-  const passedTests = testResults.filter((result) => result.status === 'pass').length;
-  const failedTests = totalTests - passedTests;
+  for (const result of results) {
+    totalRequests += 1;
+    totalTests += result.testResults.length;
+    totalAssertions += result.assertionResults.length;
+    let anyFailed = false;
+    let hasAnyTestsOrAssertions = false;
+    for (const testResult of result.testResults) {
+      hasAnyTestsOrAssertions = true;
+      if (testResult.status === 'pass') {
+        passedTests += 1;
+      } else {
+        anyFailed = true;
+        failedTests += 1;
+      }
+    }
+    for (const assertionResult of result.assertionResults) {
+      hasAnyTestsOrAssertions = true;
+      if (assertionResult.status === 'pass') {
+        passedAssertions += 1;
+      } else {
+        anyFailed = true;
+        failedAssertions += 1;
+      }
+    }
+    if (!hasAnyTestsOrAssertions && result.error) {
+      failedRequests += 1;
+    } else {
+      passedRequests += 1;
+    }
+  }
+
   const maxLength = 12;
+
+  let requestSummary = `${rpad('Requests:', maxLength)} ${chalk.green(`${passedRequests} passed`)}`;
+  if (failedRequests > 0) {
+    requestSummary += `, ${chalk.red(`${failedRequests} failed`)}`;
+  }
+  requestSummary += `, ${totalRequests} total`;
 
   let assertSummary = `${rpad('Tests:', maxLength)} ${chalk.green(`${passedTests} passed`)}`;
   if (failedTests > 0) {
@@ -35,10 +74,14 @@ const printRunSummary = (assertionResults, testResults) => {
   }
   testSummary += `, ${totalAssertions} total`;
 
-  console.log('\n' + chalk.bold(assertSummary));
+  console.log('\n' + chalk.bold(requestSummary));
+  console.log(chalk.bold(assertSummary));
   console.log(chalk.bold(testSummary));
 
   return {
+    totalRequests,
+    passedRequests,
+    failedRequests,
     totalAssertions,
     passedAssertions,
     failedAssertions,
@@ -255,9 +298,7 @@ const handler = async function (argv) {
     }
 
     const _isFile = await isFile(filename);
-    let assertionResults = [];
-    let testResults = [];
-    let testrunResults = [];
+    let results = [];
 
     let bruJsons = [];
 
@@ -311,16 +352,10 @@ const handler = async function (argv) {
         brunoConfig
       );
 
-      if (result) {
-        testrunResults.push(result);
-        const { assertionResults: _assertionResults, testResults: _testResults } = result;
-
-        assertionResults = assertionResults.concat(_assertionResults);
-        testResults = testResults.concat(_testResults);
-      }
+      results.push(result);
     }
 
-    const summary = printRunSummary(assertionResults, testResults);
+    const summary = printRunSummary(results);
     console.log(chalk.dim(chalk.grey('Ran all requests.')));
 
     if (outputPath && outputPath.length) {
@@ -333,14 +368,14 @@ const handler = async function (argv) {
 
       const outputJson = {
         summary,
-        results: testrunResults
+        results
       };
 
       fs.writeFileSync(outputPath, JSON.stringify(outputJson, null, 2));
       console.log(chalk.dim(chalk.grey(`Wrote results to ${outputPath}`)));
     }
 
-    if (summary.failedAssertions > 0 || summary.failedTests > 0) {
+    if (summary.failedAssertions + summary.failedTests + summary.failedRequests > 0) {
       process.exit(1);
     }
   } catch (err) {

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -20,9 +20,9 @@ const runSingleRequest = async function (
   processEnvVars,
   brunoConfig
 ) {
-  let request;
-
   try {
+    let request;
+
     request = prepareRequest(bruJson.request);
 
     // make axios work in node using form data
@@ -122,8 +122,34 @@ const runSingleRequest = async function (
       request.data = qs.stringify(request.data);
     }
 
-    // run request
-    const response = await axios(request);
+    let response;
+    try {
+      // run request
+      response = await axios(request);
+    } catch (err) {
+      if (err && err.response) {
+        response = err.response;
+      } else {
+        console.log(chalk.red(stripExtension(filename)) + chalk.dim(` (${err.message})`));
+        return {
+          request: {
+            method: request.method,
+            url: request.url,
+            headers: request.headers,
+            data: request.data
+          },
+          response: {
+            status: null,
+            statusText: null,
+            headers: null,
+            data: null
+          },
+          error: err.message,
+          assertionResults: [],
+          testResults: []
+        };
+      }
+    }
 
     console.log(chalk.green(stripExtension(filename)) + chalk.dim(` (${response.status} ${response.statusText})`));
 
@@ -223,100 +249,28 @@ const runSingleRequest = async function (
         headers: response.headers,
         data: response.data
       },
+      error: null,
       assertionResults,
       testResults
     };
   } catch (err) {
-    if (err && err.response) {
-      console.log(
-        chalk.green(stripExtension(filename)) + chalk.dim(` (${err.response.status} ${err.response.statusText})`)
-      );
-
-      // run post-response vars
-      const postResponseVars = get(bruJson, 'request.vars.res');
-      if (postResponseVars && postResponseVars.length) {
-        const varsRuntime = new VarsRuntime();
-        varsRuntime.runPostResponseVars(
-          postResponseVars,
-          request,
-          err.response,
-          envVariables,
-          collectionVariables,
-          collectionPath,
-          processEnvVars
-        );
-      }
-
-      // run post response script
-      const responseScriptFile = get(bruJson, 'request.script.res');
-      if (responseScriptFile && responseScriptFile.length) {
-        const scriptRuntime = new ScriptRuntime();
-        await scriptRuntime.runResponseScript(
-          responseScriptFile,
-          request,
-          err.response,
-          envVariables,
-          collectionVariables,
-          collectionPath,
-          null,
-          processEnvVars
-        );
-      }
-
-      // run assertions
-      let assertionResults = [];
-      const assertions = get(bruJson, 'request.assertions');
-      if (assertions && assertions.length) {
-        const assertRuntime = new AssertRuntime();
-        assertionResults = assertRuntime.runAssertions(
-          assertions,
-          request,
-          err.response,
-          envVariables,
-          collectionVariables,
-          collectionPath
-        );
-
-        each(assertionResults, (r) => {
-          if (r.status === 'pass') {
-            console.log(chalk.green(`   ✓ `) + chalk.dim(`assert: ${r.lhsExpr}: ${r.rhsExpr}`));
-          } else {
-            console.log(chalk.red(`   ✕ `) + chalk.red(`assert: ${r.lhsExpr}: ${r.rhsExpr}`));
-            console.log(chalk.red(`      ${r.error}`));
-          }
-        });
-      }
-
-      // run tests
-      let testResults = [];
-      const testFile = get(bruJson, 'request.tests');
-      if (testFile && testFile.length) {
-        const testRuntime = new TestRuntime();
-        const result = testRuntime.runTests(
-          testFile,
-          request,
-          err.response,
-          envVariables,
-          collectionVariables,
-          collectionPath,
-          null,
-          processEnvVars
-        );
-        testResults = get(result, 'results', []);
-      }
-
-      if (testResults && testResults.length) {
-        each(testResults, (testResult) => {
-          if (testResult.status === 'pass') {
-            console.log(chalk.green(`   ✓ `) + chalk.dim(testResult.description));
-          } else {
-            console.log(chalk.red(`   ✕ `) + chalk.red(testResult.description));
-          }
-        });
-      }
-    } else {
-      console.log(chalk.red(stripExtension(filename)) + chalk.dim(` (${err.message})`));
-    }
+    return {
+      request: {
+        method: null,
+        url: null,
+        headers: null,
+        data: null
+      },
+      response: {
+        status: null,
+        statusText: null,
+        headers: null,
+        data: null
+      },
+      error: err.message,
+      assertionResults: [],
+      testResults: []
+    };
   }
 };
 


### PR DESCRIPTION
This PR addresses some issues I ran into when requests failed to run. Basically, if a request produced an error (not due to status code), then it would show not show up as failed and not contribute to the status of the run. It also was not reflected in show results.

This modification makes it so that request information is tracked, and so that this reflects in exit code. The JSON report (the `--output` flag) also shows information for the response. In this case, it shows `null` for all fields in `response` and adds an `error` field.

I also cleaned up `runSingleRequest` to reduce the amount of duplicated logic around handling non-OK status codes.

An example of new CLI output:

![image](https://github.com/usebruno/bruno/assets/31828764/32ac497a-bca2-4b07-add5-0b71b8c2c9e5)
