### PR TITLE
feat: handle postman import with same folder names (#955)

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -55,16 +55,27 @@ const convertV21Auth = (array) => {
 
 const importPostmanV2CollectionItem = (brunoParent, item, parentAuth) => {
   brunoParent.items = brunoParent.items || [];
+  const folderMap = {};
 
   each(item, (i) => {
     if (isItemAFolder(i)) {
+      const baseFolderName = i.name;
+      let folderName = baseFolderName;
+      let count = 1;
+
+      while (folderMap[folderName]) {
+        folderName = `${baseFolderName}_${count}`;
+        count++;
+      }
+
       const brunoFolderItem = {
         uid: uuid(),
-        name: i.name,
+        name: folderName,
         type: 'folder',
         items: []
       };
       brunoParent.items.push(brunoFolderItem);
+      folderMap[folderName] = brunoFolderItem;
       if (i.item && i.item.length) {
         importPostmanV2CollectionItem(brunoFolderItem, i.item, i.auth ?? parentAuth);
       }


### PR DESCRIPTION
# Description

Refers to https://github.com/usebruno/bruno/issues/955 

If you have multiple folders with the same names when you import your Postman Collection, only the first one will be imported and all of the others will be ignored. I think there are 3 solutions 
1. Merge all the requests into one folder
2. Keep the folders and add a number to the end
3. Simply notify the user that all the folders could not be imported

For now I chose the 2nd solution, see capture : 

https://github.com/usebruno/bruno/assets/46541094/91792067-9669-410f-a12f-94d9ca8585ea

Let me know if it's the desired behaviour.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
