### PR TITLE
feat(#1496) Allow ignoring path fragments from the collection configuration file

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Info/index.js
@@ -34,6 +34,10 @@ const Info = ({ collection }) => {
             <td className="py-2 px-2 break-all">{collection.pathname}</td>
           </tr>
           <tr className="">
+            <td className="py-2 px-2 text-right">Ignored files&nbsp;:</td>
+            <td className="py-2 px-2 break-all">{collection.brunoConfig.ignore.map((x) => `'${x}'`).join(', ')}</td>
+          </tr>
+          <tr className="">
             <td className="py-2 px-2 text-right">Environments&nbsp;:</td>
             <td className="py-2 px-2">{collection.environments?.length || 0}</td>
           </tr>

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -62,8 +62,13 @@ const openCollection = async (win, watcher, collectionPath, options = {}) => {
       const brunoConfig = await getCollectionConfigFile(collectionPath);
       const uid = generateUidBasedOnHash(collectionPath);
 
+      if (!brunoConfig.ignore || brunoConfig.ignore.length === 0) {
+        // Forces default behavior for legacy collections
+        brunoConfig.ignore = ['node_modules', '.git'];
+      }
+
       win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig);
-      ipcMain.emit('main:collection-opened', win, collectionPath, uid);
+      ipcMain.emit('main:collection-opened', win, collectionPath, uid, brunoConfig);
     } catch (err) {
       if (!options.dontSendDisplayErrors) {
         win.webContents.send('main:display-error', {

--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -403,17 +403,18 @@ class Watcher {
     this.watchers = {};
   }
 
-  addWatcher(win, watchPath, collectionUid) {
+  addWatcher(win, watchPath, collectionUid, brunoConfig) {
     if (this.watchers[watchPath]) {
       this.watchers[watchPath].close();
     }
 
+    const ignores = brunoConfig?.ignore || [];
     const self = this;
     setTimeout(() => {
       const watcher = chokidar.watch(watchPath, {
         ignoreInitial: false,
-        usePolling: watchPath.startsWith("\\\\") ? true : false,
-        ignored: (path) => ['node_modules', '.git'].some((s) => path.includes(s)),
+        usePolling: watchPath.startsWith('\\\\') ? true : false,
+        ignored: (path) => ignores.some((s) => path.includes(s)),
         persistent: true,
         ignorePermissionErrors: true,
         awaitWriteFinish: {

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -58,13 +58,14 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
         const brunoConfig = {
           version: '1',
           name: collectionName,
-          type: 'collection'
+          type: 'collection',
+          ignore: ['node_modules', '.git']
         };
         const content = await stringifyJson(brunoConfig);
         await writeFile(path.join(dirPath, 'bruno.json'), content);
 
         mainWindow.webContents.send('main:collection-opened', dirPath, uid, brunoConfig);
-        ipcMain.emit('main:collection-opened', mainWindow, dirPath, uid);
+        ipcMain.emit('main:collection-opened', mainWindow, dirPath, uid, brunoConfig);
       } catch (error) {
         return Promise.reject(error);
       }
@@ -437,13 +438,14 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       const brunoConfig = {
         version: '1',
         name: collectionName,
-        type: 'collection'
+        type: 'collection',
+        ignore: ['node_modules', '.git']
       };
       const content = await stringifyJson(brunoConfig);
       await writeFile(path.join(collectionPath, 'bruno.json'), content);
 
       mainWindow.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig);
-      ipcMain.emit('main:collection-opened', mainWindow, collectionPath, uid);
+      ipcMain.emit('main:collection-opened', mainWindow, collectionPath, uid, brunoConfig);
 
       lastOpenedCollections.add(collectionPath);
 
@@ -600,8 +602,8 @@ const registerMainEventHandlers = (mainWindow, watcher, lastOpenedCollections) =
     shell.openExternal(docsURL);
   });
 
-  ipcMain.on('main:collection-opened', (win, pathname, uid) => {
-    watcher.addWatcher(win, pathname, uid);
+  ipcMain.on('main:collection-opened', (win, pathname, uid, brunoConfig) => {
+    watcher.addWatcher(win, pathname, uid, brunoConfig);
     lastOpenedCollections.add(pathname);
   });
 


### PR DESCRIPTION
# Description

This PR resolves #1496 by enhancing the `bruno.json` collection configuration file with a new property named `ignore` allowing to specify a list of path fragments which should be excluded when loading a collection.

For instance :
```json
{
  "version": "1",
  "name": "Sample Collection",
  "type": "collection",
  "ignore": [
  	".idea",
  	".vscode",
        "Test/Test2"
  ]
}
```

Collection creation behavior has also been updated so that default exclusions initially handled in the code (_node_modules, .git_ folders) are now written by default in the collection configuration file.

Opening legacy collections will work as expected as default exclusions will be applied if no exclusion configuration can be found.

The collection info tab has been updated in order to display the list of excluded path items

![image](https://github.com/usebruno/bruno/assets/15845066/ce59f5a9-df03-4306-870a-2b5578c75713)


### Contribution Checklist:

- [ X] **The pull request only addresses one issue or adds one feature.**
- [ X] **The pull request does not introduce any breaking changes**
- [ X] **I have added screenshots or gifs to help explain the change if applicable.**
- [ X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
