### PR TITLE
feat(translation-feedback): console log incomplete postman import translations with stats and details

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -54,6 +54,8 @@ const convertV21Auth = (array) => {
   }, {});
 };
 
+const translationLog = {};
+
 const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) => {
   brunoParent.items = brunoParent.items || [];
   const folderMap = {};
@@ -114,7 +116,25 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
             }
           }
         };
+        /* struct of translation log
+        {
+         [collectionName]: {
+            script: [index1, index2],
+            test: [index1, index2]
+         }
+        }
+        */
 
+        // type could be script or test
+        const pushTranslationLog = (type, index) => {
+          if (!translationLog[i.name]) {
+            translationLog[i.name] = {};
+          }
+          if (!translationLog[i.name][type]) {
+            translationLog[i.name][type] = [];
+          }
+          translationLog[i.name][type].push(index + 1);
+        };
         if (i.event) {
           i.event.forEach((event) => {
             if (event.listen === 'prerequest' && event.script && event.script.exec) {
@@ -123,11 +143,15 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
               }
               if (Array.isArray(event.script.exec)) {
                 brunoRequestItem.request.script.req = event.script.exec
-                  .map((line) => (options.enablePostmanTranslations.enabled ? postmanTranslation(line) : `// ${line}`))
+                  .map((line, index) =>
+                    options.enablePostmanTranslations.enabled
+                      ? postmanTranslation(line, () => pushTranslationLog('script', index))
+                      : `// ${line}`
+                  )
                   .join('\n');
               } else {
                 brunoRequestItem.request.script.req = options.enablePostmanTranslations.enabled
-                  ? postmanTranslation(event.script.exec[0])
+                  ? postmanTranslation(event.script.exec[0], () => pushTranslationLog('script', 0))
                   : `// ${event.script.exec[0]} `;
               }
             }
@@ -137,11 +161,15 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
               }
               if (Array.isArray(event.script.exec)) {
                 brunoRequestItem.request.tests = event.script.exec
-                  .map((line) => (options.enablePostmanTranslations.enabled ? postmanTranslation(line) : `// ${line}`))
+                  .map((line, index) =>
+                    options.enablePostmanTranslations.enabled
+                      ? postmanTranslation(line, () => pushTranslationLog('test', index))
+                      : `// ${line}`
+                  )
                   .join('\n');
               } else {
                 brunoRequestItem.request.tests = options.enablePostmanTranslations.enabled
-                  ? postmanTranslation(event.script.exec[0])
+                  ? postmanTranslation(event.script.exec[0], () => pushTranslationLog('test', 0))
                   : `// ${event.script.exec[0]} `;
               }
             }
@@ -313,6 +341,21 @@ const parsePostmanCollection = (str, options) => {
   });
 };
 
+const logTranslationDetails = (translationLog) => {
+  if (Object.keys(translationLog || {}).length > 0) {
+    console.log(
+      `======== Postman Translation Logs ========
+|| Collections incomplete : ${Object.keys(translationLog || {}).length}` +
+        `\n|| Total lines incomplete : ${Object.values(translationLog || {}).reduce(
+          (acc, curr) => acc + (curr.script?.length || 0) + (curr.test?.length || 0),
+          0
+        )}` +
+        `\n|| See details below :`,
+      translationLog
+    );
+  }
+};
+
 const importCollection = (options) => {
   return new Promise((resolve, reject) => {
     fileDialog({ accept: 'application/json' })
@@ -325,7 +368,8 @@ const importCollection = (options) => {
       .catch((err) => {
         console.log(err);
         reject(new BrunoError('Import collection failed'));
-      });
+      })
+      .then(() => logTranslationDetails(translationLog));
   });
 };
 

