### PR TITLE
feat: Natural sort collection names with numbers

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -76,15 +76,16 @@ export const collectionsSlice = createSlice({
     },
     sortCollections: (state, action) => {
       state.collectionSortOrder = action.payload.order;
+      const collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
       switch (action.payload.order) {
         case 'default':
           state.collections = state.collections.sort((a, b) => a.importedAt - b.importedAt);
           break;
         case 'alphabetical':
-          state.collections = state.collections.sort((a, b) => a.name.localeCompare(b.name));
+          state.collections = state.collections.sort((a, b) => collator.compare(a.name, b.name));
           break;
         case 'reverseAlphabetical':
-          state.collections = state.collections.sort((a, b) => b.name.localeCompare(a.name));
+          state.collections = state.collections.sort((a, b) => -collator.compare(a.name, b.name));
           break;
       }
     },


### PR DESCRIPTION
# Description

Adresses: https://github.com/usebruno/bruno/issues/1974

Sorts collections by name in alphabetical order
Collections with numbers in the names are sorted in numerical order.

Results in `['Test 10', 'Test 2', 'Test 1']`
being sorted to: `['Test 1', 'Test 2', 'Test 10']` instead of: `['Test 1', 'Test 10', 'Test 2']`

Accurately sorts numbers with decimals as well.

![Screenshot 2024-11-14 at 8 27 34 PM](https://github.com/user-attachments/assets/104abfab-1e46-4be6-a6f3-597a3342d59b)
![Screenshot 2024-11-14 at 8 27 44 PM](https://github.com/user-attachments/assets/c1d54722-cfe2-4579-b372-babcdb569579)
![Screenshot 2024-11-14 at 8 27 56 PM](https://github.com/user-attachments/assets/e5050db3-ee16-4a78-83a3-8c325ffd883f)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
