### PR TITLE
feat: add validation to prevent duplicate global environment names (fixes: #3449)

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.js
@@ -92,9 +92,7 @@ export const addGlobalEnvironment = ({ name, variables = [] }) => (dispatch, get
     const uid = uuid();
     ipcRenderer
       .invoke('renderer:create-global-environment', { name, uid, variables })
-      .then(
-        dispatch(_addGlobalEnvironment({ name, uid, variables }))
-      )
+      .then(() => dispatch(_addGlobalEnvironment({ name, uid, variables })))
       .then(resolve)
       .catch(reject);
   });

--- a/packages/bruno-electron/src/store/global-environments.js
+++ b/packages/bruno-electron/src/store/global-environments.js
@@ -63,6 +63,10 @@ class GlobalEnvironmentsStore {
 
   addGlobalEnvironment({ uid, name, variables = [] }) {
     let globalEnvironments = this.getGlobalEnvironments();
+    const existingEnvironment = globalEnvironments.find(env => env?.name == name);
+    if (existingEnvironment) {
+      throw new Error('Environment with the same name already exists');
+    }
     globalEnvironments.push({
       uid,
       name,


### PR DESCRIPTION
fixes: #3449 

# Description

This PR implements logic to check for the existence of duplicate names under global environments to prevent name conflicts.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:

https://github.com/user-attachments/assets/12d17ff2-9cdd-4e18-9fb0-57367ff2df31

After:


https://github.com/user-attachments/assets/f3ee88fe-eff9-4165-8fe6-fbfbd78d6f5f

