### PR TITLE
fix: allow popus in notification iframes

### DIFF
--- a/packages/bruno-app/src/components/Notifications/index.js
+++ b/packages/bruno-app/src/components/Notifications/index.js
@@ -193,7 +193,7 @@ const Notifications = () => {
                   </div>
                   <iframe
                     src={`data:text/html,${getSanitizedDescription(selectedNotification?.description)}`}
-                    sandbox=""
+                    sandbox="allow-popups"
                     style={{ width: '100%', height: '100%' }}
                   ></iframe>
                 </div>


### PR DESCRIPTION
This is to allow is to allow users to open web pages (like bruno downloads) from the app inside Notifications

