### PR TITLE
fix: type error in jsonToBru during import collection

### DIFF
--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -261,7 +261,6 @@ ${indentString(body.sparql)}
         multipartForms
           .map((item) => {
             const enabled = item.enabled ? '' : '~';
-            console.log(item);
             if (item.type === 'text') {
               return `${enabled}${item.name}: ${getValueString(item.value)}`;
             }

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -13,7 +13,7 @@ const stripLastLine = (text) => {
 };
 
 const getValueString = (value) => {
-  const hasNewLines = value.includes('\n');
+  const hasNewLines = value?.includes('\n');
 
   if (!hasNewLines) {
     return value;
@@ -261,7 +261,7 @@ ${indentString(body.sparql)}
         multipartForms
           .map((item) => {
             const enabled = item.enabled ? '' : '~';
-
+            console.log(item);
             if (item.type === 'text') {
               return `${enabled}${item.name}: ${getValueString(item.value)}`;
             }


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- fixed #2699

- If there is undefined value in imported json item, type error occurs.
```
Error occurred in handler for 'renderer:import-collection': TypeError: Cannot read properties of undefined (reading 'includes')
```
- I fixed it by adding optinal chaing in `getValueString()` 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
