### PR TITLE
fix: Synchronize Collection Renaming with Local Folders

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -13,7 +13,8 @@ const {
   browseFiles,
   createDirectory,
   searchForBruFiles,
-  sanitizeDirectoryName
+  sanitizeDirectoryName,
+  renameDirectory
 } = require('../utils/filesystem');
 const { openCollectionDialog } = require('../app/collections');
 const { generateUidBasedOnHash, stringifyJson, safeParseJSON, safeStringifyJSON } = require('../utils/common');
@@ -140,6 +141,10 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
 
       const newContent = await stringifyJson(json);
       await writeFile(brunoJsonFilePath, newContent);
+
+      const newPathName = path.join(path.dirname(collectionPathname), newName);
+      await renameDirectory(collectionPathname, newPathName);
+      lastOpenedCollections.add(newPathName);
 
       // todo: listen for bruno.json changes and handle it in watcher
       // the app will change the name of the collection after parsing the bruno.json file contents

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -147,6 +147,19 @@ const sanitizeDirectoryName = (name) => {
   return name.replace(/[<>:"/\\|?*\x00-\x1F]+/g, '-');
 };
 
+const renameDirectory = async (oldDir, newDir) => {
+  if (!oldDir || !newDir) {
+    throw new Error(`directory: path is null`);
+  }
+  if (!fs.existsSync(oldDir)) {
+    throw new Error(`directory: ${oldDir} does not exist`);
+  }
+  if (fs.existsSync(newDir)) {
+    throw new Error(`directory: ${newDir} already exists`);
+  }
+  fs.renameSync(oldDir, newDir);
+};
+
 module.exports = {
   isValidPathname,
   exists,
@@ -164,5 +177,6 @@ module.exports = {
   chooseFileToSave,
   searchForFiles,
   searchForBruFiles,
-  sanitizeDirectoryName
+  sanitizeDirectoryName,
+  renameDirectory
 };


### PR DESCRIPTION
# Description

Fixes: #2270
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
This PR resolves an issue where renaming a collection within the application did not automatically update the corresponding folder name on the local filesystem. The fix ensures that renaming a collection within the app now triggers the update of the folder name in the local directory, ensuring consistency between the application and the local environment.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
