### PR TITLE
fix: Issue with Parameters Passed in the URL(#2124)

### DIFF
--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -18,12 +18,17 @@ const hasLength = (str) => {
 };
 
 export const parseQueryParams = (query) => {
-  if (!query || !query.length) {
+  try {
+    if (!query || !query.length) {
+      return [];
+    }
+
+    return Array.from(new URLSearchParams(query.split('#')[0]).entries())
+      .map(([name, value]) => ({ name, value }));
+  } catch (error) {
+    console.error('Error parsing query params:', error);
     return [];
   }
-
-  return Array.from(new URLSearchParams(query.split('#')[0]).entries())
-    .map(([name, value]) => ({ name, value }));
 };
 
 export const parsePathParams = (url) => {

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -22,12 +22,8 @@ export const parseQueryParams = (query) => {
     return [];
   }
 
-  let params = query.split('&').map((param) => {
-    let [name, value = ''] = param.split('=');
-    return { name, value };
-  });
-
-  return filter(params, (p) => hasLength(p.name));
+  return Array.from(new URLSearchParams(query.split('#')[0]).entries())
+    .map(([name, value]) => ({ name, value }));
 };
 
 export const parsePathParams = (url) => {

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -49,6 +49,23 @@ describe('Url Utils - parseQueryParams', () => {
       { name: 'b', value: '2' }
     ]);
   });
+
+  it('should parse query with "=" character - case 9', () => {
+    const params = parseQueryParams('a=1&b={color=red,size=large}&c=3');
+    expect(params).toEqual([
+      { name: 'a', value: '1' },
+      { name: 'b', value: '{color=red,size=large}' },
+      { name: 'c', value: '3' }
+    ]);
+  });
+
+  it('should parse query with fragment - case 10', () => {
+    const params = parseQueryParams('a=1&b=2#I-AM-FRAGMENT');
+    expect(params).toEqual([
+      { name: 'a', value: '1' },
+      { name: 'b', value: '2' }
+    ]);
+  });
 });
 
 describe('Url Utils - parsePathParams', () => {


### PR DESCRIPTION
This PR fixes query parameter parsing from URL field. The '=' should be allowed within query parameter value. While first equals sign separates parameter name from its value, any subsequent occurrences are valid and should not be discarded.

Additionally in curent implementation the last query parameter value incorrectly contains what should be URI fragment (anything that follows #), which this PR also addresses.

fixes: #2124 
fixes: #2731

Before:
![Screenshot from 2024-04-19 19-33-27](https://github.com/usebruno/bruno/assets/2108093/c882809a-e7e7-4345-800f-5a17ffa86a1d)

After:
![Screenshot from 2024-04-19 19-32-30](https://github.com/usebruno/bruno/assets/2108093/75b858c0-ffb4-4816-b041-ba1f04cbb357)
