### PR TITLE
Bruno CLI tries to execute folder.bru #2584

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -417,7 +417,7 @@ const handler = async function (argv) {
       if (!recursive) {
         console.log(chalk.yellow('Running Folder \n'));
         const files = fs.readdirSync(filename);
-        const bruFiles = files.filter((file) => file.endsWith('.bru'));
+        const bruFiles = files.filter((file) => !['folder.bru'].includes(file) && file.endsWith('.bru'));
 
         for (const bruFile of bruFiles) {
           const bruFilepath = path.join(filename, bruFile);


### PR DESCRIPTION
# Description

We need to exclude folder.bru files when executing all requests in a directory (NOT recursively)

### Contribution Checklist:

- [ X] **The pull request only addresses one issue or adds one feature.**
- [ X] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [X ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ X] **Create an issue and link to the pull request.**

#2584 