### PR TITLE
fix(#1855): Fix typo for the argument name enableTranslation

### DIFF
--- a/packages/bruno-app/src/components/Welcome/index.js
+++ b/packages/bruno-app/src/components/Welcome/index.js
@@ -29,7 +29,7 @@ const Welcome = () => {
     setImportCollectionLocationModalOpen(true);
   };
 
-  const handleImportCollectionLocation = (collectionLocation, enableTRanslation = true) => {
+  const handleImportCollectionLocation = (collectionLocation, enableTranslation = true) => {
     dispatch(importCollection(importedCollection, collectionLocation, enableTranslation));
     setImportCollectionLocationModalOpen(false);
     setImportedCollection(null);


### PR DESCRIPTION
I suspect the typo makes to fail imports.
This commit fixes the typo.

# Description

Fixes the issue #1855.
I suspect a typo in the argument name enableTranslations causes the imports to fail.

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
