### PR TITLE
Fix: Horizontal Rules missing in markdown docs preview

### DIFF
--- a/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
@@ -55,7 +55,7 @@ const StyledMarkdownBodyWrapper = styled.div`
       height: 1px;
       padding: 0;
       margin: 24px 0;
-      background-color: var(--color-border-default);
+      background-color: var(--color-sidebar-collection-item-active-indent-border);
       border: 0;
     }
 


### PR DESCRIPTION
# Description

Addressing issue: #3733 
Fixed styling for Horizontal Rules in markdown preview section

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="472" alt="Screenshot 2025-01-16 at 2 21 56 PM" src="https://github.com/user-attachments/assets/9cf35951-a763-419b-b0b7-d43b1b6c9542" />

<img width="472" alt="Screenshot 2025-01-16 at 2 22 09 PM" src="https://github.com/user-attachments/assets/76835c37-8bfa-4d9b-8133-0bff441469e1" />
