### PR TITLE
fix: decomment not working in json body

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -87,10 +87,11 @@ const prepareRequest = (request, collectionRoot) => {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/json';
     }
+    const jsonBody = decomment(request.body.json);
     try {
-      axiosRequest.data = JSONbig.parse(decomment(request.body.json));
+      axiosRequest.data = JSONbig.parse(jsonBody);
     } catch (ex) {
-      axiosRequest.data = request.body.json;
+      axiosRequest.data = jsonBody;
     }
   }
 

--- a/packages/bruno-cli/tests/runner/prepare-request.spec.js
+++ b/packages/bruno-cli/tests/runner/prepare-request.spec.js
@@ -1,0 +1,21 @@
+const { describe, it, expect } = require('@jest/globals');
+
+const prepareRequest = require('../../src/runner/prepare-request');
+
+describe('prepare-request: prepareRequest', () => {
+  describe('Decomments request body', () => {
+    it('If request body is valid JSON', async () => {
+      const body = { mode: 'json', json: '{\n"test": "{{someVar}}" // comment\n}' };
+      const expected = { test: '{{someVar}}' };
+      const result = prepareRequest({ body });
+      expect(result.data).toEqual(expected);
+    });
+
+    it('If request body is not valid JSON', async () => {
+      const body = { mode: 'json', json: '{\n"test": {{someVar}} // comment\n}' };
+      const expected = '{\n"test": {{someVar}} \n}';
+      const result = prepareRequest({ body });
+      expect(result.data).toEqual(expected);
+    });
+  });
+});

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -179,10 +179,11 @@ const prepareRequest = (request, collectionRoot, collectionPath) => {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/json';
     }
+    const body = decomment(request.body.json);
     try {
-      axiosRequest.data = JSONbig.parse(decomment(request.body.json));
+      axiosRequest.data = JSONbig.parse(body);
     } catch (ex) {
-      axiosRequest.data = request.body.json;
+      axiosRequest.data = body;
     }
   }
 

--- a/packages/bruno-electron/tests/network/prepare-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-request.spec.js
@@ -1,0 +1,21 @@
+const { describe, it, expect } = require('@jest/globals');
+
+const prepareRequest = require('../../src/ipc/network/prepare-request');
+
+describe('prepare-request: prepareRequest', () => {
+  describe('Decomments request body', () => {
+    it('If request body is valid JSON', async () => {
+      const body = { mode: 'json', json: '{\n"test": "{{someVar}}" // comment\n}' };
+      const expected = { test: '{{someVar}}' };
+      const result = prepareRequest({ body });
+      expect(result.data).toEqual(expected);
+    });
+
+    it('If request body is not valid JSON', async () => {
+      const body = { mode: 'json', json: '{\n"test": {{someVar}} // comment\n}' };
+      const expected = '{\n"test": {{someVar}} \n}';
+      const result = prepareRequest({ body });
+      expect(result.data).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
Request body json was not decommented if json parsing fails, which would happen if variables are not quoted.

Fixes usebruno#888

# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
