### PR TITLE
Shorten method name for OPTIONS and DELETE

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.js
@@ -23,7 +23,9 @@ const RequestMethod = ({ item }) => {
   return (
     <StyledWrapper>
       <div className={getClassname(item.request.method)}>
-        <span className="uppercase">{item.request.method}</span>
+        <span className="uppercase">
+          {item.request.method.length > 5 ? item.request.method.substring(0, 3) : item.request.method}
+        </span>
       </div>
     </StyledWrapper>
   );


### PR DESCRIPTION
fixes #584 

The fix shorten the method name to only starting 3 characters which have length greater than 5

Below is the screenshot for how it looks


![fix584](https://github.com/usebruno/bruno/assets/48991799/da3b4749-87fd-4b8c-add4-0e5ab38c21b0)
