### PR TITLE
Option to save response in utf-8 instead of Unicode #1765

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseSave/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseSave/index.js
@@ -10,8 +10,11 @@ const ResponseSave = ({ item }) => {
 
   const saveResponseToFile = () => {
     return new Promise((resolve, reject) => {
+      // Convert the response data to a string in UTF-8 format
+      const data = Buffer.from(response.dataBuffer).toString('utf-8');
+
       ipcRenderer
-        .invoke('renderer:save-response-to-file', response, item.requestSent.url)
+        .invoke('renderer:save-response-to-file', data, item.requestSent.url)
         .then(resolve)
         .catch((err) => {
           toast.error(get(err, 'error.message') || 'Something went wrong!');


### PR DESCRIPTION
This PR introduces a new feature that allows users to save response data in UTF-8 format. Previously, the response data was saved in Unicode format by default. With this update, users working with non-English character sets, like Japanese, will have their data saved correctly in UTF-8 format. This enhances Bruno’s usability and accessibility for a wider range of users.