### PR TITLE
Remove rogue apostrophes and capitalise API in text.

### DIFF
--- a/packages/bruno-app/src/components/VariablesEditor/index.js
+++ b/packages/bruno-app/src/components/VariablesEditor/index.js
@@ -87,7 +87,7 @@ const VariablesEditor = ({ collection }) => {
       <EnvVariables collection={collection} theme={reactInspectorTheme} />
 
       <div className="mt-8 muted text-xs">
-        Note: As of today, collection variables can only be set via the api -{' '}
+        Note: As of today, collection variables can only be set via the API -{' '}
         <span className="font-medium">getVar()</span> and <span className="font-medium">setVar()</span>. <br />
         In the next release, we will add a UI to set and modify collection variables.
       </div>

--- a/packages/bruno-app/src/components/Welcome/index.js
+++ b/packages/bruno-app/src/components/Welcome/index.js
@@ -54,7 +54,7 @@ const Welcome = () => {
         <Bruno width={50} />
       </div>
       <div className="text-xl font-semibold select-none">bruno</div>
-      <div className="mt-4">Opensource IDE for exploring and testing api's</div>
+      <div className="mt-4">Opensource IDE for exploring and testing APIs</div>
 
       <div className="uppercase font-semibold heading mt-10">Collections</div>
       <div className="mt-4 flex items-center collection-options select-none">

--- a/packages/bruno-cli/src/index.js
+++ b/packages/bruno-cli/src/index.js
@@ -20,7 +20,7 @@ const run = async () => {
     .commandDir('commands')
     .epilogue(CLI_EPILOGUE)
     .usage('Usage: $0 <command> [options]')
-    .demandCommand(1, "Woof !! Let's play with some apis !!")
+    .demandCommand(1, "Woof !! Let's play with some APIs !!")
     .help('h')
     .alias('h', 'help');
 };

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <br />
 <img src="assets/images/logo-transparent.png" width="80"/>
 
-### Bruno - Opensource IDE for exploring and testing api's. 
+### Bruno - Opensource IDE for exploring and testing APIs. 
 
 [![GitHub version](https://badge.fury.io/gh/usebruno%2Fbruno.svg)](https://badge.fury.io/gh/usebruno%bruno)
 [![CI](https://github.com/usebruno/bruno/actions/workflows/unit-tests.yml/badge.svg?branch=main)](https://github.com/usebruno/bruno/workflows/unit-tests.yml)
@@ -15,7 +15,7 @@ Bruno is a new and innovative API client, aimed at revolutionizing the status qu
 
 Bruno stores your collections directly in a folder on your filesystem. We use a plain text markup language, Bru, to save information about API requests.
 
-You can use git or any version control of your choice to collaborate over your api collections.
+You can use git or any version control of your choice to collaborate over your API collections.
 
 
 ![bruno](assets/images/landing-2.png) <br /><br />


### PR DESCRIPTION
Signed-off-by: Andy Piper <andypiper@users.noreply.github.com>
