### PR TITLE
fix: improve masking logic in MaskedEditor for large content handling (fixes #2842)

### DIFF
--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -52,17 +52,33 @@ export class MaskedEditor {
   /** Replaces all rendered characters, with the provided character. */
   maskContent = () => {
     const content = this.editor.getValue();
+    const lineCount = this.editor.lineCount();
+
+    if (lineCount === 0) return;
     this.editor.operation(() => {
       // Clear previous masked text
       this.editor.getAllMarks().forEach((mark) => mark.clear());
       // Apply new masked text
-      for (let i = 0; i < content.length; i++) {
-        if (content[i] !== '\n') {
-          const maskedNode = document.createTextNode(this.maskChar);
+
+      if (content.length <= 500) {
+        for (let i = 0; i < content.length; i++) {
+          if (content[i] !== '\n') {
+            const maskedNode = document.createTextNode(this.maskChar);
+            this.editor.markText(
+              { line: this.editor.posFromIndex(i).line, ch: this.editor.posFromIndex(i).ch },
+              { line: this.editor.posFromIndex(i + 1).line, ch: this.editor.posFromIndex(i + 1).ch },
+              { replacedWith: maskedNode, handleMouseEvents: true }
+            );
+          }
+        }
+      } else {
+        for (let line = 0; line < lineCount; line++) {
+          const lineLength = this.editor.getLine(line).length;
+          const maskedNode = document.createTextNode('*'.repeat(lineLength)); // Masking based on line length
           this.editor.markText(
-            { line: this.editor.posFromIndex(i).line, ch: this.editor.posFromIndex(i).ch },
-            { line: this.editor.posFromIndex(i + 1).line, ch: this.editor.posFromIndex(i + 1).ch },
-            { replacedWith: maskedNode, handleMouseEvents: true }
+            { line, ch: 0 },
+            { line, ch: lineLength },
+            { replacedWith: maskedNode, handleMouseEvents: false } // Avoid unnecessary mouse events unless needed
           );
         }
       }

--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -74,11 +74,11 @@ export class MaskedEditor {
       } else {
         for (let line = 0; line < lineCount; line++) {
           const lineLength = this.editor.getLine(line).length;
-          const maskedNode = document.createTextNode('*'.repeat(lineLength)); // Masking based on line length
+          const maskedNode = document.createTextNode('*'.repeat(lineLength)); 
           this.editor.markText(
             { line, ch: 0 },
             { line, ch: lineLength },
-            { replacedWith: maskedNode, handleMouseEvents: false } // Avoid unnecessary mouse events unless needed
+            { replacedWith: maskedNode, handleMouseEvents: false } 
           );
         }
       }


### PR DESCRIPTION
fixes: #2842 

# Description

This PR is implemented to improve the app's performance when masking text in the SingleLineEditor. The logic in PR #2240 created a new node for every masked text range. While this logic performs well when the content length is less than 1000 characters, its performance degrades as the length exceeds 1000 characters. In this PR, I've addressed these performance issues.

Changes made:
1. Added an early return if there are no lines in the editor.
2. Limited the previous logic to cases where the number of masked characters is less than 500. This is more efficient for editing small content, such as secret environment variables.
3. For content greater than 500 characters, implemented a line-by-line masking approach to improve performance.


Before:

https://github.com/user-attachments/assets/4b920159-1a16-4a29-b984-c460e5e6bb94

After:

https://github.com/user-attachments/assets/6c63dfea-5d0f-4c79-8e0a-80216c482573



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


