### PR TITLE
Style: Update `Toolhint` Z-Index and Add Toolhint for `GlobalEnvironmentSelector`

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/index.js
@@ -68,7 +68,12 @@ const CollectionToolBar = ({ collection }) => {
               <IconSettings className="cursor-pointer" size={18} strokeWidth={1.5} onClick={viewCollectionSettings} />
             </ToolHint>
           </span>
-          <GlobalEnvironmentSelector />
+          <span>
+            <ToolHint text="Global Environments" toolhintId="GlobalEnvironmentsToolhintId">
+              <GlobalEnvironmentSelector />
+            </ToolHint>
+          </span>
+          
           <EnvironmentSelector collection={collection} />
         </div>
       </div>

--- a/packages/bruno-app/src/components/ToolHint/index.js
+++ b/packages/bruno-app/src/components/ToolHint/index.js
@@ -22,6 +22,7 @@ const ToolHint = ({
     ...tooltipStyle,
     fontSize: '0.75rem',
     padding: '0.25rem 0.5rem',
+    zIndex: 9999,
     backgroundColor: toolhintBackgroundColor,
     color: toolhintTextColor
   };


### PR DESCRIPTION
fixes: #3278 

# Description

This PR implements a style fix for the Toolhint component. I have added the z-index for the Toolhint (Tooltip's) UI, allowing it to rise above the tab scroll and the 'Add Request' button when multiple tabs are open.

Additionally, I've added the Tooltip for the `GlobalEnvironmentSelector` component.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:

![image](https://github.com/user-attachments/assets/02828d0c-f46b-444e-9b27-ec46596358d3)

After:

![image](https://github.com/user-attachments/assets/7ac1c99e-6071-4d31-9caf-6f752f5a564e)
