### PR TITLE
feat(#354): Use collection level auth if available for introspection request

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -493,7 +493,8 @@ const registerNetworkIpc = (mainWindow) => {
   ipcMain.handle('fetch-gql-schema', async (event, endpoint, environment, request, collection) => {
     try {
       const envVars = getEnvVars(environment);
-      const preparedRequest = prepareGqlIntrospectionRequest(endpoint, envVars, request);
+      const collectionRoot = get(collection, 'root', {});
+      const preparedRequest = prepareGqlIntrospectionRequest(endpoint, envVars, request, collectionRoot);
 
       const preferences = getPreferences();
       const sslVerification = get(preferences, 'request.sslVerification', true);
@@ -711,14 +712,14 @@ const registerNetworkIpc = (mainWindow) => {
 
               if (socksEnabled) {
                 const socksProxyAgent = new SocksProxyAgent(proxyUri);
-      
+
                 request.httpsAgent = socksProxyAgent;
                 request.httpAgent = socksProxyAgent;
               } else {
                 request.httpsAgent = new HttpsProxyAgent(proxyUri, {
                   rejectUnauthorized: sslVerification
                 });
-  
+
                 request.httpAgent = new HttpProxyAgent(proxyUri);
               }
             } else if (!sslVerification) {

--- a/packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js
@@ -1,15 +1,14 @@
 const Handlebars = require('handlebars');
 const { getIntrospectionQuery } = require('graphql');
-const { get } = require('lodash');
+const { setAuthHeaders } = require('./prepare-request');
 
-const prepareGqlIntrospectionRequest = (endpoint, envVars, request) => {
+const prepareGqlIntrospectionRequest = (endpoint, envVars, request, collectionRoot) => {
   if (endpoint && endpoint.length) {
     endpoint = Handlebars.compile(endpoint, { noEscape: true })(envVars);
   }
 
-  const introspectionQuery = getIntrospectionQuery();
   const queryParams = {
-    query: introspectionQuery
+    query: getIntrospectionQuery()
   };
 
   let axiosRequest = {
@@ -23,20 +22,7 @@ const prepareGqlIntrospectionRequest = (endpoint, envVars, request) => {
     data: JSON.stringify(queryParams)
   };
 
-  if (request.auth) {
-    if (request.auth.mode === 'basic') {
-      axiosRequest.auth = {
-        username: get(request, 'auth.basic.username'),
-        password: get(request, 'auth.basic.password')
-      };
-    }
-
-    if (request.auth.mode === 'bearer') {
-      axiosRequest.headers.authorization = `Bearer ${get(request, 'auth.bearer.token')}`;
-    }
-  }
-
-  return axiosRequest;
+  return setAuthHeaders(axiosRequest, request, collectionRoot);
 };
 
 const mapHeaders = (headers) => {


### PR DESCRIPTION
With https://github.com/usebruno/bruno/commit/1ce8d707f1b4cc461235333174b3bdcb290c9c40 merged I think it makes sense to reuse the same logic for the introspection request. Use the collection level authentication if possible, else use request level authentication.