### PR TITLE
Fixes large numbers parsed incorrectly when using JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "packages/bruno-graphql-docs"
       ],
       "dependencies": {
-        "json-bigint": "^1.0.0",
         "lossless-json": "^4.0.1"
       },
       "devDependencies": {
@@ -6144,14 +6143,6 @@
         "node": "*"
       }
     },
-    "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "license": "MIT",
@@ -12015,14 +12006,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -18702,7 +18685,6 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
         "inquirer": "^9.1.4",
-        "json-bigint": "^1.0.0",
         "lodash": "^4.17.21",
         "mustache": "^4.2.0",
         "qs": "^6.11.0",
@@ -19755,7 +19737,6 @@
         "https-proxy-agent": "^7.0.2",
         "is-valid-path": "^0.1.1",
         "js-yaml": "^4.1.0",
-        "json-bigint": "^1.0.0",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.35",
         "mustache": "^4.2.0",
@@ -24338,7 +24319,6 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
         "inquirer": "^9.1.4",
-        "json-bigint": "^1.0.0",
         "lodash": "^4.17.21",
         "mustache": "^4.2.0",
         "qs": "^6.11.0",
@@ -25964,11 +25944,6 @@
       "version": "5.2.2",
       "dev": true
     },
-    "bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
-    },
     "binary-extensions": {
       "version": "2.2.0"
     },
@@ -26164,7 +26139,6 @@
         "https-proxy-agent": "^7.0.2",
         "is-valid-path": "^0.1.1",
         "js-yaml": "^4.1.0",
-        "json-bigint": "^1.0.0",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.35",
         "mustache": "^4.2.0",
@@ -30546,14 +30520,6 @@
         "strip-json-comments": {
           "version": "1.0.4"
         }
-      }
-    },
-    "json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0"
       }
     },
     "json-buffer": {

--- a/package.json
+++ b/package.json
@@ -47,12 +47,10 @@
     "test:prettier:web": "npm run test:prettier --workspace=packages/bruno-app",
     "prepare": "husky install"
   },
-  
   "overrides": {
     "rollup": "3.2.5"
   },
   "dependencies": {
-    "json-bigint": "^1.0.0",
     "lossless-json": "^4.0.1"
   }
 }

--- a/packages/bruno-cli/package.json
+++ b/packages/bruno-cli/package.json
@@ -38,7 +38,6 @@
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.2",
     "inquirer": "^9.1.4",
-    "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",
     "mustache": "^4.2.0",
     "qs": "^6.11.0",

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -1,6 +1,5 @@
 const { get, each, filter } = require('lodash');
 const fs = require('fs');
-var JSONbig = require('json-bigint');
 const decomment = require('decomment');
 
 const prepareRequest = (request, collectionRoot) => {
@@ -76,11 +75,7 @@ const prepareRequest = (request, collectionRoot) => {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/json';
     }
-    try {
-      axiosRequest.data = JSONbig.parse(decomment(request.body.json));
-    } catch (ex) {
-      axiosRequest.data = request.body.json;
-    }
+    axiosRequest.data = decomment(request.body.json);
   }
 
   if (request.body.mode === 'text') {

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -43,7 +43,6 @@
     "https-proxy-agent": "^7.0.2",
     "is-valid-path": "^0.1.1",
     "js-yaml": "^4.1.0",
-    "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",
     "mime-types": "^2.1.35",
     "mustache": "^4.2.0",

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -1,6 +1,5 @@
 const { get, each, filter, extend } = require('lodash');
 const decomment = require('decomment');
-var JSONbig = require('json-bigint');
 const FormData = require('form-data');
 const fs = require('fs');
 const path = require('path');
@@ -170,11 +169,7 @@ const prepareRequest = (request, collectionRoot, collectionPath) => {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/json';
     }
-    try {
-      axiosRequest.data = JSONbig.parse(decomment(request.body.json));
-    } catch (ex) {
-      axiosRequest.data = request.body.json;
-    }
+    axiosRequest.data = decomment(request.body.json);
   }
 
   if (request.body.mode === 'text') {


### PR DESCRIPTION
# Description

The json-bigint was being used to parse the request body when JSON was used, but the library would convert large numbers to strings, and even larger numbers to strings in scientific notation.

This PR removes the json-bigint library, and always sends the user's json body without parsing through `JSON` or `JSONbig` (but it still passes through `decomment()`). This fixes #2202 and #2207 

Old:
![image](https://github.com/usebruno/bruno/assets/46795706/9edae5b0-f975-4f61-ae31-2707debfb127)

New: 
![image](https://github.com/usebruno/bruno/assets/46795706/66f8880f-6d5e-414b-bb1f-9ec9e45b5bed)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
