### PR TITLE
[Feature] Added bru.setNextRequest into the hint words list

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -60,7 +60,8 @@ if (!SERVER_RENDERED) {
     'bru.getEnvVar(key)',
     'bru.setEnvVar(key,value)',
     'bru.getVar(key)',
-    'bru.setVar(key,value)'
+    'bru.setVar(key,value)',
+    'bru.setNextRequest(nextRequest)'
   ];
   CodeMirror.registerHelper('hint', 'brunoJS', (editor, options) => {
     const cursor = editor.getCursor();


### PR DESCRIPTION
# Description

Added `bru.setNextRequest(nextRequest)` into the hint words list. After #534 was closed, the new method of the Bru object wasn't added to the hint words list inside the desktop application. In this PR I'm adding it and probably will update the documentation on the website. If it wasn't for me exploring the discussion I wouldn't discover this very useful functionality.

Closes #1442 

Usage:
![Screenshot 2024-01-24 at 17 25 59](https://github.com/usebruno/bruno/assets/58402197/b27b9332-4a52-4a06-b373-2bb51e1604ea)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


