### PR TITLE
fix: Stale Tabs for Folder Settings on Rename/Delete (fixes: #3606) 

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js
@@ -12,10 +12,15 @@ const DeleteCollectionItem = ({ onClose, item, collection }) => {
   const isFolder = isItemAFolder(item);
   const onConfirm = () => {
     dispatch(deleteItem(item.uid, collection.uid)).then(() => {
+
       if (isFolder) {
+        // close all tabs that belong to the folder
+        // including the folder itself and its children
+        const tabUids = [...recursivelyGetAllItemUids(item.items), item.uid]
+
         dispatch(
           closeTabs({
-            tabUids: recursivelyGetAllItemUids(item.items)
+            tabUids: tabUids
           })
         );
       } else {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import { isItemAFolder } from 'utils/tabs';
 import { renameItem, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import toast from 'react-hot-toast';
+import { closeTabs } from 'providers/ReduxStore/slices/tabs';
 
 const RenameCollectionItem = ({ collection, item, onClose }) => {
   const dispatch = useDispatch();
@@ -33,7 +34,8 @@ const RenameCollectionItem = ({ collection, item, onClose }) => {
       }
       dispatch(renameItem(values.name, item.uid, collection.uid))
         .then(() => {
-          toast.success('Request renamed');
+          dispatch(closeTabs({ tabUids: [item.uid] }));
+          toast.success(isFolder ? 'Folder renamed' : 'Request renamed');
           onClose();
         })
         .catch((err) => {


### PR DESCRIPTION
fixes: #3606 

# Description

This PR resolves the issue of stale folder settings tabs caused when a folder is renamed or deleted. Additionally, I have added a small feature that displays a notification indicating "Folder renamed" if a folder is renamed. Previously, the notification for both requests and folders showed "Request renamed."

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**