### PR TITLE
feat: add button to clear collection search

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/index.js
@@ -5,7 +5,8 @@ import {
   IconFolders,
   IconArrowsSort,
   IconSortAscendingLetters,
-  IconSortDescendingLetters
+  IconSortDescendingLetters,
+  IconX
 } from '@tabler/icons';
 import Collection from '../Collections/Collection';
 import CreateCollection from '../CreateCollection';
@@ -97,8 +98,20 @@ const Collections = () => {
           spellCheck="false"
           className="block w-full pl-7 py-1 sm:text-sm"
           placeholder="search"
+          value={searchText}
           onChange={(e) => setSearchText(e.target.value.toLowerCase())}
         />
+        {searchText !== '' && (
+          <div className="absolute inset-y-0 right-0 pr-4 flex items-center">
+            <span
+              onClick={() => {
+                setSearchText('');
+              }}
+            >
+              <IconX size={16} strokeWidth={1.5} />
+            </span>
+          </div>
+        )}
       </div>
 
       <div className="mt-4 flex flex-col overflow-y-auto absolute top-32 bottom-10 left-0 right-0">


### PR DESCRIPTION
This PR will add a small clear button in the collection search field to quickly delete the input. Previously it was required that the input field was either cleared character for character or by selecting the input and hit backspace. This is a small QoL feature.

![23-10-13_17-33-25_electron](https://github.com/usebruno/bruno/assets/31533186/f0a52e7f-f87a-4e50-93c0-bf840fca4643)
