### PR TITLE
feat: Multipart Form Data file uploads

### DIFF
--- a/packages/bruno-app/src/components/FilePickerEditor/index.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/index.js
@@ -14,7 +14,6 @@ const FilePickerEditor = ({ value, onChange }) => {
   const browse = () => {
     dispatch(browseFiles())
       .then((filePaths) => {
-        // When the user closes the diolog without selecting anything dirPath will be false
         onChange(filePaths.join('|'));
       })
       .catch((error) => {

--- a/packages/bruno-app/src/components/FilePickerEditor/index.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/index.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { browseFiles } from 'providers/ReduxStore/slices/collections/actions';
+import { IconX } from '@tabler/icons';
+
+const FilePickerEditor = ({ value, onChange }) => {
+  const dispatch = useDispatch();
+  const filnames = value
+    .split('|')
+    .filter((v) => v != null && v != '')
+    .map((v) => v.split('\\').pop());
+  const title = filnames.map((v) => `- ${v}`).join('\n');
+
+  const browse = () => {
+    dispatch(browseFiles())
+      .then((filePaths) => {
+        // When the user closes the diolog without selecting anything dirPath will be false
+        onChange(filePaths.join('|'));
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  };
+
+  const clear = () => {
+    onChange('');
+  };
+
+  const renderButtonText = (filnames) => {
+    if (filnames.length == 1) {
+      return filnames[0];
+    }
+    return filnames.length + ' files selected';
+  };
+
+  return filnames.length > 0 ? (
+    <div
+      className="btn btn-secondary px-1"
+      style={{ fontWeight: 400, width: '100%', textOverflow: 'ellipsis', overflowX: 'hidden' }}
+      title={title}
+    >
+      <button className="align-middle" onClick={clear}>
+        <IconX size={18} />
+      </button>
+      &nbsp;
+      {renderButtonText(filnames)}
+    </div>
+  ) : (
+    <button className="btn btn-secondary px-1" style={{ width: '100%' }} onClick={browse}>
+      Select Files
+    </button>
+  );
+};
+
+export default FilePickerEditor;

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -12,6 +12,7 @@ import {
 import SingleLineEditor from 'components/SingleLineEditor';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import StyledWrapper from './StyledWrapper';
+import FilePickerEditor from 'components/FilePickerEditor/index';
 
 const MultipartFormParams = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -27,6 +28,16 @@ const MultipartFormParams = ({ item, collection }) => {
     );
   };
 
+  const addFile = () => {
+    dispatch(
+      addMultipartFormParam({
+        itemUid: item.uid,
+        collectionUid: collection.uid,
+        isFile: true
+      })
+    );
+  };
+
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
   const handleRun = () => dispatch(sendRequest(item, collection.uid));
   const handleParamChange = (e, _param, type) => {
@@ -38,6 +49,9 @@ const MultipartFormParams = ({ item, collection }) => {
       }
       case 'value': {
         param.value = e.target.value;
+        // if (param.isFile === true) {
+        //   param.value = `@file(${param.value})`;
+        // }
         break;
       }
       case 'enabled': {
@@ -92,24 +106,41 @@ const MultipartFormParams = ({ item, collection }) => {
                       />
                     </td>
                     <td>
-                      <SingleLineEditor
-                        onSave={onSave}
-                        theme={storedTheme}
-                        value={param.value}
-                        onChange={(newValue) =>
-                          handleParamChange(
-                            {
-                              target: {
-                                value: newValue
-                              }
-                            },
-                            param,
-                            'value'
-                          )
-                        }
-                        onRun={handleRun}
-                        collection={collection}
-                      />
+                      {param.isFile === true ? (
+                        <FilePickerEditor
+                          value={param.value}
+                          onChange={(newValue) =>
+                            handleParamChange(
+                              {
+                                target: {
+                                  value: newValue
+                                }
+                              },
+                              param,
+                              'value'
+                            )
+                          }
+                        />
+                      ) : (
+                        <SingleLineEditor
+                          onSave={onSave}
+                          theme={storedTheme}
+                          value={param.value}
+                          onChange={(newValue) =>
+                            handleParamChange(
+                              {
+                                target: {
+                                  value: newValue
+                                }
+                              },
+                              param,
+                              'value'
+                            )
+                          }
+                          onRun={handleRun}
+                          collection={collection}
+                        />
+                      )}
                     </td>
                     <td>
                       <div className="flex items-center">
@@ -131,9 +162,16 @@ const MultipartFormParams = ({ item, collection }) => {
             : null}
         </tbody>
       </table>
-      <button className="btn-add-param text-link pr-2 py-3 mt-2 select-none" onClick={addParam}>
-        + Add Param
-      </button>
+      <div>
+        <button className="btn-add-param text-link pr-2 pt-3 mt-2 select-none" onClick={addParam}>
+          + Add Param
+        </button>
+      </div>
+      <div>
+        <button className="btn-add-param text-link pr-2 pt-3 select-none" onClick={addFile}>
+          + Add File
+        </button>
+      </div>
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -49,9 +49,6 @@ const MultipartFormParams = ({ item, collection }) => {
       }
       case 'value': {
         param.value = e.target.value;
-        // if (param.isFile === true) {
-        //   param.value = `@file(${param.value})`;
-        // }
         break;
       }
       case 'enabled': {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -894,6 +894,16 @@ export const browseDirectory = () => (dispatch, getState) => {
   });
 };
 
+export const browseFiles =
+  (filters = []) =>
+  (dispatch, getState) => {
+    const { ipcRenderer } = window;
+
+    return new Promise((resolve, reject) => {
+      ipcRenderer.invoke('renderer:browse-files', filters).then(resolve).catch(reject);
+    });
+  };
+
 export const updateBrunoConfig = (brunoConfig, collectionUid) => (dispatch, getState) => {
   const state = getState();
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -607,6 +607,7 @@ export const collectionsSlice = createSlice({
           item.draft.request.body.multipartForm = item.draft.request.body.multipartForm || [];
           item.draft.request.body.multipartForm.push({
             uid: uuid(),
+            isFile: action.payload.isFile ?? false,
             name: '',
             value: '',
             description: '',
@@ -627,6 +628,7 @@ export const collectionsSlice = createSlice({
           }
           const param = find(item.draft.request.body.multipartForm, (p) => p.uid === action.payload.param.uid);
           if (param) {
+            param.isFile = action.payload.param.isFile;
             param.name = action.payload.param.name;
             param.value = action.payload.param.value;
             param.description = action.payload.param.description;

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -109,6 +109,7 @@ const prepareRequest = (request, collectionRoot) => {
     each(enabledParams, (p) => (params[p.name] = p.value));
     axiosRequest.headers['content-type'] = 'multipart/form-data';
     axiosRequest.data = params;
+    // TODO is it needed here as well ?
   }
 
   if (request.body.mode === 'graphql') {

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -39,6 +39,7 @@ const runSingleRequest = async function (
     // make axios work in node using form data
     // reference: https://github.com/axios/axios/issues/1006#issuecomment-320165427
     if (request.headers && request.headers['content-type'] === 'multipart/form-data') {
+      // TODO remove ?
       const form = new FormData();
       forOwn(request.data, (value, key) => {
         form.append(key, value);

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -10,6 +10,7 @@ const {
   hasBruExtension,
   isDirectory,
   browseDirectory,
+  browseFiles,
   createDirectory,
   searchForBruFiles,
   sanitizeDirectoryName
@@ -33,6 +34,17 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
   ipcMain.handle('renderer:browse-directory', async (event, pathname, request) => {
     try {
       return await browseDirectory(mainWindow);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  });
+
+  // browse directory for file
+  ipcMain.handle('renderer:browse-files', async (event, pathname, request, filters) => {
+    try {
+      const filePath = await browseFiles(mainWindow, filters);
+
+      return filePath;
     } catch (error) {
       return Promise.reject(error);
     }

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -468,7 +468,9 @@ const registerNetworkIpc = (mainWindow) => {
             : [response.headers['set-cookie']];
 
           for (let setCookieHeader of setCookieHeaders) {
-            addCookieToJar(setCookieHeader, request.url);
+            if (typeof setCookieHeader === 'string' && setCookieHeader.length) {
+              addCookieToJar(setCookieHeader, request.url);
+            }
           }
         }
       }

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -103,6 +103,19 @@ const browseDirectory = async (win) => {
   return isDirectory(resolvedPath) ? resolvedPath : false;
 };
 
+const browseFiles = async (win, filters) => {
+  const { filePaths } = await dialog.showOpenDialog(win, {
+    properties: ['multiSelections'],
+    filters
+  });
+
+  if (!filePaths) {
+    return [];
+  }
+
+  return filePaths.map((path) => normalizeAndResolvePath(path)).filter((path) => isFile(path));
+};
+
 const chooseFileToSave = async (win, preferredFileName = '') => {
   const { filePath } = await dialog.showSaveDialog(win, {
     defaultPath: preferredFileName
@@ -147,6 +160,7 @@ module.exports = {
   hasBruExtension,
   createDirectory,
   browseDirectory,
+  browseFiles,
   chooseFileToSave,
   searchForFiles,
   searchForBruFiles,

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -128,6 +128,18 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
   });
 };
 
+const mapPairListToKeyValPairsMultipart = (pairList = [], parseEnabled = true) => {
+  const pairs = mapPairListToKeyValPairs(pairList, parseEnabled);
+
+  return pairs.map((pair) => {
+    if (pair.value.startsWith('@file(') && pair.value.endsWith(')')) {
+      pair.isFile = true;
+      pair.value = pair.value.replace(/^@file\(/, '').replace(/\)$/, '');
+    }
+    return pair;
+  });
+};
+
 const concatArrays = (objValue, srcValue) => {
   if (_.isArray(objValue) && _.isArray(srcValue)) {
     return objValue.concat(srcValue);
@@ -376,7 +388,7 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   bodymultipart(_1, dictionary) {
     return {
       body: {
-        multipartForm: mapPairListToKeyValPairs(dictionary.ast)
+        multipartForm: mapPairListToKeyValPairsMultipart(dictionary.ast)
       }
     };
   },

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -181,18 +181,17 @@ ${indentString(body.sparql)}
 
   if (body && body.multipartForm && body.multipartForm.length) {
     bru += `body:multipart-form {`;
-    if (enabled(body.multipartForm).length) {
-      bru += `\n${indentString(
-        enabled(body.multipartForm)
-          .map((item) => `${item.name}: ${item.value}`)
-          .join('\n')
-      )}`;
-    }
+    const multipartForms = enabled(body.multipartForm).concat(disabled(body.multipartForm));
 
-    if (disabled(body.multipartForm).length) {
+    if (multipartForms.length) {
       bru += `\n${indentString(
-        disabled(body.multipartForm)
-          .map((item) => `~${item.name}: ${item.value}`)
+        multipartForms
+          .map((item) => {
+            const enabled = item.enabled ? '' : '~';
+            const value = item.isFile ? `@file(${item.value})` : item.value;
+
+            return `${enabled}${item.name}: ${value}`;
+          })
           .join('\n')
       )}`;
     }

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -24,6 +24,7 @@ const environmentsSchema = Yup.array().of(environmentSchema);
 
 const keyValueSchema = Yup.object({
   uid: uidSchema,
+  isFile: Yup.boolean().nullable(),
   name: Yup.string().nullable(),
   value: Yup.string().nullable(),
   description: Yup.string().nullable(),


### PR DESCRIPTION
This PR attempts to implement Multipart Form Data file uploads, as discussed in https://github.com/usebruno/bruno/issues/195.

I am new to this framework and have referred to the work done in https://github.com/usebruno/bruno/pull/258 and https://github.com/usebruno/bruno/pull/558 for guidance.

In the .bru file, I used a `|` to separate different files, considering that it is a forbidden character on both Windows and Linux.

![image](https://github.com/usebruno/bruno/assets/3854597/7187497e-2457-4df1-9d9b-b84c0fd789bd)

![image](https://github.com/usebruno/bruno/assets/3854597/a6f96daf-74ba-4a37-8522-1a1a458330ab)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **Create an issue and link to the pull request.**
