### PR TITLE
Added lengthBetween Assertion

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
@@ -6,33 +6,34 @@ import lightTheme from 'themes/light';
 /**
  * Assertion operators
  *
- * eq          : equal to
- * neq         : not equal to
- * gt          : greater than
- * gte         : greater than or equal to
- * lt          : less than
- * lte         : less than or equal to
- * in          : in
- * notIn       : not in
- * contains    : contains
- * notContains : not contains
- * length      : length
- * matches     : matches
- * notMatches  : not matches
- * startsWith  : starts with
- * endsWith    : ends with
- * between     : between
- * isEmpty     : is empty
- * isNull      : is null
- * isUndefined : is undefined
- * isDefined   : is defined
- * isTruthy    : is truthy
- * isFalsy     : is falsy
- * isJson      : is json
- * isNumber    : is number
- * isString    : is string
- * isBoolean   : is boolean
- * isArray     : is array
+ * eq            : equal to
+ * neq           : not equal to
+ * gt            : greater than
+ * gte           : greater than or equal to
+ * lt            : less than
+ * lte           : less than or equal to
+ * in            : in
+ * notIn         : not in
+ * contains      : contains
+ * notContains   : not contains
+ * length        : length
+ * lengthBetween : length between
+ * matches       : matches
+ * notMatches    : not matches
+ * startsWith    : starts with
+ * endsWith      : ends with
+ * between       : between
+ * isEmpty       : is empty
+ * isNull        : is null
+ * isUndefined   : is undefined
+ * isDefined     : is defined
+ * isTruthy      : is truthy
+ * isFalsy       : is falsy
+ * isJson        : is json
+ * isNumber      : is number
+ * isString      : is string
+ * isBoolean     : is boolean
+ * isArray       : is array
  */
 
 const AssertionOperator = ({ operator, onChange }) => {
@@ -48,6 +49,7 @@ const AssertionOperator = ({ operator, onChange }) => {
     'contains',
     'notContains',
     'length',
+    'lengthBetween',
     'matches',
     'notMatches',
     'startsWith',

--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionRow/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionRow/index.js
@@ -7,33 +7,34 @@ import { useTheme } from 'providers/Theme';
 /**
  * Assertion operators
  *
- * eq          : equal to
- * neq         : not equal to
- * gt          : greater than
- * gte         : greater than or equal to
- * lt          : less than
- * lte         : less than or equal to
- * in          : in
- * notIn       : not in
- * contains    : contains
- * notContains : not contains
- * length      : length
- * matches     : matches
- * notMatches  : not matches
- * startsWith  : starts with
- * endsWith    : ends with
- * between     : between
- * isEmpty     : is empty
- * isNull      : is null
- * isUndefined : is undefined
- * isDefined   : is defined
- * isTruthy    : is truthy
- * isFalsy     : is falsy
- * isJson      : is json
- * isNumber    : is number
- * isString    : is string
- * isBoolean   : is boolean
- * isArray     : is array
+ * eq            : equal to
+ * neq           : not equal to
+ * gt            : greater than
+ * gte           : greater than or equal to
+ * lt            : less than
+ * lte           : less than or equal to
+ * in            : in
+ * notIn         : not in
+ * contains      : contains
+ * notContains   : not contains
+ * length        : length
+ * lengthBetween : length between
+ * matches       : matches
+ * notMatches    : not matches
+ * startsWith    : starts with
+ * endsWith      : ends with
+ * between       : between
+ * isEmpty       : is empty
+ * isNull        : is null
+ * isUndefined   : is undefined
+ * isDefined     : is defined
+ * isTruthy      : is truthy
+ * isFalsy       : is falsy
+ * isJson        : is json
+ * isNumber      : is number
+ * isString      : is string
+ * isBoolean     : is boolean
+ * isArray       : is array
  */
 const parseAssertionOperator = (str = '') => {
   if (!str || typeof str !== 'string' || !str.length) {
@@ -55,6 +56,7 @@ const parseAssertionOperator = (str = '') => {
     'contains',
     'notContains',
     'length',
+    'lengthBetween',
     'matches',
     'notMatches',
     'startsWith',

--- a/packages/bruno-js/src/runtime/assert-runtime.js
+++ b/packages/bruno-js/src/runtime/assert-runtime.js
@@ -40,33 +40,34 @@ chai.use(function (chai, utils) {
 /**
  * Assertion operators
  *
- * eq          : equal to
- * neq         : not equal to
- * gt          : greater than
- * gte         : greater than or equal to
- * lt          : less than
- * lte         : less than or equal to
- * in          : in
- * notIn       : not in
- * contains    : contains
- * notContains : not contains
- * length      : length
- * matches     : matches
- * notMatches  : not matches
- * startsWith  : starts with
- * endsWith    : ends with
- * between     : between
- * isEmpty     : is empty
- * isNull      : is null
- * isUndefined : is undefined
- * isDefined   : is defined
- * isTruthy    : is truthy
- * isFalsy     : is falsy
- * isJson      : is json
- * isNumber    : is number
- * isString    : is string
- * isBoolean   : is boolean
- * isArray     : is array
+ * eq            : equal to
+ * neq           : not equal to
+ * gt            : greater than
+ * gte           : greater than or equal to
+ * lt            : less than
+ * lte           : less than or equal to
+ * in            : in
+ * notIn         : not in
+ * contains      : contains
+ * notContains   : not contains
+ * length        : length
+ * lengthBetween : length between
+ * matches       : matches
+ * notMatches    : not matches
+ * startsWith    : starts with
+ * endsWith      : ends with
+ * between       : between
+ * isEmpty       : is empty
+ * isNull        : is null
+ * isUndefined   : is undefined
+ * isDefined     : is defined
+ * isTruthy      : is truthy
+ * isFalsy       : is falsy
+ * isJson        : is json
+ * isNumber      : is number
+ * isString      : is string
+ * isBoolean     : is boolean
+ * isArray       : is array
  */
 const parseAssertionOperator = (str = '') => {
   if (!str || typeof str !== 'string' || !str.length) {
@@ -88,6 +89,7 @@ const parseAssertionOperator = (str = '') => {
     'contains',
     'notContains',
     'length',
+    'lengthBetween',
     'matches',
     'notMatches',
     'startsWith',
@@ -183,7 +185,7 @@ const evaluateRhsOperand = (rhsOperand, operator, context) => {
       .map((v) => evaluateJsTemplateLiteral(interpolateString(v.trim(), interpolationContext), context));
   }
 
-  if (operator === 'between') {
+  if (operator === 'between' || operator === 'lengthBetween') {
     const [lhs, rhs] = rhsOperand
       .split(',')
       .map((v) => evaluateJsTemplateLiteral(interpolateString(v.trim(), interpolationContext), context));
@@ -271,6 +273,10 @@ class AssertRuntime {
             break;
           case 'length':
             expect(lhs).to.have.lengthOf(rhs);
+            break;
+          case 'lengthBetween':
+            const [minLength, maxLength] = rhs;
+            expect(lhs).to.have.lengthOf.within(minLength, maxLength);
             break;
           case 'matches':
             expect(lhs).to.match(new RegExp(rhs));


### PR DESCRIPTION
# Description

Added a new assertion named lengthBetween, to validate a field's length (string or array) against an interval (now we have just an exact comparison, through "length").

Issue #2539 

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<img width="517" alt="image" src="https://github.com/usebruno/bruno/assets/811941/9e5b48ad-b303-41e5-a168-7d73d628b746">
