### PR TITLE
set the polling mode based on path type to resolve wsl2 file system issue.

### DIFF
--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -412,7 +412,7 @@ class Watcher {
     setTimeout(() => {
       const watcher = chokidar.watch(watchPath, {
         ignoreInitial: false,
-        usePolling: false,
+        usePolling: watchPath.startsWith("\\\\") ? true : false,
         ignored: (path) => ['node_modules', '.git'].some((s) => path.includes(s)),
         persistent: true,
         ignorePermissionErrors: true,


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

This PR resolves #159.
 In watcher.js:415, changed the code like following to save and open collection on wsl2 fs.
```
usePolling: watchPath.startsWith("\\\\") ? true : false,
```
after changing the code above, the bruno works fine. (see the following picture)

![image](https://github.com/usebruno/bruno/assets/48322716/cea09252-7b97-49fd-be11-e159220a1d1a)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
