### PR TITLE
fix: event mouse up triggered when hold mouse click at anywhere and release at sidebar

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -88,44 +88,41 @@ const CollectionItem = ({ item, collection, searchText }) => {
   });
 
   const handleClick = (event) => {
-    switch (event.button) {
-      case 0: // left click
-        if (isItemARequest(item)) {
-          dispatch(hideHomePage());
-          if (itemIsOpenedInTabs(item, tabs)) {
-            dispatch(
-              focusTab({
-                uid: item.uid
-              })
-            );
-            return;
-          }
-          dispatch(
-            addTab({
-              uid: item.uid,
-              collectionUid: collection.uid,
-              requestPaneTab: getDefaultRequestPaneTab(item)
-            })
-          );
-          return;
-        }
+    if (isItemARequest(item)) {
+      dispatch(hideHomePage());
+      if (itemIsOpenedInTabs(item, tabs)) {
         dispatch(
-          collectionFolderClicked({
-            itemUid: item.uid,
-            collectionUid: collection.uid
+          focusTab({
+            uid: item.uid
           })
         );
         return;
-      case 2: // right click
-        const _menuDropdown = dropdownTippyRef.current;
-        if (_menuDropdown) {
-          let menuDropdownBehavior = 'show';
-          if (_menuDropdown.state.isShown) {
-            menuDropdownBehavior = 'hide';
-          }
-          _menuDropdown[menuDropdownBehavior]();
-        }
-        return;
+      }
+      dispatch(
+        addTab({
+          uid: item.uid,
+          collectionUid: collection.uid,
+          requestPaneTab: getDefaultRequestPaneTab(item)
+        })
+      );
+      return;
+    }
+    dispatch(
+      collectionFolderClicked({
+        itemUid: item.uid,
+        collectionUid: collection.uid
+      })
+    );
+  };
+
+  const handleRightClick = (event) => {
+    const _menuDropdown = dropdownTippyRef.current;
+    if (_menuDropdown) {
+      let menuDropdownBehavior = 'show';
+      if (_menuDropdown.state.isShown) {
+        menuDropdownBehavior = 'hide';
+      }
+      _menuDropdown[menuDropdownBehavior]();
     }
   };
 
@@ -203,7 +200,8 @@ const CollectionItem = ({ item, collection, searchText }) => {
             ? indents.map((i) => {
                 return (
                   <div
-                    onMouseUp={handleClick}
+                    onClick={handleClick}
+                    onContextMenu={handleRightClick}
                     onDoubleClick={handleDoubleClick}
                     className="indent-block"
                     key={i}
@@ -219,7 +217,8 @@ const CollectionItem = ({ item, collection, searchText }) => {
               })
             : null}
           <div
-            onMouseUp={handleClick}
+            onClick={handleClick}
+            onContextMenu={handleRightClick}
             onDoubleClick={handleDoubleClick}
             className="flex flex-grow items-center h-full overflow-hidden"
             style={{

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -66,20 +66,17 @@ const Collection = ({ collection, searchText }) => {
   });
 
   const handleClick = (event) => {
+    dispatch(collectionClicked(collection.uid));
+  };
+
+  const handleRightClick = (event) => {
     const _menuDropdown = menuDropdownTippyRef.current;
-    switch (event.button) {
-      case 0: // left click
-        dispatch(collectionClicked(collection.uid));
-        return;
-      case 2: // right click
-        if (_menuDropdown) {
-          let menuDropdownBehavior = 'show';
-          if (_menuDropdown.state.isShown) {
-            menuDropdownBehavior = 'hide';
-          }
-          _menuDropdown[menuDropdownBehavior]();
-        }
-        return;
+    if (_menuDropdown) {
+      let menuDropdownBehavior = 'show';
+      if (_menuDropdown.state.isShown) {
+        menuDropdownBehavior = 'hide';
+      }
+      _menuDropdown[menuDropdownBehavior]();
     }
   };
 
@@ -138,7 +135,11 @@ const Collection = ({ collection, searchText }) => {
         <CollectionProperties collection={collection} onClose={() => setCollectionPropertiesModal(false)} />
       )}
       <div className="flex py-1 collection-name items-center" ref={drop}>
-        <div className="flex flex-grow items-center overflow-hidden" onMouseUp={handleClick}>
+        <div
+          className="flex flex-grow items-center overflow-hidden"
+          onClick={handleClick}
+          onContextMenu={handleRightClick}
+        >
           <IconChevronRight
             size={16}
             strokeWidth={2}


### PR DESCRIPTION
# Description
Fix for issue #509 also reworking for PR #537. This PR separate function left click and right click functionality to prevent event mouse up fired up when user hold mouse click and release the hold at sidebar component.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
