### PR TITLE
fix: handle Windows paths in cloneItem and getDirectoryName functions (fixes: #3401)

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -21,7 +21,7 @@ import {
   transformRequestToSaveToFilesystem
 } from 'utils/collections';
 import { uuid, waitForNextTick } from 'utils/common';
-import { PATH_SEPARATOR, getDirectoryName } from 'utils/common/platform';
+import { PATH_SEPARATOR, getDirectoryName, isWindowsPath } from 'utils/common/platform';
 import { cancelNetworkRequest, sendNetworkRequest } from 'utils/network';
 
 import {
@@ -494,7 +494,7 @@ export const cloneItem = (newName, itemUid, collectionUid) => (dispatch, getStat
       );
       if (!reqWithSameNameExists) {
         const dirname = getDirectoryName(item.pathname);
-        const fullName = path.join(dirname, filename);
+        const fullName = isWindowsPath(item.pathname) ? path.win32.join(dirname, filename) : path.join(dirname, filename);
         const { ipcRenderer } = window;
         const requestItems = filter(parentItem.items, (i) => i.type !== 'folder');
         itemToSave.seq = requestItems ? requestItems.length + 1 : 1;

--- a/packages/bruno-app/src/utils/common/platform.js
+++ b/packages/bruno-app/src/utils/common/platform.js
@@ -24,11 +24,28 @@ export const getSubdirectoriesFromRoot = (rootPath, pathname) => {
   return relativePath ? relativePath.split(path.sep) : [];
 };
 
+
+export const isWindowsPath = (pathname) => {
+
+  if (!isWindowsOS()) {
+    return false;
+  }
+
+  // Check for Windows drive letter format (e.g., "C:\")
+  const hasDriveLetter = /^[a-zA-Z]:\\/.test(pathname);
+  
+  // Check for UNC path format (e.g., "\\server\share") a.k.a. network path || WSL path
+  const isUNCPath = pathname.startsWith('\\\\');
+
+  return hasDriveLetter || isUNCPath;
+};
+
+
 export const getDirectoryName = (pathname) => {
   // convert to unix style path
-  pathname = slash(pathname);
+  // pathname = slash(pathname);
 
-  return path.dirname(pathname);
+  return isWindowsPath(pathname) ? path.win32.dirname(pathname) : path.dirname(pathname);
 };
 
 export const isWindowsOS = () => {

--- a/packages/bruno-app/src/utils/common/platform.js
+++ b/packages/bruno-app/src/utils/common/platform.js
@@ -42,9 +42,6 @@ export const isWindowsPath = (pathname) => {
 
 
 export const getDirectoryName = (pathname) => {
-  // convert to unix style path
-  // pathname = slash(pathname);
-
   return isWindowsPath(pathname) ? path.win32.dirname(pathname) : path.dirname(pathname);
 };
 


### PR DESCRIPTION
fixes: #3401 

# Description

This PR implements a feature to better handle path functions between Windows OS and other systems based on the nature of the path. It resolves the issue mentioned above, where a WSL request cannot be cloned if it is present in a folder.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**