### PR TITLE
fix(#1320): send all values of same key in post req

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Main Process",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/bruno-electron",
+      "runtimeExecutable": "${workspaceFolder}/packages/bruno-electron/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/packages/bruno-electron/node_modules/.bin/electron.cmd"
+      },
+      "args": ["."],
+      "outputCapture": "std"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2401,52 +2401,6 @@
         "@lezer/lr": "^0.15.0"
       }
     },
-    "node_modules/@codemirror/language": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.2.tgz",
-      "integrity": "sha512-WB3Bnuusw0xhVvhBocieYKwJm04SOk5bPoOEYksVHKHcGHFOaYaw+eZVxR4gIqMMcGzOIUil0FsCmFk8yrhHpw==",
-      "peer": true,
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0",
-        "@lezer/highlight": "^0.16.0",
-        "@lezer/lr": "^0.16.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/language/node_modules/@codemirror/state": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
-      "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
-      "peer": true
-    },
-    "node_modules/@codemirror/language/node_modules/@codemirror/view": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
-      "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
-      "peer": true,
-      "dependencies": {
-        "@codemirror/state": "^0.20.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@codemirror/language/node_modules/@lezer/common": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
-      "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
-      "peer": true
-    },
-    "node_modules/@codemirror/language/node_modules/@lezer/lr": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
-      "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
-      "peer": true,
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
-      }
-    },
     "node_modules/@codemirror/rangeset": {
       "version": "0.19.9",
       "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
@@ -3961,21 +3915,6 @@
       "version": "0.15.12",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
       "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
-    },
-    "node_modules/@lezer/highlight": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
-      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
-      "peer": true,
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
-      }
-    },
-    "node_modules/@lezer/highlight/node_modules/@lezer/common": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
-      "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
-      "peer": true
     },
     "node_modules/@lezer/lr": {
       "version": "0.15.8",
@@ -14757,6 +14696,7 @@
     },
     "node_modules/react-is": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-pdf": {
@@ -18142,7 +18082,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v1.6.0",
+      "version": "v1.6.1",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.425.0",
         "@usebruno/js": "0.9.4",
@@ -20150,54 +20090,6 @@
         }
       }
     },
-    "@codemirror/language": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.20.2.tgz",
-      "integrity": "sha512-WB3Bnuusw0xhVvhBocieYKwJm04SOk5bPoOEYksVHKHcGHFOaYaw+eZVxR4gIqMMcGzOIUil0FsCmFk8yrhHpw==",
-      "peer": true,
-      "requires": {
-        "@codemirror/state": "^0.20.0",
-        "@codemirror/view": "^0.20.0",
-        "@lezer/common": "^0.16.0",
-        "@lezer/highlight": "^0.16.0",
-        "@lezer/lr": "^0.16.0",
-        "style-mod": "^4.0.0"
-      },
-      "dependencies": {
-        "@codemirror/state": {
-          "version": "0.20.1",
-          "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.20.1.tgz",
-          "integrity": "sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==",
-          "peer": true
-        },
-        "@codemirror/view": {
-          "version": "0.20.7",
-          "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.20.7.tgz",
-          "integrity": "sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==",
-          "peer": true,
-          "requires": {
-            "@codemirror/state": "^0.20.0",
-            "style-mod": "^4.0.0",
-            "w3c-keyname": "^2.2.4"
-          }
-        },
-        "@lezer/common": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
-          "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
-          "peer": true
-        },
-        "@lezer/lr": {
-          "version": "0.16.3",
-          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
-          "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
-          "peer": true,
-          "requires": {
-            "@lezer/common": "^0.16.0"
-          }
-        }
-      }
-    },
     "@codemirror/rangeset": {
       "version": "0.19.9",
       "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
@@ -20514,8 +20406,7 @@
         "ws": {
           "version": "8.13.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "requires": {}
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="
         }
       }
     },
@@ -20566,8 +20457,7 @@
         "ws": {
           "version": "8.13.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "requires": {}
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="
         }
       }
     },
@@ -20778,8 +20668,7 @@
     "@graphql-typed-document-node/core": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-      "requires": {}
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="
     },
     "@iarna/toml": {
       "version": "2.2.5"
@@ -21328,23 +21217,6 @@
       "version": "0.15.12",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
       "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
-    },
-    "@lezer/highlight": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
-      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
-      "peer": true,
-      "requires": {
-        "@lezer/common": "^0.16.0"
-      },
-      "dependencies": {
-        "@lezer/common": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
-          "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
-          "peer": true
-        }
-      }
     },
     "@lezer/lr": {
       "version": "0.15.8",
@@ -22133,8 +22005,7 @@
       }
     },
     "@tabler/icons": {
-      "version": "1.119.0",
-      "requires": {}
+      "version": "1.119.0"
     },
     "@tippyjs/react": {
       "version": "4.2.6",
@@ -22698,8 +22569,7 @@
       }
     },
     "@usebruno/schema": {
-      "version": "file:packages/bruno-schema",
-      "requires": {}
+      "version": "file:packages/bruno-schema"
     },
     "@usebruno/testbench": {
       "version": "file:packages/bruno-testbench",
@@ -22850,8 +22720,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -22862,8 +22731,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@whatwg-node/events": {
       "version": "0.0.3",
@@ -22975,8 +22843,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "0.0.8"
@@ -23876,8 +23743,7 @@
       }
     },
     "chai-string": {
-      "version": "1.5.0",
-      "requires": {}
+      "version": "1.5.0"
     },
     "chalk": {
       "version": "4.1.2",
@@ -24288,8 +24154,7 @@
     },
     "css-declaration-sorter": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-loader": {
       "version": "6.7.3",
