### PR TITLE
feat: Reuse dictionary in preferences support page

### DIFF
--- a/packages/bruno-app/src/components/Preferences/Support/index.js
+++ b/packages/bruno-app/src/components/Preferences/Support/index.js
@@ -1,39 +1,42 @@
 import React from 'react';
 import { IconSpeakerphone, IconBrandTwitter, IconBrandGithub, IconBrandDiscord, IconBook } from '@tabler/icons';
 import StyledWrapper from './StyledWrapper';
+import { useDictionary } from 'providers/Dictionary/index';
 
 const Support = () => {
+  const { dictionary } = useDictionary();
+
   return (
     <StyledWrapper>
       <div className="rows">
         <div className="mt-2">
           <a href="https://docs.usebruno.com" target="_blank" className="flex items-end">
             <IconBook size={18} strokeWidth={2} />
-            <span className="label ml-2">Documentation</span>
+            <span className="label ml-2">{dictionary.documentation}</span>
           </a>
         </div>
         <div className="mt-2">
           <a href="https://github.com/usebruno/bruno/issues" target="_blank" className="flex items-end">
             <IconSpeakerphone size={18} strokeWidth={2} />
-            <span className="label ml-2">Report Issues</span>
+            <span className="label ml-2">{dictionary.reportIssues}</span>
           </a>
         </div>
         <div className="mt-2">
           <a href="https://discord.com/invite/KgcZUncpjq" target="_blank" className="flex items-end">
             <IconBrandDiscord size={18} strokeWidth={2} />
-            <span className="label ml-2">Discord</span>
+            <span className="label ml-2">{dictionary.discord}</span>
           </a>
         </div>
         <div className="mt-2">
           <a href="https://github.com/usebruno/bruno" target="_blank" className="flex items-end">
             <IconBrandGithub size={18} strokeWidth={2} />
-            <span className="label ml-2">GitHub</span>
+            <span className="label ml-2">{dictionary.gitHub}</span>
           </a>
         </div>
         <div className="mt-2">
           <a href="https://twitter.com/use_bruno" target="_blank" className="flex items-end">
             <IconBrandTwitter size={18} strokeWidth={2} />
-            <span className="label ml-2">Twitter</span>
+            <span className="label ml-2">{dictionary.twitter}</span>
           </a>
         </div>
       </div>

--- a/packages/bruno-app/src/dictionaries/en.js
+++ b/packages/bruno-app/src/dictionaries/en.js
@@ -10,5 +10,7 @@ export default {
   collectionImportedSuccessfully: 'Collection imported successfully',
   errorWhileOpeningCollection: 'An error occurred while opening the collection',
   errorWhileImportingCollection:
-    'An error occurred while importing the collection. Check the logs for more information.'
+    'An error occurred while importing the collection. Check the logs for more information.',
+  discord: 'Discord',
+  twitter: 'Twitter'
 };


### PR DESCRIPTION
# Description

We recently merged [this PR](https://github.com/usebruno/bruno/pull/2819) to source the commonly used text from the Dictionary. This PR is about re-using the dictionary in the `Preferences->Support` component.

Refer the screenshots before and after the change:

### Before
---
<img width="599" alt="image" src="https://github.com/user-attachments/assets/767e142b-d448-4367-90ee-076b4fe15b9e">

### After
---
<img width="603" alt="image" src="https://github.com/user-attachments/assets/b9bbbb85-930e-4a5b-b4ff-908c7d78792d">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
