### PR TITLE
Don't include state in OAuth 2 exchange flow

### DIFF
--- a/packages/bruno-electron/src/ipc/network/oauth2-helper.js
+++ b/packages/bruno-electron/src/ipc/network/oauth2-helper.js
@@ -23,7 +23,7 @@ const resolveOAuth2AuthorizationCodeAccessToken = async (request, collectionUid)
   let requestCopy = cloneDeep(request);
   const { authorizationCode } = await getOAuth2AuthorizationCode(requestCopy, codeChallenge, collectionUid);
   const oAuth = get(requestCopy, 'oauth2', {});
-  const { clientId, clientSecret, callbackUrl, scope, state, pkce } = oAuth;
+  const { clientId, clientSecret, callbackUrl, scope, pkce } = oAuth;
   const data = {
     grant_type: 'authorization_code',
     code: authorizationCode,
@@ -31,9 +31,6 @@ const resolveOAuth2AuthorizationCodeAccessToken = async (request, collectionUid)
     client_id: clientId,
     client_secret: clientSecret
   };
-  if (state) {
-    data.state = state;
-  }
   if (pkce) {
     data['code_verifier'] = codeVerifier;
   }

--- a/packages/bruno-electron/src/ipc/network/oauth2-helper.js
+++ b/packages/bruno-electron/src/ipc/network/oauth2-helper.js
@@ -29,9 +29,11 @@ const resolveOAuth2AuthorizationCodeAccessToken = async (request, collectionUid)
     code: authorizationCode,
     redirect_uri: callbackUrl,
     client_id: clientId,
-    client_secret: clientSecret,
-    state: state
+    client_secret: clientSecret
   };
+  if (state) {
+    data.state = state;
+  }
   if (pkce) {
     data['code_verifier'] = codeVerifier;
   }


### PR DESCRIPTION
# Description

Some APIs don't like extraneous properties such as state. Avoiding passing that in unless it's set to a non-empty value.

Fixes https://github.com/usebruno/bruno/issues/3033.

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
