### PR TITLE
fix (#680): fixed non-string variables to be displayed correctly in code editor

### DIFF
--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -10,7 +10,7 @@ if (!SERVER_RENDERED) {
 
 const pathFoundInVariables = (path, obj) => {
   const value = get(obj, path);
-  return isString(value);
+  return value !== undefined;
 };
 
 export const defineCodeMirrorBrunoVariablesMode = (variables, mode) => {


### PR DESCRIPTION
# Description

Fixes #680.

Non-string collection variables are displayed in code editor as red without tooltip with variable value. So this PR fixes this bug and they are now correctly displayed as green also in cases value is null. They are red only in case they are undefined.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
