### PR TITLE
refactor: tab closing logic and add close tab hotkey

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, Fragment } from 'react';
+import React, { useState, useRef, Fragment, useEffect } from 'react';
 import get from 'lodash/get';
 import { closeTabs } from 'providers/ReduxStore/slices/tabs';
 import { saveRequest } from 'providers/ReduxStore/slices/collections/actions';
@@ -28,13 +28,20 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   const onDropdownCreate = (ref) => (dropdownTippyRef.current = ref);
 
   const handleCloseClick = (event) => {
-    event.stopPropagation();
-    event.preventDefault();
-    dispatch(
-      closeTabs({
-        tabUids: [tab.uid]
-      })
-    );
+    if (event) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+
+    if (!item.draft) {
+      dispatch(
+        closeTabs({
+          tabUids: [tab.uid]
+        })
+      );
+    } else {
+      setShowConfirmClose(true);
+    }
   };
 
   const handleRightClick = (_event) => {
@@ -68,6 +75,21 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
     const theme = storedTheme === 'dark' ? darkTheme : lightTheme;
     return theme.request.methods[method.toLocaleLowerCase()];
   };
+
+  // close tab hotkey
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.ctrlKey && e.key === 'w') {
+        return handleCloseClick(e);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleCloseClick]);
 
   const folder = folderUid ? findItemInCollection(collection, folderUid) : null;
   if (['collection-settings', 'folder-settings', 'variables', 'collection-runner', 'security-settings'].includes(tab.type)) {
@@ -175,18 +197,10 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
       <div
         className="flex px-2 close-icon-container"
         onClick={(e) => {
-          if (!item.draft) return handleCloseClick(e);
-
-          e.stopPropagation();
-          e.preventDefault();
-          setShowConfirmClose(true);
+          return handleCloseClick(e);
         }}
       >
-        {!item.draft ? (
-          <CloseTabIcon />
-        ) : (
-          <DraftTabIcon />
-        )}
+        {!item.draft ? <CloseTabIcon /> : <DraftTabIcon />}
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -140,23 +140,6 @@ export const HotkeysProvider = (props) => {
     };
   }, [activeTabUid, tabs, collections, setShowNewRequestModal]);
 
-  // close tab hotkey
-  useEffect(() => {
-    Mousetrap.bind([...getKeyBindingsForActionAllOS('closeTab')], (e) => {
-      dispatch(
-        closeTabs({
-          tabUids: [activeTabUid]
-        })
-      );
-
-      return false; // this stops the event bubbling
-    });
-
-    return () => {
-      Mousetrap.unbind([...getKeyBindingsForActionAllOS('closeTab')]);
-    };
-  }, [activeTabUid]);
-
   // Switch to the previous tab
   useEffect(() => {
     Mousetrap.bind([...getKeyBindingsForActionAllOS('switchToPreviousTab')], (e) => {


### PR DESCRIPTION
fixes: #3264 

# Description

This PR implements the logic for a `Ctrl+W` or `Cmd+W` hotkey to close a request tab from the `RequestTab` component. This enhancement includes a modal prompt to save changes before closing, improving the overall user experience. I removed the `Ctrl+W` hotkey functionality from the hotkeys provider and refactored the `handleCloseClick` method to reuse existing code.
### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:

https://github.com/user-attachments/assets/401af86f-638b-4106-a219-5fd7395e429c

After:

Uploading 20241017-0757-23.3456865.mp4…

