### PR TITLE
fix(#270): Fix deleted assertions & tests shown in test tab

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -161,7 +161,7 @@ const runSingleRequest = async function (
     // run assertions
     let assertionResults = [];
     const assertions = get(bruJson, 'request.assertions');
-    if (assertions && assertions.length) {
+    if (assertions) {
       const assertRuntime = new AssertRuntime();
       assertionResults = assertRuntime.runAssertions(
         assertions,
@@ -185,7 +185,7 @@ const runSingleRequest = async function (
     // run tests
     let testResults = [];
     const testFile = get(bruJson, 'request.tests');
-    if (testFile && testFile.length) {
+    if (typeof testFile === 'string') {
       const testRuntime = new TestRuntime();
       const result = await testRuntime.runTests(
         testFile,
@@ -266,7 +266,7 @@ const runSingleRequest = async function (
       // run assertions
       let assertionResults = [];
       const assertions = get(bruJson, 'request.assertions');
-      if (assertions && assertions.length) {
+      if (assertions) {
         const assertRuntime = new AssertRuntime();
         assertionResults = assertRuntime.runAssertions(
           assertions,
@@ -290,7 +290,7 @@ const runSingleRequest = async function (
       // run tests
       let testResults = [];
       const testFile = get(bruJson, 'request.tests');
-      if (testFile && testFile.length) {
+      if (typeof testFile === 'string') {
         const testRuntime = new TestRuntime();
         const result = await testRuntime.runTests(
           testFile,

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -291,7 +291,7 @@ const registerNetworkIpc = (mainWindow) => {
 
         // run assertions
         const assertions = get(request, 'assertions');
-        if (assertions && assertions.length) {
+        if (assertions) {
           const assertRuntime = new AssertRuntime();
           const results = assertRuntime.runAssertions(
             assertions,
@@ -313,7 +313,7 @@ const registerNetworkIpc = (mainWindow) => {
 
         // run tests
         const testFile = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
-        if (testFile && testFile.length) {
+        if (typeof testFile === 'string') {
           const testRuntime = new TestRuntime();
           const testResults = await testRuntime.runTests(
             testFile,
@@ -365,7 +365,7 @@ const registerNetworkIpc = (mainWindow) => {
         if (error && error.response) {
           // run assertions
           const assertions = get(request, 'assertions');
-          if (assertions && assertions.length) {
+          if (assertions) {
             const assertRuntime = new AssertRuntime();
             const results = assertRuntime.runAssertions(
               assertions,
@@ -387,7 +387,7 @@ const registerNetworkIpc = (mainWindow) => {
 
           // run tests
           const testFile = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
-          if (testFile && testFile.length) {
+          if (typeof testFile === 'string') {
             const testRuntime = new TestRuntime();
             const testResults = await testRuntime.runTests(
               testFile,
@@ -702,7 +702,7 @@ const registerNetworkIpc = (mainWindow) => {
 
             // run assertions
             const assertions = get(item, 'request.assertions');
-            if (assertions && assertions.length) {
+            if (assertions) {
               const assertRuntime = new AssertRuntime();
               const results = assertRuntime.runAssertions(
                 assertions,
@@ -723,7 +723,7 @@ const registerNetworkIpc = (mainWindow) => {
 
             // run tests
             const testFile = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
-            if (testFile && testFile.length) {
+            if (typeof testFile === 'string') {
               const testRuntime = new TestRuntime();
               const testResults = await testRuntime.runTests(
                 testFile,
@@ -781,7 +781,7 @@ const registerNetworkIpc = (mainWindow) => {
 
               // run assertions
               const assertions = get(item, 'request.assertions');
-              if (assertions && assertions.length) {
+              if (assertions) {
                 const assertRuntime = new AssertRuntime();
                 const results = assertRuntime.runAssertions(
                   assertions,
@@ -802,7 +802,7 @@ const registerNetworkIpc = (mainWindow) => {
 
               // run tests
               const testFile = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
-              if (testFile && testFile.length) {
+              if (typeof testFile === 'string') {
                 const testRuntime = new TestRuntime();
                 const testResults = await testRuntime.runTests(
                   testFile,


### PR DESCRIPTION
After all tests or assertions were deleted, the store was not updated because of the length checks. Now the assertions/tests will always try to run, to ensure the data is always updated.

Before my fix:

https://github.com/usebruno/bruno/assets/39559178/0ad3e466-f7e3-4f3d-ae02-27ecd22c616e

With my fix:

https://github.com/usebruno/bruno/assets/39559178/90edded8-a23e-4d1b-a4fb-9b5611a2a00d

