### PR TITLE
fix(#2376): send unmodified request json body

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Presets/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Presets/StyledWrapper.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
   .settings-label {
-    width: 110px;
+    width: 170px;
   }
 
   .textbox {

--- a/packages/bruno-app/src/components/CollectionSettings/Presets/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Presets/index.js
@@ -16,7 +16,8 @@ const PresetsSettings = ({ collection }) => {
     enableReinitialize: true,
     initialValues: {
       requestType: presets.requestType || 'http',
-      requestUrl: presets.requestUrl || ''
+      requestUrl: presets.requestUrl || '',
+      sendRawJsonBody: presets.sendRawJsonBody || false
     },
     onSubmit: (newPresets) => {
       const brunoConfig = cloneDeep(collection.brunoConfig);
@@ -36,7 +37,7 @@ const PresetsSettings = ({ collection }) => {
           <label className="settings-label flex  items-center" htmlFor="enabled">
             Request Type
           </label>
-          <div className="flex items-center">
+          <div className="flex items-center" style={{ width: '100%' }}>
             <input
               id="http"
               className="cursor-pointer"
@@ -82,6 +83,23 @@ const PresetsSettings = ({ collection }) => {
                 onChange={formik.handleChange}
                 value={formik.values.requestUrl || ''}
                 style={{ width: '100%' }}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="mb-3 flex items-center">
+          <label className="settings-label" htmlFor="requestUrl">
+            Raw JSON Body
+          </label>
+          <div className="flex items-center w-full">
+            <div className="flex items-center flex-grow input-container h-full">
+              <input
+                id="sendRawJsonBody"
+                name="sendRawJsonBody"
+                type="checkbox"
+                checked={formik.values.sendRawJsonBody}
+                className="cursor-pointer"
+                onChange={formik.handleChange}
               />
             </div>
           </div>

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/index.js
@@ -17,7 +17,7 @@ const Timeline = ({ request, response }) => {
     });
   });
 
-  let requestData = safeStringifyJSON(request.data);
+  let requestData = typeof request?.data !== 'string' ? safeStringifyJSON(request?.data, true) : request?.data;
 
   return (
     <StyledWrapper className="pb-4 w-full">
@@ -35,7 +35,8 @@ const Timeline = ({ request, response }) => {
 
         {requestData ? (
           <pre className="line request">
-            <span className="arrow">{'>'}</span> data {requestData}
+            <span className="arrow">{'>'}</span> data{' '}
+            <pre className="text-sm flex flex-wrap whitespace-break-spaces">{requestData}</pre>
           </pre>
         ) : null}
       </div>

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -1,6 +1,5 @@
 const { get, each, filter } = require('lodash');
 const fs = require('fs');
-var JSONbig = require('json-bigint');
 const decomment = require('decomment');
 
 const prepareRequest = (request, collectionRoot) => {
@@ -76,11 +75,7 @@ const prepareRequest = (request, collectionRoot) => {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/json';
     }
-    try {
-      axiosRequest.data = JSONbig.parse(decomment(request.body.json));
-    } catch (ex) {
-      axiosRequest.data = request.body.json;
-    }
+    axiosRequest.data = request?.body?.json;
   }
 
   if (request.body.mode === 'text') {

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -82,7 +82,7 @@ const prepareRequest = (request, collectionRoot, brunoConfig) => {
       try {
         axiosRequest.data = JSONbig.parse(decomment(request.body.json));
       } catch (ex) {
-        axiosRequest.data = decomment(request?.body?.json);
+        axiosRequest.data = request?.body?.json;
       }
     }
   }

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -1,8 +1,9 @@
 const { get, each, filter } = require('lodash');
 const fs = require('fs');
+var JSONbig = require('json-bigint');
 const decomment = require('decomment');
 
-const prepareRequest = (request, collectionRoot) => {
+const prepareRequest = (request, collectionRoot, brunoConfig) => {
   const headers = {};
   let contentTypeDefined = false;
 
@@ -75,7 +76,15 @@ const prepareRequest = (request, collectionRoot) => {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/json';
     }
-    axiosRequest.data = request?.body?.json;
+    if (brunoConfig?.presets?.sendRawJsonBody) {
+      axiosRequest.data = request?.body?.json;
+    } else {
+      try {
+        axiosRequest.data = JSONbig.parse(decomment(request.body.json));
+      } catch (ex) {
+        axiosRequest.data = decomment(request?.body?.json);
+      }
+    }
   }
 
   if (request.body.mode === 'text') {

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -34,7 +34,7 @@ const runSingleRequest = async function (
     let request;
     let nextRequestName;
 
-    request = prepareRequest(bruJson.request, collectionRoot);
+    request = prepareRequest(bruJson.request, collectionRoot, brunoConfig);
 
     const scriptingConfig = get(brunoConfig, 'scripts', {});
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -443,7 +443,7 @@ const registerNetworkIpc = (mainWindow) => {
 
     const collectionRoot = get(collection, 'root', {});
     const _request = item.draft ? item.draft.request : item.request;
-    const request = prepareRequest(_request, collectionRoot, collectionPath);
+    const request = prepareRequest(_request, collectionRoot, collectionPath, collectionUid);
     const envVars = getEnvVars(environment);
     const processEnvVars = getProcessEnvVars(collectionUid);
     const brunoConfig = getBrunoConfig(collectionUid);
@@ -882,7 +882,7 @@ const registerNetworkIpc = (mainWindow) => {
           });
 
           const _request = item.draft ? item.draft.request : item.request;
-          const request = prepareRequest(_request, collectionRoot, collectionPath);
+          const request = prepareRequest(_request, collectionRoot, collectionPath, collectionUid);
           const requestUid = uuid();
           const processEnvVars = getProcessEnvVars(collectionUid);
 

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -1,6 +1,5 @@
 const { get, each, filter, extend } = require('lodash');
 const decomment = require('decomment');
-var JSONbig = require('json-bigint');
 const FormData = require('form-data');
 const fs = require('fs');
 const path = require('path');
@@ -170,11 +169,7 @@ const prepareRequest = (request, collectionRoot, collectionPath) => {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/json';
     }
-    try {
-      axiosRequest.data = JSONbig.parse(decomment(request.body.json));
-    } catch (ex) {
-      axiosRequest.data = request.body.json;
-    }
+    axiosRequest.data = request?.body?.json;
   }
 
   if (request.body.mode === 'text') {

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -179,7 +179,7 @@ const prepareRequest = (request, collectionRoot, collectionPath, collectionUid) 
       try {
         axiosRequest.data = JSONbig.parse(decomment(request.body.json));
       } catch (ex) {
-        axiosRequest.data = decomment(request?.body?.json);
+        axiosRequest.data = request?.body?.json;
       }
     }
   }


### PR DESCRIPTION
fixes: [#2376](https://github.com/usebruno/bruno/issues/2376), [#2362](https://github.com/usebruno/bruno/issues/2362), #1768 

added a checkbox in the collection settings' presets tab to choose if the request body should be parsed and de-commented, or be sent as it is needs to be added

<img width="241" alt="Screenshot 2024-06-19 at 3 30 11 PM" src="https://github.com/usebruno/bruno/assets/25679466/9b525ed9-81c1-4b79-a1bb-11e46d638687">

(part of the bruno config presets)

https://github.com/usebruno/bruno/assets/25679466/0e8b477e-2ee4-49b8-b057-7c39968b8837

currently bruno supports adding comments in the json body
and before the actual request is made the comments are removed and the body is parsed as json
ref: [PR](https://github.com/usebruno/bruno/issues/396)
