### PR TITLE
feat: Set response body function

### DIFF
--- a/packages/bruno-js/src/bruno-response.js
+++ b/packages/bruno-js/src/bruno-response.js
@@ -27,6 +27,15 @@ class BrunoResponse {
   getResponseTime() {
     return this.res ? this.res.responseTime : null;
   }
+
+  setBody(data) {
+    if (!this.res) {
+      return;
+    }
+
+    this.body = data;
+    this.res.data = data;
+  }
 }
 
 module.exports = BrunoResponse;


### PR DESCRIPTION
# Description

Allows setting the response body from a script. Useful for when you e.g. want to base64 decode the response before displaying it.

Fixes usebruno#2441.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
