### PR TITLE
Create default environments on openapi import using server url

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -373,7 +373,7 @@ const parseOpenApiCollection = (data) => {
       // Currently parsing of openapi spec is "do your best", that is
       // allows "invalid" openapi spec
 
-      // assumes v3 if not defined. v2 no supported yet
+      // Assumes v3 if not defined. v2 is not supported yet
       if (collectionData.openapi && !collectionData.openapi.startsWith('3')) {
         reject(new BrunoError('Only OpenAPI v3 is supported currently.'));
         return;
@@ -382,7 +382,28 @@ const parseOpenApiCollection = (data) => {
       // TODO what if info.title not defined?
       brunoCollection.name = collectionData.info.title;
       let servers = collectionData.servers || [];
-      let baseUrl = servers[0] ? getDefaultUrl(servers[0]) : '';
+
+      // Create environments based on the servers
+      servers.forEach((server, index) => {
+        let basePath = getDefaultUrl(server);
+        let environmentName = server.description ? server.description : `Environment ${index + 1}`;
+
+        brunoCollection.environments.push({
+          uid: uuid(),
+          name: environmentName,
+          variables: [
+            {
+              uid: uuid(),
+              name: 'basePath',
+              value: basePath,
+              type: 'text',
+              enabled: true,
+              secret: false
+            },
+          ]
+        });
+      });
+
       let securityConfig = getSecurity(collectionData);
 
       let allRequests = Object.entries(collectionData.paths)
@@ -399,7 +420,7 @@ const parseOpenApiCollection = (data) => {
                 path: path.replace(/{([^}]+)}/g, ':$1'), // Replace placeholders enclosed in curly braces with colons
                 operationObject: operationObject,
                 global: {
-                  server: baseUrl,
+                  server: '{{basePath}}', 
                   security: securityConfig
                 }
               };

--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -385,7 +385,7 @@ const parseOpenApiCollection = (data) => {
 
       // Create environments based on the servers
       servers.forEach((server, index) => {
-        let basePath = getDefaultUrl(server);
+        let baseUrl = getDefaultUrl(server);
         let environmentName = server.description ? server.description : `Environment ${index + 1}`;
 
         brunoCollection.environments.push({
@@ -394,8 +394,8 @@ const parseOpenApiCollection = (data) => {
           variables: [
             {
               uid: uuid(),
-              name: 'basePath',
-              value: basePath,
+              name: 'baseUrl',
+              value: baseUrl,
               type: 'text',
               enabled: true,
               secret: false
@@ -420,7 +420,7 @@ const parseOpenApiCollection = (data) => {
                 path: path.replace(/{([^}]+)}/g, ':$1'), // Replace placeholders enclosed in curly braces with colons
                 operationObject: operationObject,
                 global: {
-                  server: '{{basePath}}', 
+                  server: '{{baseUrl}}', 
                   security: securityConfig
                 }
               };


### PR DESCRIPTION
Fixes: #1239 
Closes PRs: #1240, #2261
1. Instead of separate variables protocol and host, this change creates a single environment variable basePath
2. Loops through all server urls and create environments for each of them separately
3. Creates environments using the server description if that doesnot exists creates environment as Environment 1(2, 3, ...)

https://github.com/user-attachments/assets/b45b1cb8-99bd-4576-984f-d5603159c051

