### PR TITLE
fix(#901): fix headers in code generator

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -9,10 +9,11 @@ const CodeView = ({ language, item }) => {
   const { storedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
   const { target, client, language: lang } = language;
+  const headers = item.draft ? get(item, 'draft.request.headers') : get(item, 'request.headers');
   let snippet = '';
 
   try {
-    snippet = new HTTPSnippet(buildHarRequest(item.request)).convert(target, client);
+    snippet = new HTTPSnippet(buildHarRequest({ request: item.request, headers })).convert(target, client);
   } catch (e) {
     console.error(e);
     snippet = 'Error generating code snippet';

--- a/packages/bruno-app/src/utils/codegenerator/har.js
+++ b/packages/bruno-app/src/utils/codegenerator/har.js
@@ -9,25 +9,17 @@ const createContentType = (mode) => {
     case 'multipartForm':
       return 'multipart/form-data';
     default:
-      return 'application/json';
+      return '';
   }
 };
 
-const createHeaders = (headers, mode) => {
-  const contentType = createContentType(mode);
-  const headersArray = headers
+const createHeaders = (headers) => {
+  return headers
     .filter((header) => header.enabled)
-    .map((header) => {
-      return {
-        name: header.name,
-        value: header.value
-      };
-    });
-  const headerNames = headersArray.map((header) => header.name);
-  if (!headerNames.includes('Content-Type')) {
-    return [...headersArray, { name: 'Content-Type', value: contentType }];
-  }
-  return headersArray;
+    .map((header) => ({
+      name: header.name,
+      value: header.value
+    }));
 };
 
 const createQuery = (queryParams = []) => {
@@ -56,13 +48,13 @@ const createPostData = (body) => {
   }
 };
 
-export const buildHarRequest = (request) => {
+export const buildHarRequest = ({ request, headers }) => {
   return {
     method: request.method,
     url: request.url,
     httpVersion: 'HTTP/1.1',
     cookies: [],
-    headers: createHeaders(request.headers, request.body.mode),
+    headers: createHeaders(headers),
     queryString: createQuery(request.params),
     postData: createPostData(request.body),
     headersSize: 0,


### PR DESCRIPTION
# Description

Closes - #901 
While debugging the issue stated in #901, I found another issue(custom headers not being shown in code-generator at all, possibly missed in #280)

This PR addresses both of these:
* unwanted header - `content-type` added in code generator by default
* custom header not added in code generator at all

Snapshot: - pst
<img width="556" alt="Screenshot 2023-11-10 at 03 33 29" src="https://github.com/usebruno/bruno/assets/13575704/531ab070-0995-47c2-b0b2-1ae94283a5ee">

