### PR TITLE
Add RPM linux build target

### DIFF
--- a/packages/bruno-electron/.gitignore
+++ b/packages/bruno-electron/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 web
 out
+dist
 .env
 
 // certs

--- a/packages/bruno-electron/electron-builder-config.js
+++ b/packages/bruno-electron/electron-builder-config.js
@@ -1,55 +1,44 @@
 require('dotenv').config({ path: process.env.DOTENV_PATH });
 
 const config = {
-  "appId": "com.usebruno.app",
-  "productName": "Bruno",
-  "electronVersion": "21.1.1",
-  "directories": {
-    "buildResources": "resources",
-    "output": "out"
+  appId: 'com.usebruno.app',
+  productName: 'Bruno',
+  electronVersion: '21.1.1',
+  directories: {
+    buildResources: 'resources',
+    output: 'out'
   },
-  "files": [
-    "**/*"
-  ],
-  "afterSign": "notarize.js",
-  "mac": {
-    "artifactName": "${name}_${version}_${arch}_${os}.${ext}",
-    "category": "public.app-category.developer-tools",
-    "target": [
+  files: ['**/*'],
+  afterSign: 'notarize.js',
+  mac: {
+    artifactName: '${name}_${version}_${arch}_${os}.${ext}',
+    category: 'public.app-category.developer-tools',
+    target: [
       {
-        "target": "dmg",
-        "arch": [
-          "x64",
-          "arm64"
-        ]
+        target: 'dmg',
+        arch: ['x64', 'arm64']
       },
       {
-        "target": "zip",
-        "arch": [
-          "x64",
-          "arm64"
-        ]
+        target: 'zip',
+        arch: ['x64', 'arm64']
       }
     ],
-    "icon": "resources/icons/mac/icon.icns",
-    "hardenedRuntime": true,
-    "identity": "Anoop MD (W7LPPWA48L)",
-    "entitlements": "resources/entitlements.mac.plist",
-    "entitlementsInherit": "resources/entitlements.mac.plist"
+    icon: 'resources/icons/mac/icon.icns',
+    hardenedRuntime: true,
+    identity: 'Anoop MD (W7LPPWA48L)',
+    entitlements: 'resources/entitlements.mac.plist',
+    entitlementsInherit: 'resources/entitlements.mac.plist'
   },
-  "linux": {
-    "artifactName": "${name}_${version}_${arch}_linux.${ext}",
-    "icon": "resources/icons/png",
-    "target": [
-      "AppImage",
-      "deb"
-    ]
+  linux: {
+    artifactName: '${name}_${version}_${arch}_linux.${ext}',
+    icon: 'resources/icons/png',
+    target: ['AppImage', 'deb', 'rpm']
   },
-  "win": {
-    "artifactName": "${name}_${version}_${arch}_win.${ext}",
-    "icon": "resources/icons/png",
-    "certificateFile": `${process.env.WIN_CERT_FILEPATH}`,
-    "certificatePassword": `${process.env.WIN_CERT_PASSWORD}`,
+  win: {
+    artifactName: '${name}_${version}_${arch}_win.${ext}',
+    icon: 'resources/icons/png',
+    certificateFile: `${process.env.WIN_CERT_FILEPATH}`,
+    certificatePassword: `${process.env.WIN_CERT_PASSWORD}`
   }
 };
 


### PR DESCRIPTION
Adds RPM as a Linux target to the electron-builder config.
The output is a `bruno_%version%_x86_64_linux.rpm` file in the `packages/bruno-electron/out` directory.
Resolves #230.