### PR TITLE
Add an npm-script to run the Electron app with debugging enabled (#3616)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build:web": "npm run build --workspace=packages/bruno-app",
     "prettier:web": "npm run prettier --workspace=packages/bruno-app",
     "dev:electron": "npm run dev --workspace=packages/bruno-electron",
+    "dev:electron:debug": "npm run debug --workspace=packages/bruno-electron",
     "build:bruno-common": "npm run build --workspace=packages/bruno-common",
     "build:bruno-query": "npm run build --workspace=packages/bruno-query",
     "build:graphql-docs": "npm run build --workspace=packages/bruno-graphql-docs",

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "dev": "electron .",
+    "debug": "electron . --inspect=9229",
     "dist:mac": "electron-builder --mac --config electron-builder-config.js",
     "dist:win": "electron-builder --win --config electron-builder-config.js",
     "dist:linux": "electron-builder --linux AppImage --config electron-builder-config.js",


### PR DESCRIPTION
Duplicates #3616
Closes #3614

# Description

https://www.electronjs.org/docs/latest/tutorial/debugging-main-process

![2025-01-14_04-49](https://github.com/user-attachments/assets/78123fe2-b120-47d0-bcf0-dce4c21a9380)
![2025-01-14_04-48](https://github.com/user-attachments/assets/e3e8e369-3ef7-4948-868e-ca488e30bbfb)
