### PR TITLE
feat(utils): improve normalizeFileName to support Unicode characters

### DIFF
--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -68,10 +68,9 @@ export const normalizeFileName = (name) => {
     return name;
   }
 
-  const validChars = /[^\w\s-]/g;
-  const formattedName = name.replace(validChars, '-');
-
-  return formattedName;
+  // Use Unicode character classes to match alphanumeric characters, spaces, hyphens, and underscores
+  const validChars = new RegExp('[^\\p{L}\\p{M}\\p{N}\\s_-]', 'gu');
+  return name.replace(validChars, '-');
 };
 
 export const getContentType = (headers) => {

--- a/packages/bruno-app/src/utils/common/index.spec.js
+++ b/packages/bruno-app/src/utils/common/index.spec.js
@@ -15,5 +15,16 @@ describe('common utils', () => {
       expect(normalizeFileName('foo/bar/')).toBe('foo-bar-');
       expect(normalizeFileName('foo\\bar\\')).toBe('foo-bar-');
     });
+    it('should support unicode', () => {
+      // more unicode languages
+      expect(normalizeFileName('你好世界!?@#$%^&*()')).toBe('你好世界-----------');
+      expect(normalizeFileName('こんにちは世界!?@#$%^&*()')).toBe('こんにちは世界-----------');
+      expect(normalizeFileName('안녕하세요 세계!?@#$%^&*()')).toBe('안녕하세요 세계-----------');
+      expect(normalizeFileName('مرحبا بالعالم!?@#$%^&*()')).toBe('مرحبا بالعالم-----------');
+      expect(normalizeFileName('Здравствуй мир!?@#$%^&*()')).toBe('Здравствуй мир-----------');
+      expect(normalizeFileName('नमस्ते दुनिया!?@#$%^&*()')).toBe('नमस्ते दुनिया-----------');
+      expect(normalizeFileName('สวัสดีชาวโลก!?@#$%^&*()')).toBe('สวัสดีชาวโลก-----------');
+      expect(normalizeFileName('γειά σου κόσμος!?@#$%^&*()')).toBe('γειά σου κόσμος-----------');
+    });
   });
 });


### PR DESCRIPTION
This PR improves the `normalizeFileName` function in the `utils` package to support Unicode characters. Previously, the function could not correctly handle file names with Unicode characters. This update allows it to correctly replace non-alphanumeric, non-space, non-hyphen, and non-underscore characters in any language with a hyphen.

Changes include:
- Updating the `normalizeFileName` function to use a RegExp that supports Unicode characters.
- Adding tests for `normalizeFileName` with various Unicode languages.

This enhancement will allow our application to handle file names in any language, improving its usability for non-English users.