### PR TITLE
feat(cosmiconfig): Enable cli run from anywhere

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13731,6 +13731,7 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -16736,6 +16737,7 @@
         "axios": "^1.5.1",
         "chai": "^4.3.7",
         "chalk": "^3.0.0",
+        "cosmiconfig": "^8.3.6",
         "decomment": "^0.9.5",
         "form-data": "^4.0.0",
         "fs-extra": "^10.1.0",
@@ -16763,6 +16765,11 @@
         "node": ">= 14"
       }
     },
+    "packages/bruno-cli/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "packages/bruno-cli/node_modules/axios": {
       "version": "1.5.1",
       "license": "MIT",
@@ -16781,6 +16788,31 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/bruno-cli/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "packages/bruno-cli/node_modules/fs-extra": {
@@ -16818,9 +16850,20 @@
         "node": ">= 14"
       }
     },
+    "packages/bruno-cli/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v1.0.1",
+      "version": "v1.1.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.425.0",
         "@usebruno/js": "0.9.1",
@@ -20468,8 +20511,7 @@
       }
     },
     "@tabler/icons": {
-      "version": "1.119.0",
-      "requires": {}
+      "version": "1.119.0"
     },
     "@tauri-apps/cli": {
       "version": "1.2.2",
@@ -20825,6 +20867,7 @@
         "axios": "^1.5.1",
         "chai": "^4.3.7",
         "chalk": "^3.0.0",
+        "cosmiconfig": "^8.3.6",
         "decomment": "^0.9.5",
         "form-data": "^4.0.0",
         "fs-extra": "^10.1.0",
@@ -20845,6 +20888,11 @@
             "debug": "^4.3.4"
           }
         },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "axios": {
           "version": "1.5.1",
           "requires": {
@@ -20858,6 +20906,17 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+          "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+          "requires": {
+            "import-fresh": "^3.3.0",
+            "js-yaml": "^4.1.0",
+            "parse-json": "^5.2.0",
+            "path-type": "^4.0.0"
           }
         },
         "fs-extra": {
@@ -20882,6 +20941,14 @@
           "requires": {
             "agent-base": "^7.0.2",
             "debug": "4"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
           }
         }
       }
@@ -20975,8 +21042,7 @@
       }
     },
     "@usebruno/schema": {
-      "version": "file:packages/bruno-schema",
-      "requires": {}
+      "version": "file:packages/bruno-schema"
     },
     "@usebruno/testbench": {
       "version": "file:packages/bruno-testbench",
@@ -21120,8 +21186,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -21132,8 +21197,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -21209,8 +21273,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "0.0.8"
@@ -22107,8 +22170,7 @@
     "chai-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
-      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
-      "requires": {}
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -22503,8 +22565,7 @@
     },
     "css-declaration-sorter": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-loader": {
       "version": "6.7.3",
@@ -22623,8 +22684,7 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -23777,8 +23837,7 @@
       }
     },
     "goober": {
-      "version": "2.1.11",
-      "requires": {}
+      "version": "2.1.11"
     },
     "got": {
       "version": "9.6.0",
@@ -24140,8 +24199,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "idb": {
       "version": "7.1.1"
@@ -24741,8 +24799,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.2.0",
@@ -25327,8 +25384,7 @@
       "version": "1.4.1"
     },
     "meros": {
-      "version": "1.2.1",
-      "requires": {}
+      "version": "1.2.1"
     },
     "methods": {
       "version": "1.1.2"
@@ -26105,23 +26161,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-js": {
       "version": "3.0.3",
@@ -26203,8 +26255,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -26237,8 +26288,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -26714,11 +26764,11 @@
       }
     },
     "react-inspector": {
-      "version": "6.0.2",
-      "requires": {}
+      "version": "6.0.2"
     },
     "react-is": {
-      "version": "18.2.0"
+      "version": "18.2.0",
+      "dev": true
     },
     "react-redux": {
       "version": "7.2.9",
@@ -26865,8 +26915,7 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.2",
-      "requires": {}
+      "version": "2.4.2"
     },
     "regenerate": {
       "version": "1.4.2",
@@ -27103,8 +27152,7 @@
     },
     "rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -27617,8 +27665,7 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "styled-components": {
       "version": "5.3.6",
@@ -27647,8 +27694,7 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7",
-      "requires": {}
+      "version": "5.0.7"
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -28254,8 +28300,7 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -28416,8 +28461,7 @@
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "schema-utils": {
           "version": "3.1.1",

--- a/packages/bruno-cli/package.json
+++ b/packages/bruno-cli/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.5.1",
     "chai": "^4.3.7",
     "chalk": "^3.0.0",
+    "cosmiconfig": "^8.3.6",
     "decomment": "^0.9.5",
     "form-data": "^4.0.0",
     "fs-extra": "^10.1.0",


### PR DESCRIPTION
# Description

Bruno's cli is a great tool for quickly dispatching requests from the terminal. As a bruno cli user, I want to be able to run the command from any directory, supplying a relative bru file path, and have that request dispatch as though the command was run within it's containing collection.

- Adds cosmiconfig to quickly/easily resolve the bruno.json relative to the input filename.
- Make some adjustments to related variables to use new config/paths

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
