### PR TITLE
Feature/filter by url

### DIFF
--- a/packages/bruno-app/jest.config.js
+++ b/packages/bruno-app/jest.config.js
@@ -1,0 +1,10 @@
+const { compilerOptions } = require('./jsconfig.json');
+const { pathsToModuleNameMapper } = require('ts-jest');
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  modulePaths: [compilerOptions.baseUrl],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
+  transform: { '^.+\\.(js|jsx)$': 'babel-jest' }
+};

--- a/packages/bruno-app/src/utils/collections/search.js
+++ b/packages/bruno-app/src/utils/collections/search.js
@@ -3,7 +3,10 @@ import filter from 'lodash/filter';
 import find from 'lodash/find';
 
 export const doesRequestMatchSearchText = (request, searchText = '') => {
-  return request.name.toLowerCase().includes(searchText.toLowerCase());
+  return (
+    request.name.toLowerCase().includes(searchText.toLowerCase()) ||
+    request.request.url.toLowerCase().includes(searchText.toLowerCase())
+  );
 };
 
 export const doesFolderHaveItemsMatchSearchText = (item, searchText = '') => {

--- a/packages/bruno-app/src/utils/collections/search.spec.js
+++ b/packages/bruno-app/src/utils/collections/search.spec.js
@@ -1,0 +1,21 @@
+const { doesRequestMatchSearchText } = require('./search');
+
+const sampleRequest = { name: 'MyRequestName', request: { url: '{{myServer}}/api/v1/user/:userId' } };
+
+describe('Collection Utils - Search - doesRequestMatchSearchText', () => {
+  it('should match when no searchText is given', () => {
+    expect(doesRequestMatchSearchText(sampleRequest)).toBeTruthy();
+  });
+
+  it('should match the requests name (case-insensitive)', () => {
+    expect(doesRequestMatchSearchText(sampleRequest, 'equestnam')).toBeTruthy();
+  });
+
+  it('should match the requests url (case-insensitive)', () => {
+    expect(doesRequestMatchSearchText(sampleRequest, '/USER/:userid')).toBeTruthy();
+  });
+
+  it('should not match text that is not in the request', () => {
+    expect(doesRequestMatchSearchText(sampleRequest, 'lorem ipsum')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
# Description

This PR aims to resolve this Issue: https://github.com/usebruno/bruno/issues/2806.
It enables users to not only filter their request by name, but also by URL.

<img width="839" alt="Screenshot 2024-08-11 at 15 57 22" src="https://github.com/user-attachments/assets/9087f939-01f1-434c-879e-fa4973b2efa5">

I also added unit tests for the function I edited and therefore needed to add a custom _jest-config_ to the _bruno-app package_ that uses the _compilerOptions.paths_ property from the _jsconfig_.

This was necessary because jest doesn't automatically read that property from the _jsconfig_ file and therefore couldn't understand the _utils/common_ imports from the _collections/index_ file used in _search.js_.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

