### PR TITLE
fix(#1145): fix res.responseTime assertion in runner

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -179,6 +179,7 @@ const runSingleRequest = async function (
       request.data = qs.stringify(request.data);
     }
 
+    let response;
     try {
       // run request
       const axiosInstance = makeAxiosInstance();
@@ -217,7 +218,7 @@ const runSingleRequest = async function (
 
     console.log(
       chalk.green(stripExtension(filename)) +
-        chalk.dim(` (${response.status} ${response.statusText}) - ${response.responseTime} ms`)
+        chalk.dim(` (${response.status} ${response.statusText}) - ${response.headers['request-duration']} ms`)
     );
 
     // run post-response vars

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -179,7 +179,6 @@ const runSingleRequest = async function (
       request.data = qs.stringify(request.data);
     }
 
-    let response, responseTime;
     try {
       // run request
       const axiosInstance = makeAxiosInstance();
@@ -187,16 +186,10 @@ const runSingleRequest = async function (
       /** @type {import('axios').AxiosResponse} */
       response = await axiosInstance(request);
 
-      // Prevents the duration on leaking to the actual result
-      responseTime = response.headers.get('request-duration');
-      response.headers.delete('request-duration');
     } catch (err) {
       if (err?.response) {
         response = err.response;
 
-        // Prevents the duration on leaking to the actual result
-        responseTime = response.headers.get('request-duration');
-        response.headers.delete('request-duration');
       } else {
         console.log(chalk.red(stripExtension(filename)) + chalk.dim(` (${err.message})`));
         return {
@@ -221,11 +214,10 @@ const runSingleRequest = async function (
       }
     }
 
-    response.responseTime = responseTime;
 
     console.log(
       chalk.green(stripExtension(filename)) +
-        chalk.dim(` (${response.status} ${response.statusText}) - ${responseTime} ms`)
+        chalk.dim(` (${response.status} ${response.statusText}) - ${response.responseTime} ms`)
     );
 
     // run post-response vars
@@ -331,7 +323,7 @@ const runSingleRequest = async function (
         statusText: response.statusText,
         headers: response.headers,
         data: response.data,
-        responseTime
+        responseTime: response.responseTime
       },
       error: null,
       assertionResults,

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -427,14 +427,9 @@ const registerNetworkIpc = (mainWindow) => {
         collectionPath
       );
 
-      let response, responseTime;
       try {
         /** @type {import('axios').AxiosResponse} */
         response = await axiosInstance(request);
-
-        // Prevents the duration on leaking to the actual result
-        responseTime = response.headers.get('request-duration');
-        response.headers.delete('request-duration');
       } catch (error) {
         deleteCancelToken(cancelTokenUid);
 
@@ -447,10 +442,6 @@ const registerNetworkIpc = (mainWindow) => {
 
         if (error?.response) {
           response = error.response;
-
-          // Prevents the duration on leaking to the actual result
-          responseTime = response.headers.get('request-duration');
-          response.headers.delete('request-duration');
         } else {
           // if it's not a network error, don't continue
           return Promise.reject(error);
@@ -461,8 +452,6 @@ const registerNetworkIpc = (mainWindow) => {
 
       const { data, dataBuffer } = parseDataFromResponse(response);
       response.data = data;
-
-      response.responseTime = responseTime;
 
       // save cookies
       if (preferencesUtil.shouldStoreCookies()) {
@@ -561,7 +550,7 @@ const registerNetworkIpc = (mainWindow) => {
         data: response.data,
         dataBuffer: dataBuffer.toString('base64'),
         size: Buffer.byteLength(dataBuffer),
-        duration: responseTime ?? 0
+        duration: response.responseTime ?? 0
       };
     } catch (error) {
       deleteCancelToken(cancelTokenUid);

--- a/packages/bruno-js/src/bruno-response.js
+++ b/packages/bruno-js/src/bruno-response.js
@@ -25,7 +25,7 @@ class BrunoResponse {
   }
 
   getResponseTime() {
-    return this.res ? this.res.responseTime : null;
+    return this.res?.headers ? this.res.headers['request-duration'] : null;
   }
 }
 


### PR DESCRIPTION
# Description

Changes introduced to how responseTime is retrieved, which makes it available in the runner and should fix issue #1145 


![image](https://github.com/usebruno/bruno/assets/30192333/b96f0d46-7873-48fe-9153-59ed81f85c10)
![image](https://github.com/usebruno/bruno/assets/30192333/22c59754-dc98-4caa-9e1e-ed438e6283a3)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**