### PR TITLE
Fixed ignored SSL verification and client certificates configuration when using SOCKS proxy

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -158,9 +158,11 @@ const runSingleRequest = async function (
       }
 
       if (socksEnabled) {
-        const socksProxyAgent = new SocksProxyAgent(proxyUri);
-        request.httpsAgent = socksProxyAgent;
-        request.httpAgent = socksProxyAgent;
+        request.httpsAgent = new SocksProxyAgent(
+          proxyUri,
+          Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
+        );
+        request.httpAgent = new SocksProxyAgent(proxyUri);
       } else {
         request.httpsAgent = new PatchedHttpsProxyAgent(
           proxyUri,

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -169,9 +169,11 @@ const configureRequest = async (
     }
 
     if (socksEnabled) {
-      const socksProxyAgent = new SocksProxyAgent(proxyUri);
-      request.httpsAgent = socksProxyAgent;
-      request.httpAgent = socksProxyAgent;
+      request.httpsAgent = new SocksProxyAgent(
+        proxyUri,
+        Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
+      );
+      request.httpAgent = new SocksProxyAgent(proxyUri);
     } else {
       request.httpsAgent = new PatchedHttpsProxyAgent(
         proxyUri,


### PR DESCRIPTION
Fixes #1419