### PR TITLE
feat: prettify json body automatically

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -1,13 +1,15 @@
-import React, { useRef, forwardRef } from 'react';
-import get from 'lodash/get';
 import { IconCaretDown } from '@tabler/icons';
 import Dropdown from 'components/Dropdown';
-import { useDispatch } from 'react-redux';
+import get from 'lodash/get';
 import { updateRequestBodyMode } from 'providers/ReduxStore/slices/collections';
-import { humanizeRequestBodyMode } from 'utils/collections';
-import StyledWrapper from './StyledWrapper';
 import { updateRequestBody } from 'providers/ReduxStore/slices/collections/index';
+import React, { forwardRef, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { humanizeRequestBodyMode } from 'utils/collections';
 import { toastError } from 'utils/common/error';
+import useOnMount from '../../../../hooks/useOnMount/index';
+import { isValidJson } from '../../../../utils/common/index';
+import StyledWrapper from './StyledWrapper';
 
 const RequestBodyMode = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -51,6 +53,12 @@ const RequestBodyMode = ({ item, collection }) => {
       }
     }
   };
+
+  useOnMount(() => {
+    if (bodyMode === 'json' && body?.json && isValidJson(body.json)) {
+      onPrettify();
+    }
+  });
 
   return (
     <StyledWrapper>

--- a/packages/bruno-app/src/hooks/useOnMount/index.js
+++ b/packages/bruno-app/src/hooks/useOnMount/index.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export default function useOnMount(mountedFunction, cleanupFunction = null) {
+  useEffect(() => {
+    mountedFunction();
+    return () => {
+      if (cleanupFunction) {
+        cleanupFunction();
+      }
+    };
+  }, []);
+}

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -59,6 +59,16 @@ export const convertToCodeMirrorJson = (obj) => {
   }
 };
 
+export const isValidJson = (str) => {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+};
+
 export const safeParseXML = (str, options) => {
   if (!str || !str.length || typeof str !== 'string') {
     return str;


### PR DESCRIPTION
# Description

Currently, the json body is by default in "string" mode, and you have to press the prettify button to fix it. 

This update automatically prettifies the JSON on mount IF it is a valid JSON. This means that, for example, if you add a new curl import, it will default to a prettified view. And if it is not a valid JSON-format, it will do nothing. 

Here is an example:

![auto-format](https://github.com/usebruno/bruno/assets/21983557/b1461bd3-e9bc-4070-bd9c-ec6aa7cefcce)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
