### PR TITLE
GraphQL query dark mode - cursor is black when it should be white #1799

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/StyledWrapper.js
@@ -4,6 +4,7 @@ const StyledWrapper = styled.div`
   div.CodeMirror {
     background: ${(props) => props.theme.codemirror.bg};
     border: solid 1px ${(props) => props.theme.codemirror.border};
+    caret-color: #ffffff;
     /* todo: find a better way */
     height: calc(100vh - 220px);
   }


### PR DESCRIPTION
In dark mode, the cursor in the GraphQL query editor is black, making it hard to see. This issue aims to change the cursor color to white for better visibility in dark mode.