### PR TITLE
[Bug] Using a / in an Environment Name causes error in Postman Import #1761

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-environment.js
+++ b/packages/bruno-app/src/utils/importers/postman-environment.js
@@ -31,8 +31,9 @@ const importPostmanEnvironmentVariables = (brunoEnvironment, values) => {
 };
 
 const importPostmanEnvironment = (environment) => {
+  const sanitizedEnvironmentName = environment.name.replace(/\//g, '_');
   const brunoEnvironment = {
-    name: environment.name,
+    name: sanitizedEnvironmentName,
     variables: []
   };
 


### PR DESCRIPTION
This PR fixes a bug that caused environment import to fail if the name contained a /. The importPostmanEnvironment function now replaces / with _ in environment names, allowing successful import.