### PR TITLE
(feat) Add shade to modal header in dark mode

### DIFF
--- a/packages/bruno-app/src/themes/dark.js
+++ b/packages/bruno-app/src/themes/dark.js
@@ -154,7 +154,7 @@ const darkTheme = {
   modal: {
     title: {
       color: '#ccc',
-      bg: 'rgb(48, 48, 49)',
+      bg: 'rgb(38, 38, 39)',
       iconColor: '#ccc'
     },
     body: {


### PR DESCRIPTION
# Description

Current `modal` component's `title` and `body` share the same background color. 

For better UX, it would be worth adding a slight shade to the `title` to differentiate between the `title` and `body` section. I have used the shade generator utility from https://mdigi.tools/color-shades/#303031

> Note that the `light` mode already has this subtle difference, so this PR is only applicable to `dark` mode.

The change is subtle but impact on user experience is substantial. 

Take a look at the screenshots before and after

**Before**
<img width="371" alt="image" src="https://github.com/user-attachments/assets/64a3c18b-4508-430f-8a73-3b01a253ad60">

<img width="602" alt="image" src="https://github.com/user-attachments/assets/86266ea0-aab6-47a9-a85d-72851e38e424">

**After**
<img width="376" alt="image" src="https://github.com/user-attachments/assets/bde01dbf-f297-4767-b4fb-69e70ce481a1">

<img width="597" alt="image" src="https://github.com/user-attachments/assets/b789d8bd-d7bb-4e4d-9687-5718d7eb705e">

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
