### PR TITLE
#3067: handle multiple env vars

### DIFF
--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -42,14 +42,14 @@ export const parsePathParams = (url) => {
     uri = `http://${uri}`;
   }
 
+  let paths;
+
   try {
     uri = new URL(uri);
+    paths = uri.pathname.split('/');
   } catch (e) {
-    // URL is non-parsable, is it incomplete? Ignore.
-    return [];
+    paths = uri.split('/');
   }
-
-  let paths = uri.pathname.split('/');
 
   paths = paths.reduce((acc, path) => {
     if (path !== '' && path[0] === ':') {
@@ -63,7 +63,6 @@ export const parsePathParams = (url) => {
     }
     return acc;
   }, []);
-
   return paths;
 };
 


### PR DESCRIPTION
# Description

This PR address #3067. The problem was when we create a new URL() with more than one env variable, it throws an error. But since bruno supports multiple environment variable, instead of throwing error, we try to split it directly and create path params.
<img width="487" alt="image" src="https://github.com/user-attachments/assets/35a89698-04e8-4e02-91a8-d540b3458e5c">

<img width="682" alt="image" src="https://github.com/user-attachments/assets/0865f604-b629-47f6-946d-01343b1a0f31">

### Contribution Checklist:

- [ x] **The pull request only addresses one issue or adds one feature.**
- [x ] **The pull request does not introduce any breaking changes**
- [ x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ x] **Create an issue and link to the pull request.**
