### PR TITLE
fixed save all function failing with JSON in body | issue: (#2130)

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -387,7 +387,7 @@ export const transformRequestToSaveToFilesystem = (item) => {
       params: [],
       headers: [],
       auth: _item.request.auth,
-      body: _item.request.body,
+      body: { ..._item.request.body },
       script: _item.request.script,
       vars: _item.request.vars,
       assertions: _item.request.assertions,
@@ -416,8 +416,12 @@ export const transformRequestToSaveToFilesystem = (item) => {
     });
   });
 
+  //modify the body if mode is Json
   if (itemToSave.request.body.mode === 'json') {
-    itemToSave.request.body.json = replaceTabsWithSpaces(itemToSave.request.body.json);
+    itemToSave.request.body = {
+      ...itemToSave.request.body,
+      json: replaceTabsWithSpaces(itemToSave.request.body.json)
+    };
   }
 
   return itemToSave;


### PR DESCRIPTION
# Description
fix for: #2130 
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

### TLDR:
The "saveMultipleRequests" would fail during a save with JSON in the body. There was a reassignment to a read-only object. I fixed this by making the field mutable and reassigning the body if the type is JSON.  

**Steps to reproduce/test:**
1. Create new collection
2. Create 2 new requests
3. Name them something
4. Add a JSON body to them
5. Click to close and click `Save all`

### Prefix:
![output](https://github.com/usebruno/bruno/assets/74217403/1cd2bb62-cfc0-410d-beb9-42b4c978e226)
On an save all exit with JSON in body, save will fail.

### Postfix:
![output1](https://github.com/usebruno/bruno/assets/74217403/e90ad9b0-5dd5-4f54-a266-18fcd66b2ffc)
Now postfix, the save all function works perfectly without issue.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
