### PR TITLE
feat: Add descriptions for each panel in CollectionSettings

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Auth/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Auth/index.js
@@ -37,7 +37,11 @@ const Auth = ({ collection }) => {
   };
 
   return (
-    <StyledWrapper className="w-full mt-2">
+    <StyledWrapper className="w-full h-full">
+      <div className="text-sm mb-6">
+        Configures authentication for the entire collection. This applies to all requests using the 'Inherit' option in
+        the 'Auth' tab, as well as any new requests added to this collection.
+      </div>
       <div className="flex flex-grow justify-start items-center">
         <AuthMode collection={collection} />
       </div>

--- a/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
@@ -30,13 +30,13 @@ const ClientCertSettings = ({ clientCertConfig, onUpdate, onRemove }) => {
   };
 
   return (
-    <StyledWrapper>
-      <div className="flex items-center font-semibold mt-4 mb-2">
-        <IconCertificate className="mr-1 certificate-icon" size={24} strokeWidth={1.5} /> Client Certificates
-      </div>
+    <StyledWrapper className="w-full h-full">
+      <div className="text-sm mb-6">Add client certificates to be used for specific domains.</div>
+
+      <h1 className="font-semibold">Client Certificates</h1>
       <ul className="mt-4">
         {!clientCertConfig.length
-          ? 'None'
+          ? 'No client certificates added'
           : clientCertConfig.map((clientCert) => (
               <li key={uuid()} className="flex items-center available-certificates p-2 rounded-lg mb-2">
                 <div className="flex items-center w-full justify-between">

--- a/packages/bruno-app/src/components/CollectionSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Headers/index.js
@@ -63,7 +63,8 @@ const Headers = ({ collection }) => {
   };
 
   return (
-    <StyledWrapper className="w-full">
+    <StyledWrapper className="h-full w-full">
+      <div className="text-sm mb-6">Add request headers that will be sent with every request in this collection.</div>
       <table>
         <thead>
           <tr>

--- a/packages/bruno-app/src/components/CollectionSettings/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Info/index.js
@@ -23,6 +23,7 @@ function countRequests(items) {
 const Info = ({ collection }) => {
   return (
     <StyledWrapper className="w-full flex flex-col h-full">
+      <div className="text-sm mb-6">General information about the collection.</div>
       <table className="w-full border-collapse">
         <tbody>
           <tr className="">

--- a/packages/bruno-app/src/components/CollectionSettings/Presets/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Presets/index.js
@@ -27,8 +27,10 @@ const PresetsSettings = ({ collection }) => {
   });
 
   return (
-    <StyledWrapper>
-      <h1 className="font-medium mb-3">Collection Presets</h1>
+    <StyledWrapper className="h-full w-full">
+      <div className="text-sm mb-6">
+        These presets will be used as the default values for new requests in this collection.
+      </div>
       <form className="bruno-form" onSubmit={formik.handleSubmit}>
         <div className="mb-3 flex items-center">
           <label className="settings-label flex  items-center" htmlFor="enabled">
@@ -66,7 +68,7 @@ const PresetsSettings = ({ collection }) => {
           <label className="settings-label" htmlFor="requestUrl">
             Base URL
           </label>
-          <div className="flex items-center">
+          <div className="flex items-center w-full">
             <div className="flex items-center flex-grow input-container h-full">
               <input
                 id="request-url"
@@ -79,6 +81,7 @@ const PresetsSettings = ({ collection }) => {
                 spellCheck="false"
                 onChange={formik.handleChange}
                 value={formik.values.requestUrl || ''}
+                style={{ width: '100%' }}
               />
             </div>
           </div>

--- a/packages/bruno-app/src/components/CollectionSettings/ProxySettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/ProxySettings/index.js
@@ -95,8 +95,8 @@ const ProxySettings = ({ proxyConfig, onUpdate }) => {
   }, [proxyConfig]);
 
   return (
-    <StyledWrapper>
-      <h1 className="font-medium mb-3">Proxy Settings</h1>
+    <StyledWrapper className="h-full w-full">
+      <div className="text-sm mb-6">Configure proxy settings for this collection.</div>
       <form className="bruno-form" onSubmit={formik.handleSubmit}>
         <div className="mb-3 flex items-center">
           <label className="settings-label flex items-center" htmlFor="enabled">

--- a/packages/bruno-app/src/components/CollectionSettings/Script/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Script/index.js
@@ -38,7 +38,10 @@ const Script = ({ collection }) => {
   };
 
   return (
-    <StyledWrapper className="w-full flex flex-col">
+    <StyledWrapper className="w-full flex flex-col h-full">
+      <div className="text-sm mb-6">
+        Write pre and post-request scripts that will run before and after any request in this collection is sent.
+      </div>
       <div className="flex-1 mt-2">
         <div className="mb-1 title text-xs">Pre Request</div>
         <CodeEditor

--- a/packages/bruno-app/src/components/CollectionSettings/Tests/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Tests/index.js
@@ -27,6 +27,7 @@ const Tests = ({ collection }) => {
 
   return (
     <StyledWrapper className="w-full flex flex-col h-full">
+      <div className="text-sm mb-6">These tests will run any time a request in this collection is sent.</div>
       <CodeEditor
         collection={collection}
         value={tests || ''}

--- a/packages/bruno-app/src/components/CollectionSettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/index.js
@@ -140,11 +140,11 @@ const CollectionSettings = ({ collection }) => {
         <div className={getTabClassname('clientCert')} role="tab" onClick={() => setTab('clientCert')}>
           Client Certificates
         </div>
+        <div className={getTabClassname('docs')} role="tab" onClick={() => setTab('docs')}>
+          Docs
+        </div>
         <div className={getTabClassname('info')} role="tab" onClick={() => setTab('info')}>
           Info
-        </div>
-        <div className={getTabClassname('docs')} role="tab" onClick={() => setTab('docs')}>
-          Documentation
         </div>
       </div>
       <section className="mt-4 h-full">{getTabPanel(tab)}</section>

--- a/packages/bruno-app/src/components/CollectionSettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/index.js
@@ -140,16 +140,14 @@ const CollectionSettings = ({ collection }) => {
         <div className={getTabClassname('clientCert')} role="tab" onClick={() => setTab('clientCert')}>
           Client Certificates
         </div>
-        <div className={getTabClassname('docs')} role="tab" onClick={() => setTab('docs')}>
-          Docs
-        </div>
         <div className={getTabClassname('info')} role="tab" onClick={() => setTab('info')}>
           Info
         </div>
+        <div className={getTabClassname('docs')} role="tab" onClick={() => setTab('docs')}>
+          Documentation
+        </div>
       </div>
-      <section className={`flex ${['auth', 'script', 'docs', 'clientCert'].includes(tab) ? '' : 'mt-4'}`}>
-        {getTabPanel(tab)}
-      </section>
+      <section className="mt-4 h-full">{getTabPanel(tab)}</section>
     </StyledWrapper>
   );
 };


### PR DESCRIPTION
# Description

I've added descriptions to each of the panels in CollectionSettings for better user education.  Furthermore, I've also made the UI more consistent across the panels. You'll notice in the provided video that the location of the description for each tab are now all on the same line, giving a smoother feeling to transitions.

Resolves #2030 

## Demo

https://github.com/usebruno/bruno/assets/18120837/7ec1286e-6d0b-4010-98d1-4c73dc70e54f

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
