### PR TITLE
(fix#1687): Marking request as saved even when no changes are detected compared to filesystem

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -380,7 +380,7 @@ export const transformRequestToSaveToFilesystem = (item) => {
     uid: _item.uid,
     type: _item.type,
     name: _item.name,
-    seq: _item.seq,
+    seq: item.seq,
     request: {
       method: _item.request.method,
       url: _item.request.url,
@@ -539,6 +539,8 @@ export const deleteUidsInItem = (item) => {
 export const areItemsTheSameExceptSeqUpdate = (_item1, _item2) => {
   let item1 = cloneDeep(_item1);
   let item2 = cloneDeep(_item2);
+
+  if (item1.seq === item2.seq) return false;
 
   // remove seq from both items
   delete item1.seq;


### PR DESCRIPTION
# Description

Fix bug that prevents request from being marked as saved in the UI (hiding the orange dot) when the change made was reverted by user, making the draft identical to filesystem content.

This scenario is fully reproduced in this [comment](https://github.com/usebruno/bruno/issues/1491#issuecomment-1957440737).

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Closes #1687

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
