### PR TITLE
fix(#124): resolve all *.localhost to localhost, and fix ipv6 issue

### DIFF
--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -1,4 +1,31 @@
+const URL = require('url');
+const Socket = require('net').Socket;
 const axios = require('axios');
+
+const getTld = (hostname) => {
+  if (!hostname) {
+    return '';
+  }
+
+  return hostname.substring(hostname.lastIndexOf('.') + 1);
+};
+
+const checkConnection = (host, port) =>
+  new Promise((resolve) => {
+    const socket = new Socket();
+
+    socket.once('connect', () => {
+      socket.end();
+      resolve(true);
+    });
+
+    socket.once('error', () => {
+      resolve(false);
+    });
+
+    // Try to connect to the host and port
+    socket.connect(port, host);
+  });
 
 /**
  * Function that configures axios with timing interceptors
@@ -10,7 +37,22 @@ function makeAxiosInstance() {
   /** @type {axios.AxiosInstance} */
   const instance = axios.create();
 
-  instance.interceptors.request.use((config) => {
+  instance.interceptors.request.use(async (config) => {
+    const url = URL.parse(config.url);
+
+    // Resolve all *.localhost to localhost and check if it should use IPv6 or IPv4
+    // RFC: 6761 section 6.3 (https://tools.ietf.org/html/rfc6761#section-6.3)
+    // @see https://github.com/usebruno/bruno/issues/124
+    if (getTld(url.hostname) === 'localhost') {
+      config.headers.Host = url.hostname; // Put original hostname in Host
+
+      const portNumber = Number(url.port) || (url.protocol.includes('https') ? 443 : 80);
+      const useIpv6 = await checkConnection('::1', portNumber);
+      url.hostname = useIpv6 ? '::1' : '127.0.0.1';
+      delete url.host; // Clear hostname cache
+      config.url = URL.format(url);
+    }
+
     config.headers['request-start-time'] = Date.now();
     return config;
   });

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1,7 +1,6 @@
 const os = require('os');
 const fs = require('fs');
 const qs = require('qs');
-const parseUrl = require('url').parse;
 const https = require('https');
 const axios = require('axios');
 const path = require('path');
@@ -74,14 +73,6 @@ const getEnvVars = (environment = {}) => {
 };
 
 const protocolRegex = /([a-zA-Z]{2,20}:\/\/)(.*)/;
-
-const getTld = (hostname) => {
-  if (!hostname) {
-    return '';
-  }
-
-  return hostname.substring(hostname.lastIndexOf('.') + 1);
-};
 
 const configureRequest = async (
   collectionUid,
@@ -181,15 +172,6 @@ const configureRequest = async (
     request.httpsAgent = new https.Agent({
       ...httpsAgentRequestFields
     });
-  }
-
-  // resolve all *.localhost to localhost
-  // RFC: 6761 section 6.3 (https://tools.ietf.org/html/rfc6761#section-6.3)
-  // @see https://github.com/usebruno/bruno/issues/124
-  let parsedUrl = parseUrl(request.url);
-  if (getTld(parsedUrl.hostname) === 'localhost') {
-    request.headers['Host'] = parsedUrl.hostname;
-    request.url = request.url.replace(parsedUrl.hostname, 'localhost');
   }
 
   const axiosInstance = makeAxiosInstance();


### PR DESCRIPTION
# Description

This PR fix #124, by correctly handling : 
- localhost subdomains (*.localhost) even if they are not inside a hosts file
- trying ipv6 localhost first, like in google chrome.
(see RFC: 6761 section 6.3 https://tools.ietf.org/html/rfc6761#section-6.3).

This fix is heavily inspired by how PostmanRuntime is handling it (https://github.com/postmanlabs/postman-runtime/blob/develop/lib/requester/core.js#L433),  their handling is even more complex by overriding DNS lookup of node (https://github.com/postmanlabs/postman-runtime/blob/develop/lib/requester/core.js#L285).

I did some tests on windows & linux, and this PR correctly fix subdomains, or ipv6 issues.

If you have any comments on this PR let me know !

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
