### PR TITLE
bugfix(#1210): prevent collection run mapping on deleted items

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -31,35 +31,39 @@ export default function RunnerResults({ collection }) {
   }, [collection, setSelectedItem]);
 
   const collectionCopy = cloneDeep(collection);
-  const items = cloneDeep(get(collection, 'runnerResult.items', []));
   const runnerInfo = get(collection, 'runnerResult.info', {});
-  each(items, (item) => {
-    const info = findItemInCollection(collectionCopy, item.uid);
-
-    item.name = info.name;
-    item.type = info.type;
-    item.filename = info.filename;
-    item.pathname = info.pathname;
-    item.relativePath = getRelativePath(collection.pathname, info.pathname);
-
-    if (item.status !== 'error') {
-      if (item.testResults) {
-        const failed = item.testResults.filter((result) => result.status === 'fail');
-
-        item.testStatus = failed.length ? 'fail' : 'pass';
-      } else {
-        item.testStatus = 'pass';
+  const items = cloneDeep(get(collection, 'runnerResult.items', []))
+    .map((item) => {
+      const info = findItemInCollection(collectionCopy, item.uid);
+      if (!info) {
+        return null;
       }
+      const newItem = {
+        ...item,
+        name: info.name,
+        type: info.type,
+        filename: info.filename,
+        pathname: info.pathname,
+        relativePath: getRelativePath(collection.pathname, info.pathname)
+      };
+      if (newItem.status !== 'error') {
+        if (newItem.testResults) {
+          const failed = newItem.testResults.filter((result) => result.status === 'fail');
+          newItem.testStatus = failed.length ? 'fail' : 'pass';
+        } else {
+          newItem.testStatus = 'pass';
+        }
 
-      if (item.assertionResults) {
-        const failed = item.assertionResults.filter((result) => result.status === 'fail');
-
-        item.assertionStatus = failed.length ? 'fail' : 'pass';
-      } else {
-        item.assertionStatus = 'pass';
+        if (newItem.assertionResults) {
+          const failed = newItem.assertionResults.filter((result) => result.status === 'fail');
+          newItem.assertionStatus = failed.length ? 'fail' : 'pass';
+        } else {
+          newItem.assertionStatus = 'pass';
+        }
       }
-    }
-  });
+      return newItem;
+    })
+    .filter(Boolean);
 
   const runCollection = () => {
     dispatch(runCollectionFolder(collection.uid, null, true));
@@ -168,26 +172,24 @@ export default function RunnerResults({ collection }) {
                           </li>
                         ))
                       : null}
-                    {item.assertionResults
-                      ? item.assertionResults.map((result) => (
-                          <li key={result.uid}>
-                            {result.status === 'pass' ? (
-                              <span className="test-success flex items-center">
-                                <IconCheck size={18} strokeWidth={2} className="mr-2" />
-                                {result.lhsExpr}: {result.rhsExpr}
-                              </span>
-                            ) : (
-                              <>
-                                <span className="test-failure flex items-center">
-                                  <IconX size={18} strokeWidth={2} className="mr-2" />
-                                  {result.lhsExpr}: {result.rhsExpr}
-                                </span>
-                                <span className="error-message pl-8 text-xs">{result.error}</span>
-                              </>
-                            )}
-                          </li>
-                        ))
-                      : null}
+                    {item.assertionResults?.map((result) => (
+                      <li key={result.uid}>
+                        {result.status === 'pass' ? (
+                          <span className="test-success flex items-center">
+                            <IconCheck size={18} strokeWidth={2} className="mr-2" />
+                            {result.lhsExpr}: {result.rhsExpr}
+                          </span>
+                        ) : (
+                          <>
+                            <span className="test-failure flex items-center">
+                              <IconX size={18} strokeWidth={2} className="mr-2" />
+                              {result.lhsExpr}: {result.rhsExpr}
+                            </span>
+                            <span className="error-message pl-8 text-xs">{result.error}</span>
+                          </>
+                        )}
+                      </li>
+                    ))}
                   </ul>
                 </div>
               </div>


### PR DESCRIPTION
# Description
Fixing issue #1210 
Improve mapping function : 

- `return null` when item no longer exists
- add `.filter(Boolean)` to remove previous null values

https://github.com/usebruno/bruno/assets/64689165/13dc8e57-80f5-4478-83fc-32f4e69a0d80

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
