### PR TITLE
flx: add unique key prop to ImportCollection options

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
@@ -79,7 +79,7 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
         </div>
         <div className="flex justify-start w-full mt-4 max-w-[450px]">
           {Object.entries(options || {}).map(([key, option]) => (
-            <div className="relative flex items-start">
+            <div key={key} className="relative flex items-start">
               <div className="flex h-6 items-center">
                 <input
                   id="comments"


### PR DESCRIPTION
# Description

This PR uses the `key` of the `options` object in import collection to suppress the unique key prop warning.

Fixes issue #2078

Screenshot of the console after the changes (note the lack of a warning):
![image](https://github.com/usebruno/bruno/assets/11313829/b75edb88-d9a2-48be-a8bf-63fcd6e78ce7)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
