### PR TITLE
feat: request execution mode

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -55,6 +55,7 @@ if (!SERVER_RENDERED) {
     'req.setMaxRedirects(maxRedirects)',
     'req.getTimeout()',
     'req.setTimeout(timeout)',
+    'req.getExecutionMode()',
     'bru',
     'bru.cwd()',
     'bru.getEnvName(key)',

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -43,6 +43,8 @@ const runSingleRequest = async function (
 
     request = prepareRequest(bruJson.request, collectionRoot);
 
+    request.__bruno__executionMode = 'cli';
+
     const scriptingConfig = get(brunoConfig, 'scripts', {});
     scriptingConfig.runtime = runtime;
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -525,6 +525,7 @@ const registerNetworkIpc = (mainWindow) => {
 
     const collectionRoot = get(collection, 'root', {});
     const request = prepareRequest(item, collection);
+    request.__bruno__executionMode = 'standalone';
     const envVars = getEnvVars(environment);
     const processEnvVars = getProcessEnvVars(collectionUid);
     const brunoConfig = getBrunoConfig(collectionUid);
@@ -717,6 +718,7 @@ const registerNetworkIpc = (mainWindow) => {
       const collectionRoot = get(collection, 'root', {});
       const _request = collectionRoot?.request;
       const request = prepareCollectionRequest(_request, collectionRoot, collectionPath);
+      request.__bruno__executionMode = 'standalone';
       const envVars = getEnvVars(environment);
       const processEnvVars = getProcessEnvVars(collectionUid);
       const brunoConfig = getBrunoConfig(collectionUid);
@@ -960,6 +962,8 @@ const registerNetworkIpc = (mainWindow) => {
           });
 
           const request = prepareRequest(item, collection);
+          request.__bruno__executionMode = 'runner';
+          
           const requestUid = uuid();
           const processEnvVars = getProcessEnvVars(collectionUid);
 

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -173,6 +173,10 @@ class BrunoRequest {
   disableParsingResponseJson() {
     this.req.__brunoDisableParsingResponseJson = true;
   }
+
+  getExecutionMode() {
+    return this.req.__bruno__executionMode;
+  }
 }
 
 module.exports = BrunoRequest;

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-request.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-request.js
@@ -111,6 +111,12 @@ const addBrunoRequestShimToContext = (vm, req) => {
   vm.setProp(reqObject, 'disableParsingResponseJson', disableParsingResponseJson);
   disableParsingResponseJson.dispose();
 
+  let getExecutionMode = vm.newFunction('getExecutionMode', function () {
+    return marshallToVm(req.getExecutionMode(), vm);
+  });
+  vm.setProp(reqObject, 'getExecutionMode', getExecutionMode);
+  getExecutionMode.dispose();
+
   vm.setProp(vm.global, 'req', reqObject);
   reqObject.dispose();
 };


### PR DESCRIPTION
extension of pr #3105

moving the getExecutionMode fn to `req` object instead of `bru` object

`req.getExecutionMode()`

values: standalone | runner | cli