### PR TITLE
Feature/switch view request by url

### DIFF
--- a/packages/bruno-app/src/components/Preferences/Display/RequestView/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/Display/RequestView/StyledWrapper.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  color: var(--color-text);
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Preferences/Display/RequestView/index.js
+++ b/packages/bruno-app/src/components/Preferences/Display/RequestView/index.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useFormik } from 'formik';
+import { useSelector, useDispatch } from 'react-redux';
+import * as Yup from 'yup';
+import StyledWrapper from './StyledWrapper';
+import { savePreferences } from 'providers/ReduxStore/slices/app';
+
+const RequestView = () => {
+  const preferences = useSelector((state) => state.app.preferences);
+  const dispatch = useDispatch();
+
+  const formik = useFormik({
+    initialValues: {
+      requestView: preferences.viewRequestBy
+    },
+    validationSchema: Yup.object({
+      requestView: Yup.string().oneOf(['name', 'url']).required('requestView is required')
+    }),
+    onSubmit: async (values) => {
+      handleSave(values);      
+    }
+  });
+
+  const handleSave = (values) => {
+    dispatch(
+      savePreferences({
+        ...preferences,
+        viewRequestBy: values.requestView
+      })
+    )
+    .catch((err) => console.log(err) && toast.error('Failed to update preferences'));
+  };
+
+  return (
+    <StyledWrapper>
+      <div className="bruno-form">
+        <div className="flex items-center mt-2">
+          <input
+            id="name-requestView"
+            className="cursor-pointer"
+            type="radio"
+            name="requestView"
+            onChange={(e) => {
+              formik.handleChange(e);
+              formik.handleSubmit();
+            }}
+            value="name"
+            checked={formik.values.requestView === 'name'}
+          />
+          <label htmlFor="name-requestView" className="ml-1 cursor-pointer select-none">
+            Name
+          </label>
+
+          <input
+            id="url-requestView"
+            className="ml-4 cursor-pointer"
+            type="radio"
+            name="requestView"
+            onChange={(e) => {
+              formik.handleChange(e);
+              formik.handleSubmit();
+            }}
+            value="url"
+            checked={formik.values.requestView === 'url'}
+          />
+          <label htmlFor="url-requestView" className="ml-1 cursor-pointer select-none">
+            Url
+          </label>
+        </div>
+      </div>
+    </StyledWrapper>
+  );
+};
+
+export default RequestView;

--- a/packages/bruno-app/src/components/Preferences/Display/index.js
+++ b/packages/bruno-app/src/components/Preferences/Display/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Font from './Font/index';
 import Theme from './Theme/index';
