### PR TITLE
Fix #646: show exact response size in bytes on mouse hover

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseSize/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseSize/index.js
@@ -13,6 +13,10 @@ const ResponseSize = ({ size }) => {
     sizeToDisplay = size + 'B';
   }
 
-  return <StyledWrapper className="ml-4">{sizeToDisplay}</StyledWrapper>;
+  return (
+    <StyledWrapper title={size.toLocaleString() + 'B'} className="ml-4">
+      {sizeToDisplay}
+    </StyledWrapper>
+  );
 };
 export default ResponseSize;


### PR DESCRIPTION
This PR just adds a title to the ResponseSize component, showing the size in bytes, in addition to human-readable KB and MB.