### PR TITLE
Fix: Run Collection-Level Scripts During GraphQL Introspection

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/index.js
@@ -6,7 +6,6 @@ import { findEnvironmentInCollection } from 'utils/collections';
 import Dropdown from '../../Dropdown';
 
 const GraphQLSchemaActions = ({ item, collection, onSchemaLoad, toggleDocs }) => {
-  const url = item.draft ? get(item, 'draft.request.url', '') : get(item, 'request.url', '');
   const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
   const request = item.draft ? item.draft.request : item.request;
 
@@ -15,7 +14,7 @@ const GraphQLSchemaActions = ({ item, collection, onSchemaLoad, toggleDocs }) =>
     schemaSource,
     loadSchema,
     isLoading: isSchemaLoading
-  } = useGraphqlSchema(url, environment, request, collection);
+  } = useGraphqlSchema(environment, request, collection, item);
 
   useEffect(() => {
     if (onSchemaLoad) {

--- a/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/useGraphqlSchema.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/useGraphqlSchema.js
@@ -3,11 +3,13 @@ import toast from 'react-hot-toast';
 import { buildClientSchema, buildSchema } from 'graphql';
 import { fetchGqlSchema } from 'utils/network';
 import { simpleHash, safeParseJSON } from 'utils/common';
+import { get } from 'lodash';
 
 const schemaHashPrefix = 'bruno.graphqlSchema';
 
-const useGraphqlSchema = (endpoint, environment, request, collection) => {
+const useGraphqlSchema = (environment, request, collection, item) => {
   const { ipcRenderer } = window;
+  const endpoint = item.draft ? get(item, 'draft.request.url', '') : get(item, 'request.url', '');
   const localStorageKey = `${schemaHashPrefix}.${simpleHash(endpoint)}`;
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -31,7 +33,7 @@ const useGraphqlSchema = (endpoint, environment, request, collection) => {
   });
 
   const loadSchemaFromIntrospection = async () => {
-    const response = await fetchGqlSchema(endpoint, environment, request, collection);
+    const response = await fetchGqlSchema(environment, request, collection, item);
     if (!response) {
       throw new Error('Introspection query failed');
     }

--- a/packages/bruno-app/src/utils/network/index.js
+++ b/packages/bruno-app/src/utils/network/index.js
@@ -50,11 +50,11 @@ export const clearOauth2Cache = async (uid) => {
   });
 };
 
-export const fetchGqlSchema = async (endpoint, environment, request, collection) => {
+export const fetchGqlSchema = async (environment, request, collection, item) => {
   return new Promise((resolve, reject) => {
     const { ipcRenderer } = window;
 
-    ipcRenderer.invoke('fetch-gql-schema', endpoint, environment, request, collection).then(resolve).catch(reject);
+    ipcRenderer.invoke('fetch-gql-schema', environment, request, collection, item).then(resolve).catch(reject);
   });
 };
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -860,11 +860,11 @@ const registerNetworkIpc = (mainWindow) => {
     });
   });
 
-  ipcMain.handle('fetch-gql-schema', async (event, endpoint, environment, _request, collection) => {
+  ipcMain.handle('fetch-gql-schema', async (event, environment, _request, collection, item) => {
     try {
       const envVars = getEnvVars(environment);
       const collectionRoot = get(collection, 'root', {});
-      const request = prepareGqlIntrospectionRequest(endpoint, envVars, _request, collectionRoot);
+      const request = prepareGqlIntrospectionRequest(envVars, _request, collection, item);
 
       request.timeout = preferencesUtil.getRequestTimeout();
 


### PR DESCRIPTION
# Description

Addressing issue: #3861 
This PR fixes an issue where GraphQL introspection was not executing collection-level `script:pre-request` and `script:post-response` scripts.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/26839572-c396-478f-8660-4dfdba97e189

