### PR TITLE
OpenAPI import - filter out non-methods on path item objects parsing

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -326,17 +326,21 @@ const parseOpenApiCollection = (data) => {
 
       let allRequests = Object.entries(collectionData.paths)
         .map(([path, methods]) => {
-          return Object.entries(methods).map(([method, operationObject]) => {
-            return {
-              method: method,
-              path: path,
-              operationObject: operationObject,
-              global: {
-                server: baseUrl,
-                security: securityConfig
-              }
-            };
-          });
+          return Object.entries(methods)
+            .filter(([method, op]) => {
+              ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'].includes(method.toLowerCase());
+            })
+            .map(([method, operationObject]) => {
+              return {
+                method: method,
+                path: path,
+                operationObject: operationObject,
+                global: {
+                  server: baseUrl,
+                  security: securityConfig
+                }
+              };
+            });
         })
         .reduce((acc, val) => acc.concat(val), []); // flatten
 


### PR DESCRIPTION
# OpenAPI import - filter out non-methods on path item objects parsing

Fixes #744 . I included all possible methods per OpenAPI spec.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


