### PR TITLE
fix: codeeditor search box desc alignment fix

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -79,8 +79,8 @@ const StyledWrapper = styled.div`
     color: red;
   }
 
-  .graphiql-container .CodeMirror-search-hint {
-    display: block;
+  .CodeMirror-search-hint {
+    display: inline;
   }
 `;
 


### PR DESCRIPTION
before:
<img width="554" alt="before" src="https://github.com/user-attachments/assets/6a52234b-33a9-4587-8f8b-4b7384c825f8">

---

after:
<img width="521" alt="after" src="https://github.com/user-attachments/assets/d0c6cbda-cc2d-4e8f-baa4-bb5b42b11ebc">
