### PR TITLE
fix(#1035): fix falsy check of response

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -11,7 +11,7 @@ import { useEffect } from 'react';
 import { useTheme } from 'providers/Theme/index';
 
 const formatResponse = (data, mode) => {
-  if (!data) {
+  if (data === undefined) {
     return '';
   }
 

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -38,7 +38,7 @@ export const safeParseJSON = (str) => {
 };
 
 export const safeStringifyJSON = (obj, indent = false) => {
-  if (!obj) {
+  if (obj === undefined) {
     return obj;
   }
   try {


### PR DESCRIPTION
Closes: #1035 

while rendering a API response, all falsy values were ignored
this is fixed with this PR
<img width="958" alt="Screenshot 2023-11-25 at 14 23 58" src="https://github.com/usebruno/bruno/assets/13575704/0101d168-c869-49c7-a2e2-db31545db395">

