### PR TITLE
fix: support name in Chinese [#3211]

### DIFF
--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -70,13 +70,13 @@ export const safeParseXML = (str, options) => {
   }
 };
 
-// Remove any characters that are not alphanumeric, spaces, hyphens, or underscores
+// Remove any characters that are not alphanumeric, spaces, hyphens, underscores, or Chinese characters
 export const normalizeFileName = (name) => {
   if (!name) {
     return name;
   }
 
-  const validChars = /[^\w\s-]/g;
+  const validChars = /[^\w\s\u4e00-\u9fa5-]/g;
   const formattedName = name.replace(validChars, '-');
 
   return formattedName;

--- a/packages/bruno-app/src/utils/common/index.spec.js
+++ b/packages/bruno-app/src/utils/common/index.spec.js
@@ -14,6 +14,7 @@ describe('common utils', () => {
       expect(normalizeFileName('hello_world?')).toBe('hello_world-');
       expect(normalizeFileName('foo/bar/')).toBe('foo-bar-');
       expect(normalizeFileName('foo\\bar\\')).toBe('foo-bar-');
+      expect(normalizeFileName('hello_world-123中文!@#$%^&*()')).toBe('hello_world-123中文----------');
     });
   });
 


### PR DESCRIPTION
# Description

The background is that we use Chinese letter as fileName, but normalizeFileName in the `packages/bruno-app/src/utils/common/index.js` replaces Chinese Character into `-`. We should fix it by modifying the regular expressions

![image](https://github.com/user-attachments/assets/fd9f75b6-5420-4b17-b66d-c51bd8518f45)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
