### PR TITLE
Feature: Added Request Settings Tab

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -103,7 +103,6 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   const script = getPropertyFromDraftOrRequest('request.script');
   const assertions = getPropertyFromDraftOrRequest('request.assertions');
   const tests = getPropertyFromDraftOrRequest('request.tests');
-  const settings = getPropertyFromDraftOrRequest('request.settings');
   const docs = getPropertyFromDraftOrRequest('request.docs');
   const requestVars = getPropertyFromDraftOrRequest('request.vars.req');
   const responseVars = getPropertyFromDraftOrRequest('request.vars.res');
@@ -112,7 +111,6 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   const activeParamsLength = params.filter((param) => param.enabled).length;
   const activeHeadersLength = headers.filter((header) => header.enabled).length;
   const activeAssertionsLength = assertions.filter((assertion) => assertion.enabled).length;
-  const activeSettingsLength = settings.filter((setting) => setting.value == 'true').length;
   const activeVarsLength =
     requestVars.filter((request) => request.enabled).length +
     responseVars.filter((response) => response.enabled).length;
@@ -154,7 +152,6 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
         </div>
         <div className={getTabClassname('settings')} role="tab" onClick={() => selectTab('settings')}>
           Settings
-          {activeSettingsLength > 0 && <sup className="ml-1 font-medium">{activeSettingsLength}</sup>}
         </div>
         <div className={getTabClassname('docs')} role="tab" onClick={() => selectTab('docs')}>
           Docs

--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -15,6 +15,7 @@ import Tests from 'components/RequestPane/Tests';
 import StyledWrapper from './StyledWrapper';
 import { find, get } from 'lodash';
 import Documentation from 'components/Documentation/index';
