### PR TITLE
Fix: 802 - Colon in any key name of bruno requests malformat the request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13580,6 +13580,7 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -20241,8 +20242,7 @@
       }
     },
     "@tabler/icons": {
-      "version": "1.119.0",
-      "requires": {}
+      "version": "1.119.0"
     },
     "@tauri-apps/cli": {
       "version": "1.2.2",
@@ -20746,8 +20746,7 @@
       }
     },
     "@usebruno/schema": {
-      "version": "file:packages/bruno-schema",
-      "requires": {}
+      "version": "file:packages/bruno-schema"
     },
     "@usebruno/testbench": {
       "version": "file:packages/bruno-testbench",
@@ -20891,8 +20890,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -20903,8 +20901,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -20981,8 +20978,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "0.0.8"
@@ -21876,8 +21872,7 @@
     "chai-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
-      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
-      "requires": {}
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -22272,8 +22267,7 @@
     },
     "css-declaration-sorter": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-loader": {
       "version": "6.7.3",
@@ -22392,8 +22386,7 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -23553,8 +23546,7 @@
       }
     },
     "goober": {
-      "version": "2.1.11",
-      "requires": {}
+      "version": "2.1.11"
     },
     "got": {
       "version": "9.6.0",
@@ -23917,8 +23909,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "idb": {
       "version": "7.1.1"
@@ -24520,8 +24511,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.2.0",
@@ -25110,8 +25100,7 @@
       "version": "1.4.1"
     },
     "meros": {
-      "version": "1.2.1",
-      "requires": {}
+      "version": "1.2.1"
     },
     "methods": {
       "version": "1.1.2"
@@ -25871,23 +25860,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-js": {
       "version": "3.0.3",
@@ -25969,8 +25954,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -26003,8 +25987,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -26399,11 +26382,11 @@
       }
     },
     "react-inspector": {
-      "version": "6.0.2",
-      "requires": {}
+      "version": "6.0.2"
     },
     "react-is": {
-      "version": "18.2.0"
+      "version": "18.2.0",
+      "dev": true
     },
     "react-redux": {
       "version": "7.2.9",
@@ -26550,8 +26533,7 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.2",
-      "requires": {}
+      "version": "2.4.2"
     },
     "regenerate": {
       "version": "1.4.2",
@@ -26783,8 +26765,7 @@
     },
     "rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -27278,8 +27259,7 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "styled-components": {
       "version": "5.3.6",
