### PR TITLE
fix: add path params on newHttpRequest

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -39,7 +39,7 @@ import {
 import { each } from 'lodash';
 import { closeAllCollectionTabs } from 'providers/ReduxStore/slices/tabs';
 import { resolveRequestFilename } from 'utils/common/platform';
-import { parseQueryParams, splitOnFirst } from 'utils/url/index';
+import { parsePathParams, parseQueryParams, splitOnFirst } from 'utils/url/index';
 import { sendCollectionOauth2Request as _sendCollectionOauth2Request } from 'utils/network/index';
 import { name } from 'file-loader';
 
@@ -708,10 +708,19 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
     }
 
     const parts = splitOnFirst(requestUrl, '?');
-    const params = parseQueryParams(parts[1]);
-    each(params, (urlParam) => {
+    const queryParams = parseQueryParams(parts[1]);
+    each(queryParams, (urlParam) => {
       urlParam.enabled = true;
+      urlParam.type = 'query';
     });
+
+    const pathParams = parsePathParams(requestUrl);
+    each(pathParams, (pathParm) => {
+      pathParams.enabled = true;
+      pathParm.type = 'path'
+    });
+
+    const params = [...queryParams, ...pathParams];
 
     const item = {
       uid: uuid(),


### PR DESCRIPTION
# Description
- fix #2786
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

- Fixed an issue where query params and path params were not being added correctly in the `newHttpRequest()` called from the new request modal.

### Screen shots
##### only path params
https://github.com/user-attachments/assets/5b09c4bf-5b3c-4208-8204-049bc258f6af

##### only query params

https://github.com/user-attachments/assets/bf17131d-f31a-42ac-aec0-45213af4ebe6


##### query + path params

https://github.com/user-attachments/assets/01e700fa-66fd-48e6-97c7-00954138d410


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
