### PR TITLE
fix: original response modification while modifing response in tests tab

### DIFF
--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -9,7 +9,7 @@ const zlib = require('zlib');
 const url = require('url');
 const punycode = require('punycode');
 const fs = require('fs');
-const { get } = require('lodash');
+const { get, cloneDeep } = require('lodash');
 const Bru = require('../bru');
 const BrunoRequest = require('../bruno-request');
 const BrunoResponse = require('../bruno-response');
@@ -68,6 +68,9 @@ class TestRuntime {
     scriptingConfig,
     runRequestByItemPathname
   ) {
+    // Clone the response to prevent modifications to the original
+    const clonedResponse = cloneDeep(response);
+
     const globalEnvironmentVariables = request?.globalEnvironmentVariables || {};
     const collectionVariables = request?.collectionVariables || {};
     const folderVariables = request?.folderVariables || {};
@@ -75,7 +78,7 @@ class TestRuntime {
     const assertionResults = request?.assertionResults || [];
     const bru = new Bru(envVariables, runtimeVariables, processEnvVars, collectionPath, collectionVariables, folderVariables, requestVariables, globalEnvironmentVariables);
     const req = new BrunoRequest(request);
-    const res = new BrunoResponse(response);
+    const res = new BrunoResponse(clonedResponse);
     const allowScriptFilesystemAccess = get(scriptingConfig, 'filesystemAccess.allow', false);
     const moduleWhitelist = get(scriptingConfig, 'moduleWhitelist', []);
     const additionalContextRoots = get(scriptingConfig, 'additionalContextRoots', []);


### PR DESCRIPTION
# Description

### Related Issues:
This PR addresses #3443 where the original response object was being mutated during test execution, which could lead to unexpected behavior and inconsistencies in test results.

## Problem
The current implementation directly passes the response object to `BrunoResponse` constructor, which means any modifications made during test execution affect the original response object. 

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/180a64f8-c27e-49f2-8c85-56349c511618


