### PR TITLE
fix unsupport symbolic link folders

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -177,7 +177,7 @@ const getBruFilesRecursively = (dir, testsOnly) => {
 
       for (const file of filesInCurrentDir) {
         const filePath = path.join(currentPath, file);
-        const stats = fs.lstatSync(filePath);
+        const stats = fs.statSync(filePath);
 
         // todo: we might need a ignore config inside bruno.json
         if (

--- a/packages/bruno-cli/src/utils/filesystem.js
+++ b/packages/bruno-cli/src/utils/filesystem.js
@@ -29,7 +29,7 @@ const isFile = (filepath) => {
 
 const isDirectory = (dirPath) => {
   try {
-    return fs.existsSync(dirPath) && fs.lstatSync(dirPath).isDirectory();
+    return fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory();
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
# This pull request aims to address the issue where the Bruno CLI does not support symbolic link folders.

This PR is related to this issue: https://github.com/usebruno/bruno/issues/4055

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
