### PR TITLE
Fix: CLI Test Runner ignores auth:"inherit" in requests (#2206)

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -33,7 +33,7 @@ const prepareRequest = (request, collectionRoot) => {
   };
 
   const collectionAuth = get(collectionRoot, 'request.auth');
-  if (collectionAuth && request.auth.mode === 'none') {
+  if (collectionAuth && request.auth.mode === 'inherit') {
     if (collectionAuth.mode === 'basic') {
       axiosRequest.auth = {
         username: get(collectionAuth, 'basic.username'),


### PR DESCRIPTION
# Description

Fixes issue introduced in #1667 - None means None 

Now also inherit means inherit

fixes #2206 and unit tests

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
