### PR TITLE
Fix: Allow to set custom user agent

### DIFF
--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -9,11 +9,14 @@ const { CLI_VERSION } = require('../constants');
  */
 function makeAxiosInstance() {
   /** @type {axios.AxiosInstance} */
-  const instance = axios.create();
+  const instance = axios.create({
+    headers: {
+      "User-Agent": `bruno-runtime/${CLI_VERSION}`
+    }
+  });
 
   instance.interceptors.request.use((config) => {
     config.headers['request-start-time'] = Date.now();
-    config.headers['user-agent'] = `bruno-runtime/${CLI_VERSION}`;
     return config;
   });
 

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -7,6 +7,7 @@ const electronApp = require("electron");
 const LOCAL_IPV6 = '::1';
 const LOCAL_IPV4 = '127.0.0.1';
 const LOCALHOST = 'localhost';
+const version = electronApp?.app?.getVersion()?.substring(1) ?? "";
 
 const getTld = (hostname) => {
   if (!hostname) {
@@ -66,9 +67,11 @@ function makeAxiosInstance() {
       }, this);
       return data;
     },
-    proxy: false
+    proxy: false,
+    headers: {
+      "User-Agent": `bruno-runtime/${version}`
+    }
   });
-  const version = electronApp?.app?.getVersion()?.substring(1) ?? "";
 
   instance.interceptors.request.use(async (config) => {
     const url = URL.parse(config.url);
@@ -88,7 +91,6 @@ function makeAxiosInstance() {
     }
 
     config.headers['request-start-time'] = Date.now();
-    config.headers['user-agent'] = `bruno-runtime/${version}`;
     return config;
   });
 


### PR DESCRIPTION
# Description
Fixes #3126 .
In previous release there was PR that forcibly sets user-agent header. It was done in request interceptors, so it cannot be changed when user wants different. 
So I changed code to set user-agent header when creating axios, and after it if user specifies this header, users header will be used, if not, Bruno default header will be used.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

without user-set header:
![image](https://github.com/user-attachments/assets/995b3dba-cd36-4009-bd77-f0ea3f68a741)
with user-set header:
![image](https://github.com/user-attachments/assets/8937ded7-819b-4263-a4cc-770a1ef7b51b)

