### PR TITLE
feat: Add variables auto completion

### DIFF
--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -80,14 +80,12 @@ class SingleLineEditor extends Component {
         'Shift-Tab': false
       }
     });
-    if (this.props.autocomplete) {
-      this.editor.on('keyup', (cm, event) => {
-        if (!cm.state.completionActive /*Enables keyboard navigation in autocomplete list*/ && event.keyCode != 13) {
-          /*Enter - do not open autocomplete list just after item has been selected in it*/
-          CodeMirror.commands.autocomplete(cm, CodeMirror.hint.anyword, { autocomplete: this.props.autocomplete });
-        }
-      });
-    }
+    this.editor.on('keyup', (cm, event) => {
+      if (!cm.state.completionActive /*Enables keyboard navigation in autocomplete list*/ && event.keyCode != 13) {
+        /*Enter - do not open autocomplete list just after item has been selected in it*/
+        CodeMirror.commands.autocomplete(cm, CodeMirror.hint.anyword, { autocomplete: this.props.autocomplete });
+      }
+    });
     this.editor.setValue(String(this.props.value) || '');
     this.editor.on('change', this._onEdit);
     this.addOverlay();

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -13,6 +13,27 @@ const { get } = require('lodash');
 if (!SERVER_RENDERED) {
   CodeMirror = require('codemirror');
 
+  const formatHints = (hints = {}) => {
+    const render = (element, self, data) => {
+      let text = data.text;
+      if (typeof hints[text] !== 'object' && hints[text]) {
+        text = text + `: <i>${hints[text]}</i>`;
+      }
+      element.innerHTML = text;
+      return element;
+    };
+    try {
+      const keys = Object.keys(hints);
+
+      return keys.map((key) => ({
+        text: key,
+        render
+      }));
+    } catch {
+      return [];
+    }
+  };
+
   const renderVarInfo = (token, options, cm, pos) => {
     const str = token.string || '';
     if (!str || !str.length || typeof str !== 'string') {

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -628,15 +628,14 @@ export const getTotalRequestCountInCollection = (collection) => {
 
 export const getAllVariables = (collection) => {
   const environmentVariables = getEnvironmentVariables(collection);
+  const processEnvVariables = Object.keys(collection.processEnvVariables ?? {}).length
+    ? { process: { env: { ...collection.processEnvVariables } } }
+    : {};
 
   return {
     ...environmentVariables,
     ...collection.collectionVariables,
-    process: {
-      env: {
-        ...collection.processEnvVariables
-      }
-    }
+    ...processEnvVariables
   };
 };
 


### PR DESCRIPTION
# Description
Add autocomplete for environment variables. 

https://github.com/usebruno/bruno/assets/134304/701515eb-9e95-4571-89f5-ef71ec33eb5f

The trigger is `{{` that shows all available environment variables. Supports all fields that have collection passed to it, i.e auth, headers etc. 
Might need sanity check for all the places where it's currently applied. 
Fixes #1141, #606, #412.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
