### PR TITLE
feat: allow test to be asynchrone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+#dev editor
+bruno.iml
+.idea

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -187,7 +187,7 @@ const runSingleRequest = async function (
     const testFile = get(bruJson, 'request.tests');
     if (testFile && testFile.length) {
       const testRuntime = new TestRuntime();
-      const result = testRuntime.runTests(
+      const result = await testRuntime.runTests(
         testFile,
         request,
         response,
@@ -292,7 +292,7 @@ const runSingleRequest = async function (
       const testFile = get(bruJson, 'request.tests');
       if (testFile && testFile.length) {
         const testRuntime = new TestRuntime();
-        const result = testRuntime.runTests(
+        const result = await testRuntime.runTests(
           testFile,
           request,
           err.response,

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -315,7 +315,7 @@ const registerNetworkIpc = (mainWindow) => {
         const testFile = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
         if (testFile && testFile.length) {
           const testRuntime = new TestRuntime();
-          const testResults = testRuntime.runTests(
+          const testResults = await testRuntime.runTests(
             testFile,
             request,
             response,
@@ -389,7 +389,7 @@ const registerNetworkIpc = (mainWindow) => {
           const testFile = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
           if (testFile && testFile.length) {
             const testRuntime = new TestRuntime();
-            const testResults = testRuntime.runTests(
+            const testResults = await testRuntime.runTests(
               testFile,
               request,
               error.response,
@@ -725,7 +725,7 @@ const registerNetworkIpc = (mainWindow) => {
             const testFile = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
             if (testFile && testFile.length) {
               const testRuntime = new TestRuntime();
-              const testResults = testRuntime.runTests(
+              const testResults = await testRuntime.runTests(
                 testFile,
                 request,
                 response,
@@ -804,7 +804,7 @@ const registerNetworkIpc = (mainWindow) => {
               const testFile = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
               if (testFile && testFile.length) {
                 const testRuntime = new TestRuntime();
-                const testResults = testRuntime.runTests(
+                const testResults = await testRuntime.runTests(
                   testFile,
                   request,
                   error.response,

--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -10,6 +10,7 @@ const { cleanJson } = require('../utils');
 
 // Inbuilt Library Support
 const atob = require('atob');
+const axios = require('axios');
 const btoa = require('btoa');
 const lodash = require('lodash');
 const moment = require('moment');
@@ -20,7 +21,7 @@ const CryptoJS = require('crypto-js');
 class TestRuntime {
   constructor() {}
 
-  runTests(
+  async runTests(
     testsFile,
     request,
     response,
@@ -78,6 +79,7 @@ class TestRuntime {
         root: [collectionPath],
         mock: {
           atob,
+          axios,
           btoa,
           lodash,
           moment,
@@ -89,7 +91,8 @@ class TestRuntime {
       }
     });
 
-    vm.run(testsFile, path.join(collectionPath, 'vm.js'));
+    const asyncVM = vm.run(`module.exports = async () => { ${testsFile}}`, path.join(collectionPath, 'vm.js'));
+    await asyncVM();
 
     return {
       request,

--- a/packages/bruno-js/src/test.js
+++ b/packages/bruno-js/src/test.js
@@ -1,6 +1,6 @@
-const Test = (__brunoTestResults, chai) => (description, callback) => {
+const Test = (__brunoTestResults, chai) => async (description, callback) => {
   try {
-    callback();
+    await callback();
     __brunoTestResults.addResult({ description, status: 'pass' });
   } catch (error) {
     console.log(chai.AssertionError);

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -1,0 +1,53 @@
+const { describe, it, expect } = require('@jest/globals');
+const TestRuntime = require('../src/runtime/test-runtime');
+
+describe('runtime', () => {
+  describe('test-runtime', () => {
+    const baseRequest = {
+      method: 'GET',
+      url: 'http://localhost:3000/',
+      headers: {},
+      data: undefined
+    };
+    const baseResponse = {
+      status: 200,
+      statusText: 'OK',
+      data: [
+        {
+          id: 1
+        },
+        {
+          id: 2
+        },
+        {
+          id: 3
+        }
+      ]
+    };
+
+    it('should wait async tests', async () => {
+      const testFile = `
+                await test('async test', ()=> {
+                    return new Promise((resolve)=> {
+                        setTimeout(()=> {resolve()},200)
+                    })
+                })
+            `;
+
+      const runtime = new TestRuntime();
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env
+      );
+      expect(result.results.map((el) => ({ description: el.description, status: el.status }))).toEqual([
+        { description: 'async test', status: 'pass' }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Description
allow use async in tests

## Motivation and context
I'm using bruno/cli for integration testing and want to put some asynchronous stuff in the tests to allow queries to be run after getting the results to check data consistency.

## How was this tested?
I added a new test file for test-rutime in bruno-js