### PR TITLE
feat(scripting): allow multiple script context roots in response scripts

### DIFF
--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -144,6 +144,11 @@ class ScriptRuntime {
     const res = new BrunoResponse(response);
     const allowScriptFilesystemAccess = get(scriptingConfig, 'filesystemAccess.allow', false);
     const moduleWhitelist = get(scriptingConfig, 'moduleWhitelist', []);
+    const additionalContextRoots = get(scriptingConfig, 'additionalContextRoots', []);
+    const additionalContextRootsAbsolute = lodash
+      .chain(additionalContextRoots)
+      .map((acr) => (acr.startsWith('/') ? acr : path.join(collectionPath, acr)))
+      .value();
 
     const whitelistedModules = {};
 
@@ -181,7 +186,7 @@ class ScriptRuntime {
       require: {
         context: 'sandbox',
         external: true,
-        root: [collectionPath],
+        root: [collectionPath, ...additionalContextRootsAbsolute],
         mock: {
           // node libs
           path,


### PR DESCRIPTION
# Description

Same as https://github.com/usebruno/bruno/pull/795 but adding the functionality to the response scripts as well.
### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


