### PR TITLE
Feature: match postman-cli default when openapi definition does not include a server 

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -321,8 +321,7 @@ const parseOpenApiCollection = (data) => {
         return;
       }
 
-      // TODO what if info.title not defined?
-      brunoCollection.name = collectionData.info.title;
+      brunoCollection.name = collectionData.info ? collectionData.info.title : '';
       let servers = collectionData.servers || [];
       let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '{{baseUrl}}';
       let securityConfig = getSecurity(collectionData);

--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -30,9 +30,12 @@ const readFile = (files) => {
   });
 };
 
-const ensureUrl = (url) => {
-  let protUrl = url.startsWith('http') ? url : `http://${url}`;
-  // replace any double or triple slashes
+const ensureUrl = (url) => (url.startsWith('http') ? url : `http://${url}`);
+
+const ensureUrlOrVariable = (url) => {
+  let protUrl = !!url.match('^{{.*}}') ? url : ensureUrl(url);
+
+  // replace any double or triple slashes. This also handles the default {{baseUrl}}// case
   return protUrl.replace(/([^:]\/)\/+/g, '$1');
 };
 
@@ -64,7 +67,7 @@ const transformOpenapiRequestItem = (request) => {
     name: operationName,
     type: 'http-request',
     request: {
-      url: ensureUrl(request.global.server + '/' + request.path),
+      url: ensureUrlOrVariable(request.global.server + '/' + request.path),
       method: request.method.toUpperCase(),
       auth: {
         mode: 'none',

--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -324,7 +324,7 @@ const parseOpenApiCollection = (data) => {
       // TODO what if info.title not defined?
       brunoCollection.name = collectionData.info.title;
       let servers = collectionData.servers || [];
-      let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '';
+      let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '{{baseUrl}}';
       let securityConfig = getSecurity(collectionData);
 
       let allRequests = Object.entries(collectionData.paths)


### PR DESCRIPTION
# Description

Matches the [existing behaviour](https://github.com/postmanlabs/openapi-to-postman/blob/228c462c3f542e72e420c1e27fc9b5bfcb839a24/libV2/helpers/collection/generateCollectionFromOpenAPI.js#L92) of postman-cli's 'Import from openapi' with a couple of defaults:
 - uses `{{baseUrl}}` when no `servers` entry is found. This addresses https://github.com/usebruno/bruno/issues/1239
 - uses an empty string when `info` field is not present

Example result:
![Screenshot 2024-05-08 at 11 06 27 AM](https://github.com/usebruno/bruno/assets/32408698/cdd7f5bc-1bfd-43f2-9a53-ea013dbee310)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
