### PR TITLE
feat(#731): support theme sync with system

### DIFF
--- a/packages/bruno-app/src/components/Preferences/Theme/index.js
+++ b/packages/bruno-app/src/components/Preferences/Theme/index.js
@@ -13,7 +13,7 @@ const Theme = () => {
       theme: storedTheme
     },
     validationSchema: Yup.object({
-      theme: Yup.string().oneOf(['light', 'dark']).required('theme is required')
+      theme: Yup.string().oneOf(['light', 'dark', 'system']).required('theme is required')
     }),
     onSubmit: (values) => {
       setStoredTheme(values.theme);
@@ -54,6 +54,22 @@ const Theme = () => {
           />
           <label htmlFor="dark-theme" className="ml-1 cursor-pointer select-none">
             Dark
+          </label>
+
+          <input
+            id="system-theme"
+            className="ml-4 cursor-pointer"
+            type="radio"
+            name="theme"
+            onChange={(e) => {
+              formik.handleChange(e);
+              formik.handleSubmit();
+            }}
+            value="system"
+            checked={formik.values.theme === 'system'}
+          />
+          <label htmlFor="system-theme" className="ml-1 cursor-pointer select-none">
+            System
           </label>
         </div>
       </div>

--- a/packages/bruno-app/src/providers/Theme/index.js
+++ b/packages/bruno-app/src/providers/Theme/index.js
@@ -1,7 +1,7 @@
 import themes from 'themes/index';
 import useLocalStorage from 'hooks/useLocalStorage/index';
 
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { ThemeProvider as SCThemeProvider } from 'styled-components';
 
 export const ThemeContext = createContext();
@@ -10,10 +10,12 @@ export const ThemeProvider = (props) => {
   const [displayedTheme, setDisplayedTheme] = useState(isBrowserThemeLight ? 'light' : 'dark');
   const [storedTheme, setStoredTheme] = useLocalStorage('bruno.theme', 'system');
 
-  window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', (e) => {
-    if (storedTheme !== 'system') return;
-    setDisplayedTheme(e.matches ? 'light' : 'dark');
-  });
+  useEffect(() => {
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', (e) => {
+      if (storedTheme !== 'system') return;
+      setDisplayedTheme(e.matches ? 'light' : 'dark');
+    });
+  }, []);
 
   const theme = storedTheme === 'system' ? themes[displayedTheme] : themes[storedTheme];
   const themeOptions = Object.keys(themes);

--- a/packages/bruno-app/src/providers/Theme/index.js
+++ b/packages/bruno-app/src/providers/Theme/index.js
@@ -1,15 +1,21 @@
 import themes from 'themes/index';
 import useLocalStorage from 'hooks/useLocalStorage/index';
 
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useState } from 'react';
 import { ThemeProvider as SCThemeProvider } from 'styled-components';
 
 export const ThemeContext = createContext();
 export const ThemeProvider = (props) => {
   const isBrowserThemeLight = window.matchMedia('(prefers-color-scheme: light)').matches;
-  const [storedTheme, setStoredTheme] = useLocalStorage('bruno.theme', isBrowserThemeLight ? 'light' : 'dark');
+  const [displayedTheme, setDisplayedTheme] = useState(isBrowserThemeLight ? 'light' : 'dark');
+  const [storedTheme, setStoredTheme] = useLocalStorage('bruno.theme', 'system');
 
-  const theme = themes[storedTheme];
+  window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', (e) => {
+    if (storedTheme !== 'system') return;
+    setDisplayedTheme(e.matches ? 'light' : 'dark');
+  });
+
+  const theme = storedTheme === 'system' ? themes[displayedTheme] : themes[storedTheme];
   const themeOptions = Object.keys(themes);
   const value = {
     theme,


### PR DESCRIPTION
# Description

Added a "System" theme options, which means "Sync with system". Does not break explicitly specified Light and Dark options.

Resolves #731 

| Sync with system dark | Sync with system light |
|--|--|
|![image](https://github.com/usebruno/bruno/assets/9428948/cf1b358b-f3dd-4b4b-ae62-1429257af8fc)|![image](https://github.com/usebruno/bruno/assets/9428948/adeebb44-7a1e-4093-83c8-9f2208244405)|


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
