### PR TITLE
fix: remove duplicate tailwind classes in RequestNotFound component

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/RequestNotFound/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/RequestNotFound/index.js
@@ -30,7 +30,7 @@ const RequestNotFound = ({ itemUid }) => {
 
   return (
     <div className="mt-6 px-6">
-      <div className="p-4 bg-orange-100 border-l-4 border-yellow-500 text-yellow-700 bg-yellow-100 p-4">
+      <div className="p-4 bg-orange-100 border-l-4 border-yellow-500 text-yellow-700">
         <div>Request no longer exists.</div>
         <div className="mt-2">
           This can happen when the .bru file associated with this request was deleted on your filesystem.


### PR DESCRIPTION
# Description

I'm just removing classes that are duplicated in the RequestNotFound component.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


