### PR TITLE
Fix inifinite loop in openapi-spec import with self-references

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -187,17 +187,23 @@ const transformOpenapiRequestItem = (request) => {
   return brunoRequestItem;
 };
 
-const resolveRefs = (spec, components = spec.components) => {
+const resolveRefs = (spec, components = spec.components, visitedItems = new Set()) => {
   if (!spec || typeof spec !== 'object') {
     return spec;
   }
 
   if (Array.isArray(spec)) {
-    return spec.map((item) => resolveRefs(item, components));
+    return spec.map((item) => resolveRefs(item, components, visitedItems));
   }
 
   if ('$ref' in spec) {
     const refPath = spec.$ref;
+
+    if (visitedItems.has(refPath)) {
+      return spec;
+    } else {
+      visitedItems.add(refPath);
+    }
 
     if (refPath.startsWith('#/components/')) {
       // Local reference within components
@@ -213,7 +219,7 @@ const resolveRefs = (spec, components = spec.components) => {
         }
       }
 
-      return resolveRefs(ref, components);
+      return resolveRefs(ref, components, visitedItems);
     } else {
       // Handle external references (not implemented here)
       // You would need to fetch the external reference and resolve it.
@@ -223,7 +229,7 @@ const resolveRefs = (spec, components = spec.components) => {
 
   // Recursively resolve references in nested objects
   for (const prop in spec) {
-    spec[prop] = resolveRefs(spec[prop], components);
+    spec[prop] = resolveRefs(spec[prop], components, visitedItems);
   }
 
   return spec;


### PR DESCRIPTION
# Description

Problem: Issue relates to OpenAPI specs which have self referencing components, resulting in infinite loops being made within resolveRefs.

Solution: Added basic use of Set to store already-traversed items within the OpenAPI spec.

Tested against the API Spec mentioned in issue [939](https://github.com/usebruno/bruno/issues/939#issue-1986513743) - both as JSON and YAML.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** - existing issue [939](https://github.com/usebruno/bruno/issues/939#issue-1986513743)

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
