### PR TITLE
Added a menu-item to show Folder and Requests in native file-browser

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -6,7 +6,7 @@ import { useDrag, useDrop } from 'react-dnd';
 import { IconChevronRight, IconDots } from '@tabler/icons';
 import { useSelector, useDispatch } from 'react-redux';
 import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
-import { moveItem, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { moveItem, revealInFinder, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { collectionFolderClicked } from 'providers/ReduxStore/slices/collections';
 import Dropdown from 'components/Dropdown';
 import NewRequest from 'components/Sidebar/NewRequest';
@@ -220,6 +220,12 @@ const CollectionItem = ({ item, collection, searchText }) => {
     }
   };
 
+  const handleReveal = () => {
+    dispatch(revealInFinder(item.pathname)).catch((error) => {
+      toast.error('Error revealing file:', error);
+    });
+  };
+
   const requestItems = sortRequestItems(filter(item.items, (i) => isItemARequest(i)));
   const folderItems = sortFolderItems(filter(item.items, (i) => isItemAFolder(i)));
 
@@ -369,6 +375,17 @@ const CollectionItem = ({ item, collection, searchText }) => {
                   }}
                 >
                   Generate Code
+                </div>
+              )}
+              {!isFolder && (
+                <div
+                  className="dropdown-item"
+                  onClick={(e) => {
+                    dropdownTippyRef.current.hide();
+                    handleReveal();
+                  }}
+                >
+                  Reveal in Finder
                 </div>
               )}
               <div

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -6,7 +6,7 @@ import { useDrag, useDrop } from 'react-dnd';
 import { IconChevronRight, IconDots } from '@tabler/icons';
 import { useSelector, useDispatch } from 'react-redux';
 import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
-import { moveItem, revealInFinder, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { moveItem, showInFolder, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { collectionFolderClicked } from 'providers/ReduxStore/slices/collections';
 import Dropdown from 'components/Dropdown';
 import NewRequest from 'components/Sidebar/NewRequest';
@@ -220,9 +220,10 @@ const CollectionItem = ({ item, collection, searchText }) => {
     }
   };
 
-  const handleReveal = () => {
-    dispatch(revealInFinder(item.pathname)).catch((error) => {
-      toast.error('Error revealing file:', error);
+  const handleShowInFolder = () => {
+    dispatch(showInFolder(item.pathname)).catch((error) => {
+      console.error('Error opening the folder', error);
+      toast.error('Error opening the folder');
     });
   };
 
@@ -377,17 +378,15 @@ const CollectionItem = ({ item, collection, searchText }) => {
                   Generate Code
                 </div>
               )}
-              {!isFolder && (
-                <div
-                  className="dropdown-item"
-                  onClick={(e) => {
-                    dropdownTippyRef.current.hide();
-                    handleReveal();
-                  }}
-                >
-                  Reveal in Finder
-                </div>
-              )}
+              <div
+                className="dropdown-item"
+                onClick={(e) => {
+                  dropdownTippyRef.current.hide();
+                  handleShowInFolder();
+                }}
+              >
+                Show in Folder
+              </div>
               <div
                 className="dropdown-item delete-item"
                 onClick={(e) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1219,3 +1219,12 @@ export const mountCollection = ({ collectionUid, collectionPathname, brunoConfig
       });
   });
 };
+
+  export const revealInFinder = (collectionPath) => () => {
+    return new Promise((resolve, reject) => {
+      const { ipcRenderer } = window;
+  
+      ipcRenderer.invoke('renderer:reveal-in-finder', collectionPath).then(resolve).catch(reject);
+    });
+  };
+  

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1220,11 +1220,9 @@ export const mountCollection = ({ collectionUid, collectionPathname, brunoConfig
   });
 };
 
