### PR TITLE
feat(#1017) Added ability to run a single request from sidebar

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -24,6 +24,7 @@ import { getDefaultRequestPaneTab } from 'utils/collections';
 import { hideHomePage } from 'providers/ReduxStore/slices/app';
 import toast from 'react-hot-toast';
 import StyledWrapper from './StyledWrapper';
+import NetworkError from 'components/ResponsePane/NetworkError/index';
 
 const CollectionItem = ({ item, collection, searchText }) => {
   const tabs = useSelector((state) => state.tabs.tabs);

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -8,6 +8,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
 import { collectionFolderClicked } from 'providers/ReduxStore/slices/collections';
 import { moveItem } from 'providers/ReduxStore/slices/collections/actions';
+import { sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import Dropdown from 'components/Dropdown';
 import NewRequest from 'components/Sidebar/NewRequest';
 import NewFolder from 'components/Sidebar/NewFolder';
@@ -93,6 +94,14 @@ const CollectionItem = ({ item, collection, searchText }) => {
     if (activeTab) {
       activeTab.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
+  };
+
+  const handleRun = async () => {
+    dispatch(sendRequest(item, collection.uid)).catch((err) =>
+      toast.custom((t) => <NetworkError onClose={() => toast.dismiss(t.id)} />, {
+        duration: 5000
+      })
+    );
   };
 
   const handleClick = (event) => {
@@ -297,15 +306,27 @@ const CollectionItem = ({ item, collection, searchText }) => {
                 Rename
               </div>
               {!isFolder && (
-                <div
-                  className="dropdown-item"
-                  onClick={(e) => {
-                    dropdownTippyRef.current.hide();
-                    setCloneItemModalOpen(true);
-                  }}
-                >
-                  Clone
-                </div>
+                <>
+                  <div
+                    className="dropdown-item"
+                    onClick={(e) => {
+                      dropdownTippyRef.current.hide();
+                      setCloneItemModalOpen(true);
+                    }}
+                  >
+                    Clone
+                  </div>
+                  <div
+                    className="dropdown-item"
+                    onClick={(e) => {
+                      dropdownTippyRef.current.hide();
+                      handleClick(null);
+                      handleRun();
+                    }}
+                  >
+                    Run
+                  </div>
+                </>
               )}
               {!isFolder && item.type === 'http-request' && (
                 <div


### PR DESCRIPTION
Hello,

I've added a feature that allows users to run an item directly from the sidebar menu. 
![image](https://github.com/usebruno/bruno/assets/20698024/61bde505-91c1-4dd2-a416-68726ab6e188)

With this update, when you right-click on an item in the sidebar, you now have the option to run it. This action opens the tab with the selected item (if it's not already open) and executes it. This enhancement eliminates the need to click on each item and then go to the top-right corner to find and click the IconArrowRight in the queryUrl to run it.

It’s an alternative to the run collection if you want to do it step by step.

Issue : #1017 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
