### PR TITLE
fix dark mode colors of golden edition modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/GoldenEdition/index.js
+++ b/packages/bruno-app/src/components/Sidebar/GoldenEdition/index.js
@@ -5,6 +5,7 @@ import { uuid } from 'utils/common';
 import { IconHeart, IconUser, IconUsers } from '@tabler/icons';
 import platformLib from 'platform';
 import StyledWrapper from './StyledWrapper';
+import { useTheme } from 'providers/Theme/index';
 
 let posthogClient = null;
 const posthogApiKey = 'phc_7gtqSrrdZRohiozPMLIacjzgHbUlhalW1Bu16uYijMR';
@@ -58,6 +59,8 @@ const CheckIcon = () => {
 };
 
 const GoldenEdition = ({ onClose }) => {
+  const { storedTheme } = useTheme();
+
   useEffect(() => {
     const anonymousId = getAnonymousTrackingId();
     const client = getPosthogClient();
@@ -101,10 +104,15 @@ const GoldenEdition = ({ onClose }) => {
     setPricingOption(option);
   };
 
+  const themeBasedContainerClassNames = storedTheme === 'light' ? 'text-gray-900' : 'text-white';
+  const themeBasedTabContainerClassNames = storedTheme === 'light' ? 'bg-gray-200' : 'bg-gray-800';
+  const themeBasedActiveTabClassNames =
+    storedTheme === 'light' ? 'bg-white text-gray-900 font-medium' : 'bg-gray-700 text-white font-medium';
+
   return (
     <StyledWrapper>
       <Modal size="sm" title={'Golden Edition'} handleCancel={onClose} hideFooter={true}>
-        <div className="flex flex-col text-gray-900 bg-white w-full">
+        <div className={`flex flex-col w-full ${themeBasedContainerClassNames}`}>
           <div className="flex items-center justify-between">
             <h3 className="text-lg font-semibold">Golden Edition</h3>
             <a
@@ -124,7 +132,7 @@ const GoldenEdition = ({ onClose }) => {
               <div className="my-4">
                 <span className="text-3xl font-extrabold">$19</span>
               </div>
-              <p className="bg-yellow-200 rounded-md px-2 py-1 mb-2 inline-flex text-sm">One Time Payment</p>
+              <p className="bg-yellow-200 text-black rounded-md px-2 py-1 mb-2 inline-flex text-sm">One Time Payment</p>
               <p className="text-sm">perpetual license for 2 devices, with 2 years of updates</p>
             </div>
           ) : (
@@ -136,12 +144,12 @@ const GoldenEdition = ({ onClose }) => {
             </div>
           )}
           <div
-            className="flex items-center justify-between my-8 w-40 bg-gray-200 rounded-full p-1"
+            className={`flex items-center justify-between my-8 w-40 rounded-full p-1 ${themeBasedTabContainerClassNames}`}
             style={{ width: '24rem' }}
           >
             <div
               className={`cursor-pointer w-1/2 h-8 flex items-center justify-center rounded-full ${
-                pricingOption === 'individuals' ? 'bg-white text-gray-900 font-medium' : 'text-gray-500'
+                pricingOption === 'individuals' ? themeBasedActiveTabClassNames : 'text-gray-500'
               }`}
               onClick={() => handlePricingOptionChange('individuals')}
             >
@@ -149,7 +157,7 @@ const GoldenEdition = ({ onClose }) => {
             </div>
             <div
               className={`cursor-pointer w-1/2 h-8 flex items-center justify-center rounded-full ${
-                pricingOption === 'organizations' ? 'bg-white text-gray-900 font-medium' : 'text-gray-500'
+                pricingOption === 'organizations' ? themeBasedActiveTabClassNames : 'text-gray-500'
               }`}
               onClick={() => handlePricingOptionChange('organizations')}
             >


### PR DESCRIPTION
# Description
changed colors of golden edition modal in dark mode

previous:
dark mode:
![dark-prev](https://github.com/usebruno/bruno/assets/76877078/06702a60-6e2c-4eac-a5f6-8bbf8afe7aaa)

light mode:
![light-prev](https://github.com/usebruno/bruno/assets/76877078/4146f3b9-4cd4-48a3-9a0f-3a0365fcb92f)


now:
dark mode:
![dark-new](https://github.com/usebruno/bruno/assets/76877078/bbb22d85-9a67-4666-ac41-2b83548169fe)

light mode:
![light-new](https://github.com/usebruno/bruno/assets/76877078/ae0f37d4-2800-4db9-af4c-5e233620889d)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

