### PR TITLE
bru electron: bump to version that supports node_extra_ca_certs

### DIFF
--- a/packages/bruno-electron/electron-builder-config.js
+++ b/packages/bruno-electron/electron-builder-config.js
@@ -3,7 +3,7 @@ require('dotenv').config({ path: process.env.DOTENV_PATH });
 const config = {
   appId: 'com.usebruno.app',
   productName: 'Bruno',
-  electronVersion: '21.1.1',
+  electronVersion: '30.0.2',
   directories: {
     buildResources: 'resources',
     output: 'out'


### PR DESCRIPTION
# Description

Closes #2257. As it turns out, Electron finally added support for this under version v30.0.0 🚀

Electron feature req: https://github.com/electron/electron/issues/41590
Original PR: https://github.com/electron/electron/pull/41689
Backport for v30: https://github.com/electron/electron/pull/41822

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