+import Settings from '../Settings/index';
 
 const ContentIndicator = () => {
   return (
@@ -64,6 +65,9 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
       case 'tests': {
         return <Tests item={item} collection={collection} />;
       }
+      case 'settings': {
+        return <Settings item={item} collection={collection} />;
+      }
       case 'docs': {
         return <Documentation item={item} collection={collection} />;
       }
@@ -99,6 +103,7 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   const script = getPropertyFromDraftOrRequest('request.script');
   const assertions = getPropertyFromDraftOrRequest('request.assertions');
   const tests = getPropertyFromDraftOrRequest('request.tests');
+  const settings = getPropertyFromDraftOrRequest('request.settings');
   const docs = getPropertyFromDraftOrRequest('request.docs');
   const requestVars = getPropertyFromDraftOrRequest('request.vars.req');
   const responseVars = getPropertyFromDraftOrRequest('request.vars.res');
@@ -107,6 +112,7 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
   const activeParamsLength = params.filter((param) => param.enabled).length;
   const activeHeadersLength = headers.filter((header) => header.enabled).length;
   const activeAssertionsLength = assertions.filter((assertion) => assertion.enabled).length;
+  const activeSettingsLength = settings.filter((setting) => setting.value == 'true').length;
   const activeVarsLength =
     requestVars.filter((request) => request.enabled).length +
     responseVars.filter((response) => response.enabled).length;
@@ -145,6 +151,10 @@ const HttpRequestPane = ({ item, collection, leftPaneWidth }) => {
         <div className={getTabClassname('tests')} role="tab" onClick={() => selectTab('tests')}>
           Tests
           {tests && tests.length > 0 && <ContentIndicator />}
+        </div>
+        <div className={getTabClassname('settings')} role="tab" onClick={() => selectTab('settings')}>
+          Settings
+          {activeSettingsLength > 0 && <sup className="ml-1 font-medium">{activeSettingsLength}</sup>}
         </div>
         <div className={getTabClassname('docs')} role="tab" onClick={() => selectTab('docs')}>
           Docs

--- a/packages/bruno-app/src/components/RequestPane/Settings/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Settings/index.js
@@ -1,0 +1,84 @@
+import React, { useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import get from 'lodash/get';
+import { updateRequestSettings } from 'providers/ReduxStore/slices/collections';
+
+const Settings = ({ item, collection }) => {
+  const dispatch = useDispatch();
+
+  const displayNames = {
+    disableParsingResponseJson: 'Disable Parsing Response Json'
+  };
+
+  const defaultSettings = [
+    {
+      name: 'disableParsingResponseJson',
+      value: false,
+    },
+  ];
+
+  const storedSettings = item.draft
+    ? get(item, 'draft.request.settings', [])
+    : get(item, 'request.settings', []);
+
+  // Merge default settings with stored settings
+  const mergedSettings = useMemo(() => {
+    const settingsMap = {};
+    defaultSettings.forEach((setting) => {
+      settingsMap[setting.name] = { ...setting };
+    });
+
+    storedSettings.forEach((setting) => {
+      if (settingsMap[setting.name]) {
+        settingsMap[setting.name] = {
+          ...settingsMap[setting.name],
+          ...setting,
+        };
+      } else {
+        settingsMap[setting.name] = setting;
+      }
+    });
+
+    return Object.values(settingsMap);
+  }, [defaultSettings, storedSettings]);
+
+  const handleSettingChange = (settingName, value) => {
+    const updatedSettings = mergedSettings.map((setting) => {
+      if (setting.name === settingName) {
+        return { ...setting, value: value.toString() };
+      }
+      return setting;
+    });
+
+    dispatch(
+      updateRequestSettings({
+        settings: updatedSettings,
+        itemUid: item.uid,
+        collectionUid: collection.uid,
+      })
+    );
+  };
+
+  return (
+    <div className="flex-1 mt-2">
+      {mergedSettings.map((setting) => (
+        <tr key={setting.name}>
+          <td>
+            <label className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={setting.value == 'true'}
+                onChange={(e) =>
+                  handleSettingChange(setting.name, e.target.checked)
+                }
+              />
+              <span>{displayNames[setting.name]}</span>
+            </label>
+          </td>
+        </tr>
+      ))}
+    </div>
+  );
+};
+
+export default Settings;

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
@@ -10,6 +10,7 @@ import 'react-pdf/dist/esm/Page/TextLayer.css';
 import { GlobalWorkerOptions } from 'pdfjs-dist/build/pdf';
 GlobalWorkerOptions.workerSrc = 'pdfjs-dist/legacy/build/pdf.worker.min.mjs';
 import ReactPlayer from 'react-player';
+const iconv = require('iconv-lite');
 
 const VideoPreview = React.memo(({ contentType, dataBuffer }) => {
   const [videoUrl, setVideoUrl] = useState(null);
@@ -48,7 +49,7 @@ const QueryResultPreview = ({
   collection,
   mode,
   disableRunEventListener,
-  displayedTheme
+  displayedTheme,
 }) => {
   const preferences = useSelector((state) => state.app.preferences);
   const dispatch = useDispatch();
@@ -102,8 +103,27 @@ const QueryResultPreview = ({
     case 'preview-video': {
       return <VideoPreview contentType={contentType} dataBuffer={dataBuffer} />;
     }
+    case 'json': {
+      return (
+        <CodeEditor
+          collection={collection}
+          font={get(preferences, 'font.codeFont', 'default')}
+          fontSize={get(preferences, 'font.codeFontSize')}
+          theme={displayedTheme}
+          onRun={onRun}
+          value={formattedData}
+          mode={mode}
+          readOnly
+        />
+      );
+    }
     default:
     case 'raw': {
+      if(allowedPreviewModes.find(obj => obj.mode == 'json')){
+        const dataRaw = iconv.decode(Buffer.from(dataBuffer, 'base64'), 'utf-8');
+        formattedData = dataRaw.replace(/^\uFEFF/, '');
+      }
+      
       return (
         <CodeEditor
           collection={collection}

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -87,6 +87,8 @@ const QueryResult = ({ item, collection, data, dataBuffer, width, disableRunEven
       allowedPreviewModes.unshift({ mode: 'preview-audio', name: 'Audio', uid: uuid() });
     } else if (contentType.includes('video')) {
       allowedPreviewModes.unshift({ mode: 'preview-video', name: 'Video', uid: uuid() });
+    }  else   if (typeof data === 'object' && data !== null) {
+      allowedPreviewModes.unshift({ mode: 'json', name: 'JSON', uid: uuid() });
     }
 
     return allowedPreviewModes;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1121,6 +1121,21 @@ export const collectionsSlice = createSlice({
         }
       }
     },
+    updateRequestSettings: (state, action) => {
+      const { collectionUid, itemUid, settings } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+
+      if (collection) {
+        const item = findItemInCollection(collection, itemUid);
+
+        if (item && isItemARequest(item)) {
+          if (!item.draft) {
+            item.draft = cloneDeep(item);
+          }
+          item.draft.request.settings = settings;
+        }
+      }
+    },    
     updateRequestMethod: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
 
@@ -2052,6 +2067,7 @@ export const {
   updateRequestScript,
   updateResponseScript,
   updateRequestTests,
+  updateRequestSettings,
   updateRequestMethod,
   addAssertion,
   updateAssertion,

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -579,6 +579,7 @@ export const transformRequestToSaveToFilesystem = (item) => {
       vars: _item.request.vars,
       assertions: _item.request.assertions,
       tests: _item.request.tests,
+      settings: _item.request.settings,
       docs: _item.request.docs
     }
   };

--- a/packages/bruno-electron/src/bru/index.js
+++ b/packages/bruno-electron/src/bru/index.js
@@ -140,6 +140,7 @@ const bruToJson = (data, parsed = false) => {
         vars: _.get(json, 'vars', {}),
         assertions: _.get(json, 'assertions', []),
         tests: _.get(json, 'tests', ''),
+        settings: _.get(json, 'settings', []),
         docs: _.get(json, 'docs', '')
       }
     };
@@ -246,6 +247,7 @@ const jsonToBruViaWorker = async (json) => {
     },
     assertions: _.get(json, 'request.assertions', []),
     tests: _.get(json, 'request.tests', ''),
+    settings: _.get(json, 'request.settings', []),
     docs: _.get(json, 'request.docs', '')
   };
 

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -216,7 +216,8 @@ const prepareRequest = async (item, collection = {}, abortController) => {
     url,
     headers,
     pathParams: request?.params?.filter((param) => param.type === 'path'),
-    responseType: 'arraybuffer'
+    responseType: 'arraybuffer',
+    settings: request.settings,
   };
 
   axiosRequest = setAuthHeaders(axiosRequest, request, collectionRoot);

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -22,7 +22,7 @@ const { outdentString } = require('../../v1/src/utils');
  *
  */
 const grammar = ohm.grammar(`Bru {
-  BruFile = (meta | http | query | params | headers | auths | bodies | varsandassert | script | tests | docs)*
+  BruFile = (meta | http | query | params | headers | auths | bodies | varsandassert | script | tests | settings | docs)*
   auths = authawsv4 | authbasic | authbearer | authdigest | authNTLM | authOAuth2 | authwsse | authapikey
   bodies = bodyjson | bodytext | bodyxml | bodysparql | bodygraphql | bodygraphqlvars | bodyforms | body
   bodyforms = bodyformurlencoded | bodymultipart | bodyfile
@@ -73,6 +73,7 @@ const grammar = ohm.grammar(`Bru {
   trace = "trace" dictionary
 
   headers = "headers" dictionary
+  settings = "settings" dictionary
 
   query = "query" dictionary
   paramspath = "params:path" dictionary
@@ -415,6 +416,11 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   headers(_1, dictionary) {
     return {
       headers: mapPairListToKeyValPairs(dictionary.ast)
+    };
+  },
+  settings(_1, dictionary) {
+    return {
+      settings: mapPairListToKeyValPairs(dictionary.ast, false)
     };
   },
   authawsv4(_1, dictionary) {

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -30,8 +30,7 @@ const getValueString = (value) => {
 };
 
 const jsonToBru = (json) => {
-  const { meta, http, params, headers, auth, body, script, tests, vars, assertions, docs } = json;
-
+  const { meta, http, params, headers, auth, body, script, tests, settings, vars, assertions, docs } = json;
   let bru = '';
 
   if (meta) {
@@ -449,6 +448,16 @@ ${indentString(tests)}
 
 `;
   }
+
+if (settings && settings.length) {
+  bru += 'settings {';
+
+  bru += `\n${indentString(
+    settings.map((setting) => `${setting.name}: ${setting.value}`).join('\n')
+  )}`;
+
+  bru += '\n}\n\n';
+}
 
   if (docs && docs.length) {
     bru += `docs {

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -276,7 +276,7 @@ const requestSchema = Yup.object({
     .nullable(),
   assertions: Yup.array().of(keyValueSchema).nullable(),
   tests: Yup.string().nullable(),
-  settings: Yup.array().of(requestSettingSchema).required('settings are required'),
+  settings: Yup.array().of(requestSettingSchema).nullable(),
   docs: Yup.string().nullable()
 })
   .noUnknown(true)

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -243,6 +243,14 @@ const requestParamsSchema = Yup.object({
   .noUnknown(true)
   .strict();
 
+  const requestSettingSchema = Yup.object({
+    name: Yup.string().required('Setting name is required'),
+    value: Yup.string().required('Setting value is required'),
+  })
+   .noUnknown(true)
+   .strict();
+  
+
 // Right now, the request schema is very tightly coupled with http request
 // As we introduce more request types in the future, we will improve the definition to support
 // schema structure based on other request type
@@ -268,6 +276,7 @@ const requestSchema = Yup.object({
     .nullable(),
   assertions: Yup.array().of(keyValueSchema).nullable(),
   tests: Yup.string().nullable(),
+  settings: Yup.array().of(requestSettingSchema).required('settings are required'),
   docs: Yup.string().nullable()
 })
   .noUnknown(true)


### PR DESCRIPTION
# Description

By default, Bruno parses all JSON responses, which can lead to precision loss in BigInt numbers. Users can prevent this by using the `req.disableParsingResponseJson();` method in the pre-request script.  

With this PR, we are introducing a **new "Settings" tab** in the request panel. This tab will serve as a centralized place for managing request-related options in the future. For now, we have added an option to enable or disable `disableParsingResponseJson`, making it more accessible and improving the user experience.  

Additionally, we have introduced a new **"Raw" tab** in the response panel for JSON responses. If a JSON response is parsed, users can switch to the Raw tab to view the unparsed JSON.  

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<img width="530" alt="Screenshot 2025-02-12 at 5 09 46 PM" src="https://github.com/user-attachments/assets/1abbf2c1-1925-4044-bc8e-47a35f740176" />

<img width="645" alt="Screenshot 2025-02-12 at 5 10 20 PM" src="https://github.com/user-attachments/assets/4ddc248b-939c-4c3d-a61e-9257f3c3e809" />
