### PR TITLE
Styling improvements in collection overview

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
@@ -1,18 +1,19 @@
 import React from 'react';
 import { getTotalRequestCountInCollection } from 'utils/collections/';
-import { IconFolder, IconFileOff, IconWorld, IconApi } from '@tabler/icons';
+import { IconFolder,IconWorld, IconApi } from '@tabler/icons';
+
 
 const Info = ({ collection }) => {
   const totalRequestsInCollection = getTotalRequestCountInCollection(collection);
 
   return (
-    <div className="w-full flex flex-col h-fit">
+    <div className="w-full flex flex-col h-fit mb-6">
       <div className="rounded-lg py-6">
         <div className="grid gap-6">
           {/* Location Row */}
           <div className="flex items-start">
             <div className="flex-shrink-0 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-              <IconFolder className="w-5 h-5 text-blue-500" stroke={1.5} />
+              <IconFolder className="w-5 h-5 text-[#569cd6]" stroke={1.5} />
             </div>
             <div className="ml-4">
               <div className="font-semibold text-sm">Location</div>
@@ -25,7 +26,7 @@ const Info = ({ collection }) => {
           {/* Environments Row */}
           <div className="flex items-start">
             <div className="flex-shrink-0 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
-              <IconWorld className="w-5 h-5 text-green-500" stroke={1.5} />
+              <IconWorld className="w-5 h-5 text-[#8cd656]" stroke={1.5} />
             </div>
             <div className="ml-4">
               <div className="font-semibold text-sm">Environments</div>
@@ -38,7 +39,7 @@ const Info = ({ collection }) => {
           {/* Requests Row */}
           <div className="flex items-start">
             <div className="flex-shrink-0 p-3 bg-purple-50 dark:bg-purple-900/20 rounded-lg">
-              <IconApi className="w-5 h-5 text-purple-500" stroke={1.5} />
+              <IconApi className="w-5 h-5 text-[#cd56d6]" stroke={1.5} />
             </div>
             <div className="ml-4">
               <div className="font-semibold text-sm">Requests</div>

--- a/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
@@ -2,10 +2,28 @@ import React from 'react';
 import { flattenItems } from "utils/collections";
 import { IconAlertTriangle } from '@tabler/icons';
 import StyledWrapper from "./StyledWrapper";
+import { useDispatch, useSelector } from 'react-redux';
+import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
 
 const RequestsNotLoaded = ({ collection }) => {
+  const dispatch = useDispatch();
+  const tabs = useSelector((state) => state.tabs.tabs);
   const flattenedItems = flattenItems(collection.items);
   const itemsFailedLoading = flattenedItems?.filter(item => item?.partial && !item?.loading);
+
+  const handlePathClick = (item) => {
+    const existingTab = tabs.find(tab => tab.uid === item.uid);
+    if (existingTab) {
+      dispatch(focusTab({ uid: item.uid }));
+    } else {
+      dispatch(addTab({
+        uid: item.uid,
+        collectionUid: collection.uid,
+        pathname: item.pathname,
+        type: 'request'
+      }));
+    }
+  };
 
   if (!itemsFailedLoading?.length) {
     return null;
@@ -33,7 +51,12 @@ const RequestsNotLoaded = ({ collection }) => {
             item?.partial && !item?.loading ? (
               <tr key={index}>
                 <td className="py-1.5 px-3">
-                  {item?.pathname?.split(`${collection?.pathname}/`)?.[1]}
+                  <button 
+                    onClick={() => handlePathClick(item)}
+                    className="text-[#1663bb] hover:text-blue-800 hover:underline text-left"
+                  >
+                    {item?.pathname?.split(`${collection?.pathname}/`)?.[1]}
+                  </button>
                 </td>
                 <td className="py-1.5 px-3">
                   {item?.size?.toFixed?.(2)}&nbsp;MB

--- a/packages/bruno-app/src/components/CollectionSettings/Overview/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/index.js
@@ -1,14 +1,17 @@
+import React, { useState } from 'react';
 import StyledWrapper from "./StyledWrapper";
 import Docs from "../Docs";
 import Info from "./Info";
-import { IconBox } from '@tabler/icons';
+import { IconBox, IconChevronLeft, IconChevronRight } from '@tabler/icons';
 import RequestsNotLoaded from "./RequestsNotLoaded";
 
 const Overview = ({ collection }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
   return (
     <div className="h-full">
-      <div className="grid grid-cols-5 gap-4 h-full">
-        <div className="col-span-2">
+      <div className="flex h-full">
+        <div className={`transition-all duration-300 ${isExpanded ? 'w-0 opacity-0' : 'w-2/5 opacity-100'}`}>
           <div className="text-xl font-semibold flex items-center gap-2">
             <IconBox size={24} stroke={1.5} />
             {collection?.name}
@@ -16,7 +19,20 @@ const Overview = ({ collection }) => {
           <Info collection={collection} />
           <RequestsNotLoaded collection={collection} />
         </div>
-        <div className="col-span-3">
+        <div className="relative group/divider">
+          <div className="w-[0.5px] bg-gray-200 dark:bg-gray-700 mx-6 h-full"></div>
+          <button
+            className="absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 w-6 h-6 rounded-full bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 flex items-center justify-center cursor-pointer transition-all opacity-0 group-hover/divider:opacity-100 group"
+            onClick={() => setIsExpanded(!isExpanded)}
+          >
+            {isExpanded ? (
+              <IconChevronRight size={16} className="text-gray-600 dark:text-gray-300 group-hover:text-gray-800 dark:group-hover:text-white" />
+            ) : (
+              <IconChevronLeft size={16} className="text-gray-600 dark:text-gray-300 group-hover:text-gray-800 dark:group-hover:text-white" />
+            )}
+          </button>
+        </div>
+        <div className={`transition-all duration-300 ${isExpanded ? 'flex-1' : 'flex-1'}`}>
           <Docs collection={collection} />
         </div>
       </div>


### PR DESCRIPTION
# Description

- Added hyperlinks to request tabs in the Collection Overview alerts table.
- Added an icon for expanding/collapsing the **Docs** section, which appears on hover near the divider line.
- Updated icon colors to align with the app's color palette.


### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
