### PR TITLE
fix: cli run-summary count fix for requests with ECONNREFUSED error

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -246,7 +246,7 @@ const runSingleRequest = async function (
             data: null,
             responseTime: 0
           },
-          error: err?.errors?.map(e => e?.message)?.at(0) || err?.code || 'Request Failed!',
+          error: err?.message || err?.errors?.map(e => e?.message)?.at(0) || err?.code || 'Request Failed!',
           assertionResults: [],
           testResults: [],
           nextRequestName: nextRequestName

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -246,7 +246,7 @@ const runSingleRequest = async function (
             data: null,
             responseTime: 0
           },
-          error: err.message,
+          error: err?.errors?.map(e => e?.message)?.at(0) || err?.code || 'Request Failed!',
           assertionResults: [],
           testResults: [],
           nextRequestName: nextRequestName


### PR DESCRIPTION
fixes the below scenario:

~ if the request fails with an `ECONNREFUSED` error, the cli run summary indicated that the request passed.