### PR TITLE
feat(#1630) Add contextual menu entries to reveal and edit the selected collection items

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -9,6 +9,7 @@ import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
 import { collectionFolderClicked } from 'providers/ReduxStore/slices/collections';
 import { moveItem } from 'providers/ReduxStore/slices/collections/actions';
 import { sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { shellOpenCollectionPath } from 'providers/ReduxStore/slices/collections/actions';
 import Dropdown from 'components/Dropdown';
 import NewRequest from 'components/Sidebar/NewRequest';
 import NewFolder from 'components/Sidebar/NewFolder';
@@ -103,6 +104,14 @@ const CollectionItem = ({ item, collection, searchText }) => {
         duration: 5000
       })
     );
+  };
+
+  const handleShellRevealItem = () => {
+    dispatch(shellOpenCollectionPath(item.pathname, false, false));
+  };
+
+  const handleShellEditItem = () => {
+    dispatch(shellOpenCollectionPath(item.pathname, false, true));
   };
 
   const handleClick = (event) => {
@@ -346,6 +355,26 @@ const CollectionItem = ({ item, collection, searchText }) => {
               >
                 Delete
               </div>
+              <div
+                className="dropdown-item"
+                onClick={(e) => {
+                  dropdownTippyRef.current.hide();
+                  handleShellRevealItem();
+                }}
+              >
+                Open Location
+              </div>
+              {!isFolder && (
+                <div
+                  className="dropdown-item"
+                  onClick={(e) => {
+                    dropdownTippyRef.current.hide();
+                    handleShellEditItem();
+                  }}
+                >
+                  Edit
+                </div>
+              )}
             </Dropdown>
           </div>
         </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -7,6 +7,7 @@ import { IconChevronRight, IconDots } from '@tabler/icons';
 import Dropdown from 'components/Dropdown';
 import { collectionClicked } from 'providers/ReduxStore/slices/collections';
 import { moveItemToRootOfCollection } from 'providers/ReduxStore/slices/collections/actions';
+import { shellOpenCollectionPath } from 'providers/ReduxStore/slices/collections/actions';
 import { useDispatch } from 'react-redux';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
@@ -77,6 +78,14 @@ const Collection = ({ collection, searchText }) => {
       }
       _menuDropdown[menuDropdownBehavior]();
     }
+  };
+
+  const handleShellRevealCollection = () => {
+    dispatch(shellOpenCollectionPath(collection.pathname, true, false));
+  };
+
+  const handleShellEditCollection = () => {
+    dispatch(shellOpenCollectionPath(collection.pathname, true, true));
   };
 
   const viewCollectionSettings = () => {
@@ -227,6 +236,24 @@ const Collection = ({ collection, searchText }) => {
               }}
             >
               Settings
+            </div>
+            <div
+              className="dropdown-item"
+              onClick={(e) => {
+                menuDropdownTippyRef.current.hide();
+                handleShellRevealCollection();
+              }}
+            >
+              Open Location
+            </div>
+            <div
+              className="dropdown-item"
+              onClick={(e) => {
+                menuDropdownTippyRef.current.hide();
+                handleShellEditCollection();
+              }}
+            >
+              Edit bruno.json
             </div>
           </Dropdown>
         </div>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1020,3 +1020,11 @@ export const importCollection = (collection, collectionLocation) => (dispatch, g
     ipcRenderer.invoke('renderer:import-collection', collection, collectionLocation).then(resolve).catch(reject);
   });
 };
+
+export const shellOpenCollectionPath = (itemPath, isCollection, edit) => () => {
+  return new Promise((resolve, reject) => {
+    const { ipcRenderer } = window;
+
+    ipcRenderer.invoke('renderer:shell-open', itemPath, isCollection, edit).then(resolve).catch(reject);
+  });
+};

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -560,6 +560,22 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
     }
   });
 
+  ipcMain.handle('renderer:shell-open', async (event, itemPath, isCollection, edit) => {
+    if (isCollection) {
+      itemPath = path.join(itemPath, 'bruno.json');
+    }
+
+    if (fs.existsSync(itemPath)) {
+      const isDir = fs.statSync(itemPath).isDirectory();
+
+      if (edit && !isDir) {
+        shell.openPath(itemPath);
+      } else {
+        shell.showItemInFolder(itemPath);
+      }
+    }
+  });
+
   ipcMain.handle('renderer:update-bruno-config', async (event, brunoConfig, collectionPath, collectionUid) => {
     try {
       const brunoConfigPath = path.join(collectionPath, 'bruno.json');


### PR DESCRIPTION
# Description

This PR adds new contextual menu entries (right-click menu) on collections and collections items which allow users to directly access the underlying files on the filesystem or edit it with their favorite editor.
This has been done using electron's built in **openPath** and **showItemInFolder** functions which are taking care of using the adequate features of the user's operating system

![image](https://github.com/usebruno/bruno/assets/15845066/b7a44fc5-78f7-41a4-9e34-30489da8da0c)

The following contextual menus have been added:
- **"Open Location"** which reveals the selected item in the system's file explorer
  - _Available on Collections, Folders and Requests_
- **"Edit"** which opens the system's default editor for the selected item
  - _Available on Requests only_
- **"Edit bruno.json"** available on collection level only - opens the collection's bruno.json file in the system default editor

### Contribution Checklist:

- [ X] **The pull request only addresses one issue or adds one feature.**
- [ X] **The pull request does not introduce any breaking changes**
- [ X] **I have added screenshots or gifs to help explain the change if applicable.**
- [ X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
