### PR TITLE
fix(#529): Fix Ctrl+W closes Bruno

### DIFF
--- a/packages/bruno-electron/src/app/menu-template.js
+++ b/packages/bruno-electron/src/app/menu-template.js
@@ -44,7 +44,7 @@ const template = [
   },
   {
     role: 'window',
-    submenu: [{ role: 'minimize' }, { role: 'close' }]
+    submenu: [{ role: 'minimize' }, { role: 'close', accelerator: 'CommandOrControl+Shift+Q' }]
   },
   {
     role: 'help',


### PR DESCRIPTION
The default shortcut to close in the menu is Ctrl+W, I changed it to Ctrl+Shift+Q because Firefox uses this shortcut for closing