### PR TITLE
Bugfix/remove disclaimer

### DIFF
--- a/packages/bruno-app/src/components/Documentation/index.js
+++ b/packages/bruno-app/src/components/Documentation/index.js
@@ -39,7 +39,7 @@ const Documentation = ({ item, collection }) => {
   return (
     <StyledWrapper className="flex flex-col gap-y-1 h-full w-full relative">
       <div className="editing-mode" role="tab" onClick={toggleViewMode}>
-        {isEditing ? 'Preview' : 'Edit'}
+        {isEditing ? 'Preview1' : 'Edit'}
       </div>
 
       {isEditing ? (

--- a/packages/bruno-app/src/components/Documentation/index.js
+++ b/packages/bruno-app/src/components/Documentation/index.js
@@ -39,7 +39,7 @@ const Documentation = ({ item, collection }) => {
   return (
     <StyledWrapper className="flex flex-col gap-y-1 h-full w-full relative">
       <div className="editing-mode" role="tab" onClick={toggleViewMode}>
-        {isEditing ? 'Preview1' : 'Edit'}
+        {isEditing ? 'Preview' : 'Edit'}
       </div>
 
       {isEditing ? (

--- a/packages/bruno-app/src/components/RemoveButton/index.js
+++ b/packages/bruno-app/src/components/RemoveButton/index.js
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import { IconTrash, IconAlertCircle } from '@tabler/icons';
+
+const RemoveButton = ({ onClick }) => {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const CONFIRM_DURATION = 3000; // 3 seconds
+
+  useEffect(() => {
+    let timer;
+    if (isConfirming) {
+      timer = setTimeout(() => {
+        setIsConfirming(false);
+      }, CONFIRM_DURATION);
+    }
+    return () => clearTimeout(timer);
+  }, [isConfirming]);
+
+  const handleClick = () => {
+    if (isConfirming) {
+      onClick();
+      setIsConfirming(false);
+    } else {
+      setIsConfirming(true);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`flex items-center justify-center ${
+        isConfirming && 'text-yellow-500 hover:text-yellow-700'
+      } focus:outline-none transition-colors duration-300`}
+      aria-label={isConfirming ? 'Confirm delete' : 'Delete'}
+    >
+      {isConfirming ? (
+        <IconAlertCircle strokeWidth={1.5} size={20} />
+      ) : (
+        <IconTrash strokeWidth={1.5} size={20} />
+      )}
+    </button>
+  );
+};
+
+export default RemoveButton;

--- a/packages/bruno-app/src/components/RequestPane/Assertions/AssertionRow/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/AssertionRow/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { IconTrash } from '@tabler/icons';
 import SingleLineEditor from 'components/SingleLineEditor';
 import AssertionOperator from '../AssertionOperator';
 import { useTheme } from 'providers/Theme';
+import RemoveButton from 'components/RemoveButton/index';
 
 /**
  * Assertion operators
@@ -211,9 +211,7 @@ const AssertionRow = ({
             className="mr-3 mousetrap"
             onChange={(e) => handleAssertionChange(e, assertion, 'enabled')}
           />
-          <button tabIndex="-1" onClick={() => handleRemoveAssertion(assertion)}>
-            <IconTrash strokeWidth={1.5} size={20} />
-          </button>
+          <RemoveButton onClick={() => handleRemoveAssertion(assertion)} />
         </div>
       </td>
     </tr>

--- a/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
-import { IconTrash } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import {
@@ -12,6 +11,7 @@ import {
 import MultiLineEditor from 'components/MultiLineEditor';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import StyledWrapper from './StyledWrapper';
+import RemoveButton from 'components/RemoveButton/index';
 
 const FormUrlEncodedParams = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -122,9 +122,7 @@ const FormUrlEncodedParams = ({ item, collection }) => {
                           className="mr-3 mousetrap"
                           onChange={(e) => handleParamChange(e, param, 'enabled')}
                         />
-                        <button tabIndex="-1" onClick={() => handleRemoveParams(param)}>
-                          <IconTrash strokeWidth={1.5} size={20} />
-                        </button>
+                        <RemoveButton onClick={() => handleRemoveParams(param)} />
                       </div>
                     </td>
                   </tr>

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
-import { IconTrash } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import {
@@ -13,6 +12,7 @@ import MultiLineEditor from 'components/MultiLineEditor';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import StyledWrapper from './StyledWrapper';
 import FilePickerEditor from 'components/FilePickerEditor';
+import RemoveButton from 'components/RemoveButton';
 
 const MultipartFormParams = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -180,9 +180,7 @@ const MultipartFormParams = ({ item, collection }) => {
                           className="mr-3 mousetrap"
                           onChange={(e) => handleParamChange(e, param, 'enabled')}
                         />
-                        <button tabIndex="-1" onClick={() => handleRemoveParams(param)}>
-                          <IconTrash strokeWidth={1.5} size={20} />
-                        </button>
+                        <RemoveButton onClick={() => handleRemoveParams(param)} />
                       </div>
                     </td>
                   </tr>

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 import InfoTip from 'components/InfoTip';
-import { IconTrash } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import {
@@ -18,6 +17,7 @@ import { saveRequest, sendRequest } from 'providers/ReduxStore/slices/collection
 import StyledWrapper from './StyledWrapper';
 import Table from 'components/Table/index';
 import ReorderTable from 'components/ReorderTable';
+import RemoveButton from 'components/RemoveButton';
 
 const QueryParams = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -160,9 +160,7 @@ const QueryParams = ({ item, collection }) => {
                           className="mr-3 mousetrap"
                           onChange={(e) => handleQueryParamChange(e, param, 'enabled')}
                         />
-                        <button tabIndex="-1" onClick={() => handleRemoveQueryParam(param)}>
-                          <IconTrash strokeWidth={1.5} size={20} />
-                        </button>
+                        <RemoveButton onClick={() => handleRemoveQueryParam(param)} />
                       </div>
                     </td>
                   </tr>

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
-import { IconTrash } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import { addRequestHeader, updateRequestHeader, deleteRequestHeader } from 'providers/ReduxStore/slices/collections';
@@ -10,6 +9,7 @@ import SingleLineEditor from 'components/SingleLineEditor';
 import StyledWrapper from './StyledWrapper';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
 import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
+import RemoveButton from 'components/RemoveButton/index';
 const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
 
 const RequestHeaders = ({ item, collection }) => {
@@ -131,9 +131,7 @@ const RequestHeaders = ({ item, collection }) => {
                           className="mr-3 mousetrap"
                           onChange={(e) => handleHeaderValueChange(e, header, 'enabled')}
                         />
-                        <button tabIndex="-1" onClick={() => handleRemoveHeader(header)}>
-                          <IconTrash strokeWidth={1.5} size={20} />
-                        </button>
+                        <RemoveButton onClick={() => handleRemoveHeader(header)} />
                       </div>
                     </td>
                   </tr>

--- a/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
-import { IconTrash } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import { addVar, updateVar, deleteVar } from 'providers/ReduxStore/slices/collections';
@@ -10,6 +9,7 @@ import InfoTip from 'components/InfoTip';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
+import RemoveButton from 'components/RemoveButton/index';
 
 const VarsTable = ({ item, collection, vars, varType }) => {
   const dispatch = useDispatch();
@@ -143,9 +143,7 @@ const VarsTable = ({ item, collection, vars, varType }) => {
                           className="mr-3 mousetrap"
                           onChange={(e) => handleVarChange(e, _var, 'enabled')}
                         />
-                        <button tabIndex="-1" onClick={() => handleRemoveVar(_var)}>
-                          <IconTrash strokeWidth={1.5} size={20} />
-                        </button>
+                        <RemoveButton onClick={() => handleRemoveVar(_var)} />
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
# Description

Addressing issue: #3633 

This PR Addresses the issue of accidental deletions by introducing a two-step process for deleting variables (params, body, vars, headers, and assert). Instead of immediate deletion upon clicking the delete icon, the icon now transforms into a disclaimer icon, requiring a second click to confirm the deletion. This change reduces the risk of unintentional deletions and enhances user experience by adding a layer of confirmation before removing any items.




### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/86dc0ebf-cc92-4828-8dde-1ca417104e34


