### PR TITLE
Fix URL generation bug in postman collection exporter #2496

### DIFF
--- a/packages/bruno-app/src/utils/exporters/postman-collection.js
+++ b/packages/bruno-app/src/utils/exporters/postman-collection.js
@@ -173,13 +173,18 @@ export const exportCollection = (collection) => {
 
   const generateHost = (url) => {
     try {
-      const { hostname } = new URL(url);
-      return hostname.split('.');
+      if (url.includes('{{') && url.includes('}}')) {
+        return url;
+      } else {
+        const { hostname } = new URL(url);
+        return hostname.split('.');
+      }
     } catch (error) {
       console.error(`Invalid URL: ${url}`, error);
       return [];
     }
   };
+
 
   const generatePathParams = (params) => {
     return params.filter((param) => param.type === 'path').map((param) => `:${param.name}`);


### PR DESCRIPTION

# Description

This PR fixes an issue mentioned in #2496 where exporting a postman collection which has variables in the url leads to getting only '/' in the place of full URL.  Now we have a check for template variables before generating URL hostname so that it does not try to create a URL variable anymore which led to the mentioned error.

**BEFORE**
Bruno -
![image](https://github.com/usebruno/bruno/assets/47787284/7af47fb2-326c-48ca-9253-dfa7686da26d)

Postman -
![image](https://github.com/usebruno/bruno/assets/47787284/78a01f11-98c6-434f-8b3a-d4080de74944)

**AFTER**
Postman -
![image](https://github.com/usebruno/bruno/assets/47787284/051c4d7f-b5ea-4c09-b825-5523f94c5ccb)



### Contribution Checklist:

- [x ] **The pull request only addresses one issue or adds one feature.**
- [x ] **The pull request does not introduce any breaking changes**
- [x ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x ] **Create an issue and link to the pull request.**
