### PR TITLE
fix: add hints of 'bru' object for 'getFolderVar' and 'getCollectionVar' methods

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -61,6 +61,8 @@ if (!SERVER_RENDERED) {
     'bru.getProcessEnv(key)',
     'bru.hasEnvVar(key)',
     'bru.getEnvVar(key)',
+    'bru.getFolderVar(key)',
+    'bru.getCollectionVar(key)',
     'bru.setEnvVar(key,value)',
     'bru.hasVar(key)',
     'bru.getVar(key)',


### PR DESCRIPTION
As mentioned in https://github.com/usebruno/bruno/issues/3043 there are no word hints for the new methods _getFolderVar_ and _getCollectionVar_  which were introduced with #2963


# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
