### PR TITLE
Feature/duplicate request names

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -298,7 +298,7 @@ export const renameItem = (newName, itemUid, collectionUid) => (dispatch, getSta
     if (item.type === 'folder') {
       newPathname = path.join(dirname, trim(sanitize(newName)));
     } else {
-      const filename = resolveRequestFilename(newName);
+      const filename = resolveRequestFilename(sanitize(newName));
       newPathname = path.join(dirname, filename);
     }
     const { ipcRenderer } = window;

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -64,6 +64,7 @@ export const safeParseXML = (str, options) => {
 
 // Remove any characters that are not alphanumeric, spaces, hyphens, or underscores
 export const normalizeFileName = (name) => {
+  return name;
   if (!name) {
     return name;
   }

--- a/packages/bruno-app/src/utils/common/platform.js
+++ b/packages/bruno-app/src/utils/common/platform.js
@@ -16,7 +16,10 @@ export const isLocalCollection = (collection) => {
 };
 
 export const resolveRequestFilename = (name) => {
-  return `${trim(name)}.bru`;
+  const sanitizeDirectoryName = (n) => {
+    return n.replace(/[<>:"/\\|?*\x00-\x1F]+/g, '-');
+  };
+  return `${trim(sanitizeDirectoryName(name))}.bru`;
 };
 
 export const getSubdirectoriesFromRoot = (rootPath, pathname) => {

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -286,8 +286,14 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       if (!fs.existsSync(oldPath)) {
         throw new Error(`path: ${oldPath} does not exist`);
       }
-      if (fs.existsSync(newPath)) {
-        throw new Error(`path: ${oldPath} already exists`);
+      if (fs.existsSync(newPath) && oldPath !== newPath) {
+        let nameSuffix = 1;
+        const curPath = newPath.slice(0, -4);
+
+        while (fs.existsSync(newPath)) {
+          newPath = `${curPath}_${nameSuffix}.bru`;
+          nameSuffix++;
+        }
       }
 
       // if its directory, rename and return
@@ -316,7 +322,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
 
       const content = jsonToBru(jsonData);
       await writeFile(newPath, content);
-      await fs.unlinkSync(oldPath);
+      if (oldPath !== newPath) {
+        await fs.unlinkSync(oldPath);
+      }
     } catch (error) {
       return Promise.reject(error);
     }


### PR DESCRIPTION
# Description

This PR allows for duplicate request names using the meta tag for requests in the app.
It also allows special characters in request names and collections.

This is not a fine-polished solution and should be treated as a proof of concept.

Collection names allow for special characters (slashes among others), but on import it's normalized to dashes.



Changes are done to how names are handled, but as mentioned, it's just a proof of concept. The regex for the filenames should be better, my ability in regex however is quite not at that level.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
(there shouldn't be any breaking changes as far as I'm aware)
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

![image](https://github.com/usebruno/bruno/assets/30192333/b8b0aa24-95d7-470a-8d52-403f18a31cc1)

