### PR TITLE
fix: remove scope with auth code grant

### DIFF
--- a/packages/bruno-electron/src/ipc/network/oauth2-helper.js
+++ b/packages/bruno-electron/src/ipc/network/oauth2-helper.js
@@ -32,9 +32,6 @@ const resolveOAuth2AuthorizationCodeAccessToken = async (request, collectionUid)
     client_secret: clientSecret,
     state: state
   };
-  if (scope) {
-    data['scope'] = scope;
-  }
   if (pkce) {
     data['code_verifier'] = codeVerifier;
   }


### PR DESCRIPTION
# Description

Removes the "scope" parameter from token endpoint requests when using authorization_code grant.
With authorization_code grant the "scope" parameter isn't supported:
https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** 

fixes https://github.com/usebruno/bruno/issues/2814