### PR TITLE
feat(#2187): Add Headers and Response to JUnit Reports

### DIFF
--- a/packages/bruno-cli/src/reporters/junit.js
+++ b/packages/bruno-cli/src/reporters/junit.js
@@ -23,8 +23,31 @@ const makeJUnitOutput = async (results, outputPath) => {
       '@timestamp': new Date().toISOString().split('Z')[0],
       '@hostname': os.hostname(),
       '@time': result.runtime.toFixed(3),
+      'system-out': { '#cdata': `> ${result.request.method} ${result.request.url}\n` },
       testcase: []
     };
+
+    if (result.request.headers) {
+      Object.entries(result.request.headers).forEach((header) => {
+        suite['system-out']['#cdata'] += `> ${header[0]}: ${header[1]}\n`;
+      });
+    }
+    suite['system-out']['#cdata'] += '>\n';
+
+    if (result.response && result.response.status) {
+      suite['system-out']['#cdata'] += `< ${result.response.status} ${result.response.statusText}\n`;
+      if (result.response.headers) {
+        Object.entries(result.response.headers).forEach((header) => {
+          suite['system-out']['#cdata'] += `< ${header[0]}: ${header[1]}\n`;
+        });
+      }
+      suite['system-out']['#cdata'] += '<\n';
+
+      if (result.response.data) {
+        suite['system-out']['#cdata'] +=
+          typeof result.response.data === 'string' ? result.response.data : JSON.stringify(result.response.data);
+      }
+    }
 
     result.assertionResults &&
       result.assertionResults.forEach((assertion) => {
@@ -79,7 +102,7 @@ const makeJUnitOutput = async (results, outputPath) => {
     output.testsuites.testsuite.push(suite);
   });
 
-  fs.writeFileSync(outputPath, xmlbuilder.create(output).end({ pretty: true }));
+  fs.writeFileSync(outputPath, xmlbuilder.create(output, { invalidCharReplacement: ' ' }).end({ pretty: true }));
 };
 
 module.exports = makeJUnitOutput;

--- a/packages/bruno-cli/tests/reporters/junit.spec.js
+++ b/packages/bruno-cli/tests/reporters/junit.spec.js
@@ -25,7 +25,18 @@ describe('makeJUnitOutput', () => {
         suitename: 'Tests/Suite A',
         request: {
           method: 'GET',
-          url: 'https://ima.test'
+          url: 'https://ima.test',
+          headers: {
+            Authorization: 'Bearer your_secret_token'
+          }
+        },
+        response: {
+          status: 200,
+          statusText: 'OK',
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8'
+          },
+          data: 'I am the response content'
         },
         assertionResults: [
           {
@@ -73,6 +84,15 @@ describe('makeJUnitOutput', () => {
 
     expect(junit.testsuites).toBeDefined;
     expect(junit.testsuites.testsuite.length).toBe(2);
+    expect(junit.testsuites.testsuite[0]['system-out']['#cdata']).toContain('> GET https://ima.test');
+    expect(junit.testsuites.testsuite[0]['system-out']['#cdata']).toContain(
+      '> Authorization: Bearer your_secret_token'
+    );
+    expect(junit.testsuites.testsuite[0]['system-out']['#cdata']).toContain('< 200 OK');
+    expect(junit.testsuites.testsuite[0]['system-out']['#cdata']).toContain(
+      '< Content-Type: text/plain; charset=utf-8'
+    );
+    expect(junit.testsuites.testsuite[0]['system-out']['#cdata']).toContain('I am the response content');
     expect(junit.testsuites.testsuite[0].testcase.length).toBe(2);
     expect(junit.testsuites.testsuite[1].testcase.length).toBe(2);
 


### PR DESCRIPTION
# Description

Resolves https://github.com/usebruno/bruno/issues/2187.

Adds Request and Response Headers and Response Data to JUnit Reports, so they can be viewed using tools like IntelliJs Test Output Panel.

![image](https://github.com/usebruno/bruno/assets/12899553/a05441fa-5584-4752-a50b-744efcfb79ab) 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
