### PR TITLE
feat: Add Persistent Collection Location

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -7,17 +7,19 @@ import { createCollection } from 'providers/ReduxStore/slices/collections/action
 import toast from 'react-hot-toast';
 import Tooltip from 'components/Tooltip';
 import Modal from 'components/Modal';
+import useLocalStorage from 'hooks/useLocalStorage/index';
 
 const CreateCollection = ({ onClose }) => {
   const inputRef = useRef();
   const dispatch = useDispatch();
+  const [defaultCollectionPath, setDefaultCollectionPath] = useLocalStorage('bruno.default.collection.path', '');
 
   const formik = useFormik({
     enableReinitialize: true,
     initialValues: {
       collectionName: '',
       collectionFolderName: '',
-      collectionLocation: ''
+      collectionLocation: defaultCollectionPath
     },
     validationSchema: Yup.object({
       collectionName: Yup.string()
@@ -32,10 +34,10 @@ const CreateCollection = ({ onClose }) => {
       collectionLocation: Yup.string().min(1, 'location is required').required('location is required')
     }),
     onSubmit: (values) => {
+      setDefaultCollectionPath(values.collectionLocation);
       dispatch(createCollection(values.collectionName, values.collectionFolderName, values.collectionLocation))
         .then(() => {
           toast.success('Collection created');
-          localStorage.setItem('collection_path', values.collectionLocation);
           onClose();
         })
         .catch(() => toast.error('An error occurred while creating the collection'));
@@ -45,7 +47,7 @@ const CreateCollection = ({ onClose }) => {
   const browse = () => {
     dispatch(browseDirectory())
       .then((dirPath) => {
-        // When the user closes the diolog without selecting anything dirPath will be false
+        // When the user closes the dialog without selecting anything dirPath will be false
         if (typeof dirPath === 'string') {
           formik.setFieldValue('collectionLocation', dirPath);
         }
@@ -61,13 +63,6 @@ const CreateCollection = ({ onClose }) => {
       inputRef.current.focus();
     }
   }, [inputRef]);
-
-  useEffect(() => {
-    const collectionPath = localStorage.getItem('collection_path');
-    if (collectionPath) {
-      formik.setFieldValue('collectionLocation', collectionPath);
-    }
-  }, []);
 
   const onSubmit = () => formik.handleSubmit();
 

--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -35,6 +35,7 @@ const CreateCollection = ({ onClose }) => {
       dispatch(createCollection(values.collectionName, values.collectionFolderName, values.collectionLocation))
         .then(() => {
           toast.success('Collection created');
+          localStorage.setItem('collection_path', values.collectionLocation);
           onClose();
         })
         .catch(() => toast.error('An error occurred while creating the collection'));
@@ -60,6 +61,13 @@ const CreateCollection = ({ onClose }) => {
       inputRef.current.focus();
     }
   }, [inputRef]);
+
+  useEffect(() => {
+    const collectionPath = localStorage.getItem('collection_path');
+    if (collectionPath) {
+      formik.setFieldValue('collectionLocation', collectionPath);
+    }
+  }, []);
 
   const onSubmit = () => formik.handleSubmit();
 


### PR DESCRIPTION
# Description
This PR addresses the following feature request:
- #636

With this pull request, Bruno can now utilize the LocalStorage API to save the previously selected collection location. Users no longer need to repeatedly input a collection location every time they create a new collection.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
