### PR TITLE
Bugfix/window UI distortion electron

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -50,7 +50,7 @@ app.on('ready', async () => {
     height,
     minWidth: 1000,
     minHeight: 640,
-    show: true,
+    show: false,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: true,

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -68,6 +68,7 @@ app.on('ready', async () => {
     mainWindow.maximize();
   }
 
+  mainWindow.show();
   const url = isDev
     ? 'http://localhost:3000'
     : format({


### PR DESCRIPTION
# Description

There was a small issue with the Windows version (maybe in Linux too) where, when we initially started the application, it showed a broken window. This has now been fixed by setting the window's show property to false during initialization, so it gets directly loaded.

It fixes: [#2712](https://github.com/usebruno/bruno/issues/2712)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:

https://github.com/user-attachments/assets/85225ab6-a132-469a-8ec9-6c9a8465162e

After:

https://github.com/user-attachments/assets/e9c63e1f-4a8a-48b3-91cc-6f3ceca28086


