### PR TITLE
fix: Use system dark theme correctly with assertion operator dropdown

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
@@ -81,13 +81,17 @@ const AssertionOperator = ({ operator, onChange }) => {
     }
   };
 
-  const { storedTheme } = useTheme();
+  const { displayedTheme } = useTheme();
+  const effectiveTheme = displayedTheme === darkTheme.name ? darkTheme : lightTheme;
 
   return (
     <select value={operator} onChange={handleChange} className="mousetrap">
       {operators.map((operator) => (
         <option
-          style={{ backgroundColor: storedTheme === 'dark' ? darkTheme.bg : lightTheme.bg }}
+          style={{
+            color: effectiveTheme.dropdown.color,
+            backgroundColor: effectiveTheme.dropdown.bg
+          }}
           key={operator}
           value={operator}
         >

--- a/packages/bruno-app/src/themes/dark.js
+++ b/packages/bruno-app/src/themes/dark.js
@@ -1,4 +1,5 @@
 const darkTheme = {
+  name: 'dark',
   brand: '#546de5',
   text: '#d4d4d4',
   textLink: '#569cd6',

--- a/packages/bruno-app/src/themes/light.js
+++ b/packages/bruno-app/src/themes/light.js
@@ -1,4 +1,5 @@
 const lightTheme = {
+  name: 'light',
   brand: '#546de5',
   text: 'rgb(52, 52, 52)',
   textLink: '#1663bb',


### PR DESCRIPTION
# Description

Following are the changes in short:

- Adding `name` key to the theme so to reuse this across the codebase thereby reducing tech debt.
- Fixed the issue where the assertion operator dropdown theme does not apply the system dark theme correctly. Also using correct theme variable for the dropdown.

Refer the screenshot before and after below.

## Before (Dark System Theme)

![image](https://github.com/user-attachments/assets/83b85384-a112-4a82-a8d9-e4311912dca3)

## After (Dark System Theme)

![image](https://github.com/user-attachments/assets/35f76faa-89ab-413f-9475-152f8dfb75aa)

## After (Light System Theme)
![image](https://github.com/user-attachments/assets/d6f909c6-fb63-49e4-9f36-ad012075704e)

## After (Light Theme)
![image](https://github.com/user-attachments/assets/235792fd-872e-4c6d-b416-caf58fcd1225)

## After (Dark Theme)
![image](https://github.com/user-attachments/assets/b08006fa-8fbb-4ca9-8f4a-ada8d47ce7bd)

# Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

# Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
