### PR TITLE
Put constant in outer scope

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -123,9 +123,9 @@ const runSingleRequest = async function (
     }
 
     let response, responseTime;
+    const start = Date.now();
     try {
       // run request
-      const start = Date.now();
       response = await axios(request);
       responseTime = Date.now() - start;
     } catch (err) {

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -273,7 +273,8 @@ const runSingleRequest = async function (
         status: null,
         statusText: null,
         headers: null,
-        data: null
+        data: null,
+        responseTime: 0
       },
       error: err.message,
       assertionResults: [],


### PR DESCRIPTION
This PR fixes an issue with `start` constant not being in scope

There is still an issue with a failed request not being shown as failed (the yellow marked):

<img src="https://github.com/usebruno/bruno/assets/239058/2956637f-df97-4fa7-9c1f-ae28fc53537d" width="400px" />

This should probably fixed in a separate PR?
