### PR TITLE
fix(#1545): empty strings encryption

### DIFF
--- a/packages/bruno-electron/src/store/env-secrets.js
+++ b/packages/bruno-electron/src/store/env-secrets.js
@@ -28,7 +28,7 @@ class EnvironmentSecretsStore {
   }
 
   isValidValue(val) {
-    return val && typeof val === 'string' && val.length > 0;
+    return typeof val === 'string' && val.length >= 0;
   }
 
   storeEnvSecrets(collectionPathname, environment) {

--- a/packages/bruno-electron/src/utils/encryption.js
+++ b/packages/bruno-electron/src/utils/encryption.js
@@ -48,7 +48,7 @@ function safeStorageDecrypt(str) {
 }
 
 function encryptString(str) {
-  if (!str || typeof str !== 'string' || str.length === 0) {
+  if (typeof str !== 'string') {
     throw new Error('Encrypt failed: invalid string');
   }
 


### PR DESCRIPTION
# Description

This enables empty strings to be encrypted (fixes #1545).

As reported in #1545, it's not possible to use an empty value as a secret.
Current:
- when saving an empty string as secret this is in the end populated with `null` which then gets into the auth header
<img width="849" alt="image" src="https://github.com/usebruno/bruno/assets/6736499/6acde600-3532-4954-aaaf-0beaf1450f46">
<img width="846" alt="image" src="https://github.com/usebruno/bruno/assets/6736499/dde2cba5-701c-4b70-b5dc-698683808f9d">
<img width="1071" alt="image" src="https://github.com/usebruno/bruno/assets/6736499/b12545d5-ccd1-40cb-84df-d8355045d10d">
<img width="286" alt="image" src="https://github.com/usebruno/bruno/assets/6736499/d5ba9925-aa23-4cfe-abe6-aafe3ffd5fa5">

After:
- empty string can be saved as a secret and the value is as expected in the resulting auth header
<img width="845" alt="image" src="https://github.com/usebruno/bruno/assets/6736499/1c9887a6-c4b9-4d88-9aa3-9c11418f5fdc">
<img width="843" alt="image" src="https://github.com/usebruno/bruno/assets/6736499/fd8224fd-d72f-4a68-85e5-4eb6a9fb36f6">
<img width="1124" alt="image" src="https://github.com/usebruno/bruno/assets/6736499/848a7f6d-3cc1-447c-8042-70ff61c2670b">
<img width="276" alt="image" src="https://github.com/usebruno/bruno/assets/6736499/da061311-fa51-4540-b5f5-c9f7635070ca">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

