### PR TITLE
assert operator dropdown bgcolor fix

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import { useTheme } from 'providers/Theme/index';
+import darkTheme from 'themes/dark';
+import lightTheme from 'themes/light';
 
 /**
  * Assertion operators
@@ -76,10 +79,16 @@ const AssertionOperator = ({ operator, onChange }) => {
     }
   };
 
+  const { storedTheme } = useTheme();
+
   return (
     <select value={operator} onChange={handleChange} className="mousetrap">
       {operators.map((operator) => (
-        <option key={operator} value={operator}>
+        <option
+          style={{ backgroundColor: storedTheme === 'dark' ? darkTheme.bg : lightTheme.bg }}
+          key={operator}
+          value={operator}
+        >
           {getLabel(operator)}
         </option>
       ))}


### PR DESCRIPTION
In dark mode assert operator dropdown background color was not changing to dark
before:
![before](https://github.com/usebruno/bruno/assets/76877078/1d75e3bb-3593-4481-b9ab-d231bbeacd2e)

after:
![after](https://github.com/usebruno/bruno/assets/76877078/66bafe88-f323-441e-a0d6-01d4baecbd84)
