### PR TITLE
Enhancement/scrollable tabs in response pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14297,6 +14297,7 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-pdf": {
@@ -17670,7 +17671,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v1.3.0",
+      "version": "v1.4.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.425.0",
         "@usebruno/js": "0.9.3",
@@ -21404,8 +21405,7 @@
       }
     },
     "@tabler/icons": {
-      "version": "1.119.0",
-      "requires": {}
+      "version": "1.119.0"
     },
     "@tippyjs/react": {
       "version": "4.2.6",
@@ -21957,8 +21957,7 @@
       }
     },
     "@usebruno/schema": {
-      "version": "file:packages/bruno-schema",
-      "requires": {}
+      "version": "file:packages/bruno-schema"
     },
     "@usebruno/testbench": {
       "version": "file:packages/bruno-testbench",
@@ -22102,8 +22101,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -22114,8 +22112,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -22197,8 +22194,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "0.0.8"
@@ -23147,8 +23143,7 @@
     "chai-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
-      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
-      "requires": {}
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -23583,8 +23578,7 @@
     },
     "css-declaration-sorter": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-loader": {
       "version": "6.7.3",
@@ -23703,8 +23697,7 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -24931,8 +24924,7 @@
       }
     },
     "goober": {
-      "version": "2.1.11",
-      "requires": {}
+      "version": "2.1.11"
     },
     "gopd": {
       "version": "1.0.1",
@@ -25326,8 +25318,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "idb": {
       "version": "7.1.1"
@@ -25927,8 +25918,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.2.0",
@@ -26647,8 +26637,7 @@
     "merge-refs": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.2.2.tgz",
-      "integrity": "sha512-RwcT7GsQR3KbuLw1rRuodq4Nt547BKEBkliZ0qqsrpyNne9bGTFtsFIsIpx82huWhcl3kOlOlH4H0xkPk/DqVw==",
-      "requires": {}
+      "integrity": "sha512-RwcT7GsQR3KbuLw1rRuodq4Nt547BKEBkliZ0qqsrpyNne9bGTFtsFIsIpx82huWhcl3kOlOlH4H0xkPk/DqVw=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -26658,8 +26647,7 @@
       "version": "1.4.1"
     },
     "meros": {
-      "version": "1.2.1",
-      "requires": {}
+      "version": "1.2.1"
     },
     "methods": {
       "version": "1.1.2"
@@ -27536,23 +27524,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-js": {
       "version": "3.0.3",
@@ -27634,8 +27618,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -27668,8 +27651,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -28145,11 +28127,11 @@
       }
     },
     "react-inspector": {
-      "version": "6.0.2",
-      "requires": {}
+      "version": "6.0.2"
     },
     "react-is": {
-      "version": "18.2.0"
+      "version": "18.2.0",
+      "dev": true
     },
     "react-pdf": {
       "version": "7.5.1",
@@ -28311,8 +28293,7 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.2",
-      "requires": {}
+      "version": "2.4.2"
     },
     "regenerate": {
       "version": "1.4.2",
@@ -28549,8 +28530,7 @@
     },
     "rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -29108,8 +29088,7 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "styled-components": {
       "version": "5.3.6",
@@ -29138,8 +29117,7 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7",
-      "requires": {}
+      "version": "5.0.7"
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -29812,8 +29790,7 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -29974,8 +29951,7 @@
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "schema-utils": {
           "version": "3.1.1",

--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/StyledWrapper.js
@@ -1,9 +1,18 @@
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
+  /* This is a hack to force headers-pane use all available space. Denoted by --hack-- */
+  position: relative;
+
   table {
     width: 100%;
     border-collapse: collapse;
+
+    /* --hack-- */
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    height: 100%;
 
     thead {
       color: #777777;

--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/StyledWrapper.js
@@ -19,6 +19,9 @@ const Wrapper = styled.div`
       font-size: 0.75rem;
       font-weight: 600;
       text-transform: uppercase;
+      position: sticky;
+      top: 0;
+      background: #1c1c1c;
     }
 
     td {

--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
@@ -3,7 +3,7 @@ import StyledWrapper from './StyledWrapper';
 
 const ResponseHeaders = ({ headers }) => {
   return (
-    <StyledWrapper className="pb-4 w-full">
+    <StyledWrapper className="pb-4 w-full overflow-auto">
       <table>
         <thead>
           <tr>

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/StyledWrapper.js
@@ -1,6 +1,17 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  /* This is a hack to force headers-pane use all available space.*/
+  position: relative;
+
+  > div:nth-child(2) {
+    position: absolute;
+    top: 2rem;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+  }
+
   .line {
     white-space: pre-line;
     word-wrap: break-word;

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/index.js
@@ -20,7 +20,7 @@ const Timeline = ({ request, response }) => {
   let requestData = safeStringifyJSON(request.data);
 
   return (
-    <StyledWrapper className="pb-4 w-full">
+    <StyledWrapper className="pb-4 w-full overflow-auto">
       <div>
         <pre className="line request font-bold">
           <span className="arrow">{'>'}</span> {request.method} {request.url}


### PR DESCRIPTION
# Description

**Original behaviour:** When an API response is received, the header and timeline tab in response pane used to make whole page scroll. 
[original_behaviour.webm](https://github.com/usebruno/bruno/assets/62416129/0322a14d-8d61-43b3-8b64-c4804d908a3f)

**After this PR: ** The header and timeline tab will now scroll without scrolling the page. Better UX.
[current_change.webm](https://github.com/usebruno/bruno/assets/62416129/87e42786-f20c-48e7-b929-fdddfa694647)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

