### PR TITLE
fix(ux): better text selection implementation on dark-mode

### DIFF
--- a/packages/bruno-app/src/components/SingleLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/StyledWrapper.js
@@ -49,6 +49,10 @@ const StyledWrapper = styled.div`
       padding-left: 0;
       padding-right: 0;
     }
+
+    .CodeMirror-selected {
+      background-color: rgba(212, 125, 59, 0.3);
+    }
   }
 `;
 


### PR DESCRIPTION
# Description

When I working on dark-mode, text selection at SingleLineEditor it's not eye friendly. This is class component and cannot use `useTheme`, so I made small change to provide better text selection on dark or light mode.

| Before      | After |
| ----------- | ----------- |
| <img width="1381" alt="image" src="https://github.com/usebruno/bruno/assets/13098072/d8cddd26-8160-4e97-8ecc-d562a632e647"> <img width="1381" alt="image" src="https://github.com/usebruno/bruno/assets/13098072/27afe5be-b9e6-4d72-845d-eb85db383043">    | <img width="1381" alt="image" src="https://github.com/usebruno/bruno/assets/13098072/c4f14be9-65c3-4ef8-8305-2aaaf5d49a8e">  <img width="1381" alt="image" src="https://github.com/usebruno/bruno/assets/13098072/32e7bfca-a5b6-4542-af7f-9086ed04a752">    |


### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
