### PR TITLE
fix: Oauth2: Apply TLS Certifcate valiadation preference to accessing Auth and Token URLs

### DIFF
--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -1,4 +1,5 @@
 const { BrowserWindow } = require('electron');
+const { preferencesUtil } = require('../../store/preferences');
 
 const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
   return new Promise(async (resolve, reject) => {
@@ -21,6 +22,12 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
       show: false
     });
     window.on('ready-to-show', window.show.bind(window));
+
+    // We want browser window to comply with "SSL/TLS Certificate Verification" toggle in Preferences
+    window.webContents.on('certificate-error', (event, url, error, certificate, callback) => {
+      event.preventDefault();
+      callback(!preferencesUtil.shouldVerifyTls());
+    });
 
     function onWindowRedirect(url) {
       // check if the url contains an authorization code


### PR DESCRIPTION
# Description
The browser used for user authentication in OAuth2 Access Token flow is not following user preferences to disable SSL/TLS Certificate verification or to trust custom CA Certificate. As a result completing OAuth2 flow that requires login with web browsers is impossible with local environments using self-signed certificates.

With this change, the certificate errors may be optionally ignored based on said user preference.

Fixes #1684 in most part. What this PR does not fix is making it possible for browser session to trust user specified custom CA - or more generally using the same request configuration (Proxy, mTLS, etc) - but in my eyes ignoring certificate-erros entirely will fix 99% of problems of users having to work in unsecure test environments.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

