### PR TITLE
fix(#2367): handle response body decode

### DIFF
--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -41,6 +41,7 @@
     "graphql": "^16.6.0",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.2",
+    "iconv-lite": "^0.6.3",
     "is-valid-path": "^0.1.1",
     "js-yaml": "^4.1.0",
     "json-bigint": "^1.0.0",

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -37,6 +37,7 @@ const {
   transformPasswordCredentialsRequest
 } = require('./oauth2-helper');
 const Oauth2Store = require('../../store/oauth2');
+const iconv = require('iconv-lite');
 
 // override the default escape function to prevent escaping
 Mustache.escape = function (value) {
@@ -258,13 +259,18 @@ const configureRequest = async (
 };
 
 const parseDataFromResponse = (response) => {
-  const dataBuffer = Buffer.from(response.data);
   // Parse the charset from content type: https://stackoverflow.com/a/33192813
   const charsetMatch = /charset=([^()<>@,;:"/[\]?.=\s]*)/i.exec(response.headers['content-type'] || '');
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#using_exec_with_regexp_literals
   const charsetValue = charsetMatch?.[1];
+  const dataBuffer = Buffer.from(response.data);
   // Overwrite the original data for backwards compatibility
-  let data = dataBuffer.toString(charsetValue || 'utf-8');
+  let data;
+  if (iconv.encodingExists(charsetValue)) {
+    data = iconv.decode(dataBuffer, charsetValue);
+  } else {
+    data = iconv.decode(dataBuffer, 'utf-8');
+  }
   // Try to parse response to JSON, this can quietly fail
   try {
     // Filter out ZWNBSP character

--- a/packages/bruno-tests/src/echo/index.js
+++ b/packages/bruno-tests/src/echo/index.js
@@ -31,4 +31,10 @@ router.get('/bom-json-test', (req, res) => {
   return res.send(jsonWithBom);
 });
 
+router.get('/iso-enc', (req, res) => {
+  res.set('Content-Type', 'text/plain; charset=ISO-8859-1');
+  const responseText = 'éçà';
+  return res.send(Buffer.from(responseText, 'latin1'));
+});
+
 module.exports = router;


### PR DESCRIPTION
Description: decoding response body based on the content-type charset value

<img width="1100" alt="content_type_charset" src="https://github.com/usebruno/bruno/assets/25679466/5e51e421-936c-4912-999b-c9ac25f39c40">
<img width="1103" alt="decoded_response_body" src="https://github.com/usebruno/bruno/assets/25679466/35b597e8-691f-4a4e-a524-6ad23bb238ba">
