### PR TITLE
Shorten method name in sidebar

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.js
@@ -23,7 +23,9 @@ const RequestMethod = ({ item }) => {
   return (
     <StyledWrapper>
       <div className={getClassname(item.request.method)}>
-        <span className="uppercase">{item.request.method}</span>
+        <span className="uppercase">
+          {item.request.method.length > 4 ? item.request.method.substring(0, 3) : item.request.method}
+        </span>
       </div>
     </StyledWrapper>
   );


### PR DESCRIPTION
fixes: #533 

If a method length in greater than 4, sidebar shows only starting 3 character


![fix 533(2)](https://github.com/usebruno/bruno/assets/48991799/444f89e5-dd66-47d1-89a4-fe068c0f6776)
