### PR TITLE
Cloning a dir now clone also folder.bru files recursively#2593

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -534,6 +534,15 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
             const folderPath = path.join(currentPath, item.name);
             fs.mkdirSync(folderPath);
 
+            // If folder has a root element, then I should write its folder.bru file
+            if (item.root) {
+              const _folderContent = jsonToCollectionBru(item.root, true);
+              if (_folderContent) {
+                const _folderPath = path.join(folderPath, `folder.bru`);
+                fs.writeFileSync(_folderPath, _folderContent);
+              }
+            }
+
             if (item.items && item.items.length) {
               parseCollectionItems(item.items, folderPath);
             }
@@ -542,6 +551,15 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       };
 
       await createDirectory(collectionPath);
+
+      // If initial folder has a root element, then I should write its folder.bru file
+      if (itemFolder.root) {
+        const _folderContent = jsonToCollectionBru(itemFolder.root, true);
+        if (_folderContent) {
+          const _folderPath = path.join(collectionPath, `folder.bru`);
+          fs.writeFileSync(_folderPath, _folderContent);
+        }
+      }
 
       // create folder and files based on another folder
       await parseCollectionItems(itemFolder.items, collectionPath);


### PR DESCRIPTION
# Description

When cloning a folder, requests and subfolders are cloned too, but not folder.bru files.

### Contribution Checklist:

- [X ] **The pull request only addresses one issue or adds one feature.**
- [ X] **The pull request does not introduce any breaking changes**
- [ X] **I have added screenshots or gifs to help explain the change if applicable.**
- [ X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ X] **Create an issue and link to the pull request.**

#2593 

Suppose to have this structure. : 

```
.
├── MultiLevelDir
│   ├── FirstLevel
│   │   ├── SecondLevel
│   │   │   ├── Artist Finder 2.bru
│   │   │   └── folder.bru
│   │   └── folder.bru
│   └── folder.bru
├── bruno.json
└── collection.bru
```

Now, cloning the MultiLevelDir we get also folder.bru files attached to every cloned directory:

```
├── MultiLevelDir
│   ├── FirstLevel
│   │   ├── SecondLevel
│   │   │   ├── Artist Finder 2.bru
│   │   │   └── folder.bru
│   │   └── folder.bru
│   └── folder.bru
├── MultiLevelDir2
│   ├── FirstLevel
│   │   ├── SecondLevel
│   │   │   ├── Artist Finder 2.bru
│   │   │   └── folder.bru
│   │   └── folder.bru
│   └── folder.bru
├── bruno.json
└── collection.bru

```
