### PR TITLE
feature: 

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Headers/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Headers/StyledWrapper.js
@@ -25,7 +25,7 @@ const Wrapper = styled.div`
       }
 
       &:nth-child(3) {
-        width: 70px;
+        width: 85px;
       }
     }
   }

--- a/packages/bruno-app/src/components/CollectionSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Headers/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
-import { IconTrash } from '@tabler/icons';
+import { IconTrash, IconCopy } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import {
   addCollectionHeader,
+  cloneCollectionHeader,
   updateCollectionHeader,
   deleteCollectionHeader
 } from 'providers/ReduxStore/slices/collections';
@@ -49,6 +50,16 @@ const Headers = ({ collection }) => {
     dispatch(
       updateCollectionHeader({
         header: header,
+        collectionUid: collection.uid
+      })
+    );
+  };
+
+  const cloneHeader = (header) => {
+    dispatch(
+      cloneCollectionHeader({
+        header: header,
+        itemUid: item.uid,
         collectionUid: collection.uid
       })
     );
@@ -130,6 +141,10 @@ const Headers = ({ collection }) => {
                           className="mr-3 mousetrap"
                           onChange={(e) => handleHeaderValueChange(e, header, 'enabled')}
                         />
+                        <button tabIndex="-1" onClick={() => cloneHeader(header)}>
+                          <IconCopy strokeWidth={1.5} size={20} />
+                        </button>
+                        &nbsp;
                         <button tabIndex="-1" onClick={() => handleRemoveHeader(header)}>
                           <IconTrash strokeWidth={1.5} size={20} />
                         </button>

--- a/packages/bruno-app/src/components/FolderSettings/Headers/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/StyledWrapper.js
@@ -25,7 +25,7 @@ const Wrapper = styled.div`
       }
 
       &:nth-child(3) {
-        width: 70px;
+        width: 85px;
       }
     }
   }

--- a/packages/bruno-app/src/components/FolderSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/index.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
-import { IconTrash } from '@tabler/icons';
+import { IconTrash, IconCopy } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
-import { addFolderHeader, updateFolderHeader, deleteFolderHeader } from 'providers/ReduxStore/slices/collections';
+import {
+  addFolderHeader,
+  cloneFolderHeader,
+  updateFolderHeader,
+  deleteFolderHeader
+} from 'providers/ReduxStore/slices/collections';
 import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions';
 import SingleLineEditor from 'components/SingleLineEditor';
 import StyledWrapper from './StyledWrapper';
@@ -47,6 +52,16 @@ const Headers = ({ collection, folder }) => {
         header: header,
         collectionUid: collection.uid,
         folderUid: folder.uid
+      })
+    );
+  };
+
+  const cloneHeader = (header) => {
+    dispatch(
+      cloneFolderHeader({
+        header: header,
+        itemUid: item.uid,
+        collectionUid: collection.uid
       })
     );
   };
