### PR TITLE
fix: add global env vars to the active collection

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.js
@@ -9,7 +9,7 @@ const initialState = {
 };
 
 export const globalEnvironmentsSlice = createSlice({
-  name: 'app',
+  name: 'global-environments',
   initialState,
   reducers: {
     updateGlobalEnvironments: (state, action) => {


### PR DESCRIPTION
~ merge `globalEnvironmentVariables` into the active collection and rebuild the `collections` immer proxy object, instead of adding it to the cloned `collection` object.