### PR TITLE
fix: resolve function recusion

### DIFF
--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -229,26 +229,27 @@ const transformOpenapiRequestItem = (request) => {
   return brunoRequestItem;
 };
 
-const resolveRefs = (spec, components = spec?.components, visitedItems = new Set()) => {
+const resolveRefs = (spec, components = spec?.components, cache = new Map()) => {
   if (!spec || typeof spec !== 'object') {
     return spec;
   }
 
+  if (cache.has(spec)) {
+    return cache.get(spec);
+  }
+
   if (Array.isArray(spec)) {
-    return spec.map((item) => resolveRefs(item, components, visitedItems));
+    return spec.map(item => resolveRefs(item, components, cache));
   }
 
   if ('$ref' in spec) {
     const refPath = spec.$ref;
 
-    if (visitedItems.has(refPath)) {
-      return spec;
-    } else {
-      visitedItems.add(refPath);
+    if (cache.has(refPath)) {
+      return cache.get(refPath);
     }
 
     if (refPath.startsWith('#/components/')) {
-      // Local reference within components
       const refKeys = refPath.replace('#/components/', '').split('/');
       let ref = components;
 
@@ -256,25 +257,26 @@ const resolveRefs = (spec, components = spec?.components, visitedItems = new Set
         if (ref && ref[key]) {
           ref = ref[key];
         } else {
-          // Handle invalid references gracefully?
           return spec;
         }
       }
 
-      return resolveRefs(ref, components, visitedItems);
-    } else {
-      // Handle external references (not implemented here)
-      // You would need to fetch the external reference and resolve it.
-      // Example: Fetch and resolve an external reference from a URL.
+      cache.set(refPath, {});
+      const resolved = resolveRefs(ref, components, cache);
+      cache.set(refPath, resolved);
+      return resolved;
     }
+    return spec;
   }
 
-  // Recursively resolve references in nested objects
-  for (const prop in spec) {
-    spec[prop] = resolveRefs(spec[prop], components, new Set(visitedItems));
+  const resolved = {};
+  cache.set(spec, resolved);
+
+  for (const [key, value] of Object.entries(spec)) {
+    resolved[key] = resolveRefs(value, components, cache);
   }
 
-  return spec;
+  return resolved;
 };
 
 const groupRequestsByTags = (requests) => {


### PR DESCRIPTION
# Description

Addressing issue: https://github.com/usebruno/bruno/issues/3663, https://github.com/usebruno/bruno/issues/3631

Fixed OpenAPI collection import failure when handling circular references in the specification. Previously, the application would crash with a `RangeError: Maximum call stack size exceeded` error when trying to import OpenAPI collections containing circular references.

## Changes Made
- Improved `resolveRefs` function to properly handle circular references
- Implemented caching mechanism using Map to store resolved references
- Added proper handling of intermediate states during reference resolution
- Prevented infinite recursion while maintaining the integrity of the imported collection

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**