### PR TITLE
fix(#732) Option to encode query params

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -16,6 +16,7 @@ import Tests from 'components/RequestPane/Tests';
 import StyledWrapper from './StyledWrapper';
 import { get } from 'lodash';
 import Documentation from 'components/Documentation/index';
+import EncodeQueryParams from '../QueryParams/EncodeQueryParams/index';
 
 const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   const dispatch = useDispatch();
@@ -132,6 +133,11 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
         {focusedTab.requestPaneTab === 'body' ? (
           <div className="flex flex-grow justify-end items-center">
             <RequestBodyMode item={item} collection={collection} />
+          </div>
+        ) : null}
+        {focusedTab.requestPaneTab === 'params' ? (
+          <div className="flex flex-grow justify-end items-center">
+            <EncodeQueryParams item={item} collection={collection} />
           </div>
         ) : null}
       </div>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/EncodeQueryParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/EncodeQueryParams/StyledWrapper.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  font-size: 0.8125rem;
+
+  .label-item {
+    color: ${(props) => props.theme.colors.text.yellow};
+  }
+`;
+
+export default Wrapper;

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/EncodeQueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/EncodeQueryParams/index.js
@@ -1,0 +1,31 @@
+import { get } from 'lodash';
+import { updateEncodeQuery } from 'providers/ReduxStore/slices/collections/index';
+import { useDispatch } from 'react-redux';
+import StyledWrapper from './StyledWrapper';
+const EncodeQueryParams = ({ item, collection }) => {
+  const dispatch = useDispatch();
+  const encodeQuery = item.draft ? get(item, 'draft.request.encodeQuery') : get(item, 'request.encodeQuery');
+
+  const onCheckboxChange = () => {
+    dispatch(
+      updateEncodeQuery({
+        itemUid: item.uid,
+        collectionUid: collection.uid,
+        encodeQuery: !encodeQuery
+      })
+    );
+  };
+
+  return (
+    <StyledWrapper>
+      <div className="flex">
+        <input id="encodeQuery" type="checkbox" name="encodeQuery" checked={encodeQuery} onChange={onCheckboxChange} />
+        <label className="block ml-2 select-none label-item" htmlFor="encodeQuery">
+          Encode query
+        </label>
+      </div>
+    </StyledWrapper>
+  );
+};
+
+export default EncodeQueryParams;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -629,6 +629,7 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
         method: requestMethod,
         url: requestUrl,
         headers: headers ?? [],
+        encodeQuery: false,
         params,
         body: body ?? {
           mode: 'none',

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -13,20 +13,20 @@ const hasLength = (str) => {
   return str.length > 0;
 };
 
-export const parseQueryParams = (query) => {
+export const parseQueryParams = (query, decodeQuery = false) => {
   if (!query || !query.length) {
     return [];
   }
 
   let params = query.split('&').map((param) => {
     let [name, value = ''] = param.split('=');
-    return { name, value };
+    return { name, value: decodeQuery ? decodeURIComponent(value) : value };
   });
 
   return filter(params, (p) => hasLength(p.name));
 };
 
-export const stringifyQueryParams = (params) => {
+export const stringifyQueryParams = (params, encodeQuery) => {
   if (!params || isEmpty(params)) {
     return '';
   }
@@ -34,7 +34,7 @@ export const stringifyQueryParams = (params) => {
   let queryString = [];
   each(params, (p) => {
     if (!isEmpty(trim(p.name)) && !isEmpty(trim(p.value))) {
-      queryString.push(`${p.name}=${p.value}`);
+      queryString.push(`${p.name}=${encodeQuery ? encodeURIComponent(p.value) : p.value}`);
     }
   });
 
@@ -61,4 +61,14 @@ export const isValidUrl = (url) => {
   } catch (err) {
     return false;
   }
+};
+
+export const getUrlWithQueryParams = (url, params, encodeQuery) => {
+  const parts = splitOnFirst(url, '?');
+  const query = stringifyQueryParams(
+    filter(params, (p) => p.enabled),
+    encodeQuery
+  );
+  if (query && query.length) return parts[0] + '?' + query;
+  return parts[0];
 };

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -49,6 +49,11 @@ describe('Url Utils - parseQueryParams', () => {
       { name: 'b', value: '2' }
     ]);
   });
+
+  it('should parse query - case 9', () => {
+    const params = parseQueryParams('a=my test');
+    expect(params).toEqual([{ name: 'a', value: 'my%20test' }]);
+  });
 });
 
 describe('Url Utils - splitOnFirst', () => {

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -51,8 +51,8 @@ describe('Url Utils - parseQueryParams', () => {
   });
 
   it('should parse query - case 9', () => {
-    const params = parseQueryParams('a=my test');
-    expect(params).toEqual([{ name: 'a', value: 'my%20test' }]);
+    const params = parseQueryParams('a=my%20test', true);
+    expect(params).toEqual([{ name: 'a', value: 'my test' }]);
   });
 });
 


### PR DESCRIPTION
# Description

solves: #732 

Basically just added a checkbox to toggle the option to encode the query parameters as discussed in the issue


https://github.com/usebruno/bruno/assets/61945879/04c23ced-6939-4ddf-83cc-86adfaaabeca