### PR TITLE
[feature] allow multiple script context roots

### DIFF
--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -46,6 +46,11 @@ class ScriptRuntime {
     const req = new BrunoRequest(request);
     const allowScriptFilesystemAccess = get(scriptingConfig, 'filesystemAccess.allow', false);
     const moduleWhitelist = get(scriptingConfig, 'moduleWhitelist', []);
+    const additionalContextRoots = get(scriptingConfig, 'additionalContextRoots', []);
+    const additionalContextRootsAbsolute = lodash
+      .chain(additionalContextRoots)
+      .map((acr) => (acr.startsWith('/') ? acr : path.join(collectionPath, acr)))
+      .value();
 
     const whitelistedModules = {};
 
@@ -83,7 +88,7 @@ class ScriptRuntime {
       require: {
         context: 'sandbox',
         external: true,
-        root: [collectionPath],
+        root: [collectionPath, ...additionalContextRootsAbsolute],
         mock: {
           // node libs
           path,

--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -48,6 +48,11 @@ class TestRuntime {
     const res = new BrunoResponse(response);
     const allowScriptFilesystemAccess = get(scriptingConfig, 'filesystemAccess.allow', false);
     const moduleWhitelist = get(scriptingConfig, 'moduleWhitelist', []);
+    const additionalContextRoots = get(scriptingConfig, 'additionalContextRoots', []);
+    const additionalContextRootsAbsolute = lodash
+      .chain(additionalContextRoots)
+      .map((acr) => (acr.startsWith('/') ? acr : path.join(collectionPath, acr)))
+      .value();
 
     const whitelistedModules = {};
 
@@ -101,7 +106,7 @@ class TestRuntime {
       require: {
         context: 'sandbox',
         external: true,
-        root: [collectionPath],
+        root: [collectionPath, ...additionalContextRootsAbsolute],
         mock: {
           // node libs
           path,


### PR DESCRIPTION
# Description

Solves #438 (contains additional context).

This feature allows the user to add addtional script context roots to be able to share code/scripts between collections.

Example collection config:

```
{
  "version": "1",
  "name": "cloud",
  "type": "collection",
  "scripts": {
    "additionalContextRoots": [
      "../scripts"
    ]
  }
}
```

It supports absolute and relative paths.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
