### PR TITLE
Bugfix/rename with same name for `Environments`

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/RenameEnvironment/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/RenameEnvironment/index.js
@@ -24,14 +24,13 @@ const RenameEnvironment = ({ onClose, environment, collection }) => {
     onSubmit: (values) => {
       if (values.name === environment.name) {
         return;
-      } else {
-        dispatch(renameEnvironment(values.name, environment.uid, collection.uid))
-          .then(() => {
-            toast.success('Environment renamed successfully');
-            onClose();
-          })
-          .catch(() => toast.error('An error occurred while renaming the environment'));
       }
+      dispatch(renameEnvironment(values.name, environment.uid, collection.uid))
+        .then(() => {
+          toast.success('Environment renamed successfully');
+          onClose();
+        })
+        .catch(() => toast.error('An error occurred while renaming the environment'));
     }
   });
 

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/RenameEnvironment/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/RenameEnvironment/index.js
@@ -22,12 +22,16 @@ const RenameEnvironment = ({ onClose, environment, collection }) => {
         .required('name is required')
     }),
     onSubmit: (values) => {
-      dispatch(renameEnvironment(values.name, environment.uid, collection.uid))
-        .then(() => {
-          toast.success('Environment renamed successfully');
-          onClose();
-        })
-        .catch(() => toast.error('An error occurred while renaming the environment'));
+      if (values.name === environment.name) {
+        return;
+      } else {
+        dispatch(renameEnvironment(values.name, environment.uid, collection.uid))
+          .then(() => {
+            toast.success('Environment renamed successfully');
+            onClose();
+          })
+          .catch(() => toast.error('An error occurred while renaming the environment'));
+      }
     }
   });
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -298,7 +298,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       }
 
       const newEnvFilePath = path.join(envDirPath, `${newName}.bru`);
-      if (fs.existsSync(newEnvFilePath)) {
+      if (!safeToRename(envFilePath, newEnvFilePath)) {
         throw new Error(`environment: ${newEnvFilePath} already exists`);
       }
 


### PR DESCRIPTION
fixes: #3198 

# Description
This PR fixes the issue where environments with only a case difference cannot be renamed (e.g., renaming `ProD` to `Prod`), which primarily affects macOS and Windows.
- The fix involves using the `safeToRename` utility function to check if the files are identical based on their existence, rather than just comparing their names.
- This approach is particularly useful for Unix/Linux systems, which support case-sensitive filesystems.
- For more detailed context, see: [Link](https://github.com/usebruno/bruno/pull/3171#issue-2541807340)
### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:

https://github.com/user-attachments/assets/c6225df7-7669-4d7e-b099-10b307aca4b6

After:

https://github.com/user-attachments/assets/65c47354-f460-487f-b1fe-80acbd77ae37

