### PR TITLE
Prevent data-loss on rename if writing new file fails

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -392,8 +392,9 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       moveRequestUid(oldPath, newPath);
 
       const content = jsonToBru(jsonData);
-      await fs.promises.unlink(oldPath);
+      // we must write the new file first to avoid data loss if an exception occurs during write
       await writeFile(newPath, content);
+      await fs.promises.unlink(oldPath);
 
       return newPath;
     } catch (error) {


### PR DESCRIPTION
# Description

As it currently stands, bruno relies upon itself holding data in memory during rename. If a write operation fails for any reason, we have a very good chance of losing user data. If we do the delete operation after the write, then we instead only risk duplication of data (if the unlink fails), which seems axiomatically correct.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
