### PR TITLE
fix: failing to import insomnia collection when username/password in auth is null

### DIFF
--- a/packages/bruno-app/src/utils/importers/insomnia-collection.js
+++ b/packages/bruno-app/src/utils/importers/insomnia-collection.js
@@ -60,12 +60,12 @@ const addSuffixToDuplicateName = (item, index, allItems) => {
 const regexVariable = new RegExp('{{.*?}}', 'g');
 
 const normalizeVariables = (value) => {
-  value = value || '';
-  const variables = value.match(regexVariable) || [];
+  const sanitizedValue = value || '';
+  const variables = sanitizedValue.match(regexVariable) || [];
   each(variables, (variable) => {
-    value = value.replace(variable, variable.replace('_.', '').replaceAll(' ', ''));
+    sanitizedValue = sanitizedValue.replace(variable, variable.replace('_.', '').replaceAll(' ', ''));
   });
-  return value;
+  return sanitizedValue;
 };
 
 const transformInsomniaRequestItem = (request, index, allRequests) => {

--- a/packages/bruno-app/src/utils/importers/insomnia-collection.js
+++ b/packages/bruno-app/src/utils/importers/insomnia-collection.js
@@ -60,6 +60,7 @@ const addSuffixToDuplicateName = (item, index, allItems) => {
 const regexVariable = new RegExp('{{.*?}}', 'g');
 
 const normalizeVariables = (value) => {
+  value = value || '';
   const variables = value.match(regexVariable) || [];
   each(variables, (variable) => {
     value = value.replace(variable, variable.replace('_.', '').replaceAll(' ', ''));

--- a/packages/bruno-app/src/utils/importers/insomnia-collection.js
+++ b/packages/bruno-app/src/utils/importers/insomnia-collection.js
@@ -60,12 +60,12 @@ const addSuffixToDuplicateName = (item, index, allItems) => {
 const regexVariable = new RegExp('{{.*?}}', 'g');
 
 const normalizeVariables = (value) => {
-  const sanitizedValue = value || '';
-  const variables = sanitizedValue.match(regexVariable) || [];
+  value = value || '';
+  const variables = value.match(regexVariable) || [];
   each(variables, (variable) => {
-    sanitizedValue = sanitizedValue.replace(variable, variable.replace('_.', '').replaceAll(' ', ''));
+    value = value.replace(variable, variable.replace('_.', '').replaceAll(' ', ''));
   });
-  return sanitizedValue;
+  return value;
 };
 
 const transformInsomniaRequestItem = (request, index, allRequests) => {


### PR DESCRIPTION
# Description

Solves #3294 

When a user creates a request in insomnia, and sets the auth to "Basic", Insomnia will set the value of username and password to empty string.

BUT if the request has been imported from an older insomnia export, these values may be null instead of an empty string. Insomnia will not change the null value and persist it for future exports, unless the field is modified. This results in the collection failing to import as it hits a .match condition which is expecting a string value.

Steps to reproduce:
1) [Clone, setup and start Bruno](https://github.com/jake-owen-p/bruno/blob/main/contributing.md)
2) Checkout main
3) Create a file named "example.json" and copy/paste the below json into it
4) In Bruno, Click "Import Collection", add "example.json" created on (3)
5) See error message: Import collection failed: An error occurred while parsing the Insomnia collection

Steps to Resolve:
1) Checkout fix/insomnia-collection-failing-import
2) Click "Import Collection", add "example.json"

Below i've attached a screenshot showing the example request, and added the json which is the export of that request. Along with an example of the error

![Screenshot 2024-10-12 at 01 21 44](https://github.com/user-attachments/assets/8be8ca07-50bf-4b53-90c3-41cc57155975)

<img width="383" alt="Screenshot 2024-10-12 at 1 36 43 AM" src="https://github.com/user-attachments/assets/0a39fbaf-069d-4ce7-9d24-ab9a5d730daa">

```json
{
    "_type": "export",
    "__export_format": 4,
    "__export_date": "2024-10-11T23:53:31.649Z",
    "__export_source": "insomnia.desktop.app:v2023.4.0",
    "resources": [
        {
            "_id": "req_5f21bcb1dec54e998cff46c961e37188",
            "parentId": "wrk_2ac90ac4f46f4382849700f28aa79c4b",
            "modified": 1728690792025,
            "created": 1728688919111,
            "url": "www.foo.com/bar",
            "name": "FooBarRequest",
            "description": "",
            "method": "PUT",
            "body": {},
            "parameters": [],
            "headers": [],
            "authentication": {
                "type": "basic",
                "useISO88591": false,
                "disabled": false,
                "username": null,
                "password": null
            },
            "metaSortKey": -1728688987306.25,
            "isPrivate": false,
            "settingStoreCookies": true,
            "settingSendCookies": true,
            "settingDisableRenderRequestBody": false,
            "settingEncodeUrl": true,
            "settingRebuildPath": true,
            "settingFollowRedirects": "global",
            "_type": "request"
        },
        {
            "_id": "wrk_2ac90ac4f46f4382849700f28aa79c4b",
            "parentId": null,
            "modified": 1728690783068,
            "created": 1728690714797,
            "name": "FooBarCollection",
            "description": "",
            "scope": "collection",
            "_type": "workspace"
        },
        {
            "_id": "env_d928fbede709438bbb731d59f529b2de",
            "parentId": "wrk_2ac90ac4f46f4382849700f28aa79c4b",
            "modified": 1728688893510,
            "created": 1728688893510,
            "name": "Base Environment",
            "data": {},
            "dataPropertyOrder": null,
            "color": null,
            "isPrivate": false,
            "metaSortKey": 1728688893510,
            "_type": "environment"
        },
        {
            "_id": "jar_5c3d885cb1444684abffe46787000766",
            "parentId": "wrk_2ac90ac4f46f4382849700f28aa79c4b",
            "modified": 1728688893514,
            "created": 1728688893514,
            "name": "Default Jar",
            "cookies": [],
            "_type": "cookie_jar"
        }
    ]
}
```


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
