### PR TITLE
fix: space in any param name is blocking the loading of the request file in GUI

### DIFF
--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -33,7 +33,7 @@ const grammar = ohm.grammar(`Bru {
   stnl = st | nl
   tagend = nl "}"
   optionalnl = ~tagend nl
-  keychar = ~(tagend | st | nl | ":") any
+  keychar = ~(tagend | "\\t" | nl | ":") any
   valuechar = ~(nl | tagend) any
 
    // Multiline text block surrounded by '''

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -13,6 +13,7 @@ get {
 params:query {
   apiKey: secret
   numbers: 998877665
+  multi word param: is allowed
   ~message: hello
 }
 
@@ -23,6 +24,7 @@ params:path {
 headers {
   content-type: application/json
   Authorization: Bearer 123
+  multi word header: is allowed
   ~transaction-id: {{transactionId}}
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/request.json
+++ b/packages/bruno-lang/v2/tests/fixtures/request.json
@@ -24,6 +24,12 @@
       "enabled": true
     },
     {
+      "name" : "multi word param",
+      "value" : "is allowed",
+      "type": "query",
+      "enabled": true
+    },
+    {
       "name": "message",
       "value": "hello",
       "type": "query",
@@ -45,6 +51,11 @@
     {
       "name": "Authorization",
       "value": "Bearer 123",
+      "enabled": true
+    },
+    {
+      "name" : "multi word header",
+      "value" : "is allowed",
       "enabled": true
     },
     {


### PR DESCRIPTION
# Description

Adjusted Bruno grammar so the `key` element does not disallow spaces (leading and trailing space is still trimmed).
fixes #2878
fixes #2810
fixes #3942

More flexible solution, i.e. adding option to quote and escape certain special characters proposed as an alternative to this in #3045 and #3178

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
