### PR TITLE
feat: Tagging requests and filtering collection runs using tags

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
@@ -18,6 +18,7 @@ import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collection
 import StyledWrapper from './StyledWrapper';
 import Documentation from 'components/Documentation/index';
 import GraphQLSchemaActions from '../GraphQLSchemaActions/index';
+import Tags from 'components/RequestPane/Tags/index';
 
 const GraphQLRequestPane = ({ item, collection, leftPaneWidth, onSchemaLoad, toggleDocs, handleGqlClickReference }) => {
   const dispatch = useDispatch();
@@ -98,6 +99,9 @@ const GraphQLRequestPane = ({ item, collection, leftPaneWidth, onSchemaLoad, tog
       case 'docs': {
         return <Documentation item={item} collection={collection} />;
       }
+      case 'tags': {
+        return <Tags item={item} collection={collection} />;
+      }
       default: {
         return <div className="mt-4">404 | Not found</div>;
       }
@@ -148,6 +152,9 @@ const GraphQLRequestPane = ({ item, collection, leftPaneWidth, onSchemaLoad, tog
         </div>
         <div className={getTabClassname('docs')} role="tab" onClick={() => selectTab('docs')}>
           Docs
+        </div>
+        <div className={getTabClassname('tags')} role="tab" onClick={() => selectTab('tags')}>
+          Tags
         </div>
         <GraphQLSchemaActions item={item} collection={collection} onSchemaLoad={setSchema} toggleDocs={toggleDocs} />
       </div>

--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -15,6 +15,7 @@ import Tests from 'components/RequestPane/Tests';
 import StyledWrapper from './StyledWrapper';
 import { find, get } from 'lodash';
 import Documentation from 'components/Documentation/index';
+import Tags from 'components/RequestPane/Tags/index';
 
 const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   const dispatch = useDispatch();
@@ -58,6 +59,9 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
       }
       case 'docs': {
         return <Documentation item={item} collection={collection} />;
+      }
+      case 'tags': {
+        return <Tags item={item} collection={collection} />;
       }
       default: {
         return <div className="mt-4">404 | Not found</div>;
@@ -129,6 +133,9 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
         </div>
         <div className={getTabClassname('docs')} role="tab" onClick={() => selectTab('docs')}>
           Docs
+        </div>
+        <div className={getTabClassname('tags')} role="tab" onClick={() => selectTab('tags')}>
+          Tags
         </div>
         {focusedTab.requestPaneTab === 'body' ? (
           <div className="flex flex-grow justify-end items-center">

--- a/packages/bruno-app/src/components/RequestPane/Tags/TagList/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/Tags/TagList/StyledWrapper.js
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  input[type='text'] {
+    border: solid 1px transparent;
+    outline: none !important;
+    background-color: inherit;
+
+    &:focus {
+      outline: none !important;
+      border: solid 1px transparent;
+    }
+  }
+
+ li {
+     display: flex;
+     align-items: center;
+     border: 1px solid ${(props) => props.theme.text};
+     border-radius: 5px;
+     padding-inline: 5px;
+     background: ${(props) => props.theme.sidebar.bg};
+ }
+`;
+
+export default Wrapper;

--- a/packages/bruno-app/src/components/RequestPane/Tags/TagList/TagList.js
+++ b/packages/bruno-app/src/components/RequestPane/Tags/TagList/TagList.js
@@ -1,0 +1,69 @@
+import { IconX } from '@tabler/icons';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import StyledWrapper from './StyledWrapper';
+
+const TagList = ({ tags, onTagRemove, onTagAdd }) => {
+  const tagNameRegex = /^[\w-]+$/;
+  const [isEditing, setIsEditing] = useState(false);
+  const [text, setText] = useState('');
+
+  const handleChange = (e) => {
+    setText(e.target.value);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.code == 'Escape') {
+      setText('');
+      setIsEditing(false);
+      return;
+    }
+    if (e.code !== 'Enter' && e.code !== 'Space') {
+      return;
+    }
+    if (!tagNameRegex.test(text)) {
+      toast.error('Tags must only contain alpha-numeric characters, "-", "_"');
+      return;
+    }
+    if (tags.includes(text)) {
+      toast.error(`Tag "${text}" already exists`);
+      return;
+    }
+    onTagAdd(text);
+    setText('');
+    setIsEditing(false);
+  };
+
+  return (
+    <StyledWrapper className="flex flex-wrap gap-2 mt-1">
+      <ul className="flex flex-wrap gap-1">
+        {tags && tags.length
+          ? tags.map((_tag) => (
+            <li key={_tag}>
+              <span>{_tag}</span>
+              <button tabIndex={-1} onClick={() => onTagRemove(_tag)}>
+                <IconX strokeWidth={1.5} size={20} />
+              </button>
+            </li>
+          ))
+          : null}
+      </ul>
+      {isEditing ? (
+        <input
+          type="text"
+          placeholder="Space or Enter to add tag"
+          value={text}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          autoFocus
+        />
+      ) : (
+        <button className="text-link select-none" onClick={() => setIsEditing(true)}>
+          + Add
+        </button>
+      )}
+    </StyledWrapper>
+  );
+};
+
+export default TagList;

--- a/packages/bruno-app/src/components/RequestPane/Tags/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Tags/index.js
@@ -1,0 +1,39 @@
+import 'github-markdown-css/github-markdown.css';
+import get from 'lodash/get';
+import { addRequestTag, deleteRequestTag } from 'providers/ReduxStore/slices/collections';
+import { useDispatch } from 'react-redux';
+import TagList from './TagList/TagList';
+
+const Tags = ({ item, collection }) => {
+  const tags = item.draft ? get(item, 'draft.request.tags') : get(item, 'request.tags');
+
+  const dispatch = useDispatch();
+
+  const handleAdd = (_tag) => {
+    dispatch(
+      addRequestTag({
+        tag: _tag,
+        itemUid: item.uid,
+        collectionUid: collection.uid
+      })
+    );
+  };
+
+  const handleRemove = (_tag) => {
+    dispatch(
+      deleteRequestTag({
+        tag: _tag,
+        itemUid: item.uid,
+        collectionUid: collection.uid
+      })
+    );
+  };
+
+  if (!item) {
+    return null;
+  }
+
+  return <TagList tags={tags} onTagRemove={handleRemove} onTagAdd={handleAdd} />;
+};
+
+export default Tags;

--- a/packages/bruno-app/src/components/RequestPane/Tags/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Tags/index.js
@@ -33,7 +33,11 @@ const Tags = ({ item, collection }) => {
     return null;
   }
 
-  return <TagList tags={tags} onTagRemove={handleRemove} onTagAdd={handleAdd} />;
+  return (
+    <div>
+      <TagList tags={tags} onTagRemove={handleRemove} onTagAdd={handleAdd} />
+    </div>
+  );
 };
 
 export default Tags;

--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -9,6 +9,7 @@ import { IconRefresh, IconCircleCheck, IconCircleX, IconCheck, IconX, IconRun } 
 import slash from 'utils/common/slash';
 import ResponsePane from './ResponsePane';
 import StyledWrapper from './StyledWrapper';
+import TagList from 'components/RequestPane/Tags/TagList/TagList';
 
 const getRelativePath = (fullPath, pathname) => {
   // convert to unix style path
@@ -23,6 +24,8 @@ const getRelativePath = (fullPath, pathname) => {
 export default function RunnerResults({ collection }) {
   const dispatch = useDispatch();
   const [selectedItem, setSelectedItem] = useState(null);
+  const [tags, setTags] = useState({ include: [], exclude: [] });
+  const [tagsEnabled, setTagsEnabled] = useState(false);
 
   // ref for the runner output body
   const runnerBodyRef = useRef();
@@ -78,11 +81,11 @@ export default function RunnerResults({ collection }) {
     .filter(Boolean);
 
   const runCollection = () => {
-    dispatch(runCollectionFolder(collection.uid, null, true));
+    dispatch(runCollectionFolder(collection.uid, null, true, tagsEnabled && tags));
   };
 
   const runAgain = () => {
-    dispatch(runCollectionFolder(collection.uid, runnerInfo.folderUid, runnerInfo.isRecursive));
+    dispatch(runCollectionFolder(collection.uid, runnerInfo.folderUid, runnerInfo.isRecursive, tagsEnabled && tags));
   };
 
   const resetRunner = () => {
@@ -114,6 +117,38 @@ export default function RunnerResults({ collection }) {
         </div>
         <div className="mt-6">
           You have <span className="font-medium">{totalRequestsInCollection}</span> requests in this collection.
+        </div>
+
+        <div className="mt-6 flex flex-col">
+          <div className="flex gap-2">
+            <label className="block font-medium">Filter requests with tags</label>
+            <input
+              className="cursor-pointer"
+              type="checkbox"
+              checked={tagsEnabled}
+              onChange={() => setTagsEnabled(!tagsEnabled)}
+            />
+          </div>
+          {tagsEnabled && (
+            <div className="flex p-4 gap-4 max-w-xl justify-between">
+              <div className="w-1/2">
+                <span>Included tags:</span>
+                <TagList
+                  tags={tags.include}
+                  onTagAdd={(tag) => setTags({ ...tags, include: [...tags.include, tag] })}
+                  onTagRemove={(tag) => setTags({ ...tags, include: tags.include.filter((t) => t !== tag) })}
+                />
+              </div>
+              <div className="w-1/2">
+                <span>Excluded tags:</span>
+                <TagList
+                  tags={tags.exclude}
+                  onTagAdd={(tag) => setTags({ ...tags, exclude: [...tags.exclude, tag] })}
+                  onTagRemove={(tag) => setTags({ ...tags, exclude: tags.exclude.filter((t) => t !== tag) })}
+                />
+              </div>
+            </div>
+          )}
         </div>
 
         <button type="submit" className="submit btn btn-sm btn-secondary mt-6" onClick={runCollection}>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -284,7 +284,7 @@ export const cancelRunnerExecution = (cancelTokenUid) => (dispatch) => {
   cancelNetworkRequest(cancelTokenUid).catch((err) => console.log(err));
 };
 
-export const runCollectionFolder = (collectionUid, folderUid, recursive) => (dispatch, getState) => {
+export const runCollectionFolder = (collectionUid, folderUid, recursive, tags) => (dispatch, getState) => {
   const state = getState();
   const collection = findCollectionByUid(state.collections.collections, collectionUid);
 
@@ -315,7 +315,8 @@ export const runCollectionFolder = (collectionUid, folderUid, recursive) => (dis
         collectionCopy,
         environment,
         collectionCopy.runtimeVariables,
-        recursive
+        recursive,
+        tags
       )
       .then(resolve)
       .catch((err) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1616,7 +1616,41 @@ export const collectionsSlice = createSlice({
           item.draft.request.docs = action.payload.docs;
         }
       }
-    }
+    },
+    addRequestTag: (state, action) => {
+      const { tag, collectionUid, itemUid } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+
+      if (collection) {
+        const item = findItemInCollection(collection, itemUid);
+
+        if (item && isItemARequest(item)) {
+          if (!item.draft) {
+            item.draft = cloneDeep(item);
+          }
+          item.draft.request.tags = item.draft.request.tags || [];
+          if (!item.draft.request.tags.includes(tag.trim())) {
+            item.draft.request.tags.push(tag.trim());
+          }
+        }
+      }
+    },
+    deleteRequestTag: (state, action) => {
+      const { tag, collectionUid, itemUid } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+
+      if (collection) {
+        const item = findItemInCollection(collection, itemUid);
+
+        if (item && isItemARequest(item)) {
+          if (!item.draft) {
+            item.draft = cloneDeep(item);
+          }
+          item.draft.request.tags = item.draft.request.tags || [];
+          item.draft.request.tags = item.draft.request.tags.filter((t) => t !== tag.trim());
+        }
+      }
+    },
   }
 });
 
@@ -1705,7 +1739,9 @@ export const {
   runRequestEvent,
   runFolderEvent,
   resetCollectionRunner,
-  updateRequestDocs
+  updateRequestDocs,
+  addRequestTag,
+  deleteRequestTag
 } = collectionsSlice.actions;
 
 export default collectionsSlice.reducer;

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -536,7 +536,8 @@ export const transformRequestToSaveToFilesystem = (item) => {
       vars: _item.request.vars,
       assertions: _item.request.assertions,
       tests: _item.request.tests,
-      docs: _item.request.docs
+      docs: _item.request.docs,
+      tags: _item.request.tags
     }
   };
 

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -299,7 +299,9 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
           script: si.request.script,
           vars: si.request.vars,
           assertions: si.request.assertions,
-          tests: si.request.tests
+          tests: si.request.tests,
+          docs: si.request.docs,
+          tags: si.request.tags
         };
 
         // Handle auth object dynamically

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -277,6 +277,10 @@ const builder = async (yargs) => {
     .example(
       '$0 run folder --cacert myCustomCA.pem --ignore-truststore',
       'Use a custom CA certificate exclusively when validating the peers of the requests in the specified folder.'
+    )
+    .example(
+      '$0 run folder --tags=hello,world --exclude-tags=skip',
+      'Run only requests with tags "hello" or "world" and exclude any request with tag "skip".'
     );
 };
 

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -5,6 +5,7 @@ const { forOwn } = require('lodash');
 const { exists, isFile, isDirectory } = require('../utils/filesystem');
 const { runSingleRequest } = require('../runner/run-single-request');
 const { bruToEnvJson, getEnvVars } = require('../utils/bru');
+const { isRequestTagsIncluded } = require("@usebruno/common")
 const makeJUnitOutput = require('../reporters/junit');
 const makeHtmlOutput = require('../reporters/html');
 const { rpad } = require('../utils/common');
@@ -93,7 +94,7 @@ const printRunSummary = (results) => {
   };
 };
 
-const getBruFilesRecursively = (dir, testsOnly) => {
+const getBruFilesRecursively = (dir, testsOnly, includeTags, excludeTags) => {
   const environmentsPath = 'environments';
 
   const getFilesInOrder = (dir) => {
@@ -134,19 +135,20 @@ const getBruFilesRecursively = (dir, testsOnly) => {
           const bruJson = bruToJson(bruContent);
           const requestHasTests = bruJson.request?.tests;
           const requestHasActiveAsserts = bruJson.request?.assertions.some((x) => x.enabled) || false;
-
-          if (testsOnly) {
-            if (requestHasTests || requestHasActiveAsserts) {
+          if (isRequestTagsIncluded(bruJson.tags, includeTags, excludeTags)) {
+            if (testsOnly) {
+              if (requestHasTests || requestHasActiveAsserts) {
+                currentDirBruJsons.push({
+                  bruFilepath: filePath,
+                  bruJson
+                });
+              }
+            } else {
               currentDirBruJsons.push({
                 bruFilepath: filePath,
                 bruJson
               });
             }
-          } else {
-            currentDirBruJsons.push({
-              bruFilepath: filePath,
-              bruJson
-            });
           }
         }
       }
@@ -238,6 +240,14 @@ const builder = async (yargs) => {
       type: 'boolean',
       description: 'Stop execution after a failure of a request, test, or assertion'
     })
+    .option('tags', {
+      type: 'string',
+      description: 'Tags to include in the run'
+    })
+    .option('exclude-tags', {
+      type: 'string',
+      description: 'Tags to exclude from the run'
+    })
     .example('$0 run request.bru', 'Run a request')
     .example('$0 run request.bru --env local', 'Run a request with the environment set to local')
     .example('$0 run folder', 'Run all requests in a folder')
@@ -283,7 +293,9 @@ const handler = async function (argv) {
       output: outputPath,
       format,
       testsOnly,
-      bail
+      bail,
+      tags: includeTags,
+      excludeTags
     } = argv;
     const collectionPath = process.cwd();
 
@@ -347,7 +359,7 @@ const handler = async function (argv) {
           if (!match) {
             console.error(
               chalk.red(`Overridable environment variable not correct: use name=value - presented: `) +
-                chalk.dim(`${value}`)
+              chalk.dim(`${value}`)
             );
             process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE);
           }
@@ -376,6 +388,9 @@ const handler = async function (argv) {
       }
     }
     options['ignoreTruststore'] = ignoreTruststore;
+
+    includeTags = includeTags ? includeTags.split(',') : [];
+    excludeTags = excludeTags ? excludeTags.split(',') : [];
 
     if (['json', 'junit', 'html'].indexOf(format) === -1) {
       console.error(chalk.red(`Format must be one of "json", "junit or "html"`));
@@ -425,18 +440,20 @@ const handler = async function (argv) {
           const bruJson = bruToJson(bruContent);
           const requestHasTests = bruJson.request?.tests;
           const requestHasActiveAsserts = bruJson.request?.assertions.some((x) => x.enabled) || false;
-          if (testsOnly) {
-            if (requestHasTests || requestHasActiveAsserts) {
+          if (isRequestTagsIncluded(bruJson.tags, includeTags, excludeTags)) {
+            if (testsOnly) {
+              if (requestHasTests || requestHasActiveAsserts) {
+                bruJsons.push({
+                  bruFilepath,
+                  bruJson
+                });
+              }
+            } else {
               bruJsons.push({
                 bruFilepath,
                 bruJson
               });
             }
-          } else {
-            bruJsons.push({
-              bruFilepath,
-              bruJson
-            });
           }
         }
         bruJsons.sort((a, b) => {
@@ -447,7 +464,7 @@ const handler = async function (argv) {
       } else {
         console.log(chalk.yellow('Running Folder Recursively \n'));
 
-        bruJsons = getBruFilesRecursively(filename, testsOnly);
+        bruJsons = getBruFilesRecursively(filename, testsOnly, includeTags, excludeTags);
       }
     }
 

--- a/packages/bruno-cli/src/utils/bru.js
+++ b/packages/bruno-cli/src/utils/bru.js
@@ -55,6 +55,7 @@ const bruToJson = (bru) => {
       type: requestType,
       name: _.get(json, 'meta.name'),
       seq: !isNaN(sequence) ? Number(sequence) : 1,
+      tags: _.get(json, 'tags', []),
       request: {
         method: _.upperCase(_.get(json, 'http.method')),
         url: _.get(json, 'http.url'),

--- a/packages/bruno-common/src/index.ts
+++ b/packages/bruno-common/src/index.ts
@@ -1,5 +1,7 @@
 import interpolate from './interpolate';
+import isRequestTagsIncluded from './tags';
 
 export default {
-  interpolate
+  interpolate,
+  isRequestTagsIncluded
 };

--- a/packages/bruno-common/src/tags/index.spec.ts
+++ b/packages/bruno-common/src/tags/index.spec.ts
@@ -1,0 +1,43 @@
+import isRequestTagsIncluded from './index';
+
+describe('isRequestTagsIncluded', () => {
+  it('should include request when it has an included tag', () => {
+    const requestTags = ['tag1', 'tag2'];
+    const includeTags = ['tag1'];
+    const excludeTags: string[] = [];
+    const result = isRequestTagsIncluded(requestTags, includeTags, excludeTags);
+    expect(result).toBe(true);
+  });
+
+  it('should include request when included tags is empty', () => {
+    const requestTags = ['tag1', 'tag2'];
+    const includeTags: string[] = [];
+    const excludeTags: string[] = [];
+    const result = isRequestTagsIncluded(requestTags, includeTags, excludeTags);
+    expect(result).toBe(true);
+  });
+
+  it('should exclude request when it does not have an included tag', () => {
+    const requestTags = ['tag1'];
+    const includeTags = ['tag2'];
+    const excludeTags: string[] = [];
+    const result = isRequestTagsIncluded(requestTags, includeTags, excludeTags);
+    expect(result).toBe(false);
+  });
+
+  it('should exclude request when it has an excluded tag', () => {
+    const requestTags = ['tag1'];
+    const includeTags: string[] = [];
+    const excludeTags = ['tag1'];
+    const result = isRequestTagsIncluded(requestTags, includeTags, excludeTags);
+    expect(result).toBe(false);
+  });
+
+  it('should exclude request when it has both included and excluded tag', () => {
+    const requestTags = ['tag1', 'tag2'];
+    const includeTags: string[] = ['tag2'];
+    const excludeTags = ['tag1'];
+    const result = isRequestTagsIncluded(requestTags, includeTags, excludeTags);
+    expect(result).toBe(false);
+  });
+});

--- a/packages/bruno-common/src/tags/index.ts
+++ b/packages/bruno-common/src/tags/index.ts
@@ -1,0 +1,13 @@
+/**
+ * A request should be included if it has at least one tag that is included and no tags that are excluded
+ * @param requestTags Tags of the request
+ * @param includeTags Tags to include
+ * @param excludeTags Tags to exclude
+ */
+export const isRequestTagsIncluded = (requestTags: string[], includeTags: string[], excludeTags: string[]) => {
+  const shouldInclude = includeTags.length === 0 || requestTags.some((tag) => includeTags.includes(tag));
+  const shouldExclude = excludeTags.length > 0 && requestTags.some((tag) => excludeTags.includes(tag));
+  return shouldInclude && !shouldExclude;
+};
+
+export default isRequestTagsIncluded;

--- a/packages/bruno-electron/src/bru/index.js
+++ b/packages/bruno-electron/src/bru/index.js
@@ -137,7 +137,8 @@ const bruToJson = (bru) => {
         vars: _.get(json, 'vars', {}),
         assertions: _.get(json, 'assertions', []),
         tests: _.get(json, 'tests', ''),
-        docs: _.get(json, 'docs', '')
+        docs: _.get(json, 'docs', ''),
+        tags: _.get(json, 'tags', [])
       }
     };
 
@@ -192,7 +193,8 @@ const jsonToBru = (json) => {
     },
     assertions: _.get(json, 'request.assertions', []),
     tests: _.get(json, 'request.tests', ''),
-    docs: _.get(json, 'request.docs', '')
+    docs: _.get(json, 'request.docs', ''),
+    tags: _.get(json, 'request.tags', [])
   };
 
   return jsonToBruV2(bruJson);

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -38,6 +38,7 @@ const {
 } = require('./oauth2-helper');
 const Oauth2Store = require('../../store/oauth2');
 const iconv = require('iconv-lite');
+const { isRequestTagsIncluded } = require('@usebruno/common');
 
 // override the default escape function to prevent escaping
 Mustache.escape = function (value) {
@@ -825,7 +826,7 @@ const registerNetworkIpc = (mainWindow) => {
 
   ipcMain.handle(
     'renderer:run-collection-folder',
-    async (event, folder, collection, environment, runtimeVariables, recursive) => {
+    async (event, folder, collection, environment, runtimeVariables, recursive, tags) => {
       const collectionUid = collection.uid;
       const collectionPath = collection.pathname;
       const folderUid = folder ? folder.uid : null;
@@ -866,6 +867,15 @@ const registerNetworkIpc = (mainWindow) => {
           // sort requests by seq property
           folderRequests.sort((a, b) => {
             return a.seq - b.seq;
+          });
+        }
+
+        // Filter requests based on tags
+        if (tags && tags.include && tags.exclude) {
+          const includeTags = tags.include ? tags.include : [];
+          const excludeTags = tags.exclude ? tags.exclude : [];
+          folderRequests = folderRequests.filter(({ request }) => {
+            return isRequestTagsIncluded(request.tags, includeTags, excludeTags)
           });
         }
 

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -4,7 +4,7 @@ const { outdentString } = require('../../v1/src/utils');
 
 /**
  * A Bru file is made up of blocks.
- * There are two types of blocks
+ * There are three types of blocks
  *
  * 1. Dictionary Blocks - These are blocks that have key value pairs
  * ex:
@@ -19,10 +19,17 @@ const { outdentString } = require('../../v1/src/utils');
  *   "username": "John Nash",
  *   "password": "governingdynamics
  *  }
+
+ * 3. List Blocks - These are blocks that have a list of items
+ * ex:
+ *  tags [
+ *   regression
+ *   smoke-test
+ *  ]
  *
  */
 const grammar = ohm.grammar(`Bru {
-  BruFile = (meta | http | query | params | headers | auths | bodies | varsandassert | script | tests | docs)*
+  BruFile = (meta | tags | http | query | params | headers | auths | bodies | varsandassert | script | tests | docs)*
   auths = authawsv4 | authbasic | authbearer | authdigest | authOAuth2
   bodies = bodyjson | bodytext | bodyxml | bodysparql | bodygraphql | bodygraphqlvars | bodyforms | body
   bodyforms = bodyformurlencoded | bodymultipart
@@ -59,6 +66,13 @@ const grammar = ohm.grammar(`Bru {
   textline = textchar*
   textchar = ~nl any
 
+  // List
+  listend = nl "]"
+  list = st* "[" listitems? listend
+  listitems = (~listend nl)* listitem (~listend stnl* listitem)* (~listend space)*
+  listitem = st* textchar+ st*
+
+  tags = "tags" list
   meta = "meta" dictionary
 
   http = get | post | put | delete | patch | options | head | connect | trace
@@ -244,6 +258,15 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   assertkey(chars) {
     return chars.sourceString ? chars.sourceString.trim() : '';
   },
+  list(_1, _2, listitems, _3) {
+    return listitems.ast.flat()
+  },
+  listitems(_1, listitem, _2, rest, _3) {
+    return [listitem.ast, ...rest.ast]
+  },
+  listitem(_1, textchar, _2) {
+    return textchar.sourceString;
+  },
   textblock(line, _1, rest) {
     return [line.ast, ...rest.ast].join('\n');
   },
@@ -264,6 +287,9 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   },
   _iter(...elements) {
     return elements.map((e) => e.ast);
+  },
+  tags(_1, list) {
+    return { tags: list.ast };
   },
   meta(_1, dictionary) {
     let meta = mapPairListToKeyValPair(dictionary.ast);

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -30,7 +30,7 @@ const getValueString = (value) => {
 };
 
 const jsonToBru = (json) => {
-  const { meta, http, params, headers, auth, body, script, tests, vars, assertions, docs } = json;
+  const { meta, tags, http, params, headers, auth, body, script, tests, vars, assertions, docs } = json;
 
   let bru = '';
 
@@ -40,6 +40,14 @@ const jsonToBru = (json) => {
       bru += `  ${key}: ${meta[key]}\n`;
     }
     bru += '}\n\n';
+  }
+
+  if (tags) {
+    bru += 'tags [\n';
+    for (const tag of tags) {
+      bru += `  ${tag}\n`;
+    }
+    bru += ']\n\n';
   }
 
   if (http && http.method) {

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -4,6 +4,11 @@ meta {
   seq: 1
 }
 
+tags [
+  foo
+  bar
+]
+
 get {
   url: https://api.textlocal.in/send/:id
   body: json

--- a/packages/bruno-lang/v2/tests/fixtures/request.json
+++ b/packages/bruno-lang/v2/tests/fixtures/request.json
@@ -4,6 +4,7 @@
     "type": "http",
     "seq": "1"
   },
+  "tags": ["foo", "bar"],
   "http": {
     "method": "get",
     "url": "https://api.textlocal.in/send/:id",

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -227,7 +227,8 @@ const requestSchema = Yup.object({
     .nullable(),
   assertions: Yup.array().of(keyValueSchema).nullable(),
   tests: Yup.string().nullable(),
-  docs: Yup.string().nullable()
+  docs: Yup.string().nullable(),
+  tags: Yup.array().of(Yup.string().matches(/^[\w-]+$/, 'tag must be alphanumeric'))
 })
   .noUnknown(true)
   .strict();

--- a/packages/bruno-schema/src/collections/requestSchema.spec.js
+++ b/packages/bruno-schema/src/collections/requestSchema.spec.js
@@ -9,6 +9,7 @@ describe('Request Schema Validation', () => {
       method: 'GET',
       headers: [],
       params: [],
+      tags: ['smoke-test'],
       body: {
         mode: 'none'
       }

--- a/packages/bruno-toml/src/jsonToToml.js
+++ b/packages/bruno-toml/src/jsonToToml.js
@@ -47,6 +47,10 @@ const jsonToToml = (json) => {
     }
   };
 
+  if (json.tags && json.tags.length) {
+    formattedJson.tags = get(json, 'tags', []);
+  }
+
   if (json.headers && json.headers.length) {
     const hasDuplicateHeaders = keyValPairHasDuplicateKeys(json.headers);
     const hasReservedHeaders = keyValPairHasReservedKeys(json.headers);

--- a/packages/bruno-toml/src/tomlToJson.js
+++ b/packages/bruno-toml/src/tomlToJson.js
@@ -24,6 +24,10 @@ const tomlToJson = (toml) => {
     }
   };
 
+  if (json.tags && json.tags.length) {
+    formattedJson.tags = get(json, 'tags', []);
+  }
+
   if (json.headers) {
     formattedJson.headers = [];
 

--- a/packages/bruno-toml/tests/methods/get/request.json
+++ b/packages/bruno-toml/tests/methods/get/request.json
@@ -4,6 +4,7 @@
     "type": "http",
     "seq": 1
   },
+  "tags": ["foo", "bar"],
   "http": {
     "method": "GET",
     "url": "https://reqres.in/api/users"

--- a/packages/bruno-toml/tests/methods/get/request.toml
+++ b/packages/bruno-toml/tests/methods/get/request.toml
@@ -1,3 +1,5 @@
+tags = [ 'foo', 'bar' ]
+
 [meta]
 name = 'Get users'
 type = 'http'


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
This PR adds a tagging functionality that allows users to define tags for requests and to run only requests matching the desired tags both in the GUI and CLI collection runners.

This PR aims to implement the proposed solution in #1039. This also fixes #1615.

---

In `.bru` files tags are defined using a simple list structure:
```
meta {
  name: Example
  type: http
  seq: 1
}

tags [
  testing
  example
]

get {
  url: example.com
  body: none
  auth: none
}
```

Bruno CLI has new `--tags` and `--exclude-tags` options that take a comma separated list of tags to include/exclude.
Example usage: `bru run --r . --tags=smoke,sanity --exclude-tags=skip`

Tags are defined for each request in their own tab / section:

https://github.com/user-attachments/assets/382c0c13-ab43-4bd6-a9c3-a2ba6fb8f538

User has the ability to specify included and excluded tags for the collection runner:

https://github.com/user-attachments/assets/9bfc8c88-5936-4b94-86db-a68641ea425f


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
