### PR TITLE
Fix: fix population of data when data-urlencode flag is used with G flag i…

### DIFF
--- a/packages/bruno-app/src/utils/curl/parse-curl.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.js
@@ -33,7 +33,7 @@ const parseCurlCommand = (curlCommand) => {
   curlCommand = curlCommand.trim();
 
   const parsedArguments = yargs(curlCommand, {
-    boolean: ['I', 'head', 'compressed', 'L', 'k', 'silent', 's'],
+    boolean: ['I', 'head', 'compressed', 'L', 'k', 'silent', 's', 'G', 'get'],
     alias: {
       H: 'header',
       A: 'user-agent'
@@ -153,7 +153,10 @@ const parseCurlCommand = (curlCommand) => {
   // NB: the -G flag does not change the http verb. It just moves the data into the url.
   if (parsedArguments.G || parsedArguments.get) {
     urlObject.query = urlObject.query ? urlObject.query : '';
-    const option = 'd' in parsedArguments ? 'd' : 'data' in parsedArguments ? 'data' : null;
+    let option = null;
+    if ('d' in parsedArguments) option = 'd';
+    if ('data' in parsedArguments) option = 'data';
+    if ('data-urlencode' in parsedArguments) option = 'data-urlencode';
     if (option) {
       let urlQueryString = '';
 
@@ -219,6 +222,8 @@ const parseCurlCommand = (curlCommand) => {
   } else if (parsedArguments['data-raw']) {
     request.data = parsedArguments['data-raw'];
     request.isDataRaw = true;
+  } else if (parsedArguments['data-urlencode']) {
+    request.data = parsedArguments['data-urlencode'];
   }
 
   if (parsedArguments.u) {


### PR DESCRIPTION
# Description

- fix population of request data field when using the `--data-urlencode` flag along with the `-G` or `--get` flag when importing from curl closes #2010 

<img width="341" alt="Screenshot 2024-04-05 at 8 34 17 PM" src="https://github.com/usebruno/bruno/assets/18341515/353a588d-62e9-401c-ae27-2004351322dd">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
