### PR TITLE
Feature/autocomplete improvements for Headers

### DIFF
--- a/packages/bruno-app/src/components/FolderSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/index.js
@@ -10,6 +10,7 @@ import SingleLineEditor from 'components/SingleLineEditor';
 import StyledWrapper from './StyledWrapper';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
 const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
+import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
 
 const Headers = ({ collection, folder }) => {
   const dispatch = useDispatch();
@@ -117,6 +118,7 @@ const Headers = ({ collection, folder }) => {
                         }
                         collection={collection}
                         item={folder}
+                        autocomplete={MimeTypes}
                       />
                     </td>
                     <td>

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -85,19 +85,9 @@ class SingleLineEditor extends Component {
       this.editor.on('keyup', (cm, event) => {
         // Only trigger autocomplete for alphanumeric keys
         const isValidTriggerKey = /^[a-zA-Z0-9]$/.test(event.key);
+        const ignoredKeys = ['Enter', 'Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Backspace', 'Escape'];
 
-        if (
-          !cm.state.completionActive &&
-          isValidTriggerKey &&
-          event.key !== 'Enter' &&
-          event.key !== 'Tab' &&
-          event.key !== 'ArrowLeft' &&
-          event.key !== 'ArrowRight' &&
-          event.key !== 'ArrowUp' &&
-          event.key !== 'ArrowDown' &&
-          event.key !== 'Backspace' &&
-          event.key !== 'Escape'
-        ) {
+        if (!cm.state.completionActive && isValidTriggerKey && !ignoredKeys.includes(event.key)) {
           // Create a custom case-insensitive hint function
           const caseInsensitiveHint = (cm, options) => {
             const cursor = cm.getCursor();

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -97,7 +97,7 @@ class SingleLineEditor extends Component {
 
             // Get all words from the autocomplete options
             const words = options.autocomplete || [];
-            const currentWord = line.slice(Math.max(0, start - 100), start).match(/[\w$]+$/);
+            const currentWord = line.slice(Math.max(0, start - 100), start).match(/[-\w$]+$/);
             const wordStart = currentWord ? start - currentWord[0].length : start;
 
             // Filter words case-insensitively


### PR DESCRIPTION
# Description

This PR 

- adds case-insensitive autocomplete for Headers (e.g. `accept` will now match `Accept`)
- makes autocomplete trigger within words (e.g. `language` will now match `Accept-Language`)
- fixes the bug where autocomplete for Header values was not triggered on folder level

Resolves #3776 #4355

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


### Screenshots
![Screenshot 2025-01-14 at 12 11 43](https://github.com/user-attachments/assets/100a5777-8279-450a-b405-7b490bda2082)

![Screenshot 2025-01-14 at 12 11 58](https://github.com/user-attachments/assets/343ad50d-9099-462c-ab7a-08b3c1d21de6)

[JIRA](https://usebruno.atlassian.net/browse/BRU-1018)