@@ -27308,8 +27288,7 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7",
-      "requires": {}
+      "version": "5.0.7"
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -27902,8 +27881,7 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -28064,8 +28042,7 @@
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "schema-utils": {
           "version": "3.1.1",

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -1,6 +1,7 @@
 const ohm = require('ohm-js');
 const _ = require('lodash');
 const { outdentString } = require('../../v1/src/utils');
+const { decodeString } = require('./encoder');
 
 /**
  * A Bru file is made up of blocks.
@@ -104,8 +105,8 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
   }
   return _.map(pairList[0], (pair) => {
     const rawKey = _.keys(pair)[0];
-    const value = decodeURIComponent(pair[rawKey]);
-    let name = decodeURIComponent(rawKey);
+    const value = decodeString(pair[rawKey]);
+    let name = decodeString(rawKey);
 
     if (!parseEnabled) {
       return {

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -103,8 +103,9 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
     return [];
   }
   return _.map(pairList[0], (pair) => {
-    let name = decodeURIComponent(_.keys(pair)[0]);
-    let value = decodeURIComponent(pair[name]);
+    const rawKey = _.keys(pair)[0];
+    const value = decodeURIComponent(pair[rawKey]);
+    let name = decodeURIComponent(rawKey);
 
     if (!parseEnabled) {
       return {

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -103,7 +103,7 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
     return [];
   }
   return _.map(pairList[0], (pair) => {
-    let name = _.keys(pair)[0];
+    let name = decodeURIComponent(_.keys(pair)[0]);
     let value = decodeURIComponent(pair[name]);
 
     if (!parseEnabled) {

--- a/packages/bruno-lang/v2/src/encoder.js
+++ b/packages/bruno-lang/v2/src/encoder.js
@@ -1,0 +1,59 @@
+const ENCODING_MAP = new Map([
+  ['\n', 'n'],
+  ['\r', 'r'],
+  [':', 'c'],
+  ['\\', '\\'],
+  ['~', 'd'],
+  ['@', 'a']
+]);
+
+const DECODING_MAP = new Map([...ENCODING_MAP.entries()].map(([key, value]) => [value, key]));
+
+/**
+ * Replaces a character at a given position in a string
+ * @param {string} str The string to modify
+ * @param {number} pos The position of the character to replace
+ * @param {number} length The length of the character to replace
+ * @param {string} replacement The string to replace it with
+ * @returns The new string
+ */
+function spliceString(str, pos, length, replacement) {
+  return str.slice(0, pos) + replacement + str.slice(pos + length);
+}
+
+/**
+ * Encodes a string, so it can be stored in a bruno file
+ * @param {string} str The string to encode
+ * @returns The encoded string
+ */
+function encodeString(str) {
+  for (let i = 0; i < str.length; i++) {
+    if (ENCODING_MAP.has(str[i])) {
+      const replacement = ENCODING_MAP.get(str[i]);
+      str = spliceString(str, i, 1, '\\' + replacement);
+      i++;
+    }
+  }
+  return str;
+}
+
+/**
+ * Decodes a string, so it can be used in a bruno file
+ * @param {string} str The string to decode
+ * @returns The decoded string
+ */
+function decodeString(str) {
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === '\\') {
+      const replacement = DECODING_MAP.get(str[i + 1]);
+      str = spliceString(str, i, 2, replacement);
+      i++;
+    }
+  }
+  return str;
+}
+
+module.exports = {
+  encodeString,
+  decodeString
+};

--- a/packages/bruno-lang/v2/src/encoder.js
+++ b/packages/bruno-lang/v2/src/encoder.js
@@ -47,7 +47,6 @@ function decodeString(str) {
     if (str[i] === '\\') {
       const replacement = DECODING_MAP.get(str[i + 1]);
       str = spliceString(str, i, 2, replacement);
-      i++;
     }
   }
   return str;

