### PR TITLE
fix(#1000): Convert too long numbers into String for collection vars

### DIFF
--- a/packages/bruno-js/src/utils.js
+++ b/packages/bruno-js/src/utils.js
@@ -92,7 +92,12 @@ const evaluateJsTemplateLiteral = (templateLiteral, context) => {
   }
 
   if (!isNaN(templateLiteral)) {
-    return Number(templateLiteral);
+    const number = Number(templateLiteral);
+    // Check if the number is too high. Too high number might get altered, see #1000
+    if (number > Number.MAX_SAFE_INTEGER) {
+      return templateLiteral;
+    }
+    return number;
   }
 
   templateLiteral = '`' + templateLiteral + '`';


### PR DESCRIPTION
# Description

Closes #1000

Convert too long numbers into a string for collection vars so they don't get changed.

Before:

![Screenshot 2024-01-17 225517](https://github.com/usebruno/bruno/assets/39559178/d807810e-c547-4f4f-aa24-b5c9408eff21)

After:

![Screenshot 2024-01-17 225221](https://github.com/usebruno/bruno/assets/39559178/471beb10-cf38-44b9-939d-32c4f55391c8)
