### PR TITLE
fix(#1511): preferences/cookies modals overlapping with response search dialog

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -13,6 +13,10 @@ const StyledWrapper = styled.div`
     background: #d2d7db;
   }
 
+  .CodeMirror-dialog {
+    z-index: auto;
+  }
+
   textarea.cm-editor {
     position: relative;
   }


### PR DESCRIPTION
# Description
Fixes overlapping between preferences/cookies modals and CodeMirror response search dialog
Fixes #1511 
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
<img width="1194" alt="Screenshot 2024-02-02 at 15 24 49" src="https://github.com/usebruno/bruno/assets/98183799/b285d66f-96ff-4a75-9ad7-9ed9bdc8e041">

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
