### PR TITLE
fix(#263): Replace vm2 with fork of vm2 to fix security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4041,6 +4041,41 @@
         "node": ">=12"
       }
     },
+    "node_modules/@n8n/vm2": {
+      "version": "3.9.23",
+      "resolved": "https://registry.npmjs.org/@n8n/vm2/-/vm2-3.9.23.tgz",
+      "integrity": "sha512-yu+It+L89uljQsCJ2e9cQaXzoXJe9bU69QQIoWUOcUw0u5Zon37DuB7bdNNsjKS1ZdFD+fBWCQpq/FkqHsSjXQ==",
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=18.10",
+        "pnpm": ">=8.6.12"
+      }
+    },
+    "node_modules/@n8n/vm2/node_modules/acorn": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@n8n/vm2/node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "12.3.3",
       "license": "MIT"
@@ -17321,37 +17356,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/vm2": {
-      "version": "3.9.13",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "bin": {
-        "vm2": "bin/vm2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/vm2/node_modules/acorn": {
-      "version": "8.8.2",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/vm2/node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.2",
       "license": "MIT"
@@ -18142,9 +18146,10 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v1.6.0",
+      "version": "v1.6.1",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.425.0",
+        "@n8n/vm2": "^3.9.23",
         "@usebruno/js": "0.9.4",
         "@usebruno/lang": "0.9.0",
         "@usebruno/schema": "0.6.0",
@@ -18177,7 +18182,6 @@
         "socks-proxy-agent": "^8.0.2",
         "tough-cookie": "^4.1.3",
         "uuid": "^9.0.0",
-        "vm2": "^3.9.13",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -18412,7 +18416,7 @@
         "uuid": "^9.0.0"
       },
       "peerDependencies": {
-        "vm2": "^3.9.13"
+        "@n8n/vm2": "^3.9.23"
       }
     },
     "packages/bruno-js/node_modules/ajv": {
@@ -21386,6 +21390,27 @@
     "@n1ru4l/push-pull-async-iterable-iterator": {
       "version": "3.2.0"
     },
+    "@n8n/vm2": {
+      "version": "3.9.23",
+      "resolved": "https://registry.npmjs.org/@n8n/vm2/-/vm2-3.9.23.tgz",
+      "integrity": "sha512-yu+It+L89uljQsCJ2e9cQaXzoXJe9bU69QQIoWUOcUw0u5Zon37DuB7bdNNsjKS1ZdFD+fBWCQpq/FkqHsSjXQ==",
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.11.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+          "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
+        },
+        "acorn-walk": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+          "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="
+        }
+      }
+    },
     "@next/env": {
       "version": "12.3.3"
     },
@@ -23512,6 +23537,7 @@
       "version": "file:packages/bruno-electron",
       "requires": {
         "@aws-sdk/credential-providers": "^3.425.0",
+        "@n8n/vm2": "^3.9.23",
         "@usebruno/js": "0.9.4",
         "@usebruno/lang": "0.9.0",
         "@usebruno/schema": "0.6.0",
@@ -23548,7 +23574,6 @@
         "socks-proxy-agent": "^8.0.2",
         "tough-cookie": "^4.1.3",
         "uuid": "^9.0.0",
-        "vm2": "^3.9.13",
         "yup": "^0.32.11"
       },
       "dependencies": {
@@ -30492,21 +30517,6 @@
         "core-util-is": {
           "version": "1.0.2",
           "optional": true
-        }
-      }
-    },
-    "vm2": {
-      "version": "3.9.13",
-      "requires": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.8.2"
-        },
-        "acorn-walk": {
-          "version": "8.2.0"
         }
       }
     },

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -52,7 +52,7 @@
     "socks-proxy-agent": "^8.0.2",
     "tough-cookie": "^4.1.3",
     "uuid": "^9.0.0",
-    "vm2": "^3.9.13",
+    "@n8n/vm2": "^3.9.23",
     "yup": "^0.32.11"
   },
   "optionalDependencies": {

--- a/packages/bruno-js/package.json
+++ b/packages/bruno-js/package.json
@@ -8,7 +8,7 @@
     "package.json"
   ],
   "peerDependencies": {
-    "vm2": "^3.9.13"
+    "@n8n/vm2": "^3.9.23"
   },
   "scripts": {
     "test": "jest --testPathIgnorePatterns test.js"

--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -1,4 +1,4 @@
-const { NodeVM } = require('vm2');
+const { NodeVM } = require('@n8n/vm2');
 const path = require('path');
 const http = require('http');
 const https = require('https');

--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -1,4 +1,4 @@
-const { NodeVM } = require('vm2');
+const { NodeVM } = require('@n8n/vm2');
 const chai = require('chai');
 const path = require('path');
 const http = require('http');


### PR DESCRIPTION
# Description

Replaced `vm2` with `@n8n/vm2` a fork of vm2 that fixes 2 security vulnerabilities.

Closes #263 #922

---

PSA: While this closes sandbox escape vulnerabilities, you should always make sure not to run random/untrusted scripts. Bruno allows script's to access `node:fs` and other modules (If enabled in bruno.json) so be careful with what you run.