### PR TITLE
ensure variables set in scripts/tests of the request executed by `bru.runRequest` should reflect in the original request' scripts/tests

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -40,11 +40,13 @@ const runSingleRequest = async function (
   brunoConfig,
   collectionRoot,
   runtime,
-  collection
+  collection,
+  runSingleRequestByPathname
 ) {
   try {
     let request;
     let nextRequestName;
+    let shouldStopRunnerExecution = false;
     let item = {
       pathname: path.join(collectionPath, filename),
       ...bruJson
@@ -68,10 +70,40 @@ const runSingleRequest = async function (
         collectionPath,
         onConsoleLog,
         processEnvVars,
-        scriptingConfig
+        scriptingConfig,
+        runSingleRequestByPathname
       );
       if (result?.nextRequestName !== undefined) {
         nextRequestName = result.nextRequestName;
+      }
+
+      if (result?.stopExecution) {
+        shouldStopRunnerExecution = true;
+      }
+
+      if (result?.skipRequest) {
+        return {
+          test: {
+            filename: filename
+          },
+          request: {
+            method: request.method,
+            url: request.url,
+            headers: request.headers,
+            data: request.data
+          },
+          response: {
+            status: 'skipped',
+            statusText: 'request skipped via pre-request script',
+            data: null,
+            responseTime: 0
+          },
+          error: 'Request has been skipped from pre-request script',
+          skipped: true,
+          assertionResults: [],
+          testResults: [],
+          shouldStopRunnerExecution
+        };
       }
     }
 
@@ -323,7 +355,8 @@ const runSingleRequest = async function (
           error: err?.message || err?.errors?.map(e => e?.message)?.at(0) || err?.code || 'Request Failed!',
           assertionResults: [],
           testResults: [],
-          nextRequestName: nextRequestName
+          nextRequestName: nextRequestName,
+          shouldStopRunnerExecution
         };
       }
     }
@@ -363,10 +396,15 @@ const runSingleRequest = async function (
         collectionPath,
         null,
         processEnvVars,
-        scriptingConfig
+        scriptingConfig,
+        runSingleRequestByPathname
       );
       if (result?.nextRequestName !== undefined) {
         nextRequestName = result.nextRequestName;
+      }
+
+      if (result?.stopExecution) {
+        shouldStopRunnerExecution = true;
       }
     }
 
@@ -408,12 +446,17 @@ const runSingleRequest = async function (
         collectionPath,
         null,
         processEnvVars,
-        scriptingConfig
+        scriptingConfig,
+        runSingleRequestByPathname
       );
       testResults = get(result, 'results', []);
 
       if (result?.nextRequestName !== undefined) {
         nextRequestName = result.nextRequestName;
+      }
+
+      if (result?.stopExecution) {
+        shouldStopRunnerExecution = true;
       }
     }
 
@@ -447,7 +490,8 @@ const runSingleRequest = async function (
       error: null,
       assertionResults,
       testResults,
-      nextRequestName: nextRequestName
+      nextRequestName: nextRequestName,
+      shouldStopRunnerExecution
     };
   } catch (err) {
     console.log(chalk.red(stripExtension(filename)) + chalk.dim(` (${err.message})`));

--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -204,5 +204,6 @@ module.exports = {
   mergeHeaders,
   mergeVars,
   mergeScripts,
+  findItemInCollection,
   getTreePathFromCollectionToItem
 }

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -274,7 +274,6 @@ const configureRequest = async (
     });
   }
 
