### PR TITLE
Refactor CodeMirror styling to remove glow outline around folded JSON

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -13,7 +13,7 @@ const StyledWrapper = styled.div`
   /* Removes the glow outline around the folded json */
   .CodeMirror-foldmarker {
     text-shadow: none;
-    color: rgb(59, 125, 242);
+    color: ${(props) => props.theme.textLink};
   }
 
   .CodeMirror-overlayscroll-horizontal div,

--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -10,6 +10,11 @@ const StyledWrapper = styled.div`
     flex: 1 1 0;
   }
 
+  /* Removes the glow outline around the folded json */
+  .CodeMirror-foldmarker {
+    text-shadow: none;
+  }
+
   .CodeMirror-overlayscroll-horizontal div,
   .CodeMirror-overlayscroll-vertical div {
     background: #d2d7db;

--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -13,6 +13,7 @@ const StyledWrapper = styled.div`
   /* Removes the glow outline around the folded json */
   .CodeMirror-foldmarker {
     text-shadow: none;
+    color: rgb(59, 125, 242);
   }
 
   .CodeMirror-overlayscroll-horizontal div,


### PR DESCRIPTION
# Description

Fixes:
<img width="147" alt="Screenshot 2024-09-27 at 12 21 09 PM" src="https://github.com/user-attachments/assets/9cf21fd6-43df-4c6c-bdbf-93a762b07fee">

Fixed:
<img width="145" alt="Screenshot 2024-09-27 at 3 38 18 PM" src="https://github.com/user-attachments/assets/9fa5b21b-851f-4301-891e-1f626683d3bb">


### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
