### PR TITLE
feat(devcontainers): add the ability to use GitHub Codespaces and VS Code remote containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+ARG NODE_MAJOR_VERSION
+
+FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_MAJOR_VERSION}
+
+ENV EDITOR="code -w" VISUAL="code -w"
+
+# install system dependencies for playwright
+RUN npx --yes playwright install-deps
+
+# uncomment to install additional npm packages
+# RUN su node -c 'npm i -g cowsay@1.5.0'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "bruno",
+  "dockerFile": "Dockerfile",
+  "build": {
+    "args": { "NODE_MAJOR_VERSION": "18" }
+  },
+  "capAdd": ["SYS_ADMIN"], // needed for electron SUID (https://github.com/electron/electron/issues/17972)
+  "postCreateCommand": [".devcontainer/post-create.sh"],
+  "portsAttributes": {
+    "3000": { "label": "Bruno Web" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["bradlc.vscode-tailwindcss", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env zsh
+
+set -eo pipefail
+
+# when in a VS Code or GitHub Codespaces devcontainer
+if [ -n "${REMOTE_CONTAINERS}" ] || [ -n "${CODESPACES}" ]; then
+	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
+	workspace_root=$(realpath ${this_dir}/..)
+
+	# perform additional one-time setup just after
+	# the devcontainer is created
+	zsh "$NVM_DIR/nvm.sh" --install                             # install nvm node version
+	npm install --legacy-peer-deps --prefix "${workspace_root}" # install workspace node dependencies
+	npx --yes playwright install                                # install playwright browsers
+	npm run build:graphql-docs                                  # initial graphql-docs build
+	npm run build:bruno-query                                   # initial bruno-query build
+
+	# configure SUID mode and owner (https://github.com/electron/electron/issues/17972)
+	suid_sandbox="${workspace_root}/packages/bruno-electron/node_modules/electron/dist/chrome-sandbox"
+	if [ -f "${suid_sandbox}" ]; then
+		sudo chown root:root "${suid_sandbox}" && sudo chmod 4755 "${suid_sandbox}"
+	fi
+
+fi


### PR DESCRIPTION
# Description

For `Hacktoberfest`, I have been adding `GitHub Codespaces` / `VS Code Dev Containers` configuration for OSS projects to make it easier for contributors to the project to get up and running with the correct developer setup. Including the appropriate configuration for a project allows contributors to work entirely within a web browser via `GH Codespaces`, or inside of fully, and correctly configured containers on their own computer with `VS Code Remote Containers` (both of these use the same configuration, as `GH Codespaces` leverages the `Remote Containers` features under the hood).

For the `bruno` project, this configuration includes the following:
- Preinstalled `Node LTS`
- Preinstalled `ESLint`, `Tailwind CSS`, and `Prettier` extensions
- Preinstalled `playwright` dependencies
- Automation of the `npm install` when the devcontainer is first created
- Automation of the initial (required) builds of the docs and query projects

Basically everything needed for a contributor to open the project after a fresh clone and be immediately productive, either locally with `VS Code` or remotely with `GitHub Codespaces`!

> [!NOTE]
> The version of `playwright` in use in the repository is pretty out of date (`^1.27.1`, released over a year ago, is in the _package.json_ but `1.39.0` is the latest version).
>
> Due to the workspace dependency being out of date, when the `devcontainer` automation to install the playwright browsers runs it installs older versions of the browsers (playwright attempts to always install browsers compatible with the playwright version) and these older browsers rely on outdated system dependencies which aren't present in this container.
> 
> The end result of this is that some playwright tests are currently failing when run inside of the `devcontainer`, and the fix is very simple - just update the installed playwright dependency to the latest version (`1.39.0`) so that it can use newer browser builds.
>
> I did not make that change in this PR as it felt out of scope to update an application dependency while adding the `devcontainer` configuration.

For reference, here are some other repositories for whom I've opened PRs to do the same:

- https://github.com/AnilSeervi/inspirational-quotes/pull/19
- https://github.com/Icon-Shelf/icon-shelf/pull/135 (note that this one is a GUI electron app, but it's still possible to containerize it and do development in the cloud on GH Codespaces!)
- https://github.com/developertools-tech/developertools.tech/issues/36
- https://github.com/floating-ui/floating-ui/pull/2606
- https://github.com/compiler-explorer/compiler-explorer/pull/5631
- https://github.com/EveryBoard/EveryBoard/pull/155
- https://github.com/melt-ui/melt-ui/pull/658
- https://github.com/JamesLMilner/terra-draw/pull/108

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Closes #722 
Supersedes #723 (closed and re-opened with a new branch name to match requested format)