### PR TITLE
fix: error boundary adding return-to-app and force-quit options

### DIFF
--- a/packages/bruno-app/.prettierrc.json
+++ b/packages/bruno-app/.prettierrc.json
@@ -3,5 +3,5 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true,
-  "printWidth": 200
+  "printWidth": 120
 }

--- a/packages/bruno-app/.prettierrc.json
+++ b/packages/bruno-app/.prettierrc.json
@@ -3,5 +3,5 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 200
 }

--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import Bruno from 'components/Bruno/index';
+
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
@@ -14,29 +16,61 @@ class ErrorBoundary extends React.Component {
   }
   componentDidCatch(error, errorInfo) {
     console.log({ error, errorInfo });
+    this.setState({ hasError: true, error, errorInfo });
   }
+
+  returnToApp() {
+    const { ipcRenderer } = window;
+    ipcRenderer.invoke('open-file');
+
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  }
+
+  forceQuit() {
+    const { ipcRenderer } = window;
+    ipcRenderer.invoke('main:force-quit');
+  }
+
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex items-center justify-center p-10">
-          <div className="bg-white rounded-lg shadow-lg p-4 w-full">
+        <div className="flex text-center justify-center p-20 h-full">
+          <div className="bg-white rounded-lg shadow-lg p-10 w-full">
+            <div className="m-auto" style={{ width: '256px' }}>
+              <Bruno width={256} />
+            </div>
+
             <h1 className="text-2xl font-semibold text-red-600 mb-2">Oops! Something went wrong</h1>
-            <p className="text-red-600 mb-2">{this.state.error && this.state.error.toString()}</p>
-            {this.state.error && this.state.error.stack && (
-              <pre className="bg-gray-100 p-2 rounded-lg overflow-auto">{this.state.error.stack}</pre>
-            )}
+            <p className="text-red-500 mb-2">
+              If you are using an official production build: the above error is most likely a bug!
+              <br />
+              Please report this under:
+              <a
+                className="text-link hover:underline cursor-pointer ml-2"
+                href="https://github.com/usebruno/bruno/issues"
+                target="_blank"
+              >
+                https://github.com/usebruno/bruno/issues
+              </a>
+            </p>
+
             <button
               className="bg-red-500 text-white px-4 py-2 mt-4 rounded hover:bg-red-600 transition"
-              onClick={() => {
-                this.setState({ hasError: false, error: null });
-              }}
+              onClick={this.returnToApp()}
             >
-              Close
+              Return to App
             </button>
+
+            <div className="text-red-500 mt-3">
+              <a href="" className="hover:underline cursor-pointer" onClick={this.forceQuit}>
+                Force Quit
+              </a>
+            </div>
           </div>
         </div>
       );
     }
+
     return this.props.children;
   }
 }

--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -56,7 +56,7 @@ class ErrorBoundary extends React.Component {
 
             <button
               className="bg-red-500 text-white px-4 py-2 mt-4 rounded hover:bg-red-600 transition"
-              onClick={this.returnToApp()}
+              onClick={this.returnToApp}
             >
               Return to App
             </button>

--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -35,7 +35,7 @@ class ErrorBoundary extends React.Component {
     if (this.state.hasError) {
       return (
         <div className="flex text-center justify-center p-20 h-full">
-          <div className="bg-white rounded-lg shadow-lg p-10 w-full">
+          <div className="bg-white rounded-lg p-10 w-full">
             <div className="m-auto" style={{ width: '256px' }}>
               <Bruno width={256} />
             </div>

--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -56,7 +56,7 @@ class ErrorBoundary extends React.Component {
 
             <button
               className="bg-red-500 text-white px-4 py-2 mt-4 rounded hover:bg-red-600 transition"
-              onClick={this.returnToApp}
+              onClick={() => this.returnToApp()}
             >
               Return to App
             </button>

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -628,6 +628,10 @@ const registerMainEventHandlers = (mainWindow, watcher, lastOpenedCollections) =
   ipcMain.handle('main:complete-quit-flow', () => {
     mainWindow.destroy();
   });
+
+  ipcMain.handle('main:force-quit', () => {
+    process.exit();
+  });
 };
 
 const registerCollectionsIpc = (mainWindow, watcher, lastOpenedCollections) => {


### PR DESCRIPTION
# Description

This PR fixes the annoying blank screen in the event of an uncaught error which left the user with no option other than force quit. With this fix, options to return to the App and Force Quit is added.
