### PR TITLE
fix: respect rejectUnauthorized and ca opts when proxying https

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -12,11 +12,10 @@ const { ScriptRuntime, TestRuntime, VarsRuntime, AssertRuntime } = require('@use
 const { stripExtension } = require('../utils/filesystem');
 const { getOptions } = require('../utils/bru');
 const https = require('https');
-const { HttpsProxyAgent } = require('https-proxy-agent');
 const { HttpProxyAgent } = require('http-proxy-agent');
 const { SocksProxyAgent } = require('socks-proxy-agent');
 const { makeAxiosInstance } = require('../utils/axios-instance');
-const { shouldUseProxy } = require('../utils/proxy-util');
+const { shouldUseProxy, PatchedHttpsProxyAgent } = require('../utils/proxy-util');
 
 const runSingleRequest = async function (
   filename,
@@ -152,7 +151,7 @@ const runSingleRequest = async function (
         request.httpsAgent = socksProxyAgent;
         request.httpAgent = socksProxyAgent;
       } else {
-        request.httpsAgent = new HttpsProxyAgent(
+        request.httpsAgent = new PatchedHttpsProxyAgent(
           proxyUri,
           Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
         );

--- a/packages/bruno-cli/src/utils/proxy-util.js
+++ b/packages/bruno-cli/src/utils/proxy-util.js
@@ -1,4 +1,5 @@
 const parseUrl = require('url').parse;
+const { isEmpty } = require('lodash');
 
 const DEFAULT_PORTS = {
   ftp: 21,
@@ -9,7 +10,7 @@ const DEFAULT_PORTS = {
   wss: 443
 };
 /**
- * check for proxy bypass, Copied form 'proxy-from-env'
+ * check for proxy bypass, copied form 'proxy-from-env'
  */
 const shouldUseProxy = (url, proxyBypass) => {
   if (proxyBypass === '*') {
@@ -39,7 +40,6 @@ const shouldUseProxy = (url, proxyBypass) => {
     if (!dontProxyFor) {
       return true; // Skip zero-length hosts.
     }
-
     const parsedProxy = dontProxyFor.match(/^(.+):(\d+)$/);
     let parsedProxyHostname = parsedProxy ? parsedProxy[1] : dontProxyFor;
     const parsedProxyPort = parsedProxy ? parseInt(parsedProxy[2]) : 0;

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -19,12 +19,11 @@ const { sortFolder, getAllRequestsInFolderRecursively } = require('./helper');
 const { preferencesUtil } = require('../../store/preferences');
 const { getProcessEnvVars } = require('../../store/process-env');
 const { getBrunoConfig } = require('../../store/bruno-config');
-const { HttpsProxyAgent } = require('https-proxy-agent');
 const { HttpProxyAgent } = require('http-proxy-agent');
 const { SocksProxyAgent } = require('socks-proxy-agent');
 const { makeAxiosInstance } = require('./axios-instance');
 const { addAwsV4Interceptor, resolveAwsV4Credentials } = require('./awsv4auth-helper');
-const { shouldUseProxy } = require('../../utils/proxy-util');
+const { shouldUseProxy, PatchedHttpsProxyAgent } = require('../../utils/proxy-util');
 
 // override the default escape function to prevent escaping
 Mustache.escape = function (value) {
@@ -149,7 +148,7 @@ const configureRequest = async (collectionUid, request, envVars, collectionVaria
       request.httpsAgent = socksProxyAgent;
       request.httpAgent = socksProxyAgent;
     } else {
-      request.httpsAgent = new HttpsProxyAgent(
+      request.httpsAgent = new PatchedHttpsProxyAgent(
         proxyUri,
         Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
       );

--- a/packages/bruno-electron/src/utils/proxy-util.js
+++ b/packages/bruno-electron/src/utils/proxy-util.js
@@ -1,5 +1,6 @@
 const parseUrl = require('url').parse;
 const { isEmpty } = require('lodash');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 
 const DEFAULT_PORTS = {
   ftp: 21,
@@ -61,6 +62,24 @@ const shouldUseProxy = (url, proxyBypass) => {
   });
 };
 
+/**
+ * Patched version of HttpsProxyAgent to get around a bug that ignores options
+ * such as ca and rejectUnauthorized when upgrading the proxied socket to TLS:
+ * https://github.com/TooTallNate/proxy-agents/issues/194
+ */
+class PatchedHttpsProxyAgent extends HttpsProxyAgent {
+  constructor(proxy, opts) {
+    super(proxy, opts);
+    this.constructorOpts = opts;
+  }
+
+  async connect(req, opts) {
+    const combinedOpts = { ...this.constructorOpts, ...opts };
+    return super.connect(req, combinedOpts);
+  }
+}
+
 module.exports = {
-  shouldUseProxy
+  shouldUseProxy,
+  PatchedHttpsProxyAgent
 };


### PR DESCRIPTION
This PR fixes https://github.com/usebruno/bruno/issues/362

### Problem

When Bruno would make SSL/TLS connections through a proxy, it would not respect connection options like `rejectUnauthorized` or `ca`. This was making it difficult to use when going through a self-signing MiTM proxy, or using a custom certificate authority.

### Cause

The issue was caused by an upstream bug in [https-proxy-agent](https://github.com/TooTallNate/proxy-agents/tree/main/packages/https-proxy-agent), where it doesn't permit options  to be passed down when upgrading sockets to TLS:

* https://github.com/TooTallNate/proxy-agents/issues/194

The same underlying issue has been reported against multiple versions of that library over the years. As you can see in the comments, people have either switched to other libraries, or patched it to pass down such options:

* https://github.com/TooTallNate/proxy-agents/issues/89
* https://github.com/TooTallNate/proxy-agents/issues/121

### Solution

The solution employed here is to patch the class, similar to [what others have done](https://github.com/pnpm/components/blob/02d17cc303c94dc7d85458fd233303edcc452c8b/network/proxy-agent/proxy-agent.ts#L146-L157).

When/if the issue is fixed in `proxy-agents`, that should be used instead.

### Note to Reviewers:

* I put this in the existing `proxy-util.js` file, which is currently duplicated for CLI and Electron. I didn't see a good way to just have one copy of the code. Maybe the JS package would make sense eventually -- there seems to be lots of opportunity for consolidating common code there. 
* I was able to test successfully using the UI, but not the CLI -- I think there may be a separate bug in CLI currently where the Collection-configured proxy is not actually attempted to be used -- the code seems to look for `proxy.enabled: true` but it's saved as `proxy.use: true` in my `bruno.json` file in the collection dir. I didn't try to address that as part of the PR, as it seems a separate topic.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Linked issue to the pull request.**