### PR TITLE
Fixes #1935 - Underlying components no longer overlap modals

### DIFF
--- a/packages/bruno-app/src/components/Modal/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Modal/StyledWrapper.js
@@ -21,7 +21,7 @@ const Wrapper = styled.div`
     align-items: flex-start;
     justify-content: center;
     overflow-y: auto;
-    z-index: 10;
+    z-index: 11;
     background-color: rgba(0, 0, 0, 0.5);
   }
 
@@ -31,7 +31,7 @@ const Wrapper = styled.div`
     background: var(--color-background-top);
     border-radius: var(--border-radius);
     position: relative;
-    z-index: 10;
+    z-index: 11;
     max-width: calc(100% - var(--spacing-base-unit));
     box-shadow: var(--box-shadow-base);
     display: flex;


### PR DESCRIPTION
Fixes https://github.com/usebruno/bruno/issues/1935

# Description

I've adjusted the modal z-index to ensure that underlying components do not overlap the modal. This change ensures that the prettier button in a POST body no longer overlaps modal windows.

### Before ###
![Before](https://github.com/usebruno/bruno/assets/132946012/16b5d65c-6ce5-4ca5-846b-9ecb54679468)
### After ###
![After](https://github.com/usebruno/bruno/assets/132946012/763640a1-7147-4bf3-8163-5bd094123c3b)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
