### PR TITLE
Fix: all API keys are correctly added when importing OpenAPI collection

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -108,33 +108,34 @@ const transformOpenapiRequestItem = (request) => {
   let auth;
   // allow operation override
   if (_operationObject.security && _operationObject.security.length > 0) {
-    let schemeName = Object.keys(_operationObject.security[0])[0];
-    auth = request.global.security.getScheme(schemeName);
+    auth = request.global.security.getScheme();
   } else if (request.global.security.supported.length > 0) {
-    auth = request.global.security.supported[0];
+    auth = request.global.security.supported;
   }
 
   if (auth) {
-    if (auth.type === 'http' && auth.scheme === 'basic') {
-      brunoRequestItem.request.auth.mode = 'basic';
-      brunoRequestItem.request.auth.basic = {
-        username: '{{username}}',
-        password: '{{password}}'
-      };
-    } else if (auth.type === 'http' && auth.scheme === 'bearer') {
-      brunoRequestItem.request.auth.mode = 'bearer';
-      brunoRequestItem.request.auth.bearer = {
-        token: '{{token}}'
-      };
-    } else if (auth.type === 'apiKey' && auth.in === 'header') {
-      brunoRequestItem.request.headers.push({
-        uid: uuid(),
-        name: auth.name,
-        value: '{{apiKey}}',
-        description: 'Authentication header',
-        enabled: true
-      });
-    }
+    each(auth || [], (param) => {
+      if (param.type === 'http' && param.scheme === 'basic') {
+        brunoRequestItem.request.auth.mode = 'basic';
+        brunoRequestItem.request.auth.basic = {
+          username: '{{username}}',
+          password: '{{password}}'
+        };
+      } else if (param.type === 'http' && param.scheme === 'bearer') {
+        brunoRequestItem.request.auth.mode = 'bearer';
+        brunoRequestItem.request.auth.bearer = {
+          token: '{{token}}'
+        };
+      } else if (param.type === 'apiKey' && param.in === 'header') {
+        brunoRequestItem.request.headers.push({
+          uid: uuid(),
+          name: param.name,
+          value: '{{apiKey}}',
+          description: 'Authentication header',
+          enabled: true
+        });
+      }
+    });
   }
 
   // TODO: handle allOf/anyOf/oneOf
@@ -289,8 +290,8 @@ const getSecurity = (apiSpec) => {
       return securitySchemes[schemeName];
     }),
     schemes: securitySchemes,
-    getScheme: (schemeName) => {
-      return securitySchemes[schemeName];
+    getScheme: () => {
+      return securitySchemes;
     }
   };
 };


### PR DESCRIPTION
# Description

Fixes: #2254

This PR addresses the issue where only one API key was being added to the collection when importing OpenAPI collection that contain multiple keys. The fix ensures that all API keys are correctly included during the import process.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
