### PR TITLE
UI: Change the default request auth mode from "none" to "inherit"

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -762,7 +762,7 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
           formUrlEncoded: null
         },
         auth: auth ?? {
-          mode: 'none'
+          mode: 'inherit'
         }
       }
     };


### PR DESCRIPTION
Fix #2315

# Description

When I configure auth at a collection or folder level, I want the children of that folder to have the same auth by default.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
    - Changing default behavior here probably does count as a breaking change, since anyone depending on the old behavior could be surprised.  Maybe you want to delay it until v3?  But IMO it's the right change to make.
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
