### PR TITLE
fixed editors style to avoid overflow

### DIFF
--- a/packages/bruno-app/src/components/Documentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Documentation/StyledWrapper.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const StyledWrapper = styled.div`
   div.CodeMirror {
     /* todo: find a better way */
-    height: calc(100vh - 240px);
+    height: 100%;
 
     .CodeMirror-scroll {
       padding-bottom: 0px;

--- a/packages/bruno-app/src/components/Documentation/index.js
+++ b/packages/bruno-app/src/components/Documentation/index.js
@@ -36,7 +36,7 @@ const Documentation = ({ item, collection }) => {
   }
 
   return (
-    <StyledWrapper className="mt-1 h-full w-full relative">
+    <StyledWrapper className="mt-1 flex-1 flex flex-col w-full relative">
       <div className="editing-mode mb-2" role="tab" onClick={toggleViewMode}>
         {isEditing ? 'Preview' : 'Edit'}
       </div>

--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
@@ -149,7 +149,7 @@ const GraphQLRequestPane = ({ item, collection, leftPaneWidth, onSchemaLoad, tog
         </div>
         <GraphQLSchemaActions item={item} collection={collection} onSchemaLoad={setSchema} toggleDocs={toggleDocs} />
       </div>
-      <section className="flex w-full mt-5">{getTabPanel(focusedTab.requestPaneTab)}</section>
+      <section className="flex w-full h-full mt-5">{getTabPanel(focusedTab.requestPaneTab)}</section>
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/components/RequestPane/GraphQLVariables/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLVariables/StyledWrapper.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const StyledWrapper = styled.div`
   div.CodeMirror {
     /* todo: find a better way */
-    height: calc(100vh - 220px);
+    height: 100%;
   }
 `;
 

--- a/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
@@ -27,7 +27,7 @@ const GraphQLVariables = ({ variables, item, collection }) => {
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
 
   return (
-    <StyledWrapper className="w-full">
+    <StyledWrapper className="w-full h-full">
       <CodeEditor
         collection={collection}
         value={variables || ''}

--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -136,7 +136,7 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
         ) : null}
       </div>
       <section
-        className={`flex w-full ${
+        className={`flex w-full h-full ${
           ['script', 'vars', 'auth', 'docs'].includes(focusedTab.requestPaneTab) ? '' : 'mt-5'
         }`}
       >

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/StyledWrapper.js
@@ -5,7 +5,7 @@ const StyledWrapper = styled.div`
     background: ${(props) => props.theme.codemirror.bg};
     border: solid 1px ${(props) => props.theme.codemirror.border};
     /* todo: find a better way */
-    height: calc(100vh - 220px);
+    height: 100%;
   }
 
   textarea.cm-editor {

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/StyledWrapper.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
   div.CodeMirror {
     /* todo: find a better way */
-    height: calc(100vh - 220px);
+    height: 100%;
   }
 `;
 

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -40,7 +40,7 @@ const Script = ({ item, collection }) => {
 
   return (
     <StyledWrapper className="w-full flex flex-col">
-      <div className="flex-1 mt-2">
+      <div className="h-fit mt-2">
         <div className="mb-1 title text-xs">Pre Request</div>
         <CodeEditor
           collection={collection}
@@ -53,7 +53,7 @@ const Script = ({ item, collection }) => {
           onSave={onSave}
         />
       </div>
-      <div className="flex-1 mt-6">
+      <div className="h-fit mt-6">
         <div className="mt-1 mb-1 title text-xs">Post Response</div>
         <CodeEditor
           collection={collection}

--- a/packages/bruno-app/src/components/RequestPane/Tests/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/Tests/StyledWrapper.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const StyledWrapper = styled.div`
   div.CodeMirror {
     /* todo: find a better way */
-    height: calc(100vh - 220px);
+    height: 100%;
   }
 `;
 

--- a/packages/bruno-app/src/components/RequestPane/Tests/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Tests/index.js
@@ -28,7 +28,7 @@ const Tests = ({ item, collection }) => {
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
 
   return (
-    <StyledWrapper className="w-full">
+    <StyledWrapper className="w-full h-full">
       <CodeEditor
         collection={collection}
         value={tests || ''}

--- a/packages/bruno-app/src/components/RequestPane/Vars/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Vars/index.js
@@ -8,12 +8,12 @@ const Vars = ({ item, collection }) => {
   const responseVars = item.draft ? get(item, 'draft.request.vars.res') : get(item, 'request.vars.res');
 
   return (
-    <StyledWrapper className="w-full flex flex-col">
-      <div className="flex-1 mt-2">
+    <StyledWrapper className="w-full flex flex-col h-full overflow-y-auto">
+      <div className="h-fit mt-2">
         <div className="mb-1 title text-xs">Pre Request</div>
         <VarsTable item={item} collection={collection} vars={requestVars} varType="request" />
       </div>
-      <div className="flex-1">
+      <div className="h-fit">
         <div className="mt-1 mb-1 title text-xs">Post Response</div>
         <VarsTable item={item} collection={collection} vars={responseVars} varType="response" />
       </div>

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -156,7 +156,7 @@ const RequestTabPanel = () => {
             className="px-4"
             style={{
               width: `${Math.max(leftPaneWidth, MIN_LEFT_PANE_WIDTH)}px`,
-              height: `calc(100% - ${DEFAULT_PADDING}px)`
+              height: `100%`
             }}
           >
             {item.type === 'graphql-request' ? (


### PR DESCRIPTION
# Description

I noticed that on the JSON editor when it opens it shifts the layout and the entire page becomes scrollable. Now with these fixes, I changed all the heights of the editors to avoid defined values similar to calc(100vh - 22px) and use only height: 100% and display flex. The change is visible on the bottom of the page.

## Before
<img width="1728" alt="Screenshot 2023-11-07 at 13 01 08" src="https://github.com/usebruno/bruno/assets/64805332/f6747adf-5641-4843-901b-a63be734e9ef">


## After
<img width="1728" alt="Screenshot 2023-11-07 at 13 01 35" src="https://github.com/usebruno/bruno/assets/64805332/bd2b9cd8-e35e-477d-93e6-328a55cf514f">


### Contribution Checklist:

- [ X ] **The pull request only addresses one issue or adds one feature.**
- [ X ] **The pull request does not introduce any breaking changes**
- [ X ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ X ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ X ] **Create an issue and link to the pull request.**

Issue: #911 
