### PR TITLE
sanitize the imported environment filename before writing it to disk

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -141,7 +141,8 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
         await createDirectory(envDirPath);
       }
 
-      const envFilePath = path.join(envDirPath, `${name}.bru`);
+      const filename = name.replace(/[^a-z0-9]/gi, '-').toLowerCase();
+      const envFilePath = path.join(envDirPath, `${filename}.bru`);
       if (fs.existsSync(envFilePath)) {
         throw new Error(`environment: ${envFilePath} already exists`);
       }


### PR DESCRIPTION
# Description

Currently if the environment name has a bad character (like /) in it then it fails to write to the filesystem. I'm proposing this however I don't think this is functional to merge because of #663 right now. The Environment name on the UI ends up being the filename and it really should be a name stored in the environment file and not just the filename.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
