### PR TITLE
fix: file input element - replace the deprecated path prop

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
@@ -68,12 +68,13 @@ const ClientCertSettings = ({ root, clientCertConfig, onUpdate, onRemove }) => {
   });
 
   const getFile = (e) => {
-    if (e.files?.[0]?.path) {
+    const filePath = window?.ipcRenderer?.getFilePath(e?.files?.[0]);
+    if (filePath) {
       let relativePath;
       if (isWindowsOS()) {
-        relativePath = slash(path.win32.relative(root, e.files[0].path));
+        relativePath = slash(path.win32.relative(root, filePath));
       } else {
-        relativePath = path.posix.relative(root, e.files[0].path);
+        relativePath = path.posix.relative(root, filePath);
       }
       formik.setFieldValue(e.name, relativePath);
     }

--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -90,7 +90,10 @@ const General = ({ close }) => {
   };
 
   const addCaCertificate = (e) => {
-    formik.setFieldValue('customCaCertificate.filePath', e.target.files[0]?.path);
+    const filePath = window?.ipcRenderer?.getFilePath(e?.target?.files?.[0]);
+    if (filePath) {
+      formik.setFieldValue('customCaCertificate.filePath', filePath);
+    }
   };
 
   const deleteCaCertificate = () => {

--- a/packages/bruno-electron/src/preload.js
+++ b/packages/bruno-electron/src/preload.js
@@ -1,4 +1,4 @@
-const { ipcRenderer, contextBridge } = require('electron');
+const { ipcRenderer, contextBridge, webUtils } = require('electron');
 
 contextBridge.exposeInMainWorld('ipcRenderer', {
   invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
@@ -10,5 +10,9 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
     return () => {
       ipcRenderer.removeListener(channel, subscription);
     };
+  },
+  getFilePath (file) {
+    const path = webUtils.getPathForFile(file)
+    return path;
   }
 });


### PR DESCRIPTION
fixes: #3754 

the nonstandard `path` property of the `Web File` object, added in early electron versions for convenience, has been removed starting with electron 32.0 due to security concerns and deviation from standards. It is now replaced by the [webUtils.getPathForFile](https://github.com/electron/electron/blob/main/docs/api/web-utils.md#webutilsgetpathforfilefile) method.

source: https://github.com/electron/electron/blob/main/docs/breaking-changes.md#removed-filepath