### PR TITLE
feat: Use theme provider to get method color

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -61,7 +61,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   };
 
   const getMethodColor = (method = '') => {
-    const { theme } = useTheme();
+    const theme = storedTheme === 'dark' ? darkTheme : lightTheme;
     return theme.request.methods[method.toLocaleLowerCase()];
   };
 

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -61,44 +61,10 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   };
 
   const getMethodColor = (method = '') => {
-    const theme = storedTheme === 'dark' ? darkTheme : lightTheme;
-
-    let color = '';
-    method = method.toLocaleLowerCase();
-
-    switch (method) {
-      case 'get': {
-        color = theme.request.methods.get;
-        break;
-      }
-      case 'post': {
-        color = theme.request.methods.post;
-        break;
-      }
-      case 'put': {
-        color = theme.request.methods.put;
-        break;
-      }
-      case 'delete': {
-        color = theme.request.methods.delete;
-        break;
-      }
-      case 'patch': {
-        color = theme.request.methods.patch;
-        break;
-      }
-      case 'options': {
-        color = theme.request.methods.options;
-        break;
-      }
-      case 'head': {
-        color = theme.request.methods.head;
-        break;
-      }
-    }
-
-    return color;
+    const { theme } = useTheme();
+    return theme.request.methods[method.toLocaleLowerCase()];
   };
+
   const folder = folderUid ? findItemInCollection(collection, folderUid) : null;
   if (['collection-settings', 'folder-settings', 'variables', 'collection-runner'].includes(tab.type)) {
     return (


### PR DESCRIPTION
# Description

The `getMethodColor` re-uses the existing `ThemeProvider` to get the current set theme. The method further eliminates the `switch-case` which is not really required.

Screenshots attached below:

![image](https://github.com/user-attachments/assets/c0d806c6-d649-4e1f-ab2c-5f1ba57ec0b8)

![image](https://github.com/user-attachments/assets/437fc975-09d0-48f6-bea4-59ba310246da)

![image](https://github.com/user-attachments/assets/d9eae858-cd11-4e8a-800e-5f426ac55dbb)

![image](https://github.com/user-attachments/assets/425bff78-4688-44db-b29b-2c2d962a2a2c)

![image](https://github.com/user-attachments/assets/256da2be-78d7-47c7-93d8-a91c357d0a18)

![image](https://github.com/user-attachments/assets/ebf2e24b-f3d7-4dbc-a271-62e3debe789c)

![image](https://github.com/user-attachments/assets/0cde510e-ed6e-4443-bc43-e63cd577adc6)

![image](https://github.com/user-attachments/assets/f845dcc9-b329-4b94-ac1f-24d52261b444)

![image](https://github.com/user-attachments/assets/48d7e212-c1ec-4f92-8644-c9a09f652c4e)

![image](https://github.com/user-attachments/assets/dcd81969-26aa-491d-8f0e-c97e6b19c76c)

![image](https://github.com/user-attachments/assets/317c65d8-9ba1-46fa-8c61-67d19add0442)

![image](https://github.com/user-attachments/assets/2408336b-5411-4532-bbd2-547b2f017508)

![image](https://github.com/user-attachments/assets/a0246533-da31-495a-9161-9f0568a32e70)

![image](https://github.com/user-attachments/assets/45a28812-2955-46f8-960a-fbba851bde83)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
