### PR TITLE
feat: Feature/cli add parameters to specify the bruno collection path instead of cwd

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -247,6 +247,11 @@ const builder = async (yargs) => {
       type: 'boolean',
       description: 'Stop execution after a failure of a request, test, or assertion'
     })
+    .option('collection-path', {
+      type: 'string',
+      description: 'Path to the folder where the bruno collection is stored, default to current working directory',
+      default: ''
+    })
     .example('$0 run request.bru', 'Run a request')
     .example('$0 run request.bru --env local', 'Run a request with the environment set to local')
     .example('$0 run folder', 'Run all requests in a folder')
@@ -293,9 +298,11 @@ const handler = async function (argv) {
       format,
       sandbox,
       testsOnly,
-      bail
+      bail,
+      collectionPath
     } = argv;
-    const collectionPath = process.cwd();
+
+    collectionPath = (!collectionPath) ? process.cwd(): collectionPath;
 
     // todo
     // right now, bru must be run from the root of the collection
@@ -312,7 +319,8 @@ const handler = async function (argv) {
     const collectionRoot = getCollectionRoot(collectionPath);
 
     if (filename && filename.length) {
-      const pathExists = await exists(filename);
+      const filenamePath = path.join(collectionPath, filename);
+      const pathExists = await exists(filenamePath);
       if (!pathExists) {
         console.error(chalk.red(`File or directory ${filename} does not exist`));
         process.exit(constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
@@ -407,14 +415,15 @@ const handler = async function (argv) {
       });
     }
 
-    const _isFile = isFile(filename);
+    const filenamePath = path.join(collectionPath, filename);
+    const _isFile = isFile(filenamePath);
     let results = [];
 
     let bruJsons = [];
 
     if (_isFile) {
       console.log(chalk.yellow('Running Request \n'));
-      const bruContent = fs.readFileSync(filename, 'utf8');
+      const bruContent = fs.readFileSync(filenamePath, 'utf8');
       const bruJson = bruToJson(bruContent);
       bruJsons.push({
         bruFilepath: filename,
@@ -422,16 +431,16 @@ const handler = async function (argv) {
       });
     }
 
-    const _isDirectory = isDirectory(filename);
+    const _isDirectory = isDirectory(filenamePath);
     if (_isDirectory) {
       if (!recursive) {
         console.log(chalk.yellow('Running Folder \n'));
-        const files = fs.readdirSync(filename);
+        const files = fs.readdirSync(filenamePath);
         const bruFiles = files.filter((file) => !['folder.bru'].includes(file) && file.endsWith('.bru'));
 
         for (const bruFile of bruFiles) {
           const bruFilepath = path.join(filename, bruFile);
-          const bruContent = fs.readFileSync(bruFilepath, 'utf8');
+          const bruContent = fs.readFileSync(path.join(collectionPath, bruFilepath), 'utf8');
           const bruJson = bruToJson(bruContent);
           const requestHasTests = bruJson.request?.tests;
           const requestHasActiveAsserts = bruJson.request?.assertions.some((x) => x.enabled) || false;
@@ -457,7 +466,7 @@ const handler = async function (argv) {
       } else {
         console.log(chalk.yellow('Running Folder Recursively \n'));
 
-        bruJsons = getBruFilesRecursively(filename, testsOnly);
+        bruJsons = getBruFilesRecursively(filenamePath, testsOnly);
       }
     }
 


### PR DESCRIPTION
# Description

Add the possibility to run the cli outside of the Bruno collection folder.

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**



```
      --collection-path    Path to the folder where the bruno collection is
                           stored, default to current working directory
                                                          [string] [default: ""]
```


```
bru run AGENT--env nonprod --collection-path ../../../my-collections/
```


Please see issue #2967 
