### PR TITLE
bugfix/chokidar disables globbing

### DIFF
--- a/packages/bruno-electron/src/app/watcher.js
+++ b/packages/bruno-electron/src/app/watcher.js
@@ -453,7 +453,8 @@ class Watcher {
           stabilityThreshold: 80,
           pollInterval: 10
         },
-        depth: 20
+        depth: 20,
+        disableGlobbing: true
       });
 
       let startedNewWatcher = false;


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
fixes #2508 

The reason for this issue is that when [chokidar](https://github.com/paulmillr/chokidar) adds a watch directory, it calls [is-glob](https://github.com/micromatch/is-glob), which interprets strings containing `[]` as regular expressions.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
