### PR TITLE
fix misleading message

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
@@ -18,7 +18,7 @@ const RemoveCollection = ({ onClose, collection }) => {
 
   return (
     <Modal size="sm" title="Remove Collection" confirmText="Remove" handleConfirm={onConfirm} handleCancel={onClose}>
-      Are you sure you want to delete collection <span className="font-semibold">{collection.name}</span> ?
+      Are you sure you want to remove collection <span className="font-semibold">{collection.name}</span> ?
     </Modal>
   );
 };


### PR DESCRIPTION
# Description

Fixes #741 misleading message on remove collection. Replace "delete" with "remove" since collection is not deleted from disk, only remove from Bruno.

Before

![image](https://github.com/usebruno/bruno/assets/1215125/4897d1f9-51c9-4e26-b0fb-c2ca0423ac87)

After

![image](https://github.com/usebruno/bruno/assets/1215125/5a696be2-f634-4347-bd8b-01346328324c)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
