### PR TITLE
Moved collection click area from name to div

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -152,6 +152,8 @@ const Collection = ({ collection, searchText }) => {
       <div className="flex py-1 collection-name items-center" ref={drop}>
         <div
           className="flex flex-grow items-center overflow-hidden"
+          onClick={handleCollapseCollection}
+          onContextMenu={handleRightClick}
         >
           <IconChevronRight
             size={16}
@@ -160,9 +162,7 @@ const Collection = ({ collection, searchText }) => {
             style={{ width: 16, minWidth: 16, color: 'rgb(160 160 160)' }}
             onClick={handleClick}
           />
-          <div className="ml-1" id="sidebar-collection-name"    
-            onClick={handleCollapseCollection}
-            onContextMenu={handleRightClick}>
+          <div className="ml-1" id="sidebar-collection-name">
             {collection.name}
           </div>
         </div>


### PR DESCRIPTION
# Description

Previously, if you wanted to expand a collection, you had to click on the name of the collection. In this pr, I expanded the area of click from the name to the entire tile of the collection.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/602e230a-19e0-4685-9d25-6298494f0a2d


