### PR TITLE
Convert Postman collection to Bruno collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "packages/bruno-electron",
     "packages/bruno-cli",
     "packages/bruno-common",
+    "packages/bruno-converters",
+    "packages/bruno-importers",
     "packages/bruno-schema",
     "packages/bruno-query",
     "packages/bruno-js",
@@ -33,6 +35,7 @@
     "prettier:web": "npm run prettier --workspace=packages/bruno-app",
     "dev:electron": "npm run dev --workspace=packages/bruno-electron",
     "build:bruno-common": "npm run build --workspace=packages/bruno-common",
+    "build:bruno-converters": "npm run build --workspace=packages/bruno-converters",
     "build:bruno-query": "npm run build --workspace=packages/bruno-query",
     "build:graphql-docs": "npm run build --workspace=packages/bruno-graphql-docs",
     "build:electron": "node ./scripts/build-electron.js",
@@ -47,7 +50,6 @@
     "test:prettier:web": "npm run test:prettier --workspace=packages/bruno-app",
     "prepare": "husky install"
   },
-  
   "overrides": {
     "rollup": "3.2.5"
   },

--- a/packages/bruno-converters/.gitignore
+++ b/packages/bruno-converters/.gitignore
@@ -1,0 +1,22 @@
+# dependencies
+node_modules
+yarn.lock
+pnpm-lock.yaml
+package-lock.json
+.pnp
+.pnp.js
+
+# testing
+coverage
+
+# production
+dist
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/bruno-converters/license.md
+++ b/packages/bruno-converters/license.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Anoop M D, Anusree P S and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/bruno-converters/package.json
+++ b/packages/bruno-converters/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@usebruno/converters",
+  "version": "0.1.0",
+  "license": "MIT",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "package.json"
+  ],
+  "scripts": {
+    "clean": "rimraf dist",
+    "test": "jest",
+    "prebuild": "npm run clean",
+    "build": "rollup -c",
+    "watch": "rollup -c -w",
+    "prepack": "npm run test && npm run build"
+  },
+  "dependencies": {
+    "@usebruno/schema": "^0.7.0",
+    "lodash": "^4.17.21",
+    "nanoid": "3.3.4"
+  },
+  "devDependencies": {
+    "@rollup/plugin-alias": "^5.1.0",
+    "@rollup/plugin-commonjs": "^23.0.2",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^9.0.2",
+    "rimraf": "^5.0.7",
+    "rollup": "3.2.5",
+    "rollup-plugin-dts": "^5.0.0",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup-plugin-terser": "^7.0.2",
+    "typescript": "^4.8.4"
+  },
+  "overrides": {
+    "rollup": "3.2.5"
+  }
+}

--- a/packages/bruno-converters/readme.md
+++ b/packages/bruno-converters/readme.md
@@ -1,0 +1,27 @@
+# bruno-converters
+
+The converters package is responsible for converting collections from one format to a Bruno collection.
+It can be used as a standalone package or as a part of the Bruno framework.
+
+## Installation
+
+```bash
+npm install @bruno-converters
+```
+
+## Usage
+
+### Convert Postman collection to Bruno collection
+
+```javascript
+const { importPostmanCollection, exportBrunoCollection } = require('@bruno-converters');
+
+// Convert Postman collection to Bruno collection
+const postmanCollectionFile = './example.postman_collection.json';
+const brunoCollection = await importPostmanCollection(postmanCollectionFile, {
+  enablePostmanTranslations: { enabled: true }
+});
+
+// Export Bruno collection as a JSON file
+exportBrunoCollection(brunoCollection);
+```

--- a/packages/bruno-converters/rollup.config.js
+++ b/packages/bruno-converters/rollup.config.js
@@ -1,0 +1,41 @@
+const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const commonjs = require('@rollup/plugin-commonjs');
+const { terser } = require('rollup-plugin-terser');
+const peerDepsExternal = require('rollup-plugin-peer-deps-external');
+
+const packageJson = require('./package.json');
+const alias = require('@rollup/plugin-alias');
+const path = require('path');
+
+module.exports = [
+  {
+    input: 'src/index.js',
+    output: [
+      {
+        file: packageJson.main,
+        // dir: packageJson.main,
+        format: 'cjs',
+        sourcemap: true
+        // preserveModules: true
+      },
+      {
+        file: packageJson.module,
+        // dir: packageJson.module,
+        format: 'esm',
+        sourcemap: true
+        // preserveModules: true
+      }
+    ],
+    plugins: [
+      peerDepsExternal(),
+      nodeResolve({
+        extensions: ['.js', '.css'] // Resolve .js files
+      }),
+      commonjs(),
+      terser(),
+      alias({
+        entries: [{ find: 'src', replacement: path.resolve(__dirname, 'src') }]
+      })
+    ]
+  }
+];

--- a/packages/bruno-converters/src/bruno-collection.js
+++ b/packages/bruno-converters/src/bruno-collection.js
@@ -1,0 +1,43 @@
+import fileDialog from 'file-dialog';
+import { BrunoError } from 'utils/common/error';
+import { validateSchema, transformItemsInCollection, updateUidsInCollection, hydrateSeqInCollection } from './common';
+
+const readFile = (files) => {
+  return new Promise((resolve, reject) => {
+    const fileReader = new FileReader();
+    fileReader.onload = (e) => resolve(e.target.result);
+    fileReader.onerror = (err) => reject(err);
+    fileReader.readAsText(files[0]);
+  });
+};
+
+const parseJsonCollection = (str) => {
+  return new Promise((resolve, reject) => {
+    try {
+      let parsed = JSON.parse(str);
+      return resolve(parsed);
+    } catch (err) {
+      console.log(err);
+      reject(new BrunoError('Unable to parse the collection json file'));
+    }
+  });
+};
+
+const importCollection = () => {
+  return new Promise((resolve, reject) => {
+    fileDialog({ accept: 'application/json' })
+      .then(readFile)
+      .then(parseJsonCollection)
+      .then(hydrateSeqInCollection)
+      .then(updateUidsInCollection)
+      .then(transformItemsInCollection)
+      .then(validateSchema)
+      .then((collection) => resolve(collection))
+      .catch((err) => {
+        console.log(err);
+        reject(new BrunoError('Import collection failed'));
+      });
+  });
+};
+
+export default importCollection;

--- a/packages/bruno-converters/src/collections/export.js
+++ b/packages/bruno-converters/src/collections/export.js
@@ -1,0 +1,85 @@
+import get from 'lodash/get';
+import each from 'lodash/each';
+import { saveFile } from '../postman-collection';
+
+export const deleteUidsInItems = (items) => {
+  each(items, (item) => {
+    delete item.uid;
+
+    if (['http-request', 'graphql-request'].includes(item.type)) {
+      each(get(item, 'request.headers'), (header) => delete header.uid);
+      each(get(item, 'request.params'), (param) => delete param.uid);
+      each(get(item, 'request.vars.req'), (v) => delete v.uid);
+      each(get(item, 'request.vars.res'), (v) => delete v.uid);
+      each(get(item, 'request.vars.assertions'), (a) => delete a.uid);
+      each(get(item, 'request.body.multipartForm'), (param) => delete param.uid);
+      each(get(item, 'request.body.formUrlEncoded'), (param) => delete param.uid);
+    }
+
+    if (item.items && item.items.length) {
+      deleteUidsInItems(item.items);
+    }
+  });
+};
+
+/**
+ * Some of the models in the app are not consistent with the Collection Json format
+ * This function is used to transform the models to the Collection Json format
+ */
+export const transformItem = (items = []) => {
+  each(items, (item) => {
+    if (['http-request', 'graphql-request'].includes(item.type)) {
+      item.request.query = item.request.params;
+      delete item.request.params;
+
+      if (item.type === 'graphql-request') {
+        item.type = 'graphql';
+      }
+
+      if (item.type === 'http-request') {
+        item.type = 'http';
+      }
+    }
+
+    if (item.items && item.items.length) {
+      transformItem(item.items);
+    }
+  });
+};
+
+export const deleteUidsInEnvs = (envs) => {
+  each(envs, (env) => {
+    delete env.uid;
+    each(env.variables, (variable) => delete variable.uid);
+  });
+};
+
+export const deleteSecretsInEnvs = (envs) => {
+  each(envs, (env) => {
+    each(env.variables, (variable) => {
+      if (variable.secret) {
+        variable.value = '';
+      }
+    });
+  });
+};
+
+export const exportCollection = (collection, file) => {
+  // delete uids
+  delete collection.uid;
+
+  // delete process variables
+  delete collection?.processEnvVariables;
+
+  deleteUidsInItems(collection.items);
+  deleteUidsInEnvs(collection.environments);
+  deleteSecretsInEnvs(collection.environments);
+  transformItem(collection.items);
+
+  const fileName = file || `${collection.name}.json`;
+  const fileBlob = JSON.stringify(collection, null, 2);
+
+  saveFile(fileBlob, fileName).then(() => {
+    console.log(`Collection exported as ${fileName}`);
+  });
+};

