### PR TITLE
Showing active headers, params and assertions count

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -80,8 +80,11 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   // get the length of active params and headers
   const params = item.draft ? get(item, 'draft.request.params') : get(item, 'request.params');
   const headers = item.draft ? get(item, 'draft.request.headers') : get(item, 'request.headers');
+  const assertions = item.draft ? get(item, 'draft.request.assertions') : get(item, 'request.assertions');
+
   const activeParamsLength = params.filter((param) => param.enabled).length;
   const activeHeadersLength = headers.filter((header) => header.enabled).length;
+  const activeAssertionsLength = assertions.filter((assertion) => assertion.enabled).length;
 
   return (
     <StyledWrapper className="flex flex-col h-full relative">
@@ -105,7 +108,7 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
           Script
         </div>
         <div className={getTabClassname('assert')} role="tab" onClick={() => selectTab('assert')}>
-          Assert
+          Assert {activeAssertionsLength > 0 && <span>({activeAssertionsLength})</span>}
         </div>
         <div className={getTabClassname('tests')} role="tab" onClick={() => selectTab('tests')}>
           Tests

--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -90,13 +90,19 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
     <StyledWrapper className="flex flex-col h-full relative">
       <div className="flex flex-wrap items-center tabs" role="tablist">
         <div className={getTabClassname('params')} role="tab" onClick={() => selectTab('params')}>
-          Query {activeParamsLength > 0 && <span>({activeParamsLength})</span>}
+          Query
+          {activeParamsLength > 0 && (
+            <sup className="sups some-tests-failed ml-1 font-medium">{activeParamsLength}</sup>
+          )}
         </div>
         <div className={getTabClassname('body')} role="tab" onClick={() => selectTab('body')}>
           Body
         </div>
         <div className={getTabClassname('headers')} role="tab" onClick={() => selectTab('headers')}>
-          Headers {activeHeadersLength > 0 && <span>({activeHeadersLength})</span>}
+          Headers
+          {activeHeadersLength > 0 && (
+            <sup className="sups some-tests-failed ml-1 font-medium">{activeHeadersLength}</sup>
+          )}
         </div>
         <div className={getTabClassname('auth')} role="tab" onClick={() => selectTab('auth')}>
           Auth
@@ -108,7 +114,10 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
           Script
         </div>
         <div className={getTabClassname('assert')} role="tab" onClick={() => selectTab('assert')}>
-          Assert {activeAssertionsLength > 0 && <span>({activeAssertionsLength})</span>}
+          Assert
+          {activeAssertionsLength > 0 && (
+            <sup className="sups some-tests-failed ml-1 font-medium">{activeAssertionsLength}</sup>
+          )}
         </div>
         <div className={getTabClassname('tests')} role="tab" onClick={() => selectTab('tests')}>
           Tests

--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -14,6 +14,7 @@ import Assertions from 'components/RequestPane/Assertions';
 import Script from 'components/RequestPane/Script';
 import Tests from 'components/RequestPane/Tests';
 import StyledWrapper from './StyledWrapper';
+import { get } from 'lodash';
 
 const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   const dispatch = useDispatch();
@@ -76,17 +77,23 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
     });
   };
 
+  // get the length of active params and headers
+  const params = item.draft ? get(item, 'draft.request.params') : get(item, 'request.params');
+  const headers = item.draft ? get(item, 'draft.request.headers') : get(item, 'request.headers');
+  const activeParamsLength = params.filter((param) => param.enabled).length;
+  const activeHeadersLength = headers.filter((header) => header.enabled).length;
+
   return (
     <StyledWrapper className="flex flex-col h-full relative">
       <div className="flex flex-wrap items-center tabs" role="tablist">
         <div className={getTabClassname('params')} role="tab" onClick={() => selectTab('params')}>
-          Query
+          Query {activeParamsLength > 0 && <span>({activeParamsLength})</span>}
         </div>
         <div className={getTabClassname('body')} role="tab" onClick={() => selectTab('body')}>
           Body
         </div>
         <div className={getTabClassname('headers')} role="tab" onClick={() => selectTab('headers')}>
-          Headers
+          Headers {activeHeadersLength > 0 && <span>({activeHeadersLength})</span>}
         </div>
         <div className={getTabClassname('auth')} role="tab" onClick={() => selectTab('auth')}>
           Auth


### PR DESCRIPTION
Added active params, headers and assertions count on the request options tab

![Screenshot from 2023-10-08 15-43-32](https://github.com/usebruno/bruno/assets/76877078/49826cee-7a6a-4561-a1e6-e3c2284a4946)

