### PR TITLE
fix(GenerateCode): filter out disabled query params

### DIFF
--- a/packages/bruno-app/src/utils/codegenerator/har.js
+++ b/packages/bruno-app/src/utils/codegenerator/har.js
@@ -23,12 +23,12 @@ const createHeaders = (headers) => {
 };
 
 const createQuery = (queryParams = []) => {
-  return queryParams.map((param) => {
-    return {
+  return queryParams
+    .filter((param) => param.enabled)
+    .map((param) => ({
       name: param.name,
       value: param.value
-    };
-  });
+    }));
 };
 
 const createPostData = (body) => {


### PR DESCRIPTION
# Description

Fixes #1089 to filter out disabled query params when generating code

## Screenshots
![image](https://github.com/usebruno/bruno/assets/21134/81c6eb26-2849-4471-91f4-df4d5bdc85db)
![image](https://github.com/usebruno/bruno/assets/21134/f0cffc47-76a4-4b69-8c62-7051a83fcc59)
![image](https://github.com/usebruno/bruno/assets/21134/120745d8-67e5-423b-a936-76d32b488832)
![image](https://github.com/usebruno/bruno/assets/21134/2a6f1e51-f863-4656-bb22-e17c4def4635)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**