### PR TITLE
FIX: Request>Auth>Bearer configuration does not override if Collection>Auth>Basic is set.

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -1,4 +1,4 @@
-const { get, each, filter } = require('lodash');
+const { get, each, filter, isEmpty } = require('lodash');
 const decomment = require('decomment');
 
 const prepareRequest = (request, collectionRoot) => {
@@ -35,19 +35,6 @@ const prepareRequest = (request, collectionRoot) => {
   // But it cannot override the collection auth with no auth
   // We will provide support for disabling the auth via scripting in the future
   const collectionAuth = get(collectionRoot, 'request.auth');
-  if (collectionAuth) {
-    if (collectionAuth.mode === 'basic') {
-      axiosRequest.auth = {
-        username: get(collectionAuth, 'basic.username'),
-        password: get(collectionAuth, 'basic.password')
-      };
-    }
-
-    if (collectionAuth.mode === 'bearer') {
-      axiosRequest.headers['authorization'] = `Bearer ${get(collectionAuth, 'bearer.token')}`;
-    }
-  }
-
   if (request.auth) {
     if (request.auth.mode === 'basic') {
       axiosRequest.auth = {
@@ -58,6 +45,19 @@ const prepareRequest = (request, collectionRoot) => {
 
     if (request.auth.mode === 'bearer') {
       axiosRequest.headers['authorization'] = `Bearer ${get(request, 'auth.bearer.token')}`;
+    }
+  }
+
+  if (collectionAuth) {
+    if (collectionAuth.mode === 'basic' && isEmpty(axiosRequest.auth)) {
+      axiosRequest.auth = {
+        username: get(collectionAuth, 'basic.username'),
+        password: get(collectionAuth, 'basic.password')
+      };
+    }
+
+    if (collectionAuth.mode === 'bearer' && isEmpty(axiosRequest, 'headers.authorization')) {
+      axiosRequest.headers['authorization'] = `Bearer ${get(collectionAuth, 'bearer.token')}`;
     }
   }
 

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -48,15 +48,15 @@ const prepareRequest = (request, collectionRoot) => {
     }
   }
 
-  if (collectionAuth) {
-    if (collectionAuth.mode === 'basic' && isEmpty(axiosRequest.auth)) {
+  if (collectionAuth && isEmpty(axiosRequest.auth) && isEmpty(get(axiosRequest, 'headers.authorization'))) {
+    if (collectionAuth.mode === 'basic') {
       axiosRequest.auth = {
         username: get(collectionAuth, 'basic.username'),
         password: get(collectionAuth, 'basic.password')
       };
     }
 
-    if (collectionAuth.mode === 'bearer' && isEmpty(axiosRequest, 'headers.authorization')) {
+    if (collectionAuth.mode === 'bearer') {
       axiosRequest.headers['authorization'] = `Bearer ${get(collectionAuth, 'bearer.token')}`;
     }
   }

--- a/packages/bruno-cli/tests/runner/prepare-request.spec.js
+++ b/packages/bruno-cli/tests/runner/prepare-request.spec.js
@@ -1,0 +1,127 @@
+const prepareRequest = require('../../src/runner/prepare-request');
+
+describe('collection with basic auth', () => {
+  const collectionRoot = {
+    request: {
+      auth: {
+        mode: 'basic',
+        basic: {
+          username: 'mockusername',
+          password: 'password'
+        }
+      }
+    }
+  };
+
+  it('should retain auth when request has no auth configuration', () => {
+    const readyRequest = prepareRequest({}, collectionRoot);
+
+    expect(readyRequest.auth).toMatchObject(collectionRoot.request.auth.basic);
+    expect(readyRequest.headers).toMatchObject({});
+  });
+
+  it('should be overridden by request with bearer auth', () => {
+    const request = {
+      auth: {
+        mode: 'bearer',
+        // basic ignored based on mode
+        basic: {
+          username: 'username',
+          password: 'password'
+        },
+        bearer: {
+          token: 'SomeTokenOnREQUEST'
+        }
+      }
+    };
+
+    const readyRequest = prepareRequest(request, collectionRoot);
+
+    // Would benefit from specific token pattern
+    expect(readyRequest.headers['authorization']).toMatch(/^Bearer .+$/);
+  });
+
+  it('should be overridden by request with basic auth', () => {
+    const request = {
+      auth: {
+        mode: 'basic',
+        // basic ignored based on mode
+        basic: {
+          username: 'username',
+          password: 'password'
+        },
+        bearer: {
+          token: 'SomeTokenOnREQUEST'
+        }
+      }
+    };
+
+    const readyRequest = prepareRequest(request, collectionRoot);
+
+    expect(readyRequest.auth).toMatchObject(request.auth.basic);
+    expect(readyRequest.headers).toMatchObject({});
+  });
+});
+
+describe('collection with bearer auth', () => {
+  const collectionRoot = {
+    request: {
+      auth: {
+        mode: 'bearer',
+        bearer: {
+          token: 'SomeTokenOnCOLLECTION'
+        }
+      }
+    }
+  };
+
+  it('should retain auth when request has no auth configuration', () => {
+    const readyRequest = prepareRequest({}, collectionRoot);
+
+    expect(readyRequest.auth).toBeUndefined();
+    // Would benefit from specific token pattern
+    expect(readyRequest.headers['authorization']).toMatch(/^Bearer .+$/);
+  });
+
+  it('should be overridden by request with bearer auth', () => {
+    const request = {
+      auth: {
+        mode: 'bearer',
+        // basic ignored based on mode
+        basic: {
+          username: 'username',
+          password: 'password'
+        },
+        bearer: {
+          token: 'SomeTokenOnREQUEST'
+        }
+      }
+    };
+
+    const readyRequest = prepareRequest(request, collectionRoot);
+
+    // Would benefit from specific token pattern
+    expect(readyRequest.headers['authorization']).toMatch(/^Bearer .+$/);
+  });
+
+  it('should be overridden by request with basic auth', () => {
+    const request = {
+      auth: {
+        mode: 'basic',
+        basic: {
+          username: 'username',
+          password: 'password'
+        },
+        // bearer ignored based on mode
+        bearer: {
+          token: 'SomeTokenOnREQUEST'
+        }
+      }
+    };
+
+    const readyRequest = prepareRequest(request, collectionRoot);
+
+    expect(readyRequest.auth).toMatchObject(request.auth.basic);
+    expect(readyRequest.headers).toMatchObject({});
+  });
+});


### PR DESCRIPTION
# Description

Fixes https://github.com/usebruno/bruno/issues/1536 and https://github.com/usebruno/bruno/issues/960

The way axios handles the `auth` property on the request configurations makes it such that it will always take precedence over the `headers.authorization` for the headers object. This was causing issues where the Bruno Collection has Basic Auth and the Request being run has Bearer Auth.

## Reproducing

1. In Collection>Settings>Auth select Basic
2. In a Request>Auth select Bearer
3. Spin up an http server; preferably with a debugger and a breakpoint on the endpoint
4. Inspect the `req.headers` property the server received

This will result in `Basic ========`; in this fix it should be `Bearer =======`

## Alternative implementation

Instead of inverting logic and doing conditional validations consider potentially mutating the request object.
By doing `delete request.auth` on the condition for the request on bearer mode the bug can be avoided. Although I tend to shy away from mutating objects this way as it may have unintended side-effects.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
