### PR TITLE
fix(#428): moving requests into directories or into root of collection broke ordering

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -138,7 +138,7 @@ export const moveCollectionItem = (collection, draggedItem, targetItem) => {
   }
 
   if (targetItem.type === 'folder') {
-    targetItem.items = targetItem.items || [];
+    targetItem.items = sortBy(targetItem.items || [], (item) => item.seq);
     targetItem.items.push(draggedItem);
     draggedItem.pathname = path.join(targetItem.pathname, draggedItem.filename);
   } else {
@@ -166,7 +166,9 @@ export const moveCollectionItemToRootOfCollection = (collection, draggedItem) =>
     return;
   }
 
+  draggedItemParent.items = sortBy(draggedItemParent.items, (item) => item.seq);
   draggedItemParent.items = filter(draggedItemParent.items, (i) => i.uid !== draggedItem.uid);
+  collection.items = sortBy(collection.items, (item) => item.seq);
   collection.items.push(draggedItem);
   if (draggedItem.type == 'folder') {
     draggedItem.pathname = path.join(collection.pathname, draggedItem.name);


### PR DESCRIPTION
Previously I touched some code for moving requests between folders in #154, those two additional fixes should (hopefully) fully address the situation.