### PR TITLE
fix: OpenAPI v3 import by supporting path-based folder structure

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -61,15 +61,29 @@ const transformOpenapiRequestItem = (request) => {
     operationName = `${request.method} ${request.path}`;
   }
 
-  // replace OpenAPI links in path by Bruno variables
-  let path = request.path.replace(/{([a-zA-Z]+)}/g, `{{${_operationObject.operationId}_$1}}`);
+  const transformPath = (path) => {
+    const segments = path.split('/');
+    
+    const transformedSegments = segments.map(segment => {
+      if (segment.match(/^\{.*\}$/)) {
+        const paramName = segment.slice(1, -1);
+        return `:${paramName}`;
+      }
+      return segment;
+    });
+
+    return transformedSegments.join('/');
+  };
+
+  // Transform the path for the URL
+  const transformedPath = transformPath(request.path);
 
   const brunoRequestItem = {
     uid: uuid(),
     name: operationName,
     type: 'http-request',
     request: {
-      url: ensureUrl(request.global.server + path),
+      url: ensureUrl(request.global.server + transformedPath),
       method: request.method.toUpperCase(),
       auth: {
         mode: 'none',

--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -63,8 +63,8 @@ const transformOpenapiRequestItem = (request) => {
 
   const transformPath = (path) => {
     const segments = path.split('/');
-    
-    const transformedSegments = segments.map(segment => {
+
+    const transformedSegments = segments.map((segment) => {
       if (segment.match(/^\{.*\}$/)) {
         const paramName = segment.slice(1, -1);
         return `:${paramName}`;
@@ -82,7 +82,7 @@ const transformOpenapiRequestItem = (request) => {
 
   const pathParams = [];
   const urlSegments = transformedPath.split('/');
-  urlSegments.forEach(segment => {
+  urlSegments.forEach((segment) => {
     if (segment.startsWith(':')) {
       const paramName = segment.slice(1);
       pathParams.push({
@@ -377,7 +377,7 @@ const openAPIRuntimeExpressionToScript = (expression) => {
 };
 
 const getPathSegments = (path) => {
-  return path.split('/').filter(segment => segment);
+  return path.split('/').filter((segment) => segment);
 };
 
 const createFolderStructure = (paths) => {
@@ -396,14 +396,14 @@ const createFolderStructure = (paths) => {
   };
 
   // Process each request and create folder structure
-  paths.forEach(request => {
+  paths.forEach((request) => {
     const segments = getPathSegments(request.path);
     let currentLevel = folderTree;
 
     // Create folders for each segment
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i];
-      
+
       if (i === segments.length - 1) {
         const folder = getOrCreateFolder(currentLevel, segment);
         folder.requests.push(request);
@@ -491,7 +491,7 @@ export const parseOpenApiCollection = (data) => {
               type: 'text',
               enabled: true,
               secret: false
-            },
+            }
           ]
         });
       });

--- a/packages/bruno-app/src/utils/importers/openapi-collection.spec.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.spec.js
@@ -40,28 +40,85 @@ describe('openapi importer util functions', () => {
       version: '1',
       items: [
         {
-          name: 'Get a list of users',
-          type: 'http-request',
-          request: {
-            url: '{{baseUrl}}/users',
-            method: 'GET',
-            params: [
-              { name: 'page', value: '', enabled: false, type: 'query' },
-              { name: 'limit', value: '', enabled: false, type: 'query' }
-            ]
-          }
+          name: 'users',
+          type: 'folder',
+          items: [
+            {
+              name: 'Get a list of users',
+              type: 'http-request',
+              request: {
+                url: '{{baseUrl}}/users',
+                method: 'GET',
+                auth: {
+                  mode: 'none',
+                  basic: null,
+                  bearer: null,
+                  digest: null
+                },
+                headers: [],
+                params: [
+                  { name: 'page', value: '', enabled: false, type: 'query' },
+                  { name: 'limit', value: '', enabled: false, type: 'query' }
+                ],
+                body: {
+                  mode: 'none',
+                  json: null,
+                  text: null,
+                  xml: null,
+                  formUrlEncoded: [],
+                  multipartForm: []
+                },
+                script: {
+                  res: null
+                }
+              }
+            }
+          ]
         }
       ],
       environments: [
-        { name: 'Production Server', variables: [{ name: 'baseUrl', value: 'https://api.example.com/v1' }] },
-        { name: 'Staging Server', variables: [{ name: 'baseUrl', value: 'https://staging-api.example.com/v1' }] },
-        { name: 'Local Server', variables: [{ name: 'baseUrl', value: 'http://localhost:3000/v1' }] }
+        {
+          name: 'Production Server',
+          variables: [
+            {
+              name: 'baseUrl',
+              value: 'https://api.example.com/v1',
+              type: 'text',
+              enabled: true,
+              secret: false
+            }
+          ]
+        },
+        {
+          name: 'Staging Server',
+          variables: [
+            {
+              name: 'baseUrl',
+              value: 'https://staging-api.example.com/v1',
+              type: 'text',
+              enabled: true,
+              secret: false
+            }
+          ]
+        },
+        {
+          name: 'Local Server',
+          variables: [
+            {
+              name: 'baseUrl',
+              value: 'http://localhost:3000/v1',
+              type: 'text',
+              enabled: true,
+              secret: false
+            }
+          ]
+        }
       ]
     };
 
     const result = await parseOpenApiCollection(input);
 
     expect(result).toMatchObject(expectedOutput);
-    expect(uuid).toHaveBeenCalledTimes(10);
+    expect(uuid).toHaveBeenCalledTimes(11);
   });
 });


### PR DESCRIPTION
# Description

This PR addresses issue #3790 regarding incomplete OpenAPI v3 import in Bruno. The changes improve the way Bruno handles OpenAPI imports by implementing a better folder structure organization and path parameter handling.

Key changes include:
- Implemented hierarchical folder structure based on API paths
- Improved path parameter transformation from OpenAPI format ({param}) to Bruno format (:param)
- Enhanced URL handling and request processing

Before this change, only some folders were being imported when importing OpenAPI collections. The new implementation ensures all endpoints are properly organized and imported into Bruno.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
