### PR TITLE
fix: JSON response with only string not showing properly

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -19,6 +19,8 @@ const formatResponse = (data, mode, filter) => {
     return '';
   }
 
+  console.log(JSON.stringify(data), "data in formate")
+
   if (data === null) {
     return data;
   }
@@ -32,8 +34,8 @@ const formatResponse = (data, mode, filter) => {
       console.log('Error parsing JSON: ', error.message);
     }
 
-    if (!isValidJSON && typeof data === 'string') {
-      return data;
+    if (!isValidJSON) {
+      return JSON.stringify(data);
     }
 
     if (filter) {

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -19,8 +19,6 @@ const formatResponse = (data, mode, filter) => {
     return '';
   }
 
-  console.log(JSON.stringify(data), "data in formate")
-
   if (data === null) {
     return data;
   }


### PR DESCRIPTION
# Description

Ensured data is returned as a JSON string, retaining quotes, even when the input is not valid JSON. This improves the display consistency for string and empty string values. Added JSON.stringify to handle non-JSON data types and ensure proper string representation.

Addressing issues: #3676 and #3594 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
