### PR TITLE
fix(#1077): Fix params to updateNextAction

### DIFF
--- a/packages/bruno-app/src/providers/App/useCollectionNextAction.js
+++ b/packages/bruno-app/src/providers/App/useCollectionNextAction.js
@@ -17,7 +17,7 @@ const useCollectionNextAction = () => {
         const item = findItemInCollectionByPathname(collection, get(collection, 'nextAction.payload.pathname'));
 
         if (item) {
-          dispatch(updateNextAction(collection.uid, null));
+          dispatch(updateNextAction({ collectionUid: collection.uid, nextAction: null }));
           dispatch(
             addTab({
               uid: item.uid,


### PR DESCRIPTION
# Description

Fixes a slight parameter mistake in a useEffect for useCollectionNextAction. This was impacting an issue where nextAction wouldn't be properly reset and re-trigger undesirably. 

Fixes a bug described in https://github.com/usebruno/bruno/issues/1077

The param wasn't being passed correctly and the updateNextAction couldn't find a collection to set the next action to `null`

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
