### PR TITLE
feat: Add RFC 6761–compliant localhost loopback checks so `secure` cookies work on localhost (fixes: #1676)

### DIFF
--- a/packages/bruno-electron/src/utils/cookies.js
+++ b/packages/bruno-electron/src/utils/cookies.js
@@ -1,4 +1,5 @@
 const { Cookie, CookieJar } = require('tough-cookie');
+const { isPotentiallyTrustworthy } = require('./trustworthy-util');
 const each = require('lodash/each');
 
 const cookieJar = new CookieJar();
@@ -11,7 +12,9 @@ const addCookieToJar = (setCookieHeader, requestUrl) => {
 };
 
 const getCookiesForUrl = (url) => {
-  return cookieJar.getCookiesSync(url);
+  return cookieJar.getCookiesSync(url, {
+    secure: isPotentiallyTrustworthy(url)
+  });
 };
 
 const getCookieStringForUrl = (url) => {

--- a/packages/bruno-electron/src/utils/trustworthy-util.js
+++ b/packages/bruno-electron/src/utils/trustworthy-util.js
@@ -1,0 +1,102 @@
+const { URL } = require('url');
+const net = require('net');
+
+const isLoopbackV4 = (address) => {
+  // 127.0.0.0/8: first octet = 127
+  const octets = address.split('.');
+  return (
+    octets.length === 4
+  ) && parseInt(octets[0], 10) === 127;
+}
+
+const isLoopbackV6 = (address) => {
+  // dns relies on c-ares under the hood
+  // (https://nodejs.org/download/release/v0.10.29/docs/api/dns.html#dns_dns)
+  // which always compresses loopback addresses to [::1]
+  return (address === '::1');
+}
+
+const isIpLoopback = (address) => {
+  if (net.isIPv4(address)) {
+    return isLoopbackV4(address);
+  }
+
+  if (net.isIPv6(address)) {
+    return isLoopbackV6(address);
+  }
+
+  return false;
+}
+
+const isNormalizedLocalhostTLD = (host) => {
+  return host.toLowerCase().endsWith('.localhost');
+}
+
+const isLocalHostname = (host) => {
+  return host.toLowerCase() === 'localhost' ||
+    isNormalizedLocalhostTLD(host);
+}
+
+/**
+ * Removes leading and trailing square brackets if present.
+ * Adapted from https://github.com/chromium/chromium/blob/main/url/gurl.cc#L440-L448
+ *
+ * @param {string} host
+ * @returns {string}
+ */
+const hostNoBrackets = (host) => {
+  if (host.length >= 2 && host.startsWith('[') && host.endsWith(']')) {
+    return host.substring(1, host.length - 1);
+  }
+  return host;
+}
+
+/**
+ * Determines if a URL string represents a potentially trustworthy origin.
+ * 
+ * A URL is considered potentially trustworthy if it:
+ * - Uses HTTPS, WSS or file schemes
+ * - Points to a loopback address (IPv4 127.0.0.0/8 or IPv6 ::1)
+ * - Uses localhost or *.localhost hostnames
+ * 
+ * @param {string} urlString - The URL to check
+ * @returns {boolean}
+ * @see {@link https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin W3C Spec}
+ */
+const isPotentiallyTrustworthy = (urlString) => {
+  let url;
+
+  // try ... catch doubles as an opaque origin check
+  try {
+    url = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  const scheme = url.protocol.replace(':', '').toLowerCase();
+  const hostname = hostNoBrackets(
+    url.hostname
+  ).replace(/\.+$/, '');
+
+  if (
+    scheme === 'https' ||
+    scheme === 'wss' ||
+    scheme === 'file' // https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin
+  ) {
+    return true;
+  }
+
+  // If it's already an IP literal, check if it's a loopback address
+  if (net.isIP(hostname)) {
+    return isIpLoopback(hostname);
+  }
+
+  // RFC 6761 states that localhost names will always resolve
+  // to the respective IP loopback address:
+  // https://datatracker.ietf.org/doc/html/rfc6761#section-6.3
+  return isLocalHostname(hostname);
+}
+
+module.exports = {
+    isPotentiallyTrustworthy
+};


### PR DESCRIPTION
fixes: [#1676](https://github.com/usebruno/bruno/issues/1676)

# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

This commit extends how cookies are treated in secure contexts by fully recognizing `localhost` and loopback IPs as trustworthy origins, matching the de facto behavior of all modern browsers and RFC 6761. Previously, `tough-cookie` defaulted `secure` to `true` only for `https:` and `wss:` URLs, causing cookies with `secure` set to never be sent to `localhost`.

### What Changed

1. **New `trustworthy-util.js`**  
   - Implements `isPotentiallyTrustworthy(url)` by checking:
     - Schemes: `https`, `wss`, `file`
     - Loopback IPs: `127.0.0.1/8` and `::1`  
     - Hostnames: `localhost` and `*.localhost`  
   - Adapted from Chromium’s `IsLocalhost`, `IsLoopback` and `HostNoBracketsPiece`, located at:
     - [`IsLocalhost`](https://github.com/chromium/chromium/blob/main/net/base/url_util.cc#L457-L551)
     - [`IsLoopback`](https://github.com/chromium/chromium/blob/main/net/base/ip_address.cc#L228-L243)
     - [`HostNoBracketsPiece`](https://github.com/chromium/chromium/blob/main/url/gurl.cc#L440-L448)

2. **`cookies.js` Update**  
   - Passes the `{ secure: isPotentiallyTrustworthy(url) }` option to `cookieJar.getCookiesSync()`.  
   - This overrides `tough-cookie`’s built-in:
     ```js
     let secure = options.secure;
     if (secure == null && (context.protocol == "https:" || context.protocol == "wss:")) {
       secure = true;
     }
     ```
     We do everything `tough-cookie` does by default—plus treat localhost/loopback the same as modern browsers. No existing functionality is removed, only expanded.

### Testing this change

```python
from flask import Flask, request, make_response

app = Flask(__name__)

@app.route('/setcookie')
def set_cookie():
    resp = make_response('')
    resp.set_cookie('example', '', secure=True)
    return resp

@app.route('/getcookie')
def get_cookie():
    return 'Cookie is set' if 'example' in request.cookies else 'No cookie set'

app.run()
```
- **Before**: The `secure` cookie would **not** be sent to `/getcookie` after it was set by `/setcookie` due to `secure` being set to `True`.  
- **After**: The `secure` cookie would be sent to `/getcookie` which mirrors the behavior of modern browsers.

All modern browsers (Chrome et al.) and many other API testing clients (Postman et al.) handle `http://localhost` as a trustworthy origin. It only makes sense that this behavior also exists in Bruno.

