### PR TITLE
Add most common request url as initial in new req

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -11,16 +11,18 @@ import { addTab } from 'providers/ReduxStore/slices/tabs';
 import HttpMethodSelector from 'components/RequestPane/QueryUrl/HttpMethodSelector';
 import { getDefaultRequestPaneTab } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
+import { getMostCommonUrlFromCollection } from 'utils/collections/index';
 
 const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
   const dispatch = useDispatch();
   const inputRef = useRef();
+  const commonUrl = getMostCommonUrlFromCollection(collection);
   const formik = useFormik({
     enableReinitialize: true,
     initialValues: {
       requestName: '',
       requestType: 'http-request',
-      requestUrl: '',
+      requestUrl: commonUrl,
       requestMethod: 'GET'
     },
     validationSchema: Yup.object({

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -8,6 +8,14 @@ import filter from 'lodash/filter';
 import sortBy from 'lodash/sortBy';
 import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
+import head from 'lodash/head';
+import flow from 'lodash/flow';
+import countBy from 'lodash/countBy';
+import maxBy from 'lodash/maxBy';
+import last from 'lodash/last';
+import partialRight from 'lodash/partialRight';
+import entries from 'lodash/entries';
+
 import { uuid } from 'utils/common';
 import path from 'path';
 
@@ -603,4 +611,25 @@ export const getAllVariables = (collection) => {
       }
     }
   };
+};
+
+export const getRequestsUrlsFromItems = (items) => {
+  const urls = [];
+  each(items, (item) => {
+    if (isItemARequest(item) && item['request']?.url) {
+      urls.push(item['request']?.url);
+    } else if (isItemAFolder(item)) {
+      urls.push(...(getRequestsUrlsFromItems(item.items) || []));
+    }
+  });
+
+  return urls;
+};
+
+export const getMostCommonUrlFromCollection = (collection) => {
+  const urls = getRequestsUrlsFromItems(collection.items);
+
+  if (urls && urls.length) {
+    return flow(countBy, entries, partialRight(maxBy, last), head)(urls);
+  } else return '';
 };


### PR DESCRIPTION
# Description
This change sets the **initial request URL** field to the most common URL used in the collection.
This change is made to facilitate creating new requests in a collection Since most requests in the same collection share the same URL (especially GraphQL requests).
However, I didn't limit this feature to graphQL requests only, I believe it can also be helpful in restful request creation as well, because the user has to change only the last part of the URL(endpoint) and won't have to write the URL from scratch.
It is a small change but I believe it is very important for User Experience.

I will be waiting for Code Review, If there are any recommended changes I will be happy to apply them.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/usebruno/bruno/assets/7264374/1df36702-d595-4d13-9e05-b12513ca4604

