### PR TITLE
feature: Augment default truststore by default, optionally limit to custom CA certs

### DIFF
--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -47,7 +47,7 @@ const General = ({ close }) => {
         filePath: get(preferences, 'request.customCaCertificate.filePath', null)
       },
       keepDefaultCaCertificates: {
-        enabled: get(preferences, 'request.keepDefaultCaCertificates.enabled', false)
+        enabled: get(preferences, 'request.keepDefaultCaCertificates.enabled', true)
       },
       timeout: preferences.request.timeout,
       storeCookies: get(preferences, 'request.storeCookies', true),

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -18,7 +18,7 @@ const initialState = {
         filePath: null
       },
       keepDefaultCaCertificates: {
-        enabled: false
+        enabled: true
       },
       timeout: 0
     },

--- a/packages/bruno-cli/readme.md
+++ b/packages/bruno-cli/readme.md
@@ -32,16 +32,28 @@ Or run all requests in a collection's subfolder:
 bru run folder
 ```
 
-If you need to use an environment, you can specify it with the --env option:
+If you need to use an environment, you can specify it with the `--env` option:
 
 ```bash
 bru run folder --env Local
 ```
 
-If you need to collect the results of your API tests, you can specify the --output option:
+If you need to collect the results of your API tests, you can specify the `--output` option:
 
 ```bash
 bru run folder --output results.json
+```
+
+If you need to specify a custom CA certificate to validate the request peer, you can specify the `--cacert` option:
+
+```bash
+bru run request.bru --cacert myCustomCA.pem
+```
+
+If you need to run a set of requests that connect to peers with both publicly and privately signed certificates respectively, you can specify the `--extend-truststore` option in addition to the `--cacert` option:
+
+```bash
+bru run folder --cacert myCustomCA.pem --extend-truststore
 ```
 
 ## Scripting

--- a/packages/bruno-cli/readme.md
+++ b/packages/bruno-cli/readme.md
@@ -44,16 +44,16 @@ If you need to collect the results of your API tests, you can specify the `--out
 bru run folder --output results.json
 ```
 
-If you need to specify a custom CA certificate to validate the request peer, you can specify the `--cacert` option:
+If you need to run a set of requests that connect to peers with both publicly and privately signed certificates respectively, you can add private CA certificates via the `--cacert` option. By default, these certificates will be used in addition to the default truststore:
 
 ```bash
-bru run request.bru --cacert myCustomCA.pem
+bru run folder --cacert myCustomCA.pem
 ```
 
-If you need to run a set of requests that connect to peers with both publicly and privately signed certificates respectively, you can specify the `--extend-truststore` option in addition to the `--cacert` option:
+If you need to limit the trusted CA to a specified set when validating the request peer, provide them via `--cacert` and in addition use `--ignore-truststore` to disable the default truststore:
 
 ```bash
-bru run folder --cacert myCustomCA.pem --extend-truststore
+bru run request.bru --cacert myCustomCA.pem --ignore-truststore
 ```
 
 ## Scripting

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -190,6 +190,12 @@ const builder = async (yargs) => {
       type: 'string',
       description: 'CA certificate to verify peer against'
     })
+    .option('extend-truststore', {
+      type: 'boolean',
+      default: false,
+      description:
+        'The specified custom CA certificate (--cacert) will be used in addition to the default truststore, if this option is specified. Evaluated in combination with "--cacert" only.'
+    })
     .option('env', {
       describe: 'Environment variables',
       type: 'string'
@@ -241,12 +247,32 @@ const builder = async (yargs) => {
       '$0 run request.bru --output results.html --format html',
       'Run a request and write the results to results.html in html format in the current directory'
     )
-    .example('$0 run request.bru --tests-only', 'Run all requests that have a test');
+    .example('$0 run request.bru --tests-only', 'Run all requests that have a test')
+    .example(
+      '$0 run request.bru --cacert myCustomCA.pem',
+      'Use a custom CA certificate when validating the peer of this request.'
+    )
+    .example(
+      '$0 run folder --cacert myCustomCA.pem --extend-truststore',
+      'Use a custom CA certificate in combination with the default truststore when validating the peers of the requests in the specified folder.'
+    );
 };
 
 const handler = async function (argv) {
   try {
-    let { filename, cacert, env, envVar, insecure, r: recursive, output: outputPath, format, testsOnly, bail } = argv;
+    let {
+      filename,
+      cacert,
+      extendTruststore,
+      env,
+      envVar,
+      insecure,
+      r: recursive,
+      output: outputPath,
+      format,
+      testsOnly,
+      bail
+    } = argv;
     const collectionPath = process.cwd();
 
     // todo
@@ -337,6 +363,7 @@ const handler = async function (argv) {
         }
       }
     }
+    options['extendTruststore'] = extendTruststore;
 
     if (['json', 'junit', 'html'].indexOf(format) === -1) {
       console.error(chalk.red(`Format must be one of "json", "junit or "html"`));

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -190,11 +190,11 @@ const builder = async (yargs) => {
       type: 'string',
       description: 'CA certificate to verify peer against'
     })
-    .option('extend-truststore', {
+    .option('ignore-truststore', {
       type: 'boolean',
       default: false,
       description:
-        'The specified custom CA certificate (--cacert) will be used in addition to the default truststore, if this option is specified. Evaluated in combination with "--cacert" only.'
+        'The specified custom CA certificate (--cacert) will be used exclusively and the default truststore is ignored, if this option is specified. Evaluated in combination with "--cacert" only.'
     })
     .option('env', {
       describe: 'Environment variables',
@@ -247,14 +247,15 @@ const builder = async (yargs) => {
       '$0 run request.bru --output results.html --format html',
       'Run a request and write the results to results.html in html format in the current directory'
     )
+
     .example('$0 run request.bru --tests-only', 'Run all requests that have a test')
     .example(
       '$0 run request.bru --cacert myCustomCA.pem',
-      'Use a custom CA certificate when validating the peer of this request.'
+      'Use a custom CA certificate in combination with the default truststore when validating the peer of this request.'
     )
     .example(
-      '$0 run folder --cacert myCustomCA.pem --extend-truststore',
-      'Use a custom CA certificate in combination with the default truststore when validating the peers of the requests in the specified folder.'
+      '$0 run folder --cacert myCustomCA.pem --ignore-truststore',
+      'Use a custom CA certificate exclusively when validating the peers of the requests in the specified folder.'
     );
 };
 
@@ -263,7 +264,7 @@ const handler = async function (argv) {
     let {
       filename,
       cacert,
-      extendTruststore,
+      ignoreTruststore,
       env,
       envVar,
       insecure,
@@ -363,7 +364,7 @@ const handler = async function (argv) {
         }
       }
     }
-    options['extendTruststore'] = extendTruststore;
+    options['ignoreTruststore'] = ignoreTruststore;
 
     if (['json', 'junit', 'html'].indexOf(format) === -1) {
       console.error(chalk.red(`Format must be one of "json", "junit or "html"`));

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -3,6 +3,7 @@ const qs = require('qs');
 const chalk = require('chalk');
 const decomment = require('decomment');
 const fs = require('fs');
+const tls = require('tls');
 const { forOwn, isUndefined, isNull, each, extend, get, compact } = require('lodash');
 const FormData = require('form-data');
 const prepareRequest = require('./prepare-request');
@@ -104,9 +105,13 @@ const runSingleRequest = async function (
     } else {
       const caCertArray = [options['cacert'], process.env.SSL_CERT_FILE, process.env.NODE_EXTRA_CA_CERTS];
       const caCert = caCertArray.find((el) => el);
-      if (caCert && caCert.length > 1) {
+      if (options['cacert'] && caCert && caCert.length > 1) {
         try {
-          httpsAgentRequestFields['ca'] = fs.readFileSync(caCert);
+          let caCertBuffer = fs.readFileSync(caCert);
+          if (options['extendTruststore']) {
+            caCertBuffer += '\n' + tls.rootCertificates.join('\n'); // Augment default truststore with custom CA certificates
+          }
+          httpsAgentRequestFields['ca'] = caCertBuffer;
         } catch (err) {
           console.log('Error reading CA cert file:' + caCert, err);
         }

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -105,10 +105,10 @@ const runSingleRequest = async function (
     } else {
       const caCertArray = [options['cacert'], process.env.SSL_CERT_FILE, process.env.NODE_EXTRA_CA_CERTS];
       const caCert = caCertArray.find((el) => el);
-      if (options['cacert'] && caCert && caCert.length > 1) {
+      if (caCert && caCert.length > 1) {
         try {
           let caCertBuffer = fs.readFileSync(caCert);
-          if (options['extendTruststore']) {
+          if (!options['ignoreTruststore']) {
             caCertBuffer += '\n' + tls.rootCertificates.join('\n'); // Augment default truststore with custom CA certificates
           }
           httpsAgentRequestFields['ca'] = caCertBuffer;

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -16,7 +16,7 @@ const defaultPreferences = {
       filePath: null
     },
     keepDefaultCaCertificates: {
-      enabled: false
+      enabled: true
     },
     storeCookies: true,
     sendCookies: true,
@@ -118,7 +118,7 @@ const preferencesUtil = {
     return get(getPreferences(), 'request.customCaCertificate.enabled', false);
   },
   shouldKeepDefaultCaCertificates: () => {
-    return get(getPreferences(), 'request.keepDefaultCaCertificates.enabled', false);
+    return get(getPreferences(), 'request.keepDefaultCaCertificates.enabled', true);
   },
   getCustomCaCertificateFilePath: () => {
     return get(getPreferences(), 'request.customCaCertificate.filePath', null);


### PR DESCRIPTION
Continuation of PR #1937, considering the changes proposed in that PR.

# Description

The change in feature #1863 did not cover the CLI feature of Bruno, `bru`. This feature adds that part and introduces a new command line option to `bru` CLI to control the way custom CA certificates are handled: replace _or_ extend the default truststore.

The new CLI option is called `--ignore-truststore` and documented in both synopsis and readme.
This new option only is in effect, if a custom CA certificate is specified via option `--cacert`.

![image](https://github.com/usebruno/bruno/assets/8606429/b332c90a-e0e1-43dd-a6d1-fb2c67ef5316)

![image](https://github.com/usebruno/bruno/assets/8606429/7601d068-7f0b-43fa-9d22-57930881e287)

At the same time, this change inverts the default handling of specifying custom CA certificates in the GUI. Previously, the default truststore was replaced completely, if custom CA certificates had been specified. Now specifying custom CA certificates results in augmenting the default truststore: the setting "Keep default truststore" is selected by default.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
   #1080 