### PR TITLE
Fix #1300 : Handling request name conflicts while importing postman V2 collections

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -56,7 +56,8 @@ const convertV21Auth = (array) => {
 const importPostmanV2CollectionItem = (brunoParent, item, parentAuth) => {
   brunoParent.items = brunoParent.items || [];
   const folderMap = {};
-
+  const requestMap = {};
+  
   each(item, (i) => {
     if (isItemAFolder(i)) {
       const baseFolderName = i.name;
@@ -81,6 +82,15 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth) => {
       }
     } else {
       if (i.request) {
+        const baseRequestName = i.name;
+        let requestName = baseRequestName;        
+        let count = 1;
+
+        while (requestMap[requestName]) {
+          requestName = `${baseRequestName}_${count}`;
+          count++;
+        }
+        
         let url = '';
         if (typeof i.request.url === 'string') {
           url = i.request.url;
@@ -90,7 +100,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth) => {
 
         const brunoRequestItem = {
           uid: uuid(),
-          name: i.name,
+          name: requestName,
           type: 'http-request',
           request: {
             url: url,
@@ -242,6 +252,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth) => {
         });
 
         brunoParent.items.push(brunoRequestItem);
+        requestMap[requestName] = brunoRequestItem;
       }
     }
   });


### PR DESCRIPTION
# Description
## Issue: 
Fix for #1300
In Postman, multiple requests in same folder can have same name. Current importer code is creating bruneRequestItems with same name and bruno doesn't allow multiple requests with same name in a given folder. **Which is causing only one of the original requests to be actually created and other requests with the same name are missing in imported collection in bruno.**

## Fix:
Appending "_<duplicate_count>" to conflicting request names within same folder.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

