### PR TITLE
Check oauth2 authorization code redirect for exact 'code' query parameter

### DIFF
--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -24,7 +24,7 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
 
     function onWindowRedirect(url) {
       // check if the url contains an authorization code
-      if (url.match(/(code=).*/)) {
+      if (new URL(url).searchParams.has('code')) {
         finalUrl = url;
         if (!url || !finalUrl.includes(callbackUrl)) {
           reject(new Error('Invalid Callback Url'));


### PR DESCRIPTION
# Description

Redirects during OAuth2 authorization code flow are only identified through a rather broad regex match for `code` in the redirect uri. The authorization process will fail for authorization servers offering a "multi-step" authorization that include intemediate redirects casually containing the keyword `code` in their uri.

This change checks the redirect for the distinct `code` query paramter [as defined in the RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Fixes https://github.com/usebruno/bruno/issues/1778