### PR TITLE
OpenAPI - Parse environments extension

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -327,6 +327,25 @@ const parseOpenApiCollection = (data) => {
       let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '';
       let securityConfig = getSecurity(collectionData);
 
+      if(collectionData['x-bruno-environments']) {
+        collectionData['x-bruno-environments'].forEach(env => {
+          brunoCollection.environments.push({
+            uid: uuid(),
+            name: env.name,
+            variables: env.variables.map(variable => {
+              return {
+                uid: uuid(),
+                name: variable.name,
+                value: variable.value ?? '',
+                type: variable.type ?? 'text',
+                enabled: variable.enabled ?? true,
+                secret: variable.secret ?? false
+              };
+            })
+          });
+        });
+      }
+
       let allRequests = Object.entries(collectionData.paths)
         .map(([path, methods]) => {
           return Object.entries(methods)


### PR DESCRIPTION
# OpenAPI - Parse environments extension

I use the [OpenAPI Extensions](https://spec.openapis.org/oas/latest.html#specification-extensions) for describe environments.

With that we can use variables in OpenAPI file, describe our environments and import all of this.
This is usefull when you share your collection with other people or when your main input is an OpenAPI file.
So when you delete/import collection for make a refresh, you don't loose your environments

It's a first step and I would like to have feedback from the community to improve this idea.


A fork from PetStore SwaggerDoc where I use this feature [openapi_petstore.json](https://github.com/usebruno/bruno/files/14982103/openapi_petstore.json)

Look like
![image](https://github.com/usebruno/bruno/assets/9074014/769d4c31-e999-40e4-a26a-4ef2a6cc3a55)
![image](https://github.com/usebruno/bruno/assets/9074014/e8445901-5500-434e-97d9-724e716dd07c)

And generate
![image](https://github.com/usebruno/bruno/assets/9074014/5af224a5-828c-47d9-b0ef-890b16a06af9)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.