### PR TITLE
Fix interpolation with Objects and Arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19676,7 +19676,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v1.11.0",
+      "version": "v1.12.3",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.525.0",
         "@usebruno/common": "0.1.0",

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -60,8 +60,9 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     if (typeof request.data === 'object') {
       try {
         let parsed = JSON.stringify(request.data);
-        parsed = _interpolate(parsed);
-        request.data = JSON.parse(parsed);
+        // Write the interpolated body into data, so one can see his values even if parsing fails
+        request.data = _interpolate(parsed);
+        request.data = JSON.parse(request.data);
       } catch (err) {}
     }
 

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -28,7 +28,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     });
   });
 
-  const _interpolate = (str, isJsonBody = false) => {
+  const _interpolate = (str) => {
     if (!str || !str.length || typeof str !== 'string') {
       return str;
     }
@@ -44,7 +44,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
       }
     };
 
-    return interpolate(str, combinedVars, isJsonBody);
+    return interpolate(str, combinedVars);
   };
 
   request.url = _interpolate(request.url);
@@ -60,14 +60,14 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     if (typeof request.data === 'object') {
       try {
         let parsed = JSON.stringify(request.data);
-        parsed = _interpolate(parsed, true);
+        parsed = _interpolate(parsed);
         request.data = JSON.parse(parsed);
       } catch (err) {}
     }
 
     if (typeof request.data === 'string') {
       if (request.data.length) {
-        request.data = _interpolate(request.data, true);
+        request.data = _interpolate(request.data);
       }
     }
   } else if (contentType === 'application/x-www-form-urlencoded') {

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -28,7 +28,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     });
   });
 
-  const _interpolate = (str) => {
+  const _interpolate = (str, isJsonBody = false) => {
     if (!str || !str.length || typeof str !== 'string') {
       return str;
     }
@@ -44,7 +44,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
       }
     };
 
-    return interpolate(str, combinedVars);
+    return interpolate(str, combinedVars, isJsonBody);
   };
 
   request.url = _interpolate(request.url);
@@ -60,14 +60,14 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     if (typeof request.data === 'object') {
       try {
         let parsed = JSON.stringify(request.data);
-        parsed = _interpolate(parsed);
+        parsed = _interpolate(parsed, true);
         request.data = JSON.parse(parsed);
       } catch (err) {}
     }
 
     if (typeof request.data === 'string') {
       if (request.data.length) {
-        request.data = _interpolate(request.data);
+        request.data = _interpolate(request.data, true);
       }
     }
   } else if (contentType === 'application/x-www-form-urlencoded') {

--- a/packages/bruno-common/src/interpolate/index.ts
+++ b/packages/bruno-common/src/interpolate/index.ts
@@ -12,7 +12,23 @@
  */
 
 import { flattenObject } from '../utils';
-import cancelTokens from '@usebruno/app/src/utils/network/cancelTokens';
+
+function serializeObject(obj: Object) {
+  // Check if the object has a `toString` method like `Moment`
+  // Don't do it with arrays they serialize weirdly
+  if (typeof obj.toString === 'function' && !Array.isArray(obj)) {
+    try {
+      const result = obj.toString();
+      // The default object becomes '[object Object]' string
+      if (result !== '[object Object]') {
+        return result;
+      }
+    } catch {}
+  }
+
+  // Everything else will be json encoded
+  return JSON.stringify(obj);
+}
 
 const interpolate = (str: string, obj: Record<string, any>): string => {
   if (!str || typeof str !== 'string' || !obj || typeof obj !== 'object') {
@@ -30,13 +46,7 @@ const interpolate = (str: string, obj: Record<string, any>): string => {
 
     // Objects must be either JSON encoded or convert to a String via `toString`
     if (typeof replacement === 'object') {
-      // Check if the object has a `toString` method like `Moment`
-      if (typeof replacement.toString === 'function') {
-        try {
-          return replacement.toString();
-        } catch {}
-      }
-      return JSON.stringify(replacement);
+      return serializeObject(replacement);
     }
 
     return replacement;

--- a/packages/bruno-common/src/interpolate/index.ts
+++ b/packages/bruno-common/src/interpolate/index.ts
@@ -13,7 +13,7 @@
 
 import { flattenObject } from '../utils';
 
-const interpolate = (str: string, obj: Record<string, any>, isJsonBody = false): string => {
+const interpolate = (str: string, obj: Record<string, any>): string => {
   if (!str || typeof str !== 'string' || !obj || typeof obj !== 'object') {
     return str;
   }
@@ -28,7 +28,7 @@ const interpolate = (str: string, obj: Record<string, any>, isJsonBody = false):
     }
 
     // When inside json body everything must be encoded so string get double quotes
-    if (isJsonBody || typeof replacement === 'object') {
+    if (typeof replacement === 'object') {
       return JSON.stringify(replacement);
     }
     return replacement;

--- a/packages/bruno-common/src/interpolate/index.ts
+++ b/packages/bruno-common/src/interpolate/index.ts
@@ -13,19 +13,26 @@
 
 import { flattenObject } from '../utils';
 
-const interpolate = (str: string, obj: Record<string, any>): string => {
+const interpolate = (str: string, obj: Record<string, any>, isJsonBody = false): string => {
   if (!str || typeof str !== 'string' || !obj || typeof obj !== 'object') {
     return str;
   }
 
   const patternRegex = /\{\{([^}]+)\}\}/g;
   const flattenedObj = flattenObject(obj);
-  const result = str.replace(patternRegex, (match, placeholder) => {
-    const replacement = flattenedObj[placeholder];
-    return replacement !== undefined ? replacement : match;
-  });
+  return str.replace(patternRegex, (match, placeholder) => {
+    const replacement = flattenedObj[placeholder] || obj[placeholder];
+    // Return the original string so nothing gets replaced
+    if (replacement === undefined) {
+      return match;
+    }
 
-  return result;
+    // When inside json body everything must be encoded so string get double quotes
+    if (isJsonBody || typeof replacement === 'object') {
+      return JSON.stringify(replacement);
+    }
+    return replacement;
+  });
 };
 
 export default interpolate;

--- a/packages/bruno-common/src/interpolate/index.ts
+++ b/packages/bruno-common/src/interpolate/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { flattenObject } from '../utils';
+import cancelTokens from '@usebruno/app/src/utils/network/cancelTokens';
 
 const interpolate = (str: string, obj: Record<string, any>): string => {
   if (!str || typeof str !== 'string' || !obj || typeof obj !== 'object') {
@@ -27,10 +28,17 @@ const interpolate = (str: string, obj: Record<string, any>): string => {
       return match;
     }
 
-    // When inside json body everything must be encoded so string get double quotes
+    // Objects must be either JSON encoded or convert to a String via `toString`
     if (typeof replacement === 'object') {
+      // Check if the object has a `toString` method like `Moment`
+      if (typeof replacement.toString === 'function') {
+        try {
+          return replacement.toString();
+        } catch {}
+      }
       return JSON.stringify(replacement);
     }
+
     return replacement;
   });
 };

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -60,8 +60,9 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     if (typeof request.data === 'object') {
       try {
         let parsed = JSON.stringify(request.data);
-        parsed = _interpolate(parsed);
-        request.data = JSON.parse(parsed);
+        // Write the interpolated body into data, so one can see his values even if parsing fails
+        request.data = _interpolate(parsed);
+        request.data = JSON.parse(request.data);
       } catch (err) {}
     }
 

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -28,7 +28,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     });
   });
 
-  const _interpolate = (str, isJsonBody = false) => {
+  const _interpolate = (str) => {
     if (!str || !str.length || typeof str !== 'string') {
       return str;
     }
@@ -44,7 +44,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
       }
     };
 
-    return interpolate(str, combinedVars, isJsonBody);
+    return interpolate(str, combinedVars);
   };
 
   request.url = _interpolate(request.url);
@@ -60,14 +60,14 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     if (typeof request.data === 'object') {
       try {
         let parsed = JSON.stringify(request.data);
-        parsed = _interpolate(parsed, true);
+        parsed = _interpolate(parsed);
         request.data = JSON.parse(parsed);
       } catch (err) {}
     }
 
     if (typeof request.data === 'string') {
       if (request.data.length) {
-        request.data = _interpolate(request.data, true);
+        request.data = _interpolate(request.data);
       }
     }
   } else if (contentType === 'application/x-www-form-urlencoded') {

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -28,7 +28,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     });
   });
 
-  const _interpolate = (str) => {
+  const _interpolate = (str, isJsonBody = false) => {
     if (!str || !str.length || typeof str !== 'string') {
       return str;
     }
@@ -44,7 +44,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
       }
     };
 
-    return interpolate(str, combinedVars);
+    return interpolate(str, combinedVars, isJsonBody);
   };
 
   request.url = _interpolate(request.url);
@@ -60,14 +60,14 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     if (typeof request.data === 'object') {
       try {
         let parsed = JSON.stringify(request.data);
-        parsed = _interpolate(parsed);
+        parsed = _interpolate(parsed, true);
         request.data = JSON.parse(parsed);
       } catch (err) {}
     }
 
     if (typeof request.data === 'string') {
       if (request.data.length) {
-        request.data = _interpolate(request.data);
+        request.data = _interpolate(request.data, true);
       }
     }
   } else if (contentType === 'application/x-www-form-urlencoded') {


### PR DESCRIPTION
# Description

Fixes: #1910 & #1635

Update how variable interpolation works, so the behavior with objects and arrays is more as expected.

- Interpolation of objects and arrays now works
- Try to use the default `toString`-Method if available
  - Except for the default Object and arrays

Test collection: https://cdn.discordapp.com/attachments/693228572286124085/1221951301404065873/json-testing_2.zip?ex=661471d5&is=6601fcd5&hm=277420a68a493567de437403f133622d186642f689e761d0438306b7579497ad&

Before:

![image](https://github.com/usebruno/bruno/assets/39559178/961e2b42-6677-4ec3-b032-637e59fb5ed9)

After:

![image](https://github.com/usebruno/bruno/assets/39559178/257ba572-8991-4669-89bf-8ebe6fdaffa6)

Pre-Build binary with the fix: https://github.com/Its-treason/bruno/releases/tag/nightly
