### PR TITLE
bugfix(#2152): Docs not support "http" markdown image

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -24,6 +24,8 @@ const contentSecurityPolicy = [
   "font-src 'self' https:",
   // this has been commented out to make oauth2 work
   // "form-action 'none'",
+  // we make an exception and allow http for images so that
+  // they can be used as link in the embedded markdown editors
   "img-src 'self' blob: data: http: https:",
   "media-src 'self' blob: data: https:",
   "style-src 'self' 'unsafe-inline' https:"

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -24,7 +24,7 @@ const contentSecurityPolicy = [
   "font-src 'self' https:",
   // this has been commented out to make oauth2 work
   // "form-action 'none'",
-  "img-src 'self' blob: data: https:",
+  "img-src 'self' blob: data: http: https:",
   "media-src 'self' blob: data: https:",
   "style-src 'self' 'unsafe-inline' https:"
 ];


### PR DESCRIPTION
resolves: #2152

# Description

The error message was:


_Refused to load the image 'http://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png' because it violates the following Content Security Policy directive: "img-src 'self' blob: data: https:"._


Electron was not allowing to load images over "http", only "https" was allowed.

I think it's reasonable to allow it (for images only).

https://github.com/usebruno/bruno/assets/139650490/ecaa04cd-ba32-4c75-8ae5-4ee961b3bb9f



### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
