### PR TITLE
fix(#1143): Fix PR #971 - Use literal segments only for env/collection variables + Add to CLI

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -28,7 +28,7 @@ const interpolateEnvVars = (str, processEnvVars) => {
   });
 };
 
-const varsRegex = /{{((?!process\.env\.)[\w-.]*)}}/g;
+const varsRegex = /(?<!\\)\{\{(?!process\.env\.\w+)(.*\..*)\}\}/g;
 
 const interpolateVars = (request, envVars = {}, collectionVariables = {}, processEnvVars = {}) => {
   // we clone envVars because we don't want to modify the original object

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -28,6 +28,8 @@ const interpolateEnvVars = (str, processEnvVars) => {
   });
 };
 
+const varsRegex = /{{((?!process\.env\.)[\w-.]*)}}/g;
+
 const interpolateVars = (request, envVars = {}, collectionVariables = {}, processEnvVars = {}) => {
   // we clone envVars because we don't want to modify the original object
   envVars = cloneDeep(envVars);
@@ -43,6 +45,10 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
       return str;
     }
 
+    if (varsRegex.test(str)) {
+      // Handlebars doesn't allow dots as identifiers, so we need to use literal segments
+      str = str.replaceAll(varsRegex, '{{[$1]}}');
+    }
     const template = Handlebars.compile(str, { noEscape: true });
 
     // collectionVariables take precedence over envVars

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -28,6 +28,8 @@ const interpolateEnvVars = (str, processEnvVars) => {
   });
 };
 
+const varsRegex = /{{((?!process\.env\.)[\w-.]*)}}/g;
+
 const interpolateVars = (request, envVars = {}, collectionVariables = {}, processEnvVars = {}) => {
   // we clone envVars because we don't want to modify the original object
   envVars = cloneDeep(envVars);
@@ -43,9 +45,11 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
       return str;
     }
 
-    // Handlebars doesn't allow dots as identifiers, so we need to use literal segments
-    const strLiteralSegment = str.replace('{{', '{{[').replace('}}', ']}}');
-    const template = Handlebars.compile(strLiteralSegment, { noEscape: true });
+    if (varsRegex.test(str)) {
+      // Handlebars doesn't allow dots as identifiers, so we need to use literal segments
+      str = str.replaceAll(varsRegex, '{{[$1]}}');
+    }
+    const template = Handlebars.compile(str, { noEscape: true });
 
     // collectionVariables take precedence over envVars
     const combinedVars = {

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -28,7 +28,7 @@ const interpolateEnvVars = (str, processEnvVars) => {
   });
 };
 