--- a/packages/bruno-converters/src/collections/index.js
+++ b/packages/bruno-converters/src/collections/index.js
@@ -1,0 +1,655 @@
+import get from 'lodash/get';
+import each from 'lodash/each';
+import find from 'lodash/find';
+import findIndex from 'lodash/findIndex';
+import isString from 'lodash/isString';
+import map from 'lodash/map';
+import filter from 'lodash/filter';
+import sortBy from 'lodash/sortBy';
+import isEqual from 'lodash/isEqual';
+import cloneDeep from 'lodash/cloneDeep';
+import { uuid } from 'src/common/index.js';
+import path from 'path';
+
+const replaceTabsWithSpaces = (str, numSpaces = 2) => {
+  if (!str || !str.length || !isString(str)) {
+    return '';
+  }
+
+  return str.replaceAll('\t', ' '.repeat(numSpaces));
+};
+
+export const addDepth = (items = []) => {
+  const depth = (itms, initialDepth) => {
+    each(itms, (i) => {
+      i.depth = initialDepth;
+
+      if (i.items && i.items.length) {
+        depth(i.items, initialDepth + 1);
+      }
+    });
+  };
+
+  depth(items, 1);
+};
+
+export const collapseCollection = (collection) => {
+  collection.collapsed = true;
+
+  const collapseItem = (items) => {
+    each(items, (i) => {
+      i.collapsed = true;
+
+      if (i.items && i.items.length) {
+        collapseItem(i.items);
+      }
+    });
+  };
+
+  collapseItem(collection.items, 1);
+};
+
+export const sortItems = (collection) => {
+  const sort = (obj) => {
+    if (obj.items && obj.items.length) {
+      obj.items = sortBy(obj.items, 'type');
+    }
+
+    each(obj.items, (i) => sort(i));
+  };
+
+  sort(collection);
+};
+
+export const flattenItems = (items = []) => {
+  const flattenedItems = [];
+
+  const flatten = (itms, flattened) => {
+    each(itms, (i) => {
+      flattened.push(i);
+
+      if (i.items && i.items.length) {
+        flatten(i.items, flattened);
+      }
+    });
+  };
+
+  flatten(items, flattenedItems);
+
+  return flattenedItems;
+};
+
+export const findItem = (items = [], itemUid) => {
+  return find(items, (i) => i.uid === itemUid);
+};
+
+export const findCollectionByUid = (collections, collectionUid) => {
+  return find(collections, (c) => c.uid === collectionUid);
+};
+
+export const findCollectionByPathname = (collections, pathname) => {
+  return find(collections, (c) => c.pathname === pathname);
+};
+
+export const findCollectionByItemUid = (collections, itemUid) => {
+  return find(collections, (c) => {
+    return findItemInCollection(c, itemUid);
+  });
+};
+
+export const findItemByPathname = (items = [], pathname) => {
+  return find(items, (i) => i.pathname === pathname);
+};
+
+export const findItemInCollectionByPathname = (collection, pathname) => {
+  let flattenedItems = flattenItems(collection.items);
+
+  return findItemByPathname(flattenedItems, pathname);
+};
+
+export const findItemInCollection = (collection, itemUid) => {
+  let flattenedItems = flattenItems(collection.items);
+
+  return findItem(flattenedItems, itemUid);
+};
+
+export const findParentItemInCollection = (collection, itemUid) => {
+  let flattenedItems = flattenItems(collection.items);
+
+  return find(flattenedItems, (item) => {
+    return item.items && find(item.items, (i) => i.uid === itemUid);
+  });
+};
+
+export const recursivelyGetAllItemUids = (items = []) => {
+  let flattenedItems = flattenItems(items);
+
+  return map(flattenedItems, (i) => i.uid);
+};
+
+export const findEnvironmentInCollection = (collection, envUid) => {
+  return find(collection.environments, (e) => e.uid === envUid);
+};
+
+export const moveCollectionItem = (collection, draggedItem, targetItem) => {
+  let draggedItemParent = findParentItemInCollection(collection, draggedItem.uid);
+
+  if (draggedItemParent) {
+    draggedItemParent.items = sortBy(draggedItemParent.items, (item) => item.seq);
+    draggedItemParent.items = filter(draggedItemParent.items, (i) => i.uid !== draggedItem.uid);
+    draggedItem.pathname = path.join(draggedItemParent.pathname, draggedItem.filename);
+  } else {
+    collection.items = sortBy(collection.items, (item) => item.seq);
+    collection.items = filter(collection.items, (i) => i.uid !== draggedItem.uid);
+  }
+
+  if (targetItem.type === 'folder') {
+    targetItem.items = sortBy(targetItem.items || [], (item) => item.seq);
+    targetItem.items.push(draggedItem);
+    draggedItem.pathname = path.join(targetItem.pathname, draggedItem.filename);
+  } else {
+    let targetItemParent = findParentItemInCollection(collection, targetItem.uid);
+
+    if (targetItemParent) {
+      targetItemParent.items = sortBy(targetItemParent.items, (item) => item.seq);
+      let targetItemIndex = findIndex(targetItemParent.items, (i) => i.uid === targetItem.uid);
+      targetItemParent.items.splice(targetItemIndex + 1, 0, draggedItem);
+      draggedItem.pathname = path.join(targetItemParent.pathname, draggedItem.filename);
+    } else {
+      collection.items = sortBy(collection.items, (item) => item.seq);
+      let targetItemIndex = findIndex(collection.items, (i) => i.uid === targetItem.uid);
+      collection.items.splice(targetItemIndex + 1, 0, draggedItem);
+      draggedItem.pathname = path.join(collection.pathname, draggedItem.filename);
+    }
+  }
+};
+
+export const moveCollectionItemToRootOfCollection = (collection, draggedItem) => {
+  let draggedItemParent = findParentItemInCollection(collection, draggedItem.uid);
+
+  // If the dragged item is already at the root of the collection, do nothing
+  if (!draggedItemParent) {
+    return;
+  }
+
+  draggedItemParent.items = sortBy(draggedItemParent.items, (item) => item.seq);
+  draggedItemParent.items = filter(draggedItemParent.items, (i) => i.uid !== draggedItem.uid);
+  collection.items = sortBy(collection.items, (item) => item.seq);
+  collection.items.push(draggedItem);
+  if (draggedItem.type == 'folder') {
+    draggedItem.pathname = path.join(collection.pathname, draggedItem.name);
+  } else {
+    draggedItem.pathname = path.join(collection.pathname, draggedItem.filename);
+  }
+};
+
+export const getItemsToResequence = (parent, collection) => {
+  let itemsToResequence = [];
+
+  if (!parent) {
+    let index = 1;
+    each(collection.items, (item) => {
+      if (isItemARequest(item)) {
+        itemsToResequence.push({
+          pathname: item.pathname,
+          seq: index++
+        });
+      }
+    });
+    return itemsToResequence;
+  }
+
+  if (parent.items && parent.items.length) {
+    let index = 1;
+    each(parent.items, (item) => {
+      if (isItemARequest(item)) {
+        itemsToResequence.push({
+          pathname: item.pathname,
+          seq: index++
+        });
+      }
+    });
+    return itemsToResequence;
+  }
+
+  return itemsToResequence;
+};
+
+export const transformCollectionToSaveToExportAsFile = (collection, options = {}) => {
+  const copyHeaders = (headers) => {
+    return map(headers, (header) => {
+      return {
+        uid: header.uid,
+        name: header.name,
+        value: header.value,
+        description: header.description,
+        enabled: header.enabled
+      };
+    });
+  };
+
+  const copyQueryParams = (params) => {
+    return map(params, (param) => {
+      return {
+        uid: param.uid,
+        name: param.name,
+        value: param.value,
+        description: param.description,
+        enabled: param.enabled
+      };
+    });
+  };
+
+  const copyFormUrlEncodedParams = (params = []) => {
+    return map(params, (param) => {
+      return {
+        uid: param.uid,
+        name: param.name,
+        value: param.value,
+        description: param.description,
+        enabled: param.enabled
+      };
+    });
+  };
+
+  const copyMultipartFormParams = (params = []) => {
+    return map(params, (param) => {
+      return {
+        uid: param.uid,
+        type: param.type,
+        name: param.name,
+        value: param.value,
+        description: param.description,
+        enabled: param.enabled
+      };
+    });
+  };
+
+  const copyItems = (sourceItems, destItems) => {
+    each(sourceItems, (si) => {
+      const di = {
+        uid: si.uid,
+        type: si.type,
+        name: si.name,
+        seq: si.seq
+      };
+
+      // if items is draft, then take data from draft to save
+      // The condition "!options.ignoreDraft" may appear confusing
+      // When saving a collection, this option allows the caller to specify to ignore any draft changes while still saving rest of the collection.
+      // This is useful for performing rename request/collections while still leaving changes in draft not making its way into the indexeddb
+      if (si.draft && !options.ignoreDraft) {
+        if (si.draft.request) {
+          di.request = {
+            url: si.draft.request.url,
+            method: si.draft.request.method,
+            headers: copyHeaders(si.draft.request.headers),
+            params: copyQueryParams(si.draft.request.params),
+            body: {
+              mode: si.draft.request.body.mode,
+              json: si.draft.request.body.json,
+              text: si.draft.request.body.text,
+              xml: si.draft.request.body.xml,
+              graphql: si.draft.request.body.graphql,
+              sparql: si.draft.request.body.sparql,
+              formUrlEncoded: copyFormUrlEncodedParams(si.draft.request.body.formUrlEncoded),
+              multipartForm: copyMultipartFormParams(si.draft.request.body.multipartForm)
+            },
+            auth: {
+              mode: get(si.draft.request, 'auth.mode', 'none'),
+              basic: {
+                username: get(si.draft.request, 'auth.basic.username', ''),
+                password: get(si.draft.request, 'auth.basic.password', '')
+              },
+              bearer: {
+                token: get(si.draft.request, 'auth.bearer.token', '')
+              }
+            },
+            script: si.draft.request.script,
+            vars: si.draft.request.vars,
+            assertions: si.draft.request.assertions,
+            tests: si.draft.request.tests
+          };
+        }
+      } else {
+        if (si.request) {
+          di.request = {
+            url: si.request.url,
+            method: si.request.method,
+            headers: copyHeaders(si.request.headers),
+            params: copyQueryParams(si.request.params),
+            body: {
+              mode: si.request.body.mode,
+              json: si.request.body.json,
+              text: si.request.body.text,
+              xml: si.request.body.xml,
+              graphql: si.request.body.graphql,
+              sparql: si.request.body.sparql,
+              formUrlEncoded: copyFormUrlEncodedParams(si.request.body.formUrlEncoded),
+              multipartForm: copyMultipartFormParams(si.request.body.multipartForm)
+            },
+            auth: {
+              mode: get(si.request, 'auth.mode', 'none'),
+              basic: {
+                username: get(si.request, 'auth.basic.username', ''),
+                password: get(si.request, 'auth.basic.password', '')
+              },
+              bearer: {
+                token: get(si.request, 'auth.bearer.token', '')
+              }
+            },
+            script: si.request.script,
+            vars: si.request.vars,
+            assertions: si.request.assertions,
+            tests: si.request.tests
+          };
+        }
+      }
+
+      if (di.request && di.request.body.mode === 'json') {
+        di.request.body.json = replaceTabsWithSpaces(di.request.body.json);
+      }
+
+      destItems.push(di);
+
+      if (si.items && si.items.length) {
+        di.items = [];
+        copyItems(si.items, di.items);
+      }
+    });
+  };
+
+  const collectionToSave = {};
+  collectionToSave.name = collection.name;
+  collectionToSave.uid = collection.uid;
+
+  // todo: move this to the place where collection gets created
+  collectionToSave.version = '1';
+  collectionToSave.items = [];
+  collectionToSave.activeEnvironmentUid = collection.activeEnvironmentUid;
+  collectionToSave.environments = collection.environments || [];
+
+  copyItems(collection.items, collectionToSave.items);
+
+  return collectionToSave;
+};
+
+export const transformRequestToSaveToFilesystem = (item) => {
+  const _item = item.draft ? item.draft : item;
+  const itemToSave = {
+    uid: _item.uid,
+    type: _item.type,
+    name: _item.name,
+    seq: _item.seq,
+    request: {
+      method: _item.request.method,
+      url: _item.request.url,
+      params: [],
+      headers: [],
+      auth: _item.request.auth,
+      body: _item.request.body,
+      script: _item.request.script,
+      vars: _item.request.vars,
+      assertions: _item.request.assertions,
+      tests: _item.request.tests,
+      docs: _item.request.docs
+    }
+  };
+
+  each(_item.request.params, (param) => {
+    itemToSave.request.params.push({
+      uid: param.uid,
+      name: param.name,
+      value: param.value,
+      description: param.description,
+      enabled: param.enabled
+    });
+  });
+
+  each(_item.request.headers, (header) => {
+    itemToSave.request.headers.push({
+      uid: header.uid,
+      name: header.name,
+      value: header.value,
+      description: header.description,
+      enabled: header.enabled
+    });
+  });
+
+  if (itemToSave.request.body.mode === 'json') {
+    itemToSave.request.body = {
+      ...itemToSave.request.body,
+      json: replaceTabsWithSpaces(itemToSave.request.body.json)
+    };
+  }
+
+  return itemToSave;
+};
+
+// todo: optimize this
+export const deleteItemInCollection = (itemUid, collection) => {
+  collection.items = filter(collection.items, (i) => i.uid !== itemUid);
+
+  let flattenedItems = flattenItems(collection.items);
+  each(flattenedItems, (i) => {
+    if (i.items && i.items.length) {
+      i.items = filter(i.items, (i) => i.uid !== itemUid);
+    }
+  });
+};
+
+export const deleteItemInCollectionByPathname = (pathname, collection) => {
+  collection.items = filter(collection.items, (i) => i.pathname !== pathname);
+
+  let flattenedItems = flattenItems(collection.items);
+  each(flattenedItems, (i) => {
+    if (i.items && i.items.length) {
+      i.items = filter(i.items, (i) => i.pathname !== pathname);
+    }
+  });
+};
+
+export const isItemARequest = (item) => {
+  return item.hasOwnProperty('request') && ['http-request', 'graphql-request'].includes(item.type) && !item.items;
+};
+
+export const isItemAFolder = (item) => {
+  return !item.hasOwnProperty('request') && item.type === 'folder';
+};
+
+export const humanizeRequestBodyMode = (mode) => {
+  let label = 'No Body';
+  switch (mode) {
+    case 'json': {
+      label = 'JSON';
+      break;
+    }
+    case 'text': {
+      label = 'TEXT';
+      break;
+    }
+    case 'xml': {
+      label = 'XML';
+      break;
+    }
+    case 'sparql': {
+      label = 'SPARQL';
+      break;
+    }
+    case 'formUrlEncoded': {
+      label = 'Form URL Encoded';
+      break;
+    }
+    case 'multipartForm': {
+      label = 'Multipart Form';
+      break;
+    }
+  }
+
+  return label;
+};
+
+export const humanizeRequestAuthMode = (mode) => {
+  let label = 'No Auth';
+  switch (mode) {
+    case 'inherit': {
+      label = 'Inherit';
+      break;
+    }
+    case 'awsv4': {
+      label = 'AWS Sig V4';
+      break;
+    }
+    case 'basic': {
+      label = 'Basic Auth';
+      break;
+    }
+    case 'bearer': {
+      label = 'Bearer Token';
+      break;
+    }
+    case 'digest': {
+      label = 'Digest Auth';
+      break;
+    }
+    case 'oauth2': {
+      label = 'OAuth 2.0';
+      break;
+    }
+  }
+
+  return label;
+};
+
+export const humanizeGrantType = (mode) => {
+  let label = 'No Auth';
+  switch (mode) {
+    case 'password': {
+      label = 'Password Credentials';
+      break;
+    }
+    case 'authorization_code': {
+      label = 'Authorization Code';
+      break;
+    }
+    case 'client_credentials': {
+      label = 'Client Credentials';
+      break;
+    }
+  }
+
+  return label;
+};
+
+export const refreshUidsInItem = (item) => {
+  item.uid = uuid();
+
+  each(get(item, 'request.headers'), (header) => (header.uid = uuid()));
+  each(get(item, 'request.params'), (param) => (param.uid = uuid()));
+  each(get(item, 'request.body.multipartForm'), (param) => (param.uid = uuid()));
+  each(get(item, 'request.body.formUrlEncoded'), (param) => (param.uid = uuid()));
+
+  return item;
+};
+
+export const deleteUidsInItem = (item) => {
+  delete item.uid;
+  const params = get(item, 'request.params', []);
+  const headers = get(item, 'request.headers', []);
+  const bodyFormUrlEncoded = get(item, 'request.body.formUrlEncoded', []);
+  const bodyMultipartForm = get(item, 'request.body.multipartForm', []);
+
+  params.forEach((param) => delete param.uid);
+  headers.forEach((header) => delete header.uid);
+  bodyFormUrlEncoded.forEach((param) => delete param.uid);
+  bodyMultipartForm.forEach((param) => delete param.uid);
+
+  return item;
+};
+
+export const areItemsTheSameExceptSeqUpdate = (_item1, _item2) => {
+  let item1 = cloneDeep(_item1);
+  let item2 = cloneDeep(_item2);
+
+  // remove seq from both items
+  delete item1.seq;
+  delete item2.seq;
+
+  // remove draft from both items
+  delete item1.draft;
+  delete item2.draft;
+
+  // get projection of both items
+  item1 = transformRequestToSaveToFilesystem(item1);
+  item2 = transformRequestToSaveToFilesystem(item2);
+
+  // delete uids from both items
+  deleteUidsInItem(item1);
+  deleteUidsInItem(item2);
+
+  return isEqual(item1, item2);
+};
+
+export const getDefaultRequestPaneTab = (item) => {
+  if (item.type === 'http-request') {
+    return 'params';
+  }
+
+  if (item.type === 'graphql-request') {
+    return 'query';
+  }
+};
+
+export const getEnvironmentVariables = (collection) => {
+  let variables = {};
+  if (collection) {
+    const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
+    if (environment) {
+      each(environment.variables, (variable) => {
+        if (variable.name && variable.value && variable.enabled) {
+          variables[variable.name] = variable.value;
+        }
+      });
+    }
+  }
+
+  return variables;
+};
+
+export const getTotalRequestCountInCollection = (collection) => {
+  let count = 0;
+  each(collection.items, (item) => {
+    if (isItemARequest(item)) {
+      count++;
+    } else if (isItemAFolder(item)) {
+      count += getTotalRequestCountInCollection(item);
+    }
+  });
+
+  return count;
+};
+
+export const getAllVariables = (collection) => {
+  const environmentVariables = getEnvironmentVariables(collection);
+
+  return {
+    ...environmentVariables,
+    ...collection.collectionVariables,
+    process: {
+      env: {
+        ...collection.processEnvVariables
+      }
+    }
+  };
+};
+
+export const maskInputValue = (value) => {
+  if (!value || typeof value !== 'string') {
+    return '';
+  }
+
+  return value
+    .split('')
+    .map(() => '*')
+    .join('');
+};

