### PR TITLE
fix(#440) make auto-hiding menu configurable (and on by default)

### DIFF
--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { get } from 'lodash';
 import { usePreferences } from 'providers/Preferences';
 import StyledWrapper from './StyledWrapper';
 
@@ -6,19 +7,25 @@ const General = () => {
   const { preferences, setPreferences } = usePreferences();
 
   const [sslVerification, setSslVerification] = useState(preferences.request.sslVerification);
+  const [autoHideMenu, setAutoHideMenu] = useState(preferences.display.autoHideMenu);
 
-  const handleCheckboxChange = () => {
+  const handleCheckboxChange = (e) => {
     const updatedPreferences = {
       ...preferences,
       request: {
         ...preferences.request,
-        sslVerification: !sslVerification
+        sslVerification: e.target.name === 'sslVerification' ? !sslVerification : sslVerification
+      },
+      display: {
+        ...preferences.display,
+        autoHideMenu: e.target.name === 'autoHideMenu' ? !autoHideMenu : autoHideMenu
       }
     };
 
     setPreferences(updatedPreferences)
       .then(() => {
-        setSslVerification(!sslVerification);
+        setSslVerification(get(updatedPreferences, 'request.sslVerification'));
+        setAutoHideMenu(get(updatedPreferences, 'display.autoHideMenu'));
       })
       .catch((err) => {
         console.error(err);
@@ -27,9 +34,30 @@ const General = () => {
 
   return (
     <StyledWrapper>
-      <div className="flex items-center mt-2">
-        <input type="checkbox" checked={sslVerification} onChange={handleCheckboxChange} className="mr-3 mousetrap" />
-        SSL Certificate Verification
+      <div className="flex flex-col">
+        <div className="items-center my-2">
+          <h1 className="font-semibold">Request settings</h1>
+          <input
+            type="checkbox"
+            name="sslVerification"
+            checked={sslVerification}
+            onChange={handleCheckboxChange}
+            className="mr-3 mousetrap"
+          />
+          SSL Certificate Verification
+        </div>
+
+        <div className="items-center my-2">
+          <h1 className="font-semibold">Display settings</h1>
+          <input
+            type="checkbox"
+            name="autoHideMenu"
+            checked={autoHideMenu}
+            onChange={handleCheckboxChange}
+            className="mr-3 mousetrap"
+          />
+          Auto-hide menu (it's only shown when alt is pressed)
+        </div>
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/providers/Preferences/index.js
+++ b/packages/bruno-app/src/providers/Preferences/index.js
@@ -15,12 +15,18 @@ import toast from 'react-hot-toast';
 const defaultPreferences = {
   request: {
     sslVerification: true
+  },
+  display: {
+    autoHideMenu: true
   }
 };
 
 const preferencesSchema = Yup.object().shape({
   request: Yup.object().shape({
     sslVerification: Yup.boolean()
+  }),
+  display: Yup.object().shape({
+    autoHideMenu: Yup.boolean()
   })
 });
 
@@ -28,6 +34,11 @@ export const PreferencesContext = createContext();
 export const PreferencesProvider = (props) => {
   const [preferences, setPreferences] = useLocalStorage('bruno.preferences', defaultPreferences);
   const { ipcRenderer } = window;
+
+  // after we've added new keys, users of previous versions of Bruno might not yet have them in local storage
+  if (!preferences.display) {
+    preferences.display = defaultPreferences.display;
+  }
 
   useEffect(() => {
     ipcRenderer.invoke('renderer:set-preferences', preferences).catch((err) => {

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -3,14 +3,18 @@ const isDev = require('electron-is-dev');
 const { format } = require('url');
 const { BrowserWindow, app, Menu } = require('electron');
 const { setContentSecurityPolicy } = require('electron-util');
+const { get } = require('lodash');
 
 const menuTemplate = require('./app/menu-template');
 const LastOpenedCollections = require('./store/last-opened-collections');
+const { getPreferences } = require('./store/preferences');
 const registerNetworkIpc = require('./ipc/network');
 const registerCollectionsIpc = require('./ipc/collection');
 const Watcher = require('./app/watcher');
 
 const lastOpenedCollections = new LastOpenedCollections();
+
+const preferences = getPreferences();
 
 setContentSecurityPolicy(`
 	default-src * 'unsafe-inline' 'unsafe-eval';
@@ -37,10 +41,8 @@ app.on('ready', async () => {
       webviewTag: true
     },
     title: 'Bruno',
-    icon: path.join(__dirname, 'about/256x256.png')
-    // we will bring this back
-    // see https://github.com/usebruno/bruno/issues/440
-    // autoHideMenuBar: true
+    icon: path.join(__dirname, 'about/256x256.png'),
+    autoHideMenuBar: get(preferences, 'display.autoHideMenu', true)
   });
 
   const url = isDev

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -475,6 +475,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
 
   ipcMain.handle('renderer:set-preferences', async (event, preferences) => {
     setPreferences(preferences);
+    mainWindow.autoHideMenuBar = preferences.display.autoHideMenu;
+    // doesn't happen automatically when setting autoHideMenuBar to true
+    mainWindow.setMenuBarVisibility(!preferences.display.autoHideMenu);
   });
 
   ipcMain.handle('renderer:update-bruno-config', async (event, brunoConfig, collectionPath, collectionUid) => {

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -6,6 +6,9 @@
  * {
  *   request: {
  *     sslVerification: boolean
+ *   },
+ *   display: {
+ *     autoHideMenu: boolean
  *   }
  * }
  */


### PR DESCRIPTION
Adds configuration for auto-hiding menu bar. That's how it looks like:

![](https://imgur.com/9TQ0Mam.png)

There are several points of concern:

- I was not too sure where to put it in preferences, I added it as submenu in general tab, but it's probably not a great place to be - I'm open to suggestions
- we needed to handle people coming from older Bruno versions coming in and not having new keys in their preferences - I hydrated those from default in the context provider, not sure what the best practice is


I think with the comment I added about use of `alt` in preferences, having menu hidden by default is good, as people can easily discover that via settings.

Related to #440 