### PR TITLE
feat: add class when collection name is hovered during drag and drop

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
@@ -33,7 +33,8 @@ const Wrapper = styled.div`
       overflow: hidden;
     }
 
-    &:hover {
+    &:hover,
+    &.item-hovered {
       background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
       .menu-icon {
         .dropdown {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -84,7 +84,8 @@ const CollectionItem = ({ item, collection, searchText }) => {
   });
 
   const itemRowClassName = classnames('flex collection-item-name items-center', {
-    'item-focused-in-tab': item.uid == activeTabUid
+    'item-focused-in-tab': item.uid == activeTabUid,
+    'item-hovered': isOver
   });
 
   const scrollToTheActiveTab = () => {


### PR DESCRIPTION
Resolves #849

# Description

During drag and drop, the target collection has a `isOver` property provided by the `collect` function 

https://github.com/usebruno/bruno/blob/c46fbfbde39b025c5e1692477508c2162b65f4aa/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js#L60-L62

We use that to add a new class to the collection item and that class has the same property as the existing `:hover` 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

https://github.com/usebruno/bruno/assets/674667/4ff5bd47-fdcb-4ebd-abf7-bef91477b653


