### PR TITLE
feat(clone-request): select and open tab after clone the request

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CloneCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CloneCollection/index.js
@@ -7,6 +7,7 @@ import { cloneCollection } from 'providers/ReduxStore/slices/collections/actions
 import toast from 'react-hot-toast';
 import Tooltip from 'components/Tooltip';
 import Modal from 'components/Modal';
+import { collectionClicked } from 'providers/ReduxStore/slices/collections/index';
 
 const CloneCollection = ({ onClose, collection }) => {
   const inputRef = useRef();
@@ -41,6 +42,7 @@ const CloneCollection = ({ onClose, collection }) => {
         )
       )
         .then(() => {
+          dispatch(collectionClicked(collection.uid));
           toast.success('Collection created');
           onClose();
         })


### PR DESCRIPTION
# Description

Based-on UX finding at #1964

**Before**
![open-req-before](https://github.com/usebruno/bruno/assets/13098072/17d81631-17a1-42ab-9a1d-68d4e04bd6df)

**After**
![open-req-after](https://github.com/usebruno/bruno/assets/13098072/6960b944-32be-4896-b3fb-510c8da3ba89)

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**
