### PR TITLE
Feature (#550): JSON body request prettify

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -6,12 +6,15 @@ import { useDispatch } from 'react-redux';
 import { updateRequestBodyMode } from 'providers/ReduxStore/slices/collections';
 import { humanizeRequestBodyMode } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
+import { updateRequestBody } from 'providers/ReduxStore/slices/collections/index';
+import { toastError } from 'utils/common/error';
 
 const RequestBodyMode = ({ item, collection }) => {
   const dispatch = useDispatch();
   const dropdownTippyRef = useRef();
   const onDropdownCreate = (ref) => (dropdownTippyRef.current = ref);
-  const bodyMode = item.draft ? get(item, 'draft.request.body.mode') : get(item, 'request.body.mode');
+  const body = item.draft ? get(item, 'draft.request.body') : get(item, 'request.body');
+  const bodyMode = body?.mode;
 
   const Icon = forwardRef((props, ref) => {
     return (
@@ -29,6 +32,24 @@ const RequestBodyMode = ({ item, collection }) => {
         mode: value
       })
     );
+  };
+
+  const onPrettify = () => {
+    if (body?.json && bodyMode === 'json') {
+      try {
+        const bodyJson = JSON.parse(body.json);
+        const prettyBodyJson = JSON.stringify(bodyJson, null, 2);
+        dispatch(
+          updateRequestBody({
+            content: prettyBodyJson,
+            itemUid: item.uid,
+            collectionUid: collection.uid
+          })
+        );
+      } catch (e) {
+        toastError(new Error('Unable to prettify. Invalid JSON format.'));
+      }
+    }
   };
 
   return (
@@ -103,6 +124,11 @@ const RequestBodyMode = ({ item, collection }) => {
           </div>
         </Dropdown>
       </div>
+      {bodyMode === 'json' && (
+        <button className="ml-1" onClick={onPrettify}>
+          Prettify
+        </button>
+      )}
     </StyledWrapper>
   );
 };


### PR DESCRIPTION
# Description
This PR implements the prettify feature on the request body mode JSON
https://github.com/usebruno/bruno/assets/9076885/3a4812a4-07a7-4951-b564-a84c0d0663c7

the bru file save as
```
body:json {
  {
    "foo": 1,
    "bar": "test",
    "bad": 1
  }
}
```

solved #550

[![]()](https://github.com/usebruno/bruno/assets/9076885/3a4812a4-07a7-4951-b564-a84c0d0663c7
)

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
