### PR TITLE
Fix OAuth2 code verifier too short (#1793)

### DIFF
--- a/packages/bruno-electron/src/ipc/network/oauth2-helper.js
+++ b/packages/bruno-electron/src/ipc/network/oauth2-helper.js
@@ -4,7 +4,7 @@ const { authorizeUserInWindow } = require('./authorize-user-in-window');
 const Oauth2Store = require('../../store/oauth2');
 
 const generateCodeVerifier = () => {
-  return crypto.randomBytes(16).toString('hex');
+  return crypto.randomBytes(22).toString('hex');
 };
 
 const generateCodeChallenge = (codeVerifier) => {


### PR DESCRIPTION
# Description

As per [RFC 7636: Proof Key for Code Exchange](https://www.rfc-editor.org/rfc/rfc7636#page-8) we should expect code verifier to be at least 43 characters after URL encode. Current implementation gives only 32.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Fixes #1793 