### PR TITLE
feat(#2069): Make Docs tab more prominent

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -82,11 +82,13 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   };
 
   // get the length of active params, headers, asserts and vars
+  // also get if there is information inside docs tab
   const params = item.draft ? get(item, 'draft.request.params', []) : get(item, 'request.params', []);
   const headers = item.draft ? get(item, 'draft.request.headers', []) : get(item, 'request.headers', []);
   const assertions = item.draft ? get(item, 'draft.request.assertions', []) : get(item, 'request.assertions', []);
   const requestVars = item.draft ? get(item, 'draft.request.vars.req', []) : get(item, 'request.vars.req', []);
   const responseVars = item.draft ? get(item, 'draft.request.vars.res', []) : get(item, 'request.vars.res', []);
+  const docs = item.draft ? get(item, 'draft.request.docs', []) : get(item, 'request.docs', []);
 
   const activeParamsLength = params.filter((param) => param.enabled).length;
   const activeHeadersLength = headers.filter((header) => header.enabled).length;
@@ -94,6 +96,7 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   const activeVarsLength =
     requestVars.filter((request) => request.enabled).length +
     responseVars.filter((response) => response.enabled).length;
+  const haveDocs = docs.length > 0;
 
   return (
     <StyledWrapper className="flex flex-col h-full relative">
@@ -128,6 +131,7 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
         </div>
         <div className={getTabClassname('docs')} role="tab" onClick={() => selectTab('docs')}>
           Docs
+          {haveDocs && <sup className="ml-1 font-medium">*</sup>}
         </div>
         {focusedTab.requestPaneTab === 'body' ? (
           <div className="flex flex-grow justify-end items-center">


### PR DESCRIPTION
# Description

Fixes #2069 

Added an asterisk on the Docs tab to allow to know faster if there is content in it.
Idk if the asterisk is the best character to use, what are your though? We could also display a "1", the count of line, a "+", etc..
For now it's only on docs tab cause it is the content of the issue, but it could be harmonized with other tabs (Tests, Script, Auth, Body) in another Issue.

Before:
<img width="348" alt="image" src="https://github.com/usebruno/bruno/assets/46672026/f730f395-dcc9-4c70-a197-ad6c5c508628">

After:
<img width="336" alt="image" src="https://github.com/usebruno/bruno/assets/46672026/42318814-1df2-4ab9-9dc1-5cbd7b8af6a6">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
