### PR TITLE
fix: accessibility issue on the Welcome page

### DIFF
--- a/packages/bruno-app/src/components/Welcome/index.js
+++ b/packages/bruno-app/src/components/Welcome/index.js
@@ -50,7 +50,7 @@ const Welcome = () => {
         />
       ) : null}
 
-      <div className="">
+      <div aria-hidden className="">
         <Bruno width={50} />
       </div>
       <div className="text-xl font-semibold select-none">bruno</div>
@@ -58,41 +58,51 @@ const Welcome = () => {
 
       <div className="uppercase font-semibold heading mt-10">Collections</div>
       <div className="mt-4 flex items-center collection-options select-none">
-        <div className="flex items-center" onClick={() => setCreateCollectionModalOpen(true)}>
-          <IconPlus size={18} strokeWidth={2} />
+        <button className="flex items-center" onClick={() => setCreateCollectionModalOpen(true)}>
+          <IconPlus aria-hidden size={18} strokeWidth={2} />
           <span className="label ml-2" id="create-collection">
             Create Collection
           </span>
-        </div>
-        <div className="flex items-center ml-6" onClick={handleOpenCollection}>
-          <IconFolders size={18} strokeWidth={2} />
+        </button>
+        <button className="flex items-center ml-6" onClick={handleOpenCollection}>
+          <IconFolders aria-hidden size={18} strokeWidth={2} />
           <span className="label ml-2">Open Collection</span>
-        </div>
-        <div className="flex items-center ml-6" onClick={() => setImportCollectionModalOpen(true)}>
-          <IconDownload size={18} strokeWidth={2} />
+        </button>
+        <button className="flex items-center ml-6" onClick={() => setImportCollectionModalOpen(true)}>
+          <IconDownload aria-hidden size={18} strokeWidth={2} />
           <span className="label ml-2" id="import-collection">
             Import Collection
           </span>
-        </div>
+        </button>
       </div>
 
       <div className="uppercase font-semibold heading mt-10 pt-6">Links</div>
       <div className="mt-4 flex flex-col collection-options select-none">
         <div className="flex items-center mt-2">
-          <a href="https://docs.usebruno.com" target="_blank" className="inline-flex items-center">
-            <IconBook size={18} strokeWidth={2} />
+          <a
+            href="https://docs.usebruno.com"
+            aria-label="Read documentation"
+            target="_blank"
+            className="inline-flex items-center"
+          >
+            <IconBook aria-hidden size={18} strokeWidth={2} />
             <span className="label ml-2">Documentation</span>
           </a>
         </div>
         <div className="flex items-center mt-2">
           <a href="https://github.com/usebruno/bruno/issues" target="_blank" className="inline-flex items-center">
-            <IconSpeakerphone size={18} strokeWidth={2} />
+            <IconSpeakerphone aria-hidden size={18} strokeWidth={2} />
             <span className="label ml-2">Report Issues</span>
           </a>
         </div>
         <div className="flex items-center mt-2">
-          <a href="https://github.com/usebruno/bruno" target="_blank" className="flex items-center">
-            <IconBrandGithub size={18} strokeWidth={2} />
+          <a
+            href="https://github.com/usebruno/bruno"
+            aria-label="goto github"
+            target="_blank"
+            className="flex items-center"
+          >
+            <IconBrandGithub aria-hidden size={18} strokeWidth={2} />
             <span className="label ml-2">GitHub</span>
           </a>
         </div>


### PR DESCRIPTION
# Description

## Fix accessibility issues on the Welcome page:

  - use button tag for collection instead of div
  - hide decorative images for assistive technology
  - give meaningful labels to links in the Links section

Accessibility tree structure

| then | now|
|--|--|
| ![Screenshot 2024-03-23 at 10 30 44 AM](https://github.com/usebruno/bruno/assets/29778698/eca041ab-fadd-40dc-9106-dec7ac9d5239) | ![Screenshot 2024-03-23 at 10 41 30 AM](https://github.com/usebruno/bruno/assets/29778698/9b39fa6d-6cf6-41c9-a20a-990cd1adc740) |

issue link : [accessibility issue](https://github.com/usebruno/bruno/issues/1907)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

