### PR TITLE
feat: allow translation of more postman scripts

### DIFF
--- a/packages/bruno-app/src/utils/importers/translators/index.spec.js
+++ b/packages/bruno-app/src/utils/importers/translators/index.spec.js
@@ -9,6 +9,8 @@ describe('postmanTranslation function', () => {
       pm.variables.set('key', 'value');
       pm.collectionVariables.get('key');
       pm.collectionVariables.set('key', 'value');
+      const data = pm.response.json();
+      pm.expect(pm.environment.has('key')).to.be.true;
     `;
     const expectedOutput = `
       bru.getEnvVar('key');
@@ -17,6 +19,8 @@ describe('postmanTranslation function', () => {
       bru.setVar('key', 'value');
       bru.getVar('key');
       bru.setVar('key', 'value');
+      const data = res.getBody();
+      expect(bru.getEnvVar('key') !== undefined && bru.getEnvVar('key') !== null).to.be.true;
     `;
     expect(postmanTranslation(inputScript)).toBe(expectedOutput);
   });
@@ -36,13 +40,14 @@ describe('postmanTranslation function', () => {
   });
 
   test('should comment non-translated pm commands', () => {
-    const inputScript = "pm.test('random test', () => pm.response.json());";
-    const expectedOutput = "// test('random test', () => pm.response.json());";
+    const inputScript = "pm.test('random test', () => pm.variables.replaceIn('{{$guid}}'));";
+    const expectedOutput = "// test('random test', () => pm.variables.replaceIn('{{$guid}}'));";
     expect(postmanTranslation(inputScript)).toBe(expectedOutput);
   });
   test('should handle multiple pm commands on the same line', () => {
     const inputScript = "pm.environment.get('key'); pm.environment.set('key', 'value');";
-    const expectedOutput = "bru.getEnv(var); bru.setEnvVar(var, 'value');";
+    const expectedOutput = "bru.getEnvVar('key'); bru.setEnvVar('key', 'value');";
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
   });
   test('should handle comments and other JavaScript code', () => {
     const inputScript = `

--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -7,7 +7,11 @@ const replacements = {
   'pm\\.collectionVariables\\.set\\(': 'bru.setVar(',
   'pm\\.setNextRequest\\(': 'bru.setNextRequest(',
   'pm\\.test\\(': 'test(',
-  'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal('
+  'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
+  'pm\\.response\\.to\\.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
+  'pm\\.response\\.json\\(': 'res.getBody(',
+  'pm\\.expect\\(': 'expect(',
+  'pm\\.environment\\.has\\(([^)]+)\\)': 'bru.getEnvVar($1) !== undefined && bru.getEnvVar($1) !== null'
 };
 
 const compiledReplacements = Object.entries(replacements).map(([pattern, replacement]) => ({


### PR DESCRIPTION
# Description

1. This PR allows translation of additional Postman specific scripts.
   - `pm.response.json()` &rarr; `res.getBody()`
   - `pm.environment.has("xyz")` &rarr; `bru.getEnvVar("xyz") !== undefined && bru.getEnvVar("xyz") !== null`
   - `pm.expect( ... )` &rarr; `expect( ... )`
2. Tests to cover the above scenarios
3. Fix an incorrect regex in the translation script
   - `'pm.response.to.have\\.status\\('` &rarr; `'pm\\.response\\.to\\.have\\.status\\('`

Fixes #1973

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