--- a/packages/bruno-converters/src/collections/search.js
+++ b/packages/bruno-converters/src/collections/search.js
@@ -1,0 +1,21 @@
+import { flattenItems, isItemARequest } from './index';
+import filter from 'lodash/filter';
+import find from 'lodash/find';
+
+export const doesRequestMatchSearchText = (request, searchText = '') => {
+  return request.name.toLowerCase().includes(searchText.toLowerCase());
+};
+
+export const doesFolderHaveItemsMatchSearchText = (item, searchText = '') => {
+  let flattenedItems = flattenItems(item.items);
+  let requestItems = filter(flattenedItems, (item) => isItemARequest(item));
+
+  return find(requestItems, (request) => doesRequestMatchSearchText(request, searchText));
+};
+
+export const doesCollectionHaveItemsMatchingSearchText = (collection, searchText = '') => {
+  let flattenedItems = flattenItems(collection.items);
+  let requestItems = filter(flattenedItems, (item) => isItemARequest(item));
+
+  return find(requestItems, (request) => doesRequestMatchSearchText(request, searchText));
+};

--- a/packages/bruno-converters/src/common/common.js
+++ b/packages/bruno-converters/src/common/common.js
@@ -1,0 +1,123 @@
+import each from 'lodash/each';
+import get from 'lodash/get';
+
+import cloneDeep from 'lodash/cloneDeep';
+import { uuid, normalizeFileName } from './index.js';
+import { isItemARequest } from '../collections';
+import { collectionSchema } from '@usebruno/schema';
+// import { BrunoError } from 'error';
+
+export class BrunoError extends Error {
+  constructor(message, level) {
+    super(message);
+    this.name = 'BrunoError';
+    this.level = level || 'error';
+  }
+}
+
+export const validateSchema = (collection = {}) => {
+  return new Promise((resolve, reject) => {
+    collectionSchema
+      .validate(collection)
+      .then(() => resolve(collection))
+      .catch((err) => {
+        console.log(err);
+        reject(new BrunoError('The Collection file is corrupted'));
+      });
+  });
+};
+
+export const updateUidsInCollection = (_collection) => {
+  const collection = cloneDeep(_collection);
+
+  collection.uid = uuid();
+
+  const updateItemUids = (items = []) => {
+    each(items, (item) => {
+      item.uid = uuid();
+
+      each(get(item, 'request.headers'), (header) => (header.uid = uuid()));
+      each(get(item, 'request.query'), (param) => (param.uid = uuid()));
+      each(get(item, 'request.params'), (param) => (param.uid = uuid()));
+      each(get(item, 'request.vars.req'), (v) => (v.uid = uuid()));
+      each(get(item, 'request.vars.res'), (v) => (v.uid = uuid()));
+      each(get(item, 'request.assertions'), (a) => (a.uid = uuid()));
+      each(get(item, 'request.body.multipartForm'), (param) => (param.uid = uuid()));
+      each(get(item, 'request.body.formUrlEncoded'), (param) => (param.uid = uuid()));
+
+      if (item.items && item.items.length) {
+        updateItemUids(item.items);
+      }
+    });
+  };
+  updateItemUids(collection.items);
+
+  const updateEnvUids = (envs = []) => {
+    each(envs, (env) => {
+      env.uid = uuid();
+      each(env.variables, (variable) => (variable.uid = uuid()));
+    });
+  };
+  updateEnvUids(collection.environments);
+
+  return collection;
+};
+
+// todo
+// need to eventually get rid of supporting old collection app models
+// 1. start with making request type a constant fetched from a single place
+// 2. move references of param and replace it with query inside the app
+export const transformItemsInCollection = (collection) => {
+  const transformItems = (items = []) => {
+    each(items, (item) => {
+      item.name = normalizeFileName(item.name);
+
+      if (['http', 'graphql'].includes(item.type)) {
+        item.type = `${item.type}-request`;
+        if (item.request.query) {
+          item.request.params = item.request.query;
+        }
+
+        delete item.request.query;
+
+        // from 5 feb 2024, multipartFormData needs to have a type
+        // this was introduced when we added support for file uploads
+        // below logic is to make older collection exports backward compatible
+        let multipartFormData = _.get(item, 'request.body.multipartForm');
+        if (multipartFormData) {
+          _.each(multipartFormData, (form) => {
+            if (!form.type) {
+              form.type = 'text';
+            }
+          });
+        }
+      }
+
+      if (item.items && item.items.length) {
+        transformItems(item.items);
+      }
+    });
+  };
+
+  transformItems(collection.items);
+
+  return collection;
+};
+
+export const hydrateSeqInCollection = (collection) => {
+  const hydrateSeq = (items = []) => {
+    let index = 1;
+    each(items, (item) => {
+      if (isItemARequest(item) && !item.seq) {
+        item.seq = index;
+        index++;
+      }
+      if (item.items && item.items.length) {
+        hydrateSeq(item.items);
+      }
+    });
+  };
+  hydrateSeq(collection.items);
+
+  return collection;
+};

