### PR TITLE
fix(network): use axios interceptors to better reflect durations

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@playwright/test": "^1.27.1",
     "husky": "^8.0.3",
     "jest": "^29.2.0",
+    "prettier": "^2.0.2",
     "pretty-quick": "^3.1.3",
     "randomstring": "^1.2.2",
     "ts-jest": "^29.0.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "jest": "^29.2.0",
     "pretty-quick": "^3.1.3",
     "randomstring": "^1.2.2",
-    "ts-jest": "^29.0.5"
+    "ts-jest": "^29.0.5",
+    "typescript": "^5.2.2"
   },
   "scripts": {
     "dev:web": "npm run dev --workspace=packages/bruno-app",

--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -29,9 +29,7 @@ const CreateCollection = ({ onClose }) => {
         .max(50, 'must be 50 characters or less')
         .matches(/^[\w\-. ]+$/, 'Folder name contains invalid characters')
         .required('folder name is required'),
-      collectionLocation: Yup.string()
-        .min(1, 'location is required')
-        .required('location is required'),
+      collectionLocation: Yup.string().min(1, 'location is required').required('location is required')
     }),
     onSubmit: (values) => {
       dispatch(createCollection(values.collectionName, values.collectionFolderName, values.collectionLocation))
@@ -116,7 +114,10 @@ const CreateCollection = ({ onClose }) => {
 
           <label htmlFor="collection-folder-name" className="flex items-center mt-3">
             <span className="font-semibold">Folder Name</span>
-            <Tooltip text="This folder will be created under the selected location" tooltipId="collection-folder-name-tooltip" />
+            <Tooltip
+              text="This folder will be created under the selected location"
+              tooltipId="collection-folder-name-tooltip"
+            />
           </label>
           <input
             id="collection-folder-name"

--- a/packages/bruno-app/src/utils/importers/insomnia-collection.js
+++ b/packages/bruno-app/src/utils/importers/insomnia-collection.js
@@ -39,7 +39,7 @@ const addSuffixToDuplicateName = (item, index, allItems) => {
     return nameSuffix;
   }, 0);
   return nameSuffix !== 0 ? `${item.name}_${nameSuffix}` : item.name;
-}
+};
 
 const transformInsomniaRequestItem = (request, index, allRequests) => {
   const name = addSuffixToDuplicateName(request, index, allRequests);

--- a/packages/bruno-app/src/utils/network/index.js
+++ b/packages/bruno-app/src/utils/network/index.js
@@ -1,10 +1,8 @@
 export const sendNetworkRequest = async (item, collection, environment, collectionVariables) => {
   return new Promise((resolve, reject) => {
     if (['http-request', 'graphql-request'].includes(item.type)) {
-      const timeStart = Date.now();
       sendHttpRequest(item, collection, environment, collectionVariables)
         .then((response) => {
-          const timeEnd = Date.now();
           resolve({
             state: 'success',
             data: response.data,
@@ -12,7 +10,7 @@ export const sendNetworkRequest = async (item, collection, environment, collecti
             size: response.headers['content-length'] || 0,
             status: response.status,
             statusText: response.statusText,
-            duration: timeEnd - timeStart
+            duration: response.duration
           });
         })
         .catch((err) => reject(err));

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -1,0 +1,38 @@
+const axios = require('axios');
+
+/**
+ * Function that configures axios with timing interceptors
+ * Important to note here that the timings are not completely accurate.
+ * @see https://github.com/axios/axios/issues/695
+ * @returns {import('axios').AxiosStatic}
+ */
+function makeAxiosInstance() {
+  /** @type {import('axios').AxiosStatic} */
+  const instance = axios.create();
+
+  instance.interceptors.request.use((config) => {
+    config.headers['request-start-time'] = Date.now();
+    return config;
+  });
+
+  instance.interceptors.response.use(
+    (response) => {
+      const end = Date.now();
+      const start = response.config.headers['request-start-time'];
+      response.headers['request-duration'] = end - start;
+      return response;
+    },
+    (error) => {
+      const end = Date.now();
+      const start = error.config.headers['request-start-time'];
+      error.response.headers['request-duration'] = end - start;
+      return Promise.reject(error);
+    }
+  );
+
+  return instance;
+}
+
+module.exports = {
+  makeAxiosInstance
+};


### PR DESCRIPTION
Hello there 👋🏽 

### What has been done

- Create an `axios` instance that uses `interceptors.response` and `interceptors.request` to have a better/accurate request duration number
- Add missing dependencies. For example `typescript` and `prettier` were missing and they are needed by `npm run build:bruno-query` and `npm run build:graphql-docs` and `husky` respectively.
  - `pretty-quick` is an old package and depends on an older prettier version

In regards to the missing deps, let me know if you would rather have this discarded from the PR.


### Why

I recently started using Bruno after the Insomnia fiasco, and noticed that my API request durations weren't necessarily correct.

The issue being that using `Date.now()` before and after the request happens wouldn't yield correct duration results since axios has other timings steps. For example, a request in my server that takes 4ms would result in 12~14ms in the previous logic.

Now the duration hovers between 4~6ms, as we only run the timers exactly when a requests starts and it ends.

Important to note here that even using the `interceptors`, they won't provide an extremely accurate timing number since we don't have control of the axios internals to get the exact value (see issue here: https://github.com/axios/axios/issues/695). With more time we can maybe introduce an accurate timings lib.

### Before

<img width="155" alt="Screenshot 2023-10-04 at 22 33 54" src="https://github.com/usebruno/bruno/assets/249782/943072bd-68bb-4c57-986e-ec62c7f24a80">

### After
![Screenshot 2023-10-04 at 22 35 23](https://github.com/usebruno/bruno/assets/249782/8e71ad92-d29d-4e9f-bb71-8bf02a2816c1)


