### PR TITLE
fix: enhance keyboard navigation for language selection in `GenerateCodeItem`

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index.js
@@ -63,22 +63,21 @@ const GenerateCodeItem = ({ collection, item, onClose }) => {
                     tabIndex={0}
                     onClick={() => setSelectedLanguage(language)}
                     onKeyDown={(e) => {
-                      if (e.key === 'Tab') {
+                      if (e.key === 'Tab' || (e.shiftKey && e.key === 'Tab')) {
                         e.preventDefault();
                         const currentIndex = languages.findIndex((lang) => lang.name === selectedLanguage.name);
                         const nextIndex = e.shiftKey
                           ? (currentIndex - 1 + languages.length) % languages.length
                           : (currentIndex + 1) % languages.length;
                         setSelectedLanguage(languages[nextIndex]);
-                      }
 
-                      if (e.shiftKey && e.key === 'Tab') {
-                        e.preventDefault();
-                        const currentIndex = languages.findIndex((lang) => lang.name === selectedLanguage.name);
-                        const nextIndex = (currentIndex - 1 + languages.length) % languages.length;
-                        setSelectedLanguage(languages[nextIndex]);
+                        // Explicitly focus on the new active element
+                        const nextElement = document.querySelector(`[data-language="${languages[nextIndex].name}"]`);
+                        nextElement?.focus();
                       }
+                      
                     }}
+                    data-language={language.name}
                     aria-pressed={language.name === selectedLanguage.name}
                   >
                     <span className="capitalize">{language.name}</span>
@@ -89,6 +88,7 @@ const GenerateCodeItem = ({ collection, item, onClose }) => {
           <div className="flex-grow p-4">
             {isValidUrl(finalUrl) ? (
               <CodeView
+                tabIndex={-1}
                 language={selectedLanguage}
                 item={{
                   ...item,


### PR DESCRIPTION
# Description

This PR enhances the UI and accessibility of the `GenerateCodeItem` component by improving the `tabIndex` management for seamless navigation.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**


Before:

https://github.com/user-attachments/assets/ecadb8d3-8285-4e2d-ab8c-cb09791ff35b

After:

https://github.com/user-attachments/assets/ff8448fa-0d17-49da-aefc-218d2c81b4a4
