### PR TITLE
fix: reorder file operations to ensure proper rename and cleanup (fixes: #3627)

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -369,7 +369,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
           const tempDir = path.join(os.tmpdir(), `temp-folder-${Date.now()}`);
 
           await fsExtra.copy(oldPath, tempDir);
-          await fsExtra.remove(oldPath);
+          await fsExtra.remove(oldPath);    // Remove the old folder before moving the new one because there might be cases where oldPath.toLowerCase() and newPath.toLowerCase() are the same.
           await fsExtra.move(tempDir, newPath, { overwrite: true });
         } else {
           await fs.renameSync(oldPath, newPath);

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -369,8 +369,8 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
           const tempDir = path.join(os.tmpdir(), `temp-folder-${Date.now()}`);
 
           await fsExtra.copy(oldPath, tempDir);
-          await fsExtra.move(tempDir, newPath, { overwrite: true });
           await fsExtra.remove(oldPath);
+          await fsExtra.move(tempDir, newPath, { overwrite: true });
         } else {
           await fs.renameSync(oldPath, newPath);
         }


### PR DESCRIPTION
fixes: #3627

# Description

This PR fixes a bug introduced in PR #3236, which addressed an issue where folders with subfolders couldn't rename the parent folder. The original fix was developed to address two issues: case-insensitive renaming, particularly on Windows and macOS. However, while the step in `tempDir` works fine, we end up with both `temp = folder (oldPath)` and `newPath = Folder (newPath)`, which causes an issue where the `tempDir` file gets stuck in the temporary directory. 

To resolve this, I have added logic to completely remove the contents of the old path before moving the `tempDir` files into the new path. This should fix both the case-insensitive rename issue and the problem of being unable to rename the parent folder.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**