### PR TITLE
alternate collection (fixes #3395)

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { uuid } from 'utils/common';
-import { IconFiles, IconRun, IconEye, IconSettings } from '@tabler/icons';
+import { IconRun, IconEye, IconSettings, IconAB2 } from '@tabler/icons';
 import EnvironmentSelector from 'components/Environments/EnvironmentSelector';
 import GlobalEnvironmentSelector from 'components/GlobalEnvironments/EnvironmentSelector';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
@@ -9,7 +9,7 @@ import ToolHint from 'components/ToolHint';
 import StyledWrapper from './StyledWrapper';
 import JsSandboxMode from 'components/SecuritySettings/JsSandboxMode';
 
-const CollectionToolBar = ({ collection }) => {
+const CollectionToolBar = ({ collection, onClick }) => {
   const dispatch = useDispatch();
 
   const handleRun = () => {
@@ -45,9 +45,9 @@ const CollectionToolBar = ({ collection }) => {
   return (
     <StyledWrapper>
       <div className="flex items-center p-2">
-        <div className="flex flex-1 items-center cursor-pointer hover:underline" onClick={viewCollectionSettings}>
-          <IconFiles size={18} strokeWidth={1.5} />
-          <span className="ml-2 mr-4 font-semibold">{collection?.name}</span>
+      <div className="flex flex-1 items-center cursor-pointer hover:underline" onClick={onClick} >
+          <span className="ml-2 mr-2 font-semibold" >{collection?.name}</span>
+          <IconAB2 size={18} strokeWidth={1.5} />
         </div>
         <div className="flex flex-3 items-center justify-end">
           <span className="mr-2">

--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -20,6 +20,25 @@ const RequestTabs = () => {
   const leftSidebarWidth = useSelector((state) => state.app.leftSidebarWidth);
   const screenWidth = useSelector((state) => state.app.screenWidth);
 
+
+  const otherCollection = () => {
+
+    let currentCollectionUid = activeTab.collectionUid
+    let index = collections.findIndex((collection) => collection.uid === currentCollectionUid);
+    let otherTab = null
+
+    while (otherTab == null) {
+      index = (index + 1) % collections.length
+      currentCollectionUid = collections[index].uid
+      otherTab = find(tabs, (t) => t.collectionUid === collections[index].uid);
+    }
+    dispatch(
+      focusTab({
+        uid: otherTab.uid
+      })
+    )
+  };
+
   const getTabClassname = (tab, index) => {
     return classnames('request-tab select-none', {
       active: tab.uid === activeTabUid,
@@ -83,7 +102,7 @@ const RequestTabs = () => {
       )}
       {collectionRequestTabs && collectionRequestTabs.length ? (
         <>
-          <CollectionToolBar collection={activeCollection} />
+          <CollectionToolBar collection={activeCollection} onClick={otherCollection} />
           <div className="flex items-center pl-4">
             <ul role="tablist">
               {showChevrons ? (


### PR DESCRIPTION
# Description

When working with more than one collection at the same time, there is no clean way to go there and back again between open requests. The only un-neat way is to select another collection's request from the tree.

This PR enables that, by clicking in collection's name at the top left, will take you to the next open collection. Alternating between collections that have open requests, selecting the first tab in each case. Collections that doesn't have open tabs are skipped.

![image](https://github.com/user-attachments/assets/55e27644-3312-40d9-9fa0-f4762507ccc3)

![image](https://github.com/user-attachments/assets/b951e321-31c4-4c05-bb9d-26ca636f7ad7)


### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

#3395

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


https://github.com/user-attachments/assets/b7f2a01c-f8b7-4787-a5ff-00a405762ed2


