### PR TITLE
feat(#740): Add hints for local bruno setup

### DIFF
--- a/packages/bruno-app/package.json
+++ b/packages/bruno-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "private": true,
   "scripts": {
-    "dev": "cross-env ENV=dev next dev",
+    "dev": "cross-env ENV=dev next dev -p 3000",
     "build": "next build && next export",
     "start": "next start",
     "lint": "next lint",

--- a/packages/bruno-app/src/pages/_app.js
+++ b/packages/bruno-app/src/pages/_app.js
@@ -41,6 +41,15 @@ function MyApp({ Component, pageProps }) {
     return null;
   }
 
+  if (!window.ipcRenderer) {
+    return (
+      <div style={{ color: 'red' }}>
+        Error: "ipcRenderer" not found in window object. You most likely opened Bruno inside your web browser. Bruno
+        only works within Electron, you can start Electron using "npm run dev:electron".
+      </div>
+    );
+  }
+
   return (
     <ErrorBoundary>
       <SafeHydrate>

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -67,7 +67,21 @@ app.on('ready', async () => {
         slashes: true
       });
 
-  mainWindow.loadURL(url);
+  mainWindow.loadURL(url).catch((reason) => {
+    console.error(`Error: Failed to load URL: "${url}" (Electron shows a blank screen because of this).`);
+    console.error('Original message:', reason);
+    if (isDev) {
+      console.error(
+        'Could not connect to Next.Js dev server, is it running?' +
+          ' Start the dev server using "npm run dev:web" and restart electron'
+      );
+    } else {
+      console.error(
+        'If you are using an official production build: the above error is most likely a bug! ' +
+          ' Please report this under: https://github.com/usebruno/bruno/issues'
+      );
+    }
+  });
   watcher = new Watcher();
 
   const handleBoundsChange = () => {


### PR DESCRIPTION
Fixes: #740

- Custom error when opening bruno in the browser

![grafik](https://github.com/usebruno/bruno/assets/39559178/a654b3a7-fd77-4955-bf92-430207bb18c7)

- Custom error when starting electron without the web server running

![grafik](https://github.com/usebruno/bruno/assets/39559178/def65b74-c889-4662-82e4-e4a6a1101d5b)

- Force Next dev server to use port 3000
  - Added `-p 3000` to next dev command