### PR TITLE
Make Tabs closable by mouseclick. Closes #778

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -4,7 +4,7 @@ import filter from 'lodash/filter';
 import classnames from 'classnames';
 import { IconChevronRight, IconChevronLeft } from '@tabler/icons';
 import { useSelector, useDispatch } from 'react-redux';
-import { focusTab } from 'providers/ReduxStore/slices/tabs';
+import { closeTabs, focusTab } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
 import CollectionToolBar from './CollectionToolBar';
 import RequestTab from './RequestTab';
@@ -31,6 +31,14 @@ const RequestTabs = () => {
     dispatch(
       focusTab({
         uid: tab.uid
+      })
+    );
+  };
+
+  const handleCloseClick = (tab) => {
+    dispatch(
+      closeTabs({
+        tabUids: [tab.uid]
       })
     );
   };
@@ -110,6 +118,7 @@ const RequestTabs = () => {
                         className={getTabClassname(tab, index)}
                         role="tab"
                         onClick={() => handleClick(tab)}
+                        onAuxClick={() => handleCloseClick(tab)}
                       >
                         <RequestTab key={tab.uid} tab={tab} collection={activeCollection} />
                       </li>


### PR DESCRIPTION
Make Tabs closable by mouseclick.

# Description

If a user clicks on a tab with a mouse button other then the primary one -> Close the corresponding tab.

### Contribution Checklist:

- [/] **The pull request only addresses one issue or adds one feature.**
- [/] **The pull request does not introduce any breaking changes**
- [/] **I have added screenshots or gifs to help explain the change if applicable.**
- [/] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [/] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
