### PR TITLE
Fix PR #1102 - Fix test after updated dependencies

### DIFF
--- a/packages/bruno-electron/tests/network/index.spec.js
+++ b/packages/bruno-electron/tests/network/index.spec.js
@@ -1,25 +1,15 @@
-// damn jest throws an error when no tests are found in a file
-// --passWithNoTests doesn't work
+const { configureRequest } = require('../../src/ipc/network/index');
 
-describe('dummy test', () => {
-  it('should pass', () => {
-    expect(true).toBe(true);
+describe('index: configureRequest', () => {
+  it("Should add 'http://' to the URL if no protocol is specified", async () => {
+    const request = { method: 'GET', url: 'test-domain', body: {} };
+    await configureRequest(null, request, null, null, null, null);
+    expect(request.url).toEqual('http://test-domain');
+  });
+
+  it("Should NOT add 'http://' to the URL if a protocol is specified", async () => {
+    const request = { method: 'GET', url: 'ftp://test-domain', body: {} };
+    await configureRequest(null, request, null, null, null, null);
+    expect(request.url).toEqual('ftp://test-domain');
   });
 });
-
-// todo: fix this failing test
-// const { configureRequest } = require('../../src/ipc/network/index');
-
-// describe('index: configureRequest', () => {
-//   it("Should add 'http://' to the URL if no protocol is specified", async () => {
-//     const request = { method: 'GET', url: 'test-domain', body: {} };
-//     await configureRequest(null, request, null, null, null, null);
-//     expect(request.url).toEqual('http://test-domain');
-//   });
-
-//   it("Should NOT add 'http://' to the URL if a protocol is specified", async () => {
-//     const request = { method: 'GET', url: 'ftp://test-domain', body: {} };
-//     await configureRequest(null, request, null, null, null, null);
-//     expect(request.url).toEqual('ftp://test-domain');
-//   });
-// });


### PR DESCRIPTION
# Description
The unit tests from PR #1102 should now be fixed after we updated the dependencies.
Not sure why it was having issues with requiring `electron-store` before 😅.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
