### PR TITLE
feat: remember last selected environment

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -21,6 +21,7 @@ import exportCollection from 'utils/collections/export';
 import RenameCollection from './RenameCollection';
 import StyledWrapper from './StyledWrapper';
 import CloneCollection from './CloneCollection/index';
+import { selectEnvironment } from 'providers/ReduxStore/slices/collections/actions';
 
 const Collection = ({ collection, searchText }) => {
   const [showNewFolderModal, setShowNewFolderModal] = useState(false);
@@ -31,6 +32,7 @@ const Collection = ({ collection, searchText }) => {
   const [showRemoveCollectionModal, setShowRemoveCollectionModal] = useState(false);
   const [collectionIsCollapsed, setCollectionIsCollapsed] = useState(collection.collapsed);
   const dispatch = useDispatch();
+  const { ipcRenderer } = window;
 
   const menuDropdownTippyRef = useRef();
   const onMenuDropdownCreate = (ref) => (menuDropdownTippyRef.current = ref);
@@ -66,6 +68,19 @@ const Collection = ({ collection, searchText }) => {
 
   const handleClick = (event) => {
     dispatch(collectionClicked(collection.uid));
+
+    // if collection doesn't have any active environment
+    // try to load last selected environment
+    if (!collection.activeEnvironmentUid) {
+      ipcRenderer.invoke('renderer:get-last-selected-environment', collection.uid).then((lastSelectedEnvName) => {
+        const collectionEnvironments = collection.environments || [];
+        const lastSelectedEnvironment = collectionEnvironments.find((env) => env.name === lastSelectedEnvName);
+
+        if (lastSelectedEnvironment) {
+          dispatch(selectEnvironment(lastSelectedEnvironment.uid, collection.uid));
+        }
+      });
+    }
   };
 
   const handleRightClick = (event) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -128,15 +128,19 @@ export const collectionsSlice = createSlice({
       const { environmentUid, collectionUid } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
 
+      const { ipcRenderer } = window;
+
       if (collection) {
         if (environmentUid) {
           const environment = findEnvironmentInCollection(collection, environmentUid);
 
           if (environment) {
             collection.activeEnvironmentUid = environmentUid;
+            ipcRenderer.invoke('renderer:update-last-selected-environment', collectionUid, environment.name);
           }
         } else {
           collection.activeEnvironmentUid = null;
+          ipcRenderer.invoke('renderer:update-last-selected-environment', collectionUid, null);
         }
       }
     },

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -13,6 +13,7 @@ const registerPreferencesIpc = require('./ipc/preferences');
 const Watcher = require('./app/watcher');
 const { loadWindowState, saveBounds, saveMaximized } = require('./utils/window');
 const registerNotificationsIpc = require('./ipc/notifications');
+const registerEnvironmentsIpc = require('./ipc/environments');
 
 const lastOpenedCollections = new LastOpenedCollections();
 
@@ -123,6 +124,7 @@ app.on('ready', async () => {
   registerCollectionsIpc(mainWindow, watcher, lastOpenedCollections);
   registerPreferencesIpc(mainWindow, watcher, lastOpenedCollections);
   registerNotificationsIpc(mainWindow, watcher);
+  registerEnvironmentsIpc(mainWindow, watcher);
 });
 
 // Quit the app once all windows are closed

--- a/packages/bruno-electron/src/ipc/environments.js
+++ b/packages/bruno-electron/src/ipc/environments.js
@@ -1,0 +1,23 @@
+const { ipcMain } = require('electron');
+const { getLastSelectedEnvironment, updateLastSelectedEnvironment } = require('../store/last-selected-environments');
+
+const registerEnvironmentsIpc = (_mainWindow, _watcher) => {
+  ipcMain.handle('renderer:get-last-selected-environment', async (_event, collectionUid) => {
+    try {
+      const environmentName = getLastSelectedEnvironment(collectionUid);
+      return environmentName;
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  });
+
+  ipcMain.handle('renderer:update-last-selected-environment', async (_event, collectionUid, environmentName) => {
+    try {
+      updateLastSelectedEnvironment(collectionUid, environmentName);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  });
+};
+
+module.exports = registerEnvironmentsIpc;

--- a/packages/bruno-electron/src/store/last-selected-environments.js
+++ b/packages/bruno-electron/src/store/last-selected-environments.js
@@ -1,0 +1,42 @@
+const _ = require('lodash');
+const Store = require('electron-store');
+
+class LastSelectedEnvironments {
+  constructor() {
+    this.store = new Store({
+      name: 'environments',
+      clearInvalidConfig: true
+    });
+  }
+
+  updateLastSelectedEnvironment(collectionUid, environmentName) {
+    const lastSelectedEnvironments = this.store.get('lastSelectedEnvironments') || {};
+
+    const updatedLastSelectedEnvironments = {
+      ...lastSelectedEnvironments,
+      [collectionUid]: environmentName
+    };
+
+    return this.store.set('lastSelectedEnvironments', updatedLastSelectedEnvironments);
+  }
+
+  getLastSelectedEnvironment(collectionUid) {
+    const lastSelectedEnvironments = this.store.get('lastSelectedEnvironments') || {};
+    return lastSelectedEnvironments[collectionUid];
+  }
+}
+
+const lastSelectedEnvironments = new LastSelectedEnvironments();
+
+const updateLastSelectedEnvironment = (collectionUid, environmentName) => {
+  return lastSelectedEnvironments.updateLastSelectedEnvironment(collectionUid, environmentName);
+};
+
+const getLastSelectedEnvironment = (collectionUid) => {
+  return lastSelectedEnvironments.getLastSelectedEnvironment(collectionUid);
+};
+
+module.exports = {
+  updateLastSelectedEnvironment,
+  getLastSelectedEnvironment
+};


### PR DESCRIPTION
# Description
Remember and load last selected environment on opening the collection. 
Addressing #1598 #1652 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

https://github.com/usebruno/bruno/assets/76877078/91f312c8-1df1-4a21-84db-caa15827a1a4