### PR TITLE
Fix invalid characters allowed in request name on Windows

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -12,6 +12,8 @@ import HttpMethodSelector from 'components/RequestPane/QueryUrl/HttpMethodSelect
 import { getDefaultRequestPaneTab } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import { getRequestFromCurlCommand } from 'utils/curl';
+import { variableNameRegex } from 'utils/common/regex';
+import { isWindowsOS } from 'utils/common/platform';
 
 const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
   const dispatch = useDispatch();
@@ -58,6 +60,12 @@ const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
           name: 'requestName',
           message: `The request names - collection and folder is reserved in bruno`,
           test: (value) => {
+            if (isWindowsOS() && variableNameRegex.test(value) === false) {
+              toast.error(
+                `Variable contains invalid characters! Variables must only contain alpha-numeric characters, "-", "_", "."`
+              );
+              return false;
+            }
             const trimmedValue = value ? value.trim().toLowerCase() : '';
             return !['collection', 'folder'].includes(trimmedValue);
           }

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -12,7 +12,7 @@ import HttpMethodSelector from 'components/RequestPane/QueryUrl/HttpMethodSelect
 import { getDefaultRequestPaneTab } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import { getRequestFromCurlCommand } from 'utils/curl';
-import { variableNameRegex } from 'utils/common/regex';
+import { fileNameRegex } from 'utils/common/regex';
 
 const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
   const dispatch = useDispatch();
@@ -59,9 +59,9 @@ const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
           name: 'requestName',
           message: `The request names - collection and folder is reserved in bruno`,
           test: (value) => {
-            if (variableNameRegex.test(value) === false) {
+            if (fileNameRegex.test(value) === false) {
               toast.error(
-                `Request name contains invalid characters! Request names must only contain alpha-numeric characters, "-", "_", "."`
+                `Request name contains invalid characters! Request names must not contain any of the following characters: < > : " / \ | ? *`
               );
               return false;
             }

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -61,7 +61,7 @@ const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
           test: (value) => {
             if (variableNameRegex.test(value) === false) {
               toast.error(
-                `Variable contains invalid characters! Variables must only contain alpha-numeric characters, "-", "_", "."`
+                `Request name contains invalid characters! Request names must only contain alpha-numeric characters, "-", "_", "."`
               );
               return false;
             }

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -13,7 +13,6 @@ import { getDefaultRequestPaneTab } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import { getRequestFromCurlCommand } from 'utils/curl';
 import { variableNameRegex } from 'utils/common/regex';
-import { isWindowsOS } from 'utils/common/platform';
 
 const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
   const dispatch = useDispatch();
@@ -60,7 +59,7 @@ const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
           name: 'requestName',
           message: `The request names - collection and folder is reserved in bruno`,
           test: (value) => {
-            if (isWindowsOS() && variableNameRegex.test(value) === false) {
+            if (variableNameRegex.test(value) === false) {
               toast.error(
                 `Variable contains invalid characters! Variables must only contain alpha-numeric characters, "-", "_", "."`
               );

--- a/packages/bruno-app/src/utils/common/regex.js
+++ b/packages/bruno-app/src/utils/common/regex.js
@@ -1,1 +1,2 @@
 export const variableNameRegex = /^[\w-.]*$/;
+export const fileNameRegex = /^[^<>:"/\\|?*]+$/;


### PR DESCRIPTION
# Description

This PR addresses issue #2787 where invalid characters are allowed in the request name field on Windows. The current implementation does not validate the request name correctly, which can cause issues with variable names. This PR uses the variableNameRegex in regex.js to ensure it correctly validates request names before form validation on Windows.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Fun fact: this is my first PR in an open-source project, so any feedback will be greatly appreciated :)
