### PR TITLE
Fixed error handling

### DIFF
--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -23,9 +23,9 @@ function makeAxiosInstance() {
       return response;
     },
     (error) => {
-      const end = Date.now();
-      const start = error.config.headers['request-start-time'];
       if (error.response) {
+        const end = Date.now();
+        const start = error.config.headers['request-start-time'];
         error.response.headers['request-duration'] = end - start;
       }
       return Promise.reject(error);


### PR DESCRIPTION
When you try to do a request to an invalid URL, e.g. `https://`, then the following error was shown:

<img src="https://github.com/usebruno/bruno/assets/239058/d9a0a049-a96e-4ec8-859a-8988dcaf6db8" width="600px" />

With this fix the actual error is shown:

<img src="https://github.com/usebruno/bruno/assets/239058/9aa27107-0576-4a8b-8815-cf90368c5ede" width="600px" />

