### PR TITLE
"Add" cookies feature. Support for cookie propagation in case if target page returns 302.

### DIFF
--- a/packages/bruno-app/src/components/Cookies/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Cookies/StyledWrapper.js
@@ -11,6 +11,26 @@ const Wrapper = styled.div`
       user-select: none;
     }
   }
+
+  .settings-label {
+    width: 80px;
+  }
+
+  .textbox {
+    border: 1px solid #ccc;
+    padding: 0.15rem 0.45rem;
+    box-shadow: none;
+    outline: none;
+    transition: border-color ease-in-out 0.1s;
+    border-radius: 3px;
+    background-color: ${(props) => props.theme.modal.input.bg};
+    border: 1px solid ${(props) => props.theme.modal.input.border};
+
+    &:focus {
+      border: solid 1px ${(props) => props.theme.modal.input.focusBorder} !important;
+      outline: none !important;
+    }
+  }
 `;
 
 export default Wrapper;

--- a/packages/bruno-app/src/components/Cookies/index.js
+++ b/packages/bruno-app/src/components/Cookies/index.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Modal from 'components/Modal';
 import { IconTrash } from '@tabler/icons';
-import { deleteCookiesForDomain } from 'providers/ReduxStore/slices/app';
+import { deleteCookiesForDomain, addCookiesForURL } from 'providers/ReduxStore/slices/app';
 import toast from 'react-hot-toast';
+import { useFormik } from 'formik';
 
 import StyledWrapper from './StyledWrapper';
 
