### PR TITLE
feat: Multi-part requests: user should be able to set content-type fo…

### DIFF
--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -24,7 +24,11 @@ const parseFormData = (datas, collectionPath) => {
         form.append(name, fs.createReadStream(trimmedFilePath), path.basename(trimmedFilePath));
       });
     } else {
-      form.append(name, value);
+      if (isJson(value)) {
+        form.append(name, value, { contentType: 'application/json' });
+      } else {
+        form.append(name, value);
+      }
     }
   });
   return form;
@@ -139,6 +143,18 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
   }
 
   return axiosRequest;
+};
+
+/**
+ * Auto detection whether the string passed as parameter is a valid json or not
+ */
+const isJson = (str) => {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
 };
 
 const prepareRequest = (request, collectionRoot, collectionPath) => {


### PR DESCRIPTION
# Description

Fixes https://github.com/usebruno/bruno/issues/1602 

When a multi-part form is sent with multiple parameters such as:
![multipart](https://github.com/usebruno/bruno/assets/139650490/4745c81f-f02b-41cc-864f-7981ec1e5dae)

Before this PR, the Content-Type: application/json was missing for the parameter "additionalParameters".

```
    ----------------------------786169027024365718576611
    Content-Disposition: form-data; name="content"; filename="myfile.pdf"
    Content-Type: application/pdf
      
    ----------------------------786169027024365718576611
    Content-Disposition: form-data; name="name"
    
    test

    ----------------------------786169027024365718576611
    Content-Disposition: form-data; name="additionalProperties"
    Content-Type: application/json   <============== THIS LINE IS ADDED BY THE PR
      
    [{"key": "key","value": "value"}]
```
Now Bruno automatically add "Content-Type: application/json" if the value is a valid JSON string. 

If "Content-Type: application/json" is missing, the API called does not interpret the parameter as a JSON object.

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
