### PR TITLE
interpolate vars correctly in graphql introspection request

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -725,11 +725,11 @@ const registerNetworkIpc = (mainWindow) => {
     });
   });
 
-  ipcMain.handle('fetch-gql-schema', async (event, endpoint, environment, request, collection) => {
+  ipcMain.handle('fetch-gql-schema', async (event, endpoint, environment, _request, collection) => {
     try {
       const envVars = getEnvVars(environment);
       const collectionRoot = get(collection, 'root', {});
-      const preparedRequest = prepareGqlIntrospectionRequest(endpoint, envVars, request, collectionRoot);
+      const request = prepareGqlIntrospectionRequest(endpoint, envVars, _request, collectionRoot);
 
       request.timeout = preferencesUtil.getRequestTimeout();
 
@@ -759,16 +759,16 @@ const registerNetworkIpc = (mainWindow) => {
         scriptingConfig
       );
 
-      interpolateVars(preparedRequest, envVars, collection.collectionVariables, processEnvVars);
+      interpolateVars(request, envVars, collection.collectionVariables, processEnvVars);
       const axiosInstance = await configureRequest(
         collection.uid,
-        preparedRequest,
+        request,
         envVars,
         collection.collectionVariables,
         processEnvVars,
         collectionPath
       );
-      const response = await axiosInstance(preparedRequest);
+      const response = await axiosInstance(request);
 
       await runPostResponse(
         request,


### PR DESCRIPTION
# Description

It looks like there was regression with the graphql introspection query code that was preventing pre-request scripts from settings header values in the prepared request.

https://github.com/usebruno/bruno/issues/704

Using an example here, a pre-script that sets some authentication headers

![Screenshot 2024-05-15 at 17 20 59](https://github.com/usebruno/bruno/assets/4996338/c39b7d1a-532c-4fcd-a37e-919cb0ba3941)

This data now actually gets sent through to the backend
```
X-Mul-Nonce: xxxx
X-Mul-Timestamp: xxxx
X-Mul-Signature: xxxxx
```

So my (previously broken) introspection request now succeeds.

![Screenshot 2024-05-15 at 17 21 14](https://github.com/usebruno/bruno/assets/4996338/5bd7d19f-6563-4861-90e2-f0110ebfde03)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
