### PR TITLE
Implement detection for runner

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -71,8 +71,8 @@ if (!SERVER_RENDERED) {
     'bru.setNextRequest(requestName)',
     'req.disableParsingResponseJson()',
     'bru.getRequestVar(key)',
-    'bru.sleep(ms)',
-    'bru.isRunner()'
+    'bru.getExecutionMode()',
+    'bru.sleep(ms)'
   ];
   CodeMirror.registerHelper('hint', 'brunoJS', (editor, options) => {
     const cursor = editor.getCursor();

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -71,7 +71,8 @@ if (!SERVER_RENDERED) {
     'bru.setNextRequest(requestName)',
     'req.disableParsingResponseJson()',
     'bru.getRequestVar(key)',
-    'bru.sleep(ms)'
+    'bru.sleep(ms)',
+    'bru.isRunner()'
   ];
   CodeMirror.registerHelper('hint', 'brunoJS', (editor, options) => {
     const cursor = editor.getCursor();

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -36,6 +36,9 @@ const runSingleRequest = async function (
   collectionRoot,
   runtime
 ) {
+
+  runtimeVariables["__internal__executionMode"] = 'cli';
+
   try {
     let request;
     let nextRequestName;

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -871,6 +871,7 @@ const registerNetworkIpc = (mainWindow) => {
       const scriptingConfig = get(brunoConfig, 'scripts', {});
       scriptingConfig.runtime = getJsSandboxRuntime(collection);
       const collectionRoot = get(collection, 'root', {});
+      runtimeVariables["run-folder-event"] = true;
 
       const abortController = new AbortController();
       saveCancelToken(cancelTokenUid, abortController);
@@ -1125,6 +1126,8 @@ const registerNetworkIpc = (mainWindow) => {
                 testResults: testResults.results,
                 ...eventData
               });
+
+              runtimeVariables["run-folder-event"] = false;
 
               mainWindow.webContents.send('main:script-environment-update', {
                 envVariables: testResults.envVariables,

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -490,6 +490,8 @@ const registerNetworkIpc = (mainWindow) => {
     const cancelTokenUid = uuid();
     const requestUid = uuid();
 
+    runtimeVariables["__internal__executionMode"] = 'single';
+
     mainWindow.webContents.send('main:run-request-event', {
       type: 'request-queued',
       requestUid,
@@ -658,6 +660,8 @@ const registerNetworkIpc = (mainWindow) => {
           requestUid,
           collectionUid
         });
+
+        runtimeVariables["__internal__executionMode"] = undefined;
 
         mainWindow.webContents.send('main:script-environment-update', {
           envVariables: testResults.envVariables,
@@ -871,7 +875,7 @@ const registerNetworkIpc = (mainWindow) => {
       const scriptingConfig = get(brunoConfig, 'scripts', {});
       scriptingConfig.runtime = getJsSandboxRuntime(collection);
       const collectionRoot = get(collection, 'root', {});
-      runtimeVariables["run-folder-event"] = true;
+      runtimeVariables["__internal__executionMode"] = 'runner';
 
       const abortController = new AbortController();
       saveCancelToken(cancelTokenUid, abortController);
@@ -1127,7 +1131,7 @@ const registerNetworkIpc = (mainWindow) => {
                 ...eventData
               });
 
-              runtimeVariables["run-folder-event"] = false;
+              runtimeVariables["__internal__executionMode"] = undefined;
 
               mainWindow.webContents.send('main:script-environment-update', {
                 envVariables: testResults.envVariables,

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -117,8 +117,8 @@ class Bru {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  isRunner() {
-    return this.runtimeVariables["run-folder-event"] === true;
+  getExecutionMode() {
+    return this.runtimeVariables["__internal__executionMode"];
   }
 }
 

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -116,6 +116,10 @@ class Bru {
   sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
+
+  isRunner() {
+    return this.runtimeVariables["run-folder-event"] === true;
+  }
 }
 
 module.exports = Bru;

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bru.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bru.js
@@ -81,6 +81,12 @@ const addBruShimToContext = (vm, bru) => {
   vm.setProp(bruObject, 'getCollectionVar', getCollectionVar);
   getCollectionVar.dispose();
 
+  let getExecutionMode = vm.newFunction('getExecutionMode', function () {
+    return marshallToVm(bru.getExecutionMode(), vm);
+  });
+  vm.setProp(bruObject, 'getExecutionMode', getExecutionMode);
+  getExecutionMode.dispose();
+
   const sleep = vm.newFunction('sleep', (timer) => {
     const t = vm.getString(timer);
     const promise = vm.newPromise();


### PR DESCRIPTION
# Description
Implement a new function `bru.getExecutionMode()` to use inside scripting. Returns **single**, **runner** or **cli**.

Fixes #3104 
Related to #2397 
Includes changed from #1875 partially

Thank you @JorgeTrovisco this is a modified implementation of your PR. Thank you also @tlaloc911 as this also includes your changes.

<img width="1026" alt="image" src="https://github.com/user-attachments/assets/49702dbd-a328-46cb-a52a-162866b7ec8f">

The real benefit of this PR will be implemented with the merging of #2397, as this functionality has been extracted from this PR in order to keep it focussed on one feature. With both this and #2397 merged, you could do something like this in order to skip requests on runner runs but still have them for single tests.

```
if(bru.getExecutionMode() === 'runner'){
   bru.skipRequest();
}
```

Or you could even do something like this
```
if(bru.getVar("myAuthKey") === undefined){
  bru.skipRequest();
  
  if(bru.getExecutionMode() === 'runner'){
     bru.setNextRequest("getAuthToken");
  }
}
```

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
