### PR TITLE
feature/preview-response-html

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/StyledWrapper.js
@@ -3,14 +3,7 @@ import styled from 'styled-components';
 const StyledWrapper = styled.div`
   display: grid;
   grid-template-columns: 100%;
-  grid-template-rows: 50px calc(100% - 50px);
-
-  /* If there is only one element (the preview, not tabs) make it span over both grid rows */
-  > *:last-child:first-child {
-    grid-row: 1 / 3;
-    margin-top: 1.25rem;
-    height: calc(100% - 1.25rem);
-  }
+  grid-template-rows: 1.25rem calc(100% - 1.25rem);
 
   /* This is a hack to force Codemirror to use all available space */
   > div {

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/StyledWrapper.js
@@ -1,9 +1,28 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 100%;
+  grid-template-rows: 50px calc(100% - 50px);
+
+  /* If there is only one element (the preview, not tabs) make it span over both grid rows */
+  > *:last-child:first-child {
+    grid-row: 1 / 3;
+    margin-top: 1.25rem;
+    height: calc(100% - 1.25rem);
+  }
+
+  /* This is a hack to force Codemirror to use all available space */
+  > div {
+    position: relative;
+  }
+
   div.CodeMirror {
-    /* todo: find a better way */
-    height: calc(100vh - 220px);
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    width: 100%;
   }
 `;
 

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -3,11 +3,15 @@ import CodeEditor from 'components/CodeEditor';
 import { useTheme } from 'providers/Theme';
 import { useDispatch } from 'react-redux';
 import { sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import classnames from 'classnames';
 
 import StyledWrapper from './StyledWrapper';
+import { useState } from 'react';
+import { useMemo } from 'react';
 
 const QueryResult = ({ item, collection, value, width, disableRunEventListener, mode }) => {
   const { storedTheme } = useTheme();
+  const [tab, setTab] = useState('raw');
   const dispatch = useDispatch();
 
   const onRun = () => {
@@ -17,18 +21,58 @@ const QueryResult = ({ item, collection, value, width, disableRunEventListener, 
     dispatch(sendRequest(item, collection.uid));
   };
 
-  return (
-    <StyledWrapper className="px-3 w-full" style={{ maxWidth: width }}>
-      <div className="h-full">
-        <CodeEditor
-          collection={collection}
-          theme={storedTheme}
-          onRun={onRun}
-          value={value || ''}
-          mode={mode}
-          readOnly
-        />
+  const getTabClassname = (tabName) => {
+    return classnames(`tab select-none ${tabName}`, {
+      active: tabName === tab
+    });
+  };
+
+  const tabs = [(
+    <div className={getTabClassname('raw')} role="tab" onClick={() => setTab('raw')}>
+      Raw
+    </div>
+  )];
+  if (mode.includes('text/html')) {
+    tabs.push(
+      <div className={getTabClassname('preview')} role="tab" onClick={() => setTab('preview')}>
+        Preview
       </div>
+    );
+  }
+
+  const activeResult = useMemo(() => {
+    if (tab === 'preview') {
+      // Add the Base tag to the head so content loads proparly. This also needs the correct CSP settings
+      const webViewSrc = value.replace('<head>', `<head><base href="${item.requestSent.url}">`);
+      return (
+        <webview
+          src={`data:text/html; charset=utf-8,${encodeURIComponent(webViewSrc)}`}
+          webpreferences="disableDialogs=true, javascript=yes"
+          className="h-full bg-white"
+        />
+      );
+    }
+
+    return (
+      <CodeEditor
+        collection={collection}
+        theme={storedTheme}
+        onRun={onRun}
+        value={value || ''}
+        mode={mode}
+        readOnly
+      />
+    );
+  }, [tab, collection, storedTheme, onRun, value, mode]);
+
+  return (
+    <StyledWrapper className="px-3 w-full h-full" style={{ maxWidth: width }}>
+      {tabs.length > 1 ? (
+        <div className="flex flex-wrap items-center px-3 tabs mb-3" role="tablist">
+          {tabs}
+        </div>
+      ) : null}
+      {activeResult}
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -63,23 +63,28 @@ const QueryResult = ({ item, collection, data, width, disableRunEventListener, h
   };
 
   const getTabClassname = (tabName) => {
-    return classnames(`tab select-none ${tabName}`, {
-      active: tabName === tab
+    return classnames(`select-none ${tabName}`, {
+      'text-yellow-500': tabName === tab,
+      'cursor-pointer': tabName !== tab,
     });
   };
 
-  const tabs = [(
-    <div className={getTabClassname('raw')} role="tab" onClick={() => setTab('raw')}>
-      Raw
-    </div>
-  )];
-  if (mode.includes('html')) {
-    tabs.push(
-      <div className={getTabClassname('preview')} role="tab" onClick={() => setTab('preview')}>
-        Preview
-      </div>
+  const getTabs = () => {
+    if (!mode.includes('html')) {
+      return null;
+    }
+
+    return (
+      <>
+        <div className={getTabClassname('raw')} role="tab" onClick={() => setTab('raw')}>
+          Raw
+        </div>
+        <div className={getTabClassname('preview')} role="tab" onClick={() => setTab('preview')}>
+          Preview
+        </div>
+      </>
     );
-  }
+  };
 
   const activeResult = useMemo(() => {
     if (tab === 'preview') {
@@ -108,11 +113,9 @@ const QueryResult = ({ item, collection, data, width, disableRunEventListener, h
 
   return (
     <StyledWrapper className="px-3 w-full h-full" style={{ maxWidth: width }}>
-      {tabs.length > 1 ? (
-        <div className="flex flex-wrap items-center px-3 tabs mb-3" role="tablist">
-          {tabs}
-        </div>
-      ) : null}
+      <div className="flex justify-end gap-2 text-xs" role="tablist">
+        {getTabs()}
+      </div>
       {activeResult}
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -116,7 +116,7 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
           </div>
         ) : null}
       </div>
-      <section className="flex flex-grow mt-5">{getTabPanel(focusedTab.responsePaneTab)}</section>
+      <section className="flex flex-grow">{getTabPanel(focusedTab.responsePaneTab)}</section>
     </StyledWrapper>
   );
 };

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -35,7 +35,8 @@ app.on('ready', async () => {
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: true,
-      preload: path.join(__dirname, 'preload.js')
+      preload: path.join(__dirname, 'preload.js'),
+      webviewTag: true,
     }
   });
 

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -16,9 +16,7 @@ setContentSecurityPolicy(`
 	default-src * 'unsafe-inline' 'unsafe-eval';
 	script-src * 'unsafe-inline' 'unsafe-eval';
 	connect-src * 'unsafe-inline';
-	base-uri 'none';
 	form-action 'none';
-  img-src 'self' data:image/svg+xml;
 `);
 
 const menu = Menu.buildFromTemplate(menuTemplate);


### PR DESCRIPTION
https://github.com/usebruno/bruno/assets/39559178/7ffe3afd-f557-4112-b1eb-77b14ebbfcf0

The tabs are build in a way which allows for more tabs to be added in the future. We could an extra Tab for the unformatted response.

Because of the Content-Security-Policy set in electron, images, CSS and other things are not loaded properly. With the settings updated, the Preview looks better:

```diff
    setContentSecurityPolicy(`
      default-src * 'unsafe-inline' 'unsafe-eval';
      script-src * 'unsafe-inline' 'unsafe-eval';
      connect-src * 'unsafe-inline';
-     base-uri 'none';
      form-action 'none';
-     img-src 'self' data:image/svg+xml;
    `);
```

https://github.com/usebruno/bruno/assets/39559178/494493e6-a218-4372-85ca-050ebca317e7

But I'm not sure what security problem might occur with the updated Content-Security-Policy, so I did not include them in this PR.

