### PR TITLE
feat(bru-rmvar): add bru.rmVar(varType, key) command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -415,7 +414,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.23.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -423,7 +421,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.23.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -486,7 +483,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.23.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.23.5",
@@ -501,7 +497,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
       "version": "5.1.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -509,7 +504,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
@@ -616,7 +610,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.23.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -684,7 +677,6 @@
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.22.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -730,7 +722,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.23.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -751,7 +742,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.23.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.23.9",
@@ -3884,6 +3874,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@n8n/vm2": {
+      "version": "3.9.23",
+      "resolved": "https://registry.npmjs.org/@n8n/vm2/-/vm2-3.9.23.tgz",
+      "integrity": "sha512-yu+It+L89uljQsCJ2e9cQaXzoXJe9bU69QQIoWUOcUw0u5Zon37DuB7bdNNsjKS1ZdFD+fBWCQpq/FkqHsSjXQ==",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=18.10",
+        "pnpm": ">=8.6.12"
+      }
+    },
     "node_modules/@next/env": {
       "version": "12.3.3",
       "license": "MIT"
@@ -6377,7 +6384,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.22.3",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7316,7 +7322,6 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -8474,7 +8479,6 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.667",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/electron-util": {
@@ -9478,7 +9482,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -10433,7 +10436,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13111,7 +13113,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.14",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-vault": {
@@ -16112,7 +16113,6 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17838,7 +17838,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -19753,6 +19752,7 @@
         "graphql": "^16.6.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
+        "iconv-lite": "^0.6.3",
         "is-valid-path": "^0.1.1",
         "js-yaml": "^4.1.0",
         "json-bigint": "^1.0.0",
@@ -20916,7 +20916,6 @@
     },
     "@ampproject/remapping": {
       "version": "2.2.1",
-      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -21197,12 +21196,10 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.23.5",
-      "dev": true
+      "version": "7.23.5"
     },
     "@babel/core": {
       "version": "7.23.9",
-      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -21245,7 +21242,6 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.23.6",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.23.5",
         "@babel/helper-validator-option": "^7.23.5",
@@ -21256,14 +21252,12 @@
       "dependencies": {
         "lru-cache": {
           "version": "5.1.1",
-          "dev": true,
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "yallist": {
-          "version": "3.1.1",
-          "dev": true
+          "version": "3.1.1"
         }
       }
     },
@@ -21333,7 +21327,6 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.23.3",
-      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-module-imports": "^7.22.15",
@@ -21372,7 +21365,6 @@
     },
     "@babel/helper-simple-access": {
       "version": "7.22.5",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.22.5"
       }
@@ -21397,8 +21389,7 @@
       "version": "7.22.20"
     },
     "@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "dev": true
+      "version": "7.23.5"
     },
     "@babel/helper-wrap-function": {
       "version": "7.22.20",
@@ -21411,7 +21402,6 @@
     },
     "@babel/helpers": {
       "version": "7.23.9",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.23.9",
         "@babel/traverse": "^7.23.9",
@@ -21489,7 +21479,8 @@
     },
     "@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -22502,7 +22493,8 @@
           "version": "3.0.4"
         },
         "ws": {
-          "version": "8.13.0"
+          "version": "8.13.0",
+          "requires": {}
         }
       }
     },
@@ -22530,7 +22522,8 @@
       },
       "dependencies": {
         "ws": {
-          "version": "8.13.0"
+          "version": "8.13.0",
+          "requires": {}
         }
       }
     },
@@ -22654,7 +22647,8 @@
       }
     },
     "@graphql-typed-document-node/core": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "requires": {}
     },
     "@iarna/toml": {
       "version": "2.2.5"
@@ -23413,6 +23407,16 @@
     "@n1ru4l/push-pull-async-iterable-iterator": {
       "version": "3.2.0"
     },
+    "@n8n/vm2": {
+      "version": "3.9.23",
+      "resolved": "https://registry.npmjs.org/@n8n/vm2/-/vm2-3.9.23.tgz",
+      "integrity": "sha512-yu+It+L89uljQsCJ2e9cQaXzoXJe9bU69QQIoWUOcUw0u5Zon37DuB7bdNNsjKS1ZdFD+fBWCQpq/FkqHsSjXQ==",
+      "peer": true,
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      }
+    },
     "@next/env": {
       "version": "12.3.3"
     },
