### PR TITLE
Fix/bigint in response

### DIFF
--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -1,5 +1,6 @@
 import { customAlphabet } from 'nanoid';
 import xmlFormat from 'xml-formatter';
+import { stringify } from 'lossless-json';
 
 // a customized version of nanoid without using _ and -
 export const uuid = () => {
@@ -43,9 +44,9 @@ export const safeStringifyJSON = (obj, indent = false) => {
   }
   try {
     if (indent) {
-      return JSON.stringify(obj, null, 2);
+      return stringify(obj, null, 2);
     }
-    return JSON.stringify(obj);
+    return stringify(obj);
   } catch (e) {
     return obj;
   }

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -47,6 +47,7 @@
     "js-yaml": "^4.1.0",
     "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",
+    "lossless-json": "^4.0.1",
     "mime-types": "^2.1.35",
     "mustache": "^4.2.0",
     "nanoid": "3.3.4",

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -38,6 +38,7 @@ const {
 } = require('./oauth2-helper');
 const Oauth2Store = require('../../store/oauth2');
 const iconv = require('iconv-lite');
+const { parse, LosslessNumber } = require('lossless-json');
 
 // override the default escape function to prevent escaping
 Mustache.escape = function (value) {
@@ -285,7 +286,11 @@ const parseDataFromResponse = (response) => {
     // Filter out ZWNBSP character
     // https://gist.github.com/antic183/619f42b559b78028d1fe9e7ae8a1352d
     data = data.replace(/^\uFEFF/, '');
-    data = JSON.parse(data);
+    data = parse(data, null, (value) => {
+      // By default, this will return the LosslessNumber object, but because it's passed into ipc we
+      // need to convert it into a number because LosslessNumber is converted into an object
+      return new LosslessNumber(value).valueOf();
+    });
   } catch {}
 
   return { data, dataBuffer };


### PR DESCRIPTION
# Description

Use `lossless-json` to parse the response data and then later stringily so information about BigInts are not lost.

Fixes: #1753
