### PR TITLE
fix: new-request error when create request from cURL if some parameter(s) in form-urlencoded type data missing '=' (#2288)

### DIFF
--- a/packages/bruno-app/src/utils/curl/curl-to-json.js
+++ b/packages/bruno-app/src/utils/curl/curl-to-json.js
@@ -48,6 +48,13 @@ function getDataString(request) {
   }
 
   const parsedQueryString = querystring.parse(request.data, { sort: false });
+  // if missing `=`, `query-string` will set value as `null`. Reset value as empty string ('') here.
+  // https://github.com/sindresorhus/query-string/blob/3d8fbf2328220c06e45f166cdf58e70617c7ee68/base.js#L364-L366
+  Object.keys(parsedQueryString).forEach((key) => {
+    if (parsedQueryString[key] === null) {
+      parsedQueryString[key] = '';
+    }
+  });
   const keyCount = Object.keys(parsedQueryString).length;
   const singleKeyOnly = keyCount === 1 && !parsedQueryString[Object.keys(parsedQueryString)[0]];
   const singularData = request.isDataBinary || singleKeyOnly;


### PR DESCRIPTION
# Description

When create a new `form-urlencoded` request from cURL, if some parameter(s) in `form-urlencoded` type data missing `=`, like `param2` parameter below, toast that `Error invoking remote method 'renderer:new-request': TypeError: Cannot read properties of null (reading 'includes')`. #2288

e.g.:
```shell
curl 'https://example.com/api' \
  -H 'content-type: application/x-www-form-urlencoded' \
  --data-raw 'param1=1&param2'
```

<img width="523" alt="image" src="https://github.com/usebruno/bruno/assets/34596552/f4497e20-e6d3-41e6-9f7c-0c33f6657ce5">

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why?

1. When parsing `cURL` command, app will use `query-string` to parse `form-urlencoded` type data string. If some parameter(s) in `form-urlencoded` type data string missing `=`, `query-string` will set value as `null`([Missing `=` should be `null` · sindresorhus/query-string](https://github.com/sindresorhus/query-string/blob/3d8fbf2328220c06e45f166cdf58e70617c7ee68/base.js#L364-L366)).
<img width="1234" alt="image" src="https://github.com/usebruno/bruno/assets/34596552/1c2e5d73-6650-4b70-af6d-46adbfab6c7b">
<img width="1006" alt="image" src="https://github.com/usebruno/bruno/assets/34596552/768070e9-78af-4c6e-bffb-7d01bd5a6b4e">

But it isn't a bug, just a feature following W3 specification(https://www.w3.org/TR/2012/WD-url-20120524/#collect-url-parameters).
<img width="1276" alt="image" src="https://github.com/usebruno/bruno/assets/34596552/c80a0194-7b90-4ab8-8fee-40edb3d8d14e">

2. When convert json to `bru` type data in `bruno-lang` v2, will execute `value.includes('\n');`, then throw error.
<img width="1679" alt="image" src="https://github.com/usebruno/bruno/assets/34596552/eef5e4e0-e3d2-42e6-93ba-a85a032be970">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