@@ -23984,7 +23988,8 @@
       }
     },
     "@tabler/icons": {
-      "version": "1.119.0"
+      "version": "1.119.0",
+      "requires": {}
     },
     "@tippyjs/react": {
       "version": "4.2.6",
@@ -25263,7 +25268,8 @@
       }
     },
     "@usebruno/schema": {
-      "version": "file:packages/bruno-schema"
+      "version": "file:packages/bruno-schema",
+      "requires": {}
     },
     "@usebruno/tests": {
       "version": "file:packages/bruno-tests",
@@ -25407,7 +25413,8 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -25418,7 +25425,8 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@whatwg-node/events": {
       "version": "0.0.3"
@@ -25478,7 +25486,8 @@
     },
     "acorn-import-assertions": {
       "version": "1.9.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.3.2"
@@ -25520,7 +25529,8 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "amdefine": {
       "version": "0.0.8"
@@ -26125,7 +26135,6 @@
     },
     "browserslist": {
       "version": "4.22.3",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001580",
         "electron-to-chromium": "^1.4.648",
@@ -26162,6 +26171,7 @@
         "graphql": "^16.6.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
+        "iconv-lite": "^0.6.3",
         "is-valid-path": "^0.1.1",
         "js-yaml": "^4.1.0",
         "json-bigint": "^1.0.0",
@@ -27234,7 +27244,8 @@
       }
     },
     "chai-string": {
-      "version": "1.5.0"
+      "version": "1.5.0",
+      "requires": {}
     },
     "chalk": {
       "version": "3.0.0",
@@ -27577,8 +27588,7 @@
       "version": "1.0.5"
     },
     "convert-source-map": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "cookie": {
       "version": "0.6.0"
@@ -27696,7 +27706,8 @@
     },
     "css-declaration-sorter": {
       "version": "6.4.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-loader": {
       "version": "6.10.0",
@@ -27833,7 +27844,8 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -27891,7 +27903,8 @@
     },
     "dedent": {
       "version": "1.5.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "deep-eql": {
       "version": "4.1.3",
@@ -28324,8 +28337,7 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.667",
-      "dev": true
+      "version": "1.4.667"
     },
     "electron-util": {
       "version": "0.17.2",
@@ -28956,8 +28968,7 @@
       }
     },
     "gensync": {
-      "version": "1.0.0-beta.2",
-      "dev": true
+      "version": "1.0.0-beta.2"
     },
     "get-caller-file": {
       "version": "2.0.5"
@@ -29114,7 +29125,8 @@
       }
     },
     "goober": {
-      "version": "2.1.14"
+      "version": "2.1.14",
+      "requires": {}
     },
     "gopd": {
       "version": "1.0.1",
@@ -29282,7 +29294,8 @@
       }
     },
     "graphql-ws": {
-      "version": "5.12.1"
+      "version": "5.12.1",
+      "requires": {}
     },
     "handlebars": {
       "version": "4.7.8",
@@ -29543,7 +29556,6 @@
     },
     "iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -29554,7 +29566,8 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "idb": {
       "version": "7.1.1"
@@ -29857,7 +29870,8 @@
       "version": "3.0.1"
     },
     "isomorphic-ws": {
-      "version": "5.0.0"
+      "version": "5.0.0",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2"
@@ -30230,7 +30244,8 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.6.3",
@@ -30979,7 +30994,8 @@
       "version": "1.0.1"
     },
     "merge-refs": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "requires": {}
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -30989,7 +31005,8 @@
       "version": "1.4.1"
     },
     "meros": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "requires": {}
     },
     "methods": {
       "version": "1.1.2"
@@ -31236,8 +31253,7 @@
       "version": "1.1.12"
     },
     "node-releases": {
-      "version": "2.0.14",
-      "dev": true
+      "version": "2.0.14"
     },
     "node-vault": {
       "version": "0.10.2",
@@ -31856,19 +31872,23 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-import": {
       "version": "15.1.0",
@@ -31962,7 +31982,8 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.4",
@@ -31998,7 +32019,8 @@
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -32437,7 +32459,8 @@
       }
     },
     "react-inspector": {
-      "version": "6.0.2"
+      "version": "6.0.2",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1"
@@ -32587,7 +32610,8 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.2"
+      "version": "2.4.2",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -32906,7 +32930,8 @@
     },
     "rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
