### PR TITLE
interpolate collection variables in Generate Code URL

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index.js
@@ -25,6 +25,13 @@ const GenerateCodeItem = ({ collection, item, onClose }) => {
       return acc;
     }, {});
   }
+  let collectionVars = {};
+  let collectionRequestVars = get(collection, 'root.request.vars.req', []);
+  collectionRequestVars.forEach((_var) => {
+    if (_var.enabled) {
+      collectionVars[_var.name] = _var.value;
+    }
+  });
 
   const requestUrl =
     get(item, 'draft.request.url') !== undefined ? get(item, 'draft.request.url') : get(item, 'request.url');
@@ -32,6 +39,7 @@ const GenerateCodeItem = ({ collection, item, onClose }) => {
   // interpolate the url
   const interpolatedUrl = interpolateUrl({
     url: requestUrl,
+    collectionVars,
     globalEnvironmentVariables,
     envVars,
     runtimeVariables: collection.runtimeVariables,

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -108,12 +108,13 @@ export const isValidUrl = (url) => {
   }
 };
 
-export const interpolateUrl = ({ url, globalEnvironmentVariables = {}, envVars, runtimeVariables, processEnvVars }) => {
+export const interpolateUrl = ({ url, globalEnvironmentVariables = {}, envVars, collectionVars = {}, runtimeVariables, processEnvVars }) => {
   if (!url || !url.length || typeof url !== 'string') {
     return;
   }
 
   return interpolate(url, {
+    ...collectionVars,
     ...globalEnvironmentVariables,
     ...envVars,
     ...runtimeVariables,


### PR DESCRIPTION
#3824 
# Description
Collection variables aren't interpolated in Generate Code URL's. This PR adds that interpolation but doesn't address what appears to be a more general inconsistency and lack of code-sharing between this and other places where URL interpolation is done.
![image](https://github.com/user-attachments/assets/425a3a59-3b29-4b92-a1db-0e9ddd67f3c8)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
