### PR TITLE
Fix: Folder drag-and-drop crash

### DIFF
--- a/packages/bruno-app/src/components/FolderSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/index.js
@@ -14,6 +14,12 @@ const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
 const Headers = ({ collection, folder }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
+
+  // Add validation to ensure collection, folder and their required properties exist
+  if (!collection?.uid || !folder?.uid) {
+    return null;
+  }
+
   const headers = get(folder, 'root.request.headers', []);
 
   const addHeader = () => {
@@ -25,8 +31,18 @@ const Headers = ({ collection, folder }) => {
     );
   };
 
-  const handleSave = () => dispatch(saveFolderRoot(collection.uid, folder.uid));
+  const handleSave = () => {
+    if (!collection?.uid || !folder?.uid) {
+      return;
+    }
+    dispatch(saveFolderRoot(collection.uid, folder.uid));
+  };
+
   const handleHeaderValueChange = (e, _header, type) => {
+    if (!collection?.uid || !folder?.uid) {
+      return;
+    }
+
     const header = cloneDeep(_header);
     switch (type) {
       case 'name': {
@@ -52,6 +68,10 @@ const Headers = ({ collection, folder }) => {
   };
 
   const handleRemoveHeader = (header) => {
+    if (!collection?.uid || !folder?.uid || !header?.uid) {
+      return;
+    }
+
     dispatch(
       deleteFolderHeader({
         headerUid: header.uid,

--- a/packages/bruno-app/src/components/FolderSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/index.js
@@ -14,7 +14,6 @@ const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
 const Headers = ({ collection, folder }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
-
   const headers = get(folder, 'root.request.headers', []);
 
   const addHeader = () => {
@@ -26,9 +25,7 @@ const Headers = ({ collection, folder }) => {
     );
   };
 
-  const handleSave = () => {
-    dispatch(saveFolderRoot(collection.uid, folder.uid));
-  };
+  const handleSave = () => dispatch(saveFolderRoot(collection.uid, folder.uid));
 
   const handleHeaderValueChange = (e, _header, type) => {
 

--- a/packages/bruno-app/src/components/FolderSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/index.js
@@ -15,11 +15,6 @@ const Headers = ({ collection, folder }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
 
-  // Add validation to ensure collection, folder and their required properties exist
-  if (!collection?.uid || !folder?.uid) {
-    return null;
-  }
-
   const headers = get(folder, 'root.request.headers', []);
 
   const addHeader = () => {
@@ -32,16 +27,10 @@ const Headers = ({ collection, folder }) => {
   };
 
   const handleSave = () => {
-    if (!collection?.uid || !folder?.uid) {
-      return;
-    }
     dispatch(saveFolderRoot(collection.uid, folder.uid));
   };
 
   const handleHeaderValueChange = (e, _header, type) => {
-    if (!collection?.uid || !folder?.uid) {
-      return;
-    }
 
     const header = cloneDeep(_header);
     switch (type) {
@@ -68,10 +57,6 @@ const Headers = ({ collection, folder }) => {
   };
 
   const handleRemoveHeader = (header) => {
-    if (!collection?.uid || !folder?.uid || !header?.uid) {
-      return;
-    }
-
     dispatch(
       deleteFolderHeader({
         headerUid: header.uid,

--- a/packages/bruno-app/src/components/FolderSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/index.js
@@ -26,9 +26,7 @@ const Headers = ({ collection, folder }) => {
   };
 
   const handleSave = () => dispatch(saveFolderRoot(collection.uid, folder.uid));
-
   const handleHeaderValueChange = (e, _header, type) => {
-
     const header = cloneDeep(_header);
     switch (type) {
       case 'name': {

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -25,6 +25,7 @@ import { produce } from 'immer';
 import CollectionOverview from 'components/CollectionSettings/Overview';
 import RequestNotLoaded from './RequestNotLoaded';
 import RequestIsLoading from './RequestIsLoading';
+import { closeTabs } from 'providers/ReduxStore/slices/tabs';
 
 const MIN_LEFT_PANE_WIDTH = 300;
 const MIN_RIGHT_PANE_WIDTH = 350;
@@ -163,6 +164,14 @@ const RequestTabPanel = () => {
 
   if (focusedTab.type === 'folder-settings') {
     const folder = findItemInCollection(collection, focusedTab.folderUid);
+    if (!folder) {
+      dispatch(
+        closeTabs({
+          tabUids: [activeTabUid]
+        })
+      );
+    }
+    
     return <FolderSettings collection={collection} folder={folder} />;
   }
 


### PR DESCRIPTION
# Description

This PR enhances the handling of folder tabs during drag-and-drop operations to prevent crashes and improve user experience. 

## Changes:

1. Added automatic tab closure when a folder is moved to a new location in the collection hierarchy
2. Previously, when performing certain folder movements (like nesting folders), the folder settings tab would remain open but could no longer find the folder in its original location, causing errors
3. Now, when a folder is moved and its settings tab is open, the application automatically closes that tab to prevent accessing invalid folder references

## Specific scenarios fixed:

- When dragging `Folder 1` into `Folder 2`, any open settings tab for `Folder 1` is automatically closed

## Before (Bug Reproduction Video)
https://github.com/user-attachments/assets/317e8d7a-c8f3-4dd7-9acd-b648678769dc

## After (Fixed Behavior Video)
https://github.com/user-attachments/assets/04f75bdc-a914-4f62-849b-c71377429a26

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