--- a/packages/bruno-converters/src/common/error.js
+++ b/packages/bruno-converters/src/common/error.js
@@ -1,0 +1,8 @@
+// levels: 'warning, error'
+export class BrunoError extends Error {
+  constructor(message, level) {
+    super(message);
+    this.name = 'BrunoError';
+    this.level = level || 'error';
+  }
+}

--- a/packages/bruno-converters/src/common/index.js
+++ b/packages/bruno-converters/src/common/index.js
@@ -1,0 +1,139 @@
+import { customAlphabet } from 'nanoid';
+// import xmlFormat from 'xml-formatter';
+
+// a customized version of nanoid without using _ and -
+export const uuid = () => {
+  // https://github.com/ai/nanoid/blob/main/url-alphabet/index.js
+  const urlAlphabet = 'useandom26T198340PX75pxJACKVERYMINDBUSHWOLFGQZbfghjklqvwyzrict';
+  const customNanoId = customAlphabet(urlAlphabet, 21);
+
+  return customNanoId();
+};
+
+export const simpleHash = (str) => {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash &= hash; // Convert to 32bit integer
+  }
+  return new Uint32Array([hash])[0].toString(36);
+};
+
+export const waitForNextTick = () => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => resolve(), 0);
+  });
+};
+
+export const safeParseJSON = (str) => {
+  if (!str || !str.length || typeof str !== 'string') {
+    return str;
+  }
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return str;
+  }
+};
+
+export const safeStringifyJSON = (obj, indent = false) => {
+  if (obj === undefined) {
+    return obj;
+  }
+  try {
+    if (indent) {
+      return JSON.stringify(obj, null, 2);
+    }
+    return JSON.stringify(obj);
+  } catch (e) {
+    return obj;
+  }
+};
+
+// Remove any characters that are not alphanumeric, spaces, hyphens, or underscores
+export const normalizeFileName = (name) => {
+  if (!name) {
+    return name;
+  }
+
+  const validChars = /[^\w\s-]/g;
+  const formattedName = name.replace(validChars, '-');
+
+  return formattedName;
+};
+
+export const getContentType = (headers) => {
+  const headersArray = typeof headers === 'object' ? Object.entries(headers) : [];
+
+  if (headersArray.length > 0) {
+    let contentType = headersArray
+      .filter((header) => header[0].toLowerCase() === 'content-type')
+      .map((header) => {
+        return header[1];
+      });
+    if (contentType && contentType.length) {
+      if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?json/.test(contentType[0])) {
+        return 'application/ld+json';
+      } else if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?xml/.test(contentType[0])) {
+        return 'application/xml';
+      }
+
+      return contentType[0];
+    }
+  }
+
+  return '';
+};
+
+export const startsWith = (str, search) => {
+  if (!str || !str.length || typeof str !== 'string') {
+    return false;
+  }
+
+  if (!search || !search.length || typeof search !== 'string') {
+    return false;
+  }
+
+  return str.substr(0, search.length) === search;
+};
+
+export const pluralizeWord = (word, count) => {
+  return count === 1 ? word : `${word}s`;
+};
+
+export const relativeDate = (dateString) => {
+  const date = new Date(dateString);
+  const currentDate = new Date();
+
+  const difference = currentDate - date;
+  const secondsDifference = Math.floor(difference / 1000);
+  const minutesDifference = Math.floor(secondsDifference / 60);
+  const hoursDifference = Math.floor(minutesDifference / 60);
+  const daysDifference = Math.floor(hoursDifference / 24);
+  const weeksDifference = Math.floor(daysDifference / 7);
+  const monthsDifference = Math.floor(daysDifference / 30);
+
+  if (secondsDifference < 60) {
+    return 'Few seconds ago';
+  } else if (minutesDifference < 60) {
+    return `${minutesDifference} minute${minutesDifference > 1 ? 's' : ''} ago`;
+  } else if (hoursDifference < 24) {
+    return `${hoursDifference} hour${hoursDifference > 1 ? 's' : ''} ago`;
+  } else if (daysDifference < 7) {
+    return `${daysDifference} day${daysDifference > 1 ? 's' : ''} ago`;
+  } else if (weeksDifference < 4) {
+    return `${weeksDifference} week${weeksDifference > 1 ? 's' : ''} ago`;
+  } else {
+    return `${monthsDifference} month${monthsDifference > 1 ? 's' : ''} ago`;
+  }
+};
+
+export const humanizeDate = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+};

--- a/packages/bruno-converters/src/index.js
+++ b/packages/bruno-converters/src/index.js
@@ -1,0 +1,8 @@
+// export { importCollection } from './postman-collection.js';
+export { importCollection as importPostmanCollection } from './postman-collection.js';
+// export { importCollection } as importBrunoCollection from './bruno-collection';
+// export { importCollection } as importPostmanCollection from './postman-collection';
+// export importInsomniaCollection from './insomnia-collection';
+// export importOpenapiCollection from './openapi-collection';
+
+export { exportCollection as exportBrunoCollection } from './collections/export';

