### PR TITLE
fix: system theme in dark mode

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
@@ -27,7 +27,7 @@ const GraphQLRequestPane = ({ item, collection, leftPaneWidth, onSchemaLoad, tog
   const variables = item.draft
     ? get(item, 'draft.request.body.graphql.variables')
     : get(item, 'request.body.graphql.variables');
-  const { storedTheme } = useTheme();
+  const { displayedTheme } = useTheme();
   const [schema, setSchema] = useState(null);
 
   useEffect(() => {
@@ -61,7 +61,7 @@ const GraphQLRequestPane = ({ item, collection, leftPaneWidth, onSchemaLoad, tog
         return (
           <QueryEditor
             collection={collection}
-            theme={storedTheme}
+            theme={displayedTheme}
             schema={schema}
             width={leftPaneWidth}
             onSave={onSave}


### PR DESCRIPTION
# Description

Related to #1822

I fixed the issue making the text scheme theme incorrect on dark mode in Windows.

Here is the before :
![Screenshot 2024-03-15 090746](https://github.com/usebruno/bruno/assets/15325126/1cf3e0e3-06f2-41d5-8e5a-553d5add2b1a)

Here is the after : 
![Screenshot 2024-03-15 091307](https://github.com/usebruno/bruno/assets/15325126/bd5c75fe-b13d-464c-95da-9e6fa6f7950c)

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
