### PR TITLE
feat: Introduce collection-level pre/post request scripts

### DIFF
--- a/packages/bruno-electron/src/bru/index.js
+++ b/packages/bruno-electron/src/bru/index.js
@@ -46,6 +46,8 @@ const bruToJson = (bru) => {
       requestType = 'http-request';
     } else if (requestType === 'graphql') {
       requestType = 'graphql-request';
+    } else if (requestType === 'hooks') {
+      requestType = 'hooks';
     } else {
       requestType = 'http-request';
     }


### PR DESCRIPTION
Solve issue #334

### Hooks Design

A property called "hooks" can be added to the bruno.json file.
```json
{
  "version": "1",
  "name": "bruno-testbench",
  "type": "collection",
  "hooks": "\\hooks.bru"
}
```

The hooks.bru file
```bru
meta {
  type: hooks
}

script:pre-request {
  // do something with the request
}

script:post-response {
  // do something with the response
}
```
