### PR TITLE
Add TRACE to OpenAPI allowed methods during import

### DIFF
--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -48,7 +48,7 @@ const varsSchema = Yup.object({
 
 const requestUrlSchema = Yup.string().min(0).defined();
 const requestMethodSchema = Yup.string()
-  .oneOf(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'])
+  .oneOf(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE'])
   .required('method is required');
 
 const graphqlBodySchema = Yup.object({

--- a/packages/bruno-schema/src/collections/requestSchema.spec.js
+++ b/packages/bruno-schema/src/collections/requestSchema.spec.js
@@ -32,7 +32,7 @@ describe('Request Schema Validation', () => {
     return Promise.all([
       expect(requestSchema.validate(request)).rejects.toEqual(
         validationErrorWithMessages(
-          'method must be one of the following values: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS'
+          'method must be one of the following values: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE'
         )
       )
     ]);


### PR DESCRIPTION
# Description

In #2117 it was discovered by @nicolasne that the `TRACE` method caused an issue on import, this is an attempt at adding it to the list of allowed methods.

`TRACE` is already supported in other OpenAPI Collection locations such as 
https://github.com/usebruno/bruno/blob/1e0c88a2916236b73017c2df01a6a85c414d7edf/packages/bruno-app/src/utils/importers/openapi-collection.js#L342-L347

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).** (but unfortunately I had created the branch name before I read the guidelines, hope that is okay)
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.



