### PR TITLE
fix: active enviroment not updated after rename when there is single enviroment

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
@@ -43,7 +43,7 @@ const EnvironmentList = ({ selectedEnvironment, setSelectedEnvironment, collecti
       }
     }
 
-    if (prevEnvUids && prevEnvUids.length && envUids.length < prevEnvUids.length) {
+    if (prevEnvUids && prevEnvUids.length && envUids.length <= prevEnvUids.length) {
       setSelectedEnvironment(environments && environments.length ? environments[0] : null);
     }
   }, [envUids, environments, prevEnvUids]);


### PR DESCRIPTION
# Description
minor fix for when there is single environment and user renames it, active environment is not updated to the renamed environment which causes error when user tries to update or delete the active environment.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

before:
https://github.com/user-attachments/assets/3da6d45b-88fa-436d-9b3e-817ee38ff58e

after:
https://github.com/user-attachments/assets/b8d4d9cd-fe4b-48f4-b0b7-7884cee9b79c
