### PR TITLE
feat(#111): Automaticly open a newly created request

### DIFF
--- a/packages/bruno-app/src/providers/App/useCollectionTreeSync.js
+++ b/packages/bruno-app/src/providers/App/useCollectionTreeSync.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   collectionAddDirectoryEvent,
   collectionAddFileEvent,
@@ -17,9 +17,15 @@ import {
 import toast from 'react-hot-toast';
 import { openCollectionEvent, collectionAddEnvFileEvent } from 'providers/ReduxStore/slices/collections/actions';
 import { isElectron } from 'utils/common/platform';
+import { updateNewRequest } from 'providers/ReduxStore/slices/collections/index';
+import { addTab } from 'providers/ReduxStore/slices/tabs';
+import { getDefaultRequestPaneTab } from 'utils/collections/index';
+import { hideHomePage } from 'providers/ReduxStore/slices/app';
 
 const useCollectionTreeSync = () => {
   const dispatch = useDispatch();
+  const tabs = useSelector((state) => state.tabs.tabs);
+  const newRequestName = useSelector((state) => state.collections.newRequestName);
 
   useEffect(() => {
     if (!isElectron()) {
@@ -50,6 +56,22 @@ const useCollectionTreeSync = () => {
             file: val
           })
         );
+
+        // Remove the newRequestName so no random stuff happens
+        dispatch(
+          updateNewRequest({ newRequestName: null })
+        );
+        // When the request was just created open it in a new tab
+        if (newRequestName === val.data.name) {
+          dispatch(
+            addTab({
+              uid: val.data.uid,
+              collectionUid: val.meta.collectionUid,
+              requestPaneTab: getDefaultRequestPaneTab(val.data)
+            })
+          );
+          dispatch(hideHomePage());
+        }
       }
       if (type === 'change') {
         dispatch(
@@ -115,8 +137,6 @@ const useCollectionTreeSync = () => {
       dispatch(runRequestEvent(val));
     };
 
-    ipcRenderer.invoke('renderer:ready');
-
     const removeListener1 = ipcRenderer.on('main:collection-opened', _openCollection);
     const removeListener2 = ipcRenderer.on('main:collection-tree-updated', _collectionTreeUpdated);
     const removeListener3 = ipcRenderer.on('main:collection-already-opened', _collectionAlreadyOpened);
@@ -144,7 +164,16 @@ const useCollectionTreeSync = () => {
       removeListener10();
       removeListener11();
     };
-  }, [isElectron]);
+  }, [isElectron, tabs, newRequestName]);
+
+  useEffect(() => {
+    if (!isElectron()) {
+      return () => {};
+    }
+
+    const { ipcRenderer } = window;
+    ipcRenderer.invoke('renderer:ready');
+  }, []);
 };
 
 export default useCollectionTreeSync;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -39,7 +39,8 @@ import {
   renameCollection as _renameCollection,
   removeCollection as _removeCollection,
   sortCollections as _sortCollections,
-  collectionAddEnvFileEvent as _collectionAddEnvFileEvent
+  collectionAddEnvFileEvent as _collectionAddEnvFileEvent,
+  updateNewRequest
 } from './index';
 
 import { closeAllCollectionTabs } from 'providers/ReduxStore/slices/tabs';
@@ -595,6 +596,8 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
         const { ipcRenderer } = window;
 
         ipcRenderer.invoke('renderer:new-request', fullName, item).then(resolve).catch(reject);
+        // Add the new request name here so it can be opened in a new tab in useCollectionTreeSync.js
+        dispatch(updateNewRequest({ newRequestName: item.name }))
       } else {
         return reject(new Error('Duplicate request names are not allowed under the same folder'));
       }
@@ -612,6 +615,8 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
           const { ipcRenderer } = window;
 
           ipcRenderer.invoke('renderer:new-request', fullName, item).then(resolve).catch(reject);
+          // Add the new request name here so it can be opened in a new tab in useCollectionTreeSync.js
+          dispatch(updateNewRequest({ newRequestName: item.name }))
         } else {
           return reject(new Error('Duplicate request names are not allowed under the same folder'));
         }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -29,7 +29,8 @@ const PATH_SEPARATOR = path.sep;
 
 const initialState = {
   collections: [],
-  collectionSortOrder: 'default'
+  collectionSortOrder: 'default',
+  newRequestName: null
 };
 
 export const collectionsSlice = createSlice({
@@ -128,6 +129,10 @@ export const collectionsSlice = createSlice({
           collection.activeEnvironmentUid = null;
         }
       }
+    },
+    updateNewRequest: (state, action) => {
+      const { newRequestName } = action.payload;
+      state.newRequestName = newRequestName;
     },
     newItem: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
@@ -1200,6 +1205,7 @@ export const {
   collectionUnlinkEnvFileEvent,
   saveEnvironment,
   selectEnvironment,
+  updateNewRequest,
   newItem,
   deleteItem,
   renameItem,


### PR DESCRIPTION

https://github.com/usebruno/bruno/assets/39559178/bd61036c-05ff-4e27-aaf2-21ba3bac1489

So this once implemented a little hacky, because of 2 problems:

I had some skill issues figuring out how Redux works, never worked with Redux.

The way creating files is implemented makes it a little hard to implement this feature properly. When creating the request, it is written to disk and then picked up by the file watcher and read into Bruno with a new UID. For a proper implementation of this feature, we might need to rewrite how file creating works, so that the new request is directly added to the Redux store and not by the file watcher with a new UID.

This now works by writing the last created request name into the store (`newRequestName`) and when the file watcher opens a new file it checks using this name if it was newly created.