### PR TITLE
feat: run prerequest/postresponse actions when fetching gql schema

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -514,8 +514,25 @@ const registerNetworkIpc = (mainWindow) => {
         });
       }
 
-      const processEnvVars = getProcessEnvVars(collection.uid);
-      interpolateVars(preparedRequest, envVars, collection.collectionVariables, processEnvVars);
+      const requestUid = uuid();
+      const collectionPath = collection.pathname;
+      const collectionUid = collection.uid;
+      const collectionVariables = collection.collectionVariables;
+      const processEnvVars = getProcessEnvVars(collectionUid);
+      const brunoConfig = getBrunoConfig(collection.uid);
+      const scriptingConfig = get(brunoConfig, 'scripts', {});
+
+      await runPreRequest(
+        request,
+        requestUid,
+        envVars,
+        collectionPath,
+        collectionRoot,
+        collectionUid,
+        collectionVariables,
+        processEnvVars,
+        scriptingConfig
+      );
 
       const axiosInstance = await configureRequest(
         collection.uid,

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -569,6 +569,19 @@ const registerNetworkIpc = (mainWindow) => {
       );
       const response = await axiosInstance(preparedRequest);
 
+      await runPostResponse(
+        request,
+        response,
+        requestUid,
+        envVars,
+        collectionPath,
+        collectionRoot,
+        collectionUid,
+        collectionVariables,
+        processEnvVars,
+        scriptingConfig
+      );
+
       return {
         status: response.status,
         statusText: response.statusText,

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -137,6 +137,15 @@ const prepareRequest = (request, collectionRoot) => {
     each(enabledParams, (p) => (params[p.name] = p.value));
     axiosRequest.headers['content-type'] = 'multipart/form-data';
     axiosRequest.data = params;
+
+    // make axios work in node using form data
+    // reference: https://github.com/axios/axios/issues/1006#issuecomment-320165427
+    const form = new FormData();
+    forOwn(axiosRequest.data, (value, key) => {
+      form.append(key, value);
+    });
+    extend(axiosRequest.headers, form.getHeaders());
+    axiosRequest.data = form;
   }
 
   if (request.body.mode === 'graphql') {


### PR DESCRIPTION
This PR addresses the following feature request:
* https://github.com/usebruno/bruno/issues/704

It automatically runs the usual pre-request and post-response code (vars and scripts) when fetching the GQL schema. It also tries to consolidate some of the relevant code to make re-use more manageable.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**