### PR TITLE
Fix: Postman-import-translation not adding comments for unsupported APIs

### DIFF
--- a/packages/bruno-app/src/utils/importers/translators/postman_translation.js
+++ b/packages/bruno-app/src/utils/importers/translators/postman_translation.js
@@ -54,7 +54,7 @@ export const postmanTranslation = (script, logCallback) => {
     }
     if (modifiedScript.includes('pm.') || modifiedScript.includes('postman.')) {
       modifiedScript = modifiedScript.replace(/^(.*(pm\.|postman\.).*)$/gm, '// $1');
-      logCallback?.();
+      //logCallback?.();
     }
     return modifiedScript;
   } catch (e) {


### PR DESCRIPTION
There was an error in one of the WIP feature which is breaking the translation, for now commenting it out.