### PR TITLE
style: overflow of environment name fix

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
@@ -52,7 +52,7 @@ const EnvironmentSelector = ({ collection }) => {
                     dropdownTippyRef.current.hide();
                   }}
                 >
-                  <IconDatabase size={18} strokeWidth={1.5} /> <span className="ml-2">{e.name}</span>
+                  <IconDatabase size={18} strokeWidth={1.5} /> <span className="ml-2 break-all">{e.name}</span>
                 </div>
               ))
             : null}

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
@@ -28,7 +28,7 @@ const EnvironmentDetails = ({ environment, collection }) => {
       <div className="flex">
         <div className="flex flex-grow items-center">
           <IconDatabase className="cursor-pointer" size={20} strokeWidth={1.5} />
-          <span className="ml-1 font-semibold">{environment.name}</span>
+          <span className="ml-1 font-semibold break-all">{environment.name}</span>
         </div>
         <div className="flex gap-x-4 pl-4">
           <IconEdit className="cursor-pointer" size={20} strokeWidth={1.5} onClick={() => setOpenEditModal(true)} />

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
@@ -66,7 +66,7 @@ const EnvironmentList = ({ collection }) => {
                   className={selectedEnvironment.uid === env.uid ? 'environment-item active' : 'environment-item'}
                   onClick={() => setSelectedEnvironment(env)}
                 >
-                  <span>{env.name}</span>
+                  <span className="break-all">{env.name}</span>
                 </div>
               ))}
             <div className="btn-create-environment" onClick={() => setOpenCreateModal(true)}>


### PR DESCRIPTION
# Description
Fix overflow of environment name on environment dropdown and environment selector modal
Related Issue: #1459 #1458 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

before:
![before-dropdown](https://github.com/usebruno/bruno/assets/76877078/755fbc96-1606-46ee-80e4-9a2e13781a3a)

![modal-before](https://github.com/usebruno/bruno/assets/76877078/7eed6b0e-a1cb-4d1a-8017-1f32a1547bd1)


after:
![after-dropdown](https://github.com/usebruno/bruno/assets/76877078/e0ecfb91-bbc7-44af-82eb-e30431cd6085)
![modal-after](https://github.com/usebruno/bruno/assets/76877078/8c5e0efb-8927-47c3-a5db-820a75c15469)
