### PR TITLE
feat: Persist response body scroll position across tabs

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -7,7 +7,7 @@ import HttpRequestPane from 'components/RequestPane/HttpRequestPane';
 import ResponsePane from 'components/ResponsePane';
 import Welcome from 'components/Welcome';
 import { findItemInCollection } from 'utils/collections';
-import { updateRequestPaneTabWidth } from 'providers/ReduxStore/slices/tabs';
+import { updateRequestPaneTabWidth, updateResponsePaneScrollPosition } from 'providers/ReduxStore/slices/tabs';
 import { sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import RequestNotFound from './RequestNotFound';
 import QueryUrl from 'components/RequestPane/QueryUrl';
@@ -168,6 +168,12 @@ const RequestTabPanel = () => {
   }
 
   const handleRun = async () => {
+    dispatch(
+      updateResponsePaneScrollPosition({
+        uid: focusedTab.uid,
+        scrollY: 0
+      })
+    );
     dispatch(sendRequest(item, collection.uid)).catch((err) =>
       toast.custom((t) => <NetworkError onClose={() => toast.dismiss(t.id)} />, {
         duration: 5000

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import CodeEditor from 'components/CodeEditor/index';
-import { get } from 'lodash';
+import { get, debounce } from 'lodash';
+import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
+import { updateResponsePaneScrollPosition } from 'providers/ReduxStore/slices/tabs';
 import { sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { Document, Page } from 'react-pdf';
 import 'pdfjs-dist/build/pdf.worker';
@@ -51,6 +53,10 @@ const QueryResultPreview = ({
   displayedTheme
 }) => {
   const preferences = useSelector((state) => state.app.preferences);
+  const tabs = useSelector((state) => state.tabs.tabs);
+  const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
+  const focusedTab = find(tabs, (t) => t.uid === activeTabUid);
+
   const dispatch = useDispatch();
 
   const [numPages, setNumPages] = useState(null);
@@ -66,7 +72,23 @@ const QueryResultPreview = ({
     if (disableRunEventListener) {
       return;
     }
+
+    dispatch(
+      updateResponsePaneScrollPosition({
+        uid: focusedTab.uid,
+        scrollY: 0
+      })
+    );
     dispatch(sendRequest(item, collection.uid));
+  };
+
+  const updateTabScrollPos = (scrollY) => {
+    dispatch(
+      updateResponsePaneScrollPosition({
+        uid: focusedTab.uid,
+        scrollY: scrollY
+      })
+    );
   };
 
   switch (previewTab?.mode) {
@@ -113,6 +135,8 @@ const QueryResultPreview = ({
           onRun={onRun}
           value={formattedData}
           mode={mode}
+          initialScroll={focusedTab.responsePaneScrollPosition}
+          updateTabScrollPos={updateTabScrollPos}
           readOnly
         />
       );

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -40,6 +40,7 @@ export const tabsSlice = createSlice({
         requestPaneWidth: null,
         requestPaneTab: action.payload.requestPaneTab || 'params',
         responsePaneTab: 'response',
+        responsePaneScrollPosition: null,
         type: action.payload.type || 'request',
         ...(action.payload.uid ? { folderUid: action.payload.uid } : {})
       });
@@ -89,6 +90,13 @@ export const tabsSlice = createSlice({
         tab.responsePaneTab = action.payload.responsePaneTab;
       }
     },
+    updateResponsePaneScrollPosition: (state, action) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+
+      if (tab) {
+        tab.responsePaneScrollPosition = action.payload.scrollY;
+      }
+    },
     closeTabs: (state, action) => {
       const activeTab = find(state.tabs, (t) => t.uid === state.activeTabUid);
       const tabUids = action.payload.tabUids || [];
@@ -135,6 +143,7 @@ export const {
   updateRequestPaneTabWidth,
   updateRequestPaneTab,
   updateResponsePaneTab,
+  updateResponsePaneScrollPosition,
   closeTabs,
   closeAllCollectionTabs
 } = tabsSlice.actions;


### PR DESCRIPTION
# Description

Persists the response body's scroll position when changing tabs. When a user changes to another tab and then comes back to the original tab, the previous scroll position will be restored.

This aims to solve https://github.com/usebruno/bruno/issues/3147 and https://github.com/usebruno/bruno/issues/2742.

I appreciate there may be a few changes needed here needed but the general principle should be there.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**