### PR TITLE
feat: OpenAPI import: create a default environment

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -31,9 +31,8 @@ const readFile = (files) => {
 };
 
 const ensureUrl = (url) => {
-  let protUrl = url.startsWith('http') ? url : `http://${url}`;
   // replace any double or triple slashes
-  return protUrl.replace(/([^:]\/)\/+/g, '$1');
+  return url.replace(/([^:]\/)\/+/g, '$1');
 };
 
 const buildEmptyJsonBody = (bodySchema) => {
@@ -323,7 +322,46 @@ const parseOpenApiCollection = (data) => {
       // TODO what if info.title not defined?
       brunoCollection.name = collectionData.info.title;
       let servers = collectionData.servers || [];
-      let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '';
+
+      let defaultProtocol = '';
+      let defaultHost = '';
+      if (servers[0]) {
+        let fullUrl = getDefaultUrl(servers[0]);
+        let parts = fullUrl.split('://');
+        // if there is only one part after splitting, presume it is the host
+        if (parts.length > 1) {
+          defaultProtocol = parts[0];
+          defaultHost = parts[1];
+        } else {
+          defaultProtocol = 'http';
+          defaultHost = parts[0];
+        }
+      }
+
+      brunoCollection.environments = [
+        {
+          uid: uuid(),
+          name: 'default',
+          variables: [
+            {
+              uid: uuid(),
+              name: 'protocol',
+              value: defaultProtocol,
+              type: 'text',
+              enabled: true,
+              secret: false
+            },
+            {
+              uid: uuid(),
+              name: 'host',
+              value: defaultHost,
+              type: 'text',
+              enabled: true,
+              secret: false
+            }
+          ]
+        }
+      ];
       let securityConfig = getSecurity(collectionData);
 
       let allRequests = Object.entries(collectionData.paths)
@@ -340,7 +378,7 @@ const parseOpenApiCollection = (data) => {
                 path: path,
                 operationObject: operationObject,
                 global: {
-                  server: baseUrl,
+                  server: '{{protocol}}://{{host}}',
                   security: securityConfig
                 }
               };


### PR DESCRIPTION
# Description

Fixes #1239

The previous solution constructed a default server baseUrl and directly concatenated it into each request of the collection. This makes it difficult to change it later through the UI if it is wrong or if the same OpenAPI spec can be used in multiple environments.

This solution instead creates a default environment with two variables "protocol" and "host", which are filled according to the previously constructed default baseUrl. This makes it very easy to change for all requests while preserving the server information extracted from the spec.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
