### PR TITLE
Add dataBuffer to response to be available in test scripts

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -509,6 +509,7 @@ const registerNetworkIpc = (mainWindow) => {
 
       const { data, dataBuffer } = parseDataFromResponse(response);
       response.data = data;
+      response.dataBuffer = dataBuffer;
 
       response.responseTime = responseTime;
 
@@ -921,6 +922,7 @@ const registerNetworkIpc = (mainWindow) => {
 
               const { data, dataBuffer } = parseDataFromResponse(response);
               response.data = data;
+              response.dataBuffer = dataBuffer;
 
               mainWindow.webContents.send('main:run-folder-event', {
                 type: 'response-received',
@@ -939,6 +941,7 @@ const registerNetworkIpc = (mainWindow) => {
               if (error?.response && !axios.isCancel(error)) {
                 const { data, dataBuffer } = parseDataFromResponse(error.response);
                 error.response.data = data;
+                error.response.dataBuffer = dataBuffer;
 
                 timeEnd = Date.now();
                 response = {

--- a/packages/bruno-js/src/bruno-response.js
+++ b/packages/bruno-js/src/bruno-response.js
@@ -27,6 +27,10 @@ class BrunoResponse {
   getResponseTime() {
     return this.res ? this.res.responseTime : null;
   }
+
+  getDataBuffer() {
+    return this.res ? this.res.dataBuffer : null;
+  }
 }
 
 module.exports = BrunoResponse;


### PR DESCRIPTION
# Description

I have a use case for accessing the dataBuffer in tests to validate a binary response from DNS over https services.
Since the dataBuffer was already exposed some time ago for displaying preview images or such, these trivial changes made it possible to access the binary buffer in tests to parse DNS packets.

![image](https://github.com/usebruno/bruno/assets/6057874/434ae1e0-1e42-4dee-a0e2-09ed896e3b77)

![image](https://github.com/usebruno/bruno/assets/6057874/e7524529-c3d0-4a1a-8102-acf784d70bb4)

I have been able to easily merge these changes and build the app locally, but now my local build does not have the new Golden key stuff, so it would be nice to have this or similar in the main branch.

## Use case
```
meta {
  name: cloudflare-dns-query
  type: http
  seq: 6
}

get {
  url: https://cloudflare-dns.com/dns-query?dns=6bABAAABAAAAAAAAA3d3dxBnb29nbGVhZHNlcnZpY2VzA2NvbQAAAQAB
  body: none
  auth: none
}

query {
  dns: 6bABAAABAAAAAAAAA3d3dxBnb29nbGVhZHNlcnZpY2VzA2NvbQAAAQAB
  ~name: www.googleadservices.com
  ~type: A
}

headers {
  Accept: application/dns-message
  ~Accept: application/dns-json
}

tests {
  const DnsPacket = require('@dnsquery/dns-packet');
  
  const buffer = Buffer.from(res.getDataBuffer());
  const dnsPacket1 = DnsPacket.decode(buffer);
  console.log(JSON.stringify(dnsPacket1, null, 4));
  
  
  test("should get at least one answer", function() {
    expect(dnsPacket1.answers.length).to.be.greaterThan(0);
  });
  
  test("should get answer name matching query", function() {
    expect(dnsPacket1.answers.pop().name).to.equal("www.googleadservices.com");
  });
  
}
```


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
