### PR TITLE
Better BrowserWindow

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -36,6 +36,7 @@ app.on('ready', async () => {
       preload: path.join(__dirname, 'preload.js'),
       webviewTag: true
     },
+    title: 'Bruno',
     icon: path.join(__dirname, 'about/256x256.png'),
     autoHideMenuBar: true
   });

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -36,7 +36,8 @@ app.on('ready', async () => {
       preload: path.join(__dirname, 'preload.js'),
       webviewTag: true
     },
-    icon: path.join(__dirname, 'about/256x256.png')
+    icon: path.join(__dirname, 'about/256x256.png'),
+    autoHideMenuBar: true
   });
 
   const url = isDev

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -35,7 +35,8 @@ app.on('ready', async () => {
       contextIsolation: true,
       preload: path.join(__dirname, 'preload.js'),
       webviewTag: true
-    }
+    },
+    icon: path.join(__dirname, 'about/256x256.png')
   });
 
   const url = isDev


### PR DESCRIPTION
- Only setting `icon` property would set the icon of the window in Linux.
- Set `title` to `Bruno`.
- Enable `autoHideMenuBar` to prevent ugly menu bars in dark mode.

![image](https://github.com/usebruno/bruno/assets/50770114/bca2f05f-a413-4471-9dee-c4585b66edba)

I was not able to test these changes due to `phantomjs` errors but I'm sure that these changes are correct.