### PR TITLE
feat: Adding ability to import postman graphql collections

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -14,28 +14,6 @@ const readFile = (files) => {
   });
 };
 
-/**
- *
- * @param {string} query
- * @returns {string}
- */
-const parseGraphQLQuery = (query) => {
-  return query
-    .replace(/\s+/g, ' ')
-    .replace(/{ /g, '{')
-    .replace(/ {/g, '{')
-    .replace(/ }/g, '}')
-    .replace(/, /g, ',')
-    .replace(/ : /g, ': ')
-    .replace(/\n/g, '');
-};
-
-const parseGraphQLVariables = (string) => {
-  const cleanedString = string.replace(/[\n\t]/g, '').replace(/\\"/g, '"');
-  const variables = JSON.stringify(JSON.parse(cleanedString));
-  return typeof variables === 'string' ? variables : '';
-};
-
 const parseGraphQLRequest = (graphqlSource) => {
   try {
     let queryResultObject = {
@@ -48,11 +26,11 @@ const parseGraphQLRequest = (graphqlSource) => {
     }
 
     if (graphqlSource.hasOwnProperty('variables') && graphqlSource.variables !== '') {
-      queryResultObject.variables = parseGraphQLVariables(graphqlSource.variables);
+      queryResultObject.variables = graphqlSource.variables;
     }
 
     if (graphqlSource.hasOwnProperty('query') && graphqlSource.query !== '') {
-      queryResultObject.query = parseGraphQLQuery(graphqlSource.query);
+      queryResultObject.query = graphqlSource.query;
     }
 
     return queryResultObject;


### PR DESCRIPTION
Fixes: #790

# Description

This PR adds functionality to import a GraphQL collection exported from Postman client into Bruno.

**Changes:**
1. Add function `parseGraphQLQuery()` to parse and clean incoming GraphQL queries from postman collection
2. Add function `parseGraphQLVariables()` to parse and clean incoming GraphQL variables
3. Add function `parseGraphQLRequest()` to handle validating incoming data and keys

This PR check the `mode` of the request item in the collection to then trigger a GraphQL sanitisation and build a valid request to be input into Bru format.

## Testing:

### Source  Sample Collection:
```JSON
{
    "info": {
        "_postman_id": "c33bffc4-0e32-498b-a12d-2b5d54eebf14",
        "name": "Test Stub Graphql",
        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
    },
    "item": [
        {
            "name": "Get Countries",
            "id": "0e7a0dfa-9c23-40af-8a78-a102c63dc873",
            "protocolProfileBehavior": {
                "disableBodyPruning": true
            },
            "request": {
                "method": "POST",
                "header": [],
                "body": {
                    "mode": "graphql",
                    "graphql": {
                        "query": "query Countries {\n    countries {\n        awsRegion\n        capital\n        code\n        currencies\n        currency\n        emoji\n        emojiU\n        name\n        native\n        phone\n        phones\n    }\n}",
                        "variables": ""
                    }
                },
                "url": {
                    "raw": "https://countries.trevorblades.com",
                    "protocol": "https",
                    "host": [
                        "countries",
                        "trevorblades",
                        "com"
                    ]
                }
            },
            "response": []
        },
        {
            "name": "Get Country",
            "id": "5c13fa4e-5755-4acd-b4fe-9fb7fd9dd96b",
            "protocolProfileBehavior": {
                "disableBodyPruning": true
            },
            "request": {
                "method": "POST",
                "header": [],
                "body": {
                    "mode": "graphql",
                    "graphql": {
                        "query": "query GetCountry($code: ID!) {\n    country(code: $code) {\n        awsRegion\n        capital\n        code\n        currencies\n        currency\n        emoji\n        emojiU\n        name\n        native\n        phone\n        phones\n    }\n}",
                        "variables": "{\n    \"code\": \"ZA\"\n}"
                    }
                },
                "url": {
                    "raw": "https://countries.trevorblades.com",
                    "protocol": "https",
                    "host": [
                        "countries",
                        "trevorblades",
                        "com"
                    ]
                }
            },
            "response": []
        }
    ]
}
```

### Bru Collection Results
**Get Countries:**
```
meta {
  name: Get Countries
  type: graphql
  seq: 1
}

post {
  url: https://countries.trevorblades.com
  body: graphql
  auth: none
}

body:graphql {
  query Countries{countries{awsRegion capital code currencies currency emoji emojiU name native phone phones}}
}
```

**Get Country:**
```
meta {
  name: Get Country
  type: graphql
  seq: 2
}

post {
  url: https://countries.trevorblades.com
  body: graphql
  auth: none
}

body:graphql {
  query GetCountry($code: ID!){country(code: $code){awsRegion capital code currencies currency emoji emojiU name native phone phones}}
}

body:graphql:vars {
  {"code":"ZA"}
}
```


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
