### PR TITLE
fix: use html password type for password and credential inputs

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
@@ -107,7 +107,7 @@ const ClientCertSettings = ({ clientCertConfig, onUpdate, onRemove }) => {
           </label>
           <input
             id="passphrase"
-            type="text"
+            type="password"
             name="passphrase"
             className="block textbox"
             onChange={formik.handleChange}

--- a/packages/bruno-app/src/components/CollectionSettings/ProxySettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/ProxySettings/index.js
@@ -279,7 +279,7 @@ const ProxySettings = ({ proxyConfig, onUpdate }) => {
             </label>
             <input
               id="auth.password"
-              type="text"
+              type="password"
               name="auth.password"
               className="block textbox"
               autoComplete="off"

--- a/packages/bruno-app/src/components/Preferences/ProxySettings/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/index.js
@@ -242,7 +242,7 @@ const ProxySettings = ({ close }) => {
             </label>
             <input
               id="auth.password"
-              type="text"
+              type="password"
               name="auth.password"
               className="block textbox"
               autoComplete="off"


### PR DESCRIPTION
# Description

Password inputs should be hidden with the HTML password type. Added them for the proxy and the client cert settings.

Fixes issue: https://github.com/usebruno/bruno/issues/1886

Before
![image](https://github.com/usebruno/bruno/assets/11610680/20836f7f-cda7-4150-a039-6e31fd37e2ff)

After
![image](https://github.com/usebruno/bruno/assets/11610680/fb6e19e0-356d-49b1-9129-7178e0c19dac)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