--- a/packages/bruno-converters/src/insomnia-collection.js
+++ b/packages/bruno-converters/src/insomnia-collection.js
@@ -1,0 +1,248 @@
+import jsyaml from 'js-yaml';
+import each from 'lodash/each';
+import get from 'lodash/get';
+import fileDialog from 'file-dialog';
+import { uuid } from 'utils/common';
+import { BrunoError } from 'utils/common/error';
+import { validateSchema, transformItemsInCollection, hydrateSeqInCollection } from './common';
+
+const readFile = (files) => {
+  return new Promise((resolve, reject) => {
+    const fileReader = new FileReader();
+    fileReader.onload = (e) => {
+      try {
+        // try to load JSON
+        const parsedData = JSON.parse(e.target.result);
+        resolve(parsedData);
+      } catch (jsonError) {
+        // not a valid JSOn, try yaml
+        try {
+          const parsedData = jsyaml.load(e.target.result);
+          resolve(parsedData);
+        } catch (yamlError) {
+          console.error('Error parsing the file :', jsonError, yamlError);
+          reject(new BrunoError('Import collection failed'));
+        }
+      }
+    };
+    fileReader.onerror = (err) => reject(err);
+    fileReader.readAsText(files[0]);
+  });
+};
+
+const parseGraphQL = (text) => {
+  try {
+    const graphql = JSON.parse(text);
+
+    return {
+      query: graphql.query,
+      variables: JSON.stringify(graphql.variables, null, 2)
+    };
+  } catch (e) {
+    return {
+      query: '',
+      variables: ''
+    };
+  }
+};
+
+const addSuffixToDuplicateName = (item, index, allItems) => {
+  // Check if the request name already exist and if so add a number suffix
+  const nameSuffix = allItems.reduce((nameSuffix, otherItem, otherIndex) => {
+    if (otherItem.name === item.name && otherIndex < index) {
+      nameSuffix++;
+    }
+    return nameSuffix;
+  }, 0);
+  return nameSuffix !== 0 ? `${item.name}_${nameSuffix}` : item.name;
+};
+
+const regexVariable = new RegExp('{{.*?}}', 'g');
+
+const normalizeVariables = (value) => {
+  const variables = value.match(regexVariable) || [];
+  each(variables, (variable) => {
+    value = value.replace(variable, variable.replace('_.', '').replaceAll(' ', ''));
+  });
+  return value;
+};
+
+const transformInsomniaRequestItem = (request, index, allRequests) => {
+  const name = addSuffixToDuplicateName(request, index, allRequests);
+
+  const brunoRequestItem = {
+    uid: uuid(),
+    name,
+    type: 'http-request',
+    request: {
+      url: request.url,
+      method: request.method,
+      auth: {
+        mode: 'none',
+        basic: null,
+        bearer: null,
+        digest: null
+      },
+      headers: [],
+      params: [],
+      body: {
+        mode: 'none',
+        json: null,
+        text: null,
+        xml: null,
+        formUrlEncoded: [],
+        multipartForm: []
+      }
+    }
+  };
+
+  each(request.headers, (header) => {
+    brunoRequestItem.request.headers.push({
+      uid: uuid(),
+      name: header.name,
+      value: header.value,
+      description: header.description,
+      enabled: !header.disabled
+    });
+  });
+
+  each(request.parameters, (param) => {
+    brunoRequestItem.request.params.push({
+      uid: uuid(),
+      name: param.name,
+      value: param.value,
+      description: param.description,
+      enabled: !param.disabled
+    });
+  });
+
+  const authType = get(request, 'authentication.type', '');
+
+  if (authType === 'basic') {
+    brunoRequestItem.request.auth.mode = 'basic';
+    brunoRequestItem.request.auth.basic = {
+      username: normalizeVariables(get(request, 'authentication.username', '')),
+      password: normalizeVariables(get(request, 'authentication.password', ''))
+    };
+  } else if (authType === 'bearer') {
+    brunoRequestItem.request.auth.mode = 'bearer';
+    brunoRequestItem.request.auth.bearer = {
+      token: normalizeVariables(get(request, 'authentication.token', ''))
+    };
+  }
+
+  const mimeType = get(request, 'body.mimeType', '').split(';')[0];
+
+  if (mimeType === 'application/json') {
+    brunoRequestItem.request.body.mode = 'json';
+    brunoRequestItem.request.body.json = request.body.text;
+  } else if (mimeType === 'application/x-www-form-urlencoded') {
+    brunoRequestItem.request.body.mode = 'formUrlEncoded';
+    each(request.body.params, (param) => {
+      brunoRequestItem.request.body.formUrlEncoded.push({
+        uid: uuid(),
+        name: param.name,
+        value: param.value,
+        description: param.description,
+        enabled: !param.disabled
+      });
+    });
+  } else if (mimeType === 'multipart/form-data') {
+    brunoRequestItem.request.body.mode = 'multipartForm';
+    each(request.body.params, (param) => {
+      brunoRequestItem.request.body.multipartForm.push({
+        uid: uuid(),
+        type: 'text',
+        name: param.name,
+        value: param.value,
+        description: param.description,
+        enabled: !param.disabled
+      });
+    });
+  } else if (mimeType === 'text/plain') {
+    brunoRequestItem.request.body.mode = 'text';
+    brunoRequestItem.request.body.text = request.body.text;
+  } else if (mimeType === 'text/xml') {
+    brunoRequestItem.request.body.mode = 'xml';
+    brunoRequestItem.request.body.xml = request.body.text;
+  } else if (mimeType === 'application/graphql') {
+    brunoRequestItem.type = 'graphql-request';
+    brunoRequestItem.request.body.mode = 'graphql';
+    brunoRequestItem.request.body.graphql = parseGraphQL(request.body.text);
+  }
+
+  return brunoRequestItem;
+};
+
+const parseInsomniaCollection = (data) => {
+  const brunoCollection = {
+    name: '',
+    uid: uuid(),
+    version: '1',
+    items: [],
+    environments: []
+  };
+
+  return new Promise((resolve, reject) => {
+    try {
+      const insomniaExport = data;
+      const insomniaResources = get(insomniaExport, 'resources', []);
+      const insomniaCollection = insomniaResources.find((resource) => resource._type === 'workspace');
+
+      if (!insomniaCollection) {
+        reject(new BrunoError('Collection not found inside Insomnia export'));
+      }
+
+      brunoCollection.name = insomniaCollection.name;
+
+      const requestsAndFolders =
+        insomniaResources.filter((resource) => resource._type === 'request' || resource._type === 'request_group') ||
+        [];
+
+      function createFolderStructure(resources, parentId = null) {
+        const requestGroups =
+          resources.filter((resource) => resource._type === 'request_group' && resource.parentId === parentId) || [];
+        const requests = resources.filter((resource) => resource._type === 'request' && resource.parentId === parentId);
+
+        const folders = requestGroups.map((folder, index, allFolder) => {
+          const name = addSuffixToDuplicateName(folder, index, allFolder);
+          const requests = resources.filter(
+            (resource) => resource._type === 'request' && resource.parentId === folder._id
+          );
+
+          return {
+            uid: uuid(),
+            name,
+            type: 'folder',
+            items: createFolderStructure(resources, folder._id).concat(requests.map(transformInsomniaRequestItem))
+          };
+        });
+
+        return folders.concat(requests.map(transformInsomniaRequestItem));
+      }
+
+      (brunoCollection.items = createFolderStructure(requestsAndFolders, insomniaCollection._id)),
+        resolve(brunoCollection);
+    } catch (err) {
+      reject(new BrunoError('An error occurred while parsing the Insomnia collection'));
+    }
+  });
+};
+
+const importCollection = () => {
+  return new Promise((resolve, reject) => {
+    fileDialog({ accept: '.json, .yaml, .yml, application/json, application/yaml, application/x-yaml' })
+      .then(readFile)
+      .then(parseInsomniaCollection)
+      .then(transformItemsInCollection)
+      .then(hydrateSeqInCollection)
+      .then(validateSchema)
+      .then((collection) => resolve(collection))
+      .catch((err) => {
+        console.error(err);
+        reject(new BrunoError('Import collection failed: ' + err.message));
+      });
+  });
+};
+
+export default importCollection;

