### PR TITLE
Added proxy flag for cli

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -347,6 +347,11 @@ const builder = async (yargs) => {
       type: 'string',
       description: 'Path to the Client certificate config file used for securing the connection in the request'
     })
+    .option('proxy', {
+      type: 'boolean',
+      description: 'proxy',
+      default: false
+    })
 
     .example('$0 run request.bru', 'Run a request')
     .example('$0 run request.bru --env local', 'Run a request with the environment set to local')
@@ -411,7 +416,8 @@ const handler = async function (argv) {
       bail,
       reporterSkipAllHeaders,
       reporterSkipHeaders,
-      clientCertConfig
+      clientCertConfig,
+      proxy
     } = argv;
     const collectionPath = process.cwd();
 
@@ -663,7 +669,8 @@ const handler = async function (argv) {
             collectionRoot,
             runtime,
             collection,
-            runSingleRequestByPathname
+            runSingleRequestByPathname,
+            proxy
           );
           resolve(res?.response);
         }
@@ -689,7 +696,8 @@ const handler = async function (argv) {
         collectionRoot,
         runtime,
         collection,
-        runSingleRequestByPathname
+        runSingleRequestByPathname,
+        proxy
       );
 
       results.push({

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -41,7 +41,8 @@ const runSingleRequest = async function (
   collectionRoot,
   runtime,
   collection,
-  runSingleRequestByPathname
+  runSingleRequestByPathname,
+  proxy
 ) {
   try {
     let request;
@@ -183,7 +184,7 @@ const runSingleRequest = async function (
     if (collectionProxyEnabled === true) {
       proxyConfig = collectionProxyConfig;
       proxyMode = 'on';
-    } else {
+    } else if(proxy) {
       // if the collection level proxy is not set, pick the system level proxy by default, to maintain backward compatibility
       const { http_proxy, https_proxy } = getSystemProxyEnvVariables();
       if (http_proxy?.length || https_proxy?.length) {


### PR DESCRIPTION
# Description

Added a `--proxy` flag in the CLI to allow users to enable or disable the system proxy. By default, the system proxy is off, and adding the `--proxy` flag turns it on.

Issue: Previously, when running any request in the CLI, the system proxy was always picked up, and the only way to disable it was by deleting the `https_proxy` environment variables. This flag provides a more convenient way to control proxy usage.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

https://github.com/user-attachments/assets/1eaf55ac-ddde-499c-a268-79b01d890127




