### PR TITLE
hotfix: import fails when env variables are not string type

### DIFF
--- a/packages/bruno-app/src/utils/importers/bruno-collection.js
+++ b/packages/bruno-app/src/utils/importers/bruno-collection.js
@@ -1,6 +1,12 @@
 import fileDialog from 'file-dialog';
 import { BrunoError } from 'utils/common/error';
-import { validateSchema, transformItemsInCollection, updateUidsInCollection, hydrateSeqInCollection } from './common';
+import {
+  validateSchema,
+  transformItemsInCollection,
+  updateUidsInCollection,
+  hydrateSeqInCollection,
+  transformEnvironmentsInCollection
+} from './common';
 
 const readFile = (files) => {
   return new Promise((resolve, reject) => {
@@ -31,6 +37,7 @@ const importCollection = () => {
       .then(hydrateSeqInCollection)
       .then(updateUidsInCollection)
       .then(transformItemsInCollection)
+      .then(transformEnvironmentsInCollection)
       .then(validateSchema)
       .then((collection) => resolve({ collection }))
       .catch((err) => {

--- a/packages/bruno-app/src/utils/importers/common.js
+++ b/packages/bruno-app/src/utils/importers/common.js
@@ -100,6 +100,22 @@ export const transformItemsInCollection = (collection) => {
   return collection;
 };
 
+export const transformEnvironmentsInCollection = (collection) => {
+  const transformEnvironments = (envs = []) => {
+    each(envs, (env) => {
+      each(env.variables, (variable) => {
+        if (typeof variable.value !== 'string') {
+          variable.value = JSON.stringify(variable.value);
+        }
+      });
+    });
+  };
+
+  transformEnvironments(collection.environments);
+
+  return collection;
+};
+
 export const hydrateSeqInCollection = (collection) => {
   const hydrateSeq = (items = []) => {
     let index = 1;


### PR DESCRIPTION
# Description

Environment variables that are set using scripts, with `bru.setEnvVar()` when exported is being exported values that are other than type string, as we have strict string check for env variables, while importing the same collection, the the collection is failing to import.  this is just a hot fix for the imports to happen gracefully.

Need to have discussion on how to tackle this problem. 

- How to handle env variables set though script, should they get written to file or not?
- Should we implement parsing for there variables to used in scripts after import if we chose to store them in files
- Styling for values which have types other than string
- Info icon if necessary on the behaviour we chose to go ahead with.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
