### PR TITLE
Add checkbox on each line in CodeEditor

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -117,7 +117,7 @@ export default class CodeEditor extends React.Component {
       matchBrackets: true,
       showCursorWhenSelecting: true,
       foldGutter: true,
-      gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter', 'CodeMirror-lint-markers'],
+      gutters: ['control-checkboxes', 'checkboxes', 'CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
       lint: { esversion: 11 },
       readOnly: this.props.readOnly,
       scrollbarStyle: 'overlay',


### PR DESCRIPTION
# Description

Add checkbox in the CodeEditor if the property : ``checkboxEnabled`` is passed to the CodeEditor

![image](https://github.com/usebruno/bruno/assets/191879/a37fc677-4f63-4538-bb42-487d846deb6b)

To have them you need to call the CodeEditor like that (the true.. it should be a variable instead in your code.
````javascript
<CodeEditor
          collection={collection}
          font={get(preferences, 'font.codeFont', 'default')}
          theme={storedTheme}
          onRun={onRun}
          value={formattedData}
          mode={mode}
          readOnly
          checkboxEnabled={true}
        />
````

This PR is 1 of 3 to cover a more robust solution with those features implemented.
-https://github.com/usebruno/bruno/issues/1125
-https://github.com/usebruno/bruno/issues/1126
-https://github.com/usebruno/bruno/issues/1127

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**
