### PR TITLE
Fix path parameters when OpenAPI specification is imported (#2513)

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -348,7 +348,7 @@ const parseOpenApiCollection = (data) => {
             .map(([method, operationObject]) => {
               return {
                 method: method,
-                path: path,
+                path: path.replace(/{([^}]+)}/g, ':$1'), // Replace placeholders enclosed in curly braces with colons
                 operationObject: operationObject,
                 global: {
                   server: baseUrl,


### PR DESCRIPTION
# Description

Fixes [#2513](https://github.com/usebruno/bruno/issues/2513) to support path parameters when OpenAPI specification is imported.

It replaces all path placeholders enclosed in curly braces with colons when the OpenAPI spec is parsed.

**Before**

```
meta {
  name: get -users--id-
  type: http
  seq: 1
}

get {
  url: http://api.example.com/v1/users/{id}
  body: none
  auth: none
}

params:query {
  ~metadata: 
}

params:path {
  id: 
}
```

**After**

```
meta {
  name: get -users--id
  type: http
  seq: 2
}

get {
  url: http://api.example.com/v1/users/:id
  body: none
  auth: none
}

params:query {
  ~metadata: 
}

params:path {
  id: 
}
```

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
