### PR TITLE
Fix #2670: Path params trailing slash

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -62,7 +62,7 @@ const interpolateVars = (request, envVars = {}, runtimeVariables = {}, processEn
         let parsed = JSON.stringify(request.data);
         parsed = _interpolate(parsed);
         request.data = JSON.parse(parsed);
-      } catch (err) {}
+      } catch (err) { }
     }
 
     if (typeof request.data === 'string') {
@@ -76,7 +76,7 @@ const interpolateVars = (request, envVars = {}, runtimeVariables = {}, processEn
         let parsed = JSON.stringify(request.data);
         parsed = _interpolate(parsed);
         request.data = JSON.parse(parsed);
-      } catch (err) {}
+      } catch (err) { }
     }
   } else {
     request.data = _interpolate(request.data);
@@ -113,7 +113,8 @@ const interpolateVars = (request, envVars = {}, runtimeVariables = {}, processEn
       })
       .join('');
 
-    request.url = url.origin + interpolatedUrlPath + url.search;
+    const trailingSlash = url.pathname.endsWith('/') ? '/' : '';
+    request.url = url.origin + interpolatedUrlPath + trailingSlash + url.search;
   }
 
   if (request.proxy) {

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -74,7 +74,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         let parsed = JSON.stringify(request.data);
         parsed = _interpolate(parsed);
         request.data = JSON.parse(parsed);
-      } catch (err) {}
+      } catch (err) { }
     }
   } else {
     request.data = _interpolate(request.data);
@@ -111,7 +111,8 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       })
       .join('');
 
-    request.url = url.origin + urlPathnameInterpolatedWithPathParams + url.search;
+    const trailingSlash = url.pathname.endsWith('/') ? '/' : '';
+    request.url = url.origin + urlPathnameInterpolatedWithPathParams + trailingSlash + url.search;
   }
 
   if (request.proxy) {


### PR DESCRIPTION
# Description

As reported in #2670, if a URL has a trailing slash and also contains path parameters then the original logic had a bug that would drop the trailing slash.
This implements the fix proposed by @ThenTech.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
