### PR TITLE
feat: use client certificates and proxy for fetching graphql schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16717,7 +16717,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v0.24.0",
+      "version": "v0.25.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.425.0",
         "@usebruno/js": "0.8.0",

--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
@@ -36,12 +36,7 @@ const GraphQLRequestPane = ({ item, collection, leftPaneWidth, onSchemaLoad, tog
 
   const request = item.draft ? item.draft.request : item.request;
 
-  let {
-    schema,
-    loadSchema,
-    isLoading: isSchemaLoading,
-    error: schemaError
-  } = useGraphqlSchema(url, environment, request, collection);
+  let { schema, loadSchema, isLoading: isSchemaLoading } = useGraphqlSchema(url, environment, request, collection);
 
   const loadGqlSchema = () => {
     if (!isSchemaLoading) {

--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/useGraphqlSchema.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/useGraphqlSchema.js
@@ -26,7 +26,12 @@ const useGraphqlSchema = (endpoint, environment, request, collection) => {
   const loadSchema = () => {
     setIsLoading(true);
     fetchGqlSchema(endpoint, environment, request, collection)
-      .then((res) => res.data)
+      .then((res) => {
+        if (!res || res.status !== 200) {
+          return Promise.reject(new Error(res.statusText));
+        }
+        return res.data;
+      })
       .then((s) => {
         if (s && s.data) {
           setSchema(buildClientSchema(s.data));
@@ -40,7 +45,7 @@ const useGraphqlSchema = (endpoint, environment, request, collection) => {
       .catch((err) => {
         setIsLoading(false);
         setError(err);
-        toast.error('Error occurred while loading GraphQL Schema');
+        toast.error(`Error occurred while loading GraphQL Schema: ${err.message}`);
       });
   };
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -486,7 +486,14 @@ const registerNetworkIpc = (mainWindow) => {
       const processEnvVars = getProcessEnvVars(collection.uid);
       interpolateVars(preparedRequest, envVars, collection.collectionVariables, processEnvVars);
 
-      const response = await axios(preparedRequest);
+      const axiosInstance = await configureRequest(
+        collection.uid,
+        preparedRequest,
+        envVars,
+        collection.collectionVariables,
+        processEnvVars
+      );
+      const response = await axiosInstance(preparedRequest);
 
       return {
         status: response.status,


### PR DESCRIPTION
# Description

Currently the requests to fetch GraphQL schemas does not use the recently introduced client certificates or any configured proxy. This change enables that :)
In addition I added any occured error to the toast, I am not 100% certain about that as it could result in a quite long toast. On the other hand it left me wondering when the request failed without any notice what went wrong... 

<img width="404" alt="image" src="https://github.com/usebruno/bruno/assets/8899636/367b24e5-4716-4dac-a6fd-bf3789c594f9">

<img width="354" alt="image" src="https://github.com/usebruno/bruno/assets/8899636/7bd38463-14c2-48de-86d9-d46eaefa8632">

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
