### PR TITLE
feat(#981): Add bruno methods to allow vars to be deleted and to check for the existence of vars

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -58,10 +58,16 @@ if (!SERVER_RENDERED) {
     'bru.cwd()',
     'bru.getEnvName(key)',
     'bru.getProcessEnv(key)',
+    'bru.clearEnvVars()',
+    'bru.hasEnvVar(key)',
     'bru.getEnvVar(key)',
     'bru.setEnvVar(key,value)',
+    'bru.unsetEnvVar(key)',
+    'bru.clearVars()',
     'bru.getVar(key)',
+    'bru.hasVar(key)',
     'bru.setVar(key,value)',
+    'bru.unsetVar(key)',
     'bru.setNextRequest(requestName)'
   ];
   CodeMirror.registerHelper('hint', 'brunoJS', (editor, options) => {

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -39,8 +39,28 @@ class Bru {
     return this.processEnvVars[key];
   }
 
+  clearEnvVars() {
+    Object.keys(this.envVariables).forEach((k) => delete this.envVariables[k]);
+  }
+
+  hasEnvVar(key) {
+    if (!key) {
+      throw new Error('Verification of variable existence without specifying a name is not allowed.');
+    }
+
+    return !!this.getEnvVar(key);
+  }
+
   getEnvVar(key) {
     return this._interpolateEnvVar(this.envVariables[key]);
+  }
+
+  unsetEnvVar(key) {
+    if (!key) {
+      throw new Error('Reseting a env variable without specifying a name is not allowed.');
+    }
+
+    delete this.envVariables[key];
   }
 
   setEnvVar(key, value) {
@@ -49,6 +69,14 @@ class Bru {
     }
 
     this.envVariables[key] = value;
+  }
+
+  hasVar(key) {
+    if (!key) {
+      throw new Error('Verification of variable existence without specifying a name is not allowed.');
+    }
+
+    return !!this.getVar(key);
   }
 
   setVar(key, value) {
@@ -66,6 +94,21 @@ class Bru {
     this.collectionVariables[key] = value;
   }
 
+  unsetVar(key) {
+    if (!key) {
+      throw new Error('Reseting a variable without specifying a name is not allowed.');
+    }
+
+    if (variableNameRegex.test(key) === false) {
+      throw new Error(
+        `Variable name: "${key}" contains invalid characters!` +
+          ' Names must only contain alpha-numeric characters, "-", "_", "."'
+      );
+    }
+
+    delete this.collectionVariables[key];
+  }
+
   getVar(key) {
     if (variableNameRegex.test(key) === false) {
       throw new Error(
@@ -75,6 +118,10 @@ class Bru {
     }
 
     return this.collectionVariables[key];
+  }
+
+  clearVars() {
+    Object.keys(this.collectionVariables).forEach((k) => delete this.collectionVariables[k]);
   }
 
   setNextRequest(nextRequest) {

--- a/packages/bruno-js/tests/bru.spec.js
+++ b/packages/bruno-js/tests/bru.spec.js
@@ -1,0 +1,180 @@
+const { describe, it, expect } = require('@jest/globals');
+const Bru = require('../src/bru');
+
+describe('Bru', () => {
+  describe('cwd', () => {
+    it('Should return current working directory', () => {
+      const bru = new Bru(null, null, null, 'anyCollectionPath');
+      expect(bru.cwd()).toEqual('anyCollectionPath');
+    });
+  });
+
+  describe('getEnvName', () => {
+    it('Should return the env name', () => {
+      const bru = new Bru(
+        {
+          __name__: 'anyEnvName'
+        },
+        null,
+        null,
+        null
+      );
+      expect(bru.getEnvName()).toEqual('anyEnvName');
+    });
+  });
+
+  describe('getProcessEnv', () => {
+    it('Should return any process env key', () => {
+      const bru = new Bru(
+        null,
+        null,
+        {
+          anyKey: 'anyValue'
+        },
+        null
+      );
+      expect(bru.getProcessEnv('anyKey')).toEqual('anyValue');
+    });
+  });
+
+  describe('setNextRequest', () => {
+    it('Should set next request', () => {
+      const bru = new Bru(null, null, null, null);
+      bru.setNextRequest('anyNextRequest');
+      expect(bru.nextRequest).toEqual('anyNextRequest');
+    });
+  });
+
+  describe('EnvVars', () => {
+    it('Should remove all env vars', () => {
+      const envVars = {
+        anyKey: 'anyValue',
+        otherKey: 'otherValue'
+      };
+      const bru = new Bru(envVars, null, null, null);
+      bru.clearEnvVars();
+      expect(envVars).toEqual({});
+    });
+
+    it('Should return true if env var exists', () => {
+      const bru = new Bru(
+        {
+          anyKey: 'anyValue'
+        },
+        null,
+        null,
+        null
+      );
+      expect(bru.hasEnvVar('anyKey')).toBeTruthy();
+    });
+    it('Should return false if env var does not exist', () => {
+      const bru = new Bru(
+        {
+          anyKey: 'anyValue'
+        },
+        null,
+        null,
+        null
+      );
+      expect(bru.hasEnvVar('otherKey')).toBeFalsy();
+    });
+
+    it('Should get interpollated env var', () => {
+      const bru = new Bru(
+        {
+          anyKey: 'anyValue {{process.env.anyKey}}'
+        },
+        null,
+        {
+          anyKey: 'nestedValue'
+        },
+        null
+      );
+      expect(bru.getEnvVar('anyKey')).toEqual('anyValue nestedValue');
+    });
+
+    it('Should unset env var', () => {
+      const envVars = {
+        anyKey: 'anyValue'
+      };
+      const bru = new Bru(envVars, null, null, null);
+      bru.unsetEnvVar('anyKey');
+      expect(envVars).toEqual({});
+    });
+
+    it('Should set env var', () => {
+      const envVars = {
+        anyKey: 'anyValue'
+      };
+      const bru = new Bru(envVars, null, null, null);
+      bru.setEnvVar('anyKey', 'otherValue');
+      expect(envVars.anyKey).toEqual('otherValue');
+    });
+  });
+
+  describe('CollectionVars', () => {
+    it('Should remove all collection vars', () => {
+      const collectionVars = {
+        anyKey: 'anyValue',
+        otherKey: 'otherValue'
+      };
+      const bru = new Bru(null, collectionVars, null, null);
+      bru.clearVars();
+      expect(collectionVars).toEqual({});
+    });
+
+    it('Should return true if collection var exists', () => {
+      const bru = new Bru(
+        null,
+        {
+          anyKey: 'anyValue'
+        },
+        null,
+        null
+      );
+      expect(bru.hasVar('anyKey')).toBeTruthy();
+    });
+    it('Should return false if collection var does not exist', () => {
+      const bru = new Bru(
+        null,
+        {
+          anyKey: 'anyValue'
+        },
+        null,
+        null
+      );
+      expect(bru.hasVar('otherKey')).toBeFalsy();
+    });
+
+    it('Should get collection var', () => {
+      const bru = new Bru(
+        null,
+        {
+          anyKey: 'anyValue {{nestedKey}}',
+          nestedKey: 'nestedValue'
+        },
+        null,
+        null
+      );
+      expect(bru.getVar('anyKey')).toEqual('anyValue {{nestedKey}}');
+    });
+
+    it('Should unset collection var', () => {
+      const collectionVars = {
+        anyKey: 'anyValue'
+      };
+      const bru = new Bru(null, collectionVars, null, null);
+      bru.unsetVar('anyKey');
+      expect(collectionVars).toEqual({});
+    });
+
+    it('Should set collection var', () => {
+      const collectionVars = {
+        anyKey: 'anyValue'
+      };
+      const bru = new Bru(null, collectionVars, null, null);
+      bru.setVar('anyKey', 'otherValue');
+      expect(collectionVars.anyKey).toEqual('otherValue');
+    });
+  });
+});


### PR DESCRIPTION
# Description

Solves #981

Add methods to Bru to manipulate env and collection variables : 

- clearEnvVars() : Clear all variables from the environment
- hasEnvVar(key) : Check for the existence of a variable in the environment with the specified name
- unsetEnvVar(key) : Remove the specified variable from the environment
- clearVars() : Clear all variables from the collection
- hasVar(key) : Check for the existence of a variable in the collection with the specified name
- unsetVar(key) : Remove the specified variable from the collection

I also added the completion in app :

<img width="1210" alt="image" src="https://github.com/usebruno/bruno/assets/7666444/763ae7b3-a9e2-4a9a-88a3-30ebbfd0758b">

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
