### PR TITLE
Fixes #637: autofill folder name as collection name

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -76,7 +76,14 @@ const CreateCollection = ({ onClose }) => {
             name="collectionName"
             ref={inputRef}
             className="block textbox mt-2 w-full"
-            onChange={formik.handleChange}
+            onChange = {
+                (e) => {
+                    formik.handleChange(e);
+                    if (formik.values.collectionName === formik.values.collectionFolderName) {
+                        formik.setFieldValue("collectionFolderName", e.target.value);
+                    }
+                }
+            }
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"


### PR DESCRIPTION
# Description
- Autofill folder name to be the same as collection name as and when the user types in the collection name.
- In order to improve user experience further, once the user consciously updates the folder name, and then comes back to update the collection name, this time around, folder name is not updated automatically.
- Fixes issue https://github.com/usebruno/bruno/issues/637

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
