### PR TITLE
bugfix/Rename item with same name

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -335,12 +335,15 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       if (isWSLPath(newPath)) {
         newPath = normalizeWslPath(newPath);
       }
-
-      if (!fs.existsSync(oldPath)) {
-        throw new Error(`path: ${oldPath} does not exist`);
-      }
-      if (fs.existsSync(newPath)) {
-        throw new Error(`path: ${oldPath} already exists`);
+      var sameName = oldPath.replaceAll('\\', '/').toUpperCase() === newPath.replaceAll('\\', '/').toUpperCase();
+      if (!sameName)
+      {
+        if (!fs.existsSync(oldPath)) {
+          throw new Error(`path: ${oldPath} does not exist`);
+        }
+        if (fs.existsSync(newPath)) {
+          throw new Error(`path: ${oldPath} already exists`);
+        }
       }
 
       // if its directory, rename and return
@@ -364,12 +367,12 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       const jsonData = bruToJson(data);
 
       jsonData.name = newName;
-
+      
       moveRequestUid(oldPath, newPath);
 
       const content = jsonToBru(jsonData);
-      await writeFile(newPath, content);
       await fs.unlinkSync(oldPath);
+      await writeFile(newPath, content);
     } catch (error) {
       return Promise.reject(error);
     }


### PR DESCRIPTION
# Description
Fixes #2995 
In windows(case insensitive OS) when first is written into new path and than old deleted, windows rewrites same file and than deletes it. 
So when order of operations is swapped, old file is always deleted and than new is created with new name.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/3873cc92-4550-4a65-bcf3-a94038f2e4db


