### PR TITLE
Bugfix/request body value cutoff

### DIFF
--- a/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
@@ -17,7 +17,6 @@ const StyledWrapper = styled.div`
       overflow: hidden !important;
       ${'' /* padding-bottom: 50px !important; */}
       position: relative;
-      display: contents;
       margin: 0px;
       padding: 0px;
     }

--- a/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
@@ -17,6 +17,7 @@ const StyledWrapper = styled.div`
       overflow: hidden !important;
       ${'' /* padding-bottom: 50px !important; */}
       position: relative;
+      display: block;
       margin: 0px;
       padding: 0px;
     }


### PR DESCRIPTION
# Description

This PR addresses a bug with multi part form params and form url encoded params being cut off as reported in #2832.  display: contents property has been changed to display: block to resolve the text being cut off. 
![image](https://github.com/user-attachments/assets/c492bcdc-35be-4b9f-a0e8-af7fb373b3c4)
![image](https://github.com/user-attachments/assets/5f11df70-edea-4249-9c16-c9c7d5fb9f81)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
