### PR TITLE
Allow longer names in tab header

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/StyledWrapper.js
@@ -17,7 +17,7 @@ const Wrapper = styled.div`
 
     li {
       display: inline-flex;
-      max-width: 150px;
+      max-width: 250px;
       border: 1px solid transparent;
       list-style: none;
       padding-top: 8px;


### PR DESCRIPTION
# Description

This PR aims to allow longer names in tab header to resolve:

- Issue: https://github.com/usebruno/bruno/issues/839
- Similar Issue: https://github.com/usebruno/bruno/issues/2466


![image](https://github.com/user-attachments/assets/8ff930c0-abc9-4070-b16d-9eb7492d95ca)


Implementation details:

I updated css `max-width: 250px` of tab header to achieve longer name display


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
