### PR TITLE
fix(#1024): Fix validation error on GraphQL request when importing Insomnia collection

### DIFF
--- a/packages/bruno-app/src/utils/importers/insomnia-collection.js
+++ b/packages/bruno-app/src/utils/importers/insomnia-collection.js
@@ -41,7 +41,7 @@ const parseGraphQL = (text) => {
   } catch (e) {
     return {
       query: '',
-      variables: {}
+      variables: ''
     };
   }
 };


### PR DESCRIPTION
Closes #1024 

# Description
Changed `variables` to be an empty string just like `query` when there's an exception while parsing a GraphQL request.

|Before|After|
|-------|------|
|<video src="https://github.com/usebruno/bruno/assets/30027205/99c71328-9928-4656-92a5-69bbb9dd162f"></video>|<video src="https://github.com/usebruno/bruno/assets/30027205/b8dfbb1b-3406-4a04-9566-f80aeafe2f4b"></video>|

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
