### PR TITLE
Add: styling for matching brackets

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -103,9 +103,9 @@ const StyledWrapper = styled.div`
     color: #397d13 !important;
   }
   .CodeMirror-nonmatchingbracket {
-    background-color:rgba(255, 0, 0, 0.35);
-    text-decoration: none;
-    font-weight: bold; 
+    background-color: rgba(220, 53, 69, 0.3);
+    color: currentColor !important;
+    border: 1px solid rgb(220, 53, 69);
   }
   
   //matching bracket fix


### PR DESCRIPTION
# Description
Addressing issue: [#3871]

Added custom styling for matching and non-matching brackets in CodeMirror.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="621" alt="matchingBrackets" src="https://github.com/user-attachments/assets/50792fc0-008f-41da-bc51-b7d289d21f55" />

