### PR TITLE
fix: cli -- collection run -- clone request item at start

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const chalk = require('chalk');
 const path = require('path');
-const { forOwn } = require('lodash');
+const { forOwn, cloneDeep } = require('lodash');
 const { exists, isFile, isDirectory } = require('../utils/filesystem');
 const { runSingleRequest } = require('../runner/run-single-request');
 const { bruToEnvJson, getEnvVars } = require('../utils/bru');
@@ -637,7 +637,7 @@ const handler = async function (argv) {
     let currentRequestIndex = 0;
     let nJumps = 0; // count the number of jumps to avoid infinite loops
     while (currentRequestIndex < bruJsons.length) {
-      const iter = bruJsons[currentRequestIndex];
+      const iter = cloneDeep(bruJsons[currentRequestIndex]);
       const { bruFilepath, bruJson } = iter;
 
       const start = process.hrtime();


### PR DESCRIPTION
fixes: #3748 for cli

~ fixes the issue where the execution count of the collection post-response script increases with each `setNextRequest` call.
~ the original request object was being modified, and `setNextRequest` was using the modified request with the merged collection post-response script, instead of an unmodified one.

solution:
clone the request item before every execution

before:
<img width="395" alt="before" src="https://github.com/user-attachments/assets/67e6462e-0dea-4565-b6ee-7fb069baf975" />

---

after:
<img width="353" alt="after" src="https://github.com/user-attachments/assets/9e22fe34-0f8a-49c9-a921-9bbad46b54eb" />
