### PR TITLE
Feat: Add support for PKCS12 / PFX client certificates for mTLS

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { IconCertificate, IconTrash, IconWorld } from '@tabler/icons';
 import { useFormik } from 'formik';
 import { uuid } from 'utils/common';
@@ -26,8 +26,35 @@ const ClientCertSettings = ({ clientCertConfig, onUpdate, onRemove }) => {
     }),
     onSubmit: (values) => {
       onUpdate(values);
+      formik.resetForm();
     }
   });
+  const certFileChooserRef = useRef(null);
+  const keyFileChooserRef = useRef(null);
+
+  useEffect(() => {
+    if (formik.values.pfx) {
+      formik.setFieldValue('keyFilePath', undefined);
+    }
+  }, [formik.values.pfx]);
+
+  useEffect(() => {
+    if (!formik.values.keyFilePath) {
+      clearFileInput(keyFileChooserRef);
+    }
+  }, [formik.values.keyFilePath]);
+
+  useEffect(() => {
+    if (!formik.values.certFilePath) {
+      clearFileInput(certFileChooserRef);
+    }
+  }, [formik.values.certFilePath]);
+
+  const clearFileInput = (inputRef) => {
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
 
   const getFile = (e) => {
     try {
@@ -91,6 +118,7 @@ const ClientCertSettings = ({ clientCertConfig, onUpdate, onRemove }) => {
               id="certFilePath"
               type="file"
               name="certFilePath"
+              ref={certFileChooserRef}
               className="block non-passphrase-input"
               onChange={(e) => getFile(e.target)}
             />
@@ -116,6 +144,7 @@ const ClientCertSettings = ({ clientCertConfig, onUpdate, onRemove }) => {
             id="keyFilePath"
             type="file"
             name="keyFilePath"
+            ref={keyFileChooserRef}
             className="block non-passphrase-input"
             onChange={(e) => getFile(e.target)}
             disabled={formik.values.pfx}

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -125,15 +125,23 @@ const runSingleRequest = async function (
       const domain = interpolateString(clientCert.domain, interpolationOptions);
       const certFilePath = interpolateString(clientCert.certFilePath, interpolationOptions);
       const keyFilePath = interpolateString(clientCert.keyFilePath, interpolationOptions);
-      if (domain && certFilePath && keyFilePath) {
+      if (domain && certFilePath && (keyFilePath || clientCert.pfx)) {
         const hostRegex = '^https:\\/\\/' + domain.replaceAll('.', '\\.').replaceAll('*', '.*');
 
         if (request.url.match(hostRegex)) {
-          try {
-            httpsAgentRequestFields['cert'] = fs.readFileSync(certFilePath);
-            httpsAgentRequestFields['key'] = fs.readFileSync(keyFilePath);
-          } catch (err) {
-            console.log('Error reading cert/key file', err);
+          if (clientCert.pfx) {
+            try {
+              httpsAgentRequestFields['pfx'] = fs.readFileSync(certFilePath);
+            } catch (err) {
+              console.log('Error reading cert file', err);
+            }
+          } else {
+            try {
+              httpsAgentRequestFields['cert'] = fs.readFileSync(certFilePath);
+              httpsAgentRequestFields['key'] = fs.readFileSync(keyFilePath);
+            } catch (err) {
+              console.log('Error reading cert/key file', err);
+            }
           }
           httpsAgentRequestFields['passphrase'] = interpolateString(clientCert.passphrase, interpolationOptions);
           break;

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -133,20 +133,28 @@ const configureRequest = async (
     let keyFilePath = interpolateString(clientCert.keyFilePath, interpolationOptions);
     keyFilePath = path.isAbsolute(keyFilePath) ? keyFilePath : path.join(collectionPath, keyFilePath);
 
-    if (domain && certFilePath && keyFilePath) {
+    if (domain && certFilePath && (keyFilePath || clientCert.pfx)) {
       const hostRegex = '^https:\\/\\/' + domain.replaceAll('.', '\\.').replaceAll('*', '.*');
 
       if (request.url.match(hostRegex)) {
-        try {
-          httpsAgentRequestFields['cert'] = fs.readFileSync(certFilePath);
-        } catch (err) {
-          console.log('Error reading cert file', err);
-        }
+        if (clientCert.pfx) {
+          try {
+            httpsAgentRequestFields['pfx'] = fs.readFileSync(certFilePath);
+          } catch (err) {
+            console.log('Error reading cert file', err);
+          }
+        } else {
+          try {
+            httpsAgentRequestFields['cert'] = fs.readFileSync(certFilePath);
+          } catch (err) {
+            console.log('Error reading cert file', err);
+          }
 
-        try {
-          httpsAgentRequestFields['key'] = fs.readFileSync(keyFilePath);
-        } catch (err) {
-          console.log('Error reading key file', err);
+          try {
+            httpsAgentRequestFields['key'] = fs.readFileSync(keyFilePath);
+          } catch (err) {
+            console.log('Error reading key file', err);
+          }
         }
 
         httpsAgentRequestFields['passphrase'] = interpolateString(clientCert.passphrase, interpolationOptions);


### PR DESCRIPTION
# Description

This change allows bruno to use client certificates stored in PFX / PKCS12 files in addition to regular PEM cert/key pairs. 
Updated the Client Certificate selection in Collection view so that the user can specify if they are using pfx format, in which case the key file becomes unnecessary, and the control disabled.  The passphrase field works for both formats.

Axios used by _bruno_ has the support built-in so this change is a rather trivial one, with only the question of UI to solve.

resolves #1889 
resolves #1698

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

![Screenshot from 2024-05-18 02-05-06](https://github.com/usebruno/bruno/assets/2108093/b410ce50-9c73-45b1-b2cb-be45138d1a6e)
![Screenshot from 2024-05-18 02-04-52](https://github.com/usebruno/bruno/assets/2108093/8659660b-fc8c-4b14-902a-d31b154892c9)

For reference: Postman implementation
![Screenshot from 2024-05-18 02-16-20](https://github.com/usebruno/bruno/assets/2108093/70df155c-8abf-4a2e-9df2-36ebeb0a3bbb)

