### PR TITLE
Fix error when attempting to "generate code" of a request

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -43,6 +43,7 @@ const CodeView = ({ language, item }) => {
         </CopyToClipboard>
         <CodeEditor
           readOnly
+          collection={collection}
           value={snippet}
           font={get(preferences, 'font.codeFont', 'default')}
           theme={displayedTheme}


### PR DESCRIPTION
# Description

Closes #2444 

When generating code for a request, `getEnvironmentVariables()` of CodeEditor was called with an undefined value, because props of CodeEditor did not contain "collection" in the specific case of being instantiated from CodeView.
I've added this collection var when creating the CodeEditor in CodeView.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
