### PR TITLE
refactor: add sanitization for collection and folder name fixes: #160

### DIFF
--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -156,8 +156,12 @@ const searchForBruFiles = (dir) => {
   return searchForFiles(dir, '.bru');
 };
 
+const sanitizeCollectionName = (name) => {
+  return name.trim();
+}
+
 const sanitizeDirectoryName = (name) => {
-  return name.replace(/[<>:"/\\|?*\x00-\x1F]+/g, '-');
+  return name.replace(/[<>:"/\\|?*\x00-\x1F]+/g, '-').trim();
 };
 
 const safeToRename = (oldPath, newPath) => {
@@ -204,5 +208,6 @@ module.exports = {
   searchForFiles,
   searchForBruFiles,
   sanitizeDirectoryName,
+  sanitizeCollectionName,
   safeToRename
 };


### PR DESCRIPTION
fixes: #160 

# Description

This PR implements the logic for sanitizing the collection name and folder name during creation, cloning, or import by trimming leading and trailing spaces, improving navigation between files, and avoiding invalid folder names

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**