### PR TITLE
Feat: OAuth2: Show details of both token request and user request in the Timeline

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Timeline/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/index.js
@@ -6,6 +6,13 @@ import StyledWrapper from './StyledWrapper';
 const Timeline = ({ request, response }) => {
   const requestHeaders = [];
   const responseHeaders = typeof response.headers === 'object' ? Object.entries(response.headers) : [];
+  const requestData = typeof request?.data === "string" ? request?.data : safeStringifyJSON(request?.data, true);
+
+  const authRequest = request.authRequest;
+  const authResponse = request.authResponse;
+  const authRequestHeaders = typeof authRequest?.headers === 'object' ? Object.entries(authRequest.headers) : [];
+  const authResponseHeaders = typeof authResponse?.headers === 'object' ? Object.entries(authResponse?.headers) : [];
+  const authRequestData = authRequest?.data === "string" ? authRequest?.data : safeStringifyJSON(authRequest?.data, true);
 
   request = request || {};
   response = response || {};
@@ -17,10 +24,45 @@ const Timeline = ({ request, response }) => {
     });
   });
 
-  let requestData = typeof request?.data === "string" ? request?.data : safeStringifyJSON(request?.data, true);
-
   return (
     <StyledWrapper className="pb-4 w-full">
+      {authRequest ? (
+        <>
+          <div>
+            <pre className="line request font-bold">
+              <span className="arrow">{'>'}</span> {authRequest.method} {authRequest.url}
+            </pre>
+            {authRequestHeaders.map((h) => {
+              return (
+                <pre className="line request" key={h[0]}>
+                  <span className="arrow">{'>'}</span> {h[0]}: {h[1]}
+                </pre>
+              );
+            })}
+            {authRequestData ? (
+              <pre className="line request">
+                <span className="arrow">{'>'}</span> data {authRequestData}
+              </pre>
+            ) : null}
+          </div>
+          {authResponse ? (
+            <div className="mt-4">
+              <pre className="line response font-bold">
+                <span className="arrow">{'<'}</span> {authResponse.status} {authResponse.statusText}
+              </pre>
+              {authResponseHeaders.map((h) => {
+                return (
+                  <pre className="line response" key={h[0]}>
+                    <span className="arrow">{'<'}</span> {h[0]}: {h[1]}
+                  </pre>
+                );
+              })}
+            </div>
+          ) : null}
+          <div className="mt-4" />
+        </>
+      ) : null}
+
       <div>
         <pre className="line request font-bold">
           <span className="arrow">{'>'}</span> {request.method} {request.url}

--- a/packages/bruno-electron/src/ipc/network/oauth2-helper.js
+++ b/packages/bruno-electron/src/ipc/network/oauth2-helper.js
@@ -35,7 +35,7 @@ const oauth2AuthorizeWithAuthorizationCode = async (request, collectionUid) => {
   const { cachedCredentials } = getPersistedOauth2Credentials(collectionUid);
   if (cachedCredentials?.access_token) {
     console.log('Reusing Stored access token');
-    return { credentials: cachedCredentials, response: {} };
+    return { credentials: cachedCredentials, authRequest: null, authResponse: null };
   }
 
   let codeVerifier = generateCodeVerifier();
@@ -62,10 +62,11 @@ const oauth2AuthorizeWithAuthorizationCode = async (request, collectionUid) => {
   request.url = request?.oauth2?.accessTokenUrl;
 
   const axiosInstance = makeAxiosInstance();
-  const response = await axiosInstance(request);
-  const credentials = JSON.parse(response.data);
+  const authResponse = await axiosInstance(request);
+  const credentials = JSON.parse(authResponse.data);
   persistOauth2Credentials(credentials, collectionUid);
-  return { credentials, response };
+
+  return { credentials, authRequest: request, authResponse };
 };
 
 const getOAuth2AuthorizationCode = (request, codeChallenge, collectionUid) => {
@@ -108,7 +109,7 @@ const oauth2AuthorizeWithClientCredentials = async (request, collectionUid) => {
   const { cachedCredentials } = getPersistedOauth2Credentials(collectionUid);
   if (cachedCredentials?.access_token) {
     console.log('Reusing Stored access token');
-    return { credentials: cachedCredentials, response: {} };
+    return { credentials: cachedCredentials, authRequest: null, authResponse: null };
   }
 
   let requestCopy = cloneDeep(request);
@@ -129,10 +130,10 @@ const oauth2AuthorizeWithClientCredentials = async (request, collectionUid) => {
   request.url = request?.oauth2?.accessTokenUrl;
 
   const axiosInstance = makeAxiosInstance();
-  let response = await axiosInstance(request);
-  let credentials = JSON.parse(response.data);
+  let authResponse = await axiosInstance(request);
+  let credentials = JSON.parse(authResponse.data);
   persistOauth2Credentials(credentials, collectionUid);
-  return { credentials, response };
+  return { credentials, authRequest: request, authResponse };
 };
 
 // PASSWORD CREDENTIALS
@@ -141,7 +142,7 @@ const oauth2AuthorizeWithPasswordCredentials = async (request, collectionUid) =>
   const { cachedCredentials } = getPersistedOauth2Credentials(collectionUid);
   if (cachedCredentials?.access_token) {
     console.log('Reusing Stored access token');
-    return { credentials: cachedCredentials, response: {} };
+    return { credentials: cachedCredentials, authRequest: null, authResponse: null };
   }
 
   const oAuth = get(request, 'oauth2', {});
@@ -163,10 +164,10 @@ const oauth2AuthorizeWithPasswordCredentials = async (request, collectionUid) =>
   request.url = request?.oauth2?.accessTokenUrl;
 
   const axiosInstance = makeAxiosInstance();
-  let response = await axiosInstance(request);
-  let credentials = JSON.parse(response.data);
+  let authResponse = await axiosInstance(request);
+  let credentials = JSON.parse(authResponse.data);
   persistOauth2Credentials(credentials, collectionUid);
-  return { credentials, response };
+  return { credentials, authRequest: request, authResponse };
 };
 module.exports = {
   oauth2AuthorizeWithAuthorizationCode,


### PR DESCRIPTION
# Description

This PR builds on top of both  #2077 and #2164 . It enhances the timeline to show the details of both OAuth2 token request and user defined request.
This is done because: 
- Since #2077 the token request is executed in the background, and perhaps skipped, if bruno has a token cached, so there is no feedback to the user about what requests are executed
- Since #2164 the token request works in two modes (credentials in basic auth header  or request body) - this is another variable that we want the user to have better visibility of

When token request is executed, both requests are logged:
![Screenshot from 2024-05-06 23-03-43](https://github.com/usebruno/bruno/assets/2108093/50463156-a3a3-4822-845e-0a1d20522479)

When using cached credentials (previously obtained access_token), only user request is shown:
![Screenshot from 2024-05-06 23-19-15](https://github.com/usebruno/bruno/assets/2108093/f6e16930-f29b-4209-aed8-9637def06770)

Also, fixes #1933

