### PR TITLE
Fix: OAuth2 Authorization Request OPTIONAL parameters are required by bruno

### DIFF
--- a/packages/bruno-electron/src/ipc/network/oauth2-helper.js
+++ b/packages/bruno-electron/src/ipc/network/oauth2-helper.js
@@ -49,8 +49,13 @@ const getOAuth2AuthorizationCode = (request, codeChallenge, collectionUid) => {
     const { callbackUrl, clientId, authorizationUrl, scope, pkce } = oauth2;
 
     let oauth2QueryParams =
-      (authorizationUrl.indexOf('?') > -1 ? '&' : '?') +
-      `client_id=${clientId}&redirect_uri=${callbackUrl}&response_type=code&scope=${scope}`;
+      (authorizationUrl.indexOf('?') > -1 ? '&' : '?') + `client_id=${clientId}&response_type=code`;
+    if (callbackUrl) {
+      oauth2QueryParams += `&redirect_uri=${callbackUrl}`;
+    }
+    if (scope) {
+      oauth2QueryParams += `&scope=${scope}`;
+    }
     if (pkce) {
       oauth2QueryParams += `&code_challenge=${codeChallenge}&code_challenge_method=S256`;
     }


### PR DESCRIPTION
# Description

OAuth2 configuration should allow empty `scope` or `Callback URL` fields, as these are optional.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Fixes #1797
