### PR TITLE
replace single import with multiple import, and handle array of imports

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import importBrunoCollection from 'utils/importers/bruno-collection';
 import importPostmanCollection from 'utils/importers/postman-collection';
 import importInsomniaCollection from 'utils/importers/insomnia-collection';
-import importOpenapiCollection from 'utils/importers/openapi-collection';
+import importOpenapiCollections from 'utils/importers/openapi-collections';
 import { toastError } from 'utils/common/error';
 import Modal from 'components/Modal';
 
@@ -31,8 +31,8 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
       .catch((err) => toastError(err, 'Insomnia Import collection failed'));
   };
 
-  const handleImportOpenapiCollection = () => {
-    importOpenapiCollection()
+  const handleImportOpenapiCollections = () => {
+    importOpenapiCollections()
       .then((collection) => {
         handleSubmit(collection);
       })
@@ -51,7 +51,7 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
         <div className="text-link hover:underline cursor-pointer mt-2" onClick={handleImportInsomniaCollection}>
           Insomnia Collection
         </div>
-        <div className="text-link hover:underline cursor-pointer mt-2" onClick={handleImportOpenapiCollection}>
+        <div className="text-link hover:underline cursor-pointer mt-2" onClick={handleImportOpenapiCollections}>
           OpenAPI V3 Spec
         </div>
       </div>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1016,7 +1016,15 @@ export const collectionAddEnvFileEvent = (payload) => (dispatch, getState) => {
 export const importCollection = (collection, collectionLocation) => (dispatch, getState) => {
   return new Promise((resolve, reject) => {
     const { ipcRenderer } = window;
-
-    ipcRenderer.invoke('renderer:import-collection', collection, collectionLocation).then(resolve).catch(reject);
+    if (Array.isArray(collection)) {
+      console.log('collection is an array.');
+      each(collection, (item) => {
+        collectionLocation = collectionLocation || item.name;
+        ipcRenderer.invoke('renderer:import-collection', item, collectionLocation).then(resolve).catch(reject);
+      });
+    } else {
+      console.log('collection is not an array.');
+      ipcRenderer.invoke('renderer:import-collection', collection, collectionLocation).then(resolve).catch(reject);
+    }
   });
 };

--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -6,7 +6,7 @@ import { uuid } from 'utils/common';
 import { BrunoError } from 'utils/common/error';
 import { validateSchema, transformItemsInCollection, hydrateSeqInCollection } from './common';
 
-const readFile = (files) => {
+export const readFile = (files) => {
   return new Promise((resolve, reject) => {
     const fileReader = new FileReader();
     fileReader.onload = (e) => {
@@ -295,7 +295,7 @@ const getSecurity = (apiSpec) => {
   };
 };
 
-const parseOpenApiCollection = (data) => {
+export const parseOpenApiCollection = (data) => {
   const brunoCollection = {
     name: '',
     uid: uuid(),

--- a/packages/bruno-app/src/utils/importers/openapi-collections.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collections.js
@@ -1,0 +1,37 @@
+import jsyaml from 'js-yaml';
+import each from 'lodash/each';
+import get from 'lodash/get';
+import fileDialog from 'file-dialog';
+import { uuid } from 'utils/common';
+import { BrunoError } from 'utils/common/error';
+import { validateSchema, transformItemsInCollection, hydrateSeqInCollection } from './common';
+import { readFile, parseOpenApiCollection } from 'utils/importers/openapi-collection';
+
+const importCollections = async () => {
+  const collections = [];
+
+  return new Promise((resolve, reject) => {
+    fileDialog({ multiple: true })
+      .then((files) => {
+        // iterate over each file and import it
+        each(files, async (file) => {
+          readFile([file])
+            .then(parseOpenApiCollection)
+            .then(transformItemsInCollection)
+            .then(hydrateSeqInCollection)
+            .then(validateSchema)
+            .then((collection) => {
+              collections.push(collection);
+            });
+        });
+      })
+      .then(() => {
+        resolve(collections);
+      })
+      .catch((err) => {
+        reject(new BrunoError('Import collection failed'));
+      });
+  });
+};
+
+export default importCollections;


### PR DESCRIPTION
# Description

Import openAPI spec now allows you to select multiple files - and uses the "name" field of the spec to generate sub-folders

Addresses https://github.com/usebruno/bruno/discussions/1541

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