--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -343,14 +343,14 @@ const parsePostmanCollection = (str, options) => {
 
 const logTranslationDetails = (translationLog) => {
   if (Object.keys(translationLog || {}).length > 0) {
-    console.log(
-      `======== Postman Translation Logs ========
-|| Collections incomplete : ${Object.keys(translationLog || {}).length}` +
-        `\n|| Total lines incomplete : ${Object.values(translationLog || {}).reduce(
+    console.warn(
+      `[Postman Translation Logs]
+Collections incomplete : ${Object.keys(translationLog || {}).length}` +
+        `\nTotal lines incomplete : ${Object.values(translationLog || {}).reduce(
           (acc, curr) => acc + (curr.script?.length || 0) + (curr.test?.length || 0),
           0
         )}` +
-        `\n|| See details below :`,
+        `\nSee details below :`,
       translationLog
     );
   }

--- a/packages/bruno-app/src/utils/importers/translators/index.spec.js
+++ b/packages/bruno-app/src/utils/importers/translators/index.spec.js
@@ -36,8 +36,8 @@ describe('postmanTranslation function', () => {
   });
 
   test('should comment non-translated pm commands', () => {
-    const inputScript = "pm.test('random test', () => pm.response.json());";
-    const expectedOutput = "// test('random test', () => pm.response.json());";
+    const inputScript = "pm.test('random test', () => pm.imaginary.json());";
+    const expectedOutput = "// test('random test', () => pm.imaginary.json());";
     expect(postmanTranslation(inputScript)).toBe(expectedOutput);
   });
   test('should handle multiple pm commands on the same line', () => {

--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -33,7 +33,7 @@ export const postmanTranslation = (script, logCallback) => {
     }
     if (modifiedScript.includes('pm.')) {
       modifiedScript = modifiedScript.replace(/^(.*pm\..*)$/gm, '// $1');
-      logCallback();
+      logCallback?.();
     }
     return modifiedScript;
   } catch (e) {

--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -7,7 +7,13 @@ const replacements = {
   'pm\\.collectionVariables\\.set\\(': 'bru.setVar(',
   'pm\\.setNextRequest\\(': 'bru.setNextRequest(',
   'pm\\.test\\(': 'test(',
-  'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal('
+  'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
+  'pm\\.response\\.to\\.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
+  'pm\\.response\\.json\\(': 'res.getBody(',
+  'pm\\.expect\\(': 'expect(',
+  'pm\\.environment\\.has\\(([^)]+)\\)': 'bru.getEnvVar($1) !== undefined && bru.getEnvVar($1) !== null',
+  'pm\\.response\\.code': 'res.getStatus()',
+  'pm\\.response\\.text\\(': 'res.getBody()?.toString()'
 };
 
 const compiledReplacements = Object.entries(replacements).map(([pattern, replacement]) => ({
@@ -15,7 +21,7 @@ const compiledReplacements = Object.entries(replacements).map(([pattern, replace
   replacement
 }));
 
-export const postmanTranslation = (script) => {
+export const postmanTranslation = (script, logCallback) => {
   try {
     let modifiedScript = script;
     let modified = false;
@@ -25,8 +31,9 @@ export const postmanTranslation = (script) => {
         modified = true;
       }
     }
-    if (modified && modifiedScript.includes('pm.')) {
+    if (modifiedScript.includes('pm.')) {
       modifiedScript = modifiedScript.replace(/^(.*pm\..*)$/gm, '// $1');
+      logCallback();
     }
     return modifiedScript;
   } catch (e) {


### PR DESCRIPTION

# Description

Provide **useful logs** while importing a Postman collection in Bruno.
Logs will display the number of collections concerned, the number of lines to change, and a translationLog of such type : 
```ts
interface TranslationLog {
  [collectionName: string]: {
    "script"?: number[], 
    "test"?: number[]
  }
}
```
Next step : I would like to display some information about the translation failing or not **in the UI**, in the **import location dialog**. @helloanoop could I display data in the UI instead/in addition to that ?

![image](https://github.com/usebruno/bruno/assets/64689165/f79d8af0-4a04-479d-bf5a-f826299acb95)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
