### PR TITLE
fix(#1012): silently ignore invalid cookie

### DIFF
--- a/packages/bruno-electron/src/utils/cookies.js
+++ b/packages/bruno-electron/src/utils/cookies.js
@@ -5,7 +5,9 @@ const cookieJar = new CookieJar();
 
 const addCookieToJar = (setCookieHeader, requestUrl) => {
   const cookie = Cookie.parse(setCookieHeader, { loose: true });
-  cookieJar.setCookieSync(cookie, requestUrl);
+  cookieJar.setCookieSync(cookie, requestUrl, {
+    ignoreError: true // silently ignore things like parse errors and invalid domains
+  });
 };
 
 const getCookiesForUrl = (url) => {


### PR DESCRIPTION
# Description

Closes #1012

After some digging, it looks like this is fixed by using the options `ignoreError`: `true` on [tough-cookie cookieJar.setCookieSync](https://www.npmjs.com/package/tough-cookie#setcookiecookieorstring-currenturl-options-callbackerr-cookie).

This will silently ignore many invalid cooke:
![image](https://github.com/usebruno/bruno/assets/7304827/847550b6-b0ae-4035-a65a-8bae992577c7)


To validate the fix, I've added an endpoint in `bruno-testbench`:
```javascript
app.get('/cookies', function (req, res) {
  res.cookie('test-valid', 'something');
  res.cookie('test-invalid', 'something-invalid', { domain: 'invalid.com' });
  return res.send();
});
```
To keep the PR focused on the fix I have not included this but I'm happy to commit it if you prefer.

I've also tested the request in #1102 and the errors is indeed fixed.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.