### PR TITLE
Feat: Added tooltip for icons and panel with request name located in CollectionToolBar

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/StyledWrapper.js
@@ -60,6 +60,7 @@ const Wrapper = styled.div`
     opacity: 0;
     transition: opacity 0.3s;
     white-space: nowrap;
+    user-select: none;
   }
 
   .tooltiptext::after {

--- a/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/StyledWrapper.js
@@ -1,5 +1,45 @@
 import styled from 'styled-components';
 
-const StyledWrapper = styled.div``;
+const StyledWrapper = styled.div`
+  .tooltip {
+    position: relative;
+    cursor: pointer;
+  }
+
+  .tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  .tooltiptext {
+    visibility: hidden;
+    width: auto;
+    background-color: ${(props) => props.theme.requestTabs.active.bg};
+    color: ${(props) => props.theme.text};
+    text-align: center;
+    border-radius: 4px;
+    padding: 4px 8px;
+    position: absolute;
+    z-index: 1;
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 0;
+    transition: opacity 0.3s;
+    white-space: nowrap;
+    top: 165%;
+    user-select: none;
+  }
+
+  .tooltiptext::after {
+    content: '';
+    position: absolute;
+    top: -8px;
+    left: 50%;
+    margin-left: -4px;
+    border-width: 4px;
+    border-style: solid;
+    border-color: transparent transparent ${(props) => props.theme.requestTabs.active.bg} transparent;
+  }
+`;
 
 export default StyledWrapper;

--- a/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/index.js
@@ -42,19 +42,31 @@ const CollectionToolBar = ({ collection }) => {
   return (
     <StyledWrapper>
       <div className="flex items-center p-2">
-        <div className="flex flex-1 items-center cursor-pointer hover:underline" onClick={viewCollectionSettings}>
-          <IconFiles size={18} strokeWidth={1.5} />
-          <span className="ml-2 mr-4 font-semibold">{collection.name}</span>
+        <div className="flex flex-1 cursor-pointer hover:underline" onClick={viewCollectionSettings}>
+          <div className="flex items-center tooltip">
+            <IconFiles size={18} strokeWidth={1.5} />
+            <span className="ml-2 mr-4 font-semibold">{collection.name}</span>
+            <span className="tooltiptext text-xs">Collection</span>
+          </div>
         </div>
         <div className="flex flex-1 items-center justify-end">
           <span className="mr-2">
-            <IconRun className="cursor-pointer" size={20} strokeWidth={1.5} onClick={handleRun} />
+            <div className="tooltip" onClick={handleRun}>
+              <IconRun className="cursor-pointer" size={20} strokeWidth={1.5} />
+              <span className="tooltiptext text-xs">Runner</span>
+            </div>
           </span>
           <span className="mr-3">
-            <IconEye className="cursor-pointer" size={18} strokeWidth={1.5} onClick={viewVariables} />
+            <div className="tooltip" onClick={viewVariables}>
+              <IconEye className="cursor-pointer" size={18} strokeWidth={1.5} />
+              <span className="tooltiptext text-xs">Variables</span>
+            </div>
           </span>
           <span className="mr-3">
-            <IconSettings className="cursor-pointer" size={18} strokeWidth={1.5} onClick={viewCollectionSettings} />
+            <div className="tooltip" onClick={viewCollectionSettings}>
+              <IconSettings className="cursor-pointer" size={18} strokeWidth={1.5} />
+              <span className="tooltiptext text-xs">Collection</span>
+            </div>
           </span>
           <EnvironmentSelector collection={collection} />
         </div>


### PR DESCRIPTION
# Description

Resolves #2327 by adding tooltips requested in issue:
+ Tooltip for Runner button
+ Tooltip for Variables button
+ Tooltip for the Collection button
+ Tooltip for the panel with the name of the request
- Fixed style for IconDeviceFloppy in QueryUrl

Added `user-select: none;` property to tooltip styles, because if you quickly move the cursor to the tooltip area, it doesn't disappear and you can select text in it.

Before:
![before](https://github.com/usebruno/bruno/assets/45532431/928a1c6f-8650-43e2-9201-a379b2993b98)

After:
![after](https://github.com/usebruno/bruno/assets/45532431/2617c5f0-4367-4136-a04e-cb7c09132b33)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
