### PR TITLE
Fix Date Handling in Insomnia Collection Import

### DIFF
--- a/packages/bruno-app/src/utils/importers/insomnia-collection.js
+++ b/packages/bruno-app/src/utils/importers/insomnia-collection.js
@@ -17,7 +17,7 @@ const readFile = (files) => {
       } catch (jsonError) {
         // not a valid JSOn, try yaml
         try {
-          const parsedData = jsyaml.load(e.target.result);
+          const parsedData = jsyaml.load(e.target.result, { schema: jsyaml.CORE_SCHEMA });
           resolve(parsedData);
         } catch (yamlError) {
           console.error('Error parsing the file :', jsonError, yamlError);


### PR DESCRIPTION
Importng insomnia files(yaml exports) fails when it contains date values
```
 url: https://testbench-sanity.usebruno.com/api/echo/json
    name: New Request
    description: ""
    method: GET
    body: {}
    parameters:
      - id: pair_87d0dc461d5a408a93ebfe0fe500fdce
        name: date
        value: 2022-22-02
        description: ""
        disabled: false
      - id: pair_8a903b8bf636404288bba577485d6816
        name: ""
        value: ""
        description: ""
        disabled: false
        
```
The YAML parser(js-yaml) automatically converts date values into Date objects, which causes issues while validating collection schema.

I have updated the YAML parsing logic to use the CORE_SCHEMA from js-yaml. This way, we avoid automatic conversion of date.

Issue ref to js-yaml repo: https://github.com/nodeca/js-yaml/issues/161

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
