### PR TITLE
feat(#1224): use font preferences in collections

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Docs/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Docs/index.js
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import { updateCollectionDocs } from 'providers/ReduxStore/slices/collections';
 import { useTheme } from 'providers/Theme';
 import { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { saveCollectionRoot } from 'providers/ReduxStore/slices/collections/actions';
 import Markdown from 'components/MarkDown';
 import CodeEditor from 'components/CodeEditor';
@@ -14,6 +14,7 @@ const Docs = ({ collection }) => {
   const { storedTheme } = useTheme();
   const [isEditing, setIsEditing] = useState(false);
   const docs = get(collection, 'root.docs', '');
+  const preferences = useSelector((state) => state.app.preferences);
 
   const toggleViewMode = () => {
     setIsEditing((prev) => !prev);
@@ -44,6 +45,7 @@ const Docs = ({ collection }) => {
           onEdit={onEdit}
           onSave={onSave}
           mode="application/text"
+          font={get(preferences, 'font.codeFont', 'default')}
         />
       ) : (
         <Markdown onDoubleClick={toggleViewMode} content={docs} />

--- a/packages/bruno-app/src/components/CollectionSettings/Script/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Script/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import get from 'lodash/get';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import CodeEditor from 'components/CodeEditor';
 import { updateCollectionRequestScript, updateCollectionResponseScript } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionRoot } from 'providers/ReduxStore/slices/collections/actions';
@@ -13,6 +13,7 @@ const Script = ({ collection }) => {
   const responseScript = get(collection, 'root.request.script.res', '');
 
   const { storedTheme } = useTheme();
+  const preferences = useSelector((state) => state.app.preferences);
 
   const onRequestScriptEdit = (value) => {
     dispatch(
@@ -47,6 +48,7 @@ const Script = ({ collection }) => {
           onEdit={onRequestScriptEdit}
           mode="javascript"
           onSave={handleSave}
+          font={get(preferences, 'font.codeFont', 'default')}
         />
       </div>
       <div className="flex-1 mt-6">
@@ -58,6 +60,7 @@ const Script = ({ collection }) => {
           onEdit={onResponseScriptEdit}
           mode="javascript"
           onSave={handleSave}
+          font={get(preferences, 'font.codeFont', 'default')}
         />
       </div>
 

--- a/packages/bruno-app/src/components/CollectionSettings/Tests/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Tests/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import get from 'lodash/get';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import CodeEditor from 'components/CodeEditor';
 import { updateCollectionTests } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionRoot } from 'providers/ReduxStore/slices/collections/actions';
@@ -12,6 +12,7 @@ const Tests = ({ collection }) => {
   const tests = get(collection, 'root.request.tests', '');
 
   const { storedTheme } = useTheme();
+  const preferences = useSelector((state) => state.app.preferences);
 
   const onEdit = (value) => {
     dispatch(
@@ -33,6 +34,7 @@ const Tests = ({ collection }) => {
         onEdit={onEdit}
         mode="javascript"
         onSave={handleSave}
+        font={get(preferences, 'font.codeFont', 'default')}
       />
 
       <div className="mt-6">


### PR DESCRIPTION
# Description

With the changes introduced in this PR, the Code Editor Font preferences are now applied to the collection level as well. I used the same implementation as it was done in the `RequestPane` but I think adding this as a default behaviour to `CodeEditor` would make sense.

## Before
![image](https://github.com/usebruno/bruno/assets/48855715/8b476df2-0686-4bc9-b076-f8c22ecfebf8)

Collection level:
![image](https://github.com/usebruno/bruno/assets/48855715/41e2728f-fe20-47fd-a2fb-e8a28c07b045)

Request level:
![image](https://github.com/usebruno/bruno/assets/48855715/52d1b5d0-ff31-4e2b-8ab0-33a6862d26ba)

## After

![image](https://github.com/usebruno/bruno/assets/48855715/6aec3ee5-6709-43a5-a791-be8c94135fec)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
