### PR TITLE
fix(#521): Allow "context" as the name of a key/var in a JS expression

### DIFF
--- a/packages/bruno-js/src/utils.js
+++ b/packages/bruno-js/src/utils.js
@@ -18,8 +18,8 @@ const JS_KEYWORDS = `
  * ```js
  * res.data.pets.map(pet => pet.name.toUpperCase())
  *
- * function(context) {
- *   const { res, pet } = context;
+ * function(_BrunoNewFunctionInnerContext) {
+ *   const { res, pet } = _BrunoNewFunctionInnerContext;
  *   return res.data.pets.map(pet => pet.name.toUpperCase())
  * }
  * ```
@@ -45,9 +45,11 @@ const compileJsExpression = (expr) => {
     globals: globals.map((name) => ` ${name} = ${name} ?? globalThis.${name};`).join('')
   };
 
-  const body = `let { ${code.vars} } = context; ${code.globals}; return ${expr}`;
+  // param name that is unlikely to show up as a var in an expression
+  const param = `_BrunoNewFunctionInnerContext`;
+  const body = `let { ${code.vars} } = ${param}; ${code.globals}; return ${expr}`;
 
-  return new Function('context', body);
+  return new Function(param, body);
 };
 
 const internalExpressionCache = new Map();


### PR DESCRIPTION
Closes #521 

# Description
Changed the name of the param used in the compiled JS function since "context" would clash with any key in the response which also contains "context".

|Before|After|
|-------|------|
|![image](https://github.com/usebruno/bruno/assets/30027205/33476978-e2b3-472a-8e12-3ffd18e8f6bf)|![image](https://github.com/usebruno/bruno/assets/30027205/377b0419-95d8-4302-bf12-b156517faa36)|
||![image](https://github.com/usebruno/bruno/assets/30027205/3e4cb4c2-9011-4f57-b695-f9cc84b149fb)|

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

