### PR TITLE
 feat(devcontainers): add the ability to use GitHub Codespaces and VS Code remote containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+ARG NODE_MAJOR_VERSION
+
+FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_MAJOR_VERSION}
+
+ENV EDITOR="code -w" VISUAL="code -w"
+
+# install system dependencies for playwright
+RUN npx --yes playwright install-deps
+
+# uncomment to install additional npm packages
+# RUN su node -c 'npm i -g cowsay@1.5.0'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "bruno",
+  "dockerFile": "Dockerfile",
+  "build": {
+    "args": { "NODE_MAJOR_VERSION": "18" }
+  },
+  "capAdd": ["SYS_ADMIN"], // needed for electron SUID (https://github.com/electron/electron/issues/17972)
+  "postCreateCommand": [".devcontainer/post-create.sh"],
+  "portsAttributes": {
+    "3000": { "label": "Bruno Web" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["bradlc.vscode-tailwindcss", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # when in a VS Code or GitHub Codespaces devcontainer
-if [ -n "${REMOTE_CONTAINERS}" ]; then
+if [ -n "${REMOTE_CONTAINERS}" ] || [ -n "${CODESPACES}" ]; then
 	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
 	workspace_root=$(realpath ${this_dir}/..)
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env zsh
+
+set -eo pipefail
+
+# when in a VS Code or GitHub Codespaces devcontainer
+if [ -n "${REMOTE_CONTAINERS}" ]; then
+	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
+	workspace_root=$(realpath ${this_dir}/..)
+
+	# perform additional one-time setup just after
+	# the devcontainer is created
+	zsh "$NVM_DIR/nvm.sh" --install                             # install nvm node version
+	npm install --legacy-peer-deps --prefix "${workspace_root}" # install workspace node dependencies
+	npx --yes playwright install                                # install playwright browsers
+	npm run build:graphql-docs                                  # initial graphql-docs build
+	npm run build:bruno-query                                   # initial bruno-query build
+
+	# configure SUID mode and owner (https://github.com/electron/electron/issues/17972)
+	suid_sandbox="${workspace_root}/packages/bruno-electron/node_modules/electron/dist/chrome-sandbox"
+	if [ -f "${suid_sandbox}" ]; then
+		sudo chown root:root "${suid_sandbox}" && sudo chmod 4755 "${suid_sandbox}"
+	fi
+
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -5534,6 +5534,75 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/browserslist": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "dev": true,
@@ -5929,7 +5998,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.21.4",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7851,8 +7919,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.554",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.554.tgz",
-      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ==",
-      "dev": true
+      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ=="
     },
     "node_modules/electron-util": {
       "version": "0.17.2",
@@ -8595,6 +8662,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -11776,8 +11856,7 @@
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
-      "dev": true
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -11806,6 +11885,15 @@
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13580,7 +13668,6 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -15756,7 +15843,6 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
       "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -16631,7 +16717,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v0.26.0",
+      "version": "v0.25.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.425.0",
         "@usebruno/js": "0.8.0",
@@ -20223,7 +20309,8 @@
       }
     },
     "@tabler/icons": {
-      "version": "1.119.0"
+      "version": "1.119.0",
+      "requires": {}
     },
     "@tauri-apps/cli": {
       "version": "1.2.2",
@@ -20726,7 +20813,8 @@
       }
     },
     "@usebruno/schema": {
-      "version": "file:packages/bruno-schema"
+      "version": "file:packages/bruno-schema",
+      "requires": {}
     },
     "@usebruno/testbench": {
       "version": "file:packages/bruno-testbench",
@@ -20870,7 +20958,8 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -20881,7 +20970,8 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -20958,7 +21048,8 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "amdefine": {
       "version": "0.0.8"
@@ -21215,6 +21306,34 @@
     },
     "atomically": {
       "version": "1.7.0"
+    },
+    "autoprefixer": {
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
+      "peer": true,
+      "requires": {
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.22.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+          "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+          "peer": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001541",
+            "electron-to-chromium": "^1.4.535",
+            "node-releases": "^2.0.13",
+            "update-browserslist-db": "^1.0.13"
+          }
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -21477,7 +21596,6 @@
     },
     "browserslist": {
       "version": "4.21.4",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -21837,7 +21955,8 @@
     "chai-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
-      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw=="
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
+      "requires": {}
     },
     "chalk": {
       "version": "4.1.2",
@@ -22232,7 +22351,8 @@
     },
     "css-declaration-sorter": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-loader": {
       "version": "6.7.3",
@@ -22351,7 +22471,8 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -22827,8 +22948,7 @@
     "electron-to-chromium": {
       "version": "1.4.554",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.554.tgz",
-      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ==",
-      "dev": true
+      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ=="
     },
     "electron-util": {
       "version": "0.17.2",
@@ -23309,6 +23429,12 @@
     "forwarded": {
       "version": "0.2.0"
     },
+    "fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "peer": true
+    },
     "fresh": {
       "version": "0.5.2"
     },
@@ -23511,7 +23637,8 @@
       }
     },
     "goober": {
-      "version": "2.1.11"
+      "version": "2.1.11",
+      "requires": {}
     },
     "got": {
       "version": "9.6.0",
@@ -23874,7 +24001,8 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "idb": {
       "version": "7.1.1"
@@ -24476,7 +24604,8 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.2.0",
@@ -25065,7 +25194,8 @@
       "version": "1.4.1"
     },
     "meros": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "requires": {}
     },
     "methods": {
       "version": "1.1.2"
@@ -25313,8 +25443,7 @@
     "node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
-      "dev": true
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -25338,6 +25467,12 @@
     },
     "normalize-path": {
       "version": "3.0.0"
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "peer": true
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -25825,19 +25960,23 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-js": {
       "version": "3.0.3",
@@ -25919,7 +26058,8 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -25952,7 +26092,8 @@
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -26347,11 +26488,11 @@
       }
     },
     "react-inspector": {
-      "version": "6.0.2"
+      "version": "6.0.2",
+      "requires": {}
     },
     "react-is": {
-      "version": "18.2.0",
-      "dev": true
+      "version": "18.2.0"
     },
     "react-redux": {
       "version": "7.2.9",
@@ -26498,7 +26639,8 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.2"
+      "version": "2.4.2",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -26730,7 +26872,8 @@
     },
     "rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -27224,7 +27367,8 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "styled-components": {
       "version": "5.3.6",
@@ -27253,7 +27397,8 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7"
+      "version": "5.0.7",
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -27775,7 +27920,6 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
       "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
-      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -27846,7 +27990,8 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "requires": {}
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -28007,7 +28152,8 @@
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "schema-utils": {
           "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5534,75 +5534,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.16",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
-      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "browserslist": "^4.21.10",
-        "caniuse-lite": "^1.0.30001538",
-        "fraction.js": "^4.3.6",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/autoprefixer/node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "dev": true,
@@ -5998,6 +5929,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.21.4",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7919,7 +7851,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.554",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.554.tgz",
-      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ=="
+      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ==",
+      "dev": true
     },
     "node_modules/electron-util": {
       "version": "0.17.2",
@@ -8662,19 +8595,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "peer": true,
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -11856,7 +11776,8 @@
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -11885,15 +11806,6 @@
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13668,6 +13580,7 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -15843,6 +15756,7 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
       "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -16717,7 +16631,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v0.25.0",
+      "version": "v0.26.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.425.0",
         "@usebruno/js": "0.8.0",
@@ -20309,8 +20223,7 @@
       }
     },
     "@tabler/icons": {
-      "version": "1.119.0",
-      "requires": {}
+      "version": "1.119.0"
     },
     "@tauri-apps/cli": {
       "version": "1.2.2",
@@ -20813,8 +20726,7 @@
       }
     },
     "@usebruno/schema": {
-      "version": "file:packages/bruno-schema",
-      "requires": {}
+      "version": "file:packages/bruno-schema"
     },
     "@usebruno/testbench": {
       "version": "file:packages/bruno-testbench",
@@ -20958,8 +20870,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -20970,8 +20881,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -21048,8 +20958,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "0.0.8"
@@ -21306,34 +21215,6 @@
     },
     "atomically": {
       "version": "1.7.0"
-    },
-    "autoprefixer": {
-      "version": "10.4.16",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
-      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
-      "peer": true,
-      "requires": {
-        "browserslist": "^4.21.10",
-        "caniuse-lite": "^1.0.30001538",
-        "fraction.js": "^4.3.6",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.22.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-          "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
-          "peer": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001541",
-            "electron-to-chromium": "^1.4.535",
-            "node-releases": "^2.0.13",
-            "update-browserslist-db": "^1.0.13"
-          }
-        }
-      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -21596,6 +21477,7 @@
     },
     "browserslist": {
       "version": "4.21.4",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -21955,8 +21837,7 @@
     "chai-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
-      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
-      "requires": {}
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -22351,8 +22232,7 @@
     },
     "css-declaration-sorter": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-loader": {
       "version": "6.7.3",
@@ -22471,8 +22351,7 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -22948,7 +22827,8 @@
     "electron-to-chromium": {
       "version": "1.4.554",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.554.tgz",
-      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ=="
+      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ==",
+      "dev": true
     },
     "electron-util": {
       "version": "0.17.2",
@@ -23429,12 +23309,6 @@
     "forwarded": {
       "version": "0.2.0"
     },
-    "fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "peer": true
-    },
     "fresh": {
       "version": "0.5.2"
     },
@@ -23637,8 +23511,7 @@
       }
     },
     "goober": {
-      "version": "2.1.11",
-      "requires": {}
+      "version": "2.1.11"
     },
     "got": {
       "version": "9.6.0",
@@ -24001,8 +23874,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "idb": {
       "version": "7.1.1"
@@ -24604,8 +24476,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.2.0",
@@ -25194,8 +25065,7 @@
       "version": "1.4.1"
     },
     "meros": {
-      "version": "1.2.1",
-      "requires": {}
+      "version": "1.2.1"
     },
     "methods": {
       "version": "1.1.2"
@@ -25443,7 +25313,8 @@
     "node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -25467,12 +25338,6 @@
     },
     "normalize-path": {
       "version": "3.0.0"
-    },
-    "normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "peer": true
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -25960,23 +25825,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-js": {
       "version": "3.0.3",
@@ -26058,8 +25919,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -26092,8 +25952,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -26488,11 +26347,11 @@
       }
     },
     "react-inspector": {
-      "version": "6.0.2",
-      "requires": {}
+      "version": "6.0.2"
     },
     "react-is": {
-      "version": "18.2.0"
+      "version": "18.2.0",
+      "dev": true
     },
     "react-redux": {
       "version": "7.2.9",
@@ -26639,8 +26498,7 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.2",
-      "requires": {}
+      "version": "2.4.2"
     },
     "regenerate": {
       "version": "1.4.2",
@@ -26872,8 +26730,7 @@
     },
     "rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -27367,8 +27224,7 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "styled-components": {
       "version": "5.3.6",
@@ -27397,8 +27253,7 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7",
-      "requires": {}
+      "version": "5.0.7"
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -27920,6 +27775,7 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
       "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -27990,8 +27846,7 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -28152,8 +28007,7 @@
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "schema-utils": {
           "version": "3.1.1",


### PR DESCRIPTION
# Description

For `Hacktoberfest`, I have been adding `GitHub Codespaces` / `VS Code Dev Containers` configuration for OSS projects to make it easier for contributors to the project to get up and running with the correct developer setup. Including the appropriate configuration for a project allows contributors to work entirely within a web browser via `GH Codespaces`, or inside of fully, and correctly configured containers on their own computer with `VS Code Remote Containers` (both of these use the same configuration, as `GH Codespaces` leverages the `Remote Containers` features under the hood).

For the `bruno` project, this configuration includes the following:
- Preinstalled `Node LTS`
- Preinstalled `ESLint`, `Tailwind CSS`, and `Prettier` extensions
- Preinstalled `playwright` dependencies
- Automation of the `npm install` when the devcontainer is first created
- Automation of the initial (required) builds of the docs and query projects

Basically everything needed for a contributor to open the project after a fresh clone and be immediately productive, either locally with `VS Code` or remotely with `GitHub Codespaces`!

> [!NOTE]
> The version of `playwright` in use in the repository is pretty out of date (`^1.27.1`, released over a year ago, is in the _package.json_ but `1.39.0` is the latest version).
>
> Due to the workspace dependency being out of date, when the `devcontainer` automation to install the playwright browsers runs it installs older versions of the browsers (playwright attempts to always install browsers compatible with the playwright version) and these older browsers rely on outdated system dependencies which aren't present in this container.
> 
> The end result of this is that some playwright tests are currently failing when run inside of the `devcontainer`, and the fix is very simple - just update the installed playwright dependency to the latest version (`1.39.0`) so that it can use newer browser builds.
>
> I did not make that change in this PR as it felt out of scope to update an application dependency while adding the `devcontainer` configuration.

For reference, here are some other repositories for whom I've opened PRs to do the same:

- https://github.com/AnilSeervi/inspirational-quotes/pull/19
- https://github.com/Icon-Shelf/icon-shelf/pull/135 (note that this one is a GUI electron app, but it's still possible to containerize it and do development in the cloud on GH Codespaces!)
- https://github.com/developertools-tech/developertools.tech/issues/36
- https://github.com/floating-ui/floating-ui/pull/2606
- https://github.com/compiler-explorer/compiler-explorer/pull/5631
- https://github.com/EveryBoard/EveryBoard/pull/155
- https://github.com/melt-ui/melt-ui/pull/658
- https://github.com/JamesLMilner/terra-draw/pull/108

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Closes #722 
