### PR TITLE
[Fix] Crash when closing confirmation modal

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -28,10 +28,6 @@ You would need [Node v18.x or the latest LTS version](https://nodejs.org/en/) an
 
 Bruno is being developed as a desktop app. You need to load the app by running the Next.js app in one terminal and then run the electron app in another terminal.
 
-### Dependencies
-
-- NodeJS v18
-
 ### Local Development
 
 ```bash

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
@@ -12,6 +12,7 @@ const ConfirmRequestClose = ({ item, onCancel, onCloseWithoutSave, onSaveAndClos
       disableEscapeKey={true}
       disableCloseOnOutsideClick={true}
       closeModalFadeTimeout={150}
+      handleCancel={onCancel}
       onClick={(e) => {
         e.stopPropagation();
         e.preventDefault();


### PR DESCRIPTION
# Description

The problem was that the ConfirmRequestClose wasn't passing the `handleCancel` prop to Modal.

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Closes: #1573

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
