### PR TITLE
Bugfix: Create collection modal validation

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -28,7 +28,9 @@ const CreateCollection = ({ onClose }) => {
         .min(1, 'must be atleast 1 characters')
         .max(50, 'must be 50 characters or less')
         .required('folder name is required'),
-      collectionLocation: Yup.string().required('location is required')
+      collectionLocation: Yup.string()
+        .min(1, 'location is required')
+        .required('location is required')
     }),
     onSubmit: (values) => {
       dispatch(createCollection(values.collectionName, values.collectionFolderName, values.collectionLocation))
@@ -43,7 +45,10 @@ const CreateCollection = ({ onClose }) => {
   const browse = () => {
     dispatch(browseDirectory())
       .then((dirPath) => {
-        formik.setFieldValue('collectionLocation', dirPath);
+        // When the user closes the diolog without selecting anything dirPath will be false
+        if (typeof dirPath === 'string') {
+          formik.setFieldValue('collectionLocation', dirPath);
+        }
       })
       .catch((error) => {
         formik.setFieldValue('collectionLocation', '');


### PR DESCRIPTION
Currently:

https://github.com/usebruno/bruno/assets/39559178/9e9338f9-95b6-462c-bbee-fd705b29d739

With my fix:

https://github.com/usebruno/bruno/assets/39559178/49f87574-7d89-442b-8744-c5a14ffe34cc

---
Also, as an Idea: I think the name tooltip could be removed as it doesn't add any information and the Folder Name tooltip could be expanded to clarify that the folder will be created inside the selected location. To avoid mistakes like: `~/projects/my-api/docs/docs`.
