### PR TITLE
fix: align folder settings pane + scripts with request pane

### DIFF
--- a/packages/bruno-app/src/components/FolderSettings/Script/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/index.js
@@ -44,8 +44,8 @@ const Script = ({ collection, folder }) => {
       <div className="text-xs mb-4 text-muted">
         Pre and post-request scripts that will run before and after any request inside this folder is sent.
       </div>
-      <div className="flex-1 mt-2">
-        <div className="mb-1 title text-xs">Pre Request</div>
+      <div className="flex flex-col flex-1 mt-2 gap-y-2">
+        <div className="title text-xs">Pre Request</div>
         <CodeEditor
           collection={collection}
           value={requestScript || ''}
@@ -56,8 +56,8 @@ const Script = ({ collection, folder }) => {
           font={get(preferences, 'font.codeFont', 'default')}
         />
       </div>
-      <div className="flex-1 mt-6">
-        <div className="mt-1 mb-1 title text-xs">Post Response</div>
+      <div className="flex flex-col flex-1 mt-2 gap-y-2">
+        <div className="title text-xs">Post Response</div>
         <CodeEditor
           collection={collection}
           value={responseScript || ''}

--- a/packages/bruno-app/src/components/FolderSettings/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/index.js
@@ -50,7 +50,7 @@ const FolderSettings = ({ collection, folder }) => {
   };
 
   return (
-    <StyledWrapper>
+    <StyledWrapper className="flex flex-col h-full">
       <div className="flex flex-col h-full relative px-4 py-4">
         <div className="flex flex-wrap items-center tabs" role="tablist">
           <div className={getTabClassname('headers')} role="tab" onClick={() => setTab('headers')}>


### PR DESCRIPTION
# Description

* Fixes the sizes of the `Pre-request` + `Post-request` inputs on the Folder Settings Panel
* Fixes the size of the `Test` tab input in the Folder Settings Panel
* I've aligned the styling of the container and the children with the equivalent components in `RequestPane`

Fixes #2796

Folder Settings Scripts Tab
(Before)
![before-script](https://github.com/user-attachments/assets/3bbaac10-ebb4-4c0f-8cc7-f44f2aadee97)

(After)
![after-script](https://github.com/user-attachments/assets/76a95c0c-825a-4bb9-8acd-775ce9578143)

Folder Settings Test Tab
(Before)
![before-test](https://github.com/user-attachments/assets/3d356fa5-c4e2-42ea-a215-6fbe86abc045)

(After)
![after-test](https://github.com/user-attachments/assets/222f1f72-84bd-4f8b-a23e-cf9dfab0a23f)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
