### PR TITLE
fix #571 - allow newlines and encode uri form data

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
@@ -107,6 +107,7 @@ const FormUrlEncodedParams = ({ item, collection }) => {
                             'value'
                           )
                         }
+                        allowNewlines={true}
                         onRun={handleRun}
                         collection={collection}
                       />

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -57,6 +57,7 @@ class SingleLineEditor extends Component {
   }
   componentDidMount() {
     // Initialize CodeMirror as a single line editor
+    /** @type {import("codemirror").Editor} */
     this.editor = CodeMirror(this.editorRef.current, {
       lineWrapping: false,
       lineNumbers: false,
@@ -84,7 +85,10 @@ class SingleLineEditor extends Component {
           }
         },
         'Alt-Enter': () => {
-          if (this.props.onRun) {
+          if (this.props.allowNewlines) {
+            this.editor.setValue(this.editor.getValue() + '\n');
+            this.editor.setCursor({ line: this.editor.lineCount(), ch: 0 });
+          } else if (this.props.onRun) {
             this.props.onRun();
           }
         },

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -104,7 +104,7 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
   }
   return _.map(pairList[0], (pair) => {
     let name = _.keys(pair)[0];
-    let value = pair[name];
+    let value = decodeURIComponent(pair[name]);
 
     if (!parseEnabled) {
       return {

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -154,7 +154,7 @@ ${indentString(body.sparql)}
     if (enabled(body.formUrlEncoded).length) {
       bru += `\n${indentString(
         enabled(body.formUrlEncoded)
-          .map((item) => `${item.name}: ${item.value}`)
+          .map((item) => `${item.name}: ${encodeURIComponent(item.value)}`)
           .join('\n')
       )}`;
     }
@@ -162,7 +162,7 @@ ${indentString(body.sparql)}
     if (disabled(body.formUrlEncoded).length) {
       bru += `\n${indentString(
         disabled(body.formUrlEncoded)
-          .map((item) => `~${item.name}: ${item.value}`)
+          .map((item) => `~${item.name}: ${encodeURIComponent(item.value)}`)
           .join('\n')
       )}`;
     }


### PR DESCRIPTION
# Description

Fix #571 

- Allow newlines in form URL encoded bodies using `ALT + ENTER`
- Allow any character in the parameter values by:
  - encoding parameter values of the body before saving
  - decoding parameter values of the body after loading

## Usage
![571-fix](https://github.com/usebruno/bruno/assets/15342503/cedfd6b0-b89a-44fd-85fa-1d1d23b8bac1)
- Use `ALT + ENTER` to create a newline
- Use any character in the request

## Bruno file without fix
```
meta {
  name: Test
  type: http
  seq: 1
}

post {
  url: https://bruno-tester.requestcatcher.com/
  body: formUrlEncoded
  auth: none
}

body:form-urlencoded {
  test: 123:456
  789
}
```

## Bruno file from the GIF (with fix)
```
meta {
  name: Test
  type: http
  seq: 1
}

post {
  url: https://bruno-tester.requestcatcher.com/
  body: formUrlEncoded
  auth: none
}

body:form-urlencoded {
  test: 123%3A456%0A789
}
```

**Response Body:**
```
test=123%3A456%0A789
```

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
