### PR TITLE
github star button color fix

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/index.js
@@ -96,25 +96,14 @@ const Sidebar = () => {
                 />
               </div>
               <div className="pl-1" style={{ position: 'relative', top: '3px' }}>
-                {storedTheme === 'dark' ? (
-                  <GitHubButton
-                    href="https://github.com/usebruno/bruno"
-                    data-color-scheme="no-preference: dark; light: dark; dark: light;"
-                    data-show-count="true"
-                    aria-label="Star usebruno/bruno on GitHub"
-                  >
-                    Star
-                  </GitHubButton>
-                ) : (
-                  <GitHubButton
-                    href="https://github.com/usebruno/bruno"
-                    data-color-scheme="no-preference: light; light: light; dark: light;"
-                    data-show-count="true"
-                    aria-label="Star usebruno/bruno on GitHub"
-                  >
-                    Star
-                  </GitHubButton>
-                )}
+                <GitHubButton
+                  href="https://github.com/usebruno/bruno"
+                  data-color-scheme={storedTheme}
+                  data-show-count="true"
+                  aria-label="Star usebruno/bruno on GitHub"
+                >
+                  Star
+                </GitHubButton>
               </div>
               <div className="flex flex-grow items-center justify-end text-xs mr-2">v0.18.0</div>
             </div>


### PR DESCRIPTION
I don't know, if it was for me only but,
while on dark mode github star button was still looking white, so I made some changes to fix that.

checked on my device, works on both dark and light mode

before  changes ::
![Screenshot from 2023-10-04 22-15-56](https://github.com/usebruno/bruno/assets/76877078/7b3c3f0f-2378-48e1-beb7-8845e8f9aa3a)


after changes ::
![Screenshot from 2023-10-04 22-16-29](https://github.com/usebruno/bruno/assets/76877078/6b8ee169-befe-4e88-a8bb-e507453715d8)

