### PR TITLE
Added pre-request and tests scripts support from Postman Collection

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -62,6 +62,23 @@ const importPostmanV2CollectionItem = (brunoParent, item) => {
           }
         };
 
+        if (i.event) {
+          i.event.forEach((event) => {
+            if (event.listen === 'prerequest' && event.script && event.script.exec) {
+              if (!brunoRequestItem.request.script) {
+                brunoRequestItem.request.script = {};
+              }
+              brunoRequestItem.request.script.req = event.script.exec[0];
+            }
+            if (event.listen === 'test' && event.script && event.script.exec) {
+              if (!brunoRequestItem.request.tests) {
+                brunoRequestItem.request.tests = {};
+              }
+              brunoRequestItem.request.tests = event.script.exec[0];
+            }
+          });
+        }
+
         const bodyMode = get(i, 'request.body.mode');
         if (bodyMode) {
           if (bodyMode === 'formdata') {


### PR DESCRIPTION
# Description

In Postman you can define Pre-request scripts and tests to do when you do a request.  Those information are stored in the collection but were not imported by **bruno**

![image](https://github.com/usebruno/bruno/assets/191879/1d1ff6bc-0489-45f9-bd5d-431fdb253294)
![image](https://github.com/usebruno/bruno/assets/191879/3a510cfd-fe3d-4037-909b-460883987750)

linked to this feature :  [[FEATURE] Support Postman pre-request script and tests when Importing collection #710 ](https://github.com/usebruno/bruno/issues/710)



### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X ] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

#hacktoberfest