### PR TITLE
Add Debian dependencies (in particular, for "libasound2")

### DIFF
--- a/packages/bruno-electron/electron-builder-config.js
+++ b/packages/bruno-electron/electron-builder-config.js
@@ -34,6 +34,21 @@ const config = {
     icon: 'resources/icons/png',
     target: ['AppImage', 'deb', 'snap', 'rpm']
   },
+  deb: {
+    // Docs: https://www.electron.build/configuration/linux#debian-package-options
+    depends: [
+      'libgtk-3-0',
+      'libnotify4',
+      'libnss3',
+      'libxss1',
+      'libxtst6',
+      'xdg-utils',
+      'libatspi2.0-0',
+      'libuuid1',
+      'libsecret-1-0',
+      'libasound2' // #1036
+    ]
+  },
   win: {
     artifactName: '${name}_${version}_${arch}_win.${ext}',
     icon: 'resources/icons/png',


### PR DESCRIPTION
# Description

Fix #1036 - Add `libsound2` debian dependency when installing Bruno in Linux via Apt (see issue for more info and [discussion](https://github.com/usebruno/bruno/pull/1037#discussion_r1403537930)).

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.