### PR TITLE
Allow to keep the default truststore, when using a custom CA (#1080)

### DIFF
--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -21,6 +21,9 @@ const General = ({ close }) => {
       enabled: Yup.boolean(),
       filePath: Yup.string().nullable()
     }),
+    keepDefaultCaCertificates: Yup.object({
+      enabled: Yup.boolean()
+    }),
     storeCookies: Yup.boolean(),
     sendCookies: Yup.boolean(),
     timeout: Yup.mixed()
@@ -42,6 +45,9 @@ const General = ({ close }) => {
       customCaCertificate: {
         enabled: get(preferences, 'request.customCaCertificate.enabled', false),
         filePath: get(preferences, 'request.customCaCertificate.filePath', null)
+      },
+      keepDefaultCaCertificates: {
+        enabled: get(preferences, 'request.keepDefaultCaCertificates.enabled', false)
       },
       timeout: preferences.request.timeout,
       storeCookies: get(preferences, 'request.storeCookies', true),
@@ -67,6 +73,9 @@ const General = ({ close }) => {
           customCaCertificate: {
             enabled: newPreferences.customCaCertificate.enabled,
             filePath: newPreferences.customCaCertificate.filePath
+          },
+          keepDefaultCaCertificates: {
+            enabled: newPreferences.keepDefaultCaCertificates.enabled
           },
           timeout: newPreferences.timeout,
           storeCookies: newPreferences.storeCookies,
@@ -158,6 +167,23 @@ const General = ({ close }) => {
             </button>
           </div>
         )}
+        <div className="flex items-center mt-2">
+          <input
+            id="keepDefaultCaCertificatesEnabled"
+            type="checkbox"
+            name="keepDefaultCaCertificates.enabled"
+            checked={formik.values.keepDefaultCaCertificates.enabled}
+            onChange={formik.handleChange}
+            className={`mousetrap mr-0 ${formik.values.customCaCertificate.enabled ? '' : 'opacity-25'}`}
+            disabled={formik.values.customCaCertificate.enabled ? false : true}
+          />
+          <label
+            className={`block ml-2 select-none ${formik.values.customCaCertificate.enabled ? '' : 'opacity-25'}`}
+            htmlFor="keepDefaultCaCertificatesEnabled"
+          >
+            Keep default CA Certificates
+          </label>
+        </div>
         <div className="flex items-center mt-2">
           <input
             id="storeCookies"

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -17,6 +17,9 @@ const initialState = {
         enabled: false,
         filePath: null
       },
+      keepDefaultCaCertificates: {
+        enabled: false
+      },
       timeout: 0
     },
     font: {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -2,6 +2,7 @@ const os = require('os');
 const fs = require('fs');
 const qs = require('qs');
 const https = require('https');
+const tls = require('tls');
 const axios = require('axios');
 const path = require('path');
 const decomment = require('decomment');
@@ -105,7 +106,11 @@ const configureRequest = async (
   if (preferencesUtil.shouldUseCustomCaCertificate()) {
     const caCertFilePath = preferencesUtil.getCustomCaCertificateFilePath();
     if (caCertFilePath) {
-      httpsAgentRequestFields['ca'] = fs.readFileSync(caCertFilePath);
+      let caCertBuffer = fs.readFileSync(caCertFilePath);
+      if (preferencesUtil.shouldKeepDefaultCaCertificates()) {
+        caCertBuffer += '\n' + tls.rootCertificates.join('\n'); // Augment default truststore with custom CA certificates
+      }
+      httpsAgentRequestFields['ca'] = caCertBuffer;
     }
   }
 

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -15,6 +15,9 @@ const defaultPreferences = {
       enabled: false,
       filePath: null
     },
+    keepDefaultCaCertificates: {
+      enabled: false
+    },
     storeCookies: true,
     sendCookies: true,
     timeout: 0
@@ -42,6 +45,9 @@ const preferencesSchema = Yup.object().shape({
     customCaCertificate: Yup.object({
       enabled: Yup.boolean(),
       filePath: Yup.string().nullable()
+    }),
+    keepDefaultCaCertificates: Yup.object({
+      enabled: Yup.boolean()
     }),
     storeCookies: Yup.boolean(),
     sendCookies: Yup.boolean(),
@@ -110,6 +116,9 @@ const preferencesUtil = {
   },
   shouldUseCustomCaCertificate: () => {
     return get(getPreferences(), 'request.customCaCertificate.enabled', false);
+  },
+  shouldKeepDefaultCaCertificates: () => {
+    return get(getPreferences(), 'request.keepDefaultCaCertificates.enabled', false);
   },
   getCustomCaCertificateFilePath: () => {
     return get(getPreferences(), 'request.customCaCertificate.filePath', null);


### PR DESCRIPTION
# Description

# Description

In Bruno when specifying a custom certificate authority certificate, so connections to servers using privately signed certificates can be established securely, the Node.js default truststore is discarded. Therefore, connections to systems using officially signed certificates cannot be established any more as their root CAs are no longer part of the configuration.

While you could add the official root CA certificates to the file that contains your custom CA certificate, this is a tedious job and it is more convenient to tell Bruno directly to either augment or replace the default truststore with the custom CA certificates.

## Usage
### No custom CA certificate in use
Therefore, default truststore is in place. No need to allow for a choice. Checkbox "Keep default CA Certificates" is disabled.
<img width="336" alt="Screenshot 2024-03-19 at 20 18 47" src="https://github.com/usebruno/bruno/assets/8606429/d946738e-b9d3-4fce-8650-9350fc616ede">

### Custom CA certificate specified
Checkbox "Keep default CA Certificates" is active, but not selected yet. Therefore, only the custom CA certificate is in use and thus the default truststore is replaced. 
<img width="339" alt="Screenshot 2024-03-19 at 20 19 43" src="https://github.com/usebruno/bruno/assets/8606429/00583f9b-71be-4257-a3f5-ac6f61f80d57">

### Custom CA certificate augments default truststore
Checkbox "Keep default CA Certificates" is active and selected. Therefore, default truststore is augmented by the custom CA certificate. The super set of the CA certficiates is used.
<img width="329" alt="Screenshot 2024-03-19 at 20 19 24" src="https://github.com/usebruno/bruno/assets/8606429/c4e2a2d3-ab31-47f3-b17d-b400fa354bed">

### Custom CA certificate disabled
Only the default truststore is in place. Checkbox "Keep default CA Certificates" is disabled, but shows the previous selection state. This is in alignment with the file selector, which also still shows the selected custom CA certificate, although it is not in effect at the moment.
<img width="335" alt="Screenshot 2024-03-19 at 20 22 28" src="https://github.com/usebruno/bruno/assets/8606429/f1caf5ad-ab22-4ae4-83e1-07d55263bfc2">

Fixes #1080 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
