### PR TITLE
fix #961 by using trim

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -34,7 +34,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
       requestUrlChanged({
         itemUid: item.uid,
         collectionUid: collection.uid,
-        url: value
+        url: value.trim()
       })
     );
   };
@@ -80,7 +80,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
             }}
           >
             <IconDeviceFloppy
-              color={item.draft ? theme.colors.text.yellow : theme.requestTabs.icon.color}
+              color={item.draft ? theme.colors.text.purple : theme.requestTabs.icon.color}
               strokeWidth={1.5}
               size={22}
               className={`${item.draft ? 'cursor-pointer' : 'cursor-default'}`}


### PR DESCRIPTION
# Description

I fixed #961 by applying .trim() on the incoming url.
Unsure if tests are used to safeguard the functionality of components, I didn't see any tests for QueryUrl, but maybe I overlooked them.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
