### PR TITLE
fix(#1826): Fix changing grant type erases saved inputs

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Auth/OAuth2/GrantTypeSelector/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Auth/OAuth2/GrantTypeSelector/index.js
@@ -30,6 +30,7 @@ const GrantTypeSelector = ({ collection }) => {
         mode: 'oauth2',
         collectionUid: collection.uid,
         content: {
+          ...collection.root.request.auth.oauth2,
           grantType
         }
       })


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
It seems when switching the Grant Type instead of only updating the Grant Type in Oauth2  it completely overwrites it with only the Grant Type, leading to this issue. With the changes that I have made just the Grant type is updated in Oauth2 and the rest is kept the same which leads to same same variable being used for all Oauth2 Grant types. Please let me know if this is wrong 



before
![image](https://github.com/usebruno/bruno/assets/39237068/7126ee2e-4a14-4984-93fc-9aafd8810b33)
![image](https://github.com/usebruno/bruno/assets/39237068/ae3c55e5-4473-4e89-b7d6-c071c3f31991)
![image](https://github.com/usebruno/bruno/assets/39237068/d5fbc7ee-eafb-45cd-9b01-4fc109d27da8)

after
![image](https://github.com/usebruno/bruno/assets/39237068/55af9570-da29-4cbd-a301-0e82eb42a632)
![image](https://github.com/usebruno/bruno/assets/39237068/65d6f776-e436-47b8-9fcd-05121644f911)
![image](https://github.com/usebruno/bruno/assets/39237068/5f3d0129-a29a-4978-a8d6-62030d0a1706)




### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
