### PR TITLE
GraphQL query editor prettify icon lays on top of environment config modal #1800

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -126,7 +126,7 @@ const RequestBodyMode = ({ item, collection }) => {
         </Dropdown>
       </div>
       {bodyMode === 'json' && (
-        <button className="ml-1" onClick={onPrettify}>
+        <button className="ml-1 relative z-10" onClick={onPrettify}>
           Prettify
         </button>
       )}


### PR DESCRIPTION
This PR adjusts the `z-index` of the "Prettify" button to prevent it from overlapping with the environment config modal.