### PR TITLE
Response headers count logic update

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -97,6 +97,8 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
     });
   };
 
+  const responseHeadersCount = typeof response.headers === 'object' ? Object.entries(response.headers).length : 0;
+
   return (
     <StyledWrapper className="flex flex-col h-full relative">
       <div className="flex flex-wrap items-center pl-3 pr-4 tabs" role="tablist">
@@ -105,7 +107,7 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
         </div>
         <div className={getTabClassname('headers')} role="tab" onClick={() => selectTab('headers')}>
           Headers
-          {response.headers?.length > 0 && <sup className="ml-1 font-medium">{response.headers.length}</sup>}
+          {responseHeadersCount > 0 && <sup className="ml-1 font-medium">{responseHeadersCount}</sup>}
         </div>
         <div className={getTabClassname('timeline')} role="tab" onClick={() => selectTab('timeline')}>
           Timeline


### PR DESCRIPTION
# Description
Due to this changes https://github.com/usebruno/bruno/commit/4917f24b7cb02bbfae175fdc5079ed77a44fae2c
related to issue #1436 
response headers count logic was broken for showing headers count in the response pane, so I have updated it.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

before:
![before](https://github.com/usebruno/bruno/assets/76877078/63890026-de50-4c66-9652-1075e4098379)


after:
![after](https://github.com/usebruno/bruno/assets/76877078/5d1fc1ea-9d1e-4ed0-af82-4c7722274535)
