### PR TITLE
Add Copy to Clipboard button in Variables and Environment Views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18621,7 +18621,7 @@
     },
     "packages/bruno-electron": {
       "name": "bruno",
-      "version": "v1.28.0",
+      "version": "v1.30.1",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.525.0",
         "@usebruno/common": "0.1.0",

--- a/packages/bruno-app/src/components/CopyToClipboard/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CopyToClipboard/StyledWrapper.js
@@ -1,16 +1,12 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
-  position: relative;
-  height: 100%;
-
   .copy-to-clipboard {
     cursor: pointer;
-
     opacity: 0.5;
 
     &:hover {
-      opacity: 1;
+      opacity: 1 !important;
     }
   }
 `;

--- a/packages/bruno-app/src/components/CopyToClipboard/index.js
+++ b/packages/bruno-app/src/components/CopyToClipboard/index.js
@@ -1,0 +1,20 @@
+import { IconCopy } from '@tabler/icons';
+import toast from 'react-hot-toast';
+import { CopyToClipboard as CopyToClipboardBase } from 'react-copy-to-clipboard';
+import StyledWrapper from './StyledWrapper';
+
+/**
+ * A button to copy text to clipboard
+ *
+ * @param {Object} props The component props
+ * @param {string} props.copy The text to copy when clicked
+ */
+const CopyToClipboard = ({ copy, ...props }) => (
+  <StyledWrapper {...props}>
+    <CopyToClipboardBase className="copy-to-clipboard" text={copy} onCopy={() => toast.success('Copied to clipboard!')}>
+      <IconCopy size={25} strokeWidth={1.5} />
+    </CopyToClipboardBase>
+  </StyledWrapper>
+);
+
+export default CopyToClipboard;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/StyledCopyToClipboard.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/StyledCopyToClipboard.js
@@ -1,0 +1,11 @@
+import CopyToClipboard from 'components/CopyToClipboard';
+import styled from 'styled-components';
+
+const StyledCopyToClipboard = styled(CopyToClipboard)`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+`;
+
+export default StyledCopyToClipboard;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -5,11 +5,9 @@ import { useTheme } from 'providers/Theme/index';
 import StyledWrapper from './StyledWrapper';
 import { buildHarRequest } from 'utils/codegenerator/har';
 import { useSelector } from 'react-redux';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
-import toast from 'react-hot-toast';
-import { IconCopy } from '@tabler/icons';
 import { findCollectionByItemUid } from '../../../../../../../utils/collections/index';
 import { getAuthHeaders } from '../../../../../../../utils/codegenerator/auth';
+import StyledCopyToClipboard from './StyledCopyToClipboard';
 
 const CodeView = ({ language, item }) => {
   const { displayedTheme } = useTheme();
@@ -41,13 +39,7 @@ const CodeView = ({ language, item }) => {
   return (
     <>
       <StyledWrapper>
-        <CopyToClipboard
-          className="copy-to-clipboard"
-          text={snippet}
-          onCopy={() => toast.success('Copied to clipboard!')}
-        >
-          <IconCopy size={25} strokeWidth={1.5} />
-        </CopyToClipboard>
+        <StyledCopyToClipboard copy={snippet} />
         <CodeEditor
           readOnly
           collection={collection}

--- a/packages/bruno-app/src/components/SingleLineEditor/StyledContainer.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/StyledContainer.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const StyledContainer = styled.div`
+  .copy-to-clipboard {
+    opacity: 0;
+  }
+
+  &:hover .copy-to-clipboard {
+    opacity: 0.5;
+  }
+`;
+
+export default StyledContainer;

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -4,6 +4,8 @@ import { getAllVariables } from 'utils/collections';
 import { defineCodeMirrorBrunoVariablesMode, MaskedEditor } from 'utils/common/codemirror';
 import StyledWrapper from './StyledWrapper';
 import { IconEye, IconEyeOff } from '@tabler/icons';
+import CopyToClipboard from 'components/CopyToClipboard';
+import StyledContainer from './StyledContainer';
 
 let CodeMirror;
 const SERVER_RENDERED = typeof navigator === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
@@ -174,10 +176,20 @@ class SingleLineEditor extends Component {
 
   render() {
     return (
-      <div className="flex flex-row justify-between w-full overflow-x-auto">
+      <StyledContainer className="flex flex-row justify-between w-full overflow-x-auto">
         <StyledWrapper ref={this.editorRef} className="single-line-editor grow" />
+        <CopyToClipboard
+          className={[
+            'copy-to-clipboard',
+            'absolute',
+            'top-1/2',
+            '-translate-y-1/2',
+            this.props.isSecret ? 'right-9' : 'right-1'
+          ]}
+          copy={this.cachedValue}
+        />
         {this.secretEye(this.props.isSecret)}
-      </div>
+      </StyledContainer>
     );
   }
 }

--- a/packages/bruno-app/src/components/VariablesEditor/StyledCopyToClipboard.js
+++ b/packages/bruno-app/src/components/VariablesEditor/StyledCopyToClipboard.js
@@ -1,0 +1,11 @@
+import CopyToClipboard from 'components/CopyToClipboard';
+import styled from 'styled-components';
+
+const StyledCopyToClipboard = styled(CopyToClipboard)`
+  position: absolute;
+  right: 0.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
+export default StyledCopyToClipboard;

--- a/packages/bruno-app/src/components/VariablesEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/VariablesEditor/StyledWrapper.js
@@ -1,13 +1,25 @@
 import styled from 'styled-components';
+import StyledCopyToClipboard from './StyledCopyToClipboard';
 
 const StyledWrapper = styled.div`
   table {
     thead,
     td {
       border: 1px solid ${(props) => props.theme.table.border};
+      position: relative;
 
       li {
         background-color: ${(props) => props.theme.bg} !important;
+      }
+    }
+
+    tr {
+      ${StyledCopyToClipboard} {
+        opacity: 0;
+      }
+
+      &:hover ${StyledCopyToClipboard} {
+        opacity: 0.5;
       }
     }
   }

--- a/packages/bruno-app/src/components/VariablesEditor/index.js
+++ b/packages/bruno-app/src/components/VariablesEditor/index.js
@@ -6,6 +6,7 @@ import { useTheme } from 'providers/Theme';
 import { findEnvironmentInCollection, maskInputValue } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import { IconEye, IconEyeOff } from '@tabler/icons';
+import StyledCopyToClipboard from './StyledCopyToClipboard';
 
 const KeyValueExplorer = ({ data = [], theme }) => {
   const [showSecret, setShowSecret] = useState(false);
@@ -18,11 +19,12 @@ const KeyValueExplorer = ({ data = [], theme }) => {
           {data.map((envVar) => (
             <tr key={envVar.name}>
               <td className="px-2 py-1">{envVar.name}</td>
-              <td className="px-2 py-1">
+              <td className="px-2 py-1 pr-8">
                 <Inspector
                   data={!showSecret && envVar.secret ? maskInputValue(envVar.value) : envVar.value}
                   theme={theme}
                 />
+                <StyledCopyToClipboard copy={envVar.value} />
               </td>
             </tr>
           ))}


### PR DESCRIPTION
# Description

Add a "Copy to Clipboard" button in the Variables and Environment Views. Fixes #3164

So this PR:
- Move the `CopyToClipboard` component used in Code view to its own component for better reusability.
- Add the `CopyToClipboard` to Variables View
- Add the `CopyToClipboard` to Environment View (and ensure it shows fine no matter if entry is secret or not)
- Note that the icon only shows when the row is hovered.

Screenshots:
<img width="419" alt="image" src="https://github.com/user-attachments/assets/5f129e1a-d40e-4cd4-99c7-bfdfa2b009aa">
<img width="663" alt="image" src="https://github.com/user-attachments/assets/79d6e92c-089b-45db-a59b-143a9a3d42b7">
<img width="693" alt="image" src="https://github.com/user-attachments/assets/ddeac8b4-baa4-4222-b8d5-4d4d90bbbf0a">


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
