### PR TITLE
Bugfix/rename request open tab not found

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -401,10 +401,7 @@ export const renameItem = (newName, itemUid, collectionUid) => (dispatch, getSta
     }
     const { ipcRenderer } = window;
 
-    const normalizedPathname = normalizeAndResolvePath(item.pathname);
-    const normalizedNewPathname = normalizeAndResolvePath(newPathname);
-
-    ipcRenderer.invoke('renderer:rename-item', normalizedPathname, normalizedNewPathname, newName).then(resolve).catch(reject);
+    ipcRenderer.invoke('renderer:rename-item', item.pathname, newPathname, newName).then(resolve).catch(reject);
   });
 };
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -401,7 +401,10 @@ export const renameItem = (newName, itemUid, collectionUid) => (dispatch, getSta
     }
     const { ipcRenderer } = window;
 
-    ipcRenderer.invoke('renderer:rename-item', item.pathname, newPathname, newName).then(resolve).catch(reject);
+    const normalizedPathname = normalizeAndResolvePath(item.pathname);
+    const normalizedNewPathname = normalizeAndResolvePath(newPathname);
+
+    ipcRenderer.invoke('renderer:rename-item', normalizedPathname, normalizedNewPathname, newName).then(resolve).catch(reject);
   });
 };
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -16,6 +16,7 @@ const {
   sanitizeDirectoryName,
   isWSLPath,
   normalizeWslPath,
+  normalizeAndResolvePath
 } = require('../utils/filesystem');
 const { openCollectionDialog } = require('../app/collections');
 const { generateUidBasedOnHash, stringifyJson, safeParseJSON, safeStringifyJSON } = require('../utils/common');
@@ -329,12 +330,8 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
   ipcMain.handle('renderer:rename-item', async (event, oldPath, newPath, newName) => {
     try {
       // Normalize paths if they are WSL paths
-      if (isWSLPath(oldPath)) {
-        oldPath = normalizeWslPath(oldPath);
-      }
-      if (isWSLPath(newPath)) {
-        newPath = normalizeWslPath(newPath);
-      }
+      oldPath = isWSLPath(oldPath) ? normalizeWslPath(oldPath) : normalizeAndResolvePath(oldPath);
+      newPath = isWSLPath(newPath) ? normalizeWslPath(newPath) : normalizeAndResolvePath(newPath);
 
       if (!fs.existsSync(oldPath)) {
         throw new Error(`path: ${oldPath} does not exist`);


### PR DESCRIPTION
fixes: #460 

# Description

This PR resolves the "Not Found" error when renaming a request with an open tab, particularly on Windows. The error occurs because the path was not correctly normalized and resolved before invoking the `moveRequestUid` function, causing a mismatch in path resolution for opened requests.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:

https://github.com/user-attachments/assets/071b2bf3-e590-4938-9bf9-52635b70608e

After:

https://github.com/user-attachments/assets/d931a0a8-8f8d-4681-a6f3-6126ba8eb441

