### PR TITLE
fix(#1593): Omitting "Open Recent" menu if not macOS

### DIFF
--- a/packages/bruno-electron/src/app/menu-template.js
+++ b/packages/bruno-electron/src/app/menu-template.js
@@ -1,6 +1,9 @@
+const os = require('os');
 const { ipcMain } = require('electron');
 const openAboutWindow = require('about-window').default;
 const { join } = require('path');
+
+const isMacOs = os.platform() === 'darwin';
 
 const template = [
   {
@@ -12,16 +15,20 @@ const template = [
           ipcMain.emit('main:open-collection');
         }
       },
-      {
-        label: 'Open Recent',
-        role: 'recentdocuments',
-        submenu: [
-          {
-            label: 'Clear Recent',
-            role: 'clearrecentdocuments'
-          }
-        ]
-      },
+      ...(isMacOs
+        ? [
+            {
+              label: 'Open Recent',
+              role: 'recentdocuments',
+              submenu: [
+                {
+                  label: 'Clear Recent',
+                  role: 'clearrecentdocuments'
+                }
+              ]
+            }
+          ]
+        : []),
       {
         label: 'Preferences',
         accelerator: 'CommandOrControl+,',


### PR DESCRIPTION
# Description

As this feature is macOS-exclusive, it's now hidden if you're using another operating system.

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Closes #1593 

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