-  export const revealInFinder = (collectionPath) => () => {
+  export const showInFolder = (collectionPath) => () => {
     return new Promise((resolve, reject) => {
       const { ipcRenderer } = window;
-  
-      ipcRenderer.invoke('renderer:reveal-in-finder', collectionPath).then(resolve).catch(reject);
+      ipcRenderer.invoke('renderer:show-in-folder', collectionPath).then(resolve).catch(reject);
     });
   };
-  

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const fsExtra = require('fs-extra');
 const os = require('os');
 const path = require('path');
-const { exec } = require('child_process');
 const { ipcMain, shell, dialog, app } = require('electron');
 const { envJsonToBru, bruToJson, jsonToBruViaWorker, jsonToCollectionBru, bruToJsonViaWorker } = require('../bru');
 
@@ -911,40 +910,17 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
     watcher.addWatcher(mainWindow, collectionPathname, collectionUid, brunoConfig, false, shouldLoadCollectionAsync);
   });
 
-  ipcMain.handle('renderer:reveal-in-finder', async (event, filePath) => {
+  ipcMain.handle('renderer:show-in-folder', async (event, filePath) => {
     try {
       if (!filePath) {
-        throw new Error('File path is required.');
+        throw new Error('File path is required');
       }
-  
-      const resolvedPath = path.resolve(filePath);
-  
-      if (!fs.existsSync(resolvedPath)) {
-        throw new Error('The specified file does not exist.');
-      }
-
-      console.log(process.platform, "process.platform")
-  
-      switch (process.platform) {
-        case 'darwin': // macOS
-          shell.showItemInFolder(resolvedPath);
-          break;
-        case 'win32': // Windows
-          shell.showItemInFolder(resolvedPath);
-          break;
-        case 'linux': // Linux
-          exec(`xdg-open "${resolvedPath}"`);
-          break;
-        default:
-          throw new Error('Unsupported platform.');
-      }
-  
-      return { success: true };
+      shell.showItemInFolder(filePath);
     } catch (error) {
-      console.error('Error in reveal-in-finder:', error);
-      return { success: false, message: error.message };
+      console.error('Error in show-in-folder: ', error);
+      throw error;
     }
-  });  
+  });
 };
 
 const registerMainEventHandlers = (mainWindow, watcher, lastOpenedCollections) => {

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const fsExtra = require('fs-extra');
 const os = require('os');
 const path = require('path');
+const { exec } = require('child_process');
 const { ipcMain, shell, dialog, app } = require('electron');
 const { envJsonToBru, bruToJson, jsonToBruViaWorker, jsonToCollectionBru, bruToJsonViaWorker } = require('../bru');
 
@@ -909,6 +910,41 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
 
     watcher.addWatcher(mainWindow, collectionPathname, collectionUid, brunoConfig, false, shouldLoadCollectionAsync);
   });
+
+  ipcMain.handle('renderer:reveal-in-finder', async (event, filePath) => {
+    try {
+      if (!filePath) {
+        throw new Error('File path is required.');
+      }
+  
+      const resolvedPath = path.resolve(filePath);
+  
+      if (!fs.existsSync(resolvedPath)) {
+        throw new Error('The specified file does not exist.');
+      }
+
+      console.log(process.platform, "process.platform")
+  
+      switch (process.platform) {
+        case 'darwin': // macOS
+          shell.showItemInFolder(resolvedPath);
+          break;
+        case 'win32': // Windows
+          shell.showItemInFolder(resolvedPath);
+          break;
+        case 'linux': // Linux
+          exec(`xdg-open "${resolvedPath}"`);
+          break;
+        default:
+          throw new Error('Unsupported platform.');
+      }
+  
+      return { success: true };
+    } catch (error) {
+      console.error('Error in reveal-in-finder:', error);
+      return { success: false, message: error.message };
+    }
+  });  
 };
 
 const registerMainEventHandlers = (mainWindow, watcher, lastOpenedCollections) => {


### PR DESCRIPTION
Duplicate of #3698
Closes #3541

# Description

On clicking the triple-dot menu(kebab menu?) on a Folder or a Request, a new menu-item named `Show in Folder` is added which opens it in the native file-browser(Finder, File-Explorer, Nautilus, Ranger, etc.)

![image](https://github.com/user-attachments/assets/de93901d-1e10-4010-a1ab-a304e00501d5)
![image](https://github.com/user-attachments/assets/53ed6950-b75b-43de-a5f9-71e972af0e24)