### PR TITLE
Fix 'between' assertion

### DIFF
--- a/packages/bruno-js/src/runtime/assert-runtime.js
+++ b/packages/bruno-js/src/runtime/assert-runtime.js
@@ -268,7 +268,7 @@ class AssertRuntime {
             expect(lhs).to.endWith(rhs);
             break;
           case 'between':
-            const [min, max] = value.split(',');
+            const [min, max] = rhs;
             expect(lhs).to.be.within(min, max);
             break;
           case 'isEmpty':


### PR DESCRIPTION
This is a small fix for the 'between' runtime assert.

Without this fix, the assertion fails with the message "value is not defined"