### PR TITLE
feat: save-all command

### DIFF
--- a/packages/bruno-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
+++ b/packages/bruno-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
@@ -45,7 +45,7 @@ const SaveRequestsModal = ({ onClose }) => {
   };
 
   const closeWithSave = () => {
-    dispatch(saveMultipleRequests(currentDrafts))
+    dispatch(saveMultipleRequests(currentDrafts, true))
       .then(() => dispatch(completeQuitFlow()))
       .then(() => onClose());
   };

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -1,5 +1,6 @@
 const KeyMapping = {
   save: { mac: 'command+s', windows: 'ctrl+s', name: 'Save' },
+  saveAll: { mac: 'command+shift+s', windows: 'ctrl+shift+s', name: 'Save All' },
   sendRequest: { mac: 'command+enter', windows: 'ctrl+enter', name: 'Send Request' },
   editEnvironment: { mac: 'command+e', windows: 'ctrl+e', name: 'Edit Environment' },
   newRequest: { mac: 'command+b', windows: 'ctrl+b', name: 'New Request' },

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -95,7 +95,7 @@ export const saveRequest = (itemUid, collectionUid, saveSilently) => (dispatch, 
   });
 };
 
-export const saveMultipleRequests = (items) => (dispatch, getState) => {
+export const saveMultipleRequests = (items, saveSilently) => (dispatch, getState) => {
   const state = getState();
   const { collections } = state.collections;
 
@@ -119,6 +119,11 @@ export const saveMultipleRequests = (items) => (dispatch, getState) => {
 
     ipcRenderer
       .invoke('renderer:save-multiple-requests', itemsToSave)
+      .then(() => {
+        if (!saveSilently) {
+          toast.success('All request saved successfully');
+        }
+      })
       .then(resolve)
       .catch((err) => {
         toast.error('Failed to save requests!');


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

While using Bruno, I always wondered why the save-all feature did not exist.

I read the issues and realized that it had been addressed multiple times: #737, #846, #2916, and PR #890. However, for some reason, the PR was not merged.

I did my best to use existing functions and only added or changed code when necessary.

I mainly used the already implemented function saveMultipleRequests to handle the save-all command and needed to add saveSilently because I had to add a toast (referencing the existing saveRequest function).

![2025-01-305 33 54-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f20e79a3-ffe1-4967-94e5-ada15d802c2d)




### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
