### PR TITLE
Fix (#1038): Handle unquoted variables in JSON Lint

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -204,8 +204,8 @@ export default class CodeEditor extends React.Component {
         });
       };
       try {
-        jsonlint.parse(stripJsonComments(text));
-      } catch (e) { }
+        jsonlint.parse(stripJsonComments(text.replace(/(?<!"[^":{]*){{[^}]*}}(?![^"},]*")/g, '1')));
+      } catch (e) {}
       return found;
     });
     if (editor) {


### PR DESCRIPTION
Convert unquoted variables in JSON body to 1 in JSON linter. This allows for putting multiple environment/collection variables next to each other and still be unquoted.

# Description
This is to fix (#1038) by making the JSON linter replace unquoted variables with 1 so that it passes it's tests and matches what is allowed in the JSON body. It should also fix the prettify check that I failed last commit.
![JSON_Uncommented_Variables](https://github.com/usebruno/bruno/assets/115114979/dd442de7-1e51-4457-97b0-f93e21bd445e)

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
