### PR TITLE
fix(bruno-cli): add missing variable to `prepareRequest`

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -30,7 +30,7 @@ const runSingleRequest = async function (
   try {
     let request;
 
-    request = prepareRequest(bruJson.request);
+    request = prepareRequest(bruJson.request, collectionRoot);
 
     const scriptingConfig = get(brunoConfig, 'scripts', {});
 


### PR DESCRIPTION
Due to missing variable while calling `prepareRequest()` auth from `collection.bru` was not added to the request during `bru run`. 

Is a reproduction of the bug needed?