### PR TITLE
Feat/displaying variable hints as secrets

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -44,8 +44,11 @@ if (!SERVER_RENDERED) {
     const into = document.createElement('div');
     const descriptionDiv = document.createElement('div');
     descriptionDiv.className = 'info-description';
-
-    descriptionDiv.appendChild(document.createTextNode(variableValue));
+    if (options?.variables?.maskedEnvVariables?.includes(variableName)) {
+      descriptionDiv.appendChild(document.createTextNode('*****'));
+    } else {
+      descriptionDiv.appendChild(document.createTextNode(variableValue));
+    }
     into.appendChild(descriptionDiv);
 
     return into;
@@ -124,6 +127,7 @@ if (!SERVER_RENDERED) {
 
     const state = cm.state.brunoVarInfo;
     const options = state.options;
+    console.log('options', options);
     const token = cm.getTokenAt(pos, true);
     if (token) {
       const brunoVarInfo = renderVarInfo(token, options, cm, pos);

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -127,7 +127,6 @@ if (!SERVER_RENDERED) {
 
     const state = cm.state.brunoVarInfo;
     const options = state.options;
-    console.log('options', options);
     const token = cm.getTokenAt(pos, true);
     if (token) {
       const brunoVarInfo = renderVarInfo(token, options, cm, pos);

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -852,6 +852,13 @@ export const getAllVariables = (collection, item) => {
   const pathParams = getPathParams(item);
 
   const { processEnvVariables = {}, runtimeVariables = {} } = collection;
+  const mergedVariables = {
+    ...folderVariables,
+    ...requestVariables,
+    ...runtimeVariables
+  };
+  const maskedEnvVariables = getEnvironmentVariablesMasked(collection);
+  const filteredMaskedEnvVariables = maskedEnvVariables.filter((key) => !(key in mergedVariables));
 
   return {
     ...collectionVariables,
@@ -862,6 +869,7 @@ export const getAllVariables = (collection, item) => {
     pathParams: {
       ...pathParams
     },
+    maskedEnvVariables: filteredMaskedEnvVariables,
     process: {
       env: {
         ...processEnvVariables

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -802,6 +802,24 @@ export const getEnvironmentVariables = (collection) => {
   return variables;
 };
 
+export const getEnvironmentVariablesMasked = (collection) => {
+  // Return an empty array if the collection is invalid or not provided
+  if (!collection || !collection.activeEnvironmentUid) {
+    return [];
+  }
+
+  // Find the active environment in the collection
+  const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
+  if (!environment || !environment.variables) {
+    return [];
+  }
+
+  // Filter the environment variables to get only the masked (secret) ones
+  return environment.variables
+    .filter((variable) => variable.name && variable.value && variable.enabled && variable.secret)
+    .map((variable) => variable.name);
+};
+
 const getPathParams = (item) => {
   let pathParams = {};
   if (item && item.request && item.request.params) {


### PR DESCRIPTION
fixes: #3265 

# Description

This PR addresses the issue of secret variables being displayed on hover in editor components by implementing the following logic:
 - Checks masked variables from environment variables, which support secret variables.
 - Verifies if lower-level variables (such as request or folder variables) override the secret variables, including cases with string interpolation.
 - Creates a (*****) node to hide secret values and prevent them from being displayed.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:
![image](https://github.com/user-attachments/assets/8f7595c7-302a-4c53-9973-6a2f84e778d9)

After:

https://github.com/user-attachments/assets/7319a8e0-8dae-465a-a35c-f8fa0712ac92

