### PR TITLE
Add better CodeMirror folding options

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -70,6 +70,35 @@ export default class CodeEditor extends React.Component {
         'Ctrl-F': 'findPersistent',
         Tab: function (cm) {
           cm.replaceSelection('  ', 'end');
+        },
+        'Ctrl-Y': 'foldAll',
+        'Cmd-Y': 'foldAll',
+        'Ctrl-I': 'unfoldAll',
+        'Cmd-I': 'unfoldAll'
+      },
+      foldOptions: {
+        widget: (from, to) => {
+          var count = undefined;
+          var internal = this.editor.getRange(from, to);
+          if (this.props.mode == 'application/ld+json') {
+            if (this.editor.getLine(from.line).endsWith('[')) {
+              var toParse = '[' + internal + ']';
+            } else var toParse = '{' + internal + '}';
+            try {
+              count = Object.keys(JSON.parse(toParse)).length;
+            } catch (e) {}
+          } else if (this.props.mode == 'application/xml') {
+            var doc = new DOMParser();
+            try {
+              //add header element and remove prefix namespaces for DOMParser
+              var dcm = doc.parseFromString(
+                '<a> ' + internal.replace(/(?<=\<|<\/)\w+:/g, '') + '</a>',
+                'application/xml'
+              );
+              count = dcm.documentElement.children.length;
+            } catch (e) {}
+          }
+          return count ? `\u21A4${count}\u21A6` : '\u2194';
         }
       }
     }));

--- a/packages/bruno-app/src/pages/Bruno/index.js
+++ b/packages/bruno-app/src/pages/Bruno/index.js
@@ -21,6 +21,7 @@ if (!SERVER_RENDERED) {
   require('codemirror/addon/edit/matchbrackets');
   require('codemirror/addon/fold/brace-fold');
   require('codemirror/addon/fold/foldgutter');
+  require('codemirror/addon/fold/xml-fold');
   require('codemirror/addon/hint/show-hint');
   require('codemirror/addon/lint/lint');
   require('codemirror/addon/mode/overlay');


### PR DESCRIPTION
Add XML fold to Response and Body. Add count of object directly inside of fold.  Include hotkeys Ctrl-Y to fold and Ctrl-I to unfold all XML/JSON data.

# Description
Fix #315 by adding these hotkeys:
Ctrl-Y: fold all
Ctrl-I: unfold all

This is to create a tree-view like functionality that can completely fold XML/JSON data in Response and Body. The ability to fold XML data is helpful and only requires 1 line of code. There is no UI button to fold/unfold all but that can be added if users are looking for it.

https://github.com/usebruno/bruno/assets/115114979/5e04fbad-c6d0-46ba-bec9-f7d48c3e72be

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
