### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,18 +5,16 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  test:
+  tests:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - name: Check package-lock.json
-        run: npm ci
+          node-version-file: '.nvmrc'
       - name: Install dependencies
-        run: npm i --legacy-peer-deps
+        run: npm ci --legacy-peer-deps
       - name: Test Package bruno-query
         run: npm run test --workspace=packages/bruno-query
       - name: Build Package bruno-query
@@ -33,3 +31,15 @@ jobs:
         run: npm run test --workspace=packages/bruno-cli
       - name: Test Package bruno-electron
         run: npm run test --workspace=packages/bruno-electron
+
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Run Prettier
+        run: npm run test:prettier:web

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build:electron": "./scripts/build-electron.sh",
     "test:e2e": "npx playwright test",
     "test:report": "npx playwright show-report",
+    "test:prettier:web": "npm run test:prettier --workspace=packages/bruno-app",
     "prepare": "husky install"
   },
   "overrides": {

--- a/packages/bruno-app/package.json
+++ b/packages/bruno-app/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
+    "test:prettier": "prettier --check \"./src/**/*.{js,jsx,json,ts,tsx}\"",
     "prettier": "prettier --write \"./src/**/*.{js,jsx,json,ts,tsx}\""
   },
   "dependencies": {


### PR DESCRIPTION
- jump to `actions/checkout` v4 (latest version)
- retrieve node version from NVM instead of hard-coded
- add a new job to run prettier (in case people skip pre-commit hook)