### PR TITLE
Adds variable interpolate to assert runtime

### DIFF
--- a/packages/bruno-js/src/interpolate-string.js
+++ b/packages/bruno-js/src/interpolate-string.js
@@ -1,0 +1,55 @@
+const Handlebars = require('handlebars');
+const { forOwn, cloneDeep } = require('lodash');
+
+const interpolateEnvVars = (str, processEnvVars) => {
+  if (!str || !str.length || typeof str !== 'string') {
+    return str;
+  }
+
+  const template = Handlebars.compile(str, { noEscape: true });
+
+  return template({
+    process: {
+      env: {
+        ...processEnvVars
+      }
+    }
+  });
+};
+
+const interpolateString = (str, { envVars, collectionVariables, processEnvVars }) => {
+  if (!str || !str.length || typeof str !== 'string') {
+    return str;
+  }
+
+  processEnvVars = processEnvVars || {};
+  collectionVariables = collectionVariables || {};
+
+  // we clone envVars because we don't want to modify the original object
+  envVars = envVars ? cloneDeep(envVars) : {};
+
+  // envVars can inturn have values as {{process.env.VAR_NAME}}
+  // so we need to interpolate envVars first with processEnvVars
+  forOwn(envVars, (value, key) => {
+    envVars[key] = interpolateEnvVars(value, processEnvVars);
+  });
+
+  const template = Handlebars.compile(str, { noEscape: true });
+
+  // collectionVariables take precedence over envVars
+  const combinedVars = {
+    ...envVars,
+    ...collectionVariables,
+    process: {
+      env: {
+        ...processEnvVars
+      }
+    }
+  };
+
+  return template(combinedVars);
+};
+
+module.exports = {
+  interpolateString
+};

--- a/packages/bruno-js/src/runtime/assert-runtime.js
+++ b/packages/bruno-js/src/runtime/assert-runtime.js
@@ -4,6 +4,7 @@ const { nanoid } = require('nanoid');
 const Bru = require('../bru');
 const BrunoRequest = require('../bruno-request');
 const { evaluateJsTemplateLiteral, evaluateJsExpression, createResponseParser } = require('../utils');
+const { interpolateString } = require('../interpolate-string');
 
 const { expect } = chai;
 chai.use(require('chai-string'));
@@ -167,11 +168,15 @@ const evaluateRhsOperand = (rhsOperand, operator, context) => {
       rhsOperand = rhsOperand.substring(1, rhsOperand.length - 1);
     }
 
-    return rhsOperand.split(',').map((v) => evaluateJsTemplateLiteral(v.trim(), context));
+    return rhsOperand
+      .split(',')
+      .map((v) => evaluateJsTemplateLiteral(interpolateString(v.trim(), context.bru), context));
   }
 
   if (operator === 'between') {
-    const [lhs, rhs] = rhsOperand.split(',').map((v) => evaluateJsTemplateLiteral(v.trim(), context));
+    const [lhs, rhs] = rhsOperand
+      .split(',')
+      .map((v) => evaluateJsTemplateLiteral(interpolateString(v.trim(), context.bru), context));
     return [lhs, rhs];
   }
 
@@ -181,10 +186,10 @@ const evaluateRhsOperand = (rhsOperand, operator, context) => {
       rhsOperand = rhsOperand.substring(1, rhsOperand.length - 1);
     }
 
-    return rhsOperand;
+    return interpolateString(rhsOperand, context.bru);
   }
 
-  return evaluateJsTemplateLiteral(rhsOperand, context);
+  return evaluateJsTemplateLiteral(interpolateString(rhsOperand, context.bru), context);
 };
 
 class AssertRuntime {


### PR DESCRIPTION
# Description
Adds interpolation to variable runtime as it was missing from there. Fixes #624

> NOTE! i copied interpolate-string.js from bruno-cli. I would've required interpolateString function from bruno-cli but that would've caused depenceny cycle. My suggestion is to move all interpolate files to bruno-js and then require those to bruno-cli and other packages from there.

# Before

![](https://user-images.githubusercontent.com/13645181/275713870-b0c7094a-7631-439f-998c-a73acad383e5.png)
![](https://user-images.githubusercontent.com/13645181/275713883-c8996d3d-a9da-4447-b9e7-3951cf57b429.png)

# After
![image](https://github.com/usebruno/bruno/assets/13645181/2ae0e80d-aa49-4863-82ab-342137dd6966)
![image](https://github.com/usebruno/bruno/assets/13645181/ac2b96bd-1291-4958-a752-1c0634d976f1)


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
