### PR TITLE
feat: handle korean as a valid file name component

### DIFF
--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -70,16 +70,26 @@ export const safeParseXML = (str, options) => {
   }
 };
 
-// Remove any characters that are not alphanumeric, spaces, hyphens, or underscores
 export const normalizeFileName = (name) => {
   if (!name) {
     return name;
   }
 
-  const validChars = /[^\w\s-]/g;
-  const formattedName = name.replace(validChars, '-');
+  // alphanumerics, spaces, underscores, hyphens
+  const baseValidExpression = '\\w\\s-';
+  const additionalValidExpressions = [
+    'ㄱ-ㅎ|ㅏ-ㅣ|가-힣',  // Korean
+  ];
 
-  return formattedName;
+  const validExpression = [
+    baseValidExpression,
+    ...additionalValidExpressions,
+  ].join('|');
+
+  const invalidCharRegex = new RegExp(`[^${validExpression}]`, 'g')
+  const normalizedFileName = name.replace(invalidCharRegex, '-');
+
+  return normalizedFileName;
 };
 
 export const getContentType = (headers) => {


### PR DESCRIPTION
# Description

Bruno doesn't consider Korean character as a valid input when importing postman collection, thus replacing then with hyphens as in #3651.
This PR handle Korean characters as a valid file name and eventually importing postman collection with Korean characters in it doesn't break collection/file names.
![20241214-122300+899569620](https://github.com/user-attachments/assets/27d8520f-55f3-4436-bc11-bd2771f79785)

Resolves #3651


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

