### PR TITLE
Fix assertion value modification

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionRow/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionRow/index.js
@@ -178,7 +178,7 @@ const AssertionRow = ({
               handleAssertionChange(
                 {
                   target: {
-                    value: newValue
+                    value: `${operator} ${newValue}`
                   }
                 },
                 assertion,


### PR DESCRIPTION
This PR fixes the following bug in GUI:

> Assertion operator falls back to "eq" when user starts changing assertion value.
> 
> Steps to reproduce:
> 1. Create any assertion that requires value, except "eq" (for example "neq")
> 2. Start changing the value
>
> Expected: Operator doesn't change
> Actual: Operator falls back to "eq"