### PR TITLE
fix: Check OAuth2 redirect URL for matching callback URL and authorization code in query parameters

### DIFF
--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -1,6 +1,10 @@
 const { BrowserWindow } = require('electron');
 const { preferencesUtil } = require('../../store/preferences');
 
+const matchesCallbackUrl = (url, callbackUrl) => {
+  return url ? new URL(url).host == new URL(callbackUrl).host : false;
+};
+
 const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
   return new Promise(async (resolve, reject) => {
     let finalUrl = null;
@@ -31,7 +35,7 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
 
     function onWindowRedirect(url) {
       // check if the redirect is to the callback URL and if it contains an authorization code
-      if (url && url.includes(callbackUrl)) {
+      if (matchesCallbackUrl(url, callbackUrl)) {
         if (!new URL(url).searchParams.has('code')) {
           reject(new Error('Invalid Callback URL: Does not contain an authorization code'));
         }
@@ -93,4 +97,4 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
   });
 };
 
-module.exports = { authorizeUserInWindow };
+module.exports = { authorizeUserInWindow, matchesCallbackUrl };

--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -30,12 +30,12 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
     });
 
     function onWindowRedirect(url) {
-      // check if the url contains an authorization code
-      if (new URL(url).searchParams.has('code')) {
-        finalUrl = url;
-        if (!url || !finalUrl.includes(callbackUrl)) {
-          reject(new Error('Invalid Callback Url'));
+      // check if the redirect is to the callback URL and if it contains an authorization code
+      if (url && url.includes(callbackUrl)) {
+        if (!new URL(url).searchParams.has('code')) {
+          reject(new Error('Invalid Callback URL: Does not contain an authorization code'));
         }
+        finalUrl = url;
         window.close();
       }
       if (url.match(/(error=).*/) || url.match(/(error_description=).*/) || url.match(/(error_uri=).*/)) {

--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -2,7 +2,7 @@ const { BrowserWindow } = require('electron');
 const { preferencesUtil } = require('../../store/preferences');
 
 const matchesCallbackUrl = (url, callbackUrl) => {
-  return url ? new URL(url).host == new URL(callbackUrl).host : false;
+  return url ? url.href.startsWith(callbackUrl.href) : false;
 };
 
 const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
@@ -35,7 +35,7 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
 
     function onWindowRedirect(url) {
       // check if the redirect is to the callback URL and if it contains an authorization code
-      if (matchesCallbackUrl(url, callbackUrl)) {
+      if (matchesCallbackUrl(new URL(url), new URL(callbackUrl))) {
         if (!new URL(url).searchParams.has('code')) {
           reject(new Error('Invalid Callback URL: Does not contain an authorization code'));
         }

--- a/packages/bruno-electron/tests/network/authorize-user.spec.js
+++ b/packages/bruno-electron/tests/network/authorize-user.spec.js
@@ -1,0 +1,20 @@
+const { matchesCallbackUrl } = require('../../src/ipc/network/authorize-user-in-window');
+
+describe('matchesCallbackUrl', () => {
+  const testCases = [
+    { url: null, expected: false },
+    { url: '', expected: false },
+    { url: 'https://random-url/endpoint', expected: false },
+    { url: 'https://random-url/endpoint?code=abcd', expected: false },
+    { url: 'https://callback.url/endpoint?code=abcd', expected: true },
+    { url: 'https://callback.url/endpoint/?code=abcd', expected: true }
+  ];
+
+  it.each(testCases)('$url - should be $expected', ({ url, expected }) => {
+    let callBackUrl = 'https://callback.url/endpoint';
+
+    let actual = matchesCallbackUrl(url, callBackUrl);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/bruno-electron/tests/network/authorize-user.spec.js
+++ b/packages/bruno-electron/tests/network/authorize-user.spec.js
@@ -2,18 +2,17 @@ const { matchesCallbackUrl } = require('../../src/ipc/network/authorize-user-in-
 
 describe('matchesCallbackUrl', () => {
   const testCases = [
-    { url: null, expected: false },
-    { url: '', expected: false },
     { url: 'https://random-url/endpoint', expected: false },
     { url: 'https://random-url/endpoint?code=abcd', expected: false },
     { url: 'https://callback.url/endpoint?code=abcd', expected: true },
-    { url: 'https://callback.url/endpoint/?code=abcd', expected: true }
+    { url: 'https://callback.url/endpoint/?code=abcd', expected: true },
+    { url: 'https://callback.url/random-endpoint/?code=abcd', expected: false }
   ];
 
   it.each(testCases)('$url - should be $expected', ({ url, expected }) => {
     let callBackUrl = 'https://callback.url/endpoint';
 
-    let actual = matchesCallbackUrl(url, callBackUrl);
+    let actual = matchesCallbackUrl(new URL(url), new URL(callBackUrl));
 
     expect(actual).toBe(expected);
   });


### PR DESCRIPTION
Fixes #2147

# Description

In an Authorization code flow, there may be multiple intermediate redirects before reaching the final one which matches the callback URL and has a code in the query params.

We should wait until we see a redirect URI that matches both the conditions. This fixes the issue where, when a redirect contains `code` as a query param but is not the final one (i.e., is not to the callback URL) an error is thrown saying the callback URL is invalid.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
