### PR TITLE
feat(#628): Autocomplete possible values for Accept and Content-Type request headers

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -9,7 +9,17 @@ import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collection
 import SingleLineEditor from 'components/SingleLineEditor';
 import StyledWrapper from './StyledWrapper';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
+import MediaTypes from 'know-your-http-well/json/media-types.json';
 const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
+const mediaTypesAutoCompleteList = MediaTypes.map((e) => e.media_type);
+
+function headerValueAutoCompleteList(header) {
+  if (header.name && (header.name.toLowerCase() === 'content-type' || header.name.toLowerCase() === 'accept')) {
+    return mediaTypesAutoCompleteList;
+  }
+
+  return [];
+}
 
 const RequestHeaders = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -114,6 +124,7 @@ const RequestHeaders = ({ item, collection }) => {
                             'value'
                           )
                         }
+                        autocomplete={headerValueAutoCompleteList(header)}
                         onRun={handleRun}
                         collection={collection}
                       />


### PR DESCRIPTION
# Description

Autocomplete possible values for Accept and Content-Type request headers with media-types list. Related to #628

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
