### PR TITLE
fix: add request and folder modal validation fixes

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewFolder/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewFolder/index.js
@@ -16,6 +16,7 @@ const NewFolder = ({ collection, item, onClose }) => {
     },
     validationSchema: Yup.object({
       folderName: Yup.string()
+        .trim()
         .min(1, 'must be at least 1 character')
         .required('name is required')
         .test({
@@ -32,7 +33,7 @@ const NewFolder = ({ collection, item, onClose }) => {
     onSubmit: (values) => {
       dispatch(newFolder(values.folderName, collection.uid, item ? item.uid : null))
         .then(() => onClose())
-        .catch((err) => toast.error(err ? err.message : 'An error occurred while adding the request'));
+        .catch((err) => toast.error(err ? err.message : 'An error occurred while adding the folder'));
     }
   });
 

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -25,13 +25,14 @@ const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
     },
     validationSchema: Yup.object({
       requestName: Yup.string()
+        .trim()
         .min(1, 'must be at least 1 character')
         .required('name is required')
         .test({
           name: 'requestName',
           message: `The request names - collection and folder is reserved in bruno`,
           test: (value) => {
-            const trimmedValue = value.trim().toLowerCase();
+            const trimmedValue = value ? value.trim().toLowerCase() : '';
             return !['collection', 'folder'].includes(trimmedValue);
           }
         })


### PR DESCRIPTION
- Fixed Name Validation in Add Request and Add Folder Modals, previously it wasn't trimming the string
- Fix validation message on Add folder modal