### PR TITLE
Changed Proxied Requests to Use https-proxy-agent.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,5 @@
   },
   "overrides": {
     "rollup": "3.2.5"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -4,12 +4,12 @@ const fs = require('fs');
 const { forOwn, each, extend, get } = require('lodash');
 const FormData = require('form-data');
 const axios = require('axios');
-const https = require('https');
 const prepareRequest = require('./prepare-request');
 const interpolateVars = require('./interpolate-vars');
 const { ScriptRuntime, TestRuntime, VarsRuntime, AssertRuntime } = require('@usebruno/js');
 const { stripExtension } = require('../utils/filesystem');
 const { getOptions } = require('../utils/bru');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 const runSingleRequest = async function (
   filename,
@@ -65,31 +65,6 @@ const runSingleRequest = async function (
       );
     }
 
-    // set proxy if enabled
-    const proxyEnabled = get(brunoConfig, 'proxy.enabled', false);
-    if (proxyEnabled) {
-      const proxyProtocol = get(brunoConfig, 'proxy.protocol');
-      const proxyHostname = get(brunoConfig, 'proxy.hostname');
-      const proxyPort = get(brunoConfig, 'proxy.port');
-      const proxyAuthEnabled = get(brunoConfig, 'proxy.auth.enabled', false);
-
-      const proxyConfig = {
-        protocol: proxyProtocol,
-        hostname: proxyHostname,
-        port: proxyPort
-      };
-      if (proxyAuthEnabled) {
-        const proxyAuthUsername = get(brunoConfig, 'proxy.auth.username');
-        const proxyAuthPassword = get(brunoConfig, 'proxy.auth.password');
-        proxyConfig.auth = {
-          username: proxyAuthUsername,
-          password: proxyAuthPassword
-        };
-      }
-
-      request.proxy = proxyConfig;
-    }
-
     // interpolate variables inside request
     interpolateVars(request, envVariables, collectionVariables, processEnvVars);
 
@@ -111,7 +86,30 @@ const runSingleRequest = async function (
       }
     }
 
