### PR TITLE
fix(#904): fix environment save when empty secret exists

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
@@ -32,7 +32,7 @@ const EnvironmentVariables = ({ environment, collection }) => {
         secret: Yup.boolean(),
         type: Yup.string(),
         uid: Yup.string(),
-        value: Yup.string().trim()
+        value: Yup.string().trim().nullable()
       })
     ),
     onSubmit: (values) => {
@@ -114,7 +114,7 @@ const EnvironmentVariables = ({ environment, collection }) => {
                   className="mousetrap"
                   id={`${index}.name`}
                   name={`${index}.name`}
-                  value={formik.values[index].name}
+                  value={variable.name}
                   onChange={formik.handleChange}
                 />
                 <ErrorMessage name={`${index}.name`} />


### PR DESCRIPTION
# Description
Closes #904 

Allows empty value for an environment variable(useful as user might want to create variables and assign values later)
<img width="907" alt="Screenshot 2023-11-08 at 15 55 57" src="https://github.com/usebruno/bruno/assets/13575704/e20b08a5-d323-4ec3-85cb-9150755c7c01">

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**