### PR TITLE
Implement onClick for Runner Item

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -9,6 +9,8 @@ import { IconRefresh, IconCircleCheck, IconCircleX, IconCheck, IconX, IconRun } 
 import slash from 'utils/common/slash';
 import ResponsePane from './ResponsePane';
 import StyledWrapper from './StyledWrapper';
+import { addTab } from 'providers/ReduxStore/slices/tabs';
+import { getDefaultRequestPaneTab } from 'utils/collections/index';
 
 const getRelativePath = (fullPath, pathname) => {
   // convert to unix style path
@@ -80,6 +82,16 @@ export default function RunnerResults({ collection }) {
 
   const runCollection = () => {
     dispatch(runCollectionFolder(collection.uid, null, true, Number(delay)));
+  };
+
+  const selectCollection = (item) => {
+    dispatch(
+      addTab({
+        uid: item.uid,
+        collectionUid: collection.uid,
+        requestPaneTab: getDefaultRequestPaneTab(item)
+      })
+    );
   };
 
   const runAgain = () => {
@@ -176,7 +188,8 @@ export default function RunnerResults({ collection }) {
                       )}
                     </span>
                     <span
-                      className={`mr-1 ml-2 ${item.status == 'error' || item.testStatus == 'fail' ? 'danger' : ''}`}
+                      className={`mr-1 ml-2 cursor-pointer ${item.status == 'error' || item.testStatus == 'fail' ? 'danger' : ''}`}
+                      onClick={() => selectCollection(item)}
                     >
                       {item.relativePath}
                     </span>


### PR DESCRIPTION
Make runner item clickable.

Fixes #3005 

# Description

Implements option to not only click the status to see the result, but also the option to click the item to be able to trigger a new request or modify the request in order to successfully run.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
