### PR TITLE
Refactor: Improve expression handling across different runtimes (Fix: #3758)

### DIFF
--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -22,12 +22,12 @@ const toNumber = (value) => {
   return Number.isInteger(num) ? parseInt(value, 10) : parseFloat(value);
 };
 
-const removeQuotes = (str) => {
-  if ((str.startsWith('"') && str.endsWith('"')) || (str.startsWith("'") && str.endsWith("'"))) {
-    return str.slice(1, -1);
-  }
-  return str;
-};
+// const removeQuotes = (str) => {
+//   if ((str.startsWith('"') && str.endsWith('"')) || (str.startsWith("'") && str.endsWith("'"))) {
+//     return str.slice(1, -1);
+//   }
+//   return str;
+// };
 
 const executeQuickJsVm = ({ script: externalScript, context: externalContext, scriptType = 'template-literal' }) => {
   if (!externalScript?.length || typeof externalScript !== 'string') {
@@ -44,7 +44,8 @@ const executeQuickJsVm = ({ script: externalScript, context: externalContext, sc
   if (externalScript === 'null') return null;
   if (externalScript === 'undefined') return undefined;
 
-  externalScript = removeQuotes(externalScript);
+  // This is commented out as part of the fix for #3758
+  // externalScript = removeQuotes(externalScript);
 
   const vm = QuickJSSyncContext;
 
@@ -94,7 +95,8 @@ const executeQuickJsVmAsync = async ({ script: externalScript, context: external
   if (externalScript === 'null') return null;
   if (externalScript === 'undefined') return undefined;
 
-  externalScript = removeQuotes(externalScript);
+  // This is commented out as part of the fix for #3758
+  // externalScript = removeQuotes(externalScript);
 
   try {
     const module = await newQuickJSWASMModule();

--- a/packages/bruno-js/src/utils.js
+++ b/packages/bruno-js/src/utils.js
@@ -85,13 +85,15 @@ const evaluateJsTemplateLiteral = (templateLiteral, context) => {
     return undefined;
   }
 
-  if (templateLiteral.startsWith('"') && templateLiteral.endsWith('"')) {
-    return templateLiteral.slice(1, -1);
-  }
+  // This is commented out as part of the fix for #3758
+  // if (templateLiteral.startsWith('"') && templateLiteral.endsWith('"')) {
+  //   return templateLiteral.slice(1, -1);
+  // }
 
-  if (templateLiteral.startsWith("'") && templateLiteral.endsWith("'")) {
-    return templateLiteral.slice(1, -1);
-  }
+  // This is commented out as part of the fix for #3758
+  // if (templateLiteral.startsWith("'") && templateLiteral.endsWith("'")) {
+  //   return templateLiteral.slice(1, -1);
+  // }
 
   if (!isNaN(templateLiteral)) {
     const number = Number(templateLiteral);


### PR DESCRIPTION
fixes: #3758 

regression of: #3676 #3706 

# Description

This PR implements the logic for commenting out the unnecessary removal of single and double quotes in responses. These functions were previously required when the `responseParser` also removed quotes. In the latest release, we improved the logic for handling responses. Therefore, this PR addresses the regression issue mentioned above. The older logic has been commented out for reference. 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**