@@ -33048,8 +33073,7 @@
       }
     },
     "semver": {
-      "version": "6.3.1",
-      "devOptional": true
+      "version": "6.3.1"
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -33465,7 +33489,8 @@
     },
     "style-loader": {
       "version": "3.3.4",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "style-mod": {
       "version": "4.1.0"
@@ -33497,7 +33522,8 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7"
+      "version": "5.0.7",
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -34119,7 +34145,6 @@
     },
     "update-browserslist-db": {
       "version": "1.0.13",
-      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -34209,7 +34234,8 @@
       "version": "8.0.2"
     },
     "use-sync-external-store": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "requires": {}
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -34490,7 +34516,8 @@
       }
     },
     "ws": {
-      "version": "8.16.0"
+      "version": "8.16.0",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -62,7 +62,8 @@ if (!SERVER_RENDERED) {
     'bru.setEnvVar(key,value)',
     'bru.getVar(key)',
     'bru.setVar(key,value)',
-    'bru.setNextRequest(requestName)'
+    'bru.setNextRequest(requestName)',
+    'bru.rmVar(varType, key)'
   ];
   CodeMirror.registerHelper('hint', 'brunoJS', (editor, options) => {
     const cursor = editor.getCursor();

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -80,6 +80,10 @@ class Bru {
   setNextRequest(nextRequest) {
     this.nextRequest = nextRequest;
   }
+
+  rmVar(varType, key) {
+    delete this[varType][key];
+  }
 }
 
 module.exports = Bru;

--- a/packages/bruno-tests/collection/scripting/rm-var.bru
+++ b/packages/bruno-tests/collection/scripting/rm-var.bru
@@ -1,0 +1,59 @@
+meta {
+  name: rm-var
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+auth:awsv4 {
+  accessKeyId: a
+  secretAccessKey: b
+  sessionToken: c
+  service: d
+  region: e
+  profileName: f
+}
+
+script:post-response {
+  bru.setEnvVar("testSetEnvVar", "bruno-29653")
+}
+
+tests {
+  test("should set env var in scripts", function() {
+    const testSetEnvVar = bru.getEnvVar("testSetEnvVar")
+    expect(testSetEnvVar).to.equal("bruno-29653");
+  });
+  test("should not have env var in scripts", function() {
+    bru.rmVar("envVariables", "testSetEnvVar");
+    const testSetEnvVar = bru.getEnvVar("testSetEnvVar")
+    expect(testSetEnvVar).to.equal(undefined);
+  });
+}
+
+docs {
+  # API Documentation
+
+  ## Introduction
+
+  Welcome to the API documentation for [Your API Name]. This document provides instructions on how to make requests to the API and covers available authentication methods.
+
+  ## Authentication
+
+  Before making requests to the API, you need to authenticate your application. [Your API Name] supports the following authentication methods:
+
+  ### API Key
+
+  To use API key authentication, include your API key in the request headers as follows:
+
+  ```http
+  GET /api/endpoint
+  Host: api.example.com
+  Authorization: Bearer YOUR_API_KEY
+
+}
+


### PR DESCRIPTION
# Description

Referencing issue #2464 

Add a new **bru.rmVar()** command that helps replicate **pm.environment.unset()**

The command is recognized in the UI and can edit content from envVariables, collectionVariables and also processEnvVars.
How to use : `bru.rmVar([varType], [key])`

<img width="312" alt="image" src="https://github.com/usebruno/bruno/assets/64689165/fbba9938-256b-4718-bb0c-548dccb17944">

<img width="409" alt="image" src="https://github.com/usebruno/bruno/assets/64689165/e10f7a0f-e9bf-4dc9-873f-82bc30e4a68d">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
