### PR TITLE
feat: open setting for folder and collection when

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -128,13 +128,23 @@ const CollectionItem = ({ item, collection, searchText }) => {
       );
       return;
     }
+      dispatch(
+        addTab({
+          uid: item.uid,
+          collectionUid: collection.uid,
+          type: 'folder-settings'
+        })
+      );
+  };
+
+  const handleFolderCollapse = () => {
     dispatch(
       collectionFolderClicked({
         itemUid: item.uid,
         collectionUid: collection.uid
       })
     );
-  };
+  }
 
   const handleRightClick = (event) => {
     const _menuDropdown = dropdownTippyRef.current;
@@ -260,9 +270,6 @@ const CollectionItem = ({ item, collection, searchText }) => {
               })
             : null}
           <div
-            onClick={handleClick}
-            onContextMenu={handleRightClick}
-            onDoubleClick={handleDoubleClick}
             className="flex flex-grow items-center h-full overflow-hidden"
             style={{
               paddingLeft: 8
@@ -275,11 +282,17 @@ const CollectionItem = ({ item, collection, searchText }) => {
                   strokeWidth={2}
                   className={iconClassName}
                   style={{ color: 'rgb(160 160 160)' }}
+                  onClick={handleFolderCollapse}
                 />
               ) : null}
             </div>
 
-            <div className="ml-1 flex items-center overflow-hidden">
+            <div 
+              className="ml-1 flex items-center overflow-hidden flex-1" 
+              onClick={handleClick}
+              onContextMenu={handleRightClick}
+              onDoubleClick={handleDoubleClick}
+            >
               <RequestMethod item={item} />
               <span className="item-name" title={item.name}>
                 {item.name}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -141,16 +141,17 @@ const Collection = ({ collection, searchText }) => {
       <div className="flex py-1 collection-name items-center" ref={drop}>
         <div
           className="flex flex-grow items-center overflow-hidden"
-          onClick={handleClick}
-          onContextMenu={handleRightClick}
         >
           <IconChevronRight
             size={16}
             strokeWidth={2}
             className={iconClassName}
             style={{ width: 16, minWidth: 16, color: 'rgb(160 160 160)' }}
+            onClick={handleClick}
           />
-          <div className="ml-1" id="sidebar-collection-name">
+          <div className="ml-1" id="sidebar-collection-name"    
+            onClick={viewCollectionSettings}
+            onContextMenu={handleRightClick}>
             {collection.name}
           </div>
         </div>


### PR DESCRIPTION
# Description

when we are clicking on any collection or folder in the sidebar it should open that collection/folder setting

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

https://github.com/user-attachments/assets/fa1c55e5-e10c-4c9f-a28b-6c7308b91687


