### PR TITLE
Fix/2377  Fix humanizeDate so that it always returns the date it is passed

### DIFF
--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -149,7 +149,9 @@ export const relativeDate = (dateString) => {
 };
 
 export const humanizeDate = (dateString) => {
-  const date = new Date(dateString);
+  // See this discussion for why .split is necessary
+  // https://stackoverflow.com/questions/7556591/is-the-javascript-date-object-always-one-day-off
+  const date = new Date(dateString.split('-'));
   return date.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',

--- a/packages/bruno-app/src/utils/common/index.spec.js
+++ b/packages/bruno-app/src/utils/common/index.spec.js
@@ -1,6 +1,6 @@
 const { describe, it, expect } = require('@jest/globals');
 
-import { normalizeFileName, startsWith } from './index';
+import { normalizeFileName, startsWith, humanizeDate, relativeDate } from './index';
 
 describe('common utils', () => {
   describe('normalizeFileName', () => {
@@ -47,6 +47,52 @@ describe('common utils', () => {
       expect(startsWith('foo', 'f')).toBe(true);
       expect(startsWith('foo', 'fo')).toBe(true);
       expect(startsWith('foo', 'foo')).toBe(true);
+    });
+  });
+
+  describe('humanizeDate', () => {
+    it('should return a date string in the en-US locale', () => {
+      expect(humanizeDate('2024-03-17')).toBe('March 17, 2024');
+    });
+
+    it('should return invalid date if the date is invalid', () => {
+      expect(humanizeDate('9999-99-99')).toBe('Invalid Date');
+    });
+  });
+
+  describe('relativeDate', () => {
+    it('should return few seconds ago', () => {
+      expect(relativeDate(new Date())).toBe('Few seconds ago');
+    });
+
+    it('should return minutes ago', () => {
+      let date = new Date();
+      date.setMinutes(date.getMinutes() - 30);
+      expect(relativeDate(date)).toBe('30 minutes ago');
+    });
+
+    it('should return hours ago', () => {
+      let date = new Date();
+      date.setHours(date.getHours() - 10);
+      expect(relativeDate(date)).toBe('10 hours ago');
+    });
+
+    it('should return days ago', () => {
+      let date = new Date();
+      date.setDate(date.getDate() - 5);
+      expect(relativeDate(date)).toBe('5 days ago');
+    });
+
+    it('should return weeks ago', () => {
+      let date = new Date();
+      date.setDate(date.getDate() - 8);
+      expect(relativeDate(date)).toBe('1 week ago');
+    });
+
+    it('should return weeks ago', () => {
+      let date = new Date();
+      date.setDate(date.getDate() - 60);
+      expect(relativeDate(date)).toBe('2 months ago');
     });
   });
 });

--- a/packages/bruno-app/src/utils/common/index.spec.js
+++ b/packages/bruno-app/src/utils/common/index.spec.js
@@ -89,7 +89,7 @@ describe('common utils', () => {
       expect(relativeDate(date)).toBe('1 week ago');
     });
 
-    it('should return weeks ago', () => {
+    it('should return months ago', () => {
       let date = new Date();
       date.setDate(date.getDate() - 60);
       expect(relativeDate(date)).toBe('2 months ago');


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

-----

### Issue link: https://github.com/usebruno/bruno/issues/2377

While writing tests for the utility functions `relativeDate` and `humanizeDate`, I identified that humanizeDate will not always return the date it is given based on the user's timezone. This stackoverflow post explains this well: https://stackoverflow.com/questions/7556591/is-the-javascript-date-object-always-one-day-off/31732581#31732581

- This pull request adds tests for `humanizeDate` and `relativeDate` which are found here: `packages/bruno-app/src/utils/common/index.js`.
- It also adds a fix to `humanizeDate` to ensure it always returns the date it is given

Here is a screenshot of the failing test before I implemented a fix: 
![image](https://github.com/usebruno/bruno/assets/17558364/47cd9310-5995-4d3c-a621-9cdf5c38049d)

### Verification Steps
Run `npm run test --workspace=packages/bruno-app`