### PR TITLE
feat(#1084): Auxiliary / middle mouse button tab close

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -1,11 +1,11 @@
-import { IconChevronLeft, IconChevronRight } from '@tabler/icons';
-import classnames from 'classnames';
-import NewRequest from 'components/Sidebar/NewRequest';
-import filter from 'lodash/filter';
+import React, { useState, useRef } from 'react';
 import find from 'lodash/find';
+import filter from 'lodash/filter';
+import classnames from 'classnames';
+import { IconChevronRight, IconChevronLeft } from '@tabler/icons';
+import { useSelector, useDispatch } from 'react-redux';
 import { closeTabs, focusTab } from 'providers/ReduxStore/slices/tabs';
-import { useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import NewRequest from 'components/Sidebar/NewRequest';
 import CollectionToolBar from './CollectionToolBar';
 import RequestTab from './RequestTab';
 import StyledWrapper from './StyledWrapper';

--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -4,7 +4,7 @@ import filter from 'lodash/filter';
 import classnames from 'classnames';
 import { IconChevronRight, IconChevronLeft } from '@tabler/icons';
 import { useSelector, useDispatch } from 'react-redux';
-import { focusTab } from 'providers/ReduxStore/slices/tabs';
+import { closeTabs, focusTab } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
 import CollectionToolBar from './CollectionToolBar';
 import RequestTab from './RequestTab';
@@ -33,6 +33,14 @@ const RequestTabs = () => {
         uid: tab.uid
       })
     );
+  };
+
+  const handleAuxClick = (e, tab) => {
+    if (e.button === 1) {
+      closeTabs({
+        tabUids: [tab.uid]
+      });
+    }
   };
 
   const createNewTab = () => setNewRequestModalOpen(true);
@@ -110,6 +118,7 @@ const RequestTabs = () => {
                         className={getTabClassname(tab, index)}
                         role="tab"
                         onClick={() => handleClick(tab)}
+                        onAuxClick={(e) => handleAuxClick(e, tab)}
                       >
                         <RequestTab key={tab.uid} tab={tab} collection={activeCollection} />
                       </li>

--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -1,11 +1,11 @@
-import React, { useState, useRef } from 'react';
-import find from 'lodash/find';
-import filter from 'lodash/filter';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons';
 import classnames from 'classnames';
-import { IconChevronRight, IconChevronLeft } from '@tabler/icons';
-import { useSelector, useDispatch } from 'react-redux';
-import { closeTabs, focusTab } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
+import filter from 'lodash/filter';
+import find from 'lodash/find';
+import { closeTabs, focusTab } from 'providers/ReduxStore/slices/tabs';
+import { useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import CollectionToolBar from './CollectionToolBar';
 import RequestTab from './RequestTab';
 import StyledWrapper from './StyledWrapper';
@@ -37,9 +37,11 @@ const RequestTabs = () => {
 
   const handleAuxClick = (e, tab) => {
     if (e.button === 1) {
-      closeTabs({
-        tabUids: [tab.uid]
-      });
+      dispatch(
+        closeTabs({
+          tabUids: [tab.uid]
+        })
+      );
     }
   };
 


### PR DESCRIPTION
# Description

Closes [#1084](https://github.com/usebruno/bruno/issues/1084)

[Screencast from 2023-11-29 04-06-04.webm](https://github.com/usebruno/bruno/assets/55733050/89d007d9-bfec-4501-89dc-99c20da53a60)

New changes now allow for pressing the middle mouse button to close tabs.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
