### PR TITLE
Fix: (#3383) openapi yaml req body not importing

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -271,7 +271,7 @@ const resolveRefs = (spec, components = spec?.components, visitedItems = new Set
 
   // Recursively resolve references in nested objects
   for (const prop in spec) {
-    spec[prop] = resolveRefs(spec[prop], components, visitedItems);
+    spec[prop] = resolveRefs(spec[prop], components, new Set(visitedItems));
   }
 
   return spec;


### PR DESCRIPTION
# Description

 Fix: [#3383 ](https://github.com/usebruno/bruno/issues/3383)  Request body not imported from OpenAPI YAML
 
- It was happening because of the shared Sets. hence used independent Sets for each recursive reference resolution to prevent skipping references.


Fix reference resolution by using independent Sets for recursion
### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


Before:
![image](https://github.com/user-attachments/assets/be9ffec9-abc8-43c7-be4e-4f4f06a06d8b)
After:
![image](https://github.com/user-attachments/assets/b74a8957-05de-4832-83b1-a2b00f726688)
