### PR TITLE
feat(#1229) Include folder names in search

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -7,7 +7,7 @@ import { IconChevronRight, IconDots } from '@tabler/icons';
 import Dropdown from 'components/Dropdown';
 import { collectionClicked } from 'providers/ReduxStore/slices/collections';
 import { moveItemToRootOfCollection } from 'providers/ReduxStore/slices/collections/actions';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
 import NewFolder from 'components/Sidebar/NewFolder';
@@ -28,6 +28,7 @@ const Collection = ({ collection, searchText }) => {
   const [showExportCollectionModal, setShowExportCollectionModal] = useState(false);
   const [showRemoveCollectionModal, setShowRemoveCollectionModal] = useState(false);
   const [collectionIsCollapsed, setCollectionIsCollapsed] = useState(collection.collapsed);
+  const { includeFoldersInSearch } = useSelector((state) => state.collections);
   const dispatch = useDispatch();
 
   const menuDropdownTippyRef = useRef();
@@ -102,7 +103,7 @@ const Collection = ({ collection, searchText }) => {
   });
 
   if (searchText && searchText.length) {
-    if (!doesCollectionHaveItemsMatchingSearchText(collection, searchText)) {
+    if (!doesCollectionHaveItemsMatchingSearchText(collection, searchText, includeFoldersInSearch)) {
       return null;
     }
   }

--- a/packages/bruno-app/src/components/Sidebar/Collections/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/index.js
@@ -6,7 +6,9 @@ import {
   IconArrowsSort,
   IconSortAscendingLetters,
   IconSortDescendingLetters,
-  IconX
+  IconX,
+  IconFolder,
+  IconFolderOff
 } from '@tabler/icons';
 import Collection from '../Collections/Collection';
 import CreateCollection from '../CreateCollection';
@@ -14,7 +16,7 @@ import StyledWrapper from './StyledWrapper';
 import CreateOrOpenCollection from './CreateOrOpenCollection';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { sortCollections } from 'providers/ReduxStore/slices/collections/actions';
+import { sortCollections, toggleIncludeFoldersInSearch } from 'providers/ReduxStore/slices/collections/actions';
 
 // todo: move this to a separate folder
 // the coding convention is to keep all the components in a folder named after the component
@@ -63,8 +65,10 @@ const CollectionsBadge = () => {
 };
 
 const Collections = () => {
+  const dispatch = useDispatch();
   const [searchText, setSearchText] = useState('');
   const { collections } = useSelector((state) => state.collections);
+  const { includeFoldersInSearch } = useSelector((state) => state.collections);
   const [createCollectionModalOpen, setCreateCollectionModalOpen] = useState(false);
 
   if (!collections || !collections.length) {
@@ -102,7 +106,7 @@ const Collections = () => {
           onChange={(e) => setSearchText(e.target.value.toLowerCase())}
         />
         {searchText !== '' && (
-          <div className="absolute inset-y-0 right-0 pr-4 flex items-center">
+          <div className="absolute inset-y-0 right-5 pr-4 flex items-center">
             <span
               className="close-icon"
               onClick={() => {
@@ -113,6 +117,16 @@ const Collections = () => {
             </span>
           </div>
         )}
+        <button
+          className="absolute inset-y-0 right-0 pr-4 flex items-center"
+          onClick={() => dispatch(toggleIncludeFoldersInSearch({ includeFoldersInSearch: !includeFoldersInSearch }))}
+        >
+          {includeFoldersInSearch ? (
+            <IconFolder size={18} strokeWidth={1.5} />
+          ) : (
+            <IconFolderOff size={18} strokeWidth={1.5} />
+          )}
+        </button>
       </div>
 
       <div className="mt-4 flex flex-col overflow-y-auto absolute top-32 bottom-10 left-0 right-0">

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -39,6 +39,7 @@ import {
   renameCollection as _renameCollection,
   removeCollection as _removeCollection,
   sortCollections as _sortCollections,
+  toggleIncludeFoldersInSearch as _toggleIncludeFoldersInSearch,
   collectionAddEnvFileEvent as _collectionAddEnvFileEvent
 } from './index';
 
@@ -407,6 +408,9 @@ export const deleteItem = (itemUid, collectionUid) => (dispatch, getState) => {
 
 export const sortCollections = (payload) => (dispatch) => {
   dispatch(_sortCollections(payload));
+};
+export const toggleIncludeFoldersInSearch = (payload) => (dispatch) => {
+  dispatch(_toggleIncludeFoldersInSearch(payload));
 };
 export const moveItem = (collectionUid, draggedItemUid, targetItemUid) => (dispatch, getState) => {
   const state = getState();

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -92,6 +92,9 @@ export const collectionsSlice = createSlice({
           break;
       }
     },
+    toggleIncludeFoldersInSearch: (state, action) => {
+      state.includeFoldersInSearch = action.payload.includeFoldersInSearch;
+    },
     updateLastAction: (state, action) => {
       const { collectionUid, lastAction } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
@@ -1393,6 +1396,7 @@ export const {
   renameCollection,
   removeCollection,
   sortCollections,
+  toggleIncludeFoldersInSearch,
   updateLastAction,
   updateNextAction,
   updateSettingsSelectedTab,

--- a/packages/bruno-app/src/utils/collections/search.js
+++ b/packages/bruno-app/src/utils/collections/search.js
@@ -2,20 +2,20 @@ import { flattenItems, isItemARequest } from './index';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
 
-export const doesRequestMatchSearchText = (request, searchText = '') => {
-  return request.name.toLowerCase().includes(searchText.toLowerCase());
+export const doesItemMatchSearchText = (item, searchText = '') => {
+  return item.name.toLowerCase().includes(searchText.toLowerCase());
 };
 
-export const doesFolderHaveItemsMatchSearchText = (item, searchText = '') => {
+export const doesFolderHaveItemsMatchSearchText = (item, searchText = '', includeFolders = false) => {
   let flattenedItems = flattenItems(item.items);
-  let requestItems = filter(flattenedItems, (item) => isItemARequest(item));
+  let requestItems = includeFolders ? flattenedItems : filter(flattenedItems, (item) => isItemARequest(item));
 
-  return find(requestItems, (request) => doesRequestMatchSearchText(request, searchText));
+  return find(requestItems, (request) => doesItemMatchSearchText(request, searchText));
 };
 
-export const doesCollectionHaveItemsMatchingSearchText = (collection, searchText = '') => {
+export const doesCollectionHaveItemsMatchingSearchText = (collection, searchText = '', includeFolders = false) => {
   let flattenedItems = flattenItems(collection.items);
-  let requestItems = filter(flattenedItems, (item) => isItemARequest(item));
+  let requestItems = includeFolders ? flattenedItems : filter(flattenedItems, (item) => isItemARequest(item));
 
-  return find(requestItems, (request) => doesRequestMatchSearchText(request, searchText));
+  return find(requestItems, (request) => doesItemMatchSearchText(request, searchText));
 };


### PR DESCRIPTION
# Description

When the folder name matches the search query, it should be displayed. 
If the folder is displayed, all children should also be displayed. 
This feature can be toggled on/off by a folder button in the search bar.

<img width="1053" alt="Screenshot 2023-12-16 at 12 23 14 pm" src="https://github.com/usebruno/bruno/assets/36788304/54557f36-88f3-4f08-8d3f-820c6307d7f2">
<img width="1053" alt="Screenshot 2023-12-16 at 12 23 26 pm" src="https://github.com/usebruno/bruno/assets/36788304/175b80d3-5f04-416a-87e1-c0ad479d95ac">
<img width="707" alt="Screenshot 2023-12-16 at 12 24 25 pm" src="https://github.com/usebruno/bruno/assets/36788304/c51298f4-ad98-48b5-8b3f-31211eb8ef79">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
