### PR TITLE
Improved Request Count Calculation and UI Handling in RunCollectionItem

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RunCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RunCollectionItem/index.js
@@ -57,16 +57,16 @@ const RunCollectionItem = ({ collection, item, onClose }) => {
                   Cancel
                 </button>
               </span>
-                <span>
-                  <button type="submit" disabled={!recursiveRunLength} className="submit btn btn-md btn-secondary mr-3" onClick={() => onSubmit(true)}>
-                    Recursive Run
-                  </button>
-                </span>
-                <span>
-                  <button type="submit" disabled={!runLength} className="submit btn btn-md btn-secondary" onClick={() => onSubmit(false)}>
-                    Run
-                  </button>
-                </span>
+              <span>
+                <button type="submit" disabled={!recursiveRunLength} className="submit btn btn-md btn-secondary mr-3" onClick={() => onSubmit(true)}>
+                  Recursive Run
+                </button>
+              </span>
+              <span>
+                <button type="submit" disabled={!runLength} className="submit btn btn-md btn-secondary" onClick={() => onSubmit(false)}>
+                  Run
+                </button>
+              </span>
             </div>
           </div>
         )}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RunCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RunCollectionItem/index.js
@@ -23,43 +23,53 @@ const RunCollectionItem = ({ collection, item, onClose }) => {
     onClose();
   };
 
-  const runLength = item ? get(item, 'items.length', 0) : get(collection, 'items.length', 0);
-  const items = flattenItems(item ? item.items : collection.items);
-  const requestItems = items.filter((item) => item.type !== 'folder');
-  const recursiveRunLength = requestItems.length;
+  const getRequestsCount = (items) => {
+    const requestTypes = ['http-request', 'graphql-request']
+    return items.filter(req => requestTypes.includes(req.type)).length;
+  }
+
+  const runLength = item ? getRequestsCount(item.items) : get(collection, 'items.length', 0);
+  const flattenedItems = flattenItems(item ? item.items : collection.items);
+  const recursiveRunLength = getRequestsCount(flattenedItems);
 
   return (
     <StyledWrapper>
       <Modal size="md" title="Collection Runner" hideFooter={true} handleCancel={onClose}>
-        <div className="mb-1">
-          <span className="font-medium">Run</span>
-          <span className="ml-1 text-xs">({runLength} requests)</span>
-        </div>
-        <div className="mb-8">This will only run the requests in this folder.</div>
+        {!runLength && !recursiveRunLength ? (
+          <div className="mb-8">No request found in this folder.</div>
+        ) : (
+          <div>
+            <div className="mb-1">
+              <span className="font-medium">Run</span>
+              <span className="ml-1 text-xs">({runLength} requests)</span>
+            </div>
+            <div className="mb-8">This will only run the requests in this folder.</div>
 
-        <div className="mb-1">
-          <span className="font-medium">Recursive Run</span>
-          <span className="ml-1 text-xs">({recursiveRunLength} requests)</span>
-        </div>
-        <div className="mb-8">This will run all the requests in this folder and all its subfolders.</div>
+            <div className="mb-1">
+              <span className="font-medium">Recursive Run</span>
+              <span className="ml-1 text-xs">({recursiveRunLength} requests)</span>
+            </div>
+            <div className="mb-8">This will run all the requests in this folder and all its subfolders.</div>
 
-        <div className="flex justify-end bruno-modal-footer">
-          <span className="mr-3">
-            <button type="button" onClick={onClose} className="btn btn-md btn-close">
-              Cancel
-            </button>
-          </span>
-          <span>
-            <button type="submit" className="submit btn btn-md btn-secondary mr-3" onClick={() => onSubmit(true)}>
-              Recursive Run
-            </button>
-          </span>
-          <span>
-            <button type="submit" className="submit btn btn-md btn-secondary" onClick={() => onSubmit(false)}>
-              Run
-            </button>
-          </span>
-        </div>
+            <div className="flex justify-end bruno-modal-footer">
+              <span className="mr-3">
+                <button type="button" onClick={onClose} className="btn btn-md btn-close">
+                  Cancel
+                </button>
+              </span>
+                <span>
+                  <button type="submit" disabled={!recursiveRunLength} className="submit btn btn-md btn-secondary mr-3" onClick={() => onSubmit(true)}>
+                    Recursive Run
+                  </button>
+                </span>
+                <span>
+                  <button type="submit" disabled={!runLength} className="submit btn btn-md btn-secondary" onClick={() => onSubmit(false)}>
+                    Run
+                  </button>
+                </span>
+            </div>
+          </div>
+        )}
       </Modal>
     </StyledWrapper>
   );


### PR DESCRIPTION
# Description

1. Updated the request count logic to only include http-request and graphql-request types using a new getRequestsCount function. Currently it is calculating the folders too.
2. Added conditional rendering to display a message when no requests are found and disabled the Run and Recursive Run buttons accordingly.

current implementation:
![image](https://github.com/user-attachments/assets/26bb50fb-84de-46f5-8569-4412aae83c0d)

Updated design:
![image](https://github.com/user-attachments/assets/c027fb11-ef02-4d35-9a11-f5da41936e13)



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