--- a/packages/bruno-lang/v2/src/encoder.js
+++ b/packages/bruno-lang/v2/src/encoder.js
@@ -38,13 +38,13 @@ function encodeString(str) {
 }
 
 /**
- * Decodes a string, so it can be used in a bruno file
+ * Decodes an encoded string from a bruno file
  * @param {string} str The string to decode
  * @returns The decoded string
  */
 function decodeString(str) {
   for (let i = 0; i < str.length; i++) {
-    if (str[i] === '\\') {
+    if (str[i] === '\\' && i !== str.length - 1 && DECODING_MAP.has(str[i + 1])) {
       const replacement = DECODING_MAP.get(str[i + 1]);
       str = spliceString(str, i, 2, replacement);
     }

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -24,7 +24,10 @@ const stripLastLine = (text) => {
 function encodeKeyValueItems(items, disabled = false, prefix = '') {
   const _prefix = (disabled ? '~' : '') + prefix;
   return (
-    '\n' + indentString(items.map((item) => `${_prefix}${encodeURIComponent(item.name)}: ${item.value}`).join('\n'))
+    '\n' +
+    indentString(
+      items.map((item) => `${_prefix}${encodeURIComponent(item.name)}: ${encodeURIComponent(item.value)}`).join('\n')
+    )
   );
 }
 

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 
 const { indentString } = require('../../v1/src/utils');
+const { encodeString } = require('./encoder');
 
 const END_OF_GROUP = '\n}\n\n';
 
@@ -25,9 +26,7 @@ function encodeKeyValueItems(items, disabled = false, prefix = '') {
   const _prefix = (disabled ? '~' : '') + prefix;
   return (
     '\n' +
-    indentString(
-      items.map((item) => `${_prefix}${encodeURIComponent(item.name)}: ${encodeURIComponent(item.value)}`).join('\n')
-    )
+    indentString(items.map((item) => `${_prefix}${encodeString(item.name)}: ${encodeString(item.value)}`).join('\n'))
   );
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -67,6 +67,7 @@ body:sparql {
 body:form-urlencoded {
   apikey: secret
   numbers: +91998877665
+  speci\al: char\c \d\\
   ~message: hello
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -66,7 +66,7 @@ body:sparql {
 
 body:form-urlencoded {
   apikey: secret
-  numbers: %2B91998877665
+  numbers: +91998877665
   ~message: hello
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -17,9 +17,9 @@ query {
 }
 
 headers {
-  content-type: application/json
-  Authorization: Bearer 123
-  ~transaction-id: {{transactionId}}
+  content-type: application%2Fjson
+  Authorization: Bearer%20123
+  ~transaction-id: %7B%7BtransactionId%7D%7D
 }
 
 auth:awsv4 {
@@ -99,15 +99,15 @@ vars:pre-request {
 }
 
 vars:post-response {
-  token: $res.body.token
-  @orderNumber: $res.body.orderNumber
-  ~petId: $res.body.id
-  ~@transactionId: $res.body.transactionId
+  token: %24res.body.token
+  @orderNumber: %24res.body.orderNumber
+  ~petId: %24res.body.id
+  ~@transactionId: %24res.body.transactionId
 }
 
 assert {
-  $res.status: 200
-  ~$res.body.message: success
+  %24res.status: 200
+  ~%24res.body.message: success
 }
 
 script:pre-request {

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -72,7 +72,7 @@ body:form-urlencoded {
 
 body:multipart-form {
   apikey: secret
-  numbers: +91998877665
+  numbers: %2B91998877665
   ~message: hello
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -17,9 +17,9 @@ query {
 }
 
 headers {
-  content-type: application%2Fjson
-  Authorization: Bearer%20123
-  ~transaction-id: %7B%7BtransactionId%7D%7D
+  content-type: application/json
+  Authorization: Bearer 123
+  ~transaction-id: {{transactionId}}
 }
 
 auth:awsv4 {
@@ -72,7 +72,7 @@ body:form-urlencoded {
 
 body:multipart-form {
   apikey: secret
-  numbers: %2B91998877665
+  numbers: +91998877665
   ~message: hello
 }
 
@@ -99,15 +99,15 @@ vars:pre-request {
 }
 
 vars:post-response {
-  token: %24res.body.token
-  @orderNumber: %24res.body.orderNumber
-  ~petId: %24res.body.id
-  ~@transactionId: %24res.body.transactionId
+  token: $res.body.token
+  @orderNumber: $res.body.orderNumber
+  ~petId: $res.body.id
+  ~@transactionId: $res.body.transactionId
 }
 
 assert {
-  %24res.status: 200
-  ~%24res.body.message: success
+  $res.status: 200
+  ~$res.body.message: success
 }
 
 script:pre-request {

--- a/packages/bruno-lang/v2/tests/fixtures/request.json
+++ b/packages/bruno-lang/v2/tests/fixtures/request.json
@@ -82,6 +82,11 @@
         "enabled": true
       },
       {
+        "name": "speci@l",
+        "value": "char: ~\\",
+        "enabled": true
+      },
+      {
         "name": "message",
         "value": "hello",
         "enabled": false


### PR DESCRIPTION
# Description

Fix #802 

- encode all keys and names of dictionaries saved in the bruno file
- decode all keys and names of dictionaries saved in the bruno file
- escaped characters are: `\n`, `\r`, `:`, `\`, `~`, `@`. These are all characters that break the bruno file if used in a dictionary key name or values

**Before fix:**
![issue](https://github.com/usebruno/bruno/assets/15342503/62aef8d1-da19-4524-b49e-0aa405664d8c)

**After fix:**
![fix-802](https://github.com/usebruno/bruno/assets/15342503/648e3223-a255-4833-857e-d14bfa26838a)

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes** <-- This affects only the saving of new bruno files. The old ones are fully compatible to the decoding (existing newline, colons, ...). However, if someone used `\n` or `\c`, etc. in key names, it will break
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
