### PR TITLE
feat: add logic to handle saving collection settings on shortcut (preview mode)

### DIFF
--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -7,7 +7,7 @@ import SaveRequest from 'components/RequestPane/SaveRequest';
 import EnvironmentSettings from 'components/Environments/EnvironmentSettings';
 import NetworkError from 'components/ResponsePane/NetworkError';
 import NewRequest from 'components/Sidebar/NewRequest';
-import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { sendRequest, saveRequest, saveCollectionRoot } from 'providers/ReduxStore/slices/collections/actions';
 import { findCollectionByUid, findItemInCollection } from 'utils/collections';
 import { closeTabs, switchTab } from 'providers/ReduxStore/slices/tabs';
 
@@ -54,6 +54,8 @@ export const HotkeysProvider = (props) => {
             const item = findItemInCollection(collection, activeTab.uid);
             if (item && item.uid) {
               dispatch(saveRequest(activeTab.uid, activeTab.collectionUid));
+            } else if (activeTab.type === 'collection-settings') {
+              dispatch(saveCollectionRoot(collection.uid));
             } else {
               // todo: when ephermal requests go live
               // setShowSaveRequestModal(true);


### PR DESCRIPTION
fixes: #2219 

This PR implements the logic for saving `collection-settings` using the `Ctrl+S` or `Cmd+S` shortcut. It allows users to save the `Docs` tab even in preview mode, thereby resolving the issue.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**