### PR TITLE
Make pre-request scripts operate on completely prepared request

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -449,6 +449,16 @@ const registerNetworkIpc = (mainWindow) => {
       request.signal = controller.signal;
       saveCancelToken(cancelTokenUid, controller);
 
+      interpolateVars(request, envVars, collection.collectionVariables, processEnvVars);
+      const axiosInstance = await configureRequest(
+        collectionUid,
+        request,
+        envVars,
+        collectionVariables,
+        processEnvVars,
+        collectionPath
+      );
+
       await runPreRequest(
         request,
         requestUid,
@@ -459,15 +469,6 @@ const registerNetworkIpc = (mainWindow) => {
         collectionVariables,
         processEnvVars,
         scriptingConfig
-      );
-
-      const axiosInstance = await configureRequest(
-        collectionUid,
-        request,
-        envVars,
-        collectionVariables,
-        processEnvVars,
-        collectionPath
       );
 
       mainWindow.webContents.send('main:run-request-event', {
@@ -642,6 +643,16 @@ const registerNetworkIpc = (mainWindow) => {
       const brunoConfig = getBrunoConfig(collectionUid);
       const scriptingConfig = get(brunoConfig, 'scripts', {});
 
+      interpolateVars(request, envVars, collection.collectionVariables, processEnvVars);
+      const axiosInstance = await configureRequest(
+        collection.uid,
+        request,
+        envVars,
+        collection.collectionVariables,
+        processEnvVars,
+        collectionPath
+      );
+
       await runPreRequest(
         request,
         requestUid,
@@ -654,16 +665,6 @@ const registerNetworkIpc = (mainWindow) => {
         scriptingConfig
       );
 
-      interpolateVars(request, envVars, collection.collectionVariables, processEnvVars);
-      const axiosInstance = await configureRequest(
-        collection.uid,
-        request,
-        envVars,
-        collection.collectionVariables,
-        processEnvVars,
-        collectionPath
-      );
-
       try {
         response = await axiosInstance(request);
       } catch (error) {
@@ -673,9 +674,6 @@ const registerNetworkIpc = (mainWindow) => {
           return Promise.reject(error);
         }
       }
-
-      const { data } = parseDataFromResponse(response);
-      response.data = data;
 
       await runPostResponse(
         request,
@@ -747,6 +745,16 @@ const registerNetworkIpc = (mainWindow) => {
       const brunoConfig = getBrunoConfig(collection.uid);
       const scriptingConfig = get(brunoConfig, 'scripts', {});
 
+      interpolateVars(preparedRequest, envVars, collection.collectionVariables, processEnvVars);
+      const axiosInstance = await configureRequest(
+        collection.uid,
+        preparedRequest,
+        envVars,
+        collection.collectionVariables,
+        processEnvVars,
+        collectionPath
+      );
+
       await runPreRequest(
         request,
         requestUid,
@@ -759,15 +767,6 @@ const registerNetworkIpc = (mainWindow) => {
         scriptingConfig
       );
 
-      interpolateVars(preparedRequest, envVars, collection.collectionVariables, processEnvVars);
-      const axiosInstance = await configureRequest(
-        collection.uid,
-        preparedRequest,
-        envVars,
-        collection.collectionVariables,
-        processEnvVars,
-        collectionPath
-      );
       const response = await axiosInstance(preparedRequest);
 
       await runPostResponse(
@@ -882,6 +881,15 @@ const registerNetworkIpc = (mainWindow) => {
           const processEnvVars = getProcessEnvVars(collectionUid);
 
           try {
+            const axiosInstance = await configureRequest(
+              collectionUid,
+              request,
+              envVars,
+              collectionVariables,
+              processEnvVars,
+              collectionPath
+            );
+
             const preRequestScriptResult = await runPreRequest(
               request,
               requestUid,
@@ -913,14 +921,6 @@ const registerNetworkIpc = (mainWindow) => {
             });
 
             request.signal = abortController.signal;
-            const axiosInstance = await configureRequest(
-              collectionUid,
-              request,
-              envVars,
-              collectionVariables,
-              processEnvVars,
-              collectionPath
-            );
 
             timeStart = Date.now();
             let response, responseTime;


### PR DESCRIPTION
# Description

The pre-request script phase is now executed after configureRequest. That means the 'req' object in pre-request script has access to more data, including evaluated variables, set authorization headers, etc. 

fixes #2249

Makes sense especially if #2061 / #2077 are to be accepted, because this would allow to access OAuth2 credentials after they are obtained, but before sending actual user request.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