+import RequestView from './RequestView/index';
 
 const Display = ({ close }) => {
   return (
@@ -10,6 +11,12 @@ const Display = ({ close }) => {
             Theme
           </span>
           <Theme close={close} />
+        </div>
+        <div className='w-full flex flex-col gap-2'>
+          <span>
+            Request View
+          </span>
+          <RequestView close={close} />
         </div>
         <div className='h-[1px] bg-[#aaa5] w-full'></div>
         <div className='w-fit flex flex-col gap-2'>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -162,11 +162,11 @@ const CollectionItem = ({ item, collection, searchText }) => {
 
   if (searchText && searchText.length) {
     if (isItemARequest(item)) {
-      if (!doesRequestMatchSearchText(item, searchText)) {
+      if (!doesRequestMatchSearchText(item, searchText, preferences.viewRequestBy)) {
         return null;
       }
     } else {
-      if (!doesFolderHaveItemsMatchSearchText(item, searchText)) {
+      if (!doesFolderHaveItemsMatchSearchText(item, searchText, preferences.viewRequestBy)) {
         return null;
       }
     }

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -30,6 +30,7 @@ const CollectionItem = ({ item, collection, searchText }) => {
   const tabs = useSelector((state) => state.tabs.tabs);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const isSidebarDragging = useSelector((state) => state.app.isDragging);
+  const preferences = useSelector((state) => state.app.preferences);
   const dispatch = useDispatch();
 
   const [renameItemModalOpen, setRenameItemModalOpen] = useState(false);
@@ -282,7 +283,12 @@ const CollectionItem = ({ item, collection, searchText }) => {
             <div className="ml-1 flex items-center overflow-hidden">
               <RequestMethod item={item} />
               <span className="item-name" title={item.name}>
-                {item.name}
+                { item.type === 'http-request' && preferences.viewRequestBy === 'url' ?
+                    item.request.url.substring(item.request.url.indexOf('/', 8),
+                                              (item.request.url.includes('?') ? item.request.url.indexOf('?') : item.request.url.length)
+                                              )
+                  : item.name
+                }
               </span>
             </div>
           </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -7,7 +7,7 @@ import { IconChevronRight, IconDots } from '@tabler/icons';
 import Dropdown from 'components/Dropdown';
 import { collectionClicked } from 'providers/ReduxStore/slices/collections';
 import { moveItemToRootOfCollection } from 'providers/ReduxStore/slices/collections/actions';
-import { useDispatch } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
 import NewFolder from 'components/Sidebar/NewFolder';
@@ -30,6 +30,7 @@ const Collection = ({ collection, searchText }) => {
   const [showExportCollectionModal, setShowExportCollectionModal] = useState(false);
   const [showRemoveCollectionModal, setShowRemoveCollectionModal] = useState(false);
   const [collectionIsCollapsed, setCollectionIsCollapsed] = useState(collection.collapsed);
+  const preferences = useSelector((state) => state.app.preferences);
   const dispatch = useDispatch();
 
   const menuDropdownTippyRef = useRef();
@@ -104,7 +105,7 @@ const Collection = ({ collection, searchText }) => {
   });
 
   if (searchText && searchText.length) {
-    if (!doesCollectionHaveItemsMatchingSearchText(collection, searchText)) {
+    if (!doesCollectionHaveItemsMatchingSearchText(collection, searchText, preferences.viewRequestBy)) {
       return null;
     }
   }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -24,7 +24,8 @@ const initialState = {
     },
     font: {
       codeFont: 'default'
-    }
+    },
+    viewRequestBy: 'name'
   },
   cookies: [],
   taskQueue: [],

--- a/packages/bruno-app/src/providers/RequestView/index.js
+++ b/packages/bruno-app/src/providers/RequestView/index.js
@@ -1,0 +1,70 @@
+import themes from 'themes/index';
+import useLocalStorage from 'hooks/useLocalStorage/index';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+import { ThemeProvider as SCThemeProvider } from 'styled-components';
+
+export const ThemeContext = createContext();
+export const ThemeProvider = (props) => {
+  const isBrowserThemeLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+  const [displayedTheme, setDisplayedTheme] = useState(isBrowserThemeLight ? 'light' : 'dark');
+  const [storedTheme, setStoredTheme] = useLocalStorage('bruno.theme', 'system');
+  const toggleHtml = () => {
+    const html = document.querySelector('html');
+    if (html) {
+      html.classList.toggle('dark');
+    }
+  };
+
+  useEffect(() => {
+    window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', (e) => {
+      if (storedTheme !== 'system') return;
+      setDisplayedTheme(e.matches ? 'light' : 'dark');
+      toggleHtml();
+    });
+  }, []);
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+    if (storedTheme === 'system') {
+      const isBrowserThemeLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+      setDisplayedTheme(isBrowserThemeLight ? 'light' : 'dark');
+      root.classList.add(isBrowserThemeLight ? 'light' : 'dark');
+    } else {
+      setDisplayedTheme(storedTheme);
+      root.classList.add(storedTheme);
+    }
+  }, [storedTheme, setDisplayedTheme, window.matchMedia]);
+
+  // storedTheme can have 3 values: 'light', 'dark', 'system'
+  // displayedTheme can have 2 values: 'light', 'dark'
+
+  const theme = storedTheme === 'system' ? themes[displayedTheme] : themes[storedTheme];
+  const themeOptions = Object.keys(themes);
+  const value = {
+    theme,
+    themeOptions,
+    storedTheme,
+    displayedTheme,
+    setStoredTheme
+  };
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <SCThemeProvider theme={theme} {...props} />
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+
+  if (context === undefined) {
+    throw new Error(`useTheme must be used within a ThemeProvider`);
+  }
+
+  return context;
+};
+
+export default ThemeProvider;

--- a/packages/bruno-app/src/utils/collections/search.js
+++ b/packages/bruno-app/src/utils/collections/search.js
@@ -2,20 +2,29 @@ import { flattenItems, isItemARequest } from './index';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
 
-export const doesRequestMatchSearchText = (request, searchText = '') => {
-  return request?.name?.toLowerCase().includes(searchText.toLowerCase());
+export const doesRequestMatchSearchText = (item, searchText = '', viewRequestBy = 'name') => {
+  let value = item?.name;
+  
+  if(item.type === 'http-request' && viewRequestBy === 'url' && item?.request?.url){
+    let url = item.request.url;
+
+    value = url.substring(url.indexOf('/', 8),
+                          (url.includes('?') ? url.indexOf('?') : url.length));
+  }
+  
+  return value?.toLowerCase().includes(searchText.toLowerCase());
 };
 
-export const doesFolderHaveItemsMatchSearchText = (item, searchText = '') => {
+export const doesFolderHaveItemsMatchSearchText = (item, searchText = '', viewRequestBy = 'name') => {
   let flattenedItems = flattenItems(item.items);
   let requestItems = filter(flattenedItems, (item) => isItemARequest(item));
 
-  return find(requestItems, (request) => doesRequestMatchSearchText(request, searchText));
+  return find(requestItems, (item) => doesRequestMatchSearchText(item, searchText, viewRequestBy));
 };
 
-export const doesCollectionHaveItemsMatchingSearchText = (collection, searchText = '') => {
+export const doesCollectionHaveItemsMatchingSearchText = (collection, searchText = '', viewRequestBy = 'name') => {
   let flattenedItems = flattenItems(collection.items);
   let requestItems = filter(flattenedItems, (item) => isItemARequest(item));
 
-  return find(requestItems, (request) => doesRequestMatchSearchText(request, searchText));
+  return find(requestItems, (item) => doesRequestMatchSearchText(item, searchText, viewRequestBy));
 };


### PR DESCRIPTION
# Description
Now we can switch request usage for use the name or URL.

We can make choice in Preferences / Display / Request View
![image](https://github.com/user-attachments/assets/f5fda0a4-6ab9-46e7-8310-2e2bd5319e42)

In the left explore we can see request by URL
![image](https://github.com/user-attachments/assets/7f10579e-bbdd-4eea-81ac-70e929625d36)

And use the search bar with part of URL or path parameter
![image](https://github.com/user-attachments/assets/4923e68a-2488-4d9f-bc1d-09126ded884c)


That solve the issue #3181



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
