### PR TITLE
Save request looping issue | update request draft when there are no sequence change

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -754,6 +754,9 @@ export const deleteUidsInItem = (item) => {
 };
 
 export const areItemsTheSameExceptSeqUpdate = (_item1, _item2) => {
+  // handle case when there is no sequence update
+  if (_item1.seq === _item2.seq)  return false
+  
   let item1 = cloneDeep(_item1);
   let item2 = cloneDeep(_item2);
 


### PR DESCRIPTION
# Description

The request draft was not getting removed if there were no file changes and no sequence changes. This causes UI to show that there are still changes present even after saving.

Changes made:

Updated the areItemsTheSameExceptSeqUpdate function to return false when there are no sequence changes, so that the draft gets updated appropriately.

Fixes: #3316

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/cb884dc7-a2de-4616-a235-64d7b3a30d4d

