### PR TITLE
Style: Delete button hidden in Light theme

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
@@ -65,7 +65,7 @@ const Wrapper = styled.div`
     div.dropdown-item.delete-item {
       color: ${(props) => props.theme.colors.danger};
       &:hover {
-        background-color: ${(props) => props.theme.colors.bg.danger};
+        background-color: ${(props) => props.theme.colors.bg.danger} !important;
         color: white;
       }
     }


### PR DESCRIPTION
The PR addresses a minor style issue in the Collection Item component, specifically for the "Delete Request" button. This issue was introduced by the following [lines](https://github.com/usebruno/bruno/pull/2183/files#diff-14d7c357f3f7423edb8a6276671636a63bacf208c1e29c389e76678e569cf9efR43) in the [PR #2183](https://github.com/usebruno/bruno/pull/2183).


Before:
![image](https://github.com/user-attachments/assets/f16a4726-f6d9-4d62-8760-f3004f3440b5)

After:
![image](https://github.com/user-attachments/assets/3c9f8a77-974b-4087-8eeb-4348d4ac897a)



### Contribution Checklist:

- [x] **This pull request only addresses one issue or adds one feature.**
- [x] **This pull request does not introduce any breaking changes.**
- [x] **Screenshots or gifs have been added to help explain the change, if applicable.**