### PR TITLE
Use axios interceptor to measure response time

### DIFF
--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -1,0 +1,40 @@
+const axios = require('axios');
+
+/**
+ * Function that configures axios with timing interceptors
+ * Important to note here that the timings are not completely accurate.
+ * @see https://github.com/axios/axios/issues/695
+ * @returns {import('axios').AxiosStatic}
+ */
+function makeAxiosInstance() {
+  /** @type {import('axios').AxiosStatic} */
+  const instance = axios.create();
+
+  instance.interceptors.request.use((config) => {
+    config.headers['request-start-time'] = Date.now();
+    return config;
+  });
+
+  instance.interceptors.response.use(
+    (response) => {
+      const end = Date.now();
+      const start = response.config.headers['request-start-time'];
+      response.headers['request-duration'] = end - start;
+      return response;
+    },
+    (error) => {
+      if (error.response) {
+        const end = Date.now();
+        const start = error.config.headers['request-start-time'];
+        error.response.headers['request-duration'] = end - start;
+      }
+      return Promise.reject(error);
+    }
+  );
+
+  return instance;
+}
+
+module.exports = {
+  makeAxiosInstance
+};


### PR DESCRIPTION
Measure response time with axios interceptor, similar to https://github.com/usebruno/bruno/pull/368

There is now some code duplication with `axios-instance.js` being twice in the project. Should we address this in this PR?

Note that I also modified `axios-instance.js` slightly, since `error.response` might be undefined:

```javascript
    (error) => {
      if (error.response) {
        const end = Date.now();
        const start = error.config.headers['request-start-time'];
        error.response.headers['request-duration'] = end - start;
      }
      return Promise.reject(error);
    }
```
