### PR TITLE
bugfix: Double-{} wrapped VARS no longer resolved in scripts (#2134)

### DIFF
--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -27,6 +27,17 @@ class Bru {
     });
   };
 
+  _interpolateVar = (str) => {
+    if (!str || !str.length || typeof str !== 'string') {
+      return str;
+    }
+
+    const template = Handlebars.compile(str, { noEscape: true });
+    const result = template({ ...this.envVariables });
+
+    return this._interpolateEnvVar(result);
+  };
+
   cwd() {
     return this.collectionPath;
   }
@@ -74,7 +85,7 @@ class Bru {
       );
     }
 
-    return this.collectionVariables[key];
+    return this._interpolateVar(this.collectionVariables[key]);
   }
 
   setNextRequest(nextRequest) {

--- a/packages/bruno-tests/collection/environments/Local.bru
+++ b/packages/bruno-tests/collection/environments/Local.bru
@@ -14,6 +14,7 @@ vars {
   google_auth_url: https://accounts.google.com/o/oauth2/auth
   google_access_token_url: https://accounts.google.com/o/oauth2/token
   google_scope: https://www.googleapis.com/auth/userinfo.email
+  bark: {{process.env.PROC_ENV_VAR}}
 }
 vars:secret [
   github_client_secret,

--- a/packages/bruno-tests/collection/ping.bru
+++ b/packages/bruno-tests/collection/ping.bru
@@ -22,6 +22,8 @@ auth:awsv4 {
 vars:pre-request {
   m4: true
   pong: pong
+  dog: {{bark}}
+  secret: {{bearer_auth_token}}
 }
 
 assert {
@@ -34,6 +36,16 @@ tests {
   test("should ping pong", function() {
     const data = res.getBody();
     expect(data).to.equal(bru.getVar("pong"));
+  });
+  
+  test("dog should bark", function() {
+    const data = res.getBody();
+    expect(bru.getVar("dog")).to.equal("woof");
+  });
+  
+  test("secret var should interpolate", function() {
+    const data = res.getBody();
+    expect(bru.getVar("secret")).to.equal("your_secret_token");
   });
 }
 


### PR DESCRIPTION
Fixes: #2134 

# Description

Environment variables are now replaced properly in vars, for example with variables:

- my_env_var=123456
- my_var={{my_env_var}}

**BEFORE**: console.log( bru.getVar("my_var") ) result was {{my_env_var}}
**NOW**: console.log( bru.getVar("my_var") ) result is 123456

https://github.com/usebruno/bruno/assets/139650490/33fe68d1-9a4f-4953-8072-42328d4421e8


### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
