### PR TITLE
fix: add authorization token to generate code

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -9,6 +9,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import toast from 'react-hot-toast';
 import { IconCopy } from '@tabler/icons';
 import { findCollectionByItemUid } from '../../../../../../../utils/collections/index';
+import { getAuthHeaders } from '../../../../../../../utils/codegenerator/auth';
 
 const CodeView = ({ language, item }) => {
   const { displayedTheme } = useTheme();
@@ -20,10 +21,16 @@ const CodeView = ({ language, item }) => {
     item.uid
   );
 
-  const headers = [...(collection?.root?.request?.headers || []), ...(requestHeaders || [])];
+  const collectionRootAuth = collection?.root?.request?.auth;
+  const requestAuth = item.draft ? get(item, 'draft.request.auth') : get(item, 'request.auth');
+
+  const headers = [
+    ...getAuthHeaders(collectionRootAuth, requestAuth),
+    ...(collection?.root?.request?.headers || []),
+    ...(requestHeaders || [])
+  ];
 
   let snippet = '';
-
   try {
     snippet = new HTTPSnippet(buildHarRequest({ request: item.request, headers })).convert(target, client);
   } catch (e) {

--- a/packages/bruno-app/src/utils/codegenerator/auth.js
+++ b/packages/bruno-app/src/utils/codegenerator/auth.js
@@ -1,0 +1,30 @@
+import get from 'lodash/get';
+
+export const getAuthHeaders = (collectionRootAuth, requestAuth) => {
+  const auth = collectionRootAuth && ['inherit', 'none'].includes(requestAuth.mode) ? collectionRootAuth : requestAuth;
+
+  switch (auth.mode) {
+    case 'basic':
+      const username = get(auth, 'basic.username');
+      const password = get(auth, 'basic.password');
+      const basicToken = Buffer.from(`${username}:${password}`).toString('base64');
+
+      return [
+        {
+          enabled: true,
+          name: 'Authorization',
+          value: `Basic ${basicToken}`
+        }
+      ];
+    case 'bearer':
+      return [
+        {
+          enabled: true,
+          name: 'Authorization',
+          value: `Bearer ${get(auth, 'bearer.token')}`
+        }
+      ];
+    default:
+      return [];
+  }
+};


### PR DESCRIPTION
Fixes #1791

# Description

This PR add to Bruno the ability of generate code with Authorization headers of basic and bearer mode

![bruno-auth-token-fix](https://github.com/usebruno/bruno/assets/36305985/8dda74d4-f8d7-4bee-ad8d-63fe7e15649a)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
