### PR TITLE
Added cookie support to CLI requests

### DIFF
--- a/packages/bruno-cli/package.json
+++ b/packages/bruno-cli/package.json
@@ -35,6 +35,7 @@
     "decomment": "^0.9.5",
     "form-data": "^4.0.0",
     "fs-extra": "^10.1.0",
+    "http-cookie-agent": "^6.0.5",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.2",
     "inquirer": "^9.1.4",
@@ -43,6 +44,7 @@
     "mustache": "^4.2.0",
     "qs": "^6.11.0",
     "socks-proxy-agent": "^8.0.2",
+    "tough-cookie": "^4.1.4",
     "vm2": "^3.9.13",
     "xmlbuilder": "^15.1.1",
     "yargs": "^17.6.2"

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -207,6 +207,11 @@ const builder = async (yargs) => {
       description:
         'The specified custom CA certificate (--cacert) will be used exclusively and the default truststore is ignored, if this option is specified. Evaluated in combination with "--cacert" only.'
     })
+    .option('use-cookies', {
+      type: 'boolean',
+      default: false,
+      description: 'Automatically save and sent cookies with requests'
+    })
     .option('env', {
       describe: 'Environment variables',
       type: 'string'
@@ -276,6 +281,7 @@ const handler = async function (argv) {
       filename,
       cacert,
       ignoreTruststore,
+      useCookies,
       env,
       envVar,
       insecure,
@@ -362,6 +368,9 @@ const handler = async function (argv) {
     }
     if (insecure) {
       options['insecure'] = true;
+    }
+    if (useCookies) {
+      options['useCookies'] = true;
     }
     if (cacert && cacert.length) {
       if (insecure) {

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -19,6 +19,7 @@ const { makeAxiosInstance } = require('../utils/axios-instance');
 const { addAwsV4Interceptor, resolveAwsV4Credentials } = require('./awsv4auth-helper');
 const { shouldUseProxy, PatchedHttpsProxyAgent } = require('../utils/proxy-util');
 const path = require('path');
+const { getWrappedAgent } = require('../utils/http-agent-util');
 const protocolRegex = /^([-+\w]{1,25})(:?\/\/|:)/;
 
 const runSingleRequest = async function (
@@ -179,21 +180,16 @@ const runSingleRequest = async function (
         proxyUri = `${proxyProtocol}://${proxyHostname}${uriPort}`;
       }
 
-      if (socksEnabled) {
-        request.httpsAgent = new SocksProxyAgent(
-          proxyUri,
-          Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
-        );
-        request.httpAgent = new SocksProxyAgent(proxyUri);
-      } else {
-        request.httpsAgent = new PatchedHttpsProxyAgent(
-          proxyUri,
-          Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
-        );
-        request.httpAgent = new HttpProxyAgent(proxyUri);
-      }
+      const httpsAgentClass = socksEnabled ? SocksProxyAgent: PatchedHttpsProxyAgent;
+      const httpAgentClass = socksEnabled ? SocksProxyAgent : HttpProxyAgent;
+      request.httpsAgent = getWrappedAgent(httpsAgentClass,
+        proxyUri,
+        Object.keys(httpsAgentRequestFields).length > 0 ? { ...httpsAgentRequestFields } : undefined
+      );
+      request.httpAgent = getWrappedAgent(httpAgentClass, proxyUri);
+
     } else if (Object.keys(httpsAgentRequestFields).length > 0) {
-      request.httpsAgent = new https.Agent({
+      request.httpsAgent = getWrappedAgent(https.Agent, null, {
         ...httpsAgentRequestFields
       });
     }
@@ -206,7 +202,7 @@ const runSingleRequest = async function (
     let response, responseTime;
     try {
       // run request
-      const axiosInstance = makeAxiosInstance();
+      const axiosInstance = makeAxiosInstance(options);
 
       if (request.awsv4config) {
         // todo: make this happen in prepare-request.js

--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -1,14 +1,18 @@
 const axios = require('axios');
+const { getBaseAgents } = require('./http-agent-util');
+
+
 
 /**
  * Function that configures axios with timing interceptors
  * Important to note here that the timings are not completely accurate.
  * @see https://github.com/axios/axios/issues/695
+ * @param {{useCookies: boolean}} options Configuration options
  * @returns {axios.AxiosInstance}
  */
-function makeAxiosInstance() {
+function makeAxiosInstance(options) {
   /** @type {axios.AxiosInstance} */
-  const instance = axios.create();
+  const instance = axios.create(getBaseAgents(options));
 
   instance.interceptors.request.use((config) => {
     config.headers['request-start-time'] = Date.now();

--- a/packages/bruno-cli/src/utils/http-agent-util.js
+++ b/packages/bruno-cli/src/utils/http-agent-util.js
@@ -1,0 +1,77 @@
+const { createCookieAgent, HttpCookieAgent, HttpsCookieAgent } = require('http-cookie-agent/http');
+
+const { CookieJar } = require('tough-cookie');
+
+const jar = new CookieJar();
+
+/**
+ * Get base agent configuration for Axios.
+ * If the options enable cookies, then the base agents will enable cookies.
+ * @param options
+ * @return {{[httpAgent]: http.Agent, [httpsAgent]: https.Agent}}
+ */
+function getBaseAgents(options) {
+  if (options.useCookies) {
+    return getCookieAgents();
+  } else {
+    return {};
+  }
+}
+
+/**
+ * Wrap an existing agent class with an agent supporting the supported features
+ * @param agentClass The class to wrap
+ * @param arg Any first argument to the wrapped class constructor
+ * @param options Any options to pass to the agent. This can also include `useCookies` to enable cookies.
+ * @return {http.Agent} Wrapped agent
+ */
+function getWrappedAgent(agentClass, arg = null, options = {}) {
+  const {useCookies, ...classOptions} = options;
+
+  if (useCookies) {
+    return getCookieEnabledAgent(agentClass, arg, options);
+  } else {
+    if (arg) {
+      return new agentClass(arg, options);
+    } else {
+      return new agentClass(options);
+    }
+  }
+}
+
+/**
+ * Get cookie enabled HTTP(s) Agents
+ * @return {{httpAgent: http.Agent, httpsAgent: https.Agent}}
+ */
+function getCookieAgents() {
+  return {
+    httpAgent: new HttpCookieAgent({ cookies: { jar } }),
+    httpsAgent: new HttpsCookieAgent({ cookies: { jar } }),
+  }
+}
+
+/**
+ *
+ * @param {object} agentClass The agent class to wrap
+ * @param {object} arg Any first (non-options) argument (e.g. proxy URL)
+ * @param {object} options Any options to pass to the class
+ * @return {http.Agent} wrapped object
+ */
+function getCookieEnabledAgent(agentClass, arg = null, options= {}) {
+  const WrappedClass = createCookieAgent(agentClass);
+  const combinedArgs = {
+    ...options,
+    cookies: { jar }
+  };
+  if (arg) {
+    return new WrappedClass(arg, combinedArgs);
+  } else {
+    return new WrappedClass(combinedArgs);
+  }
+}
+
+
+module.exports = {
+  getBaseAgents,
+  getWrappedAgent
+}


### PR DESCRIPTION
# Description

Right now, Bruno CLI doesn't support cookies. Many of our collections include an "Auth" request that we can use to get a auth cookie that will be used on subsequent requests. However, without cookies, we can't run the same collections (e.g. treat them as a test suite) without adding complicated pre-request scripts to fake the cookie first.

This adds a `--use-cookies` flag that (if set to `true`) creates a cookie store for this invocation of `bru`. Hence, no existing use-cases should be impacted, but this feature would be available for those who wish to use it.

This also should work in both standard and Proxy (HTTP or SOCKS) configurations.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
