### PR TITLE
feat: Add `flow` option for "natural" flow in scripts

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -408,10 +408,13 @@ const registerNetworkIpc = (mainWindow) => {
     }
 
     // run post-response script
+    const responseScript = compact(scriptingConfig.flow === 'natural' ? [
+      get(collectionRoot, 'request.script.res'), get(request, 'script.res')
+    ] : [
+      get(request, 'script.res'), get(collectionRoot, 'request.script.res')
+    ]).join(os.EOL);
+
     let scriptResult;
-    const responseScript = compact([get(request, 'script.res'), get(collectionRoot, 'request.script.res')]).join(
-      os.EOL
-    );
     if (responseScript?.length) {
       const scriptRuntime = new ScriptRuntime();
       scriptResult = await scriptRuntime.runResponseScript(
@@ -592,10 +595,13 @@ const registerNetworkIpc = (mainWindow) => {
       }
 
       // run tests
-      const testFile = compact([
-        item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests'),
-        get(collectionRoot, 'request.tests')
+      const testScript = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
+      const testFile = compact(scriptingConfig.flow === 'natural' ? [
+        get(collectionRoot, 'request.tests'), testScript,
+      ] : [
+        testScript, get(collectionRoot, 'request.tests')
       ]).join(os.EOL);
+
       if (typeof testFile === 'string') {
         const testRuntime = new TestRuntime();
         const testResults = await testRuntime.runTests(
@@ -1029,10 +1035,13 @@ const registerNetworkIpc = (mainWindow) => {
             }
 
             // run tests
-            const testFile = compact([
-              item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests'),
-              get(collectionRoot, 'request.tests')
+            const testScript = item.draft ? get(item.draft, 'request.tests') : get(item, 'request.tests');
+            const testFile = compact(scriptingConfig.flow === 'natural' ? [
+              get(collectionRoot, 'request.tests'), testScript
+            ] : [
+              testScript, get(collectionRoot, 'request.tests')
             ]).join(os.EOL);
+
             if (typeof testFile === 'string') {
               const testRuntime = new TestRuntime();
               const testResults = await testRuntime.runTests(

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -119,7 +119,7 @@ const mergeFolderLevelVars = (request, requestTreePath) => {
   }));
 };
 
-const mergeFolderLevelScripts = (request, requestTreePath) => {
+const mergeFolderLevelScripts = (request, requestTreePath, scriptFlow) => {
   let folderCombinedPreReqScript = [];
   let folderCombinedPostResScript = [];
   let folderCombinedTests = [];
@@ -147,11 +147,19 @@ const mergeFolderLevelScripts = (request, requestTreePath) => {
   }
 
   if (folderCombinedPostResScript.length) {
-    request.script.res = compact([request?.script?.res || '', ...folderCombinedPostResScript.reverse()]).join(os.EOL);
+    if (scriptFlow === 'natural') {
+      request.script.res = compact([...folderCombinedPostResScript, request?.script?.res || '']).join(os.EOL);
+    } else {
+      request.script.res = compact([request?.script?.res || '', ...folderCombinedPostResScript.reverse()]).join(os.EOL);
+    }
   }
 
   if (folderCombinedTests.length) {
-    request.tests = compact([request?.tests || '', ...folderCombinedTests.reverse()]).join(os.EOL);
+    if (scriptFlow === 'natural') {
+      request.tests = compact([...folderCombinedTests, request?.tests || '']).join(os.EOL);
+    } else {
+      request.tests = compact([request?.tests || '', ...folderCombinedTests.reverse()]).join(os.EOL);
+    }
   }
 };
 
@@ -301,10 +309,12 @@ const prepareRequest = (item, collection) => {
     }
   });
 
+  // scriptFlow is either "sandwich" or "natural"
+  const scriptFlow = collection.brunoConfig?.scripts?.flow ?? 'sandwich';
   const requestTreePath = getTreePathFromCollectionToItem(collection, item);
   if (requestTreePath && requestTreePath.length > 0) {
     mergeFolderLevelHeaders(request, requestTreePath);
-    mergeFolderLevelScripts(request, requestTreePath);
+    mergeFolderLevelScripts(request, requestTreePath, scriptFlow);
     mergeFolderLevelVars(request, requestTreePath);
   }
 


### PR DESCRIPTION
- Adds a new key in the `bruno.json` under `scripts.flow`
- When concatenating post and tests scripts, the `flow` will now be used to determine the correct script order

Preview

https://github.com/user-attachments/assets/bd440d8d-a05c-48f0-9e20-bebb97d660e0

@sanjai0py This is a big issue for some people (See linked issues) can we merge this soon?

Fixes: #2648 #2680 #2597 #2639

