### PR TITLE
fix: Failed to construct 'URL': Invalid URL everytime the URL is modified

### DIFF
--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -44,7 +44,8 @@ export const parsePathParams = (url) => {
   try {
     uri = new URL(uri);
   } catch (e) {
-    throw e;
+    // URL is non-parsable, is it incomplete? Ignore.
+    return;
   }
 
   let paths = uri.pathname.split('/');

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -45,7 +45,7 @@ export const parsePathParams = (url) => {
     uri = new URL(uri);
   } catch (e) {
     // URL is non-parsable, is it incomplete? Ignore.
-    return;
+    return [];
   }
 
   let paths = uri.pathname.split('/');


### PR DESCRIPTION
# Description

A non-parsable URL should be an acceptable state while the text is being typed. The parsing is  now aborted, without raising an error.

fixes #2652 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
