### PR TITLE
fix: crash on opening environments screen

### DIFF
--- a/packages/bruno-app/src/components/VariablesEditor/index.js
+++ b/packages/bruno-app/src/components/VariablesEditor/index.js
@@ -16,12 +16,18 @@ const KeyValueExplorer = ({ data, theme }) => {
       <SecretToggle showSecret={showSecret} onClick={() => setShowSecret(!showSecret)} />
       <table className="border-collapse">
         <tbody>
-          {data.map((envVar) => (
-            <tr key={envVar.name}>
-              <td className="px-2 py-1">{envVar.name}</td>
+          {Object.entries(data).map(([key, envVar]) => (
+            <tr key={typeof envVar === 'string' ? key : envVar.name}>
+              <td className="px-2 py-1">{typeof envVar === 'string' ? key : envVar.name}</td>
               <td className="px-2 py-1">
                 <Inspector
-                  data={!showSecret && envVar.secret ? maskInputValue(envVar.value) : envVar.value}
+                  data={
+                    !showSecret && envVar.secret
+                      ? maskInputValue(envVar.value)
+                      : typeof envVar === 'string'
+                      ? envVar
+                      : envVar.value
+                  }
                   theme={theme}
                 />
               </td>


### PR DESCRIPTION
# Description
After populating a variable with a post response script, when opening the environments screen, Bruno crashes.
Mentioned here: [Link to issue](https://github.com/usebruno/bruno/issues/2001)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**