### PR TITLE
fixed #904 with adding a alert message to the variable value

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
@@ -32,7 +32,13 @@ const EnvironmentVariables = ({ environment, collection }) => {
         secret: Yup.boolean(),
         type: Yup.string(),
         uid: Yup.string(),
-        value: Yup.string().trim()
+        value: Yup.string()
+          .when('secret', {
+            is: true,
+            then: Yup.string().required('Value cannot be empty when secret'),
+            otherwise: Yup.string()
+          })
+          .trim()
       })
     ),
     onSubmit: (values) => {
@@ -52,7 +58,7 @@ const EnvironmentVariables = ({ environment, collection }) => {
 
   const ErrorMessage = ({ name }) => {
     const meta = formik.getFieldMeta(name);
-    console.log(name, meta);
+
     if (!meta.error) {
       return null;
     }
@@ -127,6 +133,7 @@ const EnvironmentVariables = ({ environment, collection }) => {
                   value={variable.value}
                   onChange={(newValue) => formik.setFieldValue(`${index}.value`, newValue, true)}
                 />
+                <ErrorMessage name={`${index}.value`} />
               </td>
               <td>
                 <input
@@ -161,4 +168,5 @@ const EnvironmentVariables = ({ environment, collection }) => {
     </StyledWrapper>
   );
 };
+
 export default EnvironmentVariables;


### PR DESCRIPTION
1. Implemented validation error handling.
2. Displays an error if a user tries to save an environment variable with an empty "Value" for a "secret" variable.

![Screenshot 2023-11-08 135123](https://github.com/usebruno/bruno/assets/132228919/8f98cb8d-cb7a-4602-a368-79edb7b6b6fa)

