### PR TITLE
Feature/control UI font size

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -7,6 +7,10 @@ const StyledWrapper = styled.div`
     font-family: ${(props) => (props.font ? props.font : 'default')};
   }
 
+  .CodeMirror * {
+    font-size: ${(props) => (props.size ? props.size + 'px' : '12px')};
+  }
+
   .CodeMirror-overlayscroll-horizontal div,
   .CodeMirror-overlayscroll-vertical div {
     background: #d2d7db;

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -122,6 +122,7 @@ export default class CodeEditor extends React.Component {
         className="h-full w-full"
         aria-label="Code Editor"
         font={this.props.font}
+        size={this.props.size}
         ref={(node) => {
           this._node = node;
         }}

--- a/packages/bruno-app/src/components/Preferences/Font/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/Font/StyledWrapper.js
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  .settings-label {
+    width: 80px;
+  }
   color: ${(props) => props.theme.text};
 `;
 

--- a/packages/bruno-app/src/components/Preferences/Font/index.js
+++ b/packages/bruno-app/src/components/Preferences/Font/index.js
@@ -58,6 +58,8 @@ const Font = ({ close }) => {
         </label>
         <input
           type="number"
+          min="6"
+          max="24"
           className="block textbox"
           autoComplete="off"
           autoCorrect="off"

--- a/packages/bruno-app/src/components/Preferences/Font/index.js
+++ b/packages/bruno-app/src/components/Preferences/Font/index.js
@@ -9,9 +9,14 @@ const Font = ({ close }) => {
   const preferences = useSelector((state) => state.app.preferences);
 
   const [codeFont, setCodeFont] = useState(get(preferences, 'font.codeFont', 'default'));
+  const [sizeFont, setSizeFont] = useState(get(preferences, 'font.sizeFont', '12'));
 
-  const handleInputChange = (event) => {
+  const handleStyleInputChange = (event) => {
     setCodeFont(event.target.value);
+  };
+
+  const handleSizeInputChange = (event) => {
+    setSizeFont(event.target.value);
   };
 
   const handleSave = () => {
@@ -30,17 +35,37 @@ const Font = ({ close }) => {
   return (
     <StyledWrapper>
       <label className="block font-medium">Code Editor Font</label>
-      <input
-        type="text"
-        className="block textbox mt-2 w-full"
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck="false"
-        onChange={handleInputChange}
-        defaultValue={codeFont}
-      />
+      <div className="mb-3 flex items-center">
+        <label className="settings-label" htmlFor="fontstyle">
+          Style
+        </label>
+        <input
+          type="text"
+          className="block textbox"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck="false"
+          onChange={handleStyleInputChange}
+          defaultValue={codeFont}
+        />
+      </div>
 
+      <div className="mb-3 flex items-center">
+        <label className="settings-label" htmlFor="fontsize">
+          Size
+        </label>
+        <input
+          type="number"
+          className="block textbox"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck="false"
+          onChange={handleSizeInputChange}
+          defaultValue={sizeFont}
+        />
+      </div>
       <div className="mt-10">
         <button type="submit" className="submit btn btn-sm btn-secondary" onClick={handleSave}>
           Save

--- a/packages/bruno-app/src/components/Preferences/Font/index.js
+++ b/packages/bruno-app/src/components/Preferences/Font/index.js
@@ -9,7 +9,7 @@ const Font = ({ close }) => {
   const preferences = useSelector((state) => state.app.preferences);
 
   const [codeFont, setCodeFont] = useState(get(preferences, 'font.codeFont', 'default'));
-  const [sizeFont, setSizeFont] = useState(get(preferences, 'font.sizeFont', '12'));
+  const [sizeFont, setSizeFont] = useState(get(preferences, 'font.sizeFont', 12));
 
   const handleStyleInputChange = (event) => {
     setCodeFont(event.target.value);
@@ -24,7 +24,8 @@ const Font = ({ close }) => {
       savePreferences({
         ...preferences,
         font: {
-          codeFont
+          codeFont,
+          sizeFont
         }
       })
     ).then(() => {
@@ -34,10 +35,10 @@ const Font = ({ close }) => {
 
   return (
     <StyledWrapper>
-      <label className="block font-medium">Code Editor Font</label>
+      <label className="block font-medium mb-3">Code Editor Font</label>
       <div className="mb-3 flex items-center">
         <label className="settings-label" htmlFor="fontstyle">
-          Style
+          Font
         </label>
         <input
           type="text"

--- a/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
@@ -33,6 +33,7 @@ const GraphQLVariables = ({ variables, item, collection }) => {
         value={variables || ''}
         theme={storedTheme}
         font={get(preferences, 'font.codeFont', 'default')}
+        size={get(preferences, 'font.sizeFont', '12')}
         onEdit={onEdit}
         mode="javascript"
         onRun={onRun}

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
@@ -50,6 +50,7 @@ const RequestBody = ({ item, collection }) => {
           collection={collection}
           theme={storedTheme}
           font={get(preferences, 'font.codeFont', 'default')}
+          size={get(preferences, 'font.sizeFont', '12')}
           value={bodyContent[bodyMode] || ''}
           onEdit={onEdit}
           onRun={onRun}

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -47,6 +47,7 @@ const Script = ({ item, collection }) => {
           value={requestScript || ''}
           theme={storedTheme}
           font={get(preferences, 'font.codeFont', 'default')}
+          size={get(preferences, 'font.sizeFont', '12')}
           onEdit={onRequestScriptEdit}
           mode="javascript"
           onRun={onRun}
@@ -60,6 +61,7 @@ const Script = ({ item, collection }) => {
           value={responseScript || ''}
           theme={storedTheme}
           font={get(preferences, 'font.codeFont', 'default')}
+          size={get(preferences, 'font.sizeFont', '12')}
           onEdit={onResponseScriptEdit}
           mode="javascript"
           onRun={onRun}

--- a/packages/bruno-app/src/components/RequestPane/Tests/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Tests/index.js
@@ -34,6 +34,7 @@ const Tests = ({ item, collection }) => {
         value={tests || ''}
         theme={storedTheme}
         font={get(preferences, 'font.codeFont', 'default')}
+        size={get(preferences, 'font.sizeFont', '12')}
         onEdit={onEdit}
         mode="javascript"
         onRun={onRun}

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
@@ -51,6 +51,7 @@ const QueryResultPreview = ({
         <CodeEditor
           collection={collection}
           font={get(preferences, 'font.codeFont', 'default')}
+          size={get(preferences, 'font.sizeFont', '12')}
           theme={storedTheme}
           onRun={onRun}
           value={formattedData}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -23,6 +23,7 @@ const CodeView = ({ language, item }) => {
       readOnly
       value={snippet}
       font={get(preferences, 'font.codeFont', 'default')}
+      size={get(preferences, 'font.sizeFont', '12')}
       theme={storedTheme}
       mode={lang}
     />

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -13,7 +13,8 @@ const initialState = {
       timeout: 0
     },
     font: {
-      codeFont: 'default'
+      codeFont: 'default',
+      sizeFont: 12
     }
   }
 };


### PR DESCRIPTION
# Description

This PR addresses the issue #713 and allows setting font-size on all Code Editor components from the Preferences>Font form. I have implemented it similarly to how the setting of the font family is already done.

<img width="386" alt="Capture d’écran 2023-10-24 à 21 04 42" src="https://github.com/usebruno/bruno/assets/46668755/04848c89-5cf6-4183-b823-f7049ea80059">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

