### PR TITLE
Feat/import translation for deprecated pm import

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -65,6 +65,7 @@ if (!SERVER_RENDERED) {
     'bru.getFolderVar(key)',
     'bru.getCollectionVar(key)',
     'bru.setEnvVar(key,value)',
+    'bru.deleteEnvVar(key)',
     'bru.hasVar(key)',
     'bru.getVar(key)',
     'bru.setVar(key,value)',

--- a/packages/bruno-app/src/utils/importers/translators/index.spec.js
+++ b/packages/bruno-app/src/utils/importers/translators/index.spec.js
@@ -151,3 +151,13 @@ test('should handle response commands', () => {
   `;
   expect(postmanTranslation(inputScript)).toBe(expectedOutput);
 });
+
+test('should handle tests object', () => {
+  const inputScript = `
+    tests['Status code is 200'] = responseCode.code === 200;
+  `;
+  const expectedOutput = `
+    test('Status code is 200', function() { expect(responseCode.code === 200).to.be.true; });
+  `;
+  expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+});

--- a/packages/bruno-app/src/utils/importers/translators/index.spec.js
+++ b/packages/bruno-app/src/utils/importers/translators/index.spec.js
@@ -157,7 +157,7 @@ test('should handle tests object', () => {
     tests['Status code is 200'] = responseCode.code === 200;
   `;
   const expectedOutput = `
-    test('Status code is 200', function() { expect(responseCode.code === 200).to.be.true; });
+    test("Status code is 200", function() { expect(responseCode.code === 200).to.be.true; });
   `;
   expect(postmanTranslation(inputScript)).toBe(expectedOutput);
 });

--- a/packages/bruno-app/src/utils/importers/translators/index.spec.js
+++ b/packages/bruno-app/src/utils/importers/translators/index.spec.js
@@ -11,6 +11,9 @@ describe('postmanTranslation function', () => {
       pm.collectionVariables.set('key', 'value');
       const data = pm.response.json();
       pm.expect(pm.environment.has('key')).to.be.true;
+      postman.setEnvironmentVariable('key', 'value');
+      postman.getEnvironmentVariable('key');
+      postman.clearEnvironmentVariable('key');
     `;
     const expectedOutput = `
       bru.getEnvVar('key');
@@ -23,6 +26,7 @@ describe('postmanTranslation function', () => {
       expect(bru.getEnvVar('key') !== undefined && bru.getEnvVar('key') !== null).to.be.true;
       bru.setEnvVar('key', 'value');
       bru.getEnvVar('key');
+      bru.deleteEnvVar('key');
     `;
     expect(postmanTranslation(inputScript)).toBe(expectedOutput);
   });

--- a/packages/bruno-app/src/utils/importers/translators/index.spec.js
+++ b/packages/bruno-app/src/utils/importers/translators/index.spec.js
@@ -21,6 +21,8 @@ describe('postmanTranslation function', () => {
       bru.setVar('key', 'value');
       const data = res.getBody();
       expect(bru.getEnvVar('key') !== undefined && bru.getEnvVar('key') !== null).to.be.true;
+      bru.setEnvVar('key', 'value');
+      bru.getEnvVar('key');
     `;
     expect(postmanTranslation(inputScript)).toBe(expectedOutput);
   });

--- a/packages/bruno-app/src/utils/importers/translators/index.spec.js
+++ b/packages/bruno-app/src/utils/importers/translators/index.spec.js
@@ -157,7 +157,7 @@ test('should handle tests object', () => {
     tests['Status code is 200'] = responseCode.code === 200;
   `;
   const expectedOutput = `
-    test("Status code is 200", function() { expect(responseCode.code === 200).to.be.true; });
+    test("Status code is 200", function() { expect(Boolean(responseCode.code === 200)).to.be.true; });
   `;
   expect(postmanTranslation(inputScript)).toBe(expectedOutput);
 });

--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -22,6 +22,7 @@ const replacements = {
   // deprecated translations
   'postman\\.setEnvironmentVariable\\(': 'bru.setEnvVar(',
   'postman\\.getEnvironmentVariable\\(': 'bru.getEnvVar(',
+  'postman\\.clearEnvironmentVariable\\(': 'bru.deleteEnvVar(',
 };
 
 const extendedReplacements = Object.keys(replacements).reduce((acc, key) => {

--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -18,7 +18,7 @@ const replacements = {
   'pm\\.response\\.text\\(': 'res.getBody()?.toString(',
   'pm\\.expect\\.fail\\(': 'expect.fail(',
   'pm\\.response\\.responseTime': 'res.getResponseTime()',
-  "tests\\['([^']+)'\\]\\s*=\\s*([^;]+);": 'test("$1", function() { expect($2).to.be.true; });'
+  "tests\\['([^']+)'\\]\\s*=\\s*([^;]+);": 'test("$1", function() { expect(Boolean($2)).to.be.true; });'
 };
 
 const extendedReplacements = Object.keys(replacements).reduce((acc, key) => {

--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -17,7 +17,8 @@ const replacements = {
   'pm\\.response\\.code': 'res.getStatus()',
   'pm\\.response\\.text\\(': 'res.getBody()?.toString(',
   'pm\\.expect\\.fail\\(': 'expect.fail(',
-  'pm\\.response\\.responseTime': 'res.getResponseTime()'
+  'pm\\.response\\.responseTime': 'res.getResponseTime()',
+  "tests\\['([^']+)'\\]\\s*=\\s*([^;]+);": 'test("$1", function() { $2; });',
 };
 
 const extendedReplacements = Object.keys(replacements).reduce((acc, key) => {

--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -18,7 +18,10 @@ const replacements = {
   'pm\\.response\\.text\\(': 'res.getBody()?.toString(',
   'pm\\.expect\\.fail\\(': 'expect.fail(',
   'pm\\.response\\.responseTime': 'res.getResponseTime()',
-  "tests\\['([^']+)'\\]\\s*=\\s*([^;]+);": 'test("$1", function() { expect(Boolean($2)).to.be.true; });'
+  "tests\\['([^']+)'\\]\\s*=\\s*([^;]+);": 'test("$1", function() { expect(Boolean($2)).to.be.true; });',
+  // deprecated translations
+  'postman\\.setEnvironmentVariable\\(': 'bru.setEnvVar(',
+  'postman\\.getEnvironmentVariable\\(': 'bru.getEnvVar(',
 };
 
 const extendedReplacements = Object.keys(replacements).reduce((acc, key) => {

--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -18,7 +18,7 @@ const replacements = {
   'pm\\.response\\.text\\(': 'res.getBody()?.toString(',
   'pm\\.expect\\.fail\\(': 'expect.fail(',
   'pm\\.response\\.responseTime': 'res.getResponseTime()',
-  "tests\\['([^']+)'\\]\\s*=\\s*([^;]+);": 'test("$1", function() { $2; });',
+  "tests\\['([^']+)'\\]\\s*=\\s*([^;]+);": 'test("$1", function() { expect($2).to.be.true; });'
 };
 
 const extendedReplacements = Object.keys(replacements).reduce((acc, key) => {

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -65,6 +65,10 @@ class Bru {
     this.envVariables[key] = value;
   }
 
+  deleteEnvVar(key) {
+    delete this.envVariables[key];
+  }
+
   getGlobalEnvVar(key) {
     return this._interpolate(this.globalEnvironmentVariables[key]);
   }


### PR DESCRIPTION
# Description

This PR implements the translation for importing Postman collections from the deprecated method of writing test scripts. Specifically, it translates the `test[]` check illustrated below:

> test['test description'] = boolean_condition

```javascript
test("test description", function() {
  expect(boolean_condition).to.be.true;
 ```

*working on other deprecated and missing translations

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**