### PR TITLE
fix: Ensure search field visibility in response panel

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -79,7 +79,7 @@ const StyledWrapper = styled.div`
     position: absolute;
     bottom: 0;
     margin-bottom: 10px;
-    color: black;
+    background-color: ${(props) => props.theme.modal.input.bg};
   }
 `;
 

--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -75,6 +75,12 @@ const StyledWrapper = styled.div`
   .cm-variable-invalid {
     color: red;
   }
+  .CodeMirror-search-field{
+    position: absolute;
+    bottom: 0;
+    margin-bottom: 10px;
+    color: black;
+  }
 `;
 
 export default StyledWrapper;


### PR DESCRIPTION
# Description

Fixes: #3381

This PR addresses an issue where the search field was not visible when using the `Command/Ctrl+F` shortcut in the response panel.

![Screenshot 2024-10-30 002421](https://github.com/user-attachments/assets/344739f7-5a23-49f6-b2fb-be1defe629b6)



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
