### PR TITLE
style: added bottom border for `Table` component

### DIFF
--- a/packages/bruno-app/src/components/Table/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Table/StyledWrapper.js
@@ -27,6 +27,7 @@ const StyledWrapper = styled.div`
 
   table th {
     position: relative;
+    border-bottom: 1px solid ${(props) => props.theme.collection.environment.settings.gridBorder}77;
   }
 
   table tr td {


### PR DESCRIPTION
In the `Table` component created in PR #2641 for the `ReorderTable` component, the bottom border for the header inside the table was not properly handled. As a result, the bottom border was not visible when there were no values in the `Table`. In this PR, I have addressed the issue by adding the missing border.


### Contribution Checklist:

- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**

Before:
![image](https://github.com/user-attachments/assets/947661a6-42d4-44e8-9025-15e7a967105a)

After:
![image](https://github.com/user-attachments/assets/d1e60c92-2e62-42ee-86ec-5395d874bf18)
