### PR TITLE
Persist window state (size, position)

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -9,6 +9,7 @@ const LastOpenedCollections = require('./store/last-opened-collections');
 const registerNetworkIpc = require('./ipc/network');
 const registerCollectionsIpc = require('./ipc/collection');
 const Watcher = require('./app/watcher');
+const { loadWindowState, saveWindowState } = require('./utils/window');
 
 const lastOpenedCollections = new LastOpenedCollections();
 
@@ -27,9 +28,13 @@ let watcher;
 
 // Prepare the renderer once the app is ready
 app.on('ready', async () => {
+  const { x, y, width, height } = loadWindowState();
+
   mainWindow = new BrowserWindow({
-    width: 1280,
-    height: 768,
+    x,
+    y,
+    width,
+    height,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: true,
@@ -53,6 +58,9 @@ app.on('ready', async () => {
 
   mainWindow.loadURL(url);
   watcher = new Watcher();
+
+  mainWindow.on('resize', () => saveWindowState(mainWindow));
+  mainWindow.on('move', () => saveWindowState(mainWindow));
 
   mainWindow.webContents.on('new-window', function (e, url) {
     e.preventDefault();

--- a/packages/bruno-electron/src/store/window-state.js
+++ b/packages/bruno-electron/src/store/window-state.js
@@ -1,0 +1,21 @@
+const _ = require('lodash');
+const Store = require('electron-store');
+
+class WindowStateStore {
+  constructor() {
+    this.store = new Store({
+      name: 'window-state',
+      clearInvalidConfig: true
+    });
+  }
+
+  getBounds() {
+    return this.store.get('window-bounds') || {};
+  }
+
+  setBounds(bounds) {
+    this.store.set('window-bounds', bounds);
+  }
+}
+
+module.exports = WindowStateStore;

--- a/packages/bruno-electron/src/utils/window.js
+++ b/packages/bruno-electron/src/utils/window.js
@@ -1,0 +1,28 @@
+const WindowStateStore = require('../store/window-state');
+
+const windowStateStore = new WindowStateStore();
+
+const DEFAULT_WINDOW_WIDTH = 1280;
+const DEFAULT_WINDOW_HEIGHT = 768;
+
+const loadWindowState = () => {
+  const bounds = windowStateStore.getBounds();
+
+  return {
+    x: bounds.x || undefined,
+    y: bounds.y || undefined,
+    width: bounds.width || DEFAULT_WINDOW_WIDTH,
+    height: bounds.height || DEFAULT_WINDOW_HEIGHT
+  };
+};
+
+const saveWindowState = (window) => {
+  const bounds = window.getBounds();
+
+  windowStateStore.setBounds(bounds);
+};
+
+module.exports = {
+  loadWindowState,
+  saveWindowState
+};

--- a/packages/bruno-electron/src/utils/window.js
+++ b/packages/bruno-electron/src/utils/window.js
@@ -1,3 +1,4 @@
+const { screen } = require('electron');
 const WindowStateStore = require('../store/window-state');
 
 const windowStateStore = new WindowStateStore();
@@ -8,11 +9,14 @@ const DEFAULT_WINDOW_HEIGHT = 768;
 const loadWindowState = () => {
   const bounds = windowStateStore.getBounds();
 
+  const positionValid = isPositionValid(bounds);
+  const sizeValid = isSizeValid(bounds);
+
   return {
-    x: bounds.x || undefined,
-    y: bounds.y || undefined,
-    width: bounds.width || DEFAULT_WINDOW_WIDTH,
-    height: bounds.height || DEFAULT_WINDOW_HEIGHT
+    x: bounds.x && positionValid ? bounds.x : undefined,
+    y: bounds.y && positionValid ? bounds.y : undefined,
+    width: bounds.width && sizeValid ? bounds.width : DEFAULT_WINDOW_WIDTH,
+    height: bounds.height && sizeValid ? bounds.height : DEFAULT_WINDOW_HEIGHT
   };
 };
 
@@ -20,6 +24,27 @@ const saveWindowState = (window) => {
   const bounds = window.getBounds();
 
   windowStateStore.setBounds(bounds);
+};
+
+const isPositionValid = (bounds) => {
+  const area = getArea(bounds);
+
+  return (
+    bounds.x >= area.x &&
+    bounds.y >= area.y &&
+    bounds.x + bounds.width <= area.x + area.width &&
+    bounds.y + bounds.height <= area.y + area.height
+  );
+};
+
+const isSizeValid = (bounds) => {
+  const area = getArea(bounds);
+
+  return bounds.width <= area.width && bounds.height <= area.height;
+};
+
+const getArea = (bounds) => {
+  return screen.getDisplayMatching(bounds).workArea;
 };
 
 module.exports = {


### PR DESCRIPTION
This PR implements issue #451 and adds code to persist the window state of the Electron application, including its size and position so it's starting at the same position and size when opening the application as it was closed. I also added some checks to reset both position or size to default if it's not inside the screen border's (e.g. when switching to a smaller screen).