### PR TITLE
Fix: Import collection modal closes when click on ENTER

### DIFF
--- a/packages/bruno-app/src/components/Modal/index.js
+++ b/packages/bruno-app/src/components/Modal/index.js
@@ -62,7 +62,7 @@ const Modal = ({
   confirmText,
   cancelText,
   handleCancel,
-  handleConfirm,
+  handleConfirm = () => {},
   children,
   confirmDisabled,
   hideCancel,
@@ -92,7 +92,7 @@ const Modal = ({
   };
 
   useFocusTrap(modalRef);
-  
+
   const closeModal = (args) => {
     setIsClosing(true);
     setTimeout(() => handleCancel(args), closeModalFadeTimeout);
@@ -103,7 +103,7 @@ const Modal = ({
     return () => {
       document.removeEventListener('keydown', handleKeydown);
     };
-  }, [disableEscapeKey, document]);
+  }, [disableEscapeKey, document, handleConfirm]);
 
   let classes = 'bruno-modal';
   if (isClosing) {

--- a/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
@@ -68,7 +68,7 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
     );
   };
   return (
-    <Modal size="sm" title="Import Collection" hideFooter={true} handleConfirm={onClose} handleCancel={onClose}>
+    <Modal size="sm" title="Import Collection" hideFooter={true} handleCancel={onClose}>
       <div className="flex flex-col">
         <h3 className="text-sm">Select the type of your existing collection :</h3>
         <div className="mt-4 grid grid-rows-2 grid-flow-col gap-2">


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

There are two modals in question, one is import modal and the modals that gets opened when we click on each of the type. our common modal component have event listeners for <b>ESC</b> , <b>ENTER</b> keys, outer modal has "onClose" which gets triggered when user press <b>ENTER</b> , this closes the outer modal, as the inner modals are within the outer modal, those also gets removed from the dom. 

currently i removed handleConfirm function for outer modal, so that Pressing on ENTER to not to trigger modal closing, ESC closes the modal as before. also made the handleConfirm prop optional

Additionaly, the  <b>handleConfirm</b> function we use within the callback for key-press event is not updated as it is not added as the dependency for useEffect, they continue to use the older handleConfirm, and wasn't triggering cloning or import if i press enter after putting in the url


https://github.com/user-attachments/assets/46e2c756-6e1e-4787-b884-daad5e90a0ea



### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers
<img width="973" alt="Screenshot 2025-01-17 at 12 32 43 PM" src="https://github.com/user-attachments/assets/d808c7aa-ff52-463a-b7a5-92cff539a213" />
<img width="973" alt="Screenshot 2025-01-17 at 12 32 48 PM" src="https://github.com/user-attachments/assets/8c629d04-5a12-4361-87f4-be4b06d8aa43" />
<img width="973" alt="Screenshot 2025-01-17 at 12 32 54 PM" src="https://github.com/user-attachments/assets/b7ebe14a-3fe8-4d87-bfdb-405666baf521" />


Please see [here](../publishing.md) for more information.