### PR TITLE
fix: add lodash import for utility functions

### DIFF
--- a/packages/bruno-app/src/utils/importers/common.js
+++ b/packages/bruno-app/src/utils/importers/common.js
@@ -1,5 +1,6 @@
 import each from 'lodash/each';
 import get from 'lodash/get';
+import _ from 'lodash';
 
 import cloneDeep from 'lodash/cloneDeep';
 import { uuid, normalizeFileName } from 'utils/common';


### PR DESCRIPTION
# Description

Added a missing import for lodash to enable the use of lodash functions.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**