### PR TITLE
feat: add middle mouse button click to close tab

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -28,6 +28,20 @@ const RequestTab = ({ tab, collection }) => {
     );
   };
 
+  const handleMouseUp = (e) => {
+    if (e.button === 1) {
+      e.stopPropagation();
+      e.preventDefault();
+
+      //if (item?.draft) return setShowConfirmClose(true);
+      dispatch(
+        closeTabs({
+          tabUids: [tab.uid]
+        })
+      );
+    }
+  };
+
   const getMethodColor = (method = '') => {
     const theme = storedTheme === 'dark' ? darkTheme : lightTheme;
 
@@ -124,7 +138,16 @@ const RequestTab = ({ tab, collection }) => {
           }}
         />
       )}
-      <div className="flex items-baseline tab-label pl-2">
+      <div
+        className="flex items-baseline tab-label pl-2"
+        onMouseUp={(e) => {
+          if (!item.draft) return handleMouseUp(e);
+
+          e.stopPropagation();
+          e.preventDefault();
+          setShowConfirmClose(true);
+        }}
+      >
         <span className="tab-method uppercase" style={{ color: getMethodColor(method), fontSize: 12 }}>
           {method}
         </span>

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -142,9 +142,11 @@ const RequestTab = ({ tab, collection }) => {
         onMouseUp={(e) => {
           if (!item.draft) return handleMouseUp(e);
 
-          e.stopPropagation();
-          e.preventDefault();
-          setShowConfirmClose(true);
+          if (e.button === 1) {
+            e.stopPropagation();
+            e.preventDefault();
+            setShowConfirmClose(true);
+          }
         }}
       >
         <span className="tab-method uppercase" style={{ color: getMethodColor(method), fontSize: 12 }}>

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -33,7 +33,6 @@ const RequestTab = ({ tab, collection }) => {
       e.stopPropagation();
       e.preventDefault();
 
-      //if (item?.draft) return setShowConfirmClose(true);
       dispatch(
         closeTabs({
           tabUids: [tab.uid]


### PR DESCRIPTION
# Description

## Add the possibility to close tabs with mouse middle button click.

This feature was shared first by [Sahilm416](https://github.com/Sahilm416) - [PR](https://github.com/usebruno/bruno/pull/586). But the code is like deprecated. This is a amazing feature that will improve UX of all of bruno's users!

![middle-btn-close](https://github.com/usebruno/bruno/assets/63877012/2a9ad3c6-b0d5-4301-b645-345c6660d07c)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Closes [485](https://github.com/usebruno/bruno/issues/485)
