### PR TITLE
Bugfix #1101 Vars in request override the environment variables definitely

### DIFF
--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -66,6 +66,21 @@ class Bru {
     this.collectionVariables[key] = value;
   }
 
+  deleteVar(key) {
+    if (!key) {
+      throw new Error('Deleting a variable without specifying a name is not allowed.');
+    }
+
+    if (variableNameRegex.test(key) === false) {
+      throw new Error(
+        `Variable name: "${key}" contains invalid characters!` +
+          ' Names must only contain alpha-numeric characters, "-", "_", "."'
+      );
+    }
+
+    delete this.collectionVariables[key];
+  }
+
   getVar(key) {
     if (variableNameRegex.test(key) === false) {
       throw new Error(

--- a/packages/bruno-js/src/runtime/vars-runtime.js
+++ b/packages/bruno-js/src/runtime/vars-runtime.js
@@ -5,10 +5,12 @@ const { evaluateJsTemplateLiteral, evaluateJsExpression, createResponseParser } 
 
 class VarsRuntime {
   runPreRequestVars(vars, request, envVariables, collectionVariables, collectionPath, processEnvVars) {
-    const enabledVars = _.filter(vars, (v) => v.enabled);
-    if (!enabledVars.length) {
+    if (!vars.length) {
       return;
     }
+
+    const disabledVars = _.filter(vars, (v) => !v.enabled);
+    const enabledVars = _.filter(vars, (v) => v.enabled);
 
     const bru = new Bru(envVariables, collectionVariables, processEnvVars);
     const req = new BrunoRequest(request);
@@ -29,16 +31,22 @@ class VarsRuntime {
       bru.setVar(v.name, value);
     });
 
+    _.each(disabledVars, (v) => {
+      bru.deleteVar(v.name);
+    });
+
     return {
       collectionVariables
     };
   }
 
   runPostResponseVars(vars, request, response, envVariables, collectionVariables, collectionPath, processEnvVars) {
-    const enabledVars = _.filter(vars, (v) => v.enabled);
-    if (!enabledVars.length) {
+    if (!vars.length) {
       return;
     }
+
+    const disabledVars = _.filter(vars, (v) => !v.enabled);
+    const enabledVars = _.filter(vars, (v) => v.enabled);
 
     const bru = new Bru(envVariables, collectionVariables, processEnvVars);
     const req = new BrunoRequest(request);
@@ -59,6 +67,10 @@ class VarsRuntime {
     _.each(enabledVars, (v) => {
       const value = evaluateJsExpression(v.value, context);
       bru.setVar(v.name, value);
+    });
+
+    _.each(disabledVars, (v) => {
+      bru.deleteVar(v.name);
     });
 
     return {


### PR DESCRIPTION
Bugfix #1101

# Description

Introduced new method to bru.js for deleting request variables. This will allow the user to enable and disable request variables for requests. 

![Bugfix #1101](https://github.com/usebruno/bruno/assets/646566/700e3840-5497-47ab-b182-f59f66c0fbd1)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
