### PR TITLE
[Bug] Error importing Postman Collection with [ ] symbols in it's name #1651

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -53,6 +53,10 @@ const convertV21Auth = (array) => {
   }, {});
 };
 
+function sanitizeName(name) {
+  return name.replace(/\[|\]/g, ''); // This will remove square brackets
+}
+
 const importPostmanV2CollectionItem = (brunoParent, item, parentAuth) => {
   brunoParent.items = brunoParent.items || [];
   const folderMap = {};
@@ -265,7 +269,7 @@ const searchLanguageByHeader = (headers) => {
 
 const importPostmanV2Collection = (collection) => {
   const brunoCollection = {
-    name: collection.info.name,
+    name: sanitizeName(collection.info.name),
     uid: uuid(),
     version: '1',
     items: [],


### PR DESCRIPTION
Fixes an issue with importing Postman collections that have square brackets in their names. This change sanitizes the collection name by removing square brackets, preventing import errors and crashes. Resolves issue #1651.