### PR TITLE
fix: close saved tabs button issue

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -17,6 +17,7 @@ import CloneCollectionItem from 'components/Sidebar/Collections/Collection/Colle
 import NewRequest from 'components/Sidebar/NewRequest/index';
 import CloseTabIcon from './CloseTabIcon';
 import DraftTabIcon from './DraftTabIcon';
+import { flattenItems } from 'utils/collections/index';
 
 const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUid }) => {
   const dispatch = useDispatch();
@@ -246,8 +247,9 @@ function RequestTabMenu({ onDropdownCreate, collectionRequestTabs, tabIndex, col
   function handleCloseSavedTabs(event) {
     event.stopPropagation();
 
-    const savedTabs = collection.items.filter((item) => !item.draft);
-    const savedTabIds = savedTabs.map((item) => item.uid) || [];
+    const items = flattenItems(collection?.items);
+    const savedTabs = items?.filter?.((item) => !item.draft);
+    const savedTabIds = savedTabs?.map((item) => item.uid) || [];
     dispatch(closeTabs({ tabUids: savedTabIds }));
   }
 


### PR DESCRIPTION
~ the previous implementation only closed the tabs of requests at the root of the collection