### PR TITLE
fix(#263): Implement script- & test-runtime in node:vm

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -8,7 +8,7 @@ const FormData = require('form-data');
 const prepareRequest = require('./prepare-request');
 const interpolateVars = require('./interpolate-vars');
 const { interpolateString } = require('./interpolate-string');
-const { ScriptRuntime, TestRuntime, VarsRuntime, AssertRuntime } = require('@usebruno/js');
+const { ScriptRuntime, TestRuntime, VarsRuntime, AssertRuntime, runScript } = require('@usebruno/js');
 const { stripExtension } = require('../utils/filesystem');
 const { getOptions } = require('../utils/bru');
 const https = require('https');
@@ -68,20 +68,42 @@ const runSingleRequest = async function (
       get(collectionRoot, 'request.script.req'),
       get(bruJson, 'request.script.req')
     ]).join(os.EOL);
-    if (requestScriptFile?.length) {
-      const scriptRuntime = new ScriptRuntime();
-      const result = await scriptRuntime.runRequestScript(
-        decomment(requestScriptFile),
-        request,
+    // TODO: Add feature Flag
+    if (false) {
+      const variables = {
         envVariables,
         collectionVariables,
-        collectionPath,
+        processEnvVars
+      };
+      const result = await runScript(
+        decomment(requestScriptFile),
+        request,
         null,
-        processEnvVars,
-        scriptingConfig
+        variables,
+        false,
+        collectionPath,
+        scriptingConfig,
+        null
       );
       if (result?.nextRequestName !== undefined) {
         nextRequestName = result.nextRequestName;
+      }
+    } else {
+      if (requestScriptFile?.length) {
+        const scriptRuntime = new ScriptRuntime();
+        const result = await scriptRuntime.runRequestScript(
+          decomment(requestScriptFile),
+          request,
+          envVariables,
+          collectionVariables,
+          collectionPath,
+          null,
+          processEnvVars,
+          scriptingConfig
+        );
+        if (result?.nextRequestName !== undefined) {
+          nextRequestName = result.nextRequestName;
+        }
       }
     }
 
@@ -254,21 +276,43 @@ const runSingleRequest = async function (
       get(collectionRoot, 'request.script.res'),
       get(bruJson, 'request.script.res')
     ]).join(os.EOL);
-    if (responseScriptFile?.length) {
-      const scriptRuntime = new ScriptRuntime();
-      const result = await scriptRuntime.runResponseScript(
+    // TODO: Add feature flag
+    if (false) {
+      const variables = {
+        envVariables,
+        collectionVariables,
+        processEnvVars
+      };
+      const result = await runScript(
         decomment(responseScriptFile),
         request,
         response,
-        envVariables,
-        collectionVariables,
+        variables,
+        false,
         collectionPath,
-        null,
-        processEnvVars,
-        scriptingConfig
+        scriptingConfig,
+        null
       );
       if (result?.nextRequestName !== undefined) {
         nextRequestName = result.nextRequestName;
+      }
+    } else {
+      if (responseScriptFile?.length) {
+        const scriptRuntime = new ScriptRuntime();
+        const result = await scriptRuntime.runResponseScript(
+          decomment(responseScriptFile),
+          request,
+          response,
+          envVariables,
+          collectionVariables,
+          collectionPath,
+          null,
+          processEnvVars,
+          scriptingConfig
+        );
+        if (result?.nextRequestName !== undefined) {
+          nextRequestName = result.nextRequestName;
+        }
       }
     }
 

--- a/packages/bruno-js/src/index.js
+++ b/packages/bruno-js/src/index.js
@@ -2,10 +2,12 @@ const ScriptRuntime = require('./runtime/script-runtime');
 const TestRuntime = require('./runtime/test-runtime');
 const VarsRuntime = require('./runtime/vars-runtime');
 const AssertRuntime = require('./runtime/assert-runtime');
+const { runScript } = require('./runtime/vm-helper');
 
 module.exports = {
   ScriptRuntime,
   TestRuntime,
   VarsRuntime,
-  AssertRuntime
+  AssertRuntime,
+  runScript
 };

--- a/packages/bruno-js/src/runtime/vm-helper.js
+++ b/packages/bruno-js/src/runtime/vm-helper.js
@@ -1,0 +1,232 @@
+const vm = require('node:vm');
+const Bru = require('../bru');
+const BrunoRequest = require('../bruno-request');
+const { get } = require('lodash');
+const lodash = require('lodash');
+const path = require('path');
+const { cleanJson } = require('../utils');
+const chai = require('chai');
+const BrunoResponse = require('../bruno-response');
+const TestResults = require('../test-results');
+const Test = require('../test');
+
+/**
+ * @param {string} script
+ * @param {object} request
+ * @param {object|null} response
+ * @param {{
+ *   envVariables: Record<string, unknown>,
+ *   collectionVariables: Record<string, unknown>,
+ *   processEnvVars: Record<string, unknown>,
+ * }} variables
+ * @param {boolean} useTests
+ * @param {string} collectionPath
+ * @param {object} scriptingConfig
+ * @param {(type: string, context: any) => void} onConsoleLog
+ *
+ * @returns {Promise<{
+ *   collectionVariables: Record<string, unknown>,
+ *   envVariables: Record<string, unknown>,
+ *   nextRequestName: string,
+ *   testResults: array|null,
+ * }>}
+ */
+async function runScript(
+  script,
+  request,
+  response,
+  variables,
+  useTests,
+  collectionPath,
+  scriptingConfig,
+  onConsoleLog
+) {
+  const scriptContext = buildScriptContext(
+    request,
+    response,
+    variables,
+    useTests,
+    collectionPath,
+    scriptingConfig,
+    onConsoleLog
+  );
+
+  if (script.trim().length !== 0) {
+    await vm.runInThisContext(`
+      (async ({ require, console, req, res, bru, expect, assert, test }) => {
+        ${script}
+      });
+    `)(scriptContext);
+  }
+
+  return {
+    envVariables: cleanJson(scriptContext.bru.envVariables),
+    collectionVariables: cleanJson(scriptContext.bru.collectionVariables),
+    nextRequestName: scriptContext.bru.nextRequest,
+    testResults: scriptContext.__brunoTestResults ? cleanJson(scriptContext.__brunoTestResults.getResults()) : null
+  };
+}
+
+/**
+ * @typedef {{
+ *   require: (module: string) => (*),
+ *   console: {object},
+ *   req: {BrunoRequest},
+ *   res: {BrunoResponse},
+ *   bru: {Bru},
+ *   expect: {ExpectStatic},
+ *   assert: {AssertStatic},
+ *   __brunoTestResults: {object},
+ *   test: {Test},
+ * }} ScriptContext
+ *
+ * @param {object} request
+ * @param {object|null} response
+ * @param {{
+ *   envVariables: Record<string, unknown>,
+ *   collectionVariables: Record<string, unknown>,
+ *   processEnvVars: Record<string, unknown>,
+ * }} variables
+ * @param {boolean} useTests
+ * @param {string} collectionPath
+ * @param {object} scriptingConfig
+ * @param {(type: string, context: any) => void} onConsoleLog
+ *
+ * @return {ScriptContext}
+ */
+function buildScriptContext(request, response, variables, useTests, collectionPath, scriptingConfig, onConsoleLog) {
+  const context = {
+    require: createCustomRequire(scriptingConfig, collectionPath),
+    console: createCustomConsole(onConsoleLog),
+    req: new BrunoRequest(request),
+    res: null,
+    bru: new Bru(variables.envVariables, variables.collectionVariables, variables.processEnvVars, collectionPath),
+    expect: null,
+    assert: null,
+    __brunoTestResults: null,
+    test: null
+  };
+
+  if (response) {
+    context.res = new BrunoResponse(response);
+  }
+
+  if (useTests) {
+    Object.assign(context, createTestContext());
+  }
+
+  return context;
+}
+
+const defaultModuleWhiteList = [
+  // Node libs
+  'path',
+  'stream',
+  'util',
+  'url',
+  'http',
+  'https',
+  'punycode',
+  'zlib',
+  // Pre-installed 3rd libs
+  'ajv',
+  'atob',
+  'btoa',
+  'lodash',
+  'moment',
+  'uuid',
+  'nanoid',
+  'axios',
+  'chai',
+  'crypto-js',
+  'node-vault'
+];
+
+/**
+ * @param {object} scriptingConfig Config from collection's bruno.json
+ * @param {string} collectionPath
+ *
+ * @returns {(module: string) => (*)}
+ */
+function createCustomRequire(scriptingConfig, collectionPath) {
+  const customWhitelistedModules = get(scriptingConfig, 'moduleWhitelist', []);
+
+  const whitelistedModules = [...defaultModuleWhiteList, ...customWhitelistedModules];
+
+  const allowScriptFilesystemAccess = get(scriptingConfig, 'filesystemAccess.allow', false);
+  if (allowScriptFilesystemAccess) {
+    // TODO: Allow other modules like os, child_process etc too?
+    whitelistedModules.push('fs');
+  }
+
+  const additionalContextRoots = get(scriptingConfig, 'additionalContextRoots', []);
+  const additionalContextRootsAbsolute = lodash
+    .chain(additionalContextRoots)
+    .map((acr) => (acr.startsWith('/') ? acr : path.join(collectionPath, acr)))
+    .value();
+
+  return (moduleName) => {
+    // Remove the "node:" prefix, to make sure "node:fs" and "fs" can be required and we only need to whitelist one
+    if (whitelistedModules.includes(moduleName.replace(/^node:/, ''))) {
+      try {
+        return require(moduleName);
+      } catch (error) {
+        throw new Error(`Failed to require "${moduleName}": ${error}`);
+      }
+    }
+
+    const triedPaths = [];
+    for (const contextRoot of additionalContextRootsAbsolute) {
+      const fullScriptPath = path.join(contextRoot, moduleName);
+      try {
+        return require(fullScriptPath);
+      } catch (error) {
+        triedPaths.push({ fullScriptPath, error });
+      }
+    }
+
+    const triedPathsFormatted = triedPaths.map((i) => `- "${i.fullScriptPath}": ${i.error}\n`);
+    throw new Error(`Failed to require "${moduleName}"!
+
+If you tried to require a node-module / package, make sure its whitelisted in the "bruno.json" under "scriptConfig".
+If you wanted to require an external script make sure the path is correct or added to "additionalContextRoots" in your "bruno.json".
+
+${
+  triedPathsFormatted.length === 0
+    ? 'No additional context roots where defined'
+    : 'We searched the following paths for your script:'
+}
+${triedPathsFormatted}`);
+  };
+}
+
+function createCustomConsole(onConsoleLog) {
+  const customLogger = (type) => {
+    return (...args) => {
+      console.error('LOG', args);
+      onConsoleLog(type, cleanJson(args));
+    };
+  };
+  return {
+    log: customLogger('log'),
+    info: customLogger('info'),
+    warn: customLogger('warn'),
+    error: customLogger('error')
+  };
+}
+
+function createTestContext() {
+  const __brunoTestResults = new TestResults();
+  const test = Test(__brunoTestResults, chai);
+
+  return {
+    test,
+    __brunoTestResults,
+    expect: chai.expect,
+    assert: chai.assert
+  };
+}
+
+module.exports = {
+  runScript
+};


### PR DESCRIPTION
# Description

Partially closes: #263 & #922

Implemented the existing script- & test-runtime with `node:vm` to deprecate `vm2`.

I want to create a follow-up PR to implement a feature flag, so users can first opt in to the new runtime. In this PR, the new runtime is commented out by the `if (false)` statements.

There is still some testing to be done, especially with the custom `require`.