-    if (Object.keys(httpsAgentRequestFields).length > 0) {
+    // set proxy if enabled
+    const proxyEnabled = get(brunoConfig, 'proxy.enabled', false);
+    if (proxyEnabled) {
+      const proxyProtocol = get(brunoConfig, 'proxy.protocol');
+      const proxyHostname = get(brunoConfig, 'proxy.hostname');
+      const proxyPort = get(brunoConfig, 'proxy.port');
+      const proxyAuthEnabled = get(brunoConfig, 'proxy.auth.enabled', false);
+
+      let proxy;
+
+      if (proxyAuthEnabled) {
+        const proxyAuthUsername = get(brunoConfig, 'proxy.auth.username');
+        const proxyAuthPassword = get(brunoConfig, 'proxy.auth.password');
+
+        proxy = `${proxyProtocol}://${proxyAuthUsername}:${proxyAuthPassword}@${proxyHostname}:${proxyPort}`;
+      } else {
+        proxy = `${proxyProtocol}://${proxyHostname}:${proxyPort}`;
+      }
+
+      request.httpsAgent = new HttpsProxyAgent(
+        proxy,
+        Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
+      );
+    } else if (Object.keys(httpsAgentRequestFields).length > 0) {
       request.httpsAgent = new https.Agent({
         ...httpsAgentRequestFields
       });

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -10,6 +10,7 @@ const { ScriptRuntime, TestRuntime, VarsRuntime, AssertRuntime } = require('@use
 const { stripExtension } = require('../utils/filesystem');
 const { getOptions } = require('../utils/bru');
 const { HttpsProxyAgent } = require('https-proxy-agent');
+const https = require('https');
 
 const runSingleRequest = async function (
   filename,

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -30,6 +30,7 @@
     "fs-extra": "^10.1.0",
     "graphql": "^16.6.0",
     "handlebars": "^4.7.8",
+    "https-proxy-agent": "^7.0.2",
     "is-valid-path": "^0.1.1",
     "lodash": "^4.17.21",
     "mustache": "^4.2.0",

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -15,6 +15,7 @@ const { sortFolder, getAllRequestsInFolderRecursively } = require('./helper');
 const { getPreferences } = require('../../store/preferences');
 const { getProcessEnvVars } = require('../../store/process-env');
 const { getBrunoConfig } = require('../../store/bruno-config');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 // override the default escape function to prevent escaping
 Mustache.escape = function (value) {
@@ -165,32 +166,6 @@ const registerNetworkIpc = (mainWindow) => {
           });
         }
 
-        // proxy configuration
-        const brunoConfig = getBrunoConfig(collectionUid);
-        const proxyEnabled = get(brunoConfig, 'proxy.enabled', false);
-        if (proxyEnabled) {
-          const proxyProtocol = get(brunoConfig, 'proxy.protocol');
-          const proxyHostname = get(brunoConfig, 'proxy.hostname');
-          const proxyPort = get(brunoConfig, 'proxy.port');
-          const proxyAuthEnabled = get(brunoConfig, 'proxy.auth.enabled', false);
-
-          const proxyConfig = {
-            protocol: proxyProtocol,
-            hostname: proxyHostname,
-            port: proxyPort
-          };
-          if (proxyAuthEnabled) {
-            const proxyAuthUsername = get(brunoConfig, 'proxy.auth.username');
-            const proxyAuthPassword = get(brunoConfig, 'proxy.auth.password');
-            proxyConfig.auth = {
-              username: proxyAuthUsername,
-              password: proxyAuthPassword
-            };
-          }
-
-          request.proxy = proxyConfig;
-        }
-
         interpolateVars(request, envVars, collectionVariables, processEnvVars);
 
         // stringify the request url encoded params
@@ -234,7 +209,31 @@ const registerNetworkIpc = (mainWindow) => {
           }
         }
 
-        if (Object.keys(httpsAgentRequestFields).length > 0) {
+        // proxy configuration
+        const brunoConfig = getBrunoConfig(collectionUid);
+        const proxyEnabled = get(brunoConfig, 'proxy.enabled', false);
+        if (proxyEnabled) {
+          const proxyProtocol = get(brunoConfig, 'proxy.protocol');
+          const proxyHostname = get(brunoConfig, 'proxy.hostname');
+          const proxyPort = get(brunoConfig, 'proxy.port');
+          const proxyAuthEnabled = get(brunoConfig, 'proxy.auth.enabled', false);
+
+          let proxy;
+
+          if (proxyAuthEnabled) {
+            const proxyAuthUsername = get(brunoConfig, 'proxy.auth.username');
+            const proxyAuthPassword = get(brunoConfig, 'proxy.auth.password');
+
+            proxy = `${proxyProtocol}://${proxyAuthUsername}:${proxyAuthPassword}@${proxyHostname}:${proxyPort}`;
+          } else {
+            proxy = `${proxyProtocol}://${proxyHostname}:${proxyPort}`;
+          }
+
+          request.httpsAgent = new HttpsProxyAgent(
+            proxy,
+            Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
+          );
+        } else if (Object.keys(httpsAgentRequestFields).length > 0) {
           request.httpsAgent = new https.Agent({
             ...httpsAgentRequestFields
           });
@@ -598,32 +597,6 @@ const registerNetworkIpc = (mainWindow) => {
               });
             }
 
-            // proxy configuration
-            const brunoConfig = getBrunoConfig(collectionUid);
-            const proxyEnabled = get(brunoConfig, 'proxy.enabled', false);
-            if (proxyEnabled) {
-              const proxyProtocol = get(brunoConfig, 'proxy.protocol');
-              const proxyHostname = get(brunoConfig, 'proxy.hostname');
-              const proxyPort = get(brunoConfig, 'proxy.port');
-              const proxyAuthEnabled = get(brunoConfig, 'proxy.auth.enabled', false);
-
-              const proxyConfig = {
-                protocol: proxyProtocol,
-                hostname: proxyHostname,
-                port: proxyPort
-              };
-              if (proxyAuthEnabled) {
-                const proxyAuthUsername = get(brunoConfig, 'proxy.auth.username');
-                const proxyAuthPassword = get(brunoConfig, 'proxy.auth.password');
-                proxyConfig.auth = {
-                  username: proxyAuthUsername,
-                  password: proxyAuthPassword
-                };
-              }
-
-              request.proxy = proxyConfig;
-            }
-
             // interpolate variables inside request
             interpolateVars(request, envVars, collectionVariables, processEnvVars);
 
@@ -644,7 +617,30 @@ const registerNetworkIpc = (mainWindow) => {
             const preferences = getPreferences();
             const sslVerification = get(preferences, 'request.sslVerification', true);
 
-            if (!sslVerification) {
+            // proxy configuration
+            const brunoConfig = getBrunoConfig(collectionUid);
+            const proxyEnabled = get(brunoConfig, 'proxy.enabled', false);
+            if (proxyEnabled) {
+              const proxyProtocol = get(brunoConfig, 'proxy.protocol');
+              const proxyHostname = get(brunoConfig, 'proxy.hostname');
+              const proxyPort = get(brunoConfig, 'proxy.port');
+              const proxyAuthEnabled = get(brunoConfig, 'proxy.auth.enabled', false);
+
+              let proxy;
+
+              if (proxyAuthEnabled) {
+                const proxyAuthUsername = get(brunoConfig, 'proxy.auth.username');
+                const proxyAuthPassword = get(brunoConfig, 'proxy.auth.password');
+
+                proxy = `${proxyProtocol}://${proxyAuthUsername}:${proxyAuthPassword}@${proxyHostname}:${proxyPort}`;
+              } else {
+                proxy = `${proxyProtocol}://${proxyHostname}:${proxyPort}`;
+              }
+
+              request.httpsAgent = new HttpsProxyAgent(proxy, {
+                rejectUnauthorized: sslVerification
+              });
+            } else if (!sslVerification) {
               request.httpsAgent = new https.Agent({
                 rejectUnauthorized: false
               });


### PR DESCRIPTION
HTTP proxies typically make use of TCP tunnels to send proxied HTTPS requests. However, Axios makes use of https.Agent by default which does not support TCP tunneling.

This PR makes use of the https-proxy-agent package which replaces https.Agent for proxied requests. Non-proxied requests still make use of https.Agent.

Note that this can be tested on any machine by spinning up a simple HTTP proxy with the following docker-compose:

```
services:
  proxy:
    image: ubuntu/squid
    ports:
      - "3128:3128"
```

Then, direct Bruno to use an http proxy with the hostname localhost and port 3128.

Before my changes, directing Bruno to use the proxy at localhost:3128 will result in a TLS error from Squid. After my changes, a TCP tunnel is established and HTTPS requests are able to be made.