### PR TITLE
Fix: Inconsistent Save Prompts When Closing Request Tabs

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
@@ -2,48 +2,44 @@ import React from 'react';
 import { IconAlertTriangle } from '@tabler/icons';
 import Modal from 'components/Modal';
 
-const ConfirmRequestClose = ({ item, onCancel, onCloseWithoutSave, onSaveAndClose }) => {
-  return (
-    <Modal
-      size="md"
-      title="Unsaved changes"
-      confirmText="Save and Close"
-      cancelText="Close without saving"
-      disableEscapeKey={true}
-      disableCloseOnOutsideClick={true}
-      closeModalFadeTimeout={150}
-      handleCancel={onCancel}
-      onClick={(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-      }}
-      hideFooter={true}
-    >
-      <div className="flex items-center font-normal">
-        <IconAlertTriangle size={32} strokeWidth={1.5} className="text-yellow-600" />
-        <h1 className="ml-2 text-lg font-semibold">Hold on..</h1>
+const ConfirmRequestClose = ({ tabsToClose, onCancel, onCloseWithoutSave, onSaveAndClose }) => (
+  <Modal
+    size="md"
+    title="Unsaved changes"
+    disableEscapeKey={true}
+    disableCloseOnOutsideClick={true}
+    closeModalFadeTimeout={150}
+    handleCancel={onCancel}
+    hideFooter={true}
+  >
+    <div className="flex items-center font-normal">
+      <IconAlertTriangle size={32} strokeWidth={1.5} className="text-yellow-600" />
+      <h1 className="ml-2 text-lg font-semibold">Hold on..</h1>
+    </div>
+    <div className="font-normal mt-4">
+      You have unsaved changes in the following requests:
+      <ul>
+        {tabsToClose.map(({ item }) => (
+          <li key={item.uid}>
+            <span className="font-semibold">{item.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+    <div className="flex justify-between mt-6">
+      <button className="btn btn-sm btn-danger" onClick={onCloseWithoutSave}>
+        Don't Save
+      </button>
+      <div>
+        <button className="btn btn-close btn-sm mr-2" onClick={onCancel}>
+          Cancel
+        </button>
+        <button className="btn btn-secondary btn-sm" onClick={onSaveAndClose}>
+          Save
+        </button>
       </div>
-      <div className="font-normal mt-4">
-        You have unsaved changes in request <span className="font-semibold">{item.name}</span>.
-      </div>
-
-      <div className="flex justify-between mt-6">
-        <div>
-          <button className="btn btn-sm btn-danger" onClick={onCloseWithoutSave}>
-            Don't Save
-          </button>
-        </div>
-        <div>
-          <button className="btn btn-close btn-sm mr-2" onClick={onCancel}>
-            Cancel
-          </button>
-          <button className="btn btn-secondary btn-sm" onClick={onSaveAndClose}>
-            Save
-          </button>
-        </div>
-      </div>
-    </Modal>
-  );
-};
+    </div>
+  </Modal>
+);
 
 export default ConfirmRequestClose;

--- a/packages/bruno-app/src/pages/Bruno/index.js
+++ b/packages/bruno-app/src/pages/Bruno/index.js
@@ -4,11 +4,14 @@ import Welcome from 'components/Welcome';
 import RequestTabs from 'components/RequestTabs';
 import RequestTabPanel from 'components/RequestTabPanel';
 import Sidebar from 'components/Sidebar';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import StyledWrapper from './StyledWrapper';
 import 'codemirror/theme/material.css';
 import 'codemirror/theme/monokai.css';
 import 'codemirror/addon/scroll/simplescrollbars.css';
+import ConfirmRequestClose from 'components/RequestTabs/RequestTab/ConfirmRequestClose/index';
+import { cancelCloseTabs, closeTabsConfirmed } from 'providers/ReduxStore/slices/collections/actions';
+import { hideConfirmCloseModal } from 'providers/ReduxStore/slices/tabs';
 
 const SERVER_RENDERED = typeof window === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
 if (!SERVER_RENDERED) {
@@ -49,6 +52,25 @@ export default function Main() {
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const isDragging = useSelector((state) => state.app.isDragging);
   const showHomePage = useSelector((state) => state.app.showHomePage);
+  const dispatch = useDispatch();
+  const confirmCloseModal = useSelector((state) => state.tabs.confirmCloseModal);
+
+  const { show, tabsToClose } = confirmCloseModal;
+
+  const handleCancel = () => {
+    dispatch(cancelCloseTabs());
+  };
+
+  const handleCloseWithoutSave = () => {
+    dispatch(closeTabsConfirmed('close-without-saving'));
+    dispatch(hideConfirmCloseModal())
+  };
+
+  const handleSaveAndClose = () => {
+    dispatch(closeTabsConfirmed('save-and-close'));
+    dispatch(hideConfirmCloseModal())
+  };
+
 
   // Todo: write a better logging flow that can be used to log by turning on debug flag
   // Enable for debugging.
@@ -60,6 +82,12 @@ export default function Main() {
 
   return (
     <div>
+      {show && <ConfirmRequestClose
+        tabsToClose={tabsToClose}
+        onCancel={handleCancel}
+        onCloseWithoutSave={handleCloseWithoutSave}
+        onSaveAndClose={handleSaveAndClose}
+      />}
       <StyledWrapper className={className}>
         <Sidebar />
         <section className="flex flex-grow flex-col overflow-auto">

--- a/packages/bruno-app/src/pages/Bruno/index.js
+++ b/packages/bruno-app/src/pages/Bruno/index.js
@@ -82,12 +82,6 @@ export default function Main() {
 
   return (
     <div>
-      {show && <ConfirmRequestClose
-        tabsToClose={tabsToClose}
-        onCancel={handleCancel}
-        onCloseWithoutSave={handleCloseWithoutSave}
-        onSaveAndClose={handleSaveAndClose}
-      />}
       <StyledWrapper className={className}>
         <Sidebar />
         <section className="flex flex-grow flex-col overflow-auto">
@@ -95,6 +89,12 @@ export default function Main() {
             <Welcome />
           ) : (
             <>
+              {show && <ConfirmRequestClose
+                tabsToClose={tabsToClose}
+                onCancel={handleCancel}
+                onCloseWithoutSave={handleCloseWithoutSave}
+                onSaveAndClose={handleSaveAndClose}
+              />}
               <RequestTabs />
               <RequestTabPanel key={activeTabUid} />
             </>

--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -10,7 +10,8 @@ import {
   sendRequest,
   saveRequest,
   saveCollectionRoot,
-  saveFolderRoot
+  saveFolderRoot,
+  attemptCloseTabs
 } from 'providers/ReduxStore/slices/collections/actions';
 import { findCollectionByUid, findItemInCollection } from 'utils/collections';
 import { closeTabs, switchTab } from 'providers/ReduxStore/slices/tabs';
@@ -138,12 +139,7 @@ export const HotkeysProvider = (props) => {
   // close tab hotkey
   useEffect(() => {
     Mousetrap.bind([...getKeyBindingsForActionAllOS('closeTab')], (e) => {
-      dispatch(
-        closeTabs({
-          tabUids: [activeTabUid]
-        })
-      );
-
+      dispatch(attemptCloseTabs([activeTabUid]));
       return false; // this stops the event bubbling
     });
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -8,7 +8,11 @@ import last from 'lodash/last';
 
 const initialState = {
   tabs: [],
-  activeTabUid: null
+  activeTabUid: null,
+  confirmCloseModal: {
+    show: false,
+    tabsToClose: [],
+  },
 };
 
 const tabTypeAlreadyExists = (tabs, collectionUid, type) => {
@@ -162,7 +166,16 @@ export const tabsSlice = createSlice({
       } else{
         console.error("Tab not found!")
       }
-    }
+    },
+    showConfirmCloseModal: (state, action) => {
+      state.confirmCloseModal.show = true;
+      state.confirmCloseModal.tabsToClose = action.payload.tabsToClose;
+    },
+
+    hideConfirmCloseModal: (state) => {
+      state.confirmCloseModal.show = false;
+      state.confirmCloseModal.tabsToClose = [];
+    },
   }
 });
 
@@ -175,7 +188,9 @@ export const {
   updateResponsePaneTab,
   closeTabs,
   closeAllCollectionTabs,
-  makeTabPermanent
+  makeTabPermanent,
+  hideConfirmCloseModal,
+  showConfirmCloseModal,
 } = tabsSlice.actions;
 
 export default tabsSlice.reducer;


### PR DESCRIPTION
# Description

This PR resolves two related issues concerning unsaved changes in request tabs:

- #3264 - Closing a tab with changes using the mouse prompted a save dialog, but closing with Command+W did not.

- #3224 - closing a request tab with unsaved changes automatically saved the request. This differs from the behavior when closing requests via the close icon or closing the entire application, where the user is prompted to save.

This PR standardizes the behavior by always prompting the user to save changes when closing a request tab with unsaved modifications, regardless of the closing method (mouse, Command+W, context menu).

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="752" alt="Screenshot 2025-02-17 at 3 46 14 PM" src="https://github.com/user-attachments/assets/78527079-26ae-4494-8a74-de964be00484" />
