### PR TITLE
feat: Feature/cli support multiple reporters

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -412,6 +412,8 @@ const handler = async function (argv) {
     }
 
     let formats = {};
+
+    // Maintains back compat with --format and --output
     if (outputPath && outputPath.length) {
       formats[format] = outputPath;
     }

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -419,7 +419,6 @@ const handler = async function (argv) {
     }
     options['ignoreTruststore'] = ignoreTruststore;
 
-    
     let formats;
     if (typeof format === 'string') {
       formats = [format];

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -602,7 +602,7 @@ const handler = async function (argv) {
 
         reporter(path);
 
-        console.log(chalk.dim(chalk.grey(`Wrote results to ${path}`)));
+        console.log(chalk.dim(chalk.grey(`Wrote ${formatter} results to ${path}`)));
       }
     }
 

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -226,7 +226,7 @@ const builder = async (yargs) => {
     })
     .option('output', {
       alias: 'o',
-      describe: 'Path to write file results to. Required when using --format',
+      describe: 'Path to write file results to',
       type: 'string'
     })
     .option('format', {

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -11,7 +11,6 @@ const { rpad } = require('../utils/common');
 const { bruToJson, getOptions, collectionBruToJson } = require('../utils/bru');
 const { dotenvToJson } = require('@usebruno/lang');
 const constants = require('../constants');
-const { outputJSON } = require('fs-extra');
 const command = 'run [filename]';
 const desc = 'Run a request';
 
@@ -591,13 +590,13 @@ const handler = async function (argv) {
         'html': (path) => makeHtmlOutput(outputJson, path),
       }
 
-      for (const f of formats)
+      for (const formatter of formats)
       {
-        const path = outputPaths[f] || outputPaths.default;
-        const reporter = reporters[f];
+        const path = outputPaths[formatter] || outputPaths.default;
+        const reporter = reporters[formatter];
 
         if (!reporter) {
-          console.error(chalk.red(`Reporter ${f} does not exist`));
+          console.error(chalk.red(`Reporter ${formatter} does not exist`));
           process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT);
         }
 

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -436,8 +436,6 @@ const handler = async function (argv) {
       }
     });
 
-
-
     // load .env file at root of collection if it exists
     const dotEnvPath = path.join(collectionPath, '.env');
     const dotEnvExists = await exists(dotEnvPath);


### PR DESCRIPTION
# Description
Adding the ability to pass multiple reporters using `--format`. You can specify the output files using `--output.reporter`

Sample I ran on my machine:
`node ..\..\bruno-cli\bin\bru.js run --env Prod --output junit.xml --format junit --format html --format json --output.html html.html --output.json results.json`

Console output:
![image](https://github.com/user-attachments/assets/4b0d128a-4e3d-4d6c-bf05-1f2261ec2ca2)

All 3 files were written:
![image](https://github.com/user-attachments/assets/10e19d82-583a-41db-bf06-520bcab5b0b4)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Related to #2045 