### PR TITLE
fix(#1898): Ignore empty headers to prevent sending request error

### DIFF
--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -148,7 +148,7 @@ const prepareRequest = (request, collectionRoot, collectionPath) => {
 
   // collection headers
   each(get(collectionRoot, 'request.headers', []), (h) => {
-    if (h.enabled) {
+    if (h.enabled && h.name.length > 0) {
       headers[h.name] = h.value;
       if (h.name.toLowerCase() === 'content-type') {
         contentTypeDefined = true;
@@ -157,7 +157,7 @@ const prepareRequest = (request, collectionRoot, collectionPath) => {
   });
 
   each(request.headers, (h) => {
-    if (h.enabled) {
+    if (h.enabled && h.name.length > 0) {
       headers[h.name] = h.value;
       if (h.name.toLowerCase() === 'content-type') {
         contentTypeDefined = true;


### PR DESCRIPTION
# Description

Empty headers (in request or in collections) are ignored to prevent sending request error. (https://github.com/usebruno/bruno/issues/1898)

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

![image](https://github.com/usebruno/bruno/assets/1338257/0d5ee3b1-cbe0-4bd4-bd2b-b80f55c43421)
