### PR TITLE
bug: keep resize request panel size when changing tabs

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -60,8 +60,17 @@ const RequestTabPanel = () => {
   };
 
   useEffect(() => {
-    const leftPaneWidth = (screenWidth - asideWidth) / 2.2;
-    setLeftPaneWidth(leftPaneWidth);
+
+    const min = DEFAULT_PADDING + MIN_LEFT_PANE_WIDTH;
+    const max = screenWidth - asideWidth - (DEFAULT_PADDING * 2) - MIN_RIGHT_PANE_WIDTH;
+
+    if (leftPaneWidth < min) {
+      setLeftPaneWidth(min);
+    } else if (leftPaneWidth > max) {
+      setLeftPaneWidth(max);
+    } else {
+      setLeftPaneWidth(leftPaneWidth);
+    }
   }, [screenWidth]);
 
   useEffect(() => {
@@ -89,7 +98,7 @@ const RequestTabPanel = () => {
       dispatch(
         updateRequestPaneTabWidth({
           uid: activeTabUid,
-          requestPaneWidth: e.clientX - asideWidth - DEFAULT_PADDING
+          requestPaneWidth: e.clientX - asideWidth - DEFAULT_PADDING,
         })
       );
     }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
 import last from 'lodash/last';
+import { act } from 'react';
 
 // todo: errors should be tracked in each slice and displayed as toasts
 
@@ -54,6 +55,7 @@ export const tabsSlice = createSlice({
         return;
       }
 
+
       const direction = action.payload.direction;
 
       const activeTabIndex = state.tabs.findIndex((t) => t.uid === state.activeTabUid);
@@ -72,12 +74,15 @@ export const tabsSlice = createSlice({
       const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
 
       if (tab) {
+
         tab.requestPaneWidth = action.payload.requestPaneWidth;
       }
     },
     updateRequestPaneTab: (state, action) => {
       const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
 
+      console.log("MIN", action.payload.min);
+      console.log("MAX", action.payload.max);
       if (tab) {
         tab.requestPaneTab = action.payload.requestPaneTab;
       }


### PR DESCRIPTION
# Description

See issue #3020 , keep resizing request panel size when switching tabs. When UI persistence will be added would be nice to be kept.

https://github.com/user-attachments/assets/e3e451c5-34d1-4e24-b8d2-3f4c4b5fc306


### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Resolves #3020 
