### PR TITLE
fix: trimming variable path

### DIFF
--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -9,7 +9,7 @@ if (!SERVER_RENDERED) {
 }
 
 const pathFoundInVariables = (path, obj) => {
-  const value = get(obj, path);
+  const value = get(obj, path.trim());
   return value !== undefined;
 };
 


### PR DESCRIPTION
fixes #936
# Description

Fixes a bug where when having spaces in the left or right of a variable inside the `{{ }}` syntax bruno would not find the variable:

before the fix:
![image](https://github.com/usebruno/bruno/assets/13181797/ca8e4374-7ad9-46ba-9c62-5f04834184e4)

after the fix:
![image](https://github.com/usebruno/bruno/assets/13181797/2c6484b8-5e57-4cb0-a033-7a76d49d9023)


I would happily add tests for this if it is needed, but I need some help :>)
