### PR TITLE
fix(#1363): add query param even when value is missing

### DIFF
--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -33,8 +33,13 @@ export const stringifyQueryParams = (params) => {
 
   let queryString = [];
   each(params, (p) => {
-    if (!isEmpty(trim(p.name)) && !isEmpty(trim(p.value))) {
-      queryString.push(`${p.name}=${p.value}`);
+    const hasEmptyName = isEmpty(trim(p.name));
+    const hasEmptyVal = isEmpty(trim(p.value));
+
+    // query param name must be present
+    if (!hasEmptyName) {
+      // if query param value is missing, push only <param-name>, else push <param-name: param-value>
+      queryString.push(hasEmptyVal ? p.name : `${p.name}=${p.value}`);
     }
   });
 


### PR DESCRIPTION
fixes: #1363 

Current behaviour: 
Currently, bruno incorrectly strips off a query param if the `value` or `name` for the same is empty/missing

this has been fixed with this PR

New behaviour:
if query param `Name` field is not empty, append the same in the URL (remove check for value to be present)
if query param `Name` is missing, do not append it to the URL

https://github.com/usebruno/bruno/assets/13575704/4405f2d1-6c66-4ffe-a124-25cd9e5d6d40

