### PR TITLE
Fix: Update CSP to allow posthog

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -18,7 +18,7 @@ const lastOpenedCollections = new LastOpenedCollections();
 const contentSecurityPolicy = [
   "default-src 'self'",
   "script-src * 'unsafe-inline' 'unsafe-eval'",
-  "connect-src 'self' api.github.com",
+  "connect-src 'self' api.github.com app.posthog.com",
   "font-src 'self' https:",
   "form-action 'none'",
   "img-src 'self' blob: data: https:",


### PR DESCRIPTION
Updated Electron's Content-Security-Policy to include `app.posthog.com`. This fixes telemetry data not being sent.
