### PR TITLE
fix(#1920): Ignore redirect abortion emmited by loadUrl

### DIFF
--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -75,6 +75,11 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
     try {
       await window.loadURL(authorizeUrl);
     } catch (error) {
+      // If browser redirects before load finished, loadURL throws an error with code ERR_ABORTED. This should be ignored.
+      if (error.code === 'ERR_ABORTED') {
+        console.debug('Ignoring ERR_ABORTED during authorizeUserInWindow');
+        return;
+      }
       reject(error);
       window.close();
     }


### PR DESCRIPTION
# Description

This changes fix an issue which happens during authorization process of OAuth2.0 with authorization code when loading the authorize user window of IdP which contain redirects. This redirects cause the `window.loadUrl(url)` function to throw an error due that the original requested page was not completely loaded. 

https://github.com/usebruno/bruno/blob/1349a7975082e2afa64f4cc3b1c2d0d884991b4b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js#L75-L80

Such behaviour is explained on https://github.com/electron/electron/issues/17526 and https://github.com/electron/electron/issues/27574. Insomnia also faced this as they reported on this issue https://github.com/Kong/insomnia/issues/5926

Current error:
<img width="1597" alt="316626192-46e5d5c5-22b6-4d8d-a6a0-ddf787481999" src="https://github.com/usebruno/bruno/assets/6647241/5f5aa2c1-a4d1-47ae-8a4c-7bfed103a0ae">


Fixes: #1920 

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

