### PR TITLE
fix: handle case of text when invalid JSON (#3119)

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -19,17 +19,21 @@ const formatResponse = (data, mode, filter) => {
     return '';
   }
 
+  if (data === null) {
+    return data;
+  }
+
   if (mode.includes('json')) {
     let isValidJSON = false;
-    
+
     try {
       isValidJSON = typeof JSON.parse(JSON.stringify(data)) === 'object';
     } catch (error) {
       console.log('Error parsing JSON: ', error.message);
     }
 
-    if (!isValidJSON || data === null) {
-      return data;
+    if (!isValidJSON) {
+      return safeStringifyJSON(data);
     }
 
     if (filter) {
@@ -40,7 +44,7 @@ const formatResponse = (data, mode, filter) => {
       }
     }
 
-    return safeStringifyJSON(data, true);
+    return safeStringifyJSON(data);
   }
 
   if (mode.includes('xml')) {
@@ -48,7 +52,7 @@ const formatResponse = (data, mode, filter) => {
     if (typeof parsed === 'string') {
       return parsed;
     }
-    return safeStringifyJSON(parsed, true);
+    return safeStringifyJSON(parsed);
   }
 
   return data;


### PR DESCRIPTION
# Description

This PR addresses the issue where Bruno crashes when receiving non-JSON responses (like `"true"`) with the `application/json` content type. The crash was caused by Bruno attempting to parse an invalid JSON response. The fix modifies the return data handling to prevent the crash.

### Changes Implemented:
1. **Modified return data handling:**
   - The response data is now passed through `safeStringifyJSON(data)` to ensure that even non-JSON responses are handled safely without causing a crash.
   
2. **Early return for null data:**
   - Added an early return if `data` is `null`, ensuring that the logic to process the response is skipped, preventing potential errors from treating `null` as data.

3. **Removed unused parameter:**
   - Removed the second parameter in `safeStringifyJSON` calls where it was set to `true`, since the function definition only expects one parameter.

### Testing and Validation:
- This fix has been tested to ensure that valid JSON responses are still handled correctly.
- Cases where non-JSON responses like `"true"` are returned now no longer cause the client to crash.
- Additional edge cases, such as `null` responses, are properly handled with the early return.

![image](https://github.com/user-attachments/assets/4be30eef-5f8e-48e4-8126-552f80babeae)

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] *I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**
