### PR TITLE
fix: allow node core modules in developer mode

### DIFF
--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -120,6 +120,7 @@ class ScriptRuntime {
       sandbox: context,
       require: {
         context: 'sandbox',
+        builtin: [ "*" ],
         external: true,
         root: [collectionPath, ...additionalContextRootsAbsolute],
         mock: {
@@ -246,6 +247,7 @@ class ScriptRuntime {
       sandbox: context,
       require: {
         context: 'sandbox',
+        builtin: [ "*" ],
         external: true,
         root: [collectionPath],
         mock: {


### PR DESCRIPTION
~ enables usage of node's core modules in developer mode

<img width="1106" alt="node_core_modules_usage" src="https://github.com/user-attachments/assets/4c661404-e954-4ffc-be87-2cd116e01028" />
