### PR TITLE
bugfix: hide autocomplete on escape keyup

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -232,7 +232,7 @@ export default class CodeEditor extends React.Component {
         let curWord = start != end && currentLine.slice(start, end);
         //Qualify if autocomplete will be shown
         if (
-          /^(?!Shift|Tab|Enter|ArrowUp|ArrowDown|ArrowLeft|ArrowRight|\s)\w*/.test(event.key) &&
+          /^(?!Shift|Tab|Enter|Escape|ArrowUp|ArrowDown|ArrowLeft|ArrowRight|\s)\w*/.test(event.key) &&
           curWord.length > 0 &&
           !/\/\/|\/\*|.*{{|`[^$]*{|`[^{]*$/.test(currentLine.slice(0, end)) &&
           /(?<!\d)[a-zA-Z\._]$/.test(curWord)


### PR DESCRIPTION
# Description

Fixes #2087 

This change hides the autocomplete popup (and keeps it hidden)  when `Escape` is pressed. Cursor can freely navigate  afterwards.

**Before**
[Screencast from 2024-04-15 22-08-56.webm](https://github.com/usebruno/bruno/assets/1665841/af147180-4880-4ab0-acce-8b423831de85)

**After**
[Screencast from 2024-04-15 21-58-09.webm](https://github.com/usebruno/bruno/assets/1665841/d31a4736-6837-4c7f-bb89-fb61fd1ef974)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
