### PR TITLE
Fix: Replace jsonBigint with lossless-json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "packages/bruno-graphql-docs"
       ],
       "dependencies": {
-        "json-bigint": "^1.0.0"
+        "json-bigint": "^1.0.0",
+        "lossless-json": "^4.0.1"
       },
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
@@ -12471,6 +12472,11 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lossless-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.1.tgz",
+      "integrity": "sha512-l0L+ppmgPDnb+JGxNLndPtJZGNf6+ZmVaQzoxQm3u6TXmhdnsA+YtdVR8DjzZd/em58686CQhOFDPewfJ4l7MA=="
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "license": "MIT",
@@ -19676,7 +19682,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v1.11.0",
+      "version": "v1.12.3",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.525.0",
         "@usebruno/common": "0.1.0",
@@ -30814,6 +30820,11 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lossless-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.1.tgz",
+      "integrity": "sha512-l0L+ppmgPDnb+JGxNLndPtJZGNf6+ZmVaQzoxQm3u6TXmhdnsA+YtdVR8DjzZd/em58686CQhOFDPewfJ4l7MA=="
     },
     "loupe": {
       "version": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -47,10 +47,12 @@
     "test:prettier:web": "npm run test:prettier --workspace=packages/bruno-app",
     "prepare": "husky install"
   },
+  
   "overrides": {
     "rollup": "3.2.5"
   },
   "dependencies": {
-    "json-bigint": "^1.0.0"
+    "json-bigint": "^1.0.0",
+    "lossless-json": "^4.0.1"
   }
 }

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -8,7 +8,7 @@ import { humanizeRequestBodyMode } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import { updateRequestBody } from 'providers/ReduxStore/slices/collections/index';
 import { toastError } from 'utils/common/error';
-import jsonBigint from 'json-bigint';
+import { parse, stringify } from 'lossless-json';
 
 const RequestBodyMode = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -38,8 +38,8 @@ const RequestBodyMode = ({ item, collection }) => {
   const onPrettify = () => {
     if (body?.json && bodyMode === 'json') {
       try {
-        const bodyJson = jsonBigint.parse(body.json);
-        const prettyBodyJson = jsonBigint.stringify(bodyJson, null, 2);
+        const bodyJson = parse(body.json);
+        const prettyBodyJson = stringify(bodyJson, null, 2);
         dispatch(
           updateRequestBody({
             content: prettyBodyJson,


### PR DESCRIPTION
#1933  Description
Changes to address issue #1996 

Replace usage of jsonBigint with lossless-json for the Prettify json functionality.

Behaviour after Prettify is as expected, with all data preserved:
![image](https://github.com/usebruno/bruno/assets/34069335/37f61a98-5a37-4c36-8ed1-0ac0261d4c53)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
