### PR TITLE
fix: update content-type header for XML requests to application/xml

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -318,7 +318,7 @@ const prepareRequest = (item = {}, collection = {}) => {
 
   if (request.body.mode === 'xml') {
     if (!contentTypeDefined) {
-      axiosRequest.headers['content-type'] = 'text/xml';
+      axiosRequest.headers['content-type'] = 'application/xml';
     }
     axiosRequest.data = request.body.xml;
   }

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -414,7 +414,7 @@ const prepareRequest = (item, collection) => {
 
   if (request.body.mode === 'xml') {
     if (!contentTypeDefined) {
-      axiosRequest.headers['content-type'] = 'text/xml';
+      axiosRequest.headers['content-type'] = 'application/xml';
     }
     axiosRequest.data = request.body.xml;
   }


### PR DESCRIPTION
fixes: #398 

# Description

This PR implements a fix for issue #398 by setting the `content-type` to `application/xml` instead of `text/xml` in both **Bruno** and **@usebruno/cli** as per [RFC 7303](https://www.rfc-editor.org/rfc/rfc7303)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:
![image](https://github.com/user-attachments/assets/02ddf573-dc0a-4863-bc8b-f8d4e128b02d)

After:
![image](https://github.com/user-attachments/assets/d898afc0-477f-4cda-9d47-7fac15cff56c)
