### PR TITLE
feat: add collection name to remove dialog

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
@@ -18,7 +18,7 @@ const RemoveCollection = ({ onClose, collection }) => {
 
   return (
     <Modal size="sm" title="Remove Collection" confirmText="Remove" handleConfirm={onConfirm} handleCancel={onClose}>
-      Are you sure you want to remove this collection?
+      Are you sure you want to delete collection <span className="font-semibold">{collection.name}</span> ?
     </Modal>
   );
 };


### PR DESCRIPTION
# Description
Simply adds the name of the collection to the confirmation dialog.

## Before
![image](https://github.com/usebruno/bruno/assets/213920/36956d8d-15f9-4abd-a804-ca0851285b9f)

## After
![image](https://github.com/usebruno/bruno/assets/213920/5ba65e05-fad3-4f41-b356-8dead571382b)


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** https://github.com/usebruno/bruno/issues/638
