### PR TITLE
feat: add ability for cURL to import basic auth

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -109,7 +109,8 @@ const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
             collectionUid: collection.uid,
             itemUid: item ? item.uid : null,
             headers: request.headers,
-            body: request.body
+            body: request.body,
+            auth: request.auth
           })
         )
           .then(() => onClose())

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -697,7 +697,7 @@ export const moveItemToRootOfCollection = (collectionUid, draggedItemUid) => (di
 };
 
 export const newHttpRequest = (params) => (dispatch, getState) => {
-  const { requestName, requestType, requestUrl, requestMethod, collectionUid, itemUid, headers, body } = params;
+  const { requestName, requestType, requestUrl, requestMethod, collectionUid, itemUid, headers, body, auth } = params;
 
   return new Promise((resolve, reject) => {
     const state = getState();
@@ -729,6 +729,9 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
           sparql: null,
           multipartForm: null,
           formUrlEncoded: null
+        },
+        auth: auth ?? {
+          mode: 'none'
         }
       }
     };

--- a/packages/bruno-app/src/utils/curl/curl-to-json.js
+++ b/packages/bruno-app/src/utils/curl/curl-to-json.js
@@ -160,14 +160,15 @@ const curlToJson = (curlCommand) => {
   }
 
   if (request.auth) {
-    const splitAuth = request.auth.split(':');
-    const user = splitAuth[0] || '';
-    const password = splitAuth[1] || '';
-
-    requestJson.auth = {
-      user: repr(user),
-      password: repr(password)
-    };
+    if(request.auth.mode === 'basic'){
+      requestJson.auth = {
+        mode: 'basic',
+        basic: {
+          username: repr(request.auth.basic?.username),
+          password: repr(request.auth.basic?.password)
+        }
+      }
+    }
   }
 
   return Object.keys(requestJson).length ? requestJson : {};

--- a/packages/bruno-app/src/utils/curl/index.js
+++ b/packages/bruno-app/src/utils/curl/index.js
@@ -56,7 +56,8 @@ export const getRequestFromCurlCommand = (curlCommand) => {
       url: request.url,
       method: request.method,
       body,
-      headers: headers
+      headers: headers,
+      auth: request.auth
     };
   } catch (error) {
     console.error(error);

--- a/packages/bruno-app/src/utils/curl/parse-curl.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.js
@@ -36,7 +36,8 @@ const parseCurlCommand = (curlCommand) => {
     boolean: ['I', 'head', 'compressed', 'L', 'k', 'silent', 's', 'G', 'get'],
     alias: {
       H: 'header',
-      A: 'user-agent'
+      A: 'user-agent',
+      u: 'user'
     }
   });
 
@@ -226,12 +227,19 @@ const parseCurlCommand = (curlCommand) => {
     request.data = parsedArguments['data-urlencode'];
   }
 
-  if (parsedArguments.u) {
-    request.auth = parsedArguments.u;
+  if (parsedArguments.user && typeof parsedArguments.user === 'string') {
+    const basicAuth = parsedArguments.user.split(':')
+    const username = basicAuth[0] || ''
+    const password = basicAuth[1] || ''
+    request.auth = {
+      mode: 'basic',
+      basic: {
+        username,
+        password
+      }
+    }
   }
-  if (parsedArguments.user) {
-    request.auth = parsedArguments.user;
-  }
+
   if (Array.isArray(request.data)) {
     request.dataArray = request.data;
     request.data = request.data.join('&');


### PR DESCRIPTION
# Description
Seems like there was some ground work for this ability. This also opens the door for other auth types to be imported from cURL.

closes #2774 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**