### PR TITLE
Fix Form URL Encoded data to preserve all instances of parameters with the same name on timeline

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1,6 +1,5 @@
 const os = require('os');
 const fs = require('fs');
-const qs = require('qs');
 const https = require('https');
 const tls = require('tls');
 const axios = require('axios');
@@ -16,7 +15,7 @@ const prepareRequest = require('./prepare-request');
 const prepareCollectionRequest = require('./prepare-collection-request');
 const prepareGqlIntrospectionRequest = require('./prepare-gql-introspection-request');
 const { cancelTokens, saveCancelToken, deleteCancelToken } = require('../../utils/cancel-token');
-const { uuid } = require('../../utils/common');
+const { uuid, convertFormUrlEncodedToString } = require('../../utils/common');
 const interpolateVars = require('./interpolate-vars');
 const { interpolateString } = require('./interpolate-string');
 const { sortFolder, getAllRequestsInFolderRecursively } = require('./helper');
@@ -350,7 +349,7 @@ const registerNetworkIpc = (mainWindow) => {
 
     // stringify the request url encoded params
     if (request.headers['content-type'] === 'application/x-www-form-urlencoded') {
-      request.data = qs.stringify(request.data);
+      request.data = convertFormUrlEncodedToString(request.data.data);
     }
 
     return scriptResult;

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -200,9 +200,15 @@ const prepareRequest = (request, collectionRoot, collectionPath) => {
 
   if (request.body.mode === 'formUrlEncoded') {
     axiosRequest.headers['content-type'] = 'application/x-www-form-urlencoded';
-    const params = {};
+    const params = {
+      data: []
+    };
     const enabledParams = filter(request.body.formUrlEncoded, (p) => p.enabled);
-    each(enabledParams, (p) => (params[p.name] = p.value));
+    each(enabledParams, (p) =>
+      params.data.push({
+        [p.name]: p.value
+      })
+    );
     axiosRequest.data = params;
   }
 

--- a/packages/bruno-electron/src/utils/common.js
+++ b/packages/bruno-electron/src/utils/common.js
@@ -85,6 +85,11 @@ const flattenDataForDotNotation = (data) => {
   return result;
 };
 
+function convertFormUrlEncodedToString(inputArray) {
+  const formattedStrings = inputArray.map((obj) => `${Object.keys(obj)[0]}=${Object.values(obj)[0]}`);
+  return formattedStrings.join('&');
+}
+
 module.exports = {
   uuid,
   stringifyJson,
@@ -93,5 +98,6 @@ module.exports = {
   safeParseJSON,
   simpleHash,
   generateUidBasedOnHash,
-  flattenDataForDotNotation
+  flattenDataForDotNotation,
+  convertFormUrlEncodedToString
 };


### PR DESCRIPTION
…h the same name in the timeline

# Description

Fixes: #2192

This PR resolves the issue where Form URL Encoded data was losing information when multiple parameters with the same name were present. The fix ensures that all data, including parameters with the same name, is accurately retained, thereby addressing the bug and improving the handling of Form URL Encoded data.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
