### PR TITLE
fix(RequestPane): Fix Mardown Table styling

### DIFF
--- a/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
@@ -71,6 +71,14 @@ const StyledMarkdownBodyWrapper = styled.div`
     pre {
       background: ${(props) => props.theme.sidebar.bg};
     }
+
+    table {
+      th,
+      td {
+        border: 1px solid ${(props) => props.theme.table.border};
+        background-color: ${(props) => props.theme.bg};
+      }
+    }
   }
 
   @media (max-width: 767px) {


### PR DESCRIPTION
# Description

Updated table styling in docs preview.

Before:

![grafik](https://github.com/usebruno/bruno/assets/39559178/fcfab158-6253-4447-9491-1d863d6cbded)


After:

![grafik](https://github.com/usebruno/bruno/assets/39559178/a169120a-6eb3-41a1-93df-7065b80576d4)




