### PR TITLE
fix(#440) open dev tools from menu

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/TitleBar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/TitleBar/index.js
@@ -18,6 +18,7 @@ const TitleBar = () => {
   const [importCollectionModalOpen, setImportCollectionModalOpen] = useState(false);
   const [importCollectionLocationModalOpen, setImportCollectionLocationModalOpen] = useState(false);
   const dispatch = useDispatch();
+  const { ipcRenderer } = window;
 
   const handleImportCollection = (collection) => {
     setImportedCollection(collection);
@@ -48,6 +49,10 @@ const TitleBar = () => {
     dispatch(openCollection()).catch(
       (err) => console.log(err) && toast.error('An error occurred while opening the collection')
     );
+  };
+
+  const openDevTools = () => {
+    ipcRenderer.invoke('renderer:open-devtools');
   };
 
   return (
@@ -103,6 +108,15 @@ const TitleBar = () => {
               }}
             >
               Import Collection
+            </div>
+            <div
+              className="dropdown-item"
+              onClick={(e) => {
+                menuDropdownTippyRef.current.hide();
+                openDevTools();
+              }}
+            >
+              Devtools
             </div>
           </Dropdown>
         </div>

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -486,6 +486,10 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       return Promise.reject(error);
     }
   });
+
+  ipcMain.handle('renderer:open-devtools', async () => {
+    mainWindow.webContents.openDevTools();
+  });
 };
 
 const registerMainEventHandlers = (mainWindow, watcher, lastOpenedCollections) => {


### PR DESCRIPTION
Addresses issue in #440 where a common operation, opening dev tools (ex. to debug scripts) was only available from menu, which by default is hidden, which generated some friction in user experience.