### PR TITLE
feat: path parameters

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -76,11 +76,13 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
     });
   };
 
+  const isMultipleContentTab = ['params', 'script', 'vars', 'auth'].includes(focusedTab.requestPaneTab);
+
   return (
     <StyledWrapper className="flex flex-col h-full relative">
       <div className="flex flex-wrap items-center tabs" role="tablist">
         <div className={getTabClassname('params')} role="tab" onClick={() => selectTab('params')}>
-          Query
+          Params
         </div>
         <div className={getTabClassname('body')} role="tab" onClick={() => selectTab('body')}>
           Body
@@ -110,7 +112,9 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
         ) : null}
       </div>
       <section
-        className={`flex w-full ${['script', 'vars', 'auth'].includes(focusedTab.requestPaneTab) ? '' : 'mt-5'}`}
+        className={classnames('flex w-full', {
+          'mt-5': !isMultipleContentTab
+        })}
       >
         {getTabPanel(focusedTab.requestPaneTab)}
       </section>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
+  div.title {
+    color: var(--color-tab-inactive);
+  }
   table {
     width: 100%;
     border-collapse: collapse;

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
+import has from 'lodash/has';
 import { IconTrash } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
-import { addQueryParam, updateQueryParam, deleteQueryParam } from 'providers/ReduxStore/slices/collections';
+import {
+  addQueryParam,
+  updateQueryParam,
+  deleteQueryParam,
+  updatePathParam
+} from 'providers/ReduxStore/slices/collections';
 import SingleLineEditor from 'components/SingleLineEditor';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 
@@ -14,6 +20,7 @@ const QueryParams = ({ item, collection }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
   const params = item.draft ? get(item, 'draft.request.params') : get(item, 'request.params');
+  const paths = item.draft ? get(item, 'draft.request.paths') : get(item, 'request.paths');
 
   const handleAddParam = () => {
     dispatch(
@@ -26,27 +33,56 @@ const QueryParams = ({ item, collection }) => {
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
   const handleRun = () => dispatch(sendRequest(item, collection.uid));
-  const handleParamChange = (e, _param, type) => {
-    const param = cloneDeep(_param);
+
+  const handleValueChange = (data, type, value) => {
+    const _data = cloneDeep(data);
+
+    if (!has(_data, type)) {
+      return;
+    }
+
+    _data[type] = value;
+
+    return _data;
+  };
+
+  const handleParamChange = (e, data, type) => {
+    let value;
 
     switch (type) {
       case 'name': {
-        param.name = e.target.value;
+        value = e.target.value;
         break;
       }
       case 'value': {
-        param.value = e.target.value;
+        value = e.target.value;
         break;
       }
       case 'enabled': {
-        param.enabled = e.target.checked;
+        value = e.target.checked;
         break;
       }
     }
 
+    const param = handleValueChange(data, type, value);
+
     dispatch(
       updateQueryParam({
         param,
+        itemUid: item.uid,
+        collectionUid: collection.uid
+      })
+    );
+  };
+
+  const handlePathChange = (e, data) => {
+    let value = e.target.value;
+
+    const path = handleValueChange(data, 'value', value);
+
+    dispatch(
+      updatePathParam({
+        path,
         itemUid: item.uid,
         collectionUid: collection.uid
       })
@@ -64,75 +100,128 @@ const QueryParams = ({ item, collection }) => {
   };
 
   return (
-    <StyledWrapper className="w-full">
-      <table>
-        <thead>
-          <tr>
-            <td>Name</td>
-            <td>Value</td>
-            <td></td>
-          </tr>
-        </thead>
-        <tbody>
-          {params && params.length
-            ? params.map((param, index) => {
-                return (
-                  <tr key={param.uid}>
-                    <td>
-                      <input
-                        type="text"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        autoCapitalize="off"
-                        spellCheck="false"
-                        value={param.name}
-                        className="mousetrap"
-                        onChange={(e) => handleParamChange(e, param, 'name')}
-                      />
-                    </td>
-                    <td>
-                      <SingleLineEditor
-                        value={param.value}
-                        theme={storedTheme}
-                        onSave={onSave}
-                        onChange={(newValue) =>
-                          handleParamChange(
-                            {
-                              target: {
-                                value: newValue
-                              }
-                            },
-                            param,
-                            'value'
-                          )
-                        }
-                        onRun={handleRun}
-                        collection={collection}
-                      />
-                    </td>
-                    <td>
-                      <div className="flex items-center">
+    <StyledWrapper className="w-full flex flex-col">
+      <div className="flex-1 mt-2">
+        <div className="mb-1 title text-xs">Query</div>
+        <table>
+          <thead>
+            <tr>
+              <td>Name</td>
+              <td>Value</td>
+              <td></td>
+            </tr>
+          </thead>
+          <tbody>
+            {params && params.length
+              ? params.map((param, index) => {
+                  return (
+                    <tr key={param.uid}>
+                      <td>
                         <input
-                          type="checkbox"
-                          checked={param.enabled}
-                          tabIndex="-1"
-                          className="mr-3 mousetrap"
-                          onChange={(e) => handleParamChange(e, param, 'enabled')}
+                          type="text"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          autoCapitalize="off"
+                          spellCheck="false"
+                          value={param.name}
+                          className="mousetrap"
+                          onChange={(e) => handleParamChange(e, param, 'name')}
                         />
-                        <button tabIndex="-1" onClick={() => handleRemoveParam(param)}>
-                          <IconTrash strokeWidth={1.5} size={20} />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })
-            : null}
-        </tbody>
-      </table>
-      <button className="btn-add-param text-link pr-2 py-3 mt-2 select-none" onClick={handleAddParam}>
-        +&nbsp;<span>Add Param</span>
-      </button>
+                      </td>
+                      <td>
+                        <SingleLineEditor
+                          value={param.value}
+                          theme={storedTheme}
+                          onSave={onSave}
+                          onChange={(newValue) =>
+                            handleParamChange(
+                              {
+                                target: {
+                                  value: newValue
+                                }
+                              },
+                              param,
+                              'value'
+                            )
+                          }
+                          onRun={handleRun}
+                          collection={collection}
+                        />
+                      </td>
+                      <td>
+                        <div className="flex items-center">
+                          <input
+                            type="checkbox"
+                            checked={param.enabled}
+                            tabIndex="-1"
+                            className="mr-3 mousetrap"
+                            onChange={(e) => handleParamChange(e, param, 'enabled')}
+                          />
+                          <button tabIndex="-1" onClick={() => handleRemoveParam(param)}>
+                            <IconTrash strokeWidth={1.5} size={20} />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              : null}
+          </tbody>
+        </table>
+        <button className="btn-add-param text-link pr-2 py-3 mt-2 select-none" onClick={handleAddParam}>
+          +&nbsp;<span>Add Param</span>
+        </button>
+        <div className="mb-1 title text-xs">Path</div>
+        <table>
+          <thead>
+            <tr>
+              <td>Name</td>
+              <td>Value</td>
+            </tr>
+          </thead>
+          <tbody>
+            {paths && paths.length
+              ? paths.map((path, index) => {
+                  return (
+                    <tr key={path.uid}>
+                      <td>
+                        <input
+                          type="text"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          autoCapitalize="off"
+                          spellCheck="false"
+                          value={path.name}
+                          className="mousetrap"
+                          readOnly={true}
+                        />
+                      </td>
+                      <td>
+                        <SingleLineEditor
+                          value={path.value}
+                          theme={storedTheme}
+                          onSave={onSave}
+                          onChange={(newValue) =>
+                            handlePathChange(
+                              {
+                                target: {
+                                  value: newValue
+                                }
+                              },
+                              path
+                            )
+                          }
+                          onRun={handleRun}
+                          collection={collection}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })
+              : null}
+          </tbody>
+        </table>
+      </div>
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/utils/collections/export.js
+++ b/packages/bruno-app/src/utils/collections/export.js
@@ -9,6 +9,7 @@ const deleteUidsInItems = (items) => {
     if (['http-request', 'graphql-request'].includes(item.type)) {
       each(get(item, 'request.headers'), (header) => delete header.uid);
       each(get(item, 'request.params'), (param) => delete param.uid);
+      each(get(item, 'request.paths'), (path) => delete path.uid);
       each(get(item, 'request.vars.req'), (v) => delete v.uid);
       each(get(item, 'request.vars.res'), (v) => delete v.uid);
       each(get(item, 'request.vars.assertions'), (a) => delete a.uid);

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -234,6 +234,17 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
     });
   };
 
+  const copyPathParams = (paths) => {
+    return map(paths, (path) => {
+      return {
+        uid: path.uid,
+        name: path.name,
+        value: path.value,
+        enabled: path.enabled
+      };
+    });
+  };
+
   const copyFormUrlEncodedParams = (params = []) => {
     return map(params, (param) => {
       return {
@@ -278,6 +289,7 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
             method: si.draft.request.method,
             headers: copyHeaders(si.draft.request.headers),
             params: copyQueryParams(si.draft.request.params),
+            paths: copyPathParams(si.draft.request.paths),
             body: {
               mode: si.draft.request.body.mode,
               json: si.draft.request.body.json,
@@ -310,6 +322,7 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
             method: si.request.method,
             headers: copyHeaders(si.request.headers),
             params: copyQueryParams(si.request.params),
+            paths: copyPathParams(si.request.paths),
             body: {
               mode: si.request.body.mode,
               json: si.request.body.json,
@@ -376,6 +389,7 @@ export const transformRequestToSaveToFilesystem = (item) => {
       method: _item.request.method,
       url: _item.request.url,
       params: [],
+      paths: [],
       headers: [],
       auth: _item.request.auth,
       body: _item.request.body,
@@ -393,6 +407,14 @@ export const transformRequestToSaveToFilesystem = (item) => {
       value: param.value,
       description: param.description,
       enabled: param.enabled
+    });
+  });
+
+  each(_item.request.paths, (path) => {
+    itemToSave.request.paths.push({
+      uid: path.uid,
+      name: path.name,
+      value: path.value
     });
   });
 
@@ -493,6 +515,7 @@ export const refreshUidsInItem = (item) => {
 
   each(get(item, 'request.headers'), (header) => (header.uid = uuid()));
   each(get(item, 'request.params'), (param) => (param.uid = uuid()));
+  each(get(item, 'request.paths'), (path) => (path.uid = uuid()));
   each(get(item, 'request.body.multipartForm'), (param) => (param.uid = uuid()));
   each(get(item, 'request.body.formUrlEncoded'), (param) => (param.uid = uuid()));
 
@@ -507,11 +530,13 @@ export const deleteUidsInItem = (item) => {
   delete item.uid;
   const params = get(item, 'request.params', []);
   const headers = get(item, 'request.headers', []);
+  const paths = get(item, 'request.paths', []);
   const bodyFormUrlEncoded = get(item, 'request.body.formUrlEncoded', []);
   const bodyMultipartForm = get(item, 'request.body.multipartForm', []);
 
   params.forEach((param) => delete param.uid);
   headers.forEach((header) => delete header.uid);
+  paths.forEach((path) => delete path.uid);
   bodyFormUrlEncoded.forEach((param) => delete param.uid);
   bodyMultipartForm.forEach((param) => delete param.uid);
 

--- a/packages/bruno-app/src/utils/importers/common.js
+++ b/packages/bruno-app/src/utils/importers/common.js
@@ -31,6 +31,7 @@ export const updateUidsInCollection = (_collection) => {
       each(get(item, 'request.headers'), (header) => (header.uid = uuid()));
       each(get(item, 'request.query'), (param) => (param.uid = uuid()));
       each(get(item, 'request.params'), (param) => (param.uid = uuid()));
+      each(get(item, 'request.paths'), (path) => (path.uid = uuid()));
       each(get(item, 'request.vars.req'), (v) => (v.uid = uuid()));
       each(get(item, 'request.vars.res'), (v) => (v.uid = uuid()));
       each(get(item, 'request.assertions'), (a) => (a.uid = uuid()));

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -2,6 +2,7 @@ import isEmpty from 'lodash/isEmpty';
 import trim from 'lodash/trim';
 import each from 'lodash/each';
 import filter from 'lodash/filter';
+import find from 'lodash/find';
 
 const hasLength = (str) => {
   if (!str || !str.length) {
@@ -24,6 +25,41 @@ export const parseQueryParams = (query) => {
   });
 
   return filter(params, (p) => hasLength(p.name));
+};
+
+export const parsePathParams = (url) => {
+  let uri = url.slice();
+
+  if (!uri || !uri.length) {
+    return [];
+  }
+
+  if (uri.indexOf('http://') === -1 || uri.indexOf('https://') === -1) {
+    uri = `http://${uri}`;
+  }
+
+  if (!isValidUrl(uri)) {
+    throw 'Invalid URL format';
+  }
+
+  uri = new URL(uri);
+
+  let paths = uri.pathname.split('/');
+
+  paths = paths.reduce((acc, path) => {
+    if (path !== '' && path[0] === ':') {
+      let name = path.slice(1, path.length);
+      if (name) {
+        let isExist = find(acc, (path) => path.name === name);
+        if (!isExist) {
+          acc.push({ name: path.slice(1, path.length), value: '' });
+        }
+      }
+    }
+    return acc;
+  }, []);
+
+  return paths;
 };
 
 export const stringifyQueryParams = (params) => {

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -1,4 +1,4 @@
-import { parseQueryParams, splitOnFirst } from './index';
+import { parseQueryParams, splitOnFirst, parsePathParams } from './index';
 
 describe('Url Utils - parseQueryParams', () => {
   it('should parse query - case 1', () => {
@@ -47,6 +47,51 @@ describe('Url Utils - parseQueryParams', () => {
     expect(params).toEqual([
       { name: 'a', value: '1' },
       { name: 'b', value: '2' }
+    ]);
+  });
+});
+
+describe('Url Utils - parsePathParams', () => {
+  it('should parse path - case 1', () => {
+    const params = parsePathParams('www.example.com');
+    expect(params).toEqual([]);
+  });
+
+  it('should parse path - case 2', () => {
+    const params = parsePathParams('http://www.example.com');
+    expect(params).toEqual([]);
+  });
+
+  it('should parse path - case 3', () => {
+    const params = parsePathParams('https://www.example.com');
+    expect(params).toEqual([]);
+  });
+
+  it('should parse path - case 4', () => {
+    const params = parsePathParams('https://www.example.com/users/:id');
+    expect(params).toEqual([{ name: 'id', value: '' }]);
+  });
+
+  it('should parse path - case 5', () => {
+    const params = parsePathParams('https://www.example.com/users/:id/');
+    expect(params).toEqual([{ name: 'id', value: '' }]);
+  });
+
+  it('should parse path - case 6', () => {
+    const params = parsePathParams('https://www.example.com/users/:id/:');
+    expect(params).toEqual([{ name: 'id', value: '' }]);
+  });
+
+  it('should parse path - case 7', () => {
+    const params = parsePathParams('https://www.example.com/users/:id/posts/:id');
+    expect(params).toEqual([{ name: 'id', value: '' }]);
+  });
+
+  it('should parse path - case 8', () => {
+    const params = parsePathParams('https://www.example.com/users/:id/posts/:postId');
+    expect(params).toEqual([
+      { name: 'id', value: '' },
+      { name: 'postId', value: '' }
     ]);
   });
 });

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -1,5 +1,5 @@
 const Handlebars = require('handlebars');
-const { each, forOwn, cloneDeep } = require('lodash');
+const { each, forOwn, cloneDeep, find } = require('lodash');
 
 const getContentType = (headers = {}) => {
   let contentType = '';
@@ -97,6 +97,29 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
   each(request.params, (param) => {
     param.value = interpolate(param.value);
   });
+
+  if (request.paths.length) {
+    let url = new URL(request.url);
+    let urlPaths = url.pathname.split('/');
+    urlPaths = urlPaths.reduce((acc, path) => {
+      if (path !== '') {
+        if (path[0] !== ':') {
+          acc += '/' + path;
+        } else {
+          let name = path.slice(1, path.length);
+          if (name) {
+            let existingPath = find(request.paths, (path) => path.name === name);
+            if (existingPath) {
+              acc += '/' + interpolate(existingPath.value);
+            }
+          }
+        }
+      }
+      return acc;
+    }, '');
+
+    request.url = url.origin + urlPaths + url.search;
+  }
 
   if (request.proxy) {
     request.proxy.protocol = interpolate(request.proxy.protocol);

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -27,7 +27,8 @@ const prepareRequest = (request, collectionRoot) => {
   let axiosRequest = {
     method: request.method,
     url: request.url,
-    headers: headers
+    headers: headers,
+    paths: request.paths
   };
 
   // Authentication

--- a/packages/bruno-cli/src/utils/bru.js
+++ b/packages/bruno-cli/src/utils/bru.js
@@ -14,6 +14,7 @@ const collectionBruToJson = (bru) => {
     const transformedJson = {
       request: {
         params: _.get(json, 'query', []),
+        paths: _.get(json, 'path', []),
         headers: _.get(json, 'headers', []),
         auth: _.get(json, 'auth', {}),
         script: _.get(json, 'script', {}),
@@ -61,6 +62,7 @@ const bruToJson = (bru) => {
         url: _.get(json, 'http.url'),
         auth: _.get(json, 'auth', {}),
         params: _.get(json, 'query', []),
+        paths: _.get(json, 'path', []),
         headers: _.get(json, 'headers', []),
         body: _.get(json, 'body', {}),
         vars: _.get(json, 'vars', []),

--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -48,6 +48,7 @@ const hydrateRequestWithUuid = (request, pathname) => {
   request.uid = getRequestUid(pathname);
 
   const params = _.get(request, 'request.params', []);
+  const paths = _.get(request, 'request.paths', []);
   const headers = _.get(request, 'request.headers', []);
   const requestVars = _.get(request, 'request.vars.req', []);
   const responseVars = _.get(request, 'request.vars.res', []);
@@ -56,6 +57,7 @@ const hydrateRequestWithUuid = (request, pathname) => {
   const bodyMultipartForm = _.get(request, 'request.body.multipartForm', []);
 
   params.forEach((param) => (param.uid = uuid()));
+  paths.forEach((path) => (path.uid = uuid()));
   headers.forEach((header) => (header.uid = uuid()));
   requestVars.forEach((variable) => (variable.uid = uuid()));
   responseVars.forEach((variable) => (variable.uid = uuid()));
@@ -68,11 +70,13 @@ const hydrateRequestWithUuid = (request, pathname) => {
 
 const hydrateBruCollectionFileWithUuid = (collectionRoot) => {
   const params = _.get(collectionRoot, 'request.params', []);
+  const paths = _.get(collectionRoot, 'request.paths', []);
   const headers = _.get(collectionRoot, 'request.headers', []);
   const requestVars = _.get(collectionRoot, 'request.vars.req', []);
   const responseVars = _.get(collectionRoot, 'request.vars.res', []);
 
   params.forEach((param) => (param.uid = uuid()));
+  paths.forEach((path) => (path.uid = uuid()));
   headers.forEach((header) => (header.uid = uuid()));
   requestVars.forEach((variable) => (variable.uid = uuid()));
   responseVars.forEach((variable) => (variable.uid = uuid()));

--- a/packages/bruno-electron/src/bru/index.js
+++ b/packages/bruno-electron/src/bru/index.js
@@ -15,6 +15,7 @@ const collectionBruToJson = (bru) => {
     const transformedJson = {
       request: {
         params: _.get(json, 'query', []),
+        paths: _.get(json, 'path', []),
         headers: _.get(json, 'headers', []),
         auth: _.get(json, 'auth', {}),
         script: _.get(json, 'script', {}),
@@ -33,6 +34,7 @@ const jsonToCollectionBru = (json) => {
   try {
     const collectionBruJson = {
       query: _.get(json, 'request.params', []),
+      path: _.get(json, 'request.paths', []),
       headers: _.get(json, 'request.headers', []),
       auth: _.get(json, 'request.auth', {}),
       script: {
@@ -110,6 +112,7 @@ const bruToJson = (bru) => {
         method: _.upperCase(_.get(json, 'http.method')),
         url: _.get(json, 'http.url'),
         params: _.get(json, 'query', []),
+        paths: _.get(json, 'path', []),
         headers: _.get(json, 'headers', []),
         auth: _.get(json, 'auth', {}),
         body: _.get(json, 'body', {}),
@@ -160,6 +163,7 @@ const jsonToBru = (json) => {
       body: _.get(json, 'request.body.mode', 'none')
     },
     query: _.get(json, 'request.params', []),
+    path: _.get(json, 'request.paths', []),
     headers: _.get(json, 'request.headers', []),
     auth: _.get(json, 'request.auth', {}),
     body: _.get(json, 'request.body', {}),

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -1,5 +1,5 @@
 const Handlebars = require('handlebars');
-const { each, forOwn, cloneDeep } = require('lodash');
+const { each, forOwn, cloneDeep, find } = require('lodash');
 
 const getContentType = (headers = {}) => {
   let contentType = '';
@@ -97,6 +97,29 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
   each(request.params, (param) => {
     param.value = interpolate(param.value);
   });
+
+  if (request.paths.length) {
+    let url = new URL(request.url);
+    let urlPaths = url.pathname.split('/');
+    urlPaths = urlPaths.reduce((acc, path) => {
+      if (path !== '') {
+        if (path[0] !== ':') {
+          acc += '/' + path;
+        } else {
+          let name = path.slice(1, path.length);
+          if (name) {
+            let existingPath = find(request.paths, (path) => path.name === name);
+            if (existingPath) {
+              acc += '/' + interpolate(existingPath.value);
+            }
+          }
+        }
+      }
+      return acc;
+    }, '');
+
+    request.url = url.origin + urlPaths + url.search;
+  }
 
   if (request.proxy) {
     request.proxy.protocol = interpolate(request.proxy.protocol);

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -27,7 +27,8 @@ const prepareRequest = (request, collectionRoot) => {
   let axiosRequest = {
     method: request.method,
     url: request.url,
-    headers: headers
+    headers: headers,
+    paths: request.paths
   };
 
   // Authentication

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -22,7 +22,7 @@ const { outdentString } = require('../../v1/src/utils');
  *
  */
 const grammar = ohm.grammar(`Bru {
-  BruFile = (meta | http | query | headers | auths | bodies | varsandassert | script | tests | docs)*
+  BruFile = (meta | http | query | path | headers | auths | bodies | varsandassert | script | tests | docs)*
   auths = authbasic | authbearer 
   bodies = bodyjson | bodytext | bodyxml | bodygraphql | bodygraphqlvars | bodyforms | body
   bodyforms = bodyformurlencoded | bodymultipart
@@ -70,6 +70,8 @@ const grammar = ohm.grammar(`Bru {
   headers = "headers" dictionary
 
   query = "query" dictionary
+  
+  path = "path" dictionary
 
   varsandassert = varsreq | varsres | assert
   varsreq = "vars:pre-request" dictionary
@@ -287,6 +289,11 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   query(_1, dictionary) {
     return {
       query: mapPairListToKeyValPairs(dictionary.ast)
+    };
+  },
+  path(_1, dictionary) {
+    return {
+      path: mapPairListToKeyValPairs(dictionary.ast)
     };
   },
   headers(_1, dictionary) {

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -13,7 +13,7 @@ const stripLastLine = (text) => {
 };
 
 const jsonToBru = (json) => {
-  const { meta, http, query, headers, auth, body, script, tests, vars, assertions, docs } = json;
+  const { meta, http, query, path, headers, auth, body, script, tests, vars, assertions, docs } = json;
 
   let bru = '';
 
@@ -62,6 +62,14 @@ const jsonToBru = (json) => {
           .join('\n')
       )}`;
     }
+
+    bru += '\n}\n\n';
+  }
+
+  if (path && path.length) {
+    bru += 'path {';
+
+    bru += `\n${indentString(path.map((item) => `${item.name}: ${item.value}`).join('\n'))}`;
 
     bru += '\n}\n\n';
   }

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -98,6 +98,7 @@ const requestSchema = Yup.object({
   method: requestMethodSchema,
   headers: Yup.array().of(keyValueSchema).required('headers are required'),
   params: Yup.array().of(keyValueSchema).required('params are required'),
+  paths: Yup.array().of(keyValueSchema).required('paths are required'),
   auth: authSchema,
   body: requestBodySchema,
   script: Yup.object({


### PR DESCRIPTION
Currently, for setting URL path parameter that have dynamic value such as ID only available with two options. First changing directly the URL path and using Vars Pre-Request or Collection Variables, on this PR add new section to manage path parameters for user to changing value alongside with query params at one a time or individually.