### PR TITLE
fix: add missing CSS for GraphQL docs explorer

### DIFF
--- a/packages/bruno-app/src/pages/_app.js
+++ b/packages/bruno-app/src/pages/_app.js
@@ -15,6 +15,7 @@ import 'tailwindcss/dist/tailwind.min.css';
 import 'codemirror/lib/codemirror.css';
 import 'graphiql/graphiql.min.css';
 import 'react-tooltip/dist/react-tooltip.css';
+import '@usebruno/graphql-docs/dist/esm/index.css';
 
 function SafeHydrate({ children }) {
   return <div suppressHydrationWarning>{typeof window === 'undefined' ? null : children}</div>;


### PR DESCRIPTION
The GraphQL docs explorer doesn't have any CSS styling which makes very difficult to use, see image:
<img width="1317" alt="Skärmavbild 2023-10-06 kl  17 28 32" src="https://github.com/usebruno/bruno/assets/8113142/58c69ebf-ba88-4ba3-ae07-3966cb55bc82">

I'm new to Bruno so not sure if this has worked before.

This PR simply imports the necessary CSS file in the `_app.js` file. Not very familiar with the code base so let me know if there's a better way to do this.

After image:

<img width="1291" alt="Skärmavbild 2023-10-06 kl  17 50 09" src="https://github.com/usebruno/bruno/assets/8113142/ff1d56c3-b671-4a19-81f1-9cba59f3bb4a">

