### PR TITLE
Fix (#1008) by removing comments from JSON linter.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17493,6 +17493,7 @@
         "react-redux": "^7.2.6",
         "react-tooltip": "^5.5.2",
         "sass": "^1.46.0",
+        "strip-json-comments": "^5.0.1",
         "styled-components": "^5.3.3",
         "system": "^2.0.1",
         "tailwindcss": "^2.2.19",
@@ -17618,6 +17619,17 @@
         "node": ">=6"
       }
     },
+    "packages/bruno-app/node_modules/strip-json-comments": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
+      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/bruno-cli": {
       "name": "@usebruno/cli",
       "version": "1.1.1",
@@ -17712,7 +17724,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v1.1.1",
+      "version": "v1.2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.425.0",
         "@usebruno/js": "0.9.2",
@@ -21767,6 +21779,7 @@
         "react-redux": "^7.2.6",
         "react-tooltip": "^5.5.2",
         "sass": "^1.46.0",
+        "strip-json-comments": "^5.0.1",
         "style-loader": "^3.3.1",
         "styled-components": "^5.3.3",
         "system": "^2.0.1",
@@ -21840,6 +21853,11 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
           "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+        },
+        "strip-json-comments": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
+          "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw=="
         }
       }
     },
@@ -22851,7 +22869,7 @@
         "node-machine-id": "^1.1.12",
         "qs": "^6.11.0",
         "socks-proxy-agent": "^8.0.2",
-        "tough-cookie": "*",
+        "tough-cookie": "^4.1.3",
         "uuid": "^9.0.0",
         "vm2": "^3.9.13",
         "yup": "^0.32.11"

--- a/packages/bruno-app/package.json
+++ b/packages/bruno-app/package.json
@@ -64,6 +64,7 @@
     "react-redux": "^7.2.6",
     "react-tooltip": "^5.5.2",
     "sass": "^1.46.0",
+    "strip-json-comments": "^5.0.1",
     "styled-components": "^5.3.3",
     "system": "^2.0.1",
     "tailwindcss": "^2.2.19",


### PR DESCRIPTION
Fix false linting errors for comments inside of JSON body. This is needed since Bruno already removes comments from the body of the body of JSON requests.

# Description
This is to fix #1008 by replacing all comments with spaces for the JSON linter. Had to override the normal JSON linter with one that can replace comments and keep placement of linting errors. There are other JSON linting things that could be done but I will leave them to other commits after this gets merged.

https://github.com/usebruno/bruno/assets/115114979/0c6b3c55-3dd9-461e-9129-96fdfc4a1f37

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
## Libraries added
* strip-json-comments (pretty compact and few dependencies)
### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
