### PR TITLE
feat: add option to omit headers in CLI run command output

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -259,10 +259,17 @@ const builder = async (yargs) => {
       type: 'boolean',
       description: 'Stop execution after a failure of a request, test, or assertion'
     })
+    .option('omit-headers', {
+      type: 'boolean',
+      description: 'Omit headers in the output',
+      default: false
+    })
+
     .example('$0 run request.bru', 'Run a request')
     .example('$0 run request.bru --env local', 'Run a request with the environment set to local')
     .example('$0 run folder', 'Run all requests in a folder')
     .example('$0 run folder -r', 'Run all requests in a folder recursively')
+    .example('$0 run --omit-headers', 'Run all requests in a folder recursively with omitted headers in the output')
     .example(
       '$0 run request.bru --env local --env-var secret=xxx',
       'Run a request with the environment set to local and overwrite the variable secret with value xxx'
@@ -312,7 +319,8 @@ const handler = async function (argv) {
       reporterHtml,
       sandbox,
       testsOnly,
-      bail
+      bail,
+      omitHeaders
     } = argv;
     const collectionPath = process.cwd();
 
@@ -524,6 +532,12 @@ const handler = async function (argv) {
         runtime: process.hrtime(start)[0] + process.hrtime(start)[1] / 1e9,
         suitename: bruFilepath.replace('.bru', '')
       });
+      if (omitHeaders) {
+        results.forEach((result) => {
+          result.request.headers = {};
+          result.response.headers = {};
+        });
+      }
 
       // bail if option is set and there is a failure
       if (bail) {


### PR DESCRIPTION
# Description
This PR implements the feature to completely omit all headers from the request and response after the request has run.


Example usage:
1. `bru run --omit-headers`
2. `bru run --omit-headers --reporter-html results.html`

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**