### PR TITLE
fix: pkce validation error

### DIFF
--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -165,7 +165,7 @@ const oauth2Schema = Yup.object({
   }),
   pkce: Yup.boolean().when('grantType', {
     is: (val) => ['authorization_code'].includes(val),
-    then: Yup.boolean().defined(),
+    then: Yup.boolean().default(false),
     otherwise: Yup.boolean()
   })
 })


### PR DESCRIPTION
pkce is now `false` by default to prevent save errors

Closes: #2070