### PR TITLE
feat: Add tooltips to sidebar footer

### DIFF
--- a/packages/bruno-app/src/components/Notifications/index.js
+++ b/packages/bruno-app/src/components/Notifications/index.js
@@ -84,8 +84,9 @@ const Notifications = () => {
 
   return (
     <StyledWrapper>
-      <div
-        className="relative"
+      <a
+        title="Notifications"
+        className="relative cursor-pointer"
         onClick={() => {
           dispatch(fetchNotifications());
           setShowNotificationsModal(true);
@@ -97,9 +98,9 @@ const Notifications = () => {
           className={`mr-2 hover:text-gray-700 ${unreadNotifications?.length > 0 ? 'bell' : ''}`}
         />
         {unreadNotifications.length > 0 && (
-          <div className="notification-count text-xs">{unreadNotifications.length}</div>
+          <span className="notification-count text-xs">{unreadNotifications.length}</span>
         )}
-      </div>
+      </a>
 
       {showNotificationsModal && (
         <Modal

--- a/packages/bruno-app/src/components/Sidebar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/index.js
@@ -93,26 +93,29 @@ const Sidebar = () => {
               <Collections />
             </div>
 
-            <div className="footer flex px-1 py-2 absolute bottom-0 left-0 right-0 items-center cursor-pointer select-none">
+            <div className="footer flex px-1 py-2 absolute bottom-0 left-0 right-0 items-center select-none">
               <div className="flex items-center ml-1 text-xs ">
-                <IconSettings
-                  size={18}
-                  strokeWidth={1.5}
-                  className="mr-2 hover:text-gray-700"
+                <a
+                  title="Preferences"
+                  className="mr-2 cursor-pointer hover:text-gray-700"
                   onClick={() => dispatch(showPreferences(true))}
-                />
-                <IconCookie
-                  size={18}
-                  strokeWidth={1.5}
-                  className="mr-2 hover:text-gray-700"
+                >
+                  <IconSettings size={18} strokeWidth={1.5} />
+                </a>
+                <a
+                  title="Cookies"
+                  className="mr-2 cursor-pointer hover:text-gray-700"
                   onClick={() => setCookiesOpen(true)}
-                />
-                <IconHeart
-                  size={18}
-                  strokeWidth={1.5}
-                  className="mr-2 hover:text-gray-700"
+                >
+                  <IconCookie size={18} strokeWidth={1.5} />
+                </a>
+                <a
+                  title="Golden Edition"
+                  className="mr-2 cursor-pointer hover:text-gray-700"
                   onClick={() => setGoldenEditonOpen(true)}
-                />
+                >
+                  <IconHeart size={18} strokeWidth={1.5} />
+                </a>
                 <Notifications />
               </div>
               <div className="pl-1" style={{ position: 'relative', top: '3px' }}>


### PR DESCRIPTION
# Description

Add native tooltips to the items at the bottom of the sidebar.

![Screenshot](https://github.com/usebruno/bruno/assets/552590/f58e8e4e-dd86-419e-b24e-9cbe523a6405)

See #1832

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**