-const varsRegex = /{{((?!process\.env\.)[\w-.]*)}}/g;
+const varsRegex = /(?<!\\)\{\{(?!process\.env\.\w+)(.*\..*)\}\}/g;
 
 const interpolateVars = (request, envVars = {}, collectionVariables = {}, processEnvVars = {}) => {
   // we clone envVars because we don't want to modify the original object

--- a/packages/bruno-electron/tests/network/interpolate-vars.spec.js
+++ b/packages/bruno-electron/tests/network/interpolate-vars.spec.js
@@ -70,6 +70,13 @@ describe('interpolate-vars: interpolateVars', () => {
 
   describe('Does NOT interpolate string', () => {
     describe('With environment variables', () => {
+      it('If the var is escaped', async () => {
+        const request = { method: 'GET', url: `\\{{test.url}}` };
+
+        const result = interpolateVars(request, { 'test.url': 'test.com' }, null, null);
+        expect(result.url).toEqual('{{test.url}}');
+      });
+
       it("If it's not a var (no braces)", async () => {
         const request = { method: 'GET', url: 'test' };
 

--- a/packages/bruno-electron/tests/network/interpolate-vars.spec.js
+++ b/packages/bruno-electron/tests/network/interpolate-vars.spec.js
@@ -1,0 +1,123 @@
+const interpolateVars = require('../../src/ipc/network/interpolate-vars');
+
+describe('interpolate-vars: interpolateVars', () => {
+  describe('Interpolates string', () => {
+    describe('With environment variables', () => {
+      it("If there's a var with only alphanumeric characters in its name", async () => {
+        const request = { method: 'GET', url: '{{testUrl1}}' };
+
+        const result = interpolateVars(request, { testUrl1: 'test.com' }, null, null);
+        expect(result.url).toEqual('test.com');
+      });
+
+      it("If there's a var with a '.' in its name", async () => {
+        const request = { method: 'GET', url: '{{test.url}}' };
+
+        const result = interpolateVars(request, { 'test.url': 'test.com' }, null, null);
+        expect(result.url).toEqual('test.com');
+      });
+
+      it("If there's a var with a '-' in its name", async () => {
+        const request = { method: 'GET', url: '{{test-url}}' };
+
+        const result = interpolateVars(request, { 'test-url': 'test.com' }, null, null);
+        expect(result.url).toEqual('test.com');
+      });
+
+      it("If there's a var with a '_' in its name", async () => {
+        const request = { method: 'GET', url: '{{test_url}}' };
+
+        const result = interpolateVars(request, { test_url: 'test.com' }, null, null);
+        expect(result.url).toEqual('test.com');
+      });
+
+      it('If there are multiple variables', async () => {
+        const body =
+          '{\n  "firstElem": {{body-var-1}},\n  "secondElem": [{{body.var.2}}],\n  "thirdElem": {\n    "fourthElem": {{body_var_3}},\n    "{{varAsKey}}": {{valueForKey}} }}';
+        const expectedBody =
+          '{\n  "firstElem": Test1,\n  "secondElem": [Test2],\n  "thirdElem": {\n    "fourthElem": Test3,\n    "TestKey": TestValueForKey }}';
+
+        const request = { method: 'POST', url: 'test', data: body, headers: { 'content-type': 'json' } };
+        const result = interpolateVars(
+          request,
+          {
+            'body-var-1': 'Test1',
+            'body.var.2': 'Test2',
+            body_var_3: 'Test3',
+            varAsKey: 'TestKey',
+            valueForKey: 'TestValueForKey'
+          },
+          null,
+          null
+        );
+        expect(result.data).toEqual(expectedBody);
+      });
+    });
+
+    describe('With process environment variables', () => {
+      /*
+       * It should NOT turn process env vars into literal segments.
+       * Otherwise, Handlebars will try to access the var literally
+       */
+      it("If there's a var that starts with 'process.env.'", async () => {
+        const request = { method: 'GET', url: '{{process.env.TEST_VAR}}' };
+
+        const result = interpolateVars(request, null, null, { TEST_VAR: 'test.com' });
+        expect(result.url).toEqual('test.com');
+      });
+    });
+  });
+
+  describe('Does NOT interpolate string', () => {
+    describe('With environment variables', () => {
+      it("If it's not a var (no braces)", async () => {
+        const request = { method: 'GET', url: 'test' };
+
+        const result = interpolateVars(request, { 'test.url': 'test.com' }, null, null);
+        expect(result.url).toEqual('test');
+      });
+
+      it("If it's not a var (only 1 set of braces)", async () => {
+        const request = { method: 'GET', url: '{test.url}' };
+
+        const result = interpolateVars(request, { 'test.url': 'test.com' }, null, null);
+        expect(result.url).toEqual('{test.url}');
+      });
+
+      it("If it's not a var (1 opening & 2 closing braces)", async () => {
+        const request = { method: 'GET', url: '{test.url}}' };
+
+        const result = interpolateVars(request, { 'test.url': 'test.com' }, null, null);
+        expect(result.url).toEqual('{test.url}}');
+      });
+
+      it('If there are no variables (multiple)', async () => {
+        let gqlBody = `{"query":"mutation {\\n  test(input: { native: { firstElem: \\"{should-not-get-interpolated}\\", secondElem: \\"{should-not-get-interpolated}}"}}) {\\n    __typename\\n    ... on TestType {\\n      id\\n      identifier\\n    }\\n  }\\n}","variables":"{}"}`;
+
+        const request = { method: 'POST', url: 'test', data: gqlBody };
+        const result = interpolateVars(request, { 'should-not-get-interpolated': 'ERROR' }, null, null);
+        expect(result.data).toEqual(gqlBody);
+      });
+    });
+
+    describe('With process environment variables', () => {
+      it("If there's a var that doesn't start with 'process.env.'", async () => {
+        const request = { method: 'GET', url: '{{process-env-TEST_VAR}}' };
+
+        const result = interpolateVars(request, null, null, { TEST_VAR: 'test.com' });
+        expect(result.url).toEqual('');
+      });
+    });
+  });
+
+  describe('Throws an error', () => {
+    it("If there's a var with an invalid character in its name", async () => {
+      '!@#%^&*()[{]}=+,<>;\\|'.split('').forEach((character) => {
+        const request = { method: 'GET', url: `{{test${character}Url}}` };
+        expect(() => interpolateVars(request, { [`test${character}Url`]: 'test.com' }, null, null)).toThrow(
+          /Parse error.*/
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #1143, Closes #1148, Closes #1150, Closes #1367 & Closes #1321
Fixes changes introduced by PR #971

# Description
Now we add `[]` only to variables within a string & only to variables which are not process environment variables (those that don't start with `process.env.`).

I also added this feature to the CLI.

|Before|After|
|------|------|
|<video src="https://github.com/usebruno/bruno/assets/30027205/1d439bac-0611-4b03-b7ca-38b3cd453c54"></video>|<video src="https://github.com/usebruno/bruno/assets/30027205/948852fc-e9eb-4eb7-9056-ce5137817d87"></video>|
|<video src="https://github.com/usebruno/bruno/assets/30027205/8f566262-4bdc-4595-9714-0d94a04a47ea"></video>|<video src="https://github.com/usebruno/bruno/assets/30027205/9167747d-7dc0-4c95-bdca-8bb6ac0f4c04"></video>|
|<video src="https://github.com/usebruno/bruno/assets/30027205/e0d7f775-447e-4c9e-9b72-db3491e835ae"></video>|<video src="https://github.com/usebruno/bruno/assets/30027205/80d0c3cb-7137-430a-a0eb-8a18ccf5e7df"></video>|
|<video src="https://github.com/usebruno/bruno/assets/30027205/4144df18-426f-437b-8612-9e7863656bd7"></video>|<video src="https://github.com/usebruno/bruno/assets/30027205/6e9a5826-2ae4-436c-b6c8-38003aec1cc6"></video>|

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

