### PR TITLE
bru run: allow running from anywhere

### DIFF
--- a/packages/bruno-cli/tests/commands/run.spec.js
+++ b/packages/bruno-cli/tests/commands/run.spec.js
@@ -1,6 +1,8 @@
 const { describe, it, expect } = require('@jest/globals');
 
-const { printRunSummary } = require('../../src/commands/run');
+const { findCollectionPath, printRunSummary } = require('../../src/commands/run');
+
+const fs = require('fs');
 
 describe('printRunSummary', () => {
   // Suppress console.log output
@@ -63,5 +65,23 @@ describe('printRunSummary', () => {
     expect(summary.totalTests).toBe(5);
     expect(summary.passedTests).toBe(3);
     expect(summary.failedTests).toBe(2);
+  });
+});
+
+describe('findCollectionPath', () => {
+  jest.spyOn(process, 'cwd').mockImplementation(() => '/home/bruno/collections/foobar');
+  jest.spyOn(fs, 'existsSync').mockImplementation((file) => {
+    return file === '/home/bruno/collections/bruno.json';
+  });
+
+  it('should find the collectionsPath given a subPath of it', () => {
+    const collectionPath = findCollectionPath('/home/bruno/collections/foobar');
+
+    expect(collectionPath).toBe('/home/bruno/collections');
+  });
+  it('should find the collectionsPath given it is running inside it', () => {
+    const collectionPath = findCollectionPath();
+
+    expect(collectionPath).toBe('/home/bruno/collections');
   });
 });


### PR DESCRIPTION
# Description

Implement a todo for running anywhere ~~inside the collection~~.

Walks back up from `filename` arg to find the bruno.json to determine collection root.

If `filename` _is_ the collection root, run recursively; like you would for not specifying filename.

Thanks for your time! 🙏🚀

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
