### PR TITLE
Support All Data Types in Environment Variables

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/StyledWrapper.js
@@ -33,6 +33,10 @@ const Wrapper = styled.div`
     thead td {
       padding: 6px 10px;
     }
+    select {
+      background-color: transparent;
+      width: 100%;
+    }
   }
 
   .btn-add-param {

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -4,10 +4,18 @@ const { uidSchema } = require('../common');
 const environmentVariablesSchema = Yup.object({
   uid: uidSchema,
   name: Yup.string().nullable(),
-  value: Yup.string().nullable(),
-  type: Yup.string().oneOf(['text']).required('type is required'),
+  value: Yup.mixed().nullable(),
+  displayValue: Yup.string()
+    .nullable()
+    .when('type', {
+      is: 'number',
+      then: Yup.string().matches(/^-?\d+(\.\d+)?$/, 'Invalid number'),
+      otherwise: Yup.string().nullable(),
+    }),
+
+  type: Yup.string().oneOf(['text', 'number', 'boolean', 'object']).required('Type is required'),
   enabled: Yup.boolean().defined(),
-  secret: Yup.boolean()
+  secret: Yup.boolean(),
 })
   .noUnknown(true)
   .strict();
@@ -15,7 +23,7 @@ const environmentVariablesSchema = Yup.object({
 const environmentSchema = Yup.object({
   uid: uidSchema,
   name: Yup.string().min(1).required('name is required'),
-  variables: Yup.array().of(environmentVariablesSchema).required('variables are required')
+  variables: Yup.array().of(environmentVariablesSchema).required('variables are required'),
 })
   .noUnknown(true)
   .strict();
@@ -140,14 +148,14 @@ const authDigestSchema = Yup.object({
 
 
 
-  const authNTLMSchema = Yup.object({
-    username: Yup.string().nullable(),
-    password: Yup.string().nullable(),
-    domain: Yup.string().nullable()
+const authNTLMSchema = Yup.object({
+  username: Yup.string().nullable(),
+  password: Yup.string().nullable(),
+  domain: Yup.string().nullable()
 
-  })
-    .noUnknown(true)
-    .strict();  
+})
+  .noUnknown(true)
+  .strict();
 
 const authApiKeySchema = Yup.object({
   key: Yup.string().nullable(),


### PR DESCRIPTION
# Description

Previously, collection environment variables only supported strings, but users could still store objects, numbers, and other types using the setEnvVar() function in scripts. This inconsistency led to multiple issues, including:

Errors during saving and deletion of variables
Problems with export/import of collections
This PR introduces a robust solution to officially support all data types in environment variables while maintaining backward compatibility with older collection exports.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
<img width="534" alt="Screenshot 2025-02-06 at 11 31 13 AM" src="https://github.com/user-attachments/assets/0a0d17ba-c75f-4278-84d0-d30db102df76" />

