### PR TITLE
Feat: Catch post request variable evaluation errors

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -395,6 +395,10 @@ const registerNetworkIpc = (mainWindow) => {
           collectionUid
         });
       }
+
+      if (result?.error) {
+        mainWindow.webContents.send('main:display-error', result.error);
+      }
     }
 
     // run post-response script

--- a/packages/bruno-js/src/runtime/vars-runtime.js
+++ b/packages/bruno-js/src/runtime/vars-runtime.js
@@ -56,14 +56,27 @@ class VarsRuntime {
       ...bruContext
     };
 
+    const errors = new Map();
     _.each(enabledVars, (v) => {
-      const value = evaluateJsExpression(v.value, context);
-      bru.setVar(v.name, value);
+      try {
+        const value = evaluateJsExpression(v.value, context);
+        bru.setVar(v.name, value);
+      } catch (error) {
+        errors.set(v.name, error);
+      }
     });
+
+    let error = null;
+    if (errors.size > 0) {
+      // Format all errors as a single string to be displayed in a toast
+      const errorMessage = [...errors.entries()].map(([name, err]) => `${name}: ${err.message ?? err}`).join('\n');
+      error = `${errors.size} error${errors.size === 1 ? '' : 's'} in post response variables: \n${errorMessage}`;
+    }
 
     return {
       envVariables,
-      collectionVariables
+      collectionVariables,
+      error
     };
   }
 }


### PR DESCRIPTION
fix #2005

# Description

- display post request variable evaluation errors in a toast, each individual variable error on a new line
- display the response body (was previously replaced by the an error "Error invoking remote method 'send-http-request': ..."

![image](https://github.com/usebruno/bruno/assets/7304827/d6402ec3-cf46-4b2f-a447-41359084320d)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
