### PR TITLE
fix(#853): Allow - in variable names & small refactor

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
@@ -10,6 +10,7 @@ import StyledWrapper from './StyledWrapper';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { uuid } from 'utils/common';
+import { envVariableNameRegex } from 'utils/common/regex';
 
 const EnvironmentVariables = ({ environment, collection }) => {
   const dispatch = useDispatch();
@@ -23,7 +24,10 @@ const EnvironmentVariables = ({ environment, collection }) => {
         enabled: Yup.boolean(),
         name: Yup.string()
           .required('Name cannot be empty')
-          .matches(/^(?!\d)\w*$/, 'Name contains invalid characters')
+          .matches(
+            envVariableNameRegex,
+            'Name contains invalid characters. Must only contain alphanumeric characters, "-" and "_"'
+          )
           .trim(),
         secret: Yup.boolean(),
         type: Yup.string(),

--- a/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
@@ -9,6 +9,7 @@ import SingleLineEditor from 'components/SingleLineEditor';
 import Tooltip from 'components/Tooltip';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
+import { envVariableNameRegex } from 'utils/common/regex';
 
 const VarsTable = ({ item, collection, vars, varType }) => {
   const dispatch = useDispatch();
@@ -37,8 +38,10 @@ const VarsTable = ({ item, collection, vars, varType }) => {
           return;
         }
 
-        if (/^\w*$/.test(value) === false) {
-          toast.error('Variable contains invalid character! Variables must only contain alpha-numeric characters.');
+        if (envVariableNameRegex.test(value) === false) {
+          toast.error(
+            'Variable contains invalid character! Variables must only contain alpha-numeric characters, "-" and "_".'
+          );
           return;
         }
 

--- a/packages/bruno-app/src/utils/common/regex.js
+++ b/packages/bruno-app/src/utils/common/regex.js
@@ -1,0 +1,1 @@
+export const envVariableNameRegex = /^(?!\d)[\w-]*$/;

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -1,6 +1,8 @@
 const Handlebars = require('handlebars');
 const { cloneDeep } = require('lodash');
 
+const envVariableNameRegex = /^(?!\d)[\w-]*$/;
+
 class Bru {
   constructor(envVariables, collectionVariables, processEnvVars, collectionPath) {
     this.envVariables = envVariables;
@@ -59,10 +61,10 @@ class Bru {
       throw new Error('Key is required');
     }
 
-    if (/^(?!\d)\w*$/.test(key) === false) {
+    if (envVariableNameRegex.test(key) === false) {
       throw new Error(
         `Variable name: "${key}" contains invalid characters!` +
-          ' Names must only contain alpha-numeric characters and cannot start with a digit.'
+          ' Names must only contain alpha-numeric characters, "-", "_" and cannot start with a digit.'
       );
     }
 
@@ -70,7 +72,7 @@ class Bru {
   }
 
   getVar(key) {
-    if (/^(?!\d)\w*$/.test(key) === false) {
+    if (envVariableNameRegex.test(key) === false) {
       throw new Error(
         `Variable name: "${key}" contains invalid characters!` +
           ' Names must only contain alpha-numeric characters and cannot start with a digit.'


### PR DESCRIPTION
# Description

Closes: #853 & #682

Allow `-` in variable names, update error messages & refactor the regex into a constant.