### PR TITLE
fix: multiple tab collection level settings

### DIFF
--- a/packages/bruno-app/src/components/FolderSettings/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/index.js
@@ -19,8 +19,8 @@ const FolderSettings = ({ collection, folder }) => {
   const setTab = (tab) => {
     dispatch(
       updatedFolderSettingsSelectedTab({
-        collectionUid: collection.uid,
-        folderUid: folder.uid,
+        collectionUid: collection?.uid,
+        folderUid: folder?.uid,
         tab
       })
     );

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -189,24 +189,25 @@ const CollectionItem = ({ item, collection, searchText }) => {
       toast.error('URL is required');
     }
   };
-  
+
   const viewFolderSettings = () => {
-    const newTabUid = uuid();
-    const { uid: collectionUid } = collection;
-    const { uid: folderUid } = item;
-    const tabType = 'folder-settings';
-
-    const existingTab = isFolderSettingsOpenedInTabs(tabs, { collectionUid, folderUid, type: tabType });
-
-    if (!existingTab) {
+    if (isItemAFolder(item)) {
+      if (itemIsOpenedInTabs(item, tabs)) {
+        dispatch(
+          focusTab({
+            uid: item.uid
+          })
+        );
+        return;
+      }
       dispatch(
         addTab({
-          uid: newTabUid,
-          collectionUid,
-          folderUid,
-          type: tabType
+          uid: item.uid,
+          collectionUid: collection.uid,
+          type: 'folder-settings'
         })
       );
+      return;
     }
   };
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -17,7 +17,7 @@ import CloneCollectionItem from './CloneCollectionItem';
 import DeleteCollectionItem from './DeleteCollectionItem';
 import RunCollectionItem from './RunCollectionItem';
 import GenerateCodeItem from './GenerateCodeItem';
-import { isItemARequest, isItemAFolder, itemIsOpenedInTabs } from 'utils/tabs';
+import { isItemARequest, isItemAFolder, itemIsOpenedInTabs, isFolderSettingsOpenedInTabs } from 'utils/tabs';
 import { doesRequestMatchSearchText, doesFolderHaveItemsMatchSearchText } from 'utils/collections/search';
 import { getDefaultRequestPaneTab } from 'utils/collections';
 import { hideHomePage } from 'providers/ReduxStore/slices/app';
@@ -189,16 +189,27 @@ const CollectionItem = ({ item, collection, searchText }) => {
       toast.error('URL is required');
     }
   };
+  
   const viewFolderSettings = () => {
-    dispatch(
-      addTab({
-        uid: uuid(),
-        collectionUid: collection.uid,
-        folderUid: item.uid,
-        type: 'folder-settings'
-      })
-    );
+    const newTabUid = uuid();
+    const { uid: collectionUid } = collection;
+    const { uid: folderUid } = item;
+    const tabType = 'folder-settings';
+
+    const existingTab = isFolderSettingsOpenedInTabs(tabs, { collectionUid, folderUid, type: tabType });
+
+    if (!existingTab) {
+      dispatch(
+        addTab({
+          uid: newTabUid,
+          collectionUid,
+          folderUid,
+          type: tabType
+        })
+      );
+    }
   };
+
   const requestItems = sortRequestItems(filter(item.items, (i) => isItemARequest(i)));
   const folderItems = sortFolderItems(filter(item.items, (i) => isItemAFolder(i)));
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -17,7 +17,7 @@ import CloneCollectionItem from './CloneCollectionItem';
 import DeleteCollectionItem from './DeleteCollectionItem';
 import RunCollectionItem from './RunCollectionItem';
 import GenerateCodeItem from './GenerateCodeItem';
-import { isItemARequest, isItemAFolder, itemIsOpenedInTabs, isFolderSettingsOpenedInTabs } from 'utils/tabs';
+import { isItemARequest, isItemAFolder, itemIsOpenedInTabs } from 'utils/tabs';
 import { doesRequestMatchSearchText, doesFolderHaveItemsMatchSearchText } from 'utils/collections/search';
 import { getDefaultRequestPaneTab } from 'utils/collections';
 import { hideHomePage } from 'providers/ReduxStore/slices/app';

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -41,7 +41,7 @@ export const tabsSlice = createSlice({
         requestPaneTab: action.payload.requestPaneTab || 'params',
         responsePaneTab: 'response',
         type: action.payload.type || 'request',
-        ...(action.payload.folderUid ? { folderUid: action.payload.folderUid } : {})
+        ...(action.payload.uid ? { folderUid: action.payload.uid } : {})
       });
       state.activeTabUid = action.payload.uid;
     },

--- a/packages/bruno-app/src/utils/tabs/index.js
+++ b/packages/bruno-app/src/utils/tabs/index.js
@@ -11,7 +11,3 @@ export const isItemAFolder = (item) => {
 export const itemIsOpenedInTabs = (item, tabs) => {
   return find(tabs, (t) => t.uid === item.uid);
 };
-
-export const isFolderSettingsOpenedInTabs = (tabs, { collectionUid, folderUid, type }) => {
-  return tabs.find((tab) => tab.collectionUid === collectionUid && tab.folderUid === folderUid && tab.type === type);
-};

--- a/packages/bruno-app/src/utils/tabs/index.js
+++ b/packages/bruno-app/src/utils/tabs/index.js
@@ -11,3 +11,7 @@ export const isItemAFolder = (item) => {
 export const itemIsOpenedInTabs = (item, tabs) => {
   return find(tabs, (t) => t.uid === item.uid);
 };
+
+export const isFolderSettingsOpenedInTabs = (tabs, { collectionUid, folderUid, type }) => {
+  return tabs.find((tab) => tab.collectionUid === collectionUid && tab.folderUid === folderUid && tab.type === type);
+};


### PR DESCRIPTION
Fixes: #2903 

The bug (issue #2903) is fixed by checking ```isFolderSettingsOpenedInTabs``` before opening a new tab

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:

https://github.com/user-attachments/assets/d8204bdb-0289-4b15-87a8-14fd39d860c2

After:


https://github.com/user-attachments/assets/59c32eb6-dd5a-4448-a1bc-be9d9e59f17d

