### PR TITLE
3116: fixed url slash formating from openapi

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -32,7 +32,7 @@ const readFile = (files) => {
 
 const ensureUrl = (url) => {
   // emoving multiple slashes after the protocol if it exists, or after the beginning of the string otherwise
-  return url.replace(/(^\w+:|^)\/{2,}/, '$1/');
+  return url.replace(/(^\w+:|^)\/{2,}/, '$1//');
 };
 
 const buildEmptyJsonBody = (bodySchema) => {
@@ -316,7 +316,7 @@ const getDefaultUrl = (serverObject) => {
       url = url.replace(`{${variableName}}`, sub);
     });
   }
-  return url.endsWith('/') ? url : `${url}/`;
+  return url.replace(/\/+$/,'');
 };
 
 const getSecurity = (apiSpec) => {
@@ -382,7 +382,7 @@ const parseOpenApiCollection = (data) => {
       // TODO what if info.title not defined?
       brunoCollection.name = collectionData.info.title;
       let servers = collectionData.servers || [];
-      let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '';
+      let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '/';
       let securityConfig = getSecurity(collectionData);
 
       let allRequests = Object.entries(collectionData.paths)


### PR DESCRIPTION
# Description
This PR fixes the problem of parsing / when importing openApi spec yaml #3116 .

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
We introduce changes as per specs from open API as base URL not ending with `/` and rather the path begins with `/` . Also if the base URL are not provided, then baseUrl is set to `/`. 
![image](https://github.com/user-attachments/assets/6806e887-a90f-4c86-bbe1-9a877d35185f)
![image](https://github.com/user-attachments/assets/311e8724-238d-45fb-b71b-ce45d019d243)
Can find more details here https://swagger.io/docs/specification/api-host-and-base-path/

Result after changes:
![image](https://github.com/user-attachments/assets/2c5b7d4a-beba-42c1-8033-f6de44437e30)

### Contribution Checklist:

- [ x] **The pull request only addresses one issue or adds one feature.**
- [ x] **The pull request does not introduce any breaking changes**
- [x ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
