### PR TITLE
Bugfix- Import blank directory Exception

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -115,7 +115,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, collectionName, trans
       collectionLocation: Yup.string()
         .min(1, 'must be at least 1 character')
         .max(500, 'must be 500 characters or less')
-        .required('name is required')
+        .required('Location is required')
     }),
     onSubmit: (values) => {
       handleSubmit(values.collectionLocation);

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -124,7 +124,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, collectionName, trans
   const browse = () => {
     dispatch(browseDirectory())
       .then((dirPath) => {
-        if (typeof dirPath === 'string') {
+        if (typeof dirPath === 'string' && dirPath.length > 0) {
           formik.setFieldValue('collectionLocation', dirPath);
         }
       })

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -124,7 +124,9 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, collectionName, trans
   const browse = () => {
     dispatch(browseDirectory())
       .then((dirPath) => {
-        formik.setFieldValue('collectionLocation', dirPath);
+        if (typeof dirPath === 'string') {
+          formik.setFieldValue('collectionLocation', dirPath);
+        }
       })
       .catch((error) => {
         formik.setFieldValue('collectionLocation', '');


### PR DESCRIPTION
fixes: #966 

### Pull Request Description

**Issue:** There is an exception in the Import Collection feature with the following error message:
```
Error: Error invoking remote method 'renderer:import-collection': TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type boolean (false)
```

**Changes Introduced:**

In this Pull Request, I have implemented a type check for the `location` variable in the Import Collection process. Specifically, the code now verifies if the `dirPath` is of type `string`. If `dirPath` is a string, it proceeds with the operation; otherwise, the Import Collection modal remains open for the user to select a valid path.

Here is the added code snippet for the type check:
```javascript
if (typeof dirPath === 'string') {
  formik.setFieldValue('collectionLocation', dirPath);
}
```

This exact implementation is already in place for the Create Collection modal. [reference](https://github.com/usebruno/bruno/blob/f0b7bf343022dd93094098f12602b08a6bec1f4d/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js#L47) by @Its-treason 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**

Before:
![image](https://github.com/user-attachments/assets/d0682ea2-578e-4b5e-8e80-37d9a6829449)

After:
![image](https://github.com/user-attachments/assets/8dbd997f-5049-4af7-8be8-40e69476c79e)

