### PR TITLE
Fix margin between items in Welcome > Links

### DIFF
--- a/packages/bruno-app/src/components/Welcome/index.js
+++ b/packages/bruno-app/src/components/Welcome/index.js
@@ -84,13 +84,13 @@ const Welcome = () => {
             <span className="label ml-2">Documentation</span>
           </a>
         </div>
-        <div className="mt-2">
+        <div className="flex items-center mt-2">
           <a href="https://github.com/usebruno/bruno/issues" target="_blank" className="inline-flex items-center">
             <IconSpeakerphone size={18} strokeWidth={2} />
             <span className="label ml-2">Report Issues</span>
           </a>
         </div>
-        <div className="mt-2">
+        <div className="flex items-center mt-2">
           <a href="https://github.com/usebruno/bruno" target="_blank" className="flex items-center">
             <IconBrandGithub size={18} strokeWidth={2} />
             <span className="label ml-2">GitHub</span>


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Hey! Stumbled upon the project, love the idea.
This is a _very_ minor contribution, but my OCD kicked in when I saw those uneven margins 😅 

<img width="373" alt="image" src="https://github.com/usebruno/bruno/assets/201897/4124547e-e06e-40df-817b-47cadaed6a53">

Current:

<img width="255" alt="image" src="https://github.com/usebruno/bruno/assets/201897/bf868bc4-07d2-4a97-b3c4-f4dd9a7ca7ab">

Fix:

<img width="245" alt="image" src="https://github.com/usebruno/bruno/assets/201897/0ef83fba-7747-429b-9a12-3b8314673f95">

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
