### PR TITLE
set content-type header during code generation

### DIFF
--- a/packages/bruno-app/src/utils/codegenerator/har.js
+++ b/packages/bruno-app/src/utils/codegenerator/har.js
@@ -2,10 +2,16 @@ const createContentType = (mode) => {
   switch (mode) {
     case 'json':
       return 'application/json';
+    case 'text':
+      return 'text/plain';
     case 'xml':
       return 'application/xml';
+    case 'sparql':
+      return 'application/sparql-query';
     case 'formUrlEncoded':
       return 'application/x-www-form-urlencoded';
+    case 'graphql':
+      return 'application/json'
     case 'multipartForm':
       return 'multipart/form-data';
     default:
@@ -13,13 +19,19 @@ const createContentType = (mode) => {
   }
 };
 
-const createHeaders = (headers) => {
-  return headers
+const createHeaders = (request, headers) => {
+  const enabledHeaders = headers
     .filter((header) => header.enabled)
     .map((header) => ({
       name: header.name,
       value: header.value
     }));
+  
+  const contentType = createContentType(request.body?.mode)
+  if(contentType !== ''){
+    enabledHeaders.push({name:'content-type', value: contentType})
+  }
+  return enabledHeaders;
 };
 
 const createQuery = (queryParams = []) => {
@@ -54,7 +66,7 @@ export const buildHarRequest = ({ request, headers }) => {
     url: encodeURI(request.url),
     httpVersion: 'HTTP/1.1',
     cookies: [],
-    headers: createHeaders(headers),
+    headers: createHeaders(request, headers),
     queryString: createQuery(request.params),
     postData: createPostData(request.body),
     headersSize: 0,

--- a/packages/bruno-app/src/utils/codegenerator/har.js
+++ b/packages/bruno-app/src/utils/codegenerator/har.js
@@ -11,7 +11,7 @@ const createContentType = (mode) => {
     case 'formUrlEncoded':
       return 'application/x-www-form-urlencoded';
     case 'graphql':
-      return 'application/json'
+      return 'application/json';
     case 'multipartForm':
       return 'multipart/form-data';
     default:
@@ -26,10 +26,10 @@ const createHeaders = (request, headers) => {
       name: header.name,
       value: header.value
     }));
-  
-  const contentType = createContentType(request.body?.mode)
-  if(contentType !== ''){
-    enabledHeaders.push({name:'content-type', value: contentType})
+
+  const contentType = createContentType(request.body?.mode);
+  if (contentType !== '') {
+    enabledHeaders.push({ name: 'content-type', value: contentType });
   }
   return enabledHeaders;
 };


### PR DESCRIPTION
# Description
sets the content-type header during code generation also handles missing request body modes

This kind of logic of turning body mode into content-type is duplicated in at least more than 2 places. Seems like it would be a good candidate for a shared util.

Closes #2488

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
