### PR TITLE
hide runner response (fixes #3553)

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -6,6 +6,7 @@ import { runCollectionFolder, cancelRunnerExecution } from 'providers/ReduxStore
 import { resetCollectionRunner } from 'providers/ReduxStore/slices/collections';
 import { findItemInCollection, getTotalRequestCountInCollection } from 'utils/collections';
 import { IconRefresh, IconCircleCheck, IconCircleX, IconCheck, IconX, IconRun } from '@tabler/icons';
+import { IconRefresh, IconCircleCheck, IconCircleX, IconCheck, IconX, IconRun,IconEyeOff } from '@tabler/icons';
 import slash from 'utils/common/slash';
 import ResponsePane from './ResponsePane';
 import StyledWrapper from './StyledWrapper';
@@ -183,10 +184,19 @@ export default function RunnerResults({ collection }) {
                     {item.status !== 'error' && item.status !== 'completed' ? (
                       <IconRefresh className="animate-spin ml-1" size={18} strokeWidth={1.5} />
                     ) : item.responseReceived?.status ? (
+
+                      selectedItem && JSON.stringify(item) === JSON.stringify(selectedItem) ? (
+                        <span className="text-xs link cursor-pointer ml-2" onClick={() => setSelectedItem(null)}>
+                          <IconEyeOff size={20} strokeWidth={1.5} />
+                        </span>
+                      ) : (
+
                       <span className="text-xs link cursor-pointer" onClick={() => setSelectedItem(item)}>
                         (<span className="mr-1">{item.responseReceived?.status}</span>
                         <span>{item.responseReceived?.statusText}</span>)
                       </span>
+
+                        )
                     ) : (
                       <span className="danger text-xs cursor-pointer" onClick={() => setSelectedItem(item)}>
                         (request failed)
@@ -264,6 +274,9 @@ export default function RunnerResults({ collection }) {
                   ) : (
                     <IconCircleX className="test-failure" size={20} strokeWidth={1.5} />
                   )}
+                </span>
+                <span className="text-xs link cursor-pointer ml-2" onClick={() => setSelectedItem(null)}>
+                  <IconEyeOff size={20} strokeWidth={1.5} />
                 </span>
               </div>
               {/* <div className='px-3 mb-4 font-medium'>{selectedItem.relativePath}</div> */}


### PR DESCRIPTION
# Description

Allows closing response tabs in runner by clicking in the eye

![image](https://github.com/user-attachments/assets/72dea8c6-eaba-4cab-ba74-788884e497c1)

https://github.com/user-attachments/assets/1c36f4b2-8664-4123-8c18-60147eb7cafc




### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
