### PR TITLE
fix(#1112): generate code for parameter values with spaces

### DIFF
--- a/packages/bruno-app/src/utils/codegenerator/har.js
+++ b/packages/bruno-app/src/utils/codegenerator/har.js
@@ -51,7 +51,7 @@ const createPostData = (body) => {
 export const buildHarRequest = ({ request, headers }) => {
   return {
     method: request.method,
-    url: request.url,
+    url: encodeURI(request.url),
     httpVersion: 'HTTP/1.1',
     cookies: [],
     headers: createHeaders(headers),


### PR DESCRIPTION
# Description

This fixes the error "Error generating code snippet" when Environment parameters have values with spaces

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**