### PR TITLE
fix: Add missing postman translation functions

### DIFF
--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -5,6 +5,8 @@ const replacements = {
   'pm\\.variables\\.set\\(': 'bru.setVar(',
   'pm\\.collectionVariables\\.get\\(': 'bru.getVar(',
   'pm\\.collectionVariables\\.set\\(': 'bru.setVar(',
+  'pm\\.collectionVariables\\.has\\(': 'bru.hasVar(',
+  'pm\\.collectionVariables\\.unset\\(': 'bru.deleteVar(',
   'pm\\.setNextRequest\\(': 'bru.setNextRequest(',
   'pm\\.test\\(': 'test(',
   'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',


### PR DESCRIPTION
Fixes:  #3061

# Description

Addition of two new postman collectionVariable functions mapping to equivalent bruno functions. 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

Postman: 
![Screenshot 2024-10-17 at 12 08 12 PM](https://github.com/user-attachments/assets/fe055dd9-c07f-480d-92da-fc7886866bbc)

Bruno: 
![Screenshot 2024-10-17 at 12 08 44 PM](https://github.com/user-attachments/assets/fad740d4-35be-4bf8-a2e4-5a4788d82b39)

