### PR TITLE
feat: save unsaved request changes before renaming

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
@@ -4,7 +4,7 @@ import * as Yup from 'yup';
 import Modal from 'components/Modal';
 import { useDispatch } from 'react-redux';
 import { isItemAFolder } from 'utils/tabs';
-import { renameItem } from 'providers/ReduxStore/slices/collections/actions';
+import { renameItem, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 
 const RenameCollectionItem = ({ collection, item, onClose }) => {
   const dispatch = useDispatch();
@@ -21,7 +21,12 @@ const RenameCollectionItem = ({ collection, item, onClose }) => {
         .max(50, 'must be 50 characters or less')
         .required('name is required')
     }),
-    onSubmit: (values) => {
+    onSubmit: async (values) => {
+      // if there is unsaved changes in the request,
+      // save them before renaming the request
+      if (!isFolder && item.draft) {
+        await dispatch(saveRequest(item.uid, collection.uid, true));
+      }
       dispatch(renameItem(values.name, item.uid, collection.uid));
       onClose();
     }

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -6,7 +6,7 @@ import { useDrag, useDrop } from 'react-dnd';
 import { IconChevronRight, IconDots } from '@tabler/icons';
 import { useSelector, useDispatch } from 'react-redux';
 import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
-import { saveRequest, moveItem, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { moveItem, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { collectionFolderClicked } from 'providers/ReduxStore/slices/collections';
 import Dropdown from 'components/Dropdown';
 import NewRequest from 'components/Sidebar/NewRequest';
@@ -300,12 +300,6 @@ const CollectionItem = ({ item, collection, searchText }) => {
                 className="dropdown-item"
                 onClick={(e) => {
                   dropdownTippyRef.current.hide();
-                  // if there is unsaved changes,
-                  // save them before opening the rename modal
-                  if (item.draft) {
-                    dispatch(saveRequest(item.uid, collection.uid, true));
-                  }
-
                   setRenameItemModalOpen(true);
                 }}
               >

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -55,7 +55,7 @@ export const renameCollection = (newName, collectionUid) => (dispatch, getState)
   });
 };
 
-export const saveRequest = (itemUid, collectionUid) => (dispatch, getState) => {
+export const saveRequest = (itemUid, collectionUid, saveSilently) => (dispatch, getState) => {
   const state = getState();
   const collection = findCollectionByUid(state.collections.collections, collectionUid);
 
@@ -76,7 +76,11 @@ export const saveRequest = (itemUid, collectionUid) => (dispatch, getState) => {
     itemSchema
       .validate(itemToSave)
       .then(() => ipcRenderer.invoke('renderer:save-request', item.pathname, itemToSave))
-      .then(() => toast.success('Request saved successfully'))
+      .then(() => {
+        if (!saveSilently) {
+          toast.success('Request saved successfully');
+        }
+      })
       .then(resolve)
       .catch((err) => {
         toast.error('Failed to save request!');


### PR DESCRIPTION
# Description
Small enhancement, to make sure user doesn't lose their unsaved changes while renaming the request.
Saving unsaved request changes before renaming the request

Issue: #1462

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**