### PR TITLE
feat: possibiliting slicing bruno to the sides of the screen with the…

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -19,8 +19,8 @@ import { DocExplorer } from '@usebruno/graphql-docs';
 
 import StyledWrapper from './StyledWrapper';
 
-const MIN_LEFT_PANE_WIDTH = 300;
-const MIN_RIGHT_PANE_WIDTH = 350;
+const MIN_LEFT_PANE_WIDTH = 100;
+const MIN_RIGHT_PANE_WIDTH = 220;
 const DEFAULT_PADDING = 5;
 
 const RequestTabPanel = () => {
@@ -68,6 +68,8 @@ const RequestTabPanel = () => {
 
   const handleMouseMove = (e) => {
     if (dragging) {
+      console.log(asideWidth + DEFAULT_PADDING + MIN_LEFT_PANE_WIDTH);
+      console.log(e.clientX + 2);
       e.preventDefault();
       let leftPaneXPosition = e.clientX + 2;
       if (

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -68,8 +68,6 @@ const RequestTabPanel = () => {
 
   const handleMouseMove = (e) => {
     if (dragging) {
-      console.log(asideWidth + DEFAULT_PADDING + MIN_LEFT_PANE_WIDTH);
-      console.log(e.clientX + 2);
       e.preventDefault();
       let leftPaneXPosition = e.clientX + 2;
       if (

--- a/packages/bruno-app/src/components/Sidebar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/index.js
@@ -12,7 +12,7 @@ import { IconSettings, IconCookie, IconHeart } from '@tabler/icons';
 import { updateLeftSidebarWidth, updateIsDragging, showPreferences } from 'providers/ReduxStore/slices/app';
 import { useTheme } from 'providers/Theme';
 
-const MIN_LEFT_SIDEBAR_WIDTH = 221;
+const MIN_LEFT_SIDEBAR_WIDTH = 150;
 const MAX_LEFT_SIDEBAR_WIDTH = 600;
 
 const Sidebar = () => {

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -44,7 +44,6 @@ app.on('ready', async () => {
     y,
     width,
     height,
-    minWidth: 1000,
     minHeight: 640,
     webPreferences: {
       nodeIntegration: true,


### PR DESCRIPTION
REF - BRU-4528

… Add the possibility to split view screen to the sides && improve the experience at the splitted screen

# Description

Before this PR, i was facing a annoying behaviour when i tried to press the Super Key + Left or Right arrow to move Bruno to the side of monitor to work at 2 softwares at the same time. But this is not posible, and i noticed that the Bruno app has a limitation at the minimal Browser Window width. I don't think this  provide a good experience for software developers, so i remove this limitation, and improved the flexibility of resizing the panes (left side bar, request pane and response pane)at Bruno.

![split-on-sides](https://github.com/usebruno/bruno/assets/63877012/0c882970-1df8-4e3d-961c-3e9a08d727ac)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Closes: https://github.com/usebruno/bruno/issues/1735
Please see [here](../publishing.md) for more information.
