### PR TITLE
Fix: user defined cookies getting overwritten by stored cookies

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -233,7 +233,30 @@ const runSingleRequest = async function (
     if (!options.disableCookies) {
       const cookieString = getCookieStringForUrl(request.url);
       if (cookieString && typeof cookieString === 'string' && cookieString.length) {
-        request.headers['cookie'] = cookieString;
+        const existingCookieHeaderName = Object.keys(request.headers).find(
+            name => name.toLowerCase() === 'cookie'
+        );
+        const existingCookieString = existingCookieHeaderName ? request.headers[existingCookieHeaderName] : '';
+    
+        // Helper function to parse cookies into an object
+        const parseCookies = (str) => str.split(';').reduce((cookies, cookie) => {
+            const [name, ...rest] = cookie.split('=');
+            if (name && name.trim()) {
+                cookies[name.trim()] = rest.join('=').trim();
+            }
+            return cookies;
+        }, {});
+    
+        const mergedCookies = {
+            ...parseCookies(existingCookieString),
+            ...parseCookies(cookieString),
+        };
+    
+        const combinedCookieString = Object.entries(mergedCookies)
+            .map(([name, value]) => `${name}=${value}`)
+            .join('; ');
+    
+        request.headers[existingCookieHeaderName || 'Cookie'] = combinedCookieString;
       }
     }
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -333,7 +333,30 @@ const configureRequest = async (
   if (preferencesUtil.shouldSendCookies()) {
     const cookieString = getCookieStringForUrl(request.url);
     if (cookieString && typeof cookieString === 'string' && cookieString.length) {
-      request.headers['cookie'] = cookieString;
+      const existingCookieHeaderName = Object.keys(request.headers).find(
+          name => name.toLowerCase() === 'cookie'
+      );
+      const existingCookieString = existingCookieHeaderName ? request.headers[existingCookieHeaderName] : '';
+  
+      // Helper function to parse cookies into an object
+      const parseCookies = (str) => str.split(';').reduce((cookies, cookie) => {
+          const [name, ...rest] = cookie.split('=');
+          if (name && name.trim()) {
+              cookies[name.trim()] = rest.join('=').trim();
+          }
+          return cookies;
+      }, {});
+  
+      const mergedCookies = {
+          ...parseCookies(existingCookieString),
+          ...parseCookies(cookieString),
+      };
+  
+      const combinedCookieString = Object.entries(mergedCookies)
+          .map(([name, value]) => `${name}=${value}`)
+          .join('; ');
+  
+      request.headers[existingCookieHeaderName || 'Cookie'] = combinedCookieString;
     }
   }
 


### PR DESCRIPTION
# Description

Issues: #2102, #1944 

When a user sends the first request with a user-defined Cookie header, the request works as expected. However, the response from the server may include Set-Cookie headers. When the user sends a subsequent request, these cookies overwrite the user-defined cookies, leading to unexpected behavior.

Solution
This PR resolves the issue by merging the user-defined Cookie header with the cookies received from the server's Set-Cookie response. Both sets of cookies are now combined into a single Cookie header, ensuring that user-defined cookies are preserved while including any additional cookies set by the server.



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/dcd19ef4-db2a-415b-9fa1-52f3e739c259

