### PR TITLE
OpenApi v3 case fixes

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -53,9 +53,15 @@ const buildEmptyJsonBody = (bodySchema) => {
 
 const transformOpenapiRequestItem = (request) => {
   let _operationObject = request.operationObject;
+
+  let operationName = _operationObject.operationId || _operationObject.summary || _operationObject.description;
+  if (!operationName) {
+    operationName = `${request.method} ${request.path}`;
+  }
+
   const brunoRequestItem = {
     uid: uuid(),
-    name: _operationObject.operationId,
+    name: operationName,
     type: 'http-request',
     request: {
       url: ensureUrl(request.global.server + '/' + request.path),
@@ -100,7 +106,7 @@ const transformOpenapiRequestItem = (request) => {
 
   let auth;
   // allow operation override
-  if (_operationObject.security) {
+  if (_operationObject.security && _operationObject.security.length > 0) {
     let schemeName = Object.keys(_operationObject.security[0])[0];
     auth = request.global.security.getScheme(schemeName);
   } else if (request.global.security.supported.length > 0) {


### PR DESCRIPTION
# Fixes some cases for openapi v3 spec import

- Handles no security block defined now (bugfix)
- handles no operationId defined for an operation. Now it will use some other defaults (summary, description or fall back on using Method + path)

These were mentioned in this PR: https://github.com/usebruno/bruno/pull/578

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.** (another PR, not an issue)

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
