### PR TITLE
fix: handling invalid import environment names (#2197)

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/ImportEnvironment/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/ImportEnvironment/index.js
@@ -7,6 +7,14 @@ import { importEnvironment } from 'providers/ReduxStore/slices/collections/actio
 import { toastError } from 'utils/common/error';
 import Modal from 'components/Modal';
 
+const getErrorMessage = (err) => {
+  if (err.message.endsWith('environment: contains invalid characters')) {
+    return 'The environment name contains one or more illegal characters (<, >, :, ", /, \\, |, ?, *).';
+  }
+
+  return 'An error occurred while importing the environment';
+};
+
 const ImportEnvironment = ({ onClose, collection }) => {
   const dispatch = useDispatch();
 
@@ -18,7 +26,7 @@ const ImportEnvironment = ({ onClose, collection }) => {
             toast.success('Environment imported successfully');
             onClose();
           })
-          .catch(() => toast.error('An error occurred while importing the environment'));
+          .catch((err) => toast.error(getErrorMessage(err)));
       })
       .catch((err) => toastError(err, 'Postman Import environment failed'));
   };

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -16,7 +16,13 @@ const {
   sanitizeDirectoryName
 } = require('../utils/filesystem');
 const { openCollectionDialog } = require('../app/collections');
-const { generateUidBasedOnHash, stringifyJson, safeParseJSON, safeStringifyJSON } = require('../utils/common');
+const {
+  generateUidBasedOnHash,
+  stringifyJson,
+  safeParseJSON,
+  safeStringifyJSON,
+  isInvalidFilename
+} = require('../utils/common');
 const { moveRequestUid, deleteRequestUid } = require('../cache/requestUids');
 const { deleteCookiesForDomain, getDomainsWithCookies } = require('../utils/cookies');
 const EnvironmentSecretsStore = require('../store/env-secrets');
@@ -216,6 +222,10 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       const envDirPath = path.join(collectionPathname, 'environments');
       if (!fs.existsSync(envDirPath)) {
         await createDirectory(envDirPath);
+      }
+
+      if (isInvalidFilename(name)) {
+        throw new Error(`environment: contains invalid characters`);
       }
 
       const envFilePath = path.join(envDirPath, `${name}.bru`);

--- a/packages/bruno-electron/src/utils/common.js
+++ b/packages/bruno-electron/src/utils/common.js
@@ -1,4 +1,5 @@
 const { customAlphabet } = require('nanoid');
+const { unsafePathCharacters } = require('./regex');
 
 // a customized version of nanoid without using _ and -
 const uuid = () => {
@@ -85,6 +86,10 @@ const flattenDataForDotNotation = (data) => {
   return result;
 };
 
+const isInvalidFilename = (filename) => {
+  return filename && unsafePathCharacters.test(filename);
+};
+
 module.exports = {
   uuid,
   stringifyJson,
@@ -93,5 +98,6 @@ module.exports = {
   safeParseJSON,
   simpleHash,
   generateUidBasedOnHash,
-  flattenDataForDotNotation
+  flattenDataForDotNotation,
+  isInvalidFilename
 };

--- a/packages/bruno-electron/src/utils/regex.js
+++ b/packages/bruno-electron/src/utils/regex.js
@@ -1,0 +1,5 @@
+const unsafePathCharacters = /[<>:"/\\|?* ]+/;
+
+module.exports = {
+  unsafePathCharacters
+};

--- a/packages/bruno-electron/src/utils/regex.js
+++ b/packages/bruno-electron/src/utils/regex.js
@@ -1,4 +1,4 @@
-const unsafePathCharacters = /[<>:"/\\|?* ]+/;
+const unsafePathCharacters = /[<>:"/\\|?*]+/;
 
 module.exports = {
   unsafePathCharacters

--- a/packages/bruno-electron/tests/utils/common.spec.js
+++ b/packages/bruno-electron/tests/utils/common.spec.js
@@ -16,7 +16,6 @@ describe('utils: flattenDataForDotNotation', () => {
 
     expect(flattenDataForDotNotation(input)).toEqual(expectedOutput);
   });
-
   test('Flatten an object with nested arrays', () => {
     const input = {
       users: [

--- a/packages/bruno-electron/tests/utils/common.spec.js
+++ b/packages/bruno-electron/tests/utils/common.spec.js
@@ -1,17 +1,17 @@
-const { flattenDataForDotNotation } = require('../../src/utils/common');
+const { flattenDataForDotNotation, isInvalidFilename } = require('../../src/utils/common');
 
 describe('utils: flattenDataForDotNotation', () => {
   test('Flatten a simple object with dot notation', () => {
     const input = {
       person: {
         name: 'John',
-        age: 30,
-      },
+        age: 30
+      }
     };
 
     const expectedOutput = {
       'person.name': 'John',
-      'person.age': 30,
+      'person.age': 30
     };
 
     expect(flattenDataForDotNotation(input)).toEqual(expectedOutput);
@@ -21,65 +21,144 @@ describe('utils: flattenDataForDotNotation', () => {
     const input = {
       users: [
         { name: 'Alice', age: 25 },
-        { name: 'Bob', age: 28 },
-      ],
+        { name: 'Bob', age: 28 }
+      ]
     };
-  
+
     const expectedOutput = {
       'users[0].name': 'Alice',
       'users[0].age': 25,
       'users[1].name': 'Bob',
-      'users[1].age': 28,
+      'users[1].age': 28
     };
-  
+
     expect(flattenDataForDotNotation(input)).toEqual(expectedOutput);
   });
-  
+
   test('Flatten an empty object', () => {
     const input = {};
-  
+
     const expectedOutput = {};
-  
+
     expect(flattenDataForDotNotation(input)).toEqual(expectedOutput);
   });
-  
+
   test('Flatten an object with nested objects', () => {
     const input = {
       person: {
         name: 'Alice',
         address: {
           city: 'New York',
-          zipcode: '10001',
-        },
-      },
+          zipcode: '10001'
+        }
+      }
     };
-  
+
     const expectedOutput = {
       'person.name': 'Alice',
       'person.address.city': 'New York',
-      'person.address.zipcode': '10001',
+      'person.address.zipcode': '10001'
     };
-  
+
     expect(flattenDataForDotNotation(input)).toEqual(expectedOutput);
   });
-  
+
   test('Flatten an object with arrays of objects', () => {
     const input = {
       teams: [
         { name: 'Team A', members: ['Alice', 'Bob'] },
-        { name: 'Team B', members: ['Charlie', 'David'] },
-      ],
+        { name: 'Team B', members: ['Charlie', 'David'] }
+      ]
     };
-  
+
     const expectedOutput = {
       'teams[0].name': 'Team A',
       'teams[0].members[0]': 'Alice',
       'teams[0].members[1]': 'Bob',
       'teams[1].name': 'Team B',
       'teams[1].members[0]': 'Charlie',
-      'teams[1].members[1]': 'David',
+      'teams[1].members[1]': 'David'
     };
-  
+
     expect(flattenDataForDotNotation(input)).toEqual(expectedOutput);
+  });
+});
+
+describe('utils: isInvalidFilename', () => {
+  test('Handle valid filename', () => {
+    const input = 'valid-filename';
+    const expectedOutput = false;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with smaller than symbol', () => {
+    const input = 'invalid<filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with greater than symbol', () => {
+    const input = 'invalid>filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with colon symbol', () => {
+    const input = 'invalid:filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with double quote symbol', () => {
+    const input = 'invalid"filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with forward slash symbol', () => {
+    const input = 'invalid/filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with backslash symbol', () => {
+    const input = 'invalid\\filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with pipe symbol', () => {
+    const input = 'invalid|filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with question mark symbol', () => {
+    const input = 'invalid?filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with asterisk symbol', () => {
+    const input = 'invalid*filename';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
+  });
+
+  test('Handle invalid filename with multiple invalid characters', () => {
+    const input = 'invalid<filename/with:invalid"characters\\|?*';
+    const expectedOutput = true;
+
+    expect(isInvalidFilename(input)).toEqual(expectedOutput);
   });
 });


### PR DESCRIPTION
# Description

Resolves: #2197 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
This PR effectively addresses the issue I raised (#2197). To ensure no clashes and unexpected behaviours, I've implemented a solution that displays a descriptive error instead of automatically resolving issues (unlike in the case of collections). This prevents multiple environments from having the same name, e.g. `My / Environment / Name` and `My : Environment : Name` would be translated into the same `My - Environment - Name` if the same strategy (as for collections) was used.

If the Postman collection contains any of the following: `<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, `*`, the import will fail with the following message: `The environment name contains one or more illegal characters (<, >, :, ", /, \, |, ?, *).`

**Problematic payload:**
![image](https://github.com/usebruno/bruno/assets/85931511/1d069f22-0ce4-4d13-9c59-fb5c603512f1)

**Old behaviour**
![image](https://github.com/usebruno/bruno/assets/85931511/fecb4d19-48f7-4c1a-94b3-507696bc4675)

**New behaviour**
![image](https://github.com/usebruno/bruno/assets/85931511/2eeb6a2b-f594-4a5c-b928-543addfc5ea8)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
