### PR TITLE
Fix rounding response size

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -19,7 +19,7 @@ Libraries we use
 
 ### Dependencies
 
-You would need [Node v14.x or the latest LTS version](https://nodejs.org/en/) and npm 8.x. We use npm workspaces in the project
+You would need [Node v18.x or the latest LTS version](https://nodejs.org/en/) and npm 8.x. We use npm workspaces in the project
 
 ### Lets start coding
 

--- a/packages/bruno-app/src/components/ResponsePane/ResponseSize/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseSize/index.js
@@ -7,7 +7,7 @@ const ResponseSize = ({ size }) => {
   if (size > 1024) {
     // size is greater than 1kb
     let kb = Math.floor(size / 1024);
-    let decimal = ((size % 1024) / 1024).toFixed(2) * 100;
+    let decimal = Math.round(((size % 1024) / 1024).toFixed(2) * 100);
     sizeToDisplay = kb + '.' + decimal + 'KB';
   } else {
     sizeToDisplay = size + 'B';


### PR DESCRIPTION
I noticed that sometimes the response size is weirdly displayed.
- size `112932` is displayed as `110.28.999999999999996KB`
- size `112990` is displayed as `110.34KB`

The problem is in the decimal calculation. Rounding the value ensure we don't have two `.` in the displayed size.

Size with a bug:
```js
const size = 112932

if (size > 1024) {
  // size is greater than 1kb
  let kb = Math.floor(size / 1024);
  let decimal = (((size % 1024) / 1024).toFixed(2) * 100);
  sizeToDisplay = kb + '.' + decimal + 'KB';
} else {
  sizeToDisplay = size + 'B';
}

console.log(sizeToDisplay)
```

`110.28.999999999999996KB` is displayed.

And with the current fix, `110.29KB` is displayed.

Also, update the `contributing` to increase the minimum Node version required.