### PR TITLE
fix: cursor jump to start

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -25,7 +25,12 @@ const QueryUrl = ({ item, collection, handleRun }) => {
     setMethodSelectorWidth(el.offsetWidth);
   }, [method]);
 
-  const onSave = () => {
+  const onSave = (finalValue) => {
+    dispatch(requestUrlChanged({
+      itemUid: item.uid,
+      collectionUid: collection.uid,
+      url: finalValue && typeof finalValue === 'string' ? finalValue.trim() : value
+    }));
     dispatch(saveRequest(item.uid, collection.uid));
   };
 
@@ -34,7 +39,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
       requestUrlChanged({
         itemUid: item.uid,
         collectionUid: collection.uid,
-        url: value && typeof value === 'string' ? value.trim() : value
+        url: (value && typeof value === 'string') && value
       })
     );
   };
@@ -64,7 +69,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
       >
         <SingleLineEditor
           value={url}
-          onSave={onSave}
+          onSave={(finalValue) => onSave(finalValue)}
           theme={storedTheme}
           onChange={(newValue) => onUrlChange(newValue)}
           onRun={handleRun}


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fixes: #2978

This PR fixes the cursor jumping to the start of the request URL bar when one deletes a whitespace character in the request URL bar. This was happening because the value was being trimmed every time the value was changed in the URL bar, which triggered the cursor to go to the starting. Now the request URL will only be trimmed when the request URL is being saved.


https://github.com/user-attachments/assets/e20e6fee-4862-4b80-8150-7bc21d6b5c79



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
