### PR TITLE
fix: overflowing code editor

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -5,6 +5,7 @@ const StyledWrapper = styled.div`
     background: ${(props) => props.theme.codemirror.bg};
     border: solid 1px ${(props) => props.theme.codemirror.border};
     font-family: ${(props) => (props.font ? props.font : 'default')};
+    line-break: anywhere;
   }
 
   .CodeMirror-overlayscroll-horizontal div,


### PR DESCRIPTION
# Description

(fixes: https://github.com/usebruno/bruno/issues/693)

This PR fixes the overflow issue by forcing line breaks through CSS:

| Before | After |
|---|---|
| <img width="1392" alt="overflowing-code-editor" src="https://github.com/usebruno/bruno/assets/68591/04a4627a-bf78-433a-a28b-69d60e0a9633"> | <img width="1392" alt="fixed-code-editor" src="https://github.com/usebruno/bruno/assets/68591/bb69472b-542e-48eb-9f50-efb2ea6e7038"> |

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