--- a/packages/bruno-converters/src/openapi-collection.js
+++ b/packages/bruno-converters/src/openapi-collection.js
@@ -1,0 +1,389 @@
+import jsyaml from 'js-yaml';
+import each from 'lodash/each';
+import get from 'lodash/get';
+import fileDialog from 'file-dialog';
+import { uuid } from 'utils/common';
+import { BrunoError } from 'utils/common/error';
+import { validateSchema, transformItemsInCollection, hydrateSeqInCollection } from './common';
+
+const readFile = (files) => {
+  return new Promise((resolve, reject) => {
+    const fileReader = new FileReader();
+    fileReader.onload = (e) => {
+      try {
+        // try to load JSON
+        const parsedData = JSON.parse(e.target.result);
+        resolve(parsedData);
+      } catch (jsonError) {
+        // not a valid JSOn, try yaml
+        try {
+          const parsedData = jsyaml.load(e.target.result);
+          resolve(parsedData);
+        } catch (yamlError) {
+          console.error('Error parsing the file :', jsonError, yamlError);
+          reject(new BrunoError('Import collection failed'));
+        }
+      }
+    };
+    fileReader.onerror = (err) => reject(err);
+    fileReader.readAsText(files[0]);
+  });
+};
+
+const ensureUrl = (url) => {
+  let protUrl = url.startsWith('http') ? url : `http://${url}`;
+  // replace any double or triple slashes
+  return protUrl.replace(/([^:]\/)\/+/g, '$1');
+};
+
+const buildEmptyJsonBody = (bodySchema) => {
+  let _jsonBody = {};
+  each(bodySchema.properties || {}, (prop, name) => {
+    if (prop.type === 'object') {
+      _jsonBody[name] = buildEmptyJsonBody(prop);
+      // handle arrays
+    } else if (prop.type === 'array') {
+      _jsonBody[name] = [];
+    } else {
+      _jsonBody[name] = '';
+    }
+  });
+  return _jsonBody;
+};
+
+const transformOpenapiRequestItem = (request) => {
+  let _operationObject = request.operationObject;
+
+  let operationName = _operationObject.summary || _operationObject.operationId || _operationObject.description;
+  if (!operationName) {
+    operationName = `${request.method} ${request.path}`;
+  }
+
+  const brunoRequestItem = {
+    uid: uuid(),
+    name: operationName,
+    type: 'http-request',
+    request: {
+      url: ensureUrl(request.global.server + '/' + request.path),
+      method: request.method.toUpperCase(),
+      auth: {
+        mode: 'none',
+        basic: null,
+        bearer: null,
+        digest: null
+      },
+      headers: [],
+      params: [],
+      body: {
+        mode: 'none',
+        json: null,
+        text: null,
+        xml: null,
+        formUrlEncoded: [],
+        multipartForm: []
+      }
+    }
+  };
+
+  each(_operationObject.parameters || [], (param) => {
+    if (param.in === 'query') {
+      brunoRequestItem.request.params.push({
+        uid: uuid(),
+        name: param.name,
+        value: '',
+        description: param.description || '',
+        enabled: param.required
+      });
+    } else if (param.in === 'header') {
+      brunoRequestItem.request.headers.push({
+        uid: uuid(),
+        name: param.name,
+        value: '',
+        description: param.description || '',
+        enabled: param.required
+      });
+    }
+  });
+
+  let auth;
+  // allow operation override
+  if (_operationObject.security && _operationObject.security.length > 0) {
+    let schemeName = Object.keys(_operationObject.security[0])[0];
+    auth = request.global.security.getScheme(schemeName);
+  } else if (request.global.security.supported.length > 0) {
+    auth = request.global.security.supported[0];
+  }
+
+  if (auth) {
+    if (auth.type === 'http' && auth.scheme === 'basic') {
+      brunoRequestItem.request.auth.mode = 'basic';
+      brunoRequestItem.request.auth.basic = {
+        username: '{{username}}',
+        password: '{{password}}'
+      };
+    } else if (auth.type === 'http' && auth.scheme === 'bearer') {
+      brunoRequestItem.request.auth.mode = 'bearer';
+      brunoRequestItem.request.auth.bearer = {
+        token: '{{token}}'
+      };
+    } else if (auth.type === 'apiKey' && auth.in === 'header') {
+      brunoRequestItem.request.headers.push({
+        uid: uuid(),
+        name: auth.name,
+        value: '{{apiKey}}',
+        description: 'Authentication header',
+        enabled: true
+      });
+    }
+  }
+
+  // TODO: handle allOf/anyOf/oneOf
+  if (_operationObject.requestBody) {
+    let content = get(_operationObject, 'requestBody.content', {});
+    let mimeType = Object.keys(content)[0];
+    let body = content[mimeType] || {};
+    let bodySchema = body.schema;
+    if (mimeType === 'application/json') {
+      brunoRequestItem.request.body.mode = 'json';
+      if (bodySchema && bodySchema.type === 'object') {
+        let _jsonBody = buildEmptyJsonBody(bodySchema);
+        brunoRequestItem.request.body.json = JSON.stringify(_jsonBody, null, 2);
+      }
+    } else if (mimeType === 'application/x-www-form-urlencoded') {
+      brunoRequestItem.request.body.mode = 'formUrlEncoded';
+      if (bodySchema && bodySchema.type === 'object') {
+        each(bodySchema.properties || {}, (prop, name) => {
+          brunoRequestItem.request.body.formUrlEncoded.push({
+            uid: uuid(),
+            name: name,
+            value: '',
+            description: prop.description || '',
+            enabled: true
+          });
+        });
+      }
+    } else if (mimeType === 'multipart/form-data') {
+      brunoRequestItem.request.body.mode = 'multipartForm';
+      if (bodySchema && bodySchema.type === 'object') {
+        each(bodySchema.properties || {}, (prop, name) => {
+          brunoRequestItem.request.body.multipartForm.push({
+            uid: uuid(),
+            type: 'text',
+            name: name,
+            value: '',
+            description: prop.description || '',
+            enabled: true
+          });
+        });
+      }
+    } else if (mimeType === 'text/plain') {
+      brunoRequestItem.request.body.mode = 'text';
+      brunoRequestItem.request.body.text = '';
+    } else if (mimeType === 'text/xml') {
+      brunoRequestItem.request.body.mode = 'xml';
+      brunoRequestItem.request.body.xml = '';
+    }
+  }
+
+  return brunoRequestItem;
+};
+
+const resolveRefs = (spec, components = spec.components, visitedItems = new Set()) => {
+  if (!spec || typeof spec !== 'object') {
+    return spec;
+  }
+
+  if (Array.isArray(spec)) {
+    return spec.map((item) => resolveRefs(item, components, visitedItems));
+  }
+
+  if ('$ref' in spec) {
+    const refPath = spec.$ref;
+
+    if (visitedItems.has(refPath)) {
+      return spec;
+    } else {
+      visitedItems.add(refPath);
+    }
+
+    if (refPath.startsWith('#/components/')) {
+      // Local reference within components
+      const refKeys = refPath.replace('#/components/', '').split('/');
+      let ref = components;
+
+      for (const key of refKeys) {
+        if (ref[key]) {
+          ref = ref[key];
+        } else {
+          // Handle invalid references gracefully?
+          return spec;
+        }
+      }
+
+      return resolveRefs(ref, components, visitedItems);
+    } else {
+      // Handle external references (not implemented here)
+      // You would need to fetch the external reference and resolve it.
+      // Example: Fetch and resolve an external reference from a URL.
+    }
+  }
+
+  // Recursively resolve references in nested objects
+  for (const prop in spec) {
+    spec[prop] = resolveRefs(spec[prop], components, visitedItems);
+  }
+
+  return spec;
+};
+
+const groupRequestsByTags = (requests) => {
+  let _groups = {};
+  let ungrouped = [];
+  each(requests, (request) => {
+    let tags = request.operationObject.tags || [];
+    if (tags.length > 0) {
+      let tag = tags[0]; // take first tag
+      if (!_groups[tag]) {
+        _groups[tag] = [];
+      }
+      _groups[tag].push(request);
+    } else {
+      ungrouped.push(request);
+    }
+  });
+
+  let groups = Object.keys(_groups).map((groupName) => {
+    return {
+      name: groupName,
+      requests: _groups[groupName]
+    };
+  });
+
+  return [groups, ungrouped];
+};
+
+const getDefaultUrl = (serverObject) => {
+  let url = serverObject.url;
+  if (serverObject.variables) {
+    each(serverObject.variables, (variable, variableName) => {
+      let sub = variable.default || (variable.enum ? variable.enum[0] : `{{${variableName}}}`);
+      url = url.replace(`{${variableName}}`, sub);
+    });
+  }
+  return url;
+};
+
+const getSecurity = (apiSpec) => {
+  let defaultSchemes = apiSpec.security || [];
+
+  let securitySchemes = get(apiSpec, 'components.securitySchemes', {});
+  if (Object.keys(securitySchemes) === 0) {
+    return {
+      supported: []
+    };
+  }
+
+  return {
+    supported: defaultSchemes.map((scheme) => {
+      var schemeName = Object.keys(scheme)[0];
+      return securitySchemes[schemeName];
+    }),
+    schemes: securitySchemes,
+    getScheme: (schemeName) => {
+      return securitySchemes[schemeName];
+    }
+  };
+};
+
+const parseOpenApiCollection = (data) => {
+  const brunoCollection = {
+    name: '',
+    uid: uuid(),
+    version: '1',
+    items: [],
+    environments: []
+  };
+
+  return new Promise((resolve, reject) => {
+    try {
+      const collectionData = resolveRefs(data);
+      if (!collectionData) {
+        reject(new BrunoError('Invalid OpenAPI collection. Failed to resolve refs.'));
+        return;
+      }
+
+      // Currently parsing of openapi spec is "do your best", that is
+      // allows "invalid" openapi spec
+
+      // assumes v3 if not defined. v2 no supported yet
+      if (collectionData.openapi && !collectionData.openapi.startsWith('3')) {
+        reject(new BrunoError('Only OpenAPI v3 is supported currently.'));
+        return;
+      }
+
+      // TODO what if info.title not defined?
+      brunoCollection.name = collectionData.info.title;
+      let servers = collectionData.servers || [];
+      let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '';
+      let securityConfig = getSecurity(collectionData);
+
+      let allRequests = Object.entries(collectionData.paths)
+        .map(([path, methods]) => {
+          return Object.entries(methods)
+            .filter(([method, op]) => {
+              return ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'].includes(
+                method.toLowerCase()
+              );
+            })
+            .map(([method, operationObject]) => {
+              return {
+                method: method,
+                path: path,
+                operationObject: operationObject,
+                global: {
+                  server: baseUrl,
+                  security: securityConfig
+                }
+              };
+            });
+        })
+        .reduce((acc, val) => acc.concat(val), []); // flatten
+
+      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests);
+      let brunoFolders = groups.map((group) => {
+        return {
+          uid: uuid(),
+          name: group.name,
+          type: 'folder',
+          items: group.requests.map(transformOpenapiRequestItem)
+        };
+      });
+
+      let ungroupedItems = ungroupedRequests.map(transformOpenapiRequestItem);
+      let brunoCollectionItems = brunoFolders.concat(ungroupedItems);
+      brunoCollection.items = brunoCollectionItems;
+      resolve(brunoCollection);
+    } catch (err) {
+      console.error(err);
+      reject(new BrunoError('An error occurred while parsing the OpenAPI collection'));
+    }
+  });
+};
+
+const importCollection = () => {
+  return new Promise((resolve, reject) => {
+    fileDialog({ accept: '.json, .yaml, .yml, application/json, application/yaml, application/x-yaml' })
+      .then(readFile)
+      .then(parseOpenApiCollection)
+      .then(transformItemsInCollection)
+      .then(hydrateSeqInCollection)
+      .then(validateSchema)
+      .then((collection) => resolve(collection))
+      .catch((err) => {
+        console.error(err);
+        reject(new BrunoError('Import collection failed: ' + err.message));
+      });
+  });
+};
+
+export default importCollection;

