### PR TITLE
feat: Add an npm script to run the Electron app for debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build:web": "npm run build --workspace=packages/bruno-app",
     "prettier:web": "npm run prettier --workspace=packages/bruno-app",
     "dev:electron": "npm run dev --workspace=packages/bruno-electron",
+    "dev:electron:debug": "npm run debug --workspace=packages/bruno-electron",
     "build:bruno-common": "npm run build --workspace=packages/bruno-common",
     "build:bruno-query": "npm run build --workspace=packages/bruno-query",
     "build:graphql-docs": "npm run build --workspace=packages/bruno-graphql-docs",
@@ -51,6 +52,6 @@
     "prepare": "husky install"
   },
   "overrides": {
-    "rollup":"3.29.5"
+    "rollup": "3.29.5"
   }
 }

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "dev": "electron .",
+    "debug": "electron . --inspect=9229",
     "dist:mac": "electron-builder --mac --config electron-builder-config.js",
     "dist:win": "electron-builder --win --config electron-builder-config.js",
     "dist:linux": "electron-builder --linux AppImage --config electron-builder-config.js",
@@ -19,7 +20,9 @@
     "test": "node --experimental-vm-modules $(npx which jest)"
   },
   "jest": {
-    "modulePaths": ["node_modules"]
+    "modulePaths": [
+      "node_modules"
+    ]
   },
   "dependencies": {
     "@aws-sdk/credential-providers": "3.658.1",


### PR DESCRIPTION
# Description

This allows for developers to attach Dev Tools, e.g. the Chrome "dedicated DevTools for node", to the main Electron process for debugging operations that occur on the main process when running the Electron app via `npm run dev:electron:debug`.

See https://www.electronjs.org/docs/latest/tutorial/debugging-main-process for reference.

Related to #3614

<!--- This resolves https://github.com/usebruno/bruno/issues/3614 (filed alongside this PR). --->

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**