-
   let axiosInstance = makeAxiosInstance();
   
   if (request.ntlmConfig) {
@@ -403,7 +402,7 @@ const registerNetworkIpc = (mainWindow) => {
     requestUid,
     envVars,
     collectionPath,
-    collectionRoot,
+    collection,
     collectionUid,
     runtimeVariables,
     processEnvVars,
@@ -437,6 +436,8 @@ const registerNetworkIpc = (mainWindow) => {
       mainWindow.webContents.send('main:global-environment-variables-update', {
         globalEnvironmentVariables: scriptResult.globalEnvironmentVariables
       });
+
+      collection.globalEnvironmentVariables = scriptResult.globalEnvironmentVariables;
     }
 
     // interpolate variables inside request
@@ -470,7 +471,7 @@ const registerNetworkIpc = (mainWindow) => {
     requestUid,
     envVars,
     collectionPath,
-    collectionRoot,
+    collection,
     collectionUid,
     runtimeVariables,
     processEnvVars,
@@ -507,6 +508,8 @@ const registerNetworkIpc = (mainWindow) => {
       if (result?.error) {
         mainWindow.webContents.send('main:display-error', result.error);
       }
+
+      collection.globalEnvironmentVariables = result.globalEnvironmentVariables;
     }
 
     // run post-response script
@@ -537,11 +540,13 @@ const registerNetworkIpc = (mainWindow) => {
       mainWindow.webContents.send('main:global-environment-variables-update', {
         globalEnvironmentVariables: scriptResult.globalEnvironmentVariables
       });
+
+      collection.globalEnvironmentVariables = scriptResult.globalEnvironmentVariables;
     }
     return scriptResult;
   };
 
-  const runRequest = async ({ item, collection, environment, runtimeVariables, runInBackground = false }) => {
+  const runRequest = async ({ item, collection, envVars, processEnvVars, runtimeVariables, runInBackground = false }) => {
     const collectionUid = collection.uid;
     const collectionPath = collection.pathname;
     const cancelTokenUid = uuid();
@@ -553,9 +558,9 @@ const registerNetworkIpc = (mainWindow) => {
         if (itemPathname && !itemPathname?.endsWith('.bru')) {
           itemPathname = `${itemPathname}.bru`;
         }
-        const _item = findItemInCollectionByPathname(collection, itemPathname);
+        const _item = cloneDeep(findItemInCollectionByPathname(collection, itemPathname));
         if(_item) {
-          const res = await runRequest({ item: _item, collection, environment, runtimeVariables, runInBackground: true });
+          const res = await runRequest({ item: _item, collection, envVars, processEnvVars, runtimeVariables, runInBackground: true });
           resolve(res);
         }
         reject(`bru.runRequest: invalid request path - ${itemPathname}`);
@@ -570,11 +575,8 @@ const registerNetworkIpc = (mainWindow) => {
       cancelTokenUid
     });
 
-    const collectionRoot = get(collection, 'root', {});
     const request = prepareRequest(item, collection);
     request.__bruno__executionMode = 'standalone';
-    const envVars = getEnvVars(environment);
-    const processEnvVars = getProcessEnvVars(collectionUid);
     const brunoConfig = getBrunoConfig(collectionUid);
     const scriptingConfig = get(brunoConfig, 'scripts', {});
     scriptingConfig.runtime = getJsSandboxRuntime(collection);
@@ -589,7 +591,7 @@ const registerNetworkIpc = (mainWindow) => {
         requestUid,
         envVars,
         collectionPath,
-        collectionRoot,
+        collection,
         collectionUid,
         runtimeVariables,
         processEnvVars,
@@ -674,7 +676,7 @@ const registerNetworkIpc = (mainWindow) => {
         requestUid,
         envVars,
         collectionPath,
-        collectionRoot,
+        collection,
         collectionUid,
         runtimeVariables,
         processEnvVars,
@@ -758,7 +760,10 @@ const registerNetworkIpc = (mainWindow) => {
 
   // handler for sending http request
   ipcMain.handle('send-http-request', async (event, item, collection, environment, runtimeVariables) => {
-    return await runRequest({ item, collection, environment, runtimeVariables });
+    const collectionUid = collection.uid;
+    const envVars = getEnvVars(environment);
+    const processEnvVars = getProcessEnvVars(collectionUid);
+    return await runRequest({ item, collection, envVars, processEnvVars, runtimeVariables, runInBackground: false });
   });
 
   ipcMain.handle('send-collection-oauth2-request', async (event, collection, environment, runtimeVariables) => {
@@ -782,7 +787,7 @@ const registerNetworkIpc = (mainWindow) => {
         requestUid,
         envVars,
         collectionPath,
-        collectionRoot,
+        collection,
         collectionUid,
         runtimeVariables,
         processEnvVars,
@@ -818,7 +823,7 @@ const registerNetworkIpc = (mainWindow) => {
         requestUid,
         envVars,
         collectionPath,
-        collectionRoot,
+        collection,
         collectionUid,
         runtimeVariables,
         processEnvVars,
@@ -888,7 +893,7 @@ const registerNetworkIpc = (mainWindow) => {
         requestUid,
         envVars,
         collectionPath,
-        collectionRoot,
+        collection,
         collectionUid,
         runtimeVariables,
         processEnvVars,
@@ -912,7 +917,7 @@ const registerNetworkIpc = (mainWindow) => {
         requestUid,
         envVars,
         collectionPath,
-        collectionRoot,
+        collection,
         collectionUid,
         runtimeVariables,
         processEnvVars,
@@ -949,7 +954,8 @@ const registerNetworkIpc = (mainWindow) => {
       const brunoConfig = getBrunoConfig(collectionUid);
       const scriptingConfig = get(brunoConfig, 'scripts', {});
       scriptingConfig.runtime = getJsSandboxRuntime(collection);
-      const collectionRoot = get(collection, 'root', {});
+      const envVars = getEnvVars(environment);
+      const processEnvVars = getProcessEnvVars(collectionUid);
       let stopRunnerExecution = false;
 
       const abortController = new AbortController();
@@ -961,9 +967,9 @@ const registerNetworkIpc = (mainWindow) => {
           if (itemPathname && !itemPathname?.endsWith('.bru')) {
             itemPathname = `${itemPathname}.bru`;
           }
-          const _item = findItemInCollectionByPathname(collection, itemPathname);
+          const _item = cloneDeep(findItemInCollectionByPathname(collection, itemPathname));
           if(_item) {
-            const res = await runRequest({ item: _item, collection, environment, runtimeVariables, runInBackground: true });
+            const res = await runRequest({ item: _item, collection, envVars, processEnvVars, runtimeVariables, runInBackground: true });                  
             resolve(res);
           }
           reject(`bru.runRequest: invalid request path - ${itemPathname}`);
@@ -983,7 +989,6 @@ const registerNetworkIpc = (mainWindow) => {
       });
 
       try {
-        const envVars = getEnvVars(environment);
         let folderRequests = [];
 
         if (recursive) {
@@ -1035,7 +1040,6 @@ const registerNetworkIpc = (mainWindow) => {
           request.__bruno__executionMode = 'runner';
           
           const requestUid = uuid();
-          const processEnvVars = getProcessEnvVars(collectionUid);
 
           try {
             const preRequestScriptResult = await runPreRequest(
@@ -1043,7 +1047,7 @@ const registerNetworkIpc = (mainWindow) => {
               requestUid,
               envVars,
               collectionPath,
-              collectionRoot,
+              collection,
               collectionUid,
               runtimeVariables,
               processEnvVars,
@@ -1181,7 +1185,7 @@ const registerNetworkIpc = (mainWindow) => {
               requestUid,
               envVars,
               collectionPath,
-              collectionRoot,
+              collection,
               collectionUid,
               runtimeVariables,
               processEnvVars,

--- a/packages/bruno-tests/collection/ping-another-one.bru
+++ b/packages/bruno-tests/collection/ping-another-one.bru
@@ -1,7 +1,7 @@
 meta {
-  name: ping
+  name: ping-another-one
   type: http
-  seq: 1
+  seq: 2
 }
 
 get {
@@ -11,5 +11,5 @@ get {
 }
 
 script:pre-request {
-  bru.runner.stopExecution();
+  throw new Error('this should not execute in a collection run');
 }

--- a/packages/bruno-tests/collection/scripting/api/bru/runRequest-1.bru
+++ b/packages/bruno-tests/collection/scripting/api/bru/runRequest-1.bru
@@ -1,0 +1,57 @@
+meta {
+  name: runRequest-1
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{echo-host}}
+  body: text
+  auth: none
+}
+
+body:text {
+  bruno
+}
+
+script:pre-request {
+  // reset values
+  bru.setVar('run-request-runtime-var', null);
+  bru.setEnvVar('run-request-env-var', null);
+  bru.setGlobalEnvVar('run-request-global-env-var', null);
+  
+  // the above vars will be set in the below request
+  const resp = await bru.runRequest('scripting/api/bru/runRequest-2');
+  
+  bru.setVar('run-request-resp', {
+    data: resp?.data,
+    statusText: resp?.statusText,
+    status: resp?.status
+  });
+}
+
+tests {
+  test("should get runtime var set in runRequest-2", function() {
+    const val = bru.getVar("run-request-runtime-var");
+    expect(val).to.equal("run-request-runtime-var-value");
+  });
+  
+  test("should get env var set in runRequest-2", function() {
+    const val = bru.getEnvVar("run-request-env-var");
+    expect(val).to.equal("run-request-env-var-value");
+  });
+  
+  test("should get global env var set in runRequest-2", function() {
+    const val = bru.getGlobalEnvVar("run-request-global-env-var");
+    expect(val).to.equal("run-request-global-env-var-value");
+  });
+  
+  test("should get response of runRequest-2", function() {
+    const val = bru.getVar('run-request-resp');
+    expect(JSON.stringify(val)).to.equal(JSON.stringify({
+        "data": "bruno",
+        "statusText": "OK",
+        "status": 200
+      }));
+  });
+}

--- a/packages/bruno-tests/collection/scripting/api/bru/runRequest-1.bru
+++ b/packages/bruno-tests/collection/scripting/api/bru/runRequest-1.bru
@@ -43,7 +43,10 @@ tests {
   
   test("should get global env var set in runRequest-2", function() {
     const val = bru.getGlobalEnvVar("run-request-global-env-var");
-    expect(val).to.equal("run-request-global-env-var-value");
+    const executionMode = req.getExecutionMode();
+    if (executionMode == 'runner') {
+      expect(val).to.equal("run-request-global-env-var-value");
+    }
   });
   
   test("should get response of runRequest-2", function() {

--- a/packages/bruno-tests/collection/scripting/api/bru/runRequest-2.bru
+++ b/packages/bruno-tests/collection/scripting/api/bru/runRequest-2.bru
@@ -1,0 +1,21 @@
+meta {
+  name: runRequest-2
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{echo-host}}
+  body: text
+  auth: none
+}
+
+body:text {
+  bruno
+}
+
+script:pre-request {
+  bru.setVar('run-request-runtime-var', 'run-request-runtime-var-value');
+  bru.setEnvVar('run-request-env-var', 'run-request-env-var-value');
+  bru.setGlobalEnvVar('run-request-global-env-var', 'run-request-global-env-var-value');
+}

--- a/packages/bruno-tests/collection/scripting/api/bru/runRequest.bru
+++ b/packages/bruno-tests/collection/scripting/api/bru/runRequest.bru
@@ -1,0 +1,96 @@
+meta {
+  name: runRequest
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{host}}/api/echo/json
+  body: json
+  auth: none
+}
+
+headers {
+  foo: bar
+}
+
+auth:basic {
+  username: asd
+  password: j
+}
+
+auth:bearer {
+  token: 
+}
+
+body:json {
+  {
+    "hello": "bruno"
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:pre-request {
+  bru.setVar("runRequest-ping-res-1", null);
+  bru.setVar("runRequest-ping-res-2", null);
+  bru.setVar("runRequest-ping-res-3", null);
+  
+  let pingRes = await bru.runRequest('ping');
+  bru.setVar('runRequest-ping-res-1', {
+    data: pingRes?.data,
+    statusText: pingRes?.statusText,
+    status: pingRes?.status
+  });
+}
+
+script:post-response {
+  let pingRes = await bru.runRequest('ping');
+  bru.setVar('runRequest-ping-res-2', {
+    data: pingRes?.data,
+    statusText: pingRes?.statusText,
+    status: pingRes?.status
+  });
+}
+
+tests {
+  const pingRes = await bru.runRequest('ping');
+  bru.setVar('runRequest-ping-res-3', {
+    data: pingRes?.data,
+    statusText: pingRes?.statusText,
+    status: pingRes?.status
+  });
+  
+  test("should run request and return valid response in pre-request script", function() {
+    const expectedPingRes = {
+      data: "pong",
+      statusText: "OK",
+      status: 200
+    };
+    const pingRes = bru.getVar('runRequest-ping-res-1');
+    expect(pingRes).to.eql(expectedPingRes);
+  });
+  
+  test("should run request and return valid response in post-response script", function() {
+    const expectedPingRes = {
+      data: "pong",
+      statusText: "OK",
+      status: 200
+    };
+    const pingRes = bru.getVar('runRequest-ping-res-2');
+    expect(pingRes).to.eql(expectedPingRes);
+  });
+  
+  test("should run request and return valid response in tests script", function() {
+    const expectedPingRes = {
+      data: "pong",
+      statusText: "OK",
+      status: 200
+    };
+    const pingRes = bru.getVar('runRequest-ping-res-3');
+    expect(pingRes).to.eql(expectedPingRes);
+  });
+  
+}

--- a/packages/bruno-tests/collection/scripting/api/bru/runner/1.bru
+++ b/packages/bruno-tests/collection/scripting/api/bru/runner/1.bru
@@ -1,0 +1,19 @@
+meta {
+  name: 1
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  bru.setVar('bru-runner-req', 1);
+}
+
+script:post-response {
+  bru.setVar('bru.runner.skipRequest', true);
+}

--- a/packages/bruno-tests/collection/scripting/api/bru/runner/2.bru
+++ b/packages/bruno-tests/collection/scripting/api/bru/runner/2.bru
@@ -1,0 +1,19 @@
+meta {
+  name: 2
+  type: http
+  seq: 2
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  bru.runner.skipRequest();
+}
+
+script:post-response {
+  bru.setVar('bru.runner.skipRequest', false);
+}

--- a/packages/bruno-tests/collection/scripting/api/bru/runner/3.bru
+++ b/packages/bruno-tests/collection/scripting/api/bru/runner/3.bru
@@ -1,0 +1,11 @@
+meta {
+  name: 3
+  type: http
+  seq: 3
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: none
+  auth: none
+}


### PR DESCRIPTION
~ fixes the variables set/get inconsistency with `bru.runRequest` executions
~ adds support for `bru.runRequest` and bru runner util functions support to cli

before:
![_before](https://github.com/user-attachments/assets/17da1bd3-4cb0-4bdf-a88a-60cc6db750f6)

after:
![_after](https://github.com/user-attachments/assets/20409f73-8132-4653-8295-c1f824f8e632)


https://github.com/user-attachments/assets/aa133dee-feb0-4fd7-a287-343f8c48113e



