### PR TITLE
Fix content-type in client_credentials oauth flow

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -218,6 +218,7 @@ const configureRequest = async (
         const { data: clientCredentialsData, url: clientCredentialsAccessTokenUrl } =
           await transformClientCredentialsRequest(requestCopy);
         request.method = 'POST';
+        request.headers['content-type'] = 'application/x-www-form-urlencoded';
         request.data = clientCredentialsData;
         request.url = clientCredentialsAccessTokenUrl;
         break;


### PR DESCRIPTION
# Description

I was getting error while using the client credential oauth flow on `login.microsoftonline.com`

As per [RFC 6749 section-4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) the client credential grant must have "application/x-www-form-urlencoded" format !
This PR adds the format as a header  !

I have verified this fixes the issue 😄 !

- Before 
- ![image](https://github.com/usebruno/bruno/assets/54404738/2c7120d3-626e-46ae-ba23-2b1e032c0a19)
- After the fix 
- ![image](https://github.com/usebruno/bruno/assets/54404738/d1c9e8ac-295b-469b-9427-4b38a886f6fe)


Fixes #1987
Fixes #1976
Fixes #1938


### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**
