### PR TITLE
Cookies breakdown and new fields added

### DIFF
--- a/packages/bruno-app/src/components/Cookies/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Cookies/StyledWrapper.js
@@ -14,14 +14,6 @@ const Wrapper = styled.div`
     }
     td {
       padding: 6px 10px;
-
-      &:nth-child(1) {
-        width: 30%;
-      }
-
-      &:nth-child(3) {
-        width: 70px;
-      }
     }
   }
 `;

--- a/packages/bruno-app/src/components/Cookies/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Cookies/StyledWrapper.js
@@ -3,12 +3,25 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
   table {
     width: 100%;
+    border-collapse: collapse;
+    font-weight: 300;
     table-layout: fixed;
 
     thead {
       color: ${(props) => props.theme.table.thead.color};
       font-size: 0.8125rem;
       user-select: none;
+    }
+    td {
+      padding: 6px 10px;
+
+      &:nth-child(1) {
+        width: 30%;
+      }
+
+      &:nth-child(3) {
+        width: 70px;
+      }
     }
   }
 `;

--- a/packages/bruno-app/src/components/Cookies/index.js
+++ b/packages/bruno-app/src/components/Cookies/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Modal from 'components/Modal';
 import { IconTrash } from '@tabler/icons';
-import { deleteCookiesForDomain } from 'providers/ReduxStore/slices/app';
+import { deleteCookie } from 'providers/ReduxStore/slices/app';
 import toast from 'react-hot-toast';
 
 import StyledWrapper from './StyledWrapper';
@@ -11,39 +11,77 @@ const CollectionProperties = ({ onClose }) => {
   const dispatch = useDispatch();
   const cookies = useSelector((state) => state.app.cookies) || [];
 
-  const handleDeleteDomain = (domain) => {
-    dispatch(deleteCookiesForDomain(domain))
+  const handleDeleteCookie = (domain, path, cookieKey) => {
+    dispatch(deleteCookie(domain, path, cookieKey))
       .then(() => {
-        toast.success('Domain deleted successfully');
+        toast.success('Cookie deleted successfully');
       })
-      .catch((err) => console.log(err) && toast.error('Failed to delete domain'));
+      .catch((err) => {
+        console.error(err);
+        toast.error('Failed to delete cookie');
+      });
   };
 
+
+
   return (
-    <Modal size="md" title="Cookies" hideFooter={true} handleCancel={onClose}>
+    <Modal size="lg" title="Cookies" hideFooter={true} handleCancel={onClose}>
       <StyledWrapper>
-        <table className="w-full border-collapse" style={{ marginTop: '-1rem' }}>
+        <table
+          className="w-full border-collapse"
+          style={{ marginTop: '-1rem' }}
+        >
           <thead>
             <tr>
-              <th className="py-2 px-2 text-left">Domain</th>
-              <th className="py-2 px-2 text-left">Cookie</th>
-              <th className="py-2 px-2 text-center" style={{ width: 80 }}>
+              <th className="py-2 px-2 text-left" style={{ width: 120 }}>Domain</th>
+              <th className="py-2 px-2 text-left" style={{ width: 150 }}>Name</th>
+              <th className="py-2 px-2 text-left">Value</th>
+              <th className="py-2 px-2 text-left path-column" style={{ width: 80 }}>Path</th>
+              <th className="py-2 px-2 text-left" style={{ width: 160 }}>Expiration Date</th>
+              <th
+                className="py-2 px-2 text-center"
+                style={{ width: 80 }}
+              >
                 Actions
               </th>
             </tr>
           </thead>
           <tbody>
-            {cookies.map((cookie) => (
-              <tr key={cookie.domain}>
-                <td className="py-2 px-2">{cookie.domain}</td>
-                <td className="py-2 px-2 break-all">{cookie.cookieString}</td>
-                <td className="text-center">
-                  <button tabIndex="-1" onClick={() => handleDeleteDomain(cookie.domain)}>
-                    <IconTrash strokeWidth={1.5} size={20} />
-                  </button>
-                </td>
-              </tr>
-            ))}
+            {cookies.map((domainWithCookies) =>
+              domainWithCookies.cookies.map((singleCookie) => (
+                <tr
+                  key={`${domainWithCookies.domain}_${singleCookie.path}_${singleCookie.key}`}
+                >
+                  <td className="py-2 px-2">{domainWithCookies.domain}</td>
+                  <td className="py-2 px-2 break-all">{singleCookie.key}</td>
+                  <td className="py-2 px-2 break-all w-full">
+                    {singleCookie.value}
+                  </td>
+                  <td className="py-2 px-2 break-all path-column">
+                    {singleCookie.path}
+                  </td>
+                  <td className="py-2 px-2 break-all">
+                    {singleCookie.expires
+                      ? new Date(singleCookie.expires).toLocaleString()
+                      : 'Session'}
+                  </td>
+                  <td className="text-center">
+                    <button
+                      tabIndex="-1"
+                      onClick={() =>
+                        handleDeleteCookie(
+                          domainWithCookies.domain,
+                          singleCookie.path,
+                          singleCookie.key
+                        )
+                      }
+                    >
+                      <IconTrash strokeWidth={1.5} size={20} />
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </StyledWrapper>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -114,11 +114,13 @@ export const savePreferences = (preferences) => (dispatch, getState) => {
   });
 };
 
-export const deleteCookiesForDomain = (domain) => (dispatch, getState) => {
+export const deleteCookie = (domain, path, cookieKey) => (dispatch, getState) => {
   return new Promise((resolve, reject) => {
     const { ipcRenderer } = window;
-
-    ipcRenderer.invoke('renderer:delete-cookies-for-domain', domain).then(resolve).catch(reject);
+    ipcRenderer
+      .invoke('renderer:delete-cookie', domain, path, cookieKey)
+      .then(resolve)
+      .catch(reject);
   });
 };
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -740,12 +740,14 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
     }
   });
 
-  ipcMain.handle('renderer:delete-cookies-for-domain', async (event, domain) => {
+  ipcMain.handle('renderer:delete-cookie', async (event, domain, path, cookieKey) => {
     try {
-      await deleteCookiesForDomain(domain);
-
+      await deleteCookiesForDomain(domain, path, cookieKey);
       const domainsWithCookies = await getDomainsWithCookies();
-      mainWindow.webContents.send('main:cookies-update', safeParseJSON(safeStringifyJSON(domainsWithCookies)));
+      mainWindow.webContents.send(
+        'main:cookies-update',
+        safeParseJSON(safeStringifyJSON(domainsWithCookies))
+      );
     } catch (error) {
       return Promise.reject(error);
     }

--- a/packages/bruno-electron/src/utils/cookies.js
+++ b/packages/bruno-electron/src/utils/cookies.js
@@ -64,15 +64,23 @@ const getDomainsWithCookies = () => {
   });
 };
 
-const deleteCookiesForDomain = (domain) => {
+const deleteCookiesForDomain = (domain, path, cookieKey) => {
   return new Promise((resolve, reject) => {
-    cookieJar.store.removeCookies(domain, null, (err) => {
-      if (err) {
-        return reject(err);
-      }
-
-      return resolve();
-    });
+    if (path && cookieKey) {
+      cookieJar.store.removeCookie(domain, path, cookieKey, (err) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve();
+      });
+    } else {
+      cookieJar.store.removeCookies(domain, null, (err) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve();
+      });
+    }
   });
 };
 


### PR DESCRIPTION
# Description

Previously, all cookies from a domain were displayed in a single row with the cookie values concatenated as a single string. This approach made it difficult to view individual cookies clearly.
Additionally, the cookies table lacked essential fields such as path and expiration date.

This PR introduces the following improvements to address the issue:

1. **Breakdown Cookies by Domain:**
- Each cookie from a domain is now displayed as a separate row in the cookies table.
- The value column displays individual cookie values, improving clarity and manageability.

2. **Add New Fields:**
- Path: Displays the path associated with each cookie to indicate its scope.
- Expiration Date: Displays the expiration date of each cookie, allowing users to know when cookies will expire.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<img width="1274" alt="Screenshot 2025-01-21 at 1 37 29 PM" src="https://github.com/user-attachments/assets/4a7ce047-cf1f-4594-90fe-b1e73687dd24" />

