### PR TITLE
feat: Add the ability to optionally update an existing collection on import

### DIFF
--- a/packages/bruno-app/src/components/ConfirmCollectionImportUpdate/index.js
+++ b/packages/bruno-app/src/components/ConfirmCollectionImportUpdate/index.js
@@ -1,0 +1,24 @@
+import Modal from 'components/Modal';
+import Portal from 'components/Portal/index';
+
+const ConfirmCollectionImportUpdate = ({ onConfirm, onCancel }) => {
+  return (
+    <Portal>
+      <Modal
+        size="md"
+        title="Update existing collection"
+        confirmText="Yes"
+        cancelText="No"
+        disableEscapeKey={true}
+        disableCloseOnOutsideClick={true}
+        handleConfirm={onConfirm}
+        handleCancel={onCancel}
+        hideClose={true}
+      >
+        <div>Would you like to add to the existing collection at this location?</div>
+      </Modal>
+    </Portal>
+  );
+};
+
+export default ConfirmCollectionImportUpdate;


### PR DESCRIPTION
# Description

This PR adds a new confirmation dialog that allows for a collection import to "update" an existing collection, instead of having this operation always fail as it did before.

Currently, importing a collection that already has a matching directory causes an immediate error. Now, that error is caught and the user will be prompted if they would like to add to the existing collection:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/82394cec-06c5-4e27-89ea-7989de7cfb8e">

If the user chooses to continue with the import, the existing `import-collection` logic will be run in a new `updateExistingCollection` mode, which creates necessary new directories but also traverses existing directories to add items that were parsed from the input file to existing directories.

When working with an OpenAPI spec that is frequently updated, this workflow allows users to add new endpoints from newer versions to an existing collection while preserving their environments and settings. This partially resolves the need detailed in https://github.com/usebruno/bruno/issues/1354.

Future contributions could extend on this feature in a variety of ways:
- Add additional parsing logic in the new method `handleConfirmCollectionImportUpdate` that could check for duplicate requests across the collection, regardless of folder location
    - Currently, if a user has reorganized their collection after importing, it is possible to end up with duplicates
- Add additional options to the new dialog defined in `packages/bruno-app/src/components/ConfirmCollectionImportUpdate` that would allow users to "replace existing endpoints" as well as "add new endpoints." 
    - Currently, existing endpoints are broadly ignored as pre-existing files. However, it would also be possible to overwrite existing endpoints entirely, perhaps to include new schema, or new arguments, if a user wants to do so.

I'm sure there are more ways that this could be built on in the future - this feature itself is fairly simple, but my hope is that it may spawn additional future contributions (from myself, or others) by breaking the assumption that "once a collection is imported, that directory can never be imported into again."

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
    - This PR introduces the ability to add new requests from an imported file to an existing collection, as well as the necessary UI for this feature
- [X] **The pull request does not introduce any breaking changes**
    - This PR only adds additional functionality, and does not change the behavior of the rest of the application
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
    - See above for a screenshot of the new modal being added in this request
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**
    - This PR partially resolves https://github.com/usebruno/bruno/issues/1354, and I have detailed potential future improvements above that would further meet the user need detailed in that issue. These future improvements could themselves be filed as new issues if we think that this PR resolves enough of https://github.com/usebruno/bruno/issues/1354 to consider it "closed."
