### PR TITLE
fix: Pass the scope conditionally for OAuth2 Password Credentials

### DIFF
--- a/packages/bruno-electron/src/ipc/network/oauth2-helper.js
+++ b/packages/bruno-electron/src/ipc/network/oauth2-helper.js
@@ -30,9 +30,11 @@ const resolveOAuth2AuthorizationCodeAccessToken = async (request, collectionUid)
     redirect_uri: callbackUrl,
     client_id: clientId,
     client_secret: clientSecret,
-    scope: scope,
     state: state
   };
+  if (scope) {
+    data['scope'] = scope;
+  }
   if (pkce) {
     data['code_verifier'] = codeVerifier;
   }
@@ -88,9 +90,11 @@ const transformClientCredentialsRequest = async (request) => {
   const data = {
     grant_type: 'client_credentials',
     client_id: clientId,
-    client_secret: clientSecret,
-    scope
+    client_secret: clientSecret
   };
+  if (scope) {
+    data.scope = scope;
+  }
   const url = requestCopy?.oauth2?.accessTokenUrl;
   return {
     data,
@@ -109,9 +113,11 @@ const transformPasswordCredentialsRequest = async (request) => {
     username,
     password,
     client_id: clientId,
-    client_secret: clientSecret,
-    scope
+    client_secret: clientSecret
   };
+  if (scope) {
+    data.scope = scope;
+  }
   const url = requestCopy?.oauth2?.accessTokenUrl;
   return {
     data,


### PR DESCRIPTION
The scope param is always passed (when according to the spec, it is optional).

The server responds with

{
  "error": "invalid_scope",
  "error_description": "Invalid scopes: "
}


Fixes: https://github.com/usebruno/bruno/issues/2446.