### PR TITLE
improve: delete collection ui and logic

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/StyledWrapper.js
@@ -1,0 +1,154 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  font-family: Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+
+  .collection-info {
+    padding: 0.75rem;
+    margin-bottom: 1.5rem;
+    border-radius: 0.375rem;
+    background: ${props => props.theme.modal.body.bg};
+    border: 1px solid ${props => props.theme.modal.body.border};
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: ${props => props.theme.input.focusBorder};
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+  }
+
+  .collection-name {
+    color: ${props => props.theme.text};
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .collection-path {
+    color: ${props => props.theme.colors.text.muted};
+    font-size: 0.75rem;
+    margin-top: 0.25rem;
+  }
+
+  .checkbox-wrapper {
+    margin: 1.25rem 0;
+
+    label {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      color: ${props => props.theme.text};
+      font-size: 0.8125rem;
+      font-weight: 500;
+      
+      &:hover {
+        cursor: pointer;
+        color: ${props => props.theme.colors.text.danger};
+      }
+    }
+
+    input[type="checkbox"] {
+      appearance: none;
+      width: 1rem;
+      height: 1rem;
+      border: 2px solid ${props => props.theme.input.border};
+      border-radius: 0.25rem;
+      transition: all 0.2s ease;
+      position: relative;
+      
+      &:checked {
+        border-color: ${props => props.theme.button.danger.bg};
+        background-color: ${props => props.theme.button.danger.bg};
+
+        &:after {
+          content: '';
+          position: absolute;
+          left: 4px;
+          top: 1px;
+          width: 4px;
+          height: 8px;
+          border: solid white;
+          border-width: 0 2px 2px 0;
+          transform: rotate(45deg);
+        }
+      }
+
+      &:hover {
+        border-color: ${props => props.theme.button.danger.bg};
+      }
+    }
+  }
+
+  .confirm-input {
+    animation: slideDown 0.2s ease;
+
+    label {
+      display: block;
+      font-size: 0.75rem;
+      margin-bottom: 0.5rem;
+      color: ${props => props.theme.colors.text.muted};
+      font-weight: 500;
+
+      strong {
+        color: ${props => props.theme.colors.text.danger};
+        font-weight: 600;
+      }
+    }
+
+    input {
+      width: 100%;
+      padding: 0.625rem;
+      font-size: 0.8125rem;
+      border-radius: 0.375rem;
+      border: 1px solid ${props => props.theme.input.border};
+      background: ${props => props.theme.input.bg};
+      color: ${props => props.theme.text};
+      transition: all 0.2s ease;
+
+      &:focus {
+        outline: none;
+        border-color: ${props => props.theme.button.danger.bg};
+        box-shadow: 0 0 0 3px ${props => props.theme.button.danger.bg}20;
+      }
+    }
+  }
+
+  .warning-message {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border-radius: 0.375rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    background: ${props => props.theme.requestTabPanel.url.bg};
+    color: ${props => props.theme.colors.text.muted};
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+
+    &.danger {
+      color: ${props => props.theme.colors.text.danger};
+      background: ${props => props.theme.colors.text.danger}10;
+      border-color: ${props => props.theme.colors.text.danger}20;
+    }
+
+    svg {
+      flex-shrink: 0;
+      stroke-width: 2.5;
+    }
+  }
+
+  @keyframes slideDown {
+    from {
+      opacity: 0;
+      transform: translateY(-0.5rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
@@ -1,35 +1,124 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import toast from 'react-hot-toast';
 import Modal from 'components/Modal';
 import { useDispatch } from 'react-redux';
-import { IconFiles } from '@tabler/icons';
+import { IconFiles, IconTrash, IconX, IconLoader2, IconAlertTriangle } from '@tabler/icons';
 import { removeCollection } from 'providers/ReduxStore/slices/collections/actions';
+import StyledWrapper from './StyledWrapper';
 
 const RemoveCollection = ({ onClose, collection }) => {
   const dispatch = useDispatch();
+  const [deleteFromFileSystem, setDeleteFromFileSystem] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const [collectionName, setCollectionName] = useState('');
+  const inputRef = useRef(null);
 
-  const onConfirm = () => {
-    dispatch(removeCollection(collection.uid))
-      .then(() => {
-        toast.success('Collection closed');
-        onClose();
-      })
-      .catch(() => toast.error('An error occurred while closing the collection'));
+  const isNameMatching = collectionName === collection.name;
+
+  useEffect(() => {
+    if (deleteFromFileSystem && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [deleteFromFileSystem]);
+
+  const handleConfirm = async () => {
+    if (deleteFromFileSystem && !isNameMatching) return;
+    setIsClosing(true);
+    try {
+      await dispatch(removeCollection(collection.uid, deleteFromFileSystem));
+      toast.success(deleteFromFileSystem ? 'Collection deleted' : 'Collection closed');
+      onClose();
+    } catch {
+      toast.error(deleteFromFileSystem 
+        ? 'Error deleting the collection'
+        : 'Error closing the collection'
+      );
+      setIsClosing(false);
+    }
   };
 
   return (
-    <Modal size="sm" title="Close Collection" confirmText="Close" handleConfirm={onConfirm} handleCancel={onClose}>
-      <div className="flex items-center">
-        <IconFiles size={18} strokeWidth={1.5} />
-        <span className="ml-2 mr-4 font-semibold">{collection.name}</span>
-      </div>
-      <div className="break-words text-xs mt-1">{collection.pathname}</div>
-      <div className="mt-4">
-        Are you sure you want to close collection <span className="font-semibold">{collection.name}</span> in Bruno?
-      </div>
-      <div className="mt-4">
-        It will still be available in the file system at the above location and can be re-opened later.
-      </div>
+    <Modal 
+      size="md"
+      title={
+        <div className="flex items-center gap-1.5">
+          {isClosing ? (
+            <IconLoader2 className="animate-spin" size={18} />
+          ) : deleteFromFileSystem ? (
+            <IconAlertTriangle className="text-red-500" size={18} />
+          ) : (
+            <IconX size={18} />
+          )}
+          <span className="text-base font-medium">
+            {isClosing 
+              ? (deleteFromFileSystem ? "Deleting Collection" : "Closing Collection")
+              : (deleteFromFileSystem ? "Delete Collection" : "Close Collection")
+            }
+          </span>
+        </div>
+      }
+      confirmText={isClosing ? (deleteFromFileSystem ? "Deleting..." : "Closing...") : (deleteFromFileSystem ? "Delete" : "Close")}
+      handleConfirm={handleConfirm}
+      handleCancel={onClose}
+      confirmDisabled={isClosing || (deleteFromFileSystem && !isNameMatching)}
+      cancelDisabled={isClosing}
+      confirmClassName={deleteFromFileSystem ? 'danger' : 'primary'}
+    >
+      <StyledWrapper>
+        <div className="collection-info">
+          <div className="flex items-center gap-2.5">
+            <IconFiles size={18} />
+            <div>
+              <div className="collection-name">{collection.name}</div>
+              <div className="collection-path">{collection.pathname}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="checkbox-wrapper">
+          <label>
+            <input
+              type="checkbox"
+              checked={deleteFromFileSystem}
+              onChange={(e) => {
+                setDeleteFromFileSystem(e.target.checked);
+                setCollectionName('');
+              }}
+              disabled={isClosing}
+            />
+            <span>Delete collection folder and all contents</span>
+          </label>
+        </div>
+
+        {deleteFromFileSystem && (
+          <div className="confirm-input">
+            <label>Type <strong>{collection.name}</strong> to confirm deletion:</label>
+            <input
+              ref={inputRef}
+              type="text"
+              value={collectionName}
+              onChange={(e) => setCollectionName(e.target.value)}
+              placeholder={collection.name}
+              disabled={isClosing}
+              autoComplete="off"
+            />
+          </div>
+        )}
+
+        <div className={`warning-message ${deleteFromFileSystem ? 'danger' : ''}`}>
+          {deleteFromFileSystem ? (
+            <>
+              <IconTrash size={14} />
+              <span>This action cannot be undone.</span>
+            </>
+          ) : (
+            <>
+              <IconFiles size={14} />
+              <span>Collection will remain on your file system.</span>
+            </>
+          )}
+        </div>
+      </StyledWrapper>
     </Modal>
   );
 };

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1004,7 +1004,7 @@ export const selectEnvironment = (environmentUid, collectionUid) => (dispatch, g
   });
 };
 
-export const removeCollection = (collectionUid) => (dispatch, getState) => {
+export const removeCollection = (collectionUid, deleteFromFileSystem = false) => (dispatch, getState) => {
   return new Promise((resolve, reject) => {
     const state = getState();
     const collection = findCollectionByUid(state.collections.collections, collectionUid);
@@ -1013,7 +1013,7 @@ export const removeCollection = (collectionUid) => (dispatch, getState) => {
     }
     const { ipcRenderer } = window;
     ipcRenderer
-      .invoke('renderer:remove-collection', collection.pathname)
+      .invoke('renderer:remove-collection', collection.pathname, deleteFromFileSystem)
       .then(() => {
         dispatch(closeAllCollectionTabs({ collectionUid }));
       })

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -511,11 +511,20 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
     }
   });
 
-  ipcMain.handle('renderer:remove-collection', async (event, collectionPath) => {
+  ipcMain.handle('renderer:remove-collection', async (event, collectionPath, deleteFromFileSystem) => {
     if (watcher && mainWindow) {
       console.log(`watcher stopWatching: ${collectionPath}`);
       watcher.removeWatcher(collectionPath, mainWindow);
       lastOpenedCollections.remove(collectionPath);
+
+      if (deleteFromFileSystem) {
+        try {
+          await fsExtra.remove(collectionPath);
+        } catch (error) {
+          console.error('Error deleting collection folder:', error);
+          throw error;
+        }
+      }
     }
   });
 


### PR DESCRIPTION
# Description

Added a permanent deletion option for collections

This PR adds a new checkbox option when closing/deleting a collection that allows users to:

- Permanently delete the collection folder and all its contents from the file system
- Requires typing the collection name to confirm permanent deletion
- Shows clear warning messages about the irreversible action
- Maintains the existing "close collection" behavior as default

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
