### PR TITLE
added validations for spec and ref

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -224,7 +224,7 @@ const transformOpenapiRequestItem = (request) => {
   return brunoRequestItem;
 };
 
-const resolveRefs = (spec, components = spec.components, visitedItems = new Set()) => {
+const resolveRefs = (spec, components = spec?.components, visitedItems = new Set()) => {
   if (!spec || typeof spec !== 'object') {
     return spec;
   }
@@ -248,7 +248,7 @@ const resolveRefs = (spec, components = spec.components, visitedItems = new Set(
       let ref = components;
 
       for (const key of refKeys) {
-        if (ref[key]) {
+        if (ref && ref[key]) {
           ref = ref[key];
         } else {
           // Handle invalid references gracefully?


### PR DESCRIPTION
# Description

This PR updates the resolveRefs function to handle cases where spec or spec.components is undefined. The function now includes checks to avoid errors when spec is null or components is missing.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Issue link: https://github.com/usebruno/bruno/issues/2083

Sample openapispec to generate this in current implementation

```
openapi: 3.0.0
info:
  title: API
  version: 0.0.0
  description: xxx
servers:
  - url: http://localhost
    description: Main production API server
paths:
  '/v1':
    get:
      summary: xxx
      description: dddddd
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  key:
                    type: integer
                    nullable: true
              example:
                key: null
```