### PR TITLE
feat(#947): set up ajv-formats in script and test runtimes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20764,6 +20764,7 @@
       "dependencies": {
         "@usebruno/query": "0.1.0",
         "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "atob": "^2.1.2",
         "axios": "^1.5.1",
         "btoa": "^1.2.1",

--- a/packages/bruno-js/package.json
+++ b/packages/bruno-js/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@usebruno/query": "0.1.0",
     "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
     "atob": "^2.1.2",
     "axios": "^1.5.1",
     "btoa": "^1.2.1",
@@ -28,7 +29,7 @@
     "moment": "^2.29.4",
     "nanoid": "3.3.4",
     "node-fetch": "2.*",
-    "uuid": "^9.0.0",
-    "node-vault": "^0.10.2"
+    "node-vault": "^0.10.2",
+    "uuid": "^9.0.0"
   }
 }

--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -16,6 +16,7 @@ const { cleanJson } = require('../utils');
 
 // Inbuilt Library Support
 const ajv = require('ajv');
+const addFormats = require('ajv-formats');
 const atob = require('atob');
 const btoa = require('btoa');
 const lodash = require('lodash');
@@ -102,6 +103,7 @@ class ScriptRuntime {
           zlib,
           // 3rd party libs
           ajv,
+          'ajv-formats': addFormats,
           atob,
           btoa,
           lodash,
@@ -194,6 +196,7 @@ class ScriptRuntime {
           zlib,
           // 3rd party libs
           ajv,
+          'ajv-formats': addFormats,
           atob,
           btoa,
           lodash,

--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -19,6 +19,7 @@ const { cleanJson } = require('../utils');
 
 // Inbuilt Library Support
 const ajv = require('ajv');
+const addFormats = require('ajv-formats');
 const atob = require('atob');
 const btoa = require('btoa');
 const lodash = require('lodash');
@@ -120,6 +121,7 @@ class TestRuntime {
           zlib,
           // 3rd party libs
           ajv,
+          'ajv-formats': addFormats,
           btoa,
           atob,
           lodash,

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -1,5 +1,6 @@
 const { describe, it, expect } = require('@jest/globals');
 const TestRuntime = require('../src/runtime/test-runtime');
+const ScriptRuntime = require('../src/runtime/script-runtime');
 
 describe('runtime', () => {
   describe('test-runtime', () => {
@@ -48,6 +49,130 @@ describe('runtime', () => {
       expect(result.results.map((el) => ({ description: el.description, status: el.status }))).toEqual([
         { description: 'async test', status: 'pass' }
       ]);
+    });
+
+    it('should have ajv and ajv-formats dependencies available', async () => {
+      const testFile = `
+                const Ajv = require('ajv');
+                const addFormats = require("ajv-formats");
+                const ajv = new Ajv();
+                addFormats(ajv);
+                
+                const schema = {
+                  type: 'string',
+                  format: 'date-time'
+                };
+                
+                const validate = ajv.compile(schema)
+                
+                test('format valid', () => {
+                  const valid = validate(new Date().toISOString())
+                  expect(valid).to.be.true;
+                })
+            `;
+
+      const runtime = new TestRuntime();
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env
+      );
+      expect(result.results.map((el) => ({ description: el.description, status: el.status }))).toEqual([
+        { description: 'format valid', status: 'pass' }
+      ]);
+    });
+  });
+
+  describe('script-runtime', () => {
+    describe('run-request-script', () => {
+      const baseRequest = {
+        method: 'GET',
+        url: 'http://localhost:3000/',
+        headers: {},
+        data: undefined
+      };
+
+      it('should have ajv and ajv-formats dependencies available', async () => {
+        const script = `
+                  const Ajv = require('ajv');
+                  const addFormats = require("ajv-formats");
+                  const ajv = new Ajv();
+                  addFormats(ajv);
+                  
+                  const schema = {
+                    type: 'string',
+                    format: 'date-time'
+                  };
+                  
+                  const validate = ajv.compile(schema)
+                  
+                  bru.setVar('validation', validate(new Date().toISOString()))
+              `;
+
+        const runtime = new ScriptRuntime();
+        const result = await runtime.runRequestScript(script, { ...baseRequest }, {}, {}, '.', null, process.env);
+        expect(result.collectionVariables.validation).toBeTruthy();
+      });
+    });
+
+    describe('run-response-script', () => {
+      const baseRequest = {
+        method: 'GET',
+        url: 'http://localhost:3000/',
+        headers: {},
+        data: undefined
+      };
+      const baseResponse = {
+        status: 200,
+        statusText: 'OK',
+        data: [
+          {
+            id: 1
+          },
+          {
+            id: 2
+          },
+          {
+            id: 3
+          }
+        ]
+      };
+
+      it('should have ajv and ajv-formats dependencies available', async () => {
+        const script = `
+                  const Ajv = require('ajv');
+                  const addFormats = require("ajv-formats");
+                  const ajv = new Ajv();
+                  addFormats(ajv);
+                  
+                  const schema = {
+                    type: 'string',
+                    format: 'date-time'
+                  };
+                  
+                  const validate = ajv.compile(schema)
+                  
+                  bru.setVar('validation', validate(new Date().toISOString()))
+              `;
+
+        const runtime = new ScriptRuntime();
+        const result = await runtime.runResponseScript(
+          script,
+          { ...baseRequest },
+          { ...baseResponse },
+          {},
+          {},
+          '.',
+          null,
+          process.env
+        );
+        expect(result.collectionVariables.validation).toBeTruthy();
+      });
     });
   });
 });


### PR DESCRIPTION
# Description

Add the ajv-formats dependency in test and script runtimes to perform additional json validations with ajv such as date-time or uuid. See the complete list here : https://ajv.js.org/packages/ajv-formats.html#formats.

<img width="1199" alt="image" src="https://github.com/usebruno/bruno/assets/7666444/aa8bd980-08ec-49c9-be69-248bbd0171e2">

This solves #947.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