@@ -11,13 +12,29 @@ const CollectionProperties = ({ onClose }) => {
   const dispatch = useDispatch();
   const cookies = useSelector((state) => state.app.cookies) || [];
 
-  const handleDeleteDomain = (domain) => {
-    dispatch(deleteCookiesForDomain(domain))
+  const handleDeleteDomain = (domain, path) => {
+    dispatch(deleteCookiesForDomain(domain, path))
       .then(() => {
         toast.success('Domain deleted successfully');
       })
       .catch((err) => console.log(err) && toast.error('Failed to delete domain'));
   };
+
+  const formik = useFormik({
+    initialValues: {
+      url: '',
+      cookieString: ''
+    },
+    onSubmit: (values) => {
+      dispatch(addCookiesForURL(values))
+        .then(() => {
+          toast.success(`Cookie added successfully ${values.url}, ${values.cookieString}:`);
+        })
+        .catch((err) => console.log(err) && toast.error('Failed to add cookie'));
+
+      formik.resetForm();
+    }
+  });
 
   return (
     <Modal size="md" title="Cookies" hideFooter={true} handleCancel={onClose}>
@@ -25,7 +42,7 @@ const CollectionProperties = ({ onClose }) => {
         <table className="w-full border-collapse" style={{ marginTop: '-1rem' }}>
           <thead>
             <tr>
-              <th className="py-2 px-2 text-left">Domain</th>
+              <th className="py-2 px-2 text-left">Domain & Path</th>
               <th className="py-2 px-2 text-left">Cookie</th>
               <th className="py-2 px-2 text-center" style={{ width: 80 }}>
                 Actions
@@ -34,11 +51,14 @@ const CollectionProperties = ({ onClose }) => {
           </thead>
           <tbody>
             {cookies.map((cookie) => (
-              <tr key={cookie.domain}>
-                <td className="py-2 px-2">{cookie.domain}</td>
+              <tr key={cookie.domainPath}>
+                <td className="py-2 px-2">{cookie.domainPath}</td>
                 <td className="py-2 px-2 break-all">{cookie.cookieString}</td>
                 <td className="text-center">
-                  <button tabIndex="-1" onClick={() => handleDeleteDomain(cookie.domain)}>
+                  <button
+                    tabIndex="-1"
+                    onClick={() => handleDeleteDomain(cookie.cookies[0].domain, cookie.cookies[0].path)}
+                  >
                     <IconTrash strokeWidth={1.5} size={20} />
                   </button>
                 </td>
@@ -46,6 +66,48 @@ const CollectionProperties = ({ onClose }) => {
             ))}
           </tbody>
         </table>
+        <h1 className="font-medium mb-3">Add new cookie:</h1>
+        <form className="bruno-form" onSubmit={formik.handleSubmit}>
+          <div>
+            <div className="mb-3 flex items-center">
+              <label htmlFor="url" className="settings-label">
+                URL:
+              </label>
+              <input
+                type="text"
+                cols="33"
+                id="url"
+                name="url"
+                className="block textbox"
+                onChange={formik.handleChange}
+                value={formik.values.url}
+                required
+              />
+            </div>
+            <div className="mb-3 flex items-center">
+              <label htmlFor="cookieString" className="settings-label">
+                Cookie String:
+              </label>
+              <textarea
+                type="text"
+                rows="5"
+                cols="33"
+                id="cookieString"
+                name="cookieString"
+                className="block textbox"
+                onChange={formik.handleChange}
+                value={formik.values.cookieString}
+                required
+              />
+            </div>
+
+            <div className="mt-6">
+              <button type="submit" className="submit btn btn-md btn-secondary">
+                Add Cookie
+              </button>
+            </div>
+          </div>
+        </form>
       </StyledWrapper>
     </Modal>
   );

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -101,11 +101,19 @@ export const savePreferences = (preferences) => (dispatch, getState) => {
   });
 };
 
-export const deleteCookiesForDomain = (domain) => (dispatch, getState) => {
+export const deleteCookiesForDomain = (domain, path) => (dispatch, getState) => {
   return new Promise((resolve, reject) => {
     const { ipcRenderer } = window;
 
-    ipcRenderer.invoke('renderer:delete-cookies-for-domain', domain).then(resolve).catch(reject);
+    ipcRenderer.invoke('renderer:delete-cookies-for-domain', domain, path).then(resolve).catch(reject);
+  });
+};
+
+export const addCookiesForURL = (values) => (dispatch, getState) => {
+  return new Promise((resolve, reject) => {
+    const { ipcRenderer } = window;
+
+    ipcRenderer.invoke('renderer:add-cookies-for-domain', values).then(resolve).catch(reject);
   });
 };
 

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -1,8 +1,7 @@
 const URL = require('url');
 const Socket = require('net').Socket;
 const axios = require('axios');
-const http = require('http');
-const { Cookie, CookieJar } = require('tough-cookie');
+const connectionCache = new Map(); // Cache to store checkConnection() results
 
 const LOCAL_IPV6 = '::1';
 const LOCAL_IPV4 = '127.0.0.1';

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -1,7 +1,8 @@
 const URL = require('url');
 const Socket = require('net').Socket;
 const axios = require('axios');
-const connectionCache = new Map(); // Cache to store checkConnection() results
+const http = require('http');
+const { Cookie, CookieJar } = require('tough-cookie');
 
 const LOCAL_IPV6 = '::1';
 const LOCAL_IPV4 = '127.0.0.1';

--- a/packages/bruno-electron/src/ipc/network/cookie-interceptors.js
+++ b/packages/bruno-electron/src/ipc/network/cookie-interceptors.js
@@ -1,0 +1,55 @@
+const { getCookieStringForUrl, addCookieToJar } = require('../../utils/cookies');
+
+function addRequestCookieInterceptor(axiosInstance) {
+  axiosInstance.interceptors.request.use((config) => {
+    const cookieString = getCookieStringForUrl(config.url);
+
+    if (cookieString && typeof cookieString === 'string' && cookieString.length) {
+      config.headers['cookie'] = cookieString;
+    }
+
+    return config;
+  });
+}
+
+function addResponseCookieInterceptor(axiosInstance) {
+  //There is no control over flow if we have auto re-directs
+  axiosInstance.defaults.maxRedirects = 0;
+
+  axiosInstance.interceptors.response.use(
+    (response) => {
+      updateCookieJar(response);
+
+      return response;
+    },
+    (error) => {
+      if (error.response && [301, 302].includes(error.response.status)) {
+        updateCookieJar(error.response);
+
+        const redirectUrl = error.response.headers.location;
+        return axiosInstance.get(redirectUrl);
+      }
+
+      return Promise.reject(error);
+    }
+  );
+}
+
+const updateCookieJar = (response) => {
+  if (response.headers['set-cookie']) {
+    let setCookieHeaders = Array.isArray(response.headers['set-cookie'])
+      ? response.headers['set-cookie']
+      : [response.headers['set-cookie']];
+
+    for (let setCookieHeader of setCookieHeaders) {
+      if (typeof setCookieHeader === 'string' && setCookieHeader.length) {
+        addCookieToJar(setCookieHeader, response.config.url);
+      }
+    }
+  }
+};
+
+module.exports = {
+  addRequestCookieInterceptor,
+  addResponseCookieInterceptor
+};


### PR DESCRIPTION
Related to:
https://github.com/usebruno/bruno/issues/968

If we have a chain of requests, i.e: request -> 302 re-direct -> 302 re-direct -> page.
Cookies from the first re-direct response are not propagated further.
This happens because of the way how axios works:
https://github.com/axios/axios/issues/3862

During the request preparation, if "Save cookies" checkbox is set, maxRedirections for axios instance will be set to 0 and further re-direction requests will be triggered re-cursively in error handler, new interceptors will be storing and enriching cookies.

Cookies UI:
New element allowing manual addition of the cookies is implemented. Table key is changed from domain to domain + path.