### PR TITLE
fix(#399): loading environment with empty secret variable fails

### DIFF
--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -103,7 +103,7 @@ const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) 
       const envSecrets = environmentSecretsStore.getEnvSecrets(collectionPath, file.data);
       _.each(envSecrets, (secret) => {
         const variable = _.find(file.data.variables, (v) => v.name === secret.name);
-        if (variable) {
+        if (variable && secret.value) {
           variable.value = decryptString(secret.value);
         }
       });
@@ -137,7 +137,7 @@ const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPat
       const envSecrets = environmentSecretsStore.getEnvSecrets(collectionPath, file.data);
       _.each(envSecrets, (secret) => {
         const variable = _.find(file.data.variables, (v) => v.name === secret.name);
-        if (variable) {
+        if (variable && secret.value) {
           variable.value = decryptString(secret.value);
         }
       });


### PR DESCRIPTION
Prevents this from happening when secret value is empty:

```
Error: Decrypt failed: unrecognized string format
    at decryptString (/home/me/bruno/packages/bruno-electron/src/utils/encryption.js:70:11)
    at /home/me/bruno/packages/bruno-electron/src/app/watcher.js:142:28
    at arrayEach (/home/me/bruno/node_modules/lodash/lodash.js:530:11)
    at Function.forEach (/home/me/bruno/node_modules/lodash/lodash.js:9410:14)
    at changeEnvironmentFile (/home/me/bruno/packages/bruno-electron/src/app/watcher.js:138:9)
    at change (/home/lared/projects/me/bruno/packages/bruno-electron/src/app/watcher.js:341:12)
    at FSWatcher.<anonymous> (/home/me/bruno/bruno/packages/bruno-electron/src/app/watcher.js:431:37)
    at FSWatcher.emit (node:events:527:28)
    at FSWatcher.emitWithAll (/home/me/bruno/node_modules/chokidar/index.js:540:8)
    at awfEmit (/home/me/bruno/node_modules/chokidar/index.js:607:14)
```