### PR TITLE
Fix error in actions about older node JS version

### DIFF
--- a/.github/workflows/release-snap.yml
+++ b/.github/workflows/release-snap.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
# Description

Publish to SnapCraft use checkout v3 to download git repository but this version use node JS 16 and this version is [deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).
I have bump checkout actions to [v4](https://github.com/actions/checkout/releases/tag/v4.0.0) and not setup node actions because I have see you use node JS 18.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
