### PR TITLE
fix(#2573): Fix broken resequenzing of requests

### DIFF
--- a/packages/bruno-electron/src/bru/index.js
+++ b/packages/bruno-electron/src/bru/index.js
@@ -168,7 +168,7 @@ const jsonToBru = (json) => {
     type = 'http';
   }
 
-  const sequence = _.get(json, 'meta.seq');
+  const sequence = _.get(json, 'seq');
   const bruJson = {
     meta: {
       name: _.get(json, 'name'),


### PR DESCRIPTION
# Description

Fixes broken resequenzing of Requests. The `seq` property is in the Top-Level of the JSON instead of inside `meta`.
