### PR TITLE
Add support for custom prefix with bearer auth

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Auth/BearerAuth/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Auth/BearerAuth/index.js
@@ -1,19 +1,32 @@
-import React from 'react';
-import get from 'lodash/get';
-import { useTheme } from 'providers/Theme';
-import { useDispatch } from 'react-redux';
 import SingleLineEditor from 'components/SingleLineEditor';
+import get from 'lodash/get';
 import { updateCollectionAuth } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionRoot } from 'providers/ReduxStore/slices/collections/actions';
+import { useTheme } from 'providers/Theme';
+import React from 'react';
+import { useDispatch } from 'react-redux';
 import StyledWrapper from './StyledWrapper';
 
 const BearerAuth = ({ collection }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
 
-  const bearerToken = get(collection, 'root.request.auth.bearer.token', '');
+  const bearer = get(collection, 'root.request.auth.bearer', {});
 
   const handleSave = () => dispatch(saveCollectionRoot(collection.uid));
+
+  const handlePrefixChange = (prefix) => {
+    dispatch(
+      updateCollectionAuth({
+        mode: 'bearer',
+        collectionUid: collection.uid,
+        content: {
+          prefix: prefix,
+          token: bearer.token
+        }
+      })
+    );
+  };
 
   const handleTokenChange = (token) => {
     dispatch(
@@ -21,6 +34,7 @@ const BearerAuth = ({ collection }) => {
         mode: 'bearer',
         collectionUid: collection.uid,
         content: {
+          prefix: bearer.prefix,
           token: token
         }
       })
@@ -29,10 +43,20 @@ const BearerAuth = ({ collection }) => {
 
   return (
     <StyledWrapper className="mt-2 w-full">
+      <label className="block font-medium mb-2">Prefix</label>
+      <div className="single-line-editor-wrapper mb-2">
+        <SingleLineEditor
+          value={bearer.prefix || ''}
+          theme={storedTheme}
+          onSave={handleSave}
+          onChange={(val) => handlePrefixChange(val)}
+          collection={collection}
+        />
+      </div>
       <label className="block font-medium mb-2">Token</label>
       <div className="single-line-editor-wrapper">
         <SingleLineEditor
-          value={bearerToken}
+          value={bearer.token || ''}
           theme={storedTheme}
           onSave={handleSave}
           onChange={(val) => handleTokenChange(val)}

--- a/packages/bruno-app/src/components/RequestPane/Auth/BearerAuth/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/BearerAuth/index.js
@@ -1,22 +1,34 @@
-import React from 'react';
-import get from 'lodash/get';
-import { useTheme } from 'providers/Theme';
-import { useDispatch } from 'react-redux';
 import SingleLineEditor from 'components/SingleLineEditor';
+import get from 'lodash/get';
 import { updateAuth } from 'providers/ReduxStore/slices/collections';
-import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { saveRequest, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { useTheme } from 'providers/Theme';
+import React from 'react';
+import { useDispatch } from 'react-redux';
 import StyledWrapper from './StyledWrapper';
 
 const BearerAuth = ({ item, collection }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
 
-  const bearerToken = item.draft
-    ? get(item, 'draft.request.auth.bearer.token', '')
-    : get(item, 'request.auth.bearer.token', '');
+  const bearer = item.draft ? get(item, 'draft.request.auth.bearer', {}) : get(item, 'request.auth.bearer', {});
 
   const handleRun = () => dispatch(sendRequest(item, collection.uid));
   const handleSave = () => dispatch(saveRequest(item.uid, collection.uid));
+
+  const handlePrefixChange = (prefix) => {
+    dispatch(
+      updateAuth({
+        mode: 'bearer',
+        collectionUid: collection.uid,
+        itemUid: item.uid,
+        content: {
+          prefix: prefix,
+          token: bearer.token
+        }
+      })
+    );
+  };
 
   const handleTokenChange = (token) => {
     dispatch(
@@ -25,6 +37,7 @@ const BearerAuth = ({ item, collection }) => {
         collectionUid: collection.uid,
         itemUid: item.uid,
         content: {
+          prefix: bearer.prefix,
           token: token
         }
       })
@@ -33,10 +46,21 @@ const BearerAuth = ({ item, collection }) => {
 
   return (
     <StyledWrapper className="mt-2 w-full">
+      <label className="block font-medium mb-2">Prefix</label>
+      <div className="single-line-editor-wrapper mb-2">
+        <SingleLineEditor
+          value={bearer.prefix || ''}
+          theme={storedTheme}
+          onSave={handleSave}
+          onChange={(val) => handlePrefixChange(val)}
+          onRun={handleRun}
+          collection={collection}
+        />
+      </div>
       <label className="block font-medium mb-2">Token</label>
       <div className="single-line-editor-wrapper">
         <SingleLineEditor
-          value={bearerToken}
+          value={bearer.token || ''}
           theme={storedTheme}
           onSave={handleSave}
           onChange={(val) => handleTokenChange(val)}

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1,15 +1,15 @@
-import get from 'lodash/get';
+import cloneDeep from 'lodash/cloneDeep';
 import each from 'lodash/each';
+import filter from 'lodash/filter';
 import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import isString from 'lodash/isString';
 import map from 'lodash/map';
-import filter from 'lodash/filter';
 import sortBy from 'lodash/sortBy';
-import isEqual from 'lodash/isEqual';
-import cloneDeep from 'lodash/cloneDeep';
-import { uuid } from 'utils/common';
 import path from 'path';
+import { uuid } from 'utils/common';
 
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
   if (!str || !str.length || !isString(str)) {
@@ -302,6 +302,7 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
                 password: get(si.draft.request, 'auth.basic.password', '')
               },
               bearer: {
+                preifx: get(si.draft.request, 'auth.bearer.prefix', ''),
                 token: get(si.draft.request, 'auth.bearer.token', '')
               }
             },
@@ -335,6 +336,7 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
                 password: get(si.request, 'auth.basic.password', '')
               },
               bearer: {
+                prefix: get(si.request, 'auth.bearer.prefix', ''),
                 token: get(si.request, 'auth.bearer.token', '')
               }
             },

--- a/packages/bruno-app/src/utils/exporters/postman-collection.js
+++ b/packages/bruno-app/src/utils/exporters/postman-collection.js
@@ -1,5 +1,5 @@
-import map from 'lodash/map';
 import * as FileSaver from 'file-saver';
+import map from 'lodash/map';
 import { deleteSecretsInEnvs, deleteUidsInEnvs, deleteUidsInItems } from 'utils/collections/export';
 
 export const exportCollection = (collection) => {
@@ -145,11 +145,18 @@ export const exportCollection = (collection) => {
       case 'bearer':
         return {
           type: 'bearer',
-          bearer: {
-            key: 'token',
-            value: itemAuth.bearer.token,
-            type: 'string'
-          }
+          bearer: [
+            {
+              key: 'prefix',
+              value: itemAuth.bearer.prefix,
+              type: 'string'
+            },
+            {
+              key: 'token',
+              value: itemAuth.bearer.token,
+              type: 'string'
+            }
+          ]
         };
       case 'basic': {
         return {

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -62,7 +62,10 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         };
         break;
       case 'bearer':
-        axiosRequest.headers['Authorization'] = `Bearer ${get(collectionAuth, 'bearer.token')}`;
+        axiosRequest.headers['Authorization'] = `${get(collectionAuth, 'bearer.prefix')} ${get(
+          collectionAuth,
+          'bearer.token'
+        )}`;
         break;
       case 'digest':
         axiosRequest.digestConfig = {
@@ -92,7 +95,10 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         };
         break;
       case 'bearer':
-        axiosRequest.headers['Authorization'] = `Bearer ${get(request, 'auth.bearer.token')}`;
+        axiosRequest.headers['Authorization'] = `${get(request, 'auth.bearer.prefix')} ${get(
+          request,
+          'auth.bearer.token'
+        )}`;
         break;
       case 'digest':
         axiosRequest.digestConfig = {

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -374,11 +374,14 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   authbearer(_1, dictionary) {
     const auth = mapPairListToKeyValPairs(dictionary.ast, false);
     const tokenKey = _.find(auth, { name: 'token' });
+    const prefixKey = _.find(auth, { name: 'prefix' });
     const token = tokenKey ? tokenKey.value : '';
+    const prefix = prefixKey ? prefixKey.value : '';
     return {
       auth: {
         bearer: {
-          token
+          token,
+          prefix
         }
       }
     };

--- a/packages/bruno-lang/v2/src/collectionBruToJson.js
+++ b/packages/bruno-lang/v2/src/collectionBruToJson.js
@@ -219,11 +219,14 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   authbearer(_1, dictionary) {
     const auth = mapPairListToKeyValPairs(dictionary.ast, false);
     const tokenKey = _.find(auth, { name: 'token' });
+    const prefixKey = _.find(auth, { name: 'prefix' });
     const token = tokenKey ? tokenKey.value : '';
+    const prefix = prefixKey ? prefixKey.value : '';
     return {
       auth: {
         bearer: {
-          token
+          token,
+          prefix
         }
       }
     };

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -128,6 +128,7 @@ ${indentString(`password: ${auth?.basic?.password || ''}`)}
 
   if (auth && auth.bearer) {
     bru += `auth:bearer {
+${indentString(`prefix: ${auth?.bearer?.prefix || ''}`)}
 ${indentString(`token: ${auth?.bearer?.token || ''}`)}
 }
 

--- a/packages/bruno-lang/v2/src/jsonToCollectionBru.js
+++ b/packages/bruno-lang/v2/src/jsonToCollectionBru.js
@@ -99,6 +99,7 @@ ${indentString(`password: ${auth.basic.password}`)}
 
   if (auth && auth.bearer) {
     bru += `auth:bearer {
+${indentString(`prefix: ${auth.bearer.prefix}`)}
 ${indentString(`token: ${auth.bearer.token}`)}
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/collection.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/collection.bru
@@ -18,6 +18,7 @@ auth:basic {
 }
 
 auth:bearer {
+  prefix: Token
   token: 123
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/collection.json
+++ b/packages/bruno-lang/v2/tests/fixtures/collection.json
@@ -26,6 +26,7 @@
       "password": "secret"
     },
     "bearer": {
+      "prefix": "Token",
       "token": "123"
     },
     "digest": {

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -37,6 +37,7 @@ auth:basic {
 }
 
 auth:bearer {
+  prefix: Token
   token: 123
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/request.json
+++ b/packages/bruno-lang/v2/tests/fixtures/request.json
@@ -58,6 +58,7 @@
       "password": "secret"
     },
     "bearer": {
+      "prefix": "Token",
       "token": "123"
     },
     "digest": {

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -107,6 +107,7 @@ const authBasicSchema = Yup.object({
   .strict();
 
 const authBearerSchema = Yup.object({
+  prefix: Yup.string().nullable(),
   token: Yup.string().nullable()
 })
   .noUnknown(true)


### PR DESCRIPTION
# Description

When using Bearer authentication, some services uses custom prefix to the token. This change allow the user to define a custom prefix at the collection and the request level.

This resolve https://github.com/usebruno/bruno/issues/1946

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
