### PR TITLE
Fixed typo in modal

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import Modal from 'components/Modal';
+import React from 'react';
 
 const ConfirmRequestClose = ({ onCancel, onCloseWithoutSave, onSaveAndClose }) => {
   const _handleCancel = ({ type }) => {
@@ -22,7 +22,7 @@ const ConfirmRequestClose = ({ onCancel, onCloseWithoutSave, onSaveAndClose }) =
       disableCloseOnOutsideClick={true}
       closeModalFadeTimeout={150}
     >
-      <div className="font-normal">You have unsaved changes in you request.</div>
+      <div className="font-normal">You have unsaved changes in your request.</div>
     </Modal>
   );
 };


### PR DESCRIPTION
# Description

Just fixed a typo in the close confirmation modal

![image](https://github.com/usebruno/bruno/assets/5250902/bf8e3ed6-f904-4094-9bd7-ff03d547aebd)

![image](https://github.com/usebruno/bruno/assets/5250902/a8cad39f-e22c-47a5-9c3e-f5ac2e67d875)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Closes: https://github.com/usebruno/bruno/issues/1265

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
