### PR TITLE
Fix: Env values storing as number

### DIFF
--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -73,7 +73,7 @@ class Bru {
       throw new Error('Creating a env variable without specifying a name is not allowed.');
     }
 
-    this.envVariables[key] = value;
+    this.envVariables[key] = String(value);
   }
 
   deleteEnvVar(key) {
@@ -89,7 +89,7 @@ class Bru {
       throw new Error('Creating a env variable without specifying a name is not allowed.');
     }
 
-    this.globalEnvironmentVariables[key] = value;
+    this.globalEnvironmentVariables[key] = String(value);
   }
 
   hasVar(key) {


### PR DESCRIPTION
# Description
Addressing issue: #3859 

If a user stored any number using `bru.setGlobalEnvVar` or `bru.setEnvVar`, the GUI environment variable would stop working entirely. To resolve this issue, I have implemented typecasting of values to strings before storing them.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
