### PR TITLE
fix(#329): interpolate basic auth params

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -98,6 +98,11 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     param.value = interpolate(param.value);
   });
 
+  if (request.auth) {
+    request.auth.username = interpolate(request.auth.username);
+    request.auth.password = interpolate(request.auth.password);
+  }
+
   if (request.proxy) {
     request.proxy.protocol = interpolate(request.proxy.protocol);
     request.proxy.hostname = interpolate(request.proxy.hostname);

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -98,6 +98,11 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     param.value = interpolate(param.value);
   });
 
+  if (request.auth) {
+    request.auth.username = interpolate(request.auth.username);
+    request.auth.password = interpolate(request.auth.password);
+  }
+
   if (request.proxy) {
     request.proxy.protocol = interpolate(request.proxy.protocol);
     request.proxy.hostname = interpolate(request.proxy.hostname);


### PR DESCRIPTION
We were missing interpolation for basic auth. Bearer token is fine, it was just added as a header (and those are interpolated).