### PR TITLE
adjust styles on environment dropdown and modal

### DIFF
--- a/packages/bruno-app/src/components/Dropdown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Dropdown/StyledWrapper.js
@@ -14,6 +14,8 @@ const Wrapper = styled.div`
     background-color: ${(props) => props.theme.dropdown.bg};
     box-shadow: ${(props) => props.theme.dropdown.shadow};
     border-radius: 3px;
+    max-height: 90vh;
+    overflow-y: auto;
 
     .tippy-content {
       padding-left: 0;

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/StyledWrapper.js
@@ -10,7 +10,8 @@ const StyledWrapper = styled.div`
     background-color: ${(props) => props.theme.collection.environment.settings.sidebar.bg};
     border-right: solid 1px ${(props) => props.theme.collection.environment.settings.sidebar.borderRight};
     min-height: 400px;
-    height: 100%;
+    max-height: 85vh;
+    overflow-y: auto;
   }
 
   .environment-item {


### PR DESCRIPTION
# Description

Adds an overflow for the environment dropdown and modal so they don't expand beyond the bottom of the app window

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

Before:
![image](https://github.com/usebruno/bruno/assets/7117256/c440a428-9ec5-486b-a4a9-8f4bb7359e73)
![image](https://github.com/usebruno/bruno/assets/7117256/9632278b-5f62-4069-8c6d-bc68a2f58f76)

After:
![image](https://github.com/usebruno/bruno/assets/7117256/e02d6821-d924-4429-a3d8-2f4e889f2c18)
![image](https://github.com/usebruno/bruno/assets/7117256/9ca36111-316e-431a-a2c7-7500e82f6cca)
