### PR TITLE
fix(1548): correct import of escaped curl string

### DIFF
--- a/packages/bruno-app/src/utils/curl/curl-to-json.spec.js
+++ b/packages/bruno-app/src/utils/curl/curl-to-json.spec.js
@@ -59,4 +59,20 @@ describe('curlToJson', () => {
       data: '{"email":"test@usebruno.com","password":"test"}'
     });
   });
+
+  it('should accept escaped curl string', () => {
+    const curlCommand = `curl https://www.usebruno.com
+    -H $'cookie: val_1=\'\'; val_2=\\^373:0\\^373:0; val_3=\u0068\u0065\u006C\u006C\u006F'
+    `;
+    const result = curlToJson(curlCommand);
+
+    expect(result).toEqual({
+      url: 'https://www.usebruno.com',
+      raw_url: 'https://www.usebruno.com',
+      method: 'get',
+      headers: {
+        cookie: "val_1=''; val_2=\\^373:0\\^373:0; val_3=hello"
+      }
+    });
+  });
 });

--- a/packages/bruno-app/src/utils/curl/parse-curl.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.js
@@ -12,6 +12,9 @@ import * as querystring from 'query-string';
 import yargs from 'yargs-parser';
 
 const parseCurlCommand = (curlCommand) => {
+  // catch escape sequences (e.g. -H $'cookie: it=\'\'')
+  curlCommand = curlCommand.replace(/\$('.*')/g, (match, group) => group);
+
   // Remove newlines (and from continuations)
   curlCommand = curlCommand.replace(/\\\r|\\\n/g, '');
 


### PR DESCRIPTION
# Description

Fixes #1548

<img width="652" alt="Screenshot 2024-02-08 at 1 55 02 AM" src="https://github.com/usebruno/bruno/assets/105532421/fffdfe3a-64c6-4ab3-919a-14e6263e4b5e">

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