--- a/packages/bruno-converters/src/postman-collection.js
+++ b/packages/bruno-converters/src/postman-collection.js
@@ -1,0 +1,354 @@
+import each from 'lodash/each';
+import get from 'lodash/get';
+
+import { uuid } from 'src/common/index';
+import { BrunoError } from 'src/common/common';
+import { validateSchema, transformItemsInCollection, hydrateSeqInCollection } from 'src/common/common';
+import { postmanTranslation } from 'src/translators/postman_translation';
+import * as fs from 'node:fs';
+
+export const readFile = (file) => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', (err, data) => {
+      if (err) {
+        console.error(err);
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });
+};
+
+export const saveFile = (data, fileName) => {
+  return new Promise((resolve, reject) => {
+    fs.writeFile(fileName, data, (err) => {
+      if (err) {
+        console.error(err);
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+};
+
+const parseGraphQLRequest = (graphqlSource) => {
+  try {
+    let queryResultObject = {
+      query: '',
+      variables: ''
+    };
+
+    if (typeof graphqlSource === 'string') {
+      graphqlSource = JSON.parse(text);
+    }
+
+    if (graphqlSource.hasOwnProperty('variables') && graphqlSource.variables !== '') {
+      queryResultObject.variables = graphqlSource.variables;
+    }
+
+    if (graphqlSource.hasOwnProperty('query') && graphqlSource.query !== '') {
+      queryResultObject.query = graphqlSource.query;
+    }
+
+    return queryResultObject;
+  } catch (e) {
+    return {
+      query: '',
+      variables: ''
+    };
+  }
+};
+
+const isItemAFolder = (item) => {
+  return !item.request;
+};
+
+const convertV21Auth = (array) => {
+  return array.reduce((accumulator, currentValue) => {
+    accumulator[currentValue.key] = currentValue.value;
+    return accumulator;
+  }, {});
+};
+
+const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) => {
+  brunoParent.items = brunoParent.items || [];
+  const folderMap = {};
+
+  each(item, (i) => {
+    if (isItemAFolder(i)) {
+      const baseFolderName = i.name;
+      let folderName = baseFolderName;
+      let count = 1;
+
+      while (folderMap[folderName]) {
+        folderName = `${baseFolderName}_${count}`;
+        count++;
+      }
+
+      const brunoFolderItem = {
+        uid: uuid(),
+        name: folderName,
+        type: 'folder',
+        items: []
+      };
+      brunoParent.items.push(brunoFolderItem);
+      folderMap[folderName] = brunoFolderItem;
+      if (i.item && i.item.length) {
+        importPostmanV2CollectionItem(brunoFolderItem, i.item, i.auth ?? parentAuth, options);
+      }
+    } else {
+      if (i.request) {
+        let url = '';
+        if (typeof i.request.url === 'string') {
+          url = i.request.url;
+        } else {
+          url = get(i, 'request.url.raw') || '';
+        }
+
+        const brunoRequestItem = {
+          uid: uuid(),
+          name: i.name,
+          type: 'http-request',
+          request: {
+            url: url,
+            method: i.request.method,
+            auth: {
+              mode: 'none',
+              basic: null,
+              bearer: null,
+              awsv4: null
+            },
+            headers: [],
+            params: [],
+            body: {
+              mode: 'none',
+              json: null,
+              text: null,
+              xml: null,
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        };
+
+        if (i.event) {
+          i.event.forEach((event) => {
+            if (event.listen === 'prerequest' && event.script && event.script.exec) {
+              if (!brunoRequestItem.request.script) {
+                brunoRequestItem.request.script = {};
+              }
+              if (Array.isArray(event.script.exec)) {
+                brunoRequestItem.request.script.req = event.script.exec
+                  .map((line) => (options.enablePostmanTranslations.enabled ? postmanTranslation(line) : `// ${line}`))
+                  .join('\n');
+              } else {
+                brunoRequestItem.request.script.req = options.enablePostmanTranslations.enabled
+                  ? postmanTranslation(event.script.exec[0])
+                  : `// ${event.script.exec[0]} `;
+              }
+            }
+            if (event.listen === 'test' && event.script && event.script.exec) {
+              if (!brunoRequestItem.request.tests) {
+                brunoRequestItem.request.tests = {};
+              }
+              if (Array.isArray(event.script.exec)) {
+                brunoRequestItem.request.tests = event.script.exec
+                  .map((line) => (options.enablePostmanTranslations.enabled ? postmanTranslation(line) : `// ${line}`))
+                  .join('\n');
+              } else {
+                brunoRequestItem.request.tests = options.enablePostmanTranslations.enabled
+                  ? postmanTranslation(event.script.exec[0])
+                  : `// ${event.script.exec[0]} `;
+              }
+            }
+          });
+        }
+
+        const bodyMode = get(i, 'request.body.mode');
+        if (bodyMode) {
+          if (bodyMode === 'formdata') {
+            brunoRequestItem.request.body.mode = 'multipartForm';
+            each(i.request.body.formdata, (param) => {
+              brunoRequestItem.request.body.multipartForm.push({
+                uid: uuid(),
+                type: 'text',
+                name: param.key,
+                value: param.value,
+                description: param.description,
+                enabled: !param.disabled
+              });
+            });
+          }
+
+          if (bodyMode === 'urlencoded') {
+            brunoRequestItem.request.body.mode = 'formUrlEncoded';
+            each(i.request.body.urlencoded, (param) => {
+              brunoRequestItem.request.body.formUrlEncoded.push({
+                uid: uuid(),
+                name: param.key,
+                value: param.value,
+                description: param.description,
+                enabled: !param.disabled
+              });
+            });
+          }
+
+          if (bodyMode === 'raw') {
+            let language = get(i, 'request.body.options.raw.language');
+            if (!language) {
+              language = searchLanguageByHeader(i.request.header);
+            }
+            if (language === 'json') {
+              brunoRequestItem.request.body.mode = 'json';
+              brunoRequestItem.request.body.json = i.request.body.raw;
+            } else if (language === 'xml') {
+              brunoRequestItem.request.body.mode = 'xml';
+              brunoRequestItem.request.body.xml = i.request.body.raw;
+            } else {
+              brunoRequestItem.request.body.mode = 'text';
+              brunoRequestItem.request.body.text = i.request.body.raw;
+            }
+          }
+        }
+
+        if (bodyMode === 'graphql') {
+          brunoRequestItem.type = 'graphql-request';
+          brunoRequestItem.request.body.mode = 'graphql';
+          brunoRequestItem.request.body.graphql = parseGraphQLRequest(i.request.body.graphql);
+        }
+
+        each(i.request.header, (header) => {
+          brunoRequestItem.request.headers.push({
+            uid: uuid(),
+            name: header.key,
+            value: header.value,
+            description: header.description,
+            enabled: !header.disabled
+          });
+        });
+
+        const auth = i.request.auth ?? parentAuth;
+        if (auth?.[auth.type] && auth.type !== 'noauth') {
+          let authValues = auth[auth.type];
+          if (Array.isArray(authValues)) {
+            authValues = convertV21Auth(authValues);
+          }
+          if (auth.type === 'basic') {
+            brunoRequestItem.request.auth.mode = 'basic';
+            brunoRequestItem.request.auth.basic = {
+              username: authValues.username,
+              password: authValues.password
+            };
+          } else if (auth.type === 'bearer') {
+            brunoRequestItem.request.auth.mode = 'bearer';
+            brunoRequestItem.request.auth.bearer = {
+              token: authValues.token
+            };
+          } else if (auth.type === 'awsv4') {
+            brunoRequestItem.request.auth.mode = 'awsv4';
+            brunoRequestItem.request.auth.awsv4 = {
+              accessKeyId: authValues.accessKey,
+              secretAccessKey: authValues.secretKey,
+              sessionToken: authValues.sessionToken,
+              service: authValues.service,
+              region: authValues.region,
+              profileName: ''
+            };
+          }
+        }
+
+        each(get(i, 'request.url.query'), (param) => {
+          brunoRequestItem.request.params.push({
+            uid: uuid(),
+            name: param.key,
+            value: param.value,
+            description: param.description,
+            enabled: !param.disabled
+          });
+        });
+
+        brunoParent.items.push(brunoRequestItem);
+      }
+    }
+  });
+};
+
+export const searchLanguageByHeader = (headers) => {
+  let contentType;
+  each(headers, (header) => {
+    if (header.key.toLowerCase() === 'content-type' && !header.disabled) {
+      if (typeof header.value == 'string' && /^[\w\-]+\/([\w\-]+\+)?json/.test(header.value)) {
+        contentType = 'json';
+      } else if (typeof header.value == 'string' && /^[\w\-]+\/([\w\-]+\+)?xml/.test(header.value)) {
+        contentType = 'xml';
+      }
+      return false;
+    }
+  });
+  return contentType;
+};
+
+export const importPostmanV2Collection = (collection, options) => {
+  const brunoCollection = {
+    name: collection.info.name,
+    uid: uuid(),
+    version: '1',
+    items: [],
+    environments: []
+  };
+
+  importPostmanV2CollectionItem(brunoCollection, collection.item, collection.auth, options);
+
+  return brunoCollection;
+};
+
+export const parsePostmanCollection = (str, options) => {
+  return new Promise((resolve, reject) => {
+    try {
+      let collection = JSON.parse(str);
+      let schema = get(collection, 'info.schema');
+
+      let v2Schemas = [
+        'https://schema.getpostman.com/json/collection/v2.0.0/collection.json',
+        'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      ];
+
+      if (v2Schemas.includes(schema)) {
+        return resolve(importPostmanV2Collection(collection, options));
+      }
+
+      throw new BrunoError('Unknown postman schema');
+    } catch (err) {
+      console.log(err);
+      if (err instanceof BrunoError) {
+        return reject(err);
+      }
+
+      return reject(new BrunoError('Unable to parse the postman collection json file'));
+    }
+  });
+};
+
+export const importCollection = (fileName, options) => {
+  // set default options, it not provided
+  options = options || {
+    enablePostmanTranslations: {
+      enabled: false
+    }
+  };
+  return new Promise(async (resolve, reject) => {
+    try {
+      const str = await readFile(fileName);
+      const collection = await parsePostmanCollection(str, options);
+      const transformedCollection = await transformItemsInCollection(collection);
+      const hydratedCollection = await hydrateSeqInCollection(transformedCollection);
+      const validatedCollection = await validateSchema(hydratedCollection);
+      resolve(validatedCollection);
+    } catch (err) {
+      console.log(err);
+      reject(new BrunoError('Import collection failed'));
+    }
+  });
+};

--- a/packages/bruno-converters/src/postman-environment.js
+++ b/packages/bruno-converters/src/postman-environment.js
@@ -1,0 +1,71 @@
+import each from 'lodash/each';
+import fileDialog from 'file-dialog';
+import { BrunoError } from 'utils/common/error';
+
+const readFile = (files) => {
+  return new Promise((resolve, reject) => {
+    const fileReader = new FileReader();
+    fileReader.onload = (e) => resolve(e.target.result);
+    fileReader.onerror = (err) => reject(err);
+    fileReader.readAsText(files[0]);
+  });
+};
+
+const isSecret = (type) => {
+  return type === 'secret';
+};
+
+const importPostmanEnvironmentVariables = (brunoEnvironment, values) => {
+  brunoEnvironment.variables = brunoEnvironment.variables || [];
+
+  each(values, (i) => {
+    const brunoEnvironmentVariable = {
+      name: i.key,
+      value: i.value,
+      enabled: i.enabled,
+      secret: isSecret(i.type)
+    };
+
+    brunoEnvironment.variables.push(brunoEnvironmentVariable);
+  });
+};
+
+const importPostmanEnvironment = (environment) => {
+  const brunoEnvironment = {
+    name: environment.name,
+    variables: []
+  };
+
+  importPostmanEnvironmentVariables(brunoEnvironment, environment.values);
+  return brunoEnvironment;
+};
+
+const parsePostmanEnvironment = (str) => {
+  return new Promise((resolve, reject) => {
+    try {
+      let environment = JSON.parse(str);
+      return resolve(importPostmanEnvironment(environment));
+    } catch (err) {
+      console.log(err);
+      if (err instanceof BrunoError) {
+        return reject(err);
+      }
+      return reject(new BrunoError('Unable to parse the postman environment json file'));
+    }
+  });
+};
+
+const importEnvironment = () => {
+  return new Promise((resolve, reject) => {
+    fileDialog({ accept: 'application/json' })
+      .then(readFile)
+      .then(parsePostmanEnvironment)
+      .then((environment) => resolve(environment))
+      .catch((err) => {
+        console.log(err);
+        reject(new BrunoError('Import Environment failed'));
+      });
+  });
+};
+
+export default importEnvironment;

--- a/packages/bruno-converters/src/translators/index.spec.js
+++ b/packages/bruno-converters/src/translators/index.spec.js
@@ -1,0 +1,139 @@
+const { postmanTranslation } = require('./postman_translation'); // Adjust path as needed
+
+describe('postmanTranslation function', () => {
+  test('should translate pm commands correctly', () => {
+    const inputScript = `
+      pm.environment.get('key');
+      pm.environment.set('key', 'value');
+      pm.variables.get('key');
+      pm.variables.set('key', 'value');
+      pm.collectionVariables.get('key');
+      pm.collectionVariables.set('key', 'value');
+      const data = pm.response.json();
+      pm.expect(pm.environment.has('key')).to.be.true;
+    `;
+    const expectedOutput = `
+      bru.getEnvVar('key');
+      bru.setEnvVar('key', 'value');
+      bru.getVar('key');
+      bru.setVar('key', 'value');
+      bru.getVar('key');
+      bru.setVar('key', 'value');
+      const data = res.getBody();
+      expect(bru.getEnvVar('key') !== undefined && bru.getEnvVar('key') !== null).to.be.true;
+    `;
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
+
+  test('should not translate non-pm commands', () => {
+    const inputScript = `
+      console.log('This script does not contain pm commands.');
+      const data = pm.environment.get('key');
+      pm.collectionVariables.set('key', data);
+    `;
+    const expectedOutput = `
+      console.log('This script does not contain pm commands.');
+      const data = bru.getEnvVar('key');
+      bru.setVar('key', data);
+    `;
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
+
+  test('should comment non-translated pm commands', () => {
+    const inputScript = "pm.test('random test', () => pm.variables.replaceIn('{{$guid}}'));";
+    const expectedOutput = "// test('random test', () => pm.variables.replaceIn('{{$guid}}'));";
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
+  test('should handle multiple pm commands on the same line', () => {
+    const inputScript = "pm.environment.get('key'); pm.environment.set('key', 'value');";
+    const expectedOutput = "bru.getEnvVar('key'); bru.setEnvVar('key', 'value');";
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
+  test('should handle comments and other JavaScript code', () => {
+    const inputScript = `
+      // This is a comment
+      const value = 'test';
+      pm.environment.set('key', value);
+      /*
+        Multi-line comment
+      */
+      const result = pm.environment.get('key');
+      console.log('Result:', result);
+    `;
+    const expectedOutput = `
+      // This is a comment
+      const value = 'test';
+      bru.setEnvVar('key', value);
+      /*
+        Multi-line comment
+      */
+      const result = bru.getEnvVar('key');
+      console.log('Result:', result);
+    `;
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
+
+  test('should handle nested commands and edge cases', () => {
+    const inputScript = `
+      const sampleObjects = [
+        {
+          key: pm.environment.get('key'),
+          value: pm.variables.get('value')
+        },
+        {
+          key: pm.collectionVariables.get('key'),
+          value: pm.collectionVariables.get('value')
+        }
+      ];
+      const dataTesting = Object.entries(sampleObjects || {}).reduce((acc, [key, value]) => {
+        // this is a comment
+        acc[key] = pm.collectionVariables.get(pm.environment.get(value));
+        return acc; // Return the accumulator
+      }, {});
+      Object.values(dataTesting).forEach((data) => {
+        pm.environment.set(data.key, pm.variables.get(data.value));
+      });
+    `;
+    const expectedOutput = `
+      const sampleObjects = [
+        {
+          key: bru.getEnvVar('key'),
+          value: bru.getVar('value')
+        },
+        {
+          key: bru.getVar('key'),
+          value: bru.getVar('value')
+        }
+      ];
+      const dataTesting = Object.entries(sampleObjects || {}).reduce((acc, [key, value]) => {
+        // this is a comment
+        acc[key] = bru.getVar(bru.getEnvVar(value));
+        return acc; // Return the accumulator
+      }, {});
+      Object.values(dataTesting).forEach((data) => {
+        bru.setEnvVar(data.key, bru.getVar(data.value));
+      });
+    `;
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
+
+  test('should handle test commands', () => {
+    const inputScript = `
+      pm.test('Status code is 200', () => {
+        pm.response.to.have.status(200);
+      });
+      pm.test('this test will fail', () => {
+        return false
+      });
+    `;
+    const expectedOutput = `
+      test('Status code is 200', () => {
+        expect(res.getStatus()).to.equal(200);
+      });
+      test('this test will fail', () => {
+        return false
+      });
+    `;
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
+});

--- a/packages/bruno-converters/src/translators/postman_translation.js
+++ b/packages/bruno-converters/src/translators/postman_translation.js
@@ -1,0 +1,40 @@
+const replacements = {
+  'pm\\.environment\\.get\\(': 'bru.getEnvVar(',
+  'pm\\.environment\\.set\\(': 'bru.setEnvVar(',
+  'pm\\.variables\\.get\\(': 'bru.getVar(',
+  'pm\\.variables\\.set\\(': 'bru.setVar(',
+  'pm\\.collectionVariables\\.get\\(': 'bru.getVar(',
+  'pm\\.collectionVariables\\.set\\(': 'bru.setVar(',
+  'pm\\.setNextRequest\\(': 'bru.setNextRequest(',
+  'pm\\.test\\(': 'test(',
+  'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
+  'pm.response.to.be\\.success\\(': 'expect(res.getStatus()).to.equal(200',
+  'pm\\.response\\.to\\.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
+  'pm\\.response\\.json\\(': 'res.getBody(',
+  'pm\\.expect\\(': 'expect(',
+  'pm\\.environment\\.has\\(([^)]+)\\)': 'bru.getEnvVar($1) !== undefined && bru.getEnvVar($1) !== null'
+};
+
+const compiledReplacements = Object.entries(replacements).map(([pattern, replacement]) => ({
+  regex: new RegExp(pattern, 'g'),
+  replacement
+}));
+
+export const postmanTranslation = (script) => {
+  try {
+    let modifiedScript = script;
+    let modified = false;
+    for (const { regex, replacement } of compiledReplacements) {
+      if (regex.test(modifiedScript)) {
+        modifiedScript = modifiedScript.replace(regex, replacement);
+        modified = true;
+      }
+    }
+    if (modified && modifiedScript.includes('pm.')) {
+      modifiedScript = modifiedScript.replace(/^(.*pm\..*)$/gm, '// $1');
+    }
+    return modifiedScript;
+  } catch (e) {
+    return script;
+  }
+};

--- a/packages/bruno-converters/tsconfig.json
+++ b/packages/bruno-converters/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react",
+    "module": "ESNext",
+    "declaration": true,
+    "declarationDir": "types",
+    "sourceMap": true,
+    "outDir": "dist",
+    "moduleResolution": "node",
+    "emitDeclarationOnly": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": ["dist", "node_modules", "tests"]
+}


### PR DESCRIPTION
# Description

Linked to https://github.com/usebruno/bruno/issues/2340

Provide the Bruno importers (located now in /bruno-app/src/utils/importers) as a standalone package, that can be published as a NPM package.

This would allow the open-source tools to import and use the import functions to convert Postman, OpenAPI, ... programmatically to BRU files, which can be used via the Bruno App and Bruno CLI.

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
