### PR TITLE
feat: manual sort for query parameters

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
@@ -53,7 +53,6 @@ export const QueryParamRow = ({
       if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
         return;
       }
-      console.log(`hoverIndex=${hoverIndex}, dragIndex=${dragIndex}`);
 
       // Trigger callback
       onDragEvent(dragIndex, hoverIndex);

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
@@ -114,13 +114,13 @@ export const QueryParamRow = ({
           collection={collection}
         />
       </td>
-      <td>
-        <div className="flex items-center">
+      <td className="!p-0 !m-0">
+        <div className="flex justify-evenly w-full">
           <input
             type="checkbox"
             checked={param.enabled}
             tabIndex="-1"
-            className="mr-3 mousetrap"
+            className="mousetrap"
             onChange={(e) => onChangeEvent(e, param, 'enabled')}
           />
           <button tabIndex="-1" onClick={() => onTrashEvent(param)}>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
@@ -67,14 +67,14 @@ export const QueryParamRow = ({
       return { index, param };
     },
     collect: (monitor) => ({
-      isDragging: monitor.isDragging()
+      isDragging: param.uid === monitor.getItem()?.param?.uid
     })
   });
 
   drag(drop(ref));
   return (
-    <tr key={param.uid} className="select-none">
-      <td className="draggable-handle text-right !pl-0 !pr-0 select-none" ref={ref} data-handler-id={handlerId}>
+    <tr key={param.uid} style={{ opacity: isDragging ? 0.4 : 1 }} className="select-none" data-handler-id={handlerId}>
+      <td className="draggable-handle text-right !pl-0 !pr-0 select-none" ref={ref}>
         <div className="w-full flex place-content-center">
           <IconLineHeight strokeWidth={1.5} size={20} />
         </div>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
@@ -1,0 +1,65 @@
+import { React } from 'react';
+import SingleLineEditor from 'components/SingleLineEditor';
+import { IconTrash } from '@tabler/icons';
+import { useTheme } from 'providers/Theme';
+
+export const QueryParamRow = ({ param, collection, onSave, onRun, onChangeEvent, onTrashEvent }) => {
+  const { storedTheme } = useTheme();
+
+  return (
+    <tr key={param.uid} draggable="true">
+      <td className="draggable-handle">
+        <div draggable="true" onDrag={console.log('foo')}>
+          {/* TODO replace with fitting icon */}
+          ...
+        </div>
+      </td>
+      <td>
+        <input
+          type="text"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck="false"
+          value={param.name}
+          className="mousetrap"
+          onChange={(e) => onChangeEvent(e, param, 'name')}
+        />
+      </td>
+      <td>
+        <SingleLineEditor
+          value={param.value}
+          theme={storedTheme}
+          onSave={() => onSave()}
+          onChange={(newValue) =>
+            onChangeEvent(
+              {
+                target: {
+                  value: newValue
+                }
+              },
+              param,
+              'value'
+            )
+          }
+          onRun={() => onRun()}
+          collection={collection}
+        />
+      </td>
+      <td>
+        <div className="flex items-center">
+          <input
+            type="checkbox"
+            checked={param.enabled}
+            tabIndex="-1"
+            className="mr-3 mousetrap"
+            onChange={(e) => onChangeEvent(e, param, 'enabled')}
+          />
+          <button tabIndex="-1" onClick={() => onTrashEvent(param)}>
+            <IconTrash strokeWidth={1.5} size={20} />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+};

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
@@ -4,7 +4,7 @@ import SingleLineEditor from 'components/SingleLineEditor';
 import { IconLineHeight, IconTrash } from '@tabler/icons';
 import { useTheme } from 'providers/Theme';
 
-const DRAG_ACCEPT = 'table';
+const DRAG_ACCEPT = 'QueryParamRow';
 
 export const QueryParamRow = ({
   param,
@@ -23,7 +23,7 @@ export const QueryParamRow = ({
     accept: DRAG_ACCEPT,
     collect(monitor) {
       return {
-        handlelId: monitor.getHandlerId()
+        handlerId: monitor.getHandlerId()
       };
     },
     hover(item, monitor) {
@@ -61,7 +61,7 @@ export const QueryParamRow = ({
       item.index = hoverIndex;
     }
   });
-  const [{ isDragging }, drag] = useDrag({
+  const [{ isDragging }, drag, preview] = useDrag({
     type: DRAG_ACCEPT,
     item: () => {
       return { index, param };
@@ -70,11 +70,14 @@ export const QueryParamRow = ({
       isDragging: param.uid === monitor.getItem()?.param?.uid
     })
   });
+  const getClassNames = () => {
+    return isDragging ? 'dragging select-none' : 'select-text';
+  };
 
   drag(drop(ref));
   return (
-    <tr key={param.uid} style={{ opacity: isDragging ? 0.4 : 1 }} className="select-none" data-handler-id={handlerId}>
-      <td className="draggable-handle text-right !pl-0 !pr-0 select-none" ref={ref}>
+    <tr key={param.uid} className={getClassNames()} ref={ref} data-handler-id={handlerId}>
+      <td className="draggable-handle text-right !p-0 !p-0 select-none" ref={preview}>
         <div className="w-full flex place-content-center">
           <IconLineHeight strokeWidth={1.5} size={20} />
         </div>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
@@ -1,17 +1,82 @@
-import { React } from 'react';
+import { React, useMemo, useState, useRef } from 'react';
+import { useDrag, useDrop } from 'react-dnd';
 import SingleLineEditor from 'components/SingleLineEditor';
-import { IconTrash } from '@tabler/icons';
+import { IconLineHeight, IconTrash } from '@tabler/icons';
 import { useTheme } from 'providers/Theme';
 
-export const QueryParamRow = ({ param, collection, onSave, onRun, onChangeEvent, onTrashEvent }) => {
-  const { storedTheme } = useTheme();
+const DRAG_ACCEPT = 'table';
 
+export const QueryParamRow = ({
+  param,
+  index,
+  collection,
+  onSave,
+  onRun,
+  onChangeEvent,
+  onTrashEvent,
+  onDragEvent
+}) => {
+  const { storedTheme } = useTheme();
+  const ref = useRef(null);
+
+  const [{ handlerId }, drop] = useDrop({
+    accept: DRAG_ACCEPT,
+    collect(monitor) {
+      return {
+        handlelId: monitor.getHandlerId()
+      };
+    },
+    hover(item, monitor) {
+      if (!ref.current) return;
+
+      const dragIndex = item.index;
+      const hoverIndex = index;
+      // Don't replace items with themselves
+      if (dragIndex === hoverIndex) {
+        return;
+      }
+
+      // Determine mouse position and rectangle on screen
+      const hoverBoundingRect = ref.current?.getBoundingClientRect();
+      const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+      const clientOffset = monitor.getClientOffset();
+      const hoverClientY = clientOffset.y - hoverBoundingRect.top;
+
+      // Only perform the move when the mouse has crossed half of the items height
+      // When dragging downwards, only move when the cursor is below 50%
+      // When dragging upwards, only move when the cursor is above 50%
+      // Dragging downwards
+      if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
+        return;
+      }
+      // Dragging upwards
+      if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
+        return;
+      }
+      console.log(`hoverIndex=${hoverIndex}, dragIndex=${dragIndex}`);
+
+      // Trigger callback
+      onDragEvent(dragIndex, hoverIndex);
+
+      item.index = hoverIndex;
+    }
+  });
+  const [{ isDragging }, drag] = useDrag({
+    type: DRAG_ACCEPT,
+    item: () => {
+      return { index, param };
+    },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging()
+    })
+  });
+
+  drag(drop(ref));
   return (
-    <tr key={param.uid} draggable="true">
-      <td className="draggable-handle">
-        <div draggable="true" onDrag={console.log('foo')}>
-          {/* TODO replace with fitting icon */}
-          ...
+    <tr key={param.uid} className="select-none">
+      <td className="draggable-handle text-right !pl-0 !pr-0 select-none" ref={ref} data-handler-id={handlerId}>
+        <div className="w-full flex place-content-center">
+          <IconLineHeight strokeWidth={1.5} size={20} />
         </div>
       </td>
       <td>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/QueryParamRow.js
@@ -17,7 +17,7 @@ export const QueryParamRow = ({
   onDragEvent
 }) => {
   const { storedTheme } = useTheme();
-  const ref = useRef(null);
+  const draggableRef = useRef(null);
 
   const [{ handlerId }, drop] = useDrop({
     accept: DRAG_ACCEPT,
@@ -27,7 +27,7 @@ export const QueryParamRow = ({
       };
     },
     hover(item, monitor) {
-      if (!ref.current) return;
+      if (!draggableRef.current) return;
 
       const dragIndex = item.index;
       const hoverIndex = index;
@@ -37,7 +37,7 @@ export const QueryParamRow = ({
       }
 
       // Determine mouse position and rectangle on screen
-      const hoverBoundingRect = ref.current?.getBoundingClientRect();
+      const hoverBoundingRect = draggableRef.current?.getBoundingClientRect();
       const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
       const clientOffset = monitor.getClientOffset();
       const hoverClientY = clientOffset.y - hoverBoundingRect.top;
@@ -61,7 +61,7 @@ export const QueryParamRow = ({
       item.index = hoverIndex;
     }
   });
-  const [{ isDragging }, drag, preview] = useDrag({
+  const [{ isDragging }, drag] = useDrag({
     type: DRAG_ACCEPT,
     item: () => {
       return { index, param };
@@ -71,13 +71,13 @@ export const QueryParamRow = ({
     })
   });
   const getClassNames = () => {
-    return isDragging ? 'dragging select-none' : 'select-text';
+    return isDragging ? 'dragging select-none clip-codemirror' : 'select-text clip-codemirror';
   };
 
-  drag(drop(ref));
+  drag(drop(draggableRef));
   return (
-    <tr key={param.uid} className={getClassNames()} ref={ref} data-handler-id={handlerId}>
-      <td className="draggable-handle text-right !p-0 !p-0 select-none" ref={preview}>
+    <tr key={param.uid} className={getClassNames()} ref={draggableRef} data-handler-id={handlerId}>
+      <td className="draggable-handle text-right !p-0 !p-0 select-none">
         <div className="w-full flex place-content-center">
           <IconLineHeight strokeWidth={1.5} size={20} />
         </div>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
@@ -43,6 +43,9 @@ const Wrapper = styled.div`
       cursor: grabbing;
     }
   }
+  .dragging {
+    background: ${(props) => props.theme.table.active.bg};
+  }
 
   .btn-add-param {
     font-size: 0.8125rem;

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
@@ -34,6 +34,23 @@ const Wrapper = styled.div`
     }
   }
 
+  // Fixes overlay of draggable containing neighbouring elements
+  .clip-codemirror:active {
+    .CodeMirror {
+      textarea {
+        display: none;
+      }
+    }
+    .CodeMirror-scroll {
+      padding: 0 !important;
+      margin: 0 !important;
+
+      div:nth-last-child(2) {
+        display: none;
+      }
+    }
+  }
+
   .draggable-handle {
     cursor: grab;
     white-space: nowrap;

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
@@ -21,12 +21,26 @@ const Wrapper = styled.div`
       padding: 6px 10px;
 
       &:nth-child(1) {
+        width: 50px;
+      }
+
+      &:nth-child(2) {
         width: 30%;
       }
 
-      &:nth-child(3) {
+      &:nth-child(4) {
         width: 70px;
       }
+    }
+  }
+
+  .draggable-handle {
+    cursor: grab;
+    white-space: nowrap;
+    text-align: center;
+
+    &:active {
+      cursor: grabbing;
     }
   }
 

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -1,18 +1,17 @@
-import React from 'react';
+import { React, useCallback } from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
-import { IconTrash } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
-import { useTheme } from 'providers/Theme';
 import { addQueryParam, updateQueryParam, deleteQueryParam } from 'providers/ReduxStore/slices/collections';
-import SingleLineEditor from 'components/SingleLineEditor';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import StyledWrapper from './StyledWrapper';
+import { QueryParamRow } from './QueryParamRow';
 
 const QueryParams = ({ item, collection }) => {
   const dispatch = useDispatch();
-  const { storedTheme } = useTheme();
   const params = item.draft ? get(item, 'draft.request.params') : get(item, 'request.params');
 
   const handleAddParam = () => {
@@ -65,71 +64,34 @@ const QueryParams = ({ item, collection }) => {
 
   return (
     <StyledWrapper className="w-full">
-      <table>
-        <thead>
-          <tr>
-            <td>Name</td>
-            <td>Value</td>
-            <td></td>
-          </tr>
-        </thead>
-        <tbody>
-          {params && params.length
-            ? params.map((param, index) => {
-                return (
-                  <tr key={param.uid}>
-                    <td>
-                      <input
-                        type="text"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        autoCapitalize="off"
-                        spellCheck="false"
-                        value={param.name}
-                        className="mousetrap"
-                        onChange={(e) => handleParamChange(e, param, 'name')}
-                      />
-                    </td>
-                    <td>
-                      <SingleLineEditor
-                        value={param.value}
-                        theme={storedTheme}
-                        onSave={onSave}
-                        onChange={(newValue) =>
-                          handleParamChange(
-                            {
-                              target: {
-                                value: newValue
-                              }
-                            },
-                            param,
-                            'value'
-                          )
-                        }
-                        onRun={handleRun}
-                        collection={collection}
-                      />
-                    </td>
-                    <td>
-                      <div className="flex items-center">
-                        <input
-                          type="checkbox"
-                          checked={param.enabled}
-                          tabIndex="-1"
-                          className="mr-3 mousetrap"
-                          onChange={(e) => handleParamChange(e, param, 'enabled')}
-                        />
-                        <button tabIndex="-1" onClick={() => handleRemoveParam(param)}>
-                          <IconTrash strokeWidth={1.5} size={20} />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })
-            : null}
-        </tbody>
-      </table>
+      <DndProvider backend={HTML5Backend}>
+        <table className="draggable-table">
+          <thead>
+            <tr>
+              <td></td>
+              <td>Name</td>
+              <td>Value</td>
+              <td></td>
+            </tr>
+          </thead>
+          <tbody>
+            {params && params.length
+              ? params.map((param, index) => {
+                  return (
+                    <QueryParamRow
+                      param={param}
+                      collection={collection}
+                      onSave={onSave}
+                      onRun={handleRun}
+                      onChangeEvent={handleParamChange}
+                      onTrashEvent={handleRemoveParam}
+                    />
+                  );
+                })
+              : null}
+          </tbody>
+        </table>
+      </DndProvider>
       <button className="btn-add-param text-link pr-2 py-3 mt-2 select-none" onClick={handleAddParam}>
         +&nbsp;<span>Add Param</span>
       </button>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -1,8 +1,13 @@
-import { React, useCallback } from 'react';
+import { React } from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 import { useDispatch } from 'react-redux';
-import { addQueryParam, updateQueryParam, deleteQueryParam } from 'providers/ReduxStore/slices/collections';
+import {
+  addQueryParam,
+  updateQueryParam,
+  deleteQueryParam,
+  moveQueryParam
+} from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -62,10 +67,23 @@ const QueryParams = ({ item, collection }) => {
     );
   };
 
+  const handleParamDrag = (sourceIndex, targetIndex) => {
+    console.log('handleParamDrag', sourceIndex, targetIndex, params);
+    dispatch(
+      moveQueryParam({
+        sourceIndex: sourceIndex,
+        targetIndex: targetIndex,
+        paramUid: params[sourceIndex].uid,
+        itemUid: item.uid,
+        collectionUid: collection.uid
+      })
+    );
+  };
+
   return (
     <StyledWrapper className="w-full">
       <DndProvider backend={HTML5Backend}>
-        <table className="draggable-table">
+        <table className="draggable-table select-text">
           <thead>
             <tr>
               <td></td>
@@ -80,11 +98,13 @@ const QueryParams = ({ item, collection }) => {
                   return (
                     <QueryParamRow
                       param={param}
+                      index={index}
                       collection={collection}
                       onSave={onSave}
                       onRun={handleRun}
                       onChangeEvent={handleParamChange}
                       onTrashEvent={handleRemoveParam}
+                      onDragEvent={handleParamDrag}
                     />
                   );
                 })

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -48,13 +48,7 @@ const QueryParams = ({ item, collection }) => {
       }
     }
 
-    dispatch(
-      updateQueryParam({
-        param,
-        itemUid: item.uid,
-        collectionUid: collection.uid
-      })
-    );
+    updateParam(param);
   };
 
   const handleRemoveParam = (param) => {
@@ -67,8 +61,17 @@ const QueryParams = ({ item, collection }) => {
     );
   };
 
+  const updateParam = (param) => {
+    dispatch(
+      updateQueryParam({
+        collectionUid: collection.uid,
+        itemUid: item.uid,
+        param: param
+      })
+    );
+  };
+
   const handleParamDrag = (sourceIndex, targetIndex) => {
-    console.log('handleParamDrag', sourceIndex, targetIndex, params);
     dispatch(
       moveQueryParam({
         sourceIndex: sourceIndex,
@@ -78,6 +81,7 @@ const QueryParams = ({ item, collection }) => {
         collectionUid: collection.uid
       })
     );
+    updateParam(params[sourceIndex]);
   };
 
   return (

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -431,6 +431,23 @@ export const collectionsSlice = createSlice({
         }
       }
     },
+    /**
+     * Moves a query parameter from `sourceIndex` to `targetIndex` location. The remaining items after the sourceIndex are
+     * either shifted left or right, depending on the insertion position.
+     *
+     * @example moveQueryParam({sourceIndex: 1, targetIndex: 4, collectionUid: collection.uid, itemUid: item.uid, paramUid: param.uid});
+     *
+     * | params  | before | after |
+     * | ------- | ------ | ----- |
+     * | [0].uid | a      | a     |
+     * | [1].uid | b      | c     |
+     * | [2].uid | c      | d     |
+     * | [3].uid | d      | e     |
+     * | [4].uid | e      | b     |
+     *
+     * @param {*} state
+     * @param {*} action
+     */
     moveQueryParam: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
 
@@ -441,12 +458,23 @@ export const collectionsSlice = createSlice({
             item.draft = cloneDeep(item);
           }
 
-          var sortedParams = [...item.draft.request.params];
-          var tmp = sortedParams[action.payload.sourceIndex];
+          const sortedParams = [...item.draft.request.params];
+          // Assert given input
+          console.assert(action.payload.sourceIndex >= 0, 'sourceIndex must be greater >= 0');
+          console.assert(action.payload.targetIndex >= 0, 'targetIndex must be greater >= 0');
+          console.assert(
+            action.payload.sourceIndex < sortedParams.length,
+            'sourceIndex must not exceed the params length'
+          );
+          console.assert(
+            action.payload.targetIndex < sortedParams.length,
+            'targetIndex must not exceed the params length'
+          );
+
+          const tmp = sortedParams[action.payload.sourceIndex];
           sortedParams.splice(action.payload.sourceIndex, 1);
           sortedParams.splice(action.payload.targetIndex, 0, tmp);
           item.draft.request.params = sortedParams;
-          console.log('resorted params');
         }
       }
     },

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -431,6 +431,25 @@ export const collectionsSlice = createSlice({
         }
       }
     },
+    moveQueryParam: (state, action) => {
+      const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
+
+      if (collection) {
+        const item = findItemInCollection(collection, action.payload.itemUid);
+        if (item && isItemARequest(item)) {
+          if (!item.draft) {
+            item.draft = cloneDeep(item);
+          }
+
+          var sortedParams = [...item.draft.request.params];
+          var tmp = sortedParams[action.payload.sourceIndex];
+          sortedParams.splice(action.payload.sourceIndex, 1);
+          sortedParams.splice(action.payload.targetIndex, 0, tmp);
+          item.draft.request.params = sortedParams;
+          console.log('resorted params');
+        }
+      }
+    },
     updateQueryParam: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
 
@@ -1416,6 +1435,7 @@ export const {
   requestUrlChanged,
   updateAuth,
   addQueryParam,
+  moveQueryParam,
   updateQueryParam,
   deleteQueryParam,
   addRequestHeader,

--- a/packages/bruno-app/src/themes/dark.js
+++ b/packages/bruno-app/src/themes/dark.js
@@ -248,6 +248,9 @@ const darkTheme = {
     striped: '#2A2D2F',
     input: {
       color: '#ccc'
+    },
+    active: {
+      bg: '#3D3D3D'
     }
   },
 

--- a/packages/bruno-app/src/themes/light.js
+++ b/packages/bruno-app/src/themes/light.js
@@ -252,6 +252,9 @@ const lightTheme = {
     striped: '#f3f3f3',
     input: {
       color: '#000000'
+    },
+    active: {
+      bg: '#e7e7e7'
     }
   },
 

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -64,21 +64,12 @@ const jsonToBru = (json) => {
 
   if (query && query.length) {
     bru += 'query {';
-    if (enabled(query).length) {
-      bru += `\n${indentString(
-        enabled(query)
-          .map((item) => `${item.name}: ${item.value}`)
-          .join('\n')
-      )}`;
-    }
-
-    if (disabled(query).length) {
-      bru += `\n${indentString(
-        disabled(query)
-          .map((item) => `~${item.name}: ${item.value}`)
-          .join('\n')
-      )}`;
-    }
+    var queryParams = [];
+    query.forEach((item) => {
+      if (item.enabled) queryParams.push(`${item.name}: ${item.value}`);
+      else queryParams.push(`~${item.name}: ${item.value}`);
+    });
+    bru += `\n${indentString(queryParams.join('\n'))}`;
 
     bru += '\n}\n\n';
   }


### PR DESCRIPTION
# Description

Fixes #2053 

Adds sorting capabilities to the request query parameters. It uses [react-dnd](https://react-dnd.github.io/react-dnd/about) internally. Sorting happens already while hovering other items, but changes are only permanent if the request object is saved.

I moved the rendering of the individual table rows into a dedicated file for better separation. Let me know if I should revert this and move everything back into the index.js.

I'm not 100% happy with the solution as it requires copy & paste if this kind of sorting should apply to other components. I see a valid use-case adding this to request `headers`, `vars` and `asserts` as well. It would be possible to move some of the logic into a common utils location, but this increases complexity about the internal workings due to abstraction. If this is the way forward I can refactor here a bit.

### Handle Icon
[See my comment below](#issuecomment-2106133704) for alternative icon proposals, feedback is very much appreciated.

### Drag & Drop in Action

https://github.com/usebruno/bruno/assets/1665841/04bbdb29-2480-4bb5-a744-cbe72616cea5

### Looks

*Light Theme*
![bruno-2289-drag-light](https://github.com/usebruno/bruno/assets/1665841/4b0a6ca4-7dad-4419-a2dd-910672a07f5d)

*Dark Theme*
![bruno-2289-drag-dark](https://github.com/usebruno/bruno/assets/1665841/c7850bc6-41bf-457d-8d74-7aff415a1b2b)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
