### PR TITLE
feat(#946): Send request even when protocol isn't specified in URL

### DIFF
--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -70,14 +70,14 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
   return axiosRequest;
 };
 
-const PROTOCOLS = ['http://', 'https://', 'wss://'];
+const protocolRegex = /([a-zA-Z]{2,20}:\/\/)(.*)/;
 
 const prepareRequest = (request, collectionRoot) => {
   const headers = {};
   let contentTypeDefined = false;
   let url = request.url;
 
-  if (PROTOCOLS.find((protocol) => url.startsWith(protocol)) === undefined) {
+  if (!protocolRegex.test(url)) {
     url = `http://${url}`;
   }
 
@@ -102,8 +102,8 @@ const prepareRequest = (request, collectionRoot) => {
 
   let axiosRequest = {
     method: request.method,
-    url: url,
-    headers: headers,
+    url,
+    headers,
     responseType: 'arraybuffer'
   };
 

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -70,9 +70,16 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
   return axiosRequest;
 };
 
+const PROTOCOLS = ['http://', 'https://', 'wss://'];
+
 const prepareRequest = (request, collectionRoot) => {
   const headers = {};
   let contentTypeDefined = false;
+  let url = request.url;
+
+  if (PROTOCOLS.find((protocol) => url.startsWith(protocol)) === undefined) {
+    url = `http://${url}`;
+  }
 
   // collection headers
   each(get(collectionRoot, 'request.headers', []), (h) => {
@@ -95,7 +102,7 @@ const prepareRequest = (request, collectionRoot) => {
 
   let axiosRequest = {
     method: request.method,
-    url: request.url,
+    url: url,
     headers: headers,
     responseType: 'arraybuffer'
   };

--- a/packages/bruno-electron/tests/network/prepare-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-request.spec.js
@@ -5,4 +5,9 @@ describe('prepare-request: prepareRequest', () => {
     const request = prepareRequest({ method: 'GET', url: 'test', body: {} });
     expect(request.url).toEqual('http://test');
   });
+
+  it("Should NOT add 'http://' to the URL if a protocol is specified", () => {
+    const request = prepareRequest({ method: 'GET', url: 'ftp://test', body: {} });
+    expect(request.url).toEqual('ftp://test');
+  });
 });

--- a/packages/bruno-electron/tests/network/prepare-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-request.spec.js
@@ -1,0 +1,8 @@
+const prepareRequest = require('../../src/ipc/network/prepare-request');
+
+describe('prepare-request: prepareRequest', () => {
+  it("Should add 'http://' to the URL if no protocol is specified", () => {
+    const request = prepareRequest({ method: 'GET', url: 'test', body: {} });
+    expect(request.url).toEqual('http://test');
+  });
+});


### PR DESCRIPTION
Closes #946 

# Description
This is something which I also missed from Postman, now users can send a request without specifying the protocol.
We now prepend `http://` to the URL when preparing the request if there's no protocol.

|Before|After|
|-------|------|
|<video src="https://github.com/usebruno/bruno/assets/30027205/6bfe4d66-68bc-4c6c-92e6-70bac0efadc1"></video>|<video src="https://github.com/usebruno/bruno/assets/30027205/c8e09786-c908-4191-b9e9-e3449d5062a2"></video>|


### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
