### PR TITLE
WIP: Experimental JSON storage support

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -657,7 +657,7 @@ export const addEnvironment = (name, collectionUid) => (dispatch, getState) => {
     }
 
     ipcRenderer
-      .invoke('renderer:create-environment', collection.pathname, name)
+      .invoke('renderer:create-environment', collection, name)
       .then(
         dispatch(
           updateLastAction({
@@ -688,7 +688,7 @@ export const copyEnvironment = (name, baseEnvUid, collectionUid) => (dispatch, g
     }
 
     ipcRenderer
-      .invoke('renderer:copy-environment', collection.pathname, name, baseEnv.variables)
+      .invoke('renderer:copy-environment', collection, name, baseEnv.variables)
       .then(
         dispatch(
           updateLastAction({
@@ -724,7 +724,7 @@ export const renameEnvironment = (newName, environmentUid, collectionUid) => (di
 
     environmentSchema
       .validate(environment)
-      .then(() => ipcRenderer.invoke('renderer:rename-environment', collection.pathname, oldName, newName))
+      .then(() => ipcRenderer.invoke('renderer:rename-environment', collection, oldName, newName))
       .then(resolve)
       .catch(reject);
   });
@@ -745,10 +745,7 @@ export const deleteEnvironment = (environmentUid, collectionUid) => (dispatch, g
       return reject(new Error('Environment not found'));
     }
 
-    ipcRenderer
-      .invoke('renderer:delete-environment', collection.pathname, environment.name)
-      .then(resolve)
-      .catch(reject);
+    ipcRenderer.invoke('renderer:delete-environment', collection, environment.name).then(resolve).catch(reject);
   });
 };
 
@@ -770,7 +767,7 @@ export const saveEnvironment = (variables, environmentUid, collectionUid) => (di
 
     environmentSchema
       .validate(environment)
-      .then(() => ipcRenderer.invoke('renderer:save-environment', collection.pathname, environment))
+      .then(() => ipcRenderer.invoke('renderer:save-environment', collection, environment))
       .then(resolve)
       .catch(reject);
   });

--- a/packages/bruno-cli/src/utils/filesystem.js
+++ b/packages/bruno-cli/src/utils/filesystem.js
@@ -64,8 +64,11 @@ const hasJsonExtension = (filename) => {
 };
 
 const hasBruExtension = (filename) => {
-  if (!filename || typeof filename !== 'string') return false;
-  return ['bru'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
+  if (!filename || typeof filename !== 'string') {
+    return false;
+  }
+
+  return ['bru', 'json'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
 };
 
 const createDirectory = async (dir) => {

--- a/packages/bruno-cli/src/utils/filesystem.js
+++ b/packages/bruno-cli/src/utils/filesystem.js
@@ -64,11 +64,9 @@ const hasJsonExtension = (filename) => {
 };
 
 const hasBruExtension = (filename) => {
-  if (!filename || typeof filename !== 'string') {
-    return false;
-  }
+  if (!filename || typeof filename !== 'string') return false;
 
-  return ['bru', 'json'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
+  return ['bru'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
 };
 
 const createDirectory = async (dir) => {

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -9,7 +9,8 @@ const { generateUidBasedOnHash } = require('../utils/common');
 const configSchema = Yup.object({
   name: Yup.string().max(256, 'name must be 256 characters or less').required('name is required'),
   type: Yup.string().oneOf(['collection']).required('type is required'),
-  version: Yup.string().oneOf(['1']).required('type is required')
+  version: Yup.string().oneOf(['1']).required('type is required'),
+  lang: Yup.string().oneOf(['bru', 'json']).default('bru')
 });
 
 const readConfigFile = async (pathname) => {

--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -39,14 +39,14 @@ const isBrunoConfigFile = (pathname, collectionPath) => {
 /**
  * @param {string} pathname
  * @param {string} collectionPath
+ * @param {string} collectionUid
  * @returns {boolean}
  */
-const isBruEnvironmentConfig = (pathname, collectionPath) => {
-  const dirname = path.dirname(pathname);
+const isBruEnvironmentConfig = (pathname, collectionPath, collectionUid) => {
+  const { dir, ext } = path.parse(pathname);
   const envDirectory = path.join(collectionPath, 'environments');
-  const basename = path.basename(pathname);
 
-  return dirname === envDirectory && hasBruExtension(basename);
+  return dir === envDirectory && getLangFromBrunoConfig(collectionUid) === ext;
 };
 
 const hydrateRequestWithUuid = (request, pathname) => {
@@ -261,7 +261,7 @@ const add = async (win, pathname, collectionUid, collectionPath) => {
     return;
   }
 
-  if (isBruEnvironmentConfig(pathname, collectionPath)) {
+  if (isBruEnvironmentConfig(pathname, collectionPath, collectionUid)) {
     return addEnvironmentFile(win, pathname, collectionUid, collectionPath);
   }
 
@@ -340,7 +340,7 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
     }
   }
 
-  if (isBruEnvironmentConfig(pathname, collectionPath)) {
+  if (isBruEnvironmentConfig(pathname, collectionPath, collectionUid)) {
     return changeEnvironmentFile(win, pathname, collectionUid, collectionPath);
   }
 
@@ -365,7 +365,7 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
 };
 
 const unlink = (win, pathname, collectionUid, collectionPath) => {
-  if (isBruEnvironmentConfig(pathname, collectionPath)) {
+  if (isBruEnvironmentConfig(pathname, collectionPath, collectionUid)) {
     return unlinkEnvironmentFile(win, pathname, collectionUid);
   }
 

--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -85,29 +85,28 @@ const envHasSecrets = (environment = {}) => {
  */
 const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) => {
   try {
-    const { base, name } = path.parse(pathname);
-    const lang = getLangFromBrunoConfig(collectionUid) || 'bru';
+    const { root, dir, name, base } = path.parse(pathname);
+    const lang = getLangFromBrunoConfig(collectionUid);
     const envFileContent = fs.readFileSync(pathname, 'utf8');
 
     const file = {
       meta: {
         collectionUid,
         pathname: path.format({
-          base,
+          root,
+          dir,
           name,
           // Overriding extension here to enforce lang preference
           ext: lang
         }),
         name: base
-      },
-      data: {
-        // TODO: If we add other formats we should extract this functionality for reuse
-        ...(lang === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent)),
-        // format: lang,
-        name,
-        uid: getRequestUid(pathname)
       }
     };
+
+    // TODO: If we add other formats we should extract this functionality for reuse
+    file.data = lang === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent);
+    file.name = name;
+    file.uid = getRequestUid(pathname);
 
     _.each(_.get(file, 'data.variables', []), (variable) => (variable.uid = uuid()));
 
@@ -136,29 +135,28 @@ const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) 
  */
 const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPath) => {
   try {
-    const { base, name } = path.parse(pathname);
-    const lang = getLangFromBrunoConfig(collectionUid) || 'bru';
+    const { root, dir, name, base } = path.parse(pathname);
+    const lang = getLangFromBrunoConfig(collectionUid);
     const envFileContent = fs.readFileSync(pathname, 'utf8');
 
     const file = {
       meta: {
         collectionUid,
         pathname: path.format({
-          base,
+          root,
+          dir,
           name,
           // Overriding extension here to enforce lang preference
           ext: lang
         }),
         name: base
-      },
-      data: {
-        // TODO: If we add other formats we should extract this functionality for reuse
-        ...(lang === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent)),
-        // format: lang,
-        name,
-        uid: getRequestUid(pathname)
       }
     };
+
+    // TODO: If we add other formats we should extract this functionality for reuse
+    file.data = lang === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent);
+    file.name = name;
+    file.uid = getRequestUid(pathname);
 
     _.each(_.get(file, 'data.variables', []), (variable) => (variable.uid = uuid()));
 

--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -87,22 +87,23 @@ const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) 
   try {
     const { root, dir, name, base } = path.parse(pathname);
     const lang = getLangFromBrunoConfig(collectionUid);
-    const envFileContent = fs.readFileSync(pathname, 'utf8');
+    const targetFilePath = path.format({
+      root,
+      dir,
+      name,
+      // Overriding extension here to enforce lang preference
+      ext: `.${lang}`
+    });
 
     const file = {
       meta: {
         collectionUid,
-        pathname: path.format({
-          root,
-          dir,
-          name,
-          // Overriding extension here to enforce lang preference
-          ext: lang
-        }),
+        pathname: targetFilePath,
         name: base
       }
     };
 
+    const envFileContent = fs.readFileSync(targetFilePath, 'utf8');
     // TODO: If we add other formats we should extract this functionality for reuse
     file.data = lang === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent);
     file.name = name;
@@ -137,22 +138,23 @@ const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPat
   try {
     const { root, dir, name, base } = path.parse(pathname);
     const lang = getLangFromBrunoConfig(collectionUid);
-    const envFileContent = fs.readFileSync(pathname, 'utf8');
+    const targetFilePath = path.format({
+      root,
+      dir,
+      name,
+      // Overriding extension here to enforce lang preference
+      ext: `.${lang}`
+    });
 
     const file = {
       meta: {
         collectionUid,
-        pathname: path.format({
-          root,
-          dir,
-          name,
-          // Overriding extension here to enforce lang preference
-          ext: lang
-        }),
+        pathname: targetFilePath,
         name: base
       }
     };
 
+    const envFileContent = fs.readFileSync(targetFilePath, 'utf8');
     // TODO: If we add other formats we should extract this functionality for reuse
     file.data = lang === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent);
     file.name = name;

--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -10,7 +10,7 @@ const { uuid } = require('../utils/common');
 const { getRequestUid } = require('../cache/requestUids');
 const { decryptString } = require('../utils/encryption');
 const { setDotEnvVars } = require('../store/process-env');
-const { setBrunoConfig, getBrunoConfig, getFileFormat } = require('../store/bruno-config');
+const { setBrunoConfig, getBrunoConfig, getLangFromBrunoConfig } = require('../store/bruno-config');
 const EnvironmentSecretsStore = require('../store/env-secrets');
 
 const environmentSecretsStore = new EnvironmentSecretsStore();
@@ -86,7 +86,7 @@ const envHasSecrets = (environment = {}) => {
 const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) => {
   try {
     const { base, name } = path.parse(pathname);
-    const fileFormat = getFileFormat(collectionUid) || 'bru';
+    const lang = getLangFromBrunoConfig(collectionUid) || 'bru';
     const envFileContent = fs.readFileSync(pathname, 'utf8');
 
     const file = {
@@ -95,15 +95,15 @@ const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) 
         pathname: path.format({
           base,
           name,
-          // Overriding extension here to enforce fileFormat preference
-          ext: fileFormat
+          // Overriding extension here to enforce lang preference
+          ext: lang
         }),
         name: base
       },
       data: {
         // TODO: If we add other formats we should extract this functionality for reuse
-        ...(fileFormat === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent)),
-        // format: fileFormat,
+        ...(lang === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent)),
+        // format: lang,
         name,
         uid: getRequestUid(pathname)
       }
@@ -137,7 +137,7 @@ const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) 
 const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPath) => {
   try {
     const { base, name } = path.parse(pathname);
-    const fileFormat = getFileFormat(collectionUid) || 'bru';
+    const lang = getLangFromBrunoConfig(collectionUid) || 'bru';
     const envFileContent = fs.readFileSync(pathname, 'utf8');
 
     const file = {
@@ -146,15 +146,15 @@ const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPat
         pathname: path.format({
           base,
           name,
-          // Overriding extension here to enforce fileFormat preference
-          ext: fileFormat
+          // Overriding extension here to enforce lang preference
+          ext: lang
         }),
         name: base
       },
       data: {
         // TODO: If we add other formats we should extract this functionality for reuse
-        ...(fileFormat === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent)),
-        // format: fileFormat,
+        ...(lang === 'json' ? JSON.parse(envFileContent) : bruToEnvJson(envFileContent)),
+        // format: lang,
         name,
         uid: getRequestUid(pathname)
       }

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -20,7 +20,7 @@ const { generateUidBasedOnHash } = require('../utils/common');
 const { moveRequestUid, deleteRequestUid } = require('../cache/requestUids');
 const { setPreferences } = require('../store/preferences');
 const EnvironmentSecretsStore = require('../store/env-secrets');
-const { getFileFormat } = require('../store/bruno-config');
+const { getLangFromBrunoConfig } = require('../store/bruno-config');
 
 const environmentSecretsStore = new EnvironmentSecretsStore();
 
@@ -138,9 +138,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
         await createDirectory(envDirPath);
       }
 
-      const fileFormat = getFileFormat(collection.uid);
+      const lang = getLangFromBrunoConfig(collection.uid);
       const envFilePath = path.format({
-        ext: `.${fileFormat}`,
+        ext: `.${lang}`,
         name,
         dir: envDirPath
       });
@@ -151,7 +151,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       const environment = {
         variables: []
       };
-      const content = fileFormat === 'json' ? JSON.stringify(environment, null, 2) : envJsonToBru(environment);
+      const content = lang === 'json' ? JSON.stringify(environment, null, 2) : envJsonToBru(environment);
       await writeFile(envFilePath, content);
     } catch (error) {
       return Promise.reject(error);
@@ -166,9 +166,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
         await createDirectory(envDirPath);
       }
 
-      const fileFormat = getFileFormat(collection.uid);
+      const lang = getLangFromBrunoConfig(collection.uid);
       const envFilePath = path.format({
-        ext: `.${getFileFormat}`,
+        ext: `.${getLangFromBrunoConfig}`,
         name,
         dir: envDirPath
       });
@@ -179,7 +179,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       const environment = {
         variables: baseVariables
       };
-      const content = fileFormat === 'json' ? JSON.stringify(environment, null, 2) : envJsonToBru(environment);
+      const content = lang === 'json' ? JSON.stringify(environment, null, 2) : envJsonToBru(environment);
       await writeFile(envFilePath, content);
     } catch (error) {
       return Promise.reject(error);
@@ -194,9 +194,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
         await createDirectory(envDirPath);
       }
 
-      const fileFormat = getFileFormat(collection.uid);
+      const lang = getLangFromBrunoConfig(collection.uid);
       const envFilePath = path.format({
-        ext: `.${fileFormat}`,
+        ext: `.${lang}`,
         name: environment.name,
         dir: envDirPath
       });
@@ -208,7 +208,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
         environmentSecretsStore.storeEnvSecrets(collection.pathname, environment);
       }
 
-      const content = fileFormat === 'json' ? JSON.stringify(environment, null, 2) : envJsonToBru(environment);
+      const content = lang === 'json' ? JSON.stringify(environment, null, 2) : envJsonToBru(environment);
       await writeFile(envFilePath, content);
     } catch (error) {
       return Promise.reject(error);
@@ -219,9 +219,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
   ipcMain.handle('renderer:rename-environment', async (event, collection, environmentName, newName) => {
     try {
       const envDirPath = path.join(collection.pathname, 'environments');
-      const fileFormat = getFileFormat(collection.uid);
+      const lang = getLangFromBrunoConfig(collection.uid);
       const envFilePath = path.format({
-        ext: `.${fileFormat}`,
+        ext: `.${lang}`,
         name: environmentName,
         dir: envDirPath
       });
@@ -230,7 +230,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       }
 
       const newEnvFilePath = path.format({
-        ext: `.${fileFormat}`,
+        ext: `.${lang}`,
         name: newName,
         dir: envDirPath
       });
@@ -251,7 +251,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
     try {
       const envDirPath = path.join(collection.pathname, 'environments');
       const envFilePath = path.format({
-        ext: `.${getFileFormat(collection.uid)}`,
+        ext: `.${getLangFromBrunoConfig(collection.uid)}`,
         name: environmentName,
         dir: envDirPath
       });

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -140,9 +140,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
 
       const lang = getLangFromBrunoConfig(collection.uid);
       const envFilePath = path.format({
-        ext: `.${lang}`,
+        dir: envDirPath,
         name,
-        dir: envDirPath
+        ext: `.${lang}`
       });
       if (fs.existsSync(envFilePath)) {
         throw new Error(`environment: ${envFilePath} already exists`);
@@ -168,9 +168,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
 
       const lang = getLangFromBrunoConfig(collection.uid);
       const envFilePath = path.format({
-        ext: `.${getLangFromBrunoConfig}`,
+        dir: envDirPath,
         name,
-        dir: envDirPath
+        ext: `.${getLangFromBrunoConfig}`
       });
       if (fs.existsSync(envFilePath)) {
         throw new Error(`environment: ${envFilePath} already exists`);
@@ -196,9 +196,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
 
       const lang = getLangFromBrunoConfig(collection.uid);
       const envFilePath = path.format({
-        ext: `.${lang}`,
+        dir: envDirPath,
         name: environment.name,
-        dir: envDirPath
+        ext: `.${lang}`
       });
       if (!fs.existsSync(envFilePath)) {
         throw new Error(`environment: ${envFilePath} does not exist`);
@@ -221,18 +221,18 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       const envDirPath = path.join(collection.pathname, 'environments');
       const lang = getLangFromBrunoConfig(collection.uid);
       const envFilePath = path.format({
-        ext: `.${lang}`,
+        dir: envDirPath,
         name: environmentName,
-        dir: envDirPath
+        ext: `.${lang}`
       });
       if (!fs.existsSync(envFilePath)) {
         throw new Error(`environment: ${envFilePath} does not exist`);
       }
 
       const newEnvFilePath = path.format({
-        ext: `.${lang}`,
+        dir: envDirPath,
         name: newName,
-        dir: envDirPath
+        ext: `.${lang}`
       });
       if (fs.existsSync(newEnvFilePath)) {
         throw new Error(`environment: ${newEnvFilePath} already exists`);
@@ -251,9 +251,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
     try {
       const envDirPath = path.join(collection.pathname, 'environments');
       const envFilePath = path.format({
-        ext: `.${getLangFromBrunoConfig(collection.uid)}`,
+        dir: envDirPath,
         name: environmentName,
-        dir: envDirPath
+        ext: `.${getLangFromBrunoConfig(collection.uid)}`
       });
       if (!fs.existsSync(envFilePath)) {
         throw new Error(`environment: ${envFilePath} does not exist`);

--- a/packages/bruno-electron/src/store/bruno-config.js
+++ b/packages/bruno-electron/src/store/bruno-config.js
@@ -4,7 +4,10 @@
 
 const config = {};
 
-// collectionUid is a hash based on the collection path)
+/**
+ * @param {string} collectionUid collectionUid is a hash based on the collection path
+ * @returns {{ fileFormat: 'bru' | 'json' }}
+ */
 const getBrunoConfig = (collectionUid) => {
   return config[collectionUid] || {};
 };
@@ -13,7 +16,15 @@ const setBrunoConfig = (collectionUid, brunoConfig) => {
   config[collectionUid] = brunoConfig;
 };
 
+/**
+ * Get default file format from Bruno config.
+ *
+ * @param {string} collectionUid
+ */
+const getFileFormat = (collectionUid) => getBrunoConfig(collectionUid).fileFormat;
+
 module.exports = {
   getBrunoConfig,
-  setBrunoConfig
+  setBrunoConfig,
+  getFileFormat
 };

--- a/packages/bruno-electron/src/store/bruno-config.js
+++ b/packages/bruno-electron/src/store/bruno-config.js
@@ -6,7 +6,7 @@ const config = {};
 
 /**
  * @param {string} collectionUid collectionUid is a hash based on the collection path
- * @returns {{ fileFormat: 'bru' | 'json' }}
+ * @returns {{ lang: 'bru' | 'json' }}
  */
 const getBrunoConfig = (collectionUid) => {
   return config[collectionUid] || {};
@@ -21,10 +21,10 @@ const setBrunoConfig = (collectionUid, brunoConfig) => {
  *
  * @param {string} collectionUid
  */
-const getFileFormat = (collectionUid) => getBrunoConfig(collectionUid).fileFormat;
+const getLangFromBrunoConfig = (collectionUid) => getBrunoConfig(collectionUid).lang;
 
 module.exports = {
   getBrunoConfig,
   setBrunoConfig,
-  getFileFormat
+  getLangFromBrunoConfig
 };

--- a/packages/bruno-electron/src/store/bruno-config.js
+++ b/packages/bruno-electron/src/store/bruno-config.js
@@ -17,11 +17,11 @@ const setBrunoConfig = (collectionUid, brunoConfig) => {
 };
 
 /**
- * Get default file format from Bruno config.
+ * Get lang from Bruno config.
  *
  * @param {string} collectionUid
  */
-const getLangFromBrunoConfig = (collectionUid) => getBrunoConfig(collectionUid).lang;
+const getLangFromBrunoConfig = (collectionUid) => getBrunoConfig(collectionUid).lang || 'bru';
 
 module.exports = {
   getBrunoConfig,

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -70,12 +70,9 @@ const hasJsonExtension = (filename) => {
  * @returns {boolean}
  */
 const hasBruExtension = (filename) => {
-  if (!filename || typeof filename !== 'string') {
-    return false;
-  }
+  if (!filename || typeof filename !== 'string') return false;
 
-  // TODO: Ask @helloanoop if this is safe
-  return ['bru', 'json'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
+  return ['bru'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
 };
 
 const createDirectory = async (dir) => {

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -65,9 +65,17 @@ const hasJsonExtension = (filename) => {
   return ['json'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
 };
 
+/**
+ * @param {string} filename
+ * @returns {boolean}
+ */
 const hasBruExtension = (filename) => {
-  if (!filename || typeof filename !== 'string') return false;
-  return ['bru'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
+  if (!filename || typeof filename !== 'string') {
+    return false;
+  }
+
+  // TODO: Ask @helloanoop if this is safe
+  return ['bru', 'json'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
 };
 
 const createDirectory = async (dir) => {


### PR DESCRIPTION
Experimental support for JSON files as an alternative to Bru Lang files. See #407 for more details.

This isn't quite functional yet but I think it's close.

- Adds a new `lang: 'bru' | 'json'` property. Defaults to `bru` if not specified
- Currently only affects environment files
- No UI changes have been made so enabling JSON support requires editing the `bruno.json` file manually

---

I got it mostly working at one point and then somewhere in my cleanup I started going back and forth between the environment file data not being loaded but not throwing an errors and the environment file failing to load while throwing errors.

I've been having a rough time grokking the dispatcher and where relevant processing is actually done. I've gone back and forth pretty frequently between `bruno-electron/src/app/watcher.js` and `bruno-electron/src/ipc/collection.js` and I'm either missing something in there or there's something else involved?

I'm a TypeScript developer by trade so I'm having additional complications just trying to navigate this codebase without reliable type information. I've added some JSDoc annotations to help but I'm not sure how much more effort I'm willing to invest in this. I'll take another look tomorrow as it's a bit late and being tired doesn't help. :sweat_smile: 