### PR TITLE
fix: collection/folder docs when importing postman collection

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -199,6 +199,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
         type: 'folder',
         items: [],
         root: {
+          docs: i.description ? i.description : '',
           meta: {
             name: folderName
           },
@@ -226,6 +227,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
 
       brunoParent.items.push(brunoFolderItem);
       folderMap[folderName] = brunoFolderItem;
+
     } else {
       if (i.request) {
         const baseRequestName = i.name;
@@ -483,6 +485,7 @@ const importPostmanV2Collection = (collection, options) => {
     items: [],
     environments: [],
     root: {
+      docs: collection.info.description ? collection.info.description :'',
       meta: {
         name: collection.info.name
       },

--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -199,7 +199,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
         type: 'folder',
         items: [],
         root: {
-          docs: i.description ? i.description : '',
+          docs: i.description || '',
           meta: {
             name: folderName
           },
@@ -485,7 +485,7 @@ const importPostmanV2Collection = (collection, options) => {
     items: [],
     environments: [],
     root: {
-      docs: collection.info.description ? collection.info.description :'',
+      docs: collection.info.description || '',
       meta: {
         name: collection.info.name
       },


### PR DESCRIPTION
# Description

collection/folder level docs were not getting added when importing postman collection

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**


https://github.com/user-attachments/assets/81c2695c-0b8f-4671-9d17-d699eec49161
