### PR TITLE
Revert "fix: active enviroment not updated after rename when there is single enviroment"

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
@@ -43,7 +43,7 @@ const EnvironmentList = ({ selectedEnvironment, setSelectedEnvironment, collecti
       }
     }
 
-    if (prevEnvUids && prevEnvUids.length && envUids.length <= prevEnvUids.length) {
+    if (prevEnvUids && prevEnvUids.length && envUids.length < prevEnvUids.length) {
       setSelectedEnvironment(environments && environments.length ? environments[0] : null);
     }
   }, [envUids, environments, prevEnvUids]);


### PR DESCRIPTION
Reverts usebruno/bruno#2640

Cause it's causing this bug!

https://github.com/user-attachments/assets/e76db461-1fa5-46e1-8c08-597744016ae2


