### PR TITLE
Fix Postman Export

### DIFF
--- a/packages/bruno-app/src/utils/exporters/postman-collection.js
+++ b/packages/bruno-app/src/utils/exporters/postman-collection.js
@@ -49,7 +49,7 @@ export const exportCollection = (collection) => {
 
   const generateEventSection = (item) => {
     const eventArray = [];
-    if (item.request.tests.length) {
+    if (item?.request?.tests?.length) {
       eventArray.push({
         listen: 'test',
         script: {
@@ -58,7 +58,7 @@ export const exportCollection = (collection) => {
         }
       });
     }
-    if (item.request.script.req) {
+    if (item?.request?.script?.req) {
       eventArray.push({
         listen: 'prerequest',
         script: {


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

When exporting a postman collection, the app bombs with this error:

Fixes https://github.com/usebruno/bruno/issues/1943

![Screenshot 2024-04-09 at 11 29 38 AM](https://github.com/usebruno/bruno/assets/7387001/49121223-82f2-410e-8808-7b0fd6580ca4)

This PR accesses the properties safely, so that the app doesn't crash

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
