### PR TITLE
CLI doesn't interpolate params on the URL #2587

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -82,11 +82,11 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
     request.data = _interpolate(request.data);
   }
 
-  each(request.params, (param) => {
+  each(request.pathParams, (param) => {
     param.value = _interpolate(param.value);
   });
 
-  if (request?.params?.length) {
+  if (request?.pathParams?.length) {
     let url = request.url;
 
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
@@ -107,7 +107,7 @@ const interpolateVars = (request, envVars = {}, collectionVariables = {}, proces
           return '/' + path;
         } else {
           const name = path.slice(1);
-          const existingPathParam = request.params.find((param) => param.type === 'path' && param.name === name);
+          const existingPathParam = request.pathParams.find((param) => param.type === 'path' && param.name === name);
           return existingPathParam ? '/' + existingPathParam.value : '';
         }
       })

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -29,7 +29,8 @@ const prepareRequest = (request, collectionRoot) => {
   let axiosRequest = {
     method: request.method,
     url: request.url,
-    headers: headers
+    headers: headers,
+    pathParams: request?.params?.filter((param) => param.type === 'path')
   };
 
   const collectionAuth = get(collectionRoot, 'request.auth');


### PR DESCRIPTION
# Description

The Bruno CLI doesn't interpolate params in URL

### Contribution Checklist:

- [ X] **The pull request only addresses one issue or adds one feature.**
- [ X] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ X] **Create an issue and link to the pull request.**

#2587 
[TestParams.bru.zip](https://github.com/user-attachments/files/16134362/TestParams.bru.zip)

