### PR TITLE
fix: bump axios version to handle ivp6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24210,7 +24210,7 @@
         "@usebruno/vm2": "^3.9.13",
         "about-window": "^1.15.2",
         "aws4-axios": "^3.3.0",
-        "axios": "1.7.5",
+        "axios": "1.7.7",
         "axios-ntlm": "^1.4.2",
         "chai": "^4.3.7",
         "chokidar": "^3.5.3",
@@ -24245,6 +24245,17 @@
       },
       "optionalDependencies": {
         "dmg-license": "^1.0.11"
+      }
+    },
+    "packages/bruno-electron/node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/bruno-electron/node_modules/fs-extra": {

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -33,7 +33,7 @@
     "@usebruno/vm2": "^3.9.13",
     "about-window": "^1.15.2",
     "aws4-axios": "^3.3.0",
-    "axios": "1.7.5",
+    "axios": "1.7.7",
     "axios-ntlm": "^1.4.2",
     "chai": "^4.3.7",
     "chokidar": "^3.5.3",


### PR DESCRIPTION
# Description

Currently url that contains ipv6 throws an error as reported in [this issue](https://github.com/usebruno/bruno/issues/2338)

This PR bumps axios version to 1.7.7 that has the ipv6 fix ([axios PR](https://github.com/axios/axios/pull/5731))

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