@@ -24408,8 +24273,7 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -25603,8 +25467,7 @@
       }
     },
     "goober": {
-      "version": "2.1.11",
-      "requires": {}
+      "version": "2.1.11"
     },
     "gopd": {
       "version": "1.0.1",
@@ -25813,8 +25676,7 @@
     "graphql-ws": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.12.1.tgz",
-      "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
-      "requires": {}
+      "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg=="
     },
     "handlebars": {
       "version": "4.7.8",
@@ -26091,8 +25953,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "idb": {
       "version": "7.1.1"
@@ -26443,8 +26304,7 @@
     "isomorphic-ws": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
-      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "requires": {}
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="
     },
     "isstream": {
       "version": "0.1.2"
@@ -26695,8 +26555,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.2.0",
@@ -27380,8 +27239,7 @@
       "version": "1.0.1"
     },
     "merge-refs": {
-      "version": "1.2.2",
-      "requires": {}
+      "version": "1.2.2"
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -27391,8 +27249,7 @@
       "version": "1.4.1"
     },
     "meros": {
-      "version": "1.2.1",
-      "requires": {}
+      "version": "1.2.1"
     },
     "methods": {
       "version": "1.1.2"
@@ -28190,23 +28047,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-js": {
       "version": "3.0.3",
@@ -28288,8 +28141,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -28322,8 +28174,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -28810,11 +28661,11 @@
       }
     },
     "react-inspector": {
-      "version": "6.0.2",
-      "requires": {}
+      "version": "6.0.2"
     },
     "react-is": {
-      "version": "18.2.0"
+      "version": "18.2.0",
+      "dev": true
     },
     "react-pdf": {
       "version": "7.5.1",
@@ -28974,8 +28825,7 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.2",
-      "requires": {}
+      "version": "2.4.2"
     },
     "regenerate": {
       "version": "1.4.2",
@@ -29215,8 +29065,7 @@
     },
     "rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -29728,8 +29577,7 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "style-mod": {
       "version": "4.1.0",
@@ -29763,8 +29611,7 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7",
-      "requires": {}
+      "version": "5.0.7"
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -30410,8 +30257,7 @@
       "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ=="
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -30606,8 +30452,7 @@
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "schema-utils": {
           "version": "3.1.1",
@@ -30710,8 +30555,7 @@
     "ws": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-      "requires": {}
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -138,6 +138,7 @@ const RequestTabPanel = () => {
   }
 
   const handleRun = async () => {
+    console.log({ dispatch });
     dispatch(sendRequest(item, collection.uid)).catch((err) =>
       toast.custom((t) => <NetworkError onClose={() => toast.dismiss(t.id)} />, {
         duration: 5000

--- a/packages/bruno-electron/launch.json
+++ b/packages/bruno-electron/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Main Process",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
+      "args": ["."],
+      "outputCapture": "std"
+    }
+  ]
+}

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -376,6 +376,7 @@ const registerNetworkIpc = (mainWindow) => {
 
   // handler for sending http request
   ipcMain.handle('send-http-request', async (event, item, collection, environment, collectionVariables) => {
+    console.log({ item });
     const collectionUid = collection.uid;
     const collectionPath = collection.pathname;
     const cancelTokenUid = uuid();

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -1,4 +1,4 @@
-const { get, each, filter, forOwn, extend } = require('lodash');
+const { get, each, filter, forOwn, extend, reduce } = require('lodash');
 const decomment = require('decomment');
 const FormData = require('form-data');
 
@@ -139,9 +139,23 @@ const prepareRequest = (request, collectionRoot) => {
 
   if (request.body.mode === 'formUrlEncoded') {
     axiosRequest.headers['content-type'] = 'application/x-www-form-urlencoded';
-    const params = {};
     const enabledParams = filter(request.body.formUrlEncoded, (p) => p.enabled);
-    each(enabledParams, (p) => (params[p.name] = p.value));
+
+    const params = reduce(
+      enabledParams,
+      (acc, p) => {
+        if (!acc[p.name]) {
+          acc[p.name] = p.value;
+          return acc;
+        }
+
+        const oldVal = acc[p.name];
+        acc[p.name] = [oldVal];
+        acc[p.name].push(p.value);
+        return acc;
+      },
+      {}
+    );
     axiosRequest.data = params;
   }
 


### PR DESCRIPTION
fixes - #1320 

Currently, if multiple data keys of the same name are sent in a request, bruno only takes the last one
This is because params key/value pairs are stored in an obj, so it gets overwritten with new values (old value is discarded)

Fix:
* Updated the code for `prepare-request` to check if the key is already present In resultant obj, convert the val to arr of values

for the below request:
![Screenshot 2024-01-10 at 02 33 42](https://github.com/usebruno/bruno/assets/13575704/bf72bbde-0a75-46d5-80e3-65ee0efb25ae)

`item` is an arr with 2 values
![Screenshot 2024-01-10 at 02 35 14](https://github.com/usebruno/bruno/assets/13575704/7e796ec2-188a-469c-924f-f1297db42a08)
