### PR TITLE
refactor: Move assertion utils out of components

### DIFF
--- a/packages/bruno-app/package.json
+++ b/packages/bruno-app/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
+    "test:watch": "jest --watch",
     "test:prettier": "prettier --check \"./src/**/*.{js,jsx,json,ts,tsx}\"",
     "prettier": "prettier --write \"./src/**/*.{js,jsx,json,ts,tsx}\""
   },

--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionOperator/index.js
@@ -1,88 +1,14 @@
 import React from 'react';
-
-/**
- * Assertion operators
- *
- * eq          : equal to
- * neq         : not equal to
- * gt          : greater than
- * gte         : greater than or equal to
- * lt          : less than
- * lte         : less than or equal to
- * in          : in
- * notIn       : not in
- * contains    : contains
- * notContains : not contains
- * length      : length
- * matches     : matches
- * notMatches  : not matches
- * startsWith  : starts with
- * endsWith    : ends with
- * between     : between
- * isEmpty     : is empty
- * isNull      : is null
- * isUndefined : is undefined
- * isDefined   : is defined
- * isTruthy    : is truthy
- * isFalsy     : is falsy
- * isJson      : is json
- * isNumber    : is number
- * isString    : is string
- * isBoolean   : is boolean
- * isArray     : is array
- */
+import { operators, getOperatorLabel } from 'utils/testing/assertions/index';
 
 const AssertionOperator = ({ operator, onChange }) => {
-  const operators = [
-    'eq',
-    'neq',
-    'gt',
-    'gte',
-    'lt',
-    'lte',
-    'in',
-    'notIn',
-    'contains',
-    'notContains',
-    'length',
-    'matches',
-    'notMatches',
-    'startsWith',
-    'endsWith',
-    'between',
-    'isEmpty',
-    'isNull',
-    'isUndefined',
-    'isDefined',
-    'isTruthy',
-    'isFalsy',
-    'isJson',
-    'isNumber',
-    'isString',
-    'isBoolean',
-    'isArray'
-  ];
-
-  const handleChange = (e) => {
-    onChange(e.target.value);
-  };
-
-  const getLabel = (operator) => {
-    switch (operator) {
-      case 'eq':
-        return 'equals';
-      case 'neq':
-        return 'notEquals';
-      default:
-        return operator;
-    }
-  };
+  const handleChange = (e) => onChange(e.target.value);
 
   return (
     <select value={operator} onChange={handleChange} className="mousetrap">
       {operators.map((operator) => (
         <option key={operator} value={operator}>
-          {getLabel(operator)}
+          {getOperatorLabel(operator)}
         </option>
       ))}
     </select>

--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionRow/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionRow/index.js
@@ -3,143 +3,11 @@ import { IconTrash } from '@tabler/icons';
 import SingleLineEditor from 'components/SingleLineEditor';
 import AssertionOperator from '../AssertionOperator';
 import { useTheme } from 'providers/Theme';
+import { parseAssertion, unaryOperators } from 'utils/testing/assertions/index';
 
-/**
- * Assertion operators
- *
- * eq          : equal to
- * neq         : not equal to
- * gt          : greater than
- * gte         : greater than or equal to
- * lt          : less than
- * lte         : less than or equal to
- * in          : in
- * notIn       : not in
- * contains    : contains
- * notContains : not contains
- * length      : length
- * matches     : matches
- * notMatches  : not matches
- * startsWith  : starts with
- * endsWith    : ends with
- * between     : between
- * isEmpty     : is empty
- * isNull      : is null
- * isUndefined : is undefined
- * isDefined   : is defined
- * isTruthy    : is truthy
- * isFalsy     : is falsy
- * isJson      : is json
- * isNumber    : is number
- * isString    : is string
- * isBoolean   : is boolean
- * isArray     : is array
- */
-const parseAssertionOperator = (str = '') => {
-  if (!str || typeof str !== 'string' || !str.length) {
-    return {
-      operator: 'eq',
-      value: str
-    };
-  }
-
-  const operators = [
-    'eq',
-    'neq',
-    'gt',
-    'gte',
-    'lt',
-    'lte',
-    'in',
-    'notIn',
-    'contains',
-    'notContains',
-    'length',
-    'matches',
-    'notMatches',
-    'startsWith',
-    'endsWith',
-    'between',
-    'isEmpty',
-    'isNull',
-    'isUndefined',
-    'isDefined',
-    'isTruthy',
-    'isFalsy',
-    'isJson',
-    'isNumber',
-    'isString',
-    'isBoolean',
-    'isArray'
-  ];
-
-  const unaryOperators = [
-    'isEmpty',
-    'isNull',
-    'isUndefined',
-    'isDefined',
-    'isTruthy',
-    'isFalsy',
-    'isJson',
-    'isNumber',
-    'isString',
-    'isBoolean',
-    'isArray'
-  ];
-
-  const [operator, ...rest] = str.trim().split(' ');
-  const value = rest.join(' ');
-
-  if (unaryOperators.includes(operator)) {
-    return {
-      operator,
-      value: ''
-    };
-  }
-
-  if (operators.includes(operator)) {
-    return {
-      operator,
-      value
-    };
-  }
-
-  return {
-    operator: 'eq',
-    value: str
-  };
-};
-
-const isUnaryOperator = (operator) => {
-  const unaryOperators = [
-    'isEmpty',
-    'isNull',
-    'isUndefined',
-    'isDefined',
-    'isTruthy',
-    'isFalsy',
-    'isJson',
-    'isNumber',
-    'isString',
-    'isBoolean',
-    'isArray'
-  ];
-
-  return unaryOperators.includes(operator);
-};
-
-const AssertionRow = ({
-  item,
-  collection,
-  assertion,
-  handleAssertionChange,
-  handleRemoveAssertion,
-  onSave,
-  handleRun
-}) => {
+const AssertionRow = ({ collection, assertion, handleAssertionChange, handleRemoveAssertion, onSave, handleRun }) => {
   const { storedTheme } = useTheme();
-
-  const { operator, value } = parseAssertionOperator(assertion.value);
+  const { operator, value } = parseAssertion(assertion.value);
 
   return (
     <tr key={assertion.uid}>
@@ -172,7 +40,7 @@ const AssertionRow = ({
         />
       </td>
       <td>
-        {!isUnaryOperator(operator) ? (
+        {!unaryOperators.includes(operator) ? (
           <SingleLineEditor
             value={value}
             theme={storedTheme}

--- a/packages/bruno-app/src/utils/testing/assertions/index.js
+++ b/packages/bruno-app/src/utils/testing/assertions/index.js
@@ -1,0 +1,102 @@
+import _ from 'lodash';
+
+/**
+ * Assertion operators
+ * eq          : equal to
+ * neq         : not equal to
+ * gt          : greater than
+ * gte         : greater than or equal to
+ * lt          : less than
+ * lte         : less than or equal to
+ * in          : in
+ * notIn       : not in
+ * contains    : contains
+ * notContains : not contains
+ * length      : length
+ * matches     : matches
+ * notMatches  : not matches
+ * startsWith  : starts with
+ * endsWith    : ends with
+ * between     : between
+ * isEmpty     : is empty
+ * isNull      : is null
+ * isUndefined : is undefined
+ * isDefined   : is defined
+ * isTruthy    : is truthy
+ * isFalsy     : is falsy
+ * isJson      : is json
+ * isNumber    : is number
+ * isString    : is string
+ * isBoolean   : is boolean
+ * isArray     : is array
+ */
+
+export const unaryOperators = [
+  'isEmpty',
+  'isNull',
+  'isUndefined',
+  'isDefined',
+  'isTruthy',
+  'isFalsy',
+  'isJson',
+  'isNumber',
+  'isString',
+  'isBoolean',
+  'isArray'
+];
+
+export const nonUnaryOperators = ['eq', 'neq', 'gt', 'gte', 'lt', 'lte'];
+
+export const specialOperators = [
+  'in',
+  'notIn',
+  'contains',
+  'notContains',
+  'length',
+  'matches',
+  'notMatches',
+  'startsWith',
+  'endsWith',
+  'between'
+];
+
+export const operators = [...unaryOperators, ...nonUnaryOperators, ...specialOperators];
+
+export const getOperatorLabel = (operator) => {
+  switch (operator) {
+    case 'eq':
+      return 'equals';
+    case 'neq':
+      return 'notEquals';
+    default:
+      return operator;
+  }
+};
+
+export const parseAssertion = (assertionString = '') => {
+  const defaultResult = {
+    operator: 'eq',
+    value: ''
+  };
+
+  if (!_.isString(assertionString)) {
+    return defaultResult;
+  }
+
+  const [operator, ...rest] = assertionString.trim().split(' ');
+  const value = rest.join(' ');
+
+  if (unaryOperators.includes(operator)) {
+    return {
+      operator,
+      value: ''
+    };
+  } else if ([...nonUnaryOperators, ...specialOperators].includes(operator)) {
+    return {
+      operator,
+      value
+    };
+  } else {
+    return defaultResult;
+  }
+};

--- a/packages/bruno-app/src/utils/testing/assertions/index.spec.js
+++ b/packages/bruno-app/src/utils/testing/assertions/index.spec.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from '@jest/globals';
+import { nonUnaryOperators, specialOperators, unaryOperators, parseAssertion } from './index';
+
+describe.each(['', ' ', 0, false, null, undefined, NaN])('Invalid assertions', function (assertionString) {
+  it(`should return default result when the value is ${assertionString}`, function () {
+    // arrange
+    const expectedResult = {
+      operator: 'eq',
+      value: ''
+    };
+
+    // act
+    const actualResult = parseAssertion(assertionString);
+
+    // assert
+    expect(actualResult).toEqual(expectedResult);
+  });
+});
+
+describe.each(unaryOperators)('Assertions with unary operator', function (operator) {
+  it(`should return empty string in value field when operator is ${operator}`, function () {
+    // arrange
+    const expectedResult = {
+      operator,
+      value: ''
+    };
+
+    // act
+    const actualResult = parseAssertion(`${operator} 12`);
+
+    // assert
+    expect(actualResult).toEqual(expectedResult);
+  });
+});
+
+describe.each([...nonUnaryOperators, ...specialOperators])(
+  'Assertions with non-unary/special operator',
+  function (operator) {
+    it(`should return actual value in value field when operator is ${operator}`, function () {
+      // arrange
+      const value = 'expected value';
+
+      const expectedResult = {
+        operator,
+        value
+      };
+
+      // act
+      const actualResult = parseAssertion(`${operator} ${value}`);
+
+      // assert
+      expect(actualResult).toEqual(expectedResult);
+    });
+  }
+);


### PR DESCRIPTION
# Description

- Moved the common/duplicate code related to assertions into utility class.
- Added relevant test cases to cover all parsing scenarios.
- Added `test:watch` script to run the test in watch mode.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
