### PR TITLE
Fix sources.list.d deb: make 64bit explicit to avoid warning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ flatpak install com.usebruno.Bruno
 sudo mkdir -p /etc/apt/keyrings
 sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/bruno.gpg --keyserver keyserver.ubuntu.com --recv-keys 9FA6017ECABE0266
 
-echo "deb [signed-by=/etc/apt/keyrings/bruno.gpg] http://debian.usebruno.com/ bruno stable" | sudo tee /etc/apt/sources.list.d/bruno.list
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/bruno.gpg] http://debian.usebruno.com/ bruno stable" | sudo tee /etc/apt/sources.list.d/bruno.list
 
 sudo apt update
 sudo apt install bruno


### PR DESCRIPTION
[Issue](https://github.com/usebruno/bruno/issues/1924)

# Description

Since all Bruno releases are 64bit, there is no reason to skip this argument. Without it, apt gives a warning on every run: `N: Skipping acquire of configured file 'stable/binary-i386/Packages' as repository 'http://debian.usebruno.com bruno InRelease' doesn't support architecture 'i386'`

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

before:
![image](https://github.com/usebruno/bruno/assets/30606201/77d93d2d-3647-4232-928e-954fdf98d47f)

after:
![image](https://github.com/usebruno/bruno/assets/30606201/619d8ff1-1bf9-40a5-9a6c-33afb03473b9)