@@ -128,6 +143,10 @@ const Headers = ({ collection, folder }) => {
                           className="mr-3 mousetrap"
                           onChange={(e) => handleHeaderValueChange(e, header, 'enabled')}
                         />
+                        <button tabIndex="-1" onClick={() => handleRemoveHeader(header)}>
+                          <IconCopy strokeWidth={1.5} size={20} />
+                        </button>
+                        &nbsp;
                         <button tabIndex="-1" onClick={() => handleRemoveHeader(header)}>
                           <IconTrash strokeWidth={1.5} size={20} />
                         </button>

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
@@ -25,7 +25,7 @@ const Wrapper = styled.div`
       }
 
       &:nth-child(3) {
-        width: 70px;
+        width: 85px;
       }
     }
   }

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
-import { IconTrash } from '@tabler/icons';
+import { IconCopy, IconTrash } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
-import { addRequestHeader, updateRequestHeader, deleteRequestHeader } from 'providers/ReduxStore/slices/collections';
+import {
+  addRequestHeader,
+  cloneRequestHeader,
+  updateRequestHeader,
+  deleteRequestHeader
+} from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import SingleLineEditor from 'components/SingleLineEditor';
 import StyledWrapper from './StyledWrapper';
@@ -46,6 +51,16 @@ const RequestHeaders = ({ item, collection }) => {
     }
     dispatch(
       updateRequestHeader({
+        header: header,
+        itemUid: item.uid,
+        collectionUid: collection.uid
+      })
+    );
+  };
+
+  const cloneHeader = (header) => {
+    dispatch(
+      cloneRequestHeader({
         header: header,
         itemUid: item.uid,
         collectionUid: collection.uid
@@ -131,6 +146,10 @@ const RequestHeaders = ({ item, collection }) => {
                           className="mr-3 mousetrap"
                           onChange={(e) => handleHeaderValueChange(e, header, 'enabled')}
                         />
+                        <button tabIndex="-1" onClick={() => cloneHeader(header)}>
+                          <IconCopy strokeWidth={1.5} size={20} />
+                        </button>
+                        &nbsp;
                         <button tabIndex="-1" onClick={() => handleRemoveHeader(header)}>
                           <IconTrash strokeWidth={1.5} size={20} />
                         </button>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -656,6 +656,27 @@ export const collectionsSlice = createSlice({
         }
       }
     },
+    cloneRequestHeader: (state, action) => {
+      const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
+
+      if (collection) {
+        const item = findItemInCollection(collection, action.payload.itemUid);
+
+        if (item && isItemARequest(item)) {
+          if (!item.draft) {
+            item.draft = cloneDeep(item);
+          }
+          item.draft.request.headers = item.draft.request.headers || [];
+          item.draft.request.headers.push({
+            uid: uuid(),
+            name: action.payload.header.name,
+            value: action.payload.header.value,
+            description: action.payload.header.description,
+            enabled: action.payload.header.enabled
+          });
+        }
+      }
+    },
     updateRequestHeader: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
 
@@ -1772,6 +1793,7 @@ export const {
   deleteQueryParam,
   updatePathParam,
   addRequestHeader,
+  cloneRequestHeader,
   updateRequestHeader,
   deleteRequestHeader,
   addFormUrlEncodedParam,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1218,6 +1218,21 @@ export const collectionsSlice = createSlice({
         set(folder, 'root.request.headers', headers);
       }
     },
+    cloneFolderHeader: (state, action) => {
+      const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
+      const folder = collection ? findItemInCollection(collection, action.payload.folderUid) : null;
+      if (folder) {
+        const headers = get(folder, 'root.request.headers', []);
+        headers.push({
+          uid: uuid(),
+          name: action.payload.header.name,
+          value: action.payload.header.value,
+          description: action.payload.header.description,
+          enabled: action.payload.header.enabled
+        });
+        set(folder, 'root.request.headers', headers);
+      }
+    },
     updateFolderHeader: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
       const folder = collection ? findItemInCollection(collection, action.payload.folderUid) : null;
@@ -1343,6 +1358,21 @@ export const collectionsSlice = createSlice({
           value: '',
           description: '',
           enabled: true
+        });
+        set(collection, 'root.request.headers', headers);
+      }
+    },
+    cloneCollectionHeader: (state, action) => {
+      const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
+
+      if (collection) {
+        const headers = get(collection, 'root.request.headers', []);
+        headers.push({
+          uid: uuid(),
+          name: action.payload.header.name,
+          value: action.payload.header.value,
+          description: action.payload.header.description,
+          enabled: action.payload.header.enabled
         });
         set(collection, 'root.request.headers', headers);
       }
@@ -1818,6 +1848,7 @@ export const {
   updateVar,
   deleteVar,
   addFolderHeader,
+  cloneFolderHeader,
   updateFolderHeader,
   deleteFolderHeader,
   addFolderVar,
@@ -1827,6 +1858,7 @@ export const {
   updateFolderResponseScript,
   updateFolderTests,
   addCollectionHeader,
+  cloneCollectionHeader,
   updateCollectionHeader,
   deleteCollectionHeader,
   addCollectionVar,


### PR DESCRIPTION
# Description

As in #3649, a button to clone a row in the header table
Row cloned is placed at the bottom of the table, and contains all attributes of the row

For parity, code exists for:
- request
- folder
- collection

I'm not familiar with tailwind, and I'm happy for changes to be made to my crude usage of `&nbsp;` to space the buttons, as I'm sure such a solution exists

Existing state:
![image](https://github.com/user-attachments/assets/9d8fc647-efe9-4086-9214-fdd6eeb347d9)

After changes:

Request:
![image](https://github.com/user-attachments/assets/b86ce377-a11a-4f47-a415-30b52b16e429)

Folder:
![image](https://github.com/user-attachments/assets/e457a2fb-4e76-456f-9a07-5b932d3a72ad)

Collection:
![image](https://github.com/user-attachments/assets/17c880e0-ebc7-475a-a9e1-808796bb5d89)




I'd like to add that the level of code duplication in the project makes it unwelcoming to contribute too. It is also one of the reasons that this PR is only for headers, as covering every row usage (that I can see) expands a simple change to 9 different cases, which could reasonably be two or three, and code tallying well over 100 lines. That is not a small change in my view

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
