### PR TITLE
Style/assert option bg

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
@@ -1,7 +1,4 @@
 import React from 'react';
-import { useTheme } from 'providers/Theme/index';
-import darkTheme from 'themes/dark';
-import lightTheme from 'themes/light';
 
 /**
  * Assertion operators
@@ -81,16 +78,10 @@ const AssertionOperator = ({ operator, onChange }) => {
     }
   };
 
-  const { storedTheme } = useTheme();
-
   return (
     <select value={operator} onChange={handleChange} className="mousetrap">
       {operators.map((operator) => (
-        <option
-          style={{ backgroundColor: storedTheme === 'dark' ? darkTheme.bg : lightTheme.bg }}
-          key={operator}
-          value={operator}
-        >
+        <option key={operator} value={operator}>
           {getLabel(operator)}
         </option>
       ))}

--- a/packages/bruno-app/src/components/RequestPane/Assertions/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/StyledWrapper.js
@@ -55,6 +55,9 @@ const Wrapper = styled.div`
     position: relative;
     top: 1px;
   }
+  option {
+    background-color: ${(props) => props.theme.bg};
+  }
 `;
 
 export default Wrapper;


### PR DESCRIPTION
**Fixes:** #2548

This PR fixes a UI bug that occurred when the "system" theme was used and the system's theme was set to dark mode. The bug did not occur when the "dark" theme was manually selected.

I resolved this by wrapping the style of the `AssertionOperator` component's `option` tag's background color.

### Contribution Checklist:

- [x] **The pull request addresses only one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes.**
- [x] **I have added screenshots or gifs to help explain the change, if applicable.**

**Before:**
<img src="https://github.com/user-attachments/assets/f007e6b7-ee67-4b58-8f34-64ddf4128ff8" height="300">

**After:**
<img src="https://github.com/user-attachments/assets/db7e4517-b1cb-44d4-9d85-65a93ddd14b1" height="300">