### PR TITLE
fix: Fix Content-Security-Policy config

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -14,16 +14,18 @@ const { loadWindowState, saveBounds, saveMaximized } = require('./utils/window')
 
 const lastOpenedCollections = new LastOpenedCollections();
 
+// Reference: https://content-security-policy.com/
 const contentSecurityPolicy = [
-  isDev ? "default-src 'self' 'unsafe-inline' 'unsafe-eval'" : "default-src 'self'",
-  "connect-src 'self' https://api.github.com/repos/usebruno/bruno",
-  "font-src 'self' https://fonts.gstatic.com",
+  "default-src 'self'",
+  "script-src * 'unsafe-inline' 'unsafe-eval'",
+  "connect-src 'self' api.github.com",
+  "font-src 'self' https:",
   "form-action 'none'",
-  "img-src 'self' blob: data:",
-  "style-src 'self' https://fonts.googleapis.com"
+  "img-src 'self' blob: data: https:",
+  "style-src 'self' 'unsafe-inline' https:"
 ];
 
-setContentSecurityPolicy(contentSecurityPolicy.join(';'));
+setContentSecurityPolicy(contentSecurityPolicy.join(';') + ';');
 
 const menu = Menu.buildFromTemplate(menuTemplate);
 Menu.setApplicationMenu(menu);


### PR DESCRIPTION
# Description

Fixes this electron startup error:

```
(node:9856) UnhandledPromiseRejectionWarning: Error: Each line must end in a semicolon
    at exports.setContentSecurityPolicy (C:\Users\Timon\projects\bruno\node_modules\electron-util\index.js:150:9)
(Use `electron --trace-warnings ...` to show where the warning was created)
(node:9856) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
```
This happened because the last line was missing a semicolon.

I also updated the CSP because, the app would not start with the old CSP.