### PR TITLE
Fixed url conversion when exporting to Postman

### DIFF
--- a/packages/bruno-app/src/utils/exporters/postman-collection.spec.js
+++ b/packages/bruno-app/src/utils/exporters/postman-collection.spec.js
@@ -1,0 +1,421 @@
+const { describe, it, expect } = require('@jest/globals');
+import { convertCollection } from './postman-collection';
+
+describe('exporter postman-collection', () => {
+  it('should handle full https url with variables', () => {
+    const brunoObj = {
+      items: [
+        {
+          request: {
+            url: 'https://{{hostname}}/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test',
+            method: 'GET',
+            headers: [],
+            params: [
+              {
+                name: 'queryparam1',
+                value: 'q1',
+                type: 'query',
+                enabled: true
+              },
+              {
+                name: 'variableOne',
+                value: 'v1',
+                type: 'path',
+                enabled: true
+              },
+              {
+                name: 'variableTwo',
+                value: 'v2',
+                type: 'path',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'none',
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        }
+      ]
+    }
+    const resultedUrl = convertCollection(brunoObj).item.at(0).request.url;
+
+    expect(resultedUrl.raw).toEqual('https://{{hostname}}/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test');
+    expect(resultedUrl.protocol).toEqual('https');
+    expect(resultedUrl.auth).toEqual(null);
+    expect(resultedUrl.host).toEqual(['{{hostname}}']);
+    expect(resultedUrl.path).toEqual(['path1', 'path2', ':variableOne', 'path3', ':variableTwo']);
+    expect(resultedUrl.query.at(0).key).toEqual('queryparam1');
+    expect(resultedUrl.query.at(0).value).toEqual('q1');
+    expect(resultedUrl.variable.at(0).key).toEqual('variableOne');
+    expect(resultedUrl.variable.at(0).value).toEqual('v1');
+    expect(resultedUrl.variable.at(1).key).toEqual('variableTwo');
+    expect(resultedUrl.variable.at(1).value).toEqual('v2');
+  });
+
+  it('should handle full http url with variables', () => {
+    const brunoObj = {
+      items: [
+        {
+          request: {
+            url: 'http://{{hostname}}/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test',
+            method: 'GET',
+            headers: [],
+            params: [
+              {
+                name: 'queryparam1',
+                value: 'q1',
+                type: 'query',
+                enabled: true
+              },
+              {
+                name: 'variableOne',
+                value: 'v1',
+                type: 'path',
+                enabled: true
+              },
+              {
+                name: 'variableTwo',
+                value: 'v2',
+                type: 'path',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'none',
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        }
+      ]
+    }
+    const resultedUrl = convertCollection(brunoObj).item.at(0).request.url;
+
+    expect(resultedUrl.raw).toEqual('http://{{hostname}}/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test');
+    expect(resultedUrl.protocol).toEqual('http');
+    expect(resultedUrl.auth).toEqual(null);
+    expect(resultedUrl.host).toEqual(['{{hostname}}']);
+    expect(resultedUrl.path).toEqual(['path1', 'path2', ':variableOne', 'path3', ':variableTwo']);
+    expect(resultedUrl.query.at(0).key).toEqual('queryparam1');
+    expect(resultedUrl.query.at(0).value).toEqual('q1');
+    expect(resultedUrl.variable.at(0).key).toEqual('variableOne');
+    expect(resultedUrl.variable.at(0).value).toEqual('v1');
+    expect(resultedUrl.variable.at(1).key).toEqual('variableTwo');
+    expect(resultedUrl.variable.at(1).value).toEqual('v2');
+  });
+
+  it('should handle urls with no protocol', () => {
+    const brunoObj = {
+      items: [
+        {
+          request: {
+            url: '{{hostname}}/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test',
+            method: 'GET',
+            headers: [],
+            params: [
+              {
+                name: 'queryparam1',
+                value: 'q1',
+                type: 'query',
+                enabled: true
+              },
+              {
+                name: 'variableOne',
+                value: 'v1',
+                type: 'path',
+                enabled: true
+              },
+              {
+                name: 'variableTwo',
+                value: 'v2',
+                type: 'path',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'none',
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        }
+      ]
+    }
+    const resultedUrl = convertCollection(brunoObj).item.at(0).request.url;
+
+    expect(resultedUrl.raw).toEqual('{{hostname}}/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test');
+    expect(resultedUrl.protocol).toEqual(null);
+    expect(resultedUrl.auth).toEqual(null);
+    expect(resultedUrl.host).toEqual(['{{hostname}}']);
+    expect(resultedUrl.path).toEqual(['path1', 'path2', ':variableOne', 'path3', ':variableTwo']);
+    expect(resultedUrl.query.at(0).key).toEqual('queryparam1');
+    expect(resultedUrl.query.at(0).value).toEqual('q1');
+    expect(resultedUrl.variable.at(0).key).toEqual('variableOne');
+    expect(resultedUrl.variable.at(0).value).toEqual('v1');
+    expect(resultedUrl.variable.at(1).key).toEqual('variableTwo');
+    expect(resultedUrl.variable.at(1).value).toEqual('v2');
+  });
+
+  it('should handle a normal host', () => {
+    const brunoObj = {
+      items: [
+        {
+          request: {
+            url: 'test.com/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test',
+            method: 'GET',
+            headers: [],
+            params: [
+              {
+                name: 'queryparam1',
+                value: 'q1',
+                type: 'query',
+                enabled: true
+              },
+              {
+                name: 'variableOne',
+                value: 'v1',
+                type: 'path',
+                enabled: true
+              },
+              {
+                name: 'variableTwo',
+                value: 'v2',
+                type: 'path',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'none',
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        }
+      ]
+    }
+    const resultedUrl = convertCollection(brunoObj).item.at(0).request.url;
+
+    expect(resultedUrl.raw).toEqual('test.com/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test');
+    expect(resultedUrl.protocol).toEqual(null);
+    expect(resultedUrl.auth).toEqual(null);
+    expect(resultedUrl.host).toEqual(['test', 'com']);
+    expect(resultedUrl.path).toEqual(['path1', 'path2', ':variableOne', 'path3', ':variableTwo']);
+    expect(resultedUrl.query.at(0).key).toEqual('queryparam1');
+    expect(resultedUrl.query.at(0).value).toEqual('q1');
+    expect(resultedUrl.variable.at(0).key).toEqual('variableOne');
+    expect(resultedUrl.variable.at(0).value).toEqual('v1');
+    expect(resultedUrl.variable.at(1).key).toEqual('variableTwo');
+    expect(resultedUrl.variable.at(1).value).toEqual('v2');
+  });
+
+  it('should handle no host at all', () => {
+    const brunoObj = {
+      items: [
+        {
+          request: {
+            url: '/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test',
+            method: 'GET',
+            headers: [],
+            params: [
+              {
+                name: 'queryparam1',
+                value: 'q1',
+                type: 'query',
+                enabled: true
+              },
+              {
+                name: 'variableOne',
+                value: 'v1',
+                type: 'path',
+                enabled: true
+              },
+              {
+                name: 'variableTwo',
+                value: 'v2',
+                type: 'path',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'none',
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        }
+      ]
+    }
+    const resultedUrl = convertCollection(brunoObj).item.at(0).request.url;
+
+    expect(resultedUrl.raw).toEqual('/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test');
+    expect(resultedUrl.protocol).toEqual(null);
+    expect(resultedUrl.auth).toEqual(null);
+    expect(resultedUrl.host).toEqual(null);
+    expect(resultedUrl.path).toEqual(['path1', 'path2', ':variableOne', 'path3', ':variableTwo']);
+    expect(resultedUrl.query.at(0).key).toEqual('queryparam1');
+    expect(resultedUrl.query.at(0).value).toEqual('q1');
+    expect(resultedUrl.variable.at(0).key).toEqual('variableOne');
+    expect(resultedUrl.variable.at(0).value).toEqual('v1');
+    expect(resultedUrl.variable.at(1).key).toEqual('variableTwo');
+    expect(resultedUrl.variable.at(1).value).toEqual('v2');
+  });
+
+  it('should handle a host with no dot', () => {
+    const brunoObj = {
+      items: [
+        {
+          request: {
+            url: 'test/path1/:variableOne/path3/:variableTwo?queryparam1=test',
+            method: 'GET',
+            headers: [],
+            params: [
+              {
+                name: 'queryparam1',
+                value: 'q1',
+                type: 'query',
+                enabled: true
+              },
+              {
+                name: 'variableOne',
+                value: 'v1',
+                type: 'path',
+                enabled: true
+              },
+              {
+                name: 'variableTwo',
+                value: 'v2',
+                type: 'path',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'none',
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        }
+      ]
+    }
+    const resultedUrl = convertCollection(brunoObj).item.at(0).request.url;
+
+    expect(resultedUrl.raw).toEqual('test/path1/:variableOne/path3/:variableTwo?queryparam1=test');
+    expect(resultedUrl.protocol).toEqual(null);
+    expect(resultedUrl.auth).toEqual(null);
+    expect(resultedUrl.host).toEqual(['test']);
+    expect(resultedUrl.path).toEqual(['path1', ':variableOne', 'path3', ':variableTwo']);
+    expect(resultedUrl.query.at(0).key).toEqual('queryparam1');
+    expect(resultedUrl.query.at(0).value).toEqual('q1');
+    expect(resultedUrl.variable.at(0).key).toEqual('variableOne');
+    expect(resultedUrl.variable.at(0).value).toEqual('v1');
+    expect(resultedUrl.variable.at(1).key).toEqual('variableTwo');
+    expect(resultedUrl.variable.at(1).value).toEqual('v2');
+  });
+
+  it('should handle proxy like format', () => {
+    const brunoObj = {
+      items: [
+        {
+          request: {
+            url: 'http://test1:test2@test.com/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test',
+            method: 'GET',
+            headers: [],
+            params: [
+              {
+                name: 'queryparam1',
+                value: 'q1',
+                type: 'query',
+                enabled: true
+              },
+              {
+                name: 'variableOne',
+                value: 'v1',
+                type: 'path',
+                enabled: true
+              },
+              {
+                name: 'variableTwo',
+                value: 'v2',
+                type: 'path',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'none',
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        }
+      ]
+    }
+    const resultedUrl = convertCollection(brunoObj).item.at(0).request.url;
+
+    expect(resultedUrl.raw).toEqual('http://test1:test2@test.com/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test');
+    expect(resultedUrl.protocol).toEqual('http');
+    expect(resultedUrl.auth.user).toEqual('test1');
+    expect(resultedUrl.auth.password).toEqual('test2');
+    expect(resultedUrl.host).toEqual(['test', 'com']);
+    expect(resultedUrl.path).toEqual(['path1', 'path2', ':variableOne', 'path3', ':variableTwo']);
+    expect(resultedUrl.query.at(0).key).toEqual('queryparam1');
+    expect(resultedUrl.query.at(0).value).toEqual('q1');
+    expect(resultedUrl.variable.at(0).key).toEqual('variableOne');
+    expect(resultedUrl.variable.at(0).value).toEqual('v1');
+    expect(resultedUrl.variable.at(1).key).toEqual('variableTwo');
+    expect(resultedUrl.variable.at(1).value).toEqual('v2');
+  });
+
+  it('should handle urls with hashtags', () => {
+    const brunoObj = {
+      items: [
+        {
+          request: {
+            url: 'https://{{hostname}}/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test#hashtag1',
+            method: 'GET',
+            headers: [],
+            params: [
+              {
+                name: 'queryparam1',
+                value: 'q1',
+                type: 'query',
+                enabled: true
+              },
+              {
+                name: 'variableOne',
+                value: 'v1',
+                type: 'path',
+                enabled: true
+              },
+              {
+                name: 'variableTwo',
+                value: 'v2',
+                type: 'path',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'none',
+              formUrlEncoded: [],
+              multipartForm: []
+            }
+          }
+        }
+      ]
+    }
+    const resultedUrl = convertCollection(brunoObj).item.at(0).request.url;
+
+    expect(resultedUrl.raw).toEqual('https://{{hostname}}/path1/path2/:variableOne/path3/:variableTwo?queryparam1=test#hashtag1');
+    expect(resultedUrl.protocol).toEqual('https');
+    expect(resultedUrl.auth).toEqual(null);
+    expect(resultedUrl.host).toEqual(['{{hostname}}']);
+    expect(resultedUrl.path).toEqual(['path1', 'path2', ':variableOne', 'path3', ':variableTwo']);
+    expect(resultedUrl.query.at(0).key).toEqual('queryparam1');
+    expect(resultedUrl.query.at(0).value).toEqual('q1');
+    expect(resultedUrl.variable.at(0).key).toEqual('variableOne');
+    expect(resultedUrl.variable.at(0).value).toEqual('v1');
+    expect(resultedUrl.variable.at(1).key).toEqual('variableTwo');
+    expect(resultedUrl.variable.at(1).value).toEqual('v2');
+  });
+});


### PR DESCRIPTION
# Description

The Postman export function is broken at the moment.
Fixes https://github.com/usebruno/bruno/issues/2496.

This PR fixes the following issues : 

- Protocol is not exported
- Text path segments are not exported
- Auth url parameters are not exported
- Path variables are no longer being re-ordered
- Supports the case where not hostname is provided
- Supports the case where the authentication is provided in the URL

I added a lot of unit tests to cover that part :)

With Bruno :

![image](https://github.com/user-attachments/assets/df1eff44-f0df-4049-a2a5-8c3b58a9a529)

After import in Postman, before this PR :

![image](https://github.com/user-attachments/assets/9dd8e9bb-6c1e-4927-9cbb-554a0b6ea4e8)

After import in Postman, after this PR :

![image](https://github.com/user-attachments/assets/74b4b440-9993-499c-ade6-0279c56c6a51)