### PR TITLE
Fix/invalid file name handling

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -17,7 +17,8 @@ const {
   isWSLPath,
   normalizeWslPath,
   normalizeAndResolvePath,
-  safeToRename
+  safeToRename,
+  isValidFilename
 } = require('../utils/filesystem');
 const { openCollectionDialog } = require('../app/collections');
 const { generateUidBasedOnHash, stringifyJson, safeParseJSON, safeStringifyJSON } = require('../utils/common');
@@ -195,7 +196,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       if (fs.existsSync(pathname)) {
         throw new Error(`path: ${pathname} already exists`);
       }
-
+      if (!isValidFilename(request.name)) {
+        throw new Error(`path: ${request.name}.bru is not a valid filename`);
+      }
       const content = jsonToBru(request);
       await writeFile(pathname, content);
     } catch (error) {
@@ -358,6 +361,10 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       const isBru = hasBruExtension(oldPath);
       if (!isBru) {
         throw new Error(`path: ${oldPath} is not a bru file`);
+      }
+
+      if (!isValidFilename(newName)) {
+        throw new Error(`path: ${newName} is not a valid filename`);
       }
 
       // update name in file and save new copy, then delete old copy

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -167,7 +167,7 @@ const isValidFilename = (fileName) => {
     return false;
   }
 
-  if (fileName.endsWith(' ') || fileName.endsWith('.')) {
+  if (fileName.endsWith(' ') || fileName.endsWith('.') || fileName.startsWith('.')) {
     return false;
   }
 

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -160,6 +160,20 @@ const sanitizeDirectoryName = (name) => {
   return name.replace(/[<>:"/\\|?*\x00-\x1F]+/g, '-');
 };
 
+const isValidFilename = (fileName) => {
+  const inValidChars = /[\\/:*?"<>|]/;
+
+  if (!fileName || inValidChars.test(fileName)) {
+    return false;
+  }
+
+  if (fileName.endsWith(' ') || fileName.endsWith('.')) {
+    return false;
+  }
+
+  return true;
+};
+
 const safeToRename = (oldPath, newPath) => {
   try {
     // If the new path doesn't exist, it's safe to rename
@@ -204,5 +218,6 @@ module.exports = {
   searchForFiles,
   searchForBruFiles,
   sanitizeDirectoryName,
-  safeToRename
+  safeToRename,
+  isValidFilename
 };


### PR DESCRIPTION
fixes: #3266 #1401 #3454 

# Description

This PR implements the logic for validating filenames using a new utility function called `isValidFilename` to handle cases where filenames contain invalid characters `\ / : * ? " < > |` or end with a space (` `) or a period (`.`). This function has been added to the `rename-item`, thereby fixing issue #3266 , and to the `new-request` to improve error handling.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:

https://github.com/user-attachments/assets/0aaeb9d8-f731-4bbb-93fd-081b28ca94a3

After:

https://github.com/user-attachments/assets/276aac38-fb35-47e9-87f8-83faf5cbba58


