### PR TITLE
feat: persist last opened env per collection

### DIFF
--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -83,9 +83,12 @@ const useIpcEvents = () => {
 
     const removeCollectionTreeUpdateListener = ipcRenderer.on('main:collection-tree-updated', _collectionTreeUpdated);
 
-    const removeOpenCollectionListener = ipcRenderer.on('main:collection-opened', (pathname, uid, brunoConfig) => {
-      dispatch(openCollectionEvent(uid, pathname, brunoConfig));
-    });
+    const removeOpenCollectionListener = ipcRenderer.on(
+      'main:collection-opened',
+      (pathname, uid, brunoConfig, environmentUid) => {
+        dispatch(openCollectionEvent(uid, pathname, brunoConfig, environmentUid));
+      }
+    );
 
     const removeCollectionAlreadyOpenedListener = ipcRenderer.on('main:collection-already-opened', (pathname) => {
       toast.success('Collection is already opened');

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -927,7 +927,8 @@ export const selectEnvironment = (environmentUid, collectionUid) => (dispatch, g
     }
 
     dispatch(_selectEnvironment({ environmentUid, collectionUid }));
-    resolve();
+
+    ipcRenderer.invoke('renderer:select-environment', collectionUid, environmentUid).then(resolve).catch(reject);
   });
 };
 
@@ -991,12 +992,13 @@ export const updateBrunoConfig = (brunoConfig, collectionUid) => (dispatch, getS
   });
 };
 
-export const openCollectionEvent = (uid, pathname, brunoConfig) => (dispatch, getState) => {
+export const openCollectionEvent = (uid, pathname, brunoConfig, environmentUid) => (dispatch, getState) => {
   const collection = {
     version: '1',
     uid: uid,
     name: brunoConfig.name,
     pathname: pathname,
+    activeEnvironmentUid: environmentUid,
     items: [],
     collectionVariables: {},
     brunoConfig: brunoConfig

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -4,6 +4,7 @@ const { dialog, ipcMain } = require('electron');
 const Yup = require('yup');
 const { isDirectory, normalizeAndResolvePath } = require('../utils/filesystem');
 const { generateUidBasedOnHash } = require('../utils/common');
+const { getLastOpenedEnvironment } = require('../store/last-opened-environment');
 
 // todo: bruno.json config schema validation errors must be propagated to the UI
 const configSchema = Yup.object({
@@ -70,8 +71,9 @@ const openCollection = async (win, watcher, collectionPath, options = {}) => {
         brunoConfig.ignore = ['node_modules', '.git'];
       }
 
-      win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig);
-      ipcMain.emit('main:collection-opened', win, collectionPath, uid, brunoConfig);
+      const lastOpenedEnvironmentUid = getLastOpenedEnvironment(uid);
+      win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig, lastOpenedEnvironmentUid);
+      ipcMain.emit('main:collection-opened', win, collectionPath, uid, brunoConfig, lastOpenedEnvironmentUid);
     } catch (err) {
       if (!options.dontSendDisplayErrors) {
         win.webContents.send('main:display-error', {

--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -6,7 +6,7 @@ const { hasBruExtension } = require('../utils/filesystem');
 const { bruToEnvJson, bruToJson, collectionBruToJson } = require('../bru');
 const { dotenvToJson } = require('@usebruno/lang');
 
-const { uuid } = require('../utils/common');
+const { uuid, generateUidBasedOnHash } = require('../utils/common');
 const { getRequestUid } = require('../cache/requestUids');
 const { decryptString } = require('../utils/encryption');
 const { setDotEnvVars } = require('../store/process-env');
@@ -101,7 +101,7 @@ const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) 
 
     file.data = bruToEnvJson(bruContent);
     file.data.name = basename.substring(0, basename.length - 4);
-    file.data.uid = getRequestUid(pathname);
+    file.data.uid = generateUidBasedOnHash(pathname);
 
     _.each(_.get(file, 'data.variables', []), (variable) => (variable.uid = uuid()));
 
@@ -136,7 +136,7 @@ const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPat
     const bruContent = fs.readFileSync(pathname, 'utf8');
     file.data = bruToEnvJson(bruContent);
     file.data.name = basename.substring(0, basename.length - 4);
-    file.data.uid = getRequestUid(pathname);
+    file.data.uid = generateUidBasedOnHash(pathname);
     _.each(_.get(file, 'data.variables', []), (variable) => (variable.uid = uuid()));
 
     // hydrate environment variables with secrets
@@ -168,7 +168,7 @@ const unlinkEnvironmentFile = async (win, pathname, collectionUid) => {
         name: path.basename(pathname)
       },
       data: {
-        uid: getRequestUid(pathname),
+        uid: generateUidBasedOnHash(pathname),
         name: path.basename(pathname).substring(0, path.basename(pathname).length - 4)
       }
     };

--- a/packages/bruno-electron/src/store/last-opened-environment.js
+++ b/packages/bruno-electron/src/store/last-opened-environment.js
@@ -1,0 +1,67 @@
+const Yup = require('yup');
+const Store = require('electron-store');
+
+const lastOpenedEnvironmentSchema = Yup.object().shape({
+  environmentUid: Yup.string().nullable(),
+  collectionUid: Yup.string()
+});
+
+class LastOpenedEnvironmentsStore {
+  constructor() {
+    this.store = new Store({
+      name: 'preferences',
+      clearInvalidConfig: true
+    });
+  }
+
+  get() {
+    return this.store.get('lastOpenedEnvironments') || {};
+  }
+
+  add({ environmentUid, collectionUid }) {
+    const lastOpenedEnvironments = this.get();
+
+    lastOpenedEnvironments[collectionUid] = environmentUid;
+
+    this.store.set('lastOpenedEnvironments', lastOpenedEnvironments);
+  }
+
+  remove(collectionUid) {
+    const lastOpenedEnvironments = this.get();
+
+    delete lastOpenedEnvironments[collectionUid];
+
+    this.store.set('lastOpenedEnvironments', lastOpenedEnvironments);
+  }
+}
+
+const lastOpenedEnvironmentsStore = new LastOpenedEnvironmentsStore();
+
+const getLastOpenedEnvironment = (collectionUid) => {
+  const lastOpenedEnvironments = lastOpenedEnvironmentsStore.get();
+  return lastOpenedEnvironments[collectionUid];
+};
+
+const removeLastOpenedEnvironment = (collectionUid) => {
+  lastOpenedEnvironmentsStore.remove(collectionUid);
+};
+
+const saveLastOpenedEnvironment = async (newLastOpenedEnvironment) => {
+  return new Promise((resolve, reject) => {
+    lastOpenedEnvironmentSchema
+      .validate(newLastOpenedEnvironment, { abortEarly: true })
+      .then((validatedLastOpenedEnvironment) => {
+        lastOpenedEnvironmentsStore.add(validatedLastOpenedEnvironment);
+        resolve();
+      })
+      .catch((error) => {
+        reject(error);
+      });
+  });
+};
+
+module.exports = {
+  getLastOpenedEnvironment,
+  removeLastOpenedEnvironment,
+  saveLastOpenedEnvironment
+};


### PR DESCRIPTION
fixes #112

# Description

This PR add the feature of save the last env that was opened for a collection.

![persist-last-env](https://github.com/usebruno/bruno/assets/36305985/16f72d59-f40b-46c2-ad2c-44dcb86d6754)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**