### PR TITLE
Add support for SPARQL bodies

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -77,19 +77,19 @@ const RequestBodyMode = ({ item, collection }) => {
             className="dropdown-item"
             onClick={() => {
               dropdownTippyRef.current.hide();
-              onModeChange('sparql');
+              onModeChange('text');
             }}
           >
-            SPARQL
+            TEXT
           </div>
           <div
             className="dropdown-item"
             onClick={() => {
               dropdownTippyRef.current.hide();
-              onModeChange('text');
+              onModeChange('sparql');
             }}
           >
-            TEXT
+            SPARQL
           </div>
           <div className="label-item font-medium">Other</div>
           <div

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -77,6 +77,15 @@ const RequestBodyMode = ({ item, collection }) => {
             className="dropdown-item"
             onClick={() => {
               dropdownTippyRef.current.hide();
+              onModeChange('sparql');
+            }}
+          >
+            SPARQL
+          </div>
+          <div
+            className="dropdown-item"
+            onClick={() => {
+              dropdownTippyRef.current.hide();
               onModeChange('text');
             }}
           >

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
@@ -28,17 +28,19 @@ const RequestBody = ({ item, collection }) => {
   const onRun = () => dispatch(sendRequest(item, collection.uid));
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
 
-  if (['json', 'xml', 'text'].includes(bodyMode)) {
+  if (['json', 'xml', 'text', 'sparql'].includes(bodyMode)) {
     let codeMirrorMode = {
       json: 'application/ld+json',
       text: 'application/text',
-      xml: 'application/xml'
+      xml: 'application/xml',
+      sparql: 'application/sparql-query'
     };
 
     let bodyContent = {
       json: body.json,
       text: body.text,
-      xml: body.xml
+      xml: body.xml,
+      sparql: body.sparql
     };
 
     return (

--- a/packages/bruno-app/src/pageComponents/Index/index.js
+++ b/packages/bruno-app/src/pageComponents/Index/index.js
@@ -14,6 +14,7 @@ const SERVER_RENDERED = typeof navigator === 'undefined' || global['PREVENT_CODE
 if (!SERVER_RENDERED) {
   require('codemirror/mode/javascript/javascript');
   require('codemirror/mode/xml/xml');
+  require('codemirror/mode/sparql/sparql');
   require('codemirror/addon/comment/comment');
   require('codemirror/addon/dialog/dialog');
   require('codemirror/addon/edit/closebrackets');

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -602,6 +602,7 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
           json: null,
           text: null,
           xml: null,
+          sparql: null,
           multipartForm: null,
           formUrlEncoded: null
         }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -692,6 +692,10 @@ export const collectionsSlice = createSlice({
               item.draft.request.body.xml = action.payload.content;
               break;
             }
+            case 'sparql': {
+              item.draft.request.body.sparql = action.payload.content;
+              break;
+            }
             case 'formUrlEncoded': {
               item.draft.request.body.formUrlEncoded = action.payload.content;
               break;

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -284,6 +284,7 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
               text: si.draft.request.body.text,
               xml: si.draft.request.body.xml,
               graphql: si.draft.request.body.graphql,
+              sparql: si.draft.request.body.sparql,
               formUrlEncoded: copyFormUrlEncodedParams(si.draft.request.body.formUrlEncoded),
               multipartForm: copyMultipartFormParams(si.draft.request.body.multipartForm)
             },
@@ -316,6 +317,7 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
               text: si.request.body.text,
               xml: si.request.body.xml,
               graphql: si.request.body.graphql,
+              sparql: si.request.body.sparql,
               formUrlEncoded: copyFormUrlEncodedParams(si.request.body.formUrlEncoded),
               multipartForm: copyMultipartFormParams(si.request.body.multipartForm)
             },
@@ -457,6 +459,10 @@ export const humanizeRequestBodyMode = (mode) => {
     }
     case 'xml': {
       label = 'XML';
+      break;
+    }
+    case 'sparql': {
+      label = 'SPARQL';
       break;
     }
     case 'formUrlEncoded': {

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -87,6 +87,13 @@ const prepareRequest = (request, collectionRoot) => {
     axiosRequest.data = request.body.xml;
   }
 
+  if (request.body.mode === 'sparql') {
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'application/sparql-query';
+    }
+    axiosRequest.data = request.body.sparql;
+  }
+
   if (request.body.mode === 'formUrlEncoded') {
     axiosRequest.headers['content-type'] = 'application/x-www-form-urlencoded';
     const params = {};

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -24,7 +24,7 @@ const { outdentString } = require('../../v1/src/utils');
 const grammar = ohm.grammar(`Bru {
   BruFile = (meta | http | query | headers | auths | bodies | varsandassert | script | tests | docs)*
   auths = authbasic | authbearer 
-  bodies = bodyjson | bodytext | bodyxml | bodygraphql | bodygraphqlvars | bodyforms | body
+  bodies = bodyjson | bodytext | bodyxml | bodysparql | bodygraphql | bodygraphqlvars | bodyforms | body
   bodyforms = bodyformurlencoded | bodymultipart
 
   nl = "\\r"? "\\n"
@@ -83,6 +83,7 @@ const grammar = ohm.grammar(`Bru {
   bodyjson = "body:json" st* "{" nl* textblock tagend
   bodytext = "body:text" st* "{" nl* textblock tagend
   bodyxml = "body:xml" st* "{" nl* textblock tagend
+  bodysparql = "body:sparql" st* "{" nl* textblock tagend
   bodygraphql = "body:graphql" st* "{" nl* textblock tagend
   bodygraphqlvars = "body:graphql:vars" st* "{" nl* textblock tagend
 
@@ -363,6 +364,13 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     return {
       body: {
         xml: outdentString(textblock.sourceString)
+      }
+    };
+  },
+  bodysparql(_1, _2, _3, _4, textblock, _5) {
+    return {
+      body: {
+        sparql: outdentString(textblock.sourceString)
       }
     };
   },

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -128,6 +128,14 @@ ${indentString(body.xml)}
 `;
   }
 
+  if (body && body.sparql && body.sparql.length) {
+    bru += `body:sparql {
+${indentString(body.sparql)}
+}
+
+`;
+  }
+
   if (body && body.formUrlEncoded && body.formUrlEncoded.length) {
     bru += `body:form-urlencoded {`;
     if (enabled(body.formUrlEncoded).length) {

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -48,6 +48,13 @@ body:xml {
   </xml>
 }
 
+body:sparql {
+  SELECT * WHERE {
+    ?subject ?predicate ?object .
+  }
+  LIMIT 10
+}
+
 body:form-urlencoded {
   apikey: secret
   numbers: +91998877665

--- a/packages/bruno-lang/v2/tests/fixtures/request.json
+++ b/packages/bruno-lang/v2/tests/fixtures/request.json
@@ -57,6 +57,7 @@
     "json": "{\n  \"hello\": \"world\"\n}",
     "text": "This is a text body",
     "xml": "<xml>\n  <name>John</name>\n  <age>30</age>\n</xml>",
+    "sparql": "SELECT * WHERE {\n  ?subject ?predicate ?object .\n}\nLIMIT 10",
     "graphql": {
       "query": "{\n  launchesPast {\n    launch_site {\n      site_name\n    }\n    launch_success\n  }\n}",
       "variables": "{\n  \"limit\": 5\n}"

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -57,11 +57,12 @@ const graphqlBodySchema = Yup.object({
 
 const requestBodySchema = Yup.object({
   mode: Yup.string()
-    .oneOf(['none', 'json', 'text', 'xml', 'formUrlEncoded', 'multipartForm', 'graphql'])
+    .oneOf(['none', 'json', 'text', 'xml', 'formUrlEncoded', 'multipartForm', 'graphql', 'sparql'])
     .required('mode is required'),
   json: Yup.string().nullable(),
   text: Yup.string().nullable(),
   xml: Yup.string().nullable(),
+  sparql: Yup.string().nullable(),
   formUrlEncoded: Yup.array().of(keyValueSchema).nullable(),
   multipartForm: Yup.array().of(keyValueSchema).nullable(),
   graphql: graphqlBodySchema.nullable()


### PR DESCRIPTION
This PR adds support for [SPARQL](https://en.wikipedia.org/wiki/SPARQL) bodies:

<img src="https://github.com/usebruno/bruno/assets/239058/83c0aea3-ca9d-471b-8a4a-717780b332ee" width="600px" />

SPARQL bodies are integrated into bruno-lang v2, but not in v1, is this ok or should v1 also be supported?

Example query:

```sparql
## All predicates, ordered by number of subjects
SELECT ?predicate (COUNT(DISTINCT ?subject) AS ?count) WHERE {
  ?subject ?predicate ?object .
}
GROUP BY ?predicate
ORDER BY DESC(?count)
LIMIT 10
```
