### PR TITLE
fix (#402): response/body cursor offset on resize

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -146,6 +146,9 @@ export default class CodeEditor extends React.Component {
   }
 
   render() {
+    if (this.editor) {
+      this.editor.refresh()
+    }
     return (
       <StyledWrapper
         className="h-full w-full"

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -147,7 +147,7 @@ export default class CodeEditor extends React.Component {
 
   render() {
     if (this.editor) {
-      this.editor.refresh()
+      this.editor.refresh();
     }
     return (
       <StyledWrapper


### PR DESCRIPTION
Now response/body will be refresh each time it gets resized so the cursor always stays in the right place.

# Description
This will fix #402 and make it easier to adjust the response/body window size to see them better while not losing the cursor. It might not be very efficient if the response/body is very large (haven't noticed any issues yet).

### before
https://github.com/usebruno/bruno/assets/115114979/49d53071-7a27-45d2-ad39-52754efb2508

### after
https://github.com/usebruno/bruno/assets/115114979/7c07201e-5f8a-4c8a-b0ad-f8f45d7daac3


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
