### PR TITLE
fix:handle render svg response

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -88,6 +88,7 @@ const QueryResult = ({ item, collection, data, dataBuffer, width, disableRunEven
     } else if (contentType.includes('video')) {
       allowedPreviewModes.unshift({ mode: 'preview-video', name: 'Video', uid: uuid() });
     }
+
     return allowedPreviewModes;
   }, [mode, data, formattedData]);
 

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -88,7 +88,6 @@ const QueryResult = ({ item, collection, data, dataBuffer, width, disableRunEven
     } else if (contentType.includes('video')) {
       allowedPreviewModes.unshift({ mode: 'preview-video', name: 'Video', uid: uuid() });
     }
-
     return allowedPreviewModes;
   }, [mode, data, formattedData]);
 

--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -159,7 +159,10 @@ export const getCodeMirrorModeBasedOnContentType = (contentType, body) => {
 
   if (contentType.includes('json')) {
     return 'application/ld+json';
-  } else if (contentType.includes('xml')) {
+  }else if (contentType.includes('image')) {
+    return 'application/image';
+  }
+   else if (contentType.includes('xml')) {
     return 'application/xml';
   } else if (contentType.includes('html')) {
     return 'application/html';
@@ -169,9 +172,7 @@ export const getCodeMirrorModeBasedOnContentType = (contentType, body) => {
     return 'application/xml';
   } else if (contentType.includes('yaml')) {
     return 'application/yaml';
-  } else if (contentType.includes('image')) {
-    return 'application/image';
-  } else {
+  }  else {
     return 'application/text';
   }
 };

--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -159,6 +159,8 @@ export const getCodeMirrorModeBasedOnContentType = (contentType, body) => {
 
   if (contentType.includes('json')) {
     return 'application/ld+json';
+  } else if (contentType.includes('image')) {
+    return 'application/image';
   } else if (contentType.includes('xml')) {
     return 'application/xml';
   } else if (contentType.includes('html')) {
@@ -169,8 +171,6 @@ export const getCodeMirrorModeBasedOnContentType = (contentType, body) => {
     return 'application/xml';
   } else if (contentType.includes('yaml')) {
     return 'application/yaml';
-  } else if (contentType.includes('image')) {
-    return 'application/image';
   } else {
     return 'application/text';
   }

--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -159,10 +159,7 @@ export const getCodeMirrorModeBasedOnContentType = (contentType, body) => {
 
   if (contentType.includes('json')) {
     return 'application/ld+json';
-  }else if (contentType.includes('image')) {
-    return 'application/image';
-  }
-   else if (contentType.includes('xml')) {
+  } else if (contentType.includes('xml')) {
     return 'application/xml';
   } else if (contentType.includes('html')) {
     return 'application/html';
@@ -172,7 +169,9 @@ export const getCodeMirrorModeBasedOnContentType = (contentType, body) => {
     return 'application/xml';
   } else if (contentType.includes('yaml')) {
     return 'application/yaml';
-  }  else {
+  } else if (contentType.includes('image')) {
+    return 'application/image';
+  } else {
     return 'application/text';
   }
 };

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -92,10 +92,7 @@ export const getContentType = (headers) => {
         return header[1];
       });
     if (contentType && contentType.length) {
-      if (typeof contentType[0] === 'string' && /^image\/svg\+xml/i.test(contentType[0])) {
-        return 'image/svg+xml';
-      }
-    else if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?json/.test(contentType[0])) {
+      if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?json/.test(contentType[0])) {
         return 'application/ld+json';
       } else if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?xml/.test(contentType[0])) {
         return 'application/xml';

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -94,6 +94,8 @@ export const getContentType = (headers) => {
     if (contentType && contentType.length) {
       if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?json/.test(contentType[0])) {
         return 'application/ld+json';
+      } else if (typeof contentType[0] === 'string' && /^image\/svg\+xml/i.test(contentType[0])) {
+        return 'image/svg+xml';
       } else if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?xml/.test(contentType[0])) {
         return 'application/xml';
       }

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -92,7 +92,10 @@ export const getContentType = (headers) => {
         return header[1];
       });
     if (contentType && contentType.length) {
-      if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?json/.test(contentType[0])) {
+      if (typeof contentType[0] === 'string' && /^image\/svg\+xml/i.test(contentType[0])) {
+        return 'image/svg+xml';
+      }
+    else if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?json/.test(contentType[0])) {
         return 'application/ld+json';
       } else if (typeof contentType[0] == 'string' && /^[\w\-]+\/([\w\-]+\+)?xml/.test(contentType[0])) {
         return 'application/xml';


### PR DESCRIPTION
# Description
issue ticket : #3781 

i have added functionality to handle image/svg+xml contentType in getContentType function previously it is treating image/svg + xml as application/xml that is not allowing it to render on ui, now user can see image preview as well raw.

in getCodeMirrorModeBasedOnContentType i moved image condition to before the xml to handle both seamlessly . 

![Screenshot from 2025-01-17 16-25-35](https://github.com/user-attachments/assets/0f0d78f2-e23e-483a-9d05-856fe53d5495)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
