### PR TITLE
Fix #1683 allow OAuth2 authorizationUrl with user provided query parameters

### DIFF
--- a/packages/bruno-electron/src/ipc/network/oauth2-helper.js
+++ b/packages/bruno-electron/src/ipc/network/oauth2-helper.js
@@ -47,10 +47,13 @@ const getOAuth2AuthorizationCode = (request, codeChallenge) => {
     const { oauth2 } = request;
     const { callbackUrl, clientId, authorizationUrl, scope, pkce } = oauth2;
 
-    let authorizationUrlWithQueryParams = `${authorizationUrl}?client_id=${clientId}&redirect_uri=${callbackUrl}&response_type=code&scope=${scope}`;
+    let oauth2QueryParams =
+      (authorizationUrl.indexOf('?') > -1 ? '&' : '?') +
+      `client_id=${clientId}&redirect_uri=${callbackUrl}&response_type=code&scope=${scope}`;
     if (pkce) {
-      authorizationUrlWithQueryParams += `&code_challenge=${codeChallenge}&code_challenge_method=S256`;
+      oauth2QueryParams += `&code_challenge=${codeChallenge}&code_challenge_method=S256`;
     }
+    const authorizationUrlWithQueryParams = authorizationUrl + oauth2QueryParams;
     try {
       const { authorizationCode } = await authorizeUserInWindow({
         authorizeUrl: authorizationUrlWithQueryParams,


### PR DESCRIPTION
# Description

In some cases the authroization url may already contain some query parameters expected by the specific applicaiton, in which case oauth2 authorization request specific parameters should be appended to the list. Previous implementation assumed no query component in the authrization URI.

Fixes #1683 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
