### PR TITLE
Add OAuth2 Settings for Automatic Token Fetching and Refreshing

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
@@ -2,7 +2,7 @@ import React, { useRef, forwardRef, useState, useEffect } from 'react';
 import get from 'lodash/get';
 import { useTheme } from 'providers/Theme';
 import { useDispatch } from 'react-redux';
-import { IconCaretDown, IconLoader2, IconSettings, IconKey, IconAdjustmentsHorizontal } from '@tabler/icons';
+import { IconCaretDown, IconLoader2, IconSettings, IconKey, IconHelp, IconAdjustmentsHorizontal } from '@tabler/icons';
 import Dropdown from 'components/Dropdown';
 import SingleLineEditor from 'components/SingleLineEditor';
 import { clearOauth2Cache, fetchOauth2Credentials, refreshOauth2Credentials } from 'providers/ReduxStore/slices/collections/actions';
@@ -23,29 +23,31 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
   const [showRefreshButton, setShowRefreshButton] = useState(false);
 
   const oAuth = get(request, 'auth.oauth2', {});
-  const { 
-    callbackUrl, 
-    authorizationUrl, 
-    accessTokenUrl, 
-    clientId, 
-    clientSecret, 
-    scope, 
-    credentialsPlacement, 
-    state, 
-    pkce, 
-    credentialsId, 
-    tokenPlacement, 
-    tokenHeaderPrefix, 
-    tokenQueryKey, 
-    reuseToken, 
+  const {
+    callbackUrl,
+    authorizationUrl,
+    accessTokenUrl,
+    clientId,
+    clientSecret,
+    scope,
+    credentialsPlacement,
+    state,
+    pkce,
+    credentialsId,
+    tokenPlacement,
+    tokenHeaderPrefix,
+    tokenQueryKey,
+    reuseToken,
     refreshUrl,
-    autoRefresh 
+    autoRefresh,
+    autoFetchToken,
+    autoFetchOnExpiry
   } = oAuth;
 
   const TokenPlacementIcon = forwardRef((props, ref) => {
     return (
       <div ref={ref} className="flex items-center justify-end token-placement-label select-none">
-        {tokenPlacement == 'url' ?  'URL' : 'Headers'}
+        {tokenPlacement == 'url' ? 'URL' : 'Headers'}
         <IconCaretDown className="caret ml-1 mr-1" size={14} strokeWidth={2} />
       </div>
     );
@@ -54,7 +56,7 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
   const CredentialsPlacementIcon = forwardRef((props, ref) => {
     return (
       <div ref={ref} className="flex items-center justify-end token-placement-label select-none">
-        {credentialsPlacement == 'body' ?  'Request Body' : 'Basic Auth Header'}
+        {credentialsPlacement == 'body' ? 'Request Body' : 'Basic Auth Header'}
         <IconCaretDown className="caret ml-1 mr-1" size={14} strokeWidth={2} />
       </div>
     );
@@ -71,7 +73,7 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
       toggleFetchingToken(false);
       toast.success('token fetched successfully!');
     }
-    catch(error) {
+    catch (error) {
       console.error(error);
       toggleFetchingToken(false);
       toast.error('An error occured while fetching token!');
@@ -88,14 +90,14 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
       toggleRefreshingToken(false);
       toast.success('token refreshed successfully!');
     }
-    catch(error) {
+    catch (error) {
       console.error(error);
       toggleRefreshingToken(false);
       toast.error('An error occured while refreshing token!');
     }
   }
 
-  const handleSave = () => {save();};
+  const handleSave = () => { save(); };
 
   const handleChange = (key, value) => {
     dispatch(
@@ -121,7 +123,9 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
           reuseToken,
           refreshUrl,
           autoRefresh,
-          [key]: value
+          autoFetchToken,
+          autoFetchOnExpiry,
+          [key]: value,
         }
       })
     );
@@ -148,6 +152,8 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
           tokenHeaderPrefix,
           tokenQueryKey,
           reuseToken,
+          autoFetchToken,
+          autoFetchOnExpiry,
           pkce: !Boolean(oAuth?.['pkce'])
         }
       })
@@ -165,10 +171,10 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
       });
   };
 
-    const { uid: collectionUid } = collection;
-    const interpolatedUrl = interpolateStringUsingCollectionAndItem({ collection, item, string: accessTokenUrl });
-    const credentialsData = find(collection?.oauth2Credentials, creds => creds?.url == interpolatedUrl && creds?.collectionUid == collectionUid && creds?.credentialsId == credentialsId);
-    const creds = credentialsData?.credentials || {};
+  const { uid: collectionUid } = collection;
+  const interpolatedUrl = interpolateStringUsingCollectionAndItem({ collection, item, string: accessTokenUrl });
+  const credentialsData = find(collection?.oauth2Credentials, creds => creds?.url == interpolatedUrl && creds?.collectionUid == collectionUid && creds?.credentialsId == credentialsId);
+  const creds = credentialsData?.credentials || {};
 
   useEffect(() => {
     // Update visibility whenever credentials change
@@ -302,7 +308,7 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
               />
             </div>
           </div>
-        :
+          :
           <div className="flex items-center gap-4 w-full" key={`input-token-query-param-key`}>
             <label className="block font-medium min-w-[140px]">Query Param Key</label>
             <div className="single-line-editor-wrapper flex-1">
@@ -340,24 +346,79 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
         </div>
       </div>
 
-      <div className="flex items-center gap-4 w-full mb-4">
-        <label className="block min-w-[140px]">Auto-refresh token</label>
-        <input
-          type="checkbox"
-          className="cursor-pointer w-4 h-4 accent-indigo-600"
-          checked={get(request, 'auth.oauth2.autoRefresh', false)}
-          onChange={(e) => handleChange('autoRefresh', e.target.checked)}
-        />
-        <span className="text-xs text-gray-500">Automatically refresh the token when it expires</span>
+      {/* Settings Section */}
+      <div className="flex items-center gap-2.5 mt-4">
+        <div className="flex items-center px-2.5 py-1.5 bg-indigo-50/50 dark:bg-indigo-500/10 rounded-md">
+          <IconSettings size={14} className="text-indigo-500 dark:text-indigo-400" />
+        </div>
+        <span className="text-sm font-medium">Settings</span>
       </div>
 
+      {/* Automatically Fetch Token */}
+      <div className="flex items-center gap-4 w-full">
+        <input
+          type="checkbox"
+          checked={Boolean(autoFetchToken)}
+          onChange={(e) => handleChange('autoFetchToken', e.target.checked)}
+          className="cursor-pointer ml-1"
+        />
+        <label className="block min-w-[140px]">Automatically fetch token if not found</label>
+        <div className="flex items-center gap-2">
+
+          <div className="relative group cursor-pointer">
+            <IconHelp size={16} className="text-gray-500" />
+            <span className="group-hover:opacity-100 pointer-events-none opacity-0 max-w-60 absolute left-0 bottom-full mb-1 w-max p-2 bg-gray-700 text-white text-xs rounded-md transition-opacity duration-200">
+              Automatically fetch a new token when you try to access a resource and don’t have one.
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Auto Refresh Token on Expiry */}
+      <div className="flex items-center gap-4 w-full">
+        <input
+          type="checkbox"
+          checked={Boolean(autoFetchOnExpiry)}
+          onChange={(e) => handleChange('autoFetchOnExpiry', e.target.checked)}
+          className="cursor-pointer ml-1"
+        />
+        <label className="block min-w-[140px]">Auto refresh token on expiry</label>
+        <div className="flex items-center gap-2">
+
+          <div className="relative group cursor-pointer">
+            <IconHelp size={16} className="text-gray-500" />
+            <span className="group-hover:opacity-100 pointer-events-none opacity-0 max-w-60 absolute left-0 bottom-full mb-1 w-max p-2 bg-gray-700 text-white text-xs rounded-md transition-opacity duration-200">
+              Automatically refresh your token when it expires, even if no refresh URL is set.
+            </span>
+          </div>
+        </div>
+      </div>
+      {/* Auto Refresh Token (With Refresh URL) */}
+      <div className="flex items-center gap-4 w-full">
+        <input
+          type="checkbox"
+          checked={Boolean(autoRefresh)}
+          onChange={(e) => handleChange('autoRefresh', e.target.checked)}
+          className="cursor-pointer ml-1"
+        />
+        <label className="block min-w-[140px]">Auto refresh token (with refresh URL)</label>
+        <div className="flex items-center gap-2">
+
+          <div className="relative group cursor-pointer">
+            <IconHelp size={16} className="text-gray-500" />
+            <span className="group-hover:opacity-100 pointer-events-none opacity-0 max-w-60 absolute left-0 bottom-full mb-1 w-max p-2 bg-gray-700 text-white text-xs rounded-md transition-opacity duration-200">
+              Automatically refresh your token using the refresh URL when it expires.
+            </span>
+          </div>
+        </div>
+      </div>
       <div className="flex flex-row gap-4 mt-4">
         <button onClick={handleFetchOauth2Credentials} className={`submit btn btn-sm btn-secondary w-fit flex flex-row`}>
-          Get Access Token{fetchingToken? <IconLoader2 className="animate-spin ml-2" size={18} strokeWidth={1.5} /> : ""}
+          Get Access Token{fetchingToken ? <IconLoader2 className="animate-spin ml-2" size={18} strokeWidth={1.5} /> : ""}
         </button>
         {showRefreshButton && (
           <button onClick={handleRefreshAccessToken} className={`submit btn btn-sm btn-secondary w-fit flex flex-row`}>
-            Refresh Token{refreshingToken? <IconLoader2 className="animate-spin ml-2" size={18} strokeWidth={1.5} /> : ""}
+            Refresh Token{refreshingToken ? <IconLoader2 className="animate-spin ml-2" size={18} strokeWidth={1.5} /> : ""}
           </button>
         )}
         <button onClick={handleClearCache} className="submit btn btn-sm btn-secondary w-fit">

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
@@ -44,6 +44,11 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
     autoFetchOnExpiry
   } = oAuth;
 
+  const refreshUrlAvailable = refreshUrl.trim() !== '';
+  const isAutoRefreshDisabled = !refreshUrlAvailable;
+  const isAutoFetchOnExpiryGrayedOut = autoRefresh && refreshUrlAvailable;
+
+
   const TokenPlacementIcon = forwardRef((props, ref) => {
     return (
       <div ref={ref} className="flex items-center justify-end token-placement-label select-none">
@@ -346,7 +351,6 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
         </div>
       </div>
 
-      {/* Settings Section */}
       <div className="flex items-center gap-2.5 mt-4">
         <div className="flex items-center px-2.5 py-1.5 bg-indigo-50/50 dark:bg-indigo-500/10 rounded-md">
           <IconSettings size={14} className="text-indigo-500 dark:text-indigo-400" />
@@ -364,7 +368,6 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
         />
         <label className="block min-w-[140px]">Automatically fetch token if not found</label>
         <div className="flex items-center gap-2">
-
           <div className="relative group cursor-pointer">
             <IconHelp size={16} className="text-gray-500" />
             <span className="group-hover:opacity-100 pointer-events-none opacity-0 max-w-60 absolute left-0 bottom-full mb-1 w-max p-2 bg-gray-700 text-white text-xs rounded-md transition-opacity duration-200">
@@ -380,30 +383,33 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
           type="checkbox"
           checked={Boolean(autoFetchOnExpiry)}
           onChange={(e) => handleChange('autoFetchOnExpiry', e.target.checked)}
-          className="cursor-pointer ml-1"
+          className={`cursor-pointer ml-1 ${isAutoFetchOnExpiryGrayedOut ? 'opacity-50' : ''}`}
+        // Not disabling the input, just graying it out
         />
-        <label className="block min-w-[140px]">Auto refresh token on expiry</label>
+        <label className={`block min-w-[140px] ${isAutoFetchOnExpiryGrayedOut ? 'text-gray-500' : ''}`}>Auto refresh token on expiry</label>
         <div className="flex items-center gap-2">
-
           <div className="relative group cursor-pointer">
             <IconHelp size={16} className="text-gray-500" />
             <span className="group-hover:opacity-100 pointer-events-none opacity-0 max-w-60 absolute left-0 bottom-full mb-1 w-max p-2 bg-gray-700 text-white text-xs rounded-md transition-opacity duration-200">
-              Automatically refresh your token when it expires, even if no refresh URL is set.
+              {isAutoFetchOnExpiryGrayedOut
+                ? 'Auto refresh token (with refresh URL) has higher precedence so if both options are enabled, this will not execute.'
+                : 'Automatically refresh your token when it expires, even if no refresh URL is set.'}
             </span>
           </div>
         </div>
       </div>
+
       {/* Auto Refresh Token (With Refresh URL) */}
       <div className="flex items-center gap-4 w-full">
         <input
           type="checkbox"
           checked={Boolean(autoRefresh)}
           onChange={(e) => handleChange('autoRefresh', e.target.checked)}
-          className="cursor-pointer ml-1"
+          className={`cursor-pointer ml-1 ${isAutoRefreshDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+          disabled={isAutoRefreshDisabled}
         />
-        <label className="block min-w-[140px]">Auto refresh token (with refresh URL)</label>
+        <label className={`block min-w-[140px] ${isAutoRefreshDisabled ? 'text-gray-500' : ''}`}>Auto refresh token (with refresh URL)</label>
         <div className="flex items-center gap-2">
-
           <div className="relative group cursor-pointer">
             <IconHelp size={16} className="text-gray-500" />
             <span className="group-hover:opacity-100 pointer-events-none opacity-0 max-w-60 absolute left-0 bottom-full mb-1 w-max p-2 bg-gray-700 text-white text-xs rounded-md transition-opacity duration-200">

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -367,7 +367,10 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
                   tokenPlacement: get(si.request, 'auth.oauth2.tokenPlacement', 'header'),
                   tokenHeaderPrefix: get(si.request, 'auth.oauth2.tokenHeaderPrefix', 'Bearer'),
                   tokenQueryKey: get(si.request, 'auth.oauth2.tokenQueryKey', ''),
-                  reuseToken: get(si.request, 'auth.oauth2.reuseToken', false)
+                  reuseToken: get(si.request, 'auth.oauth2.reuseToken', false),
+                  autoFetchToken: get(si.request, 'auth.oauth2.autoFetchToken', true),
+                  autoFetchOnExpiry: get(si.request, 'auth.oauth2.autoFetchOnExpiry', true),
+                  autoRefresh: get(si.request, 'auth.oauth2.autoRefresh', true),
                 };
                 break;
               case 'authorization_code':
@@ -386,7 +389,10 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
                   tokenPlacement: get(si.request, 'auth.oauth2.tokenPlacement', 'header'),
                   tokenHeaderPrefix: get(si.request, 'auth.oauth2.tokenHeaderPrefix', 'Bearer'),
                   tokenQueryKey: get(si.request, 'auth.oauth2.tokenQueryKey', ''),
-                  reuseToken: get(si.request, 'auth.oauth2.reuseToken', false)
+                  reuseToken: get(si.request, 'auth.oauth2.reuseToken', false),
+                  autoFetchToken: get(si.request, 'auth.oauth2.autoFetchToken', true),
+                  autoFetchOnExpiry: get(si.request, 'auth.oauth2.autoFetchOnExpiry', true),
+                  autoRefresh: get(si.request, 'auth.oauth2.autoRefresh', true),
                 };
                 break;
               case 'client_credentials':
@@ -402,7 +408,10 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
                   tokenPlacement: get(si.request, 'auth.oauth2.tokenPlacement', 'header'),
                   tokenHeaderPrefix: get(si.request, 'auth.oauth2.tokenHeaderPrefix', 'Bearer'),
                   tokenQueryKey: get(si.request, 'auth.oauth2.tokenQueryKey', ''),
-                  reuseToken: get(si.request, 'auth.oauth2.reuseToken', false)
+                  reuseToken: get(si.request, 'auth.oauth2.reuseToken', false),
+                  autoFetchToken: get(si.request, 'auth.oauth2.autoFetchToken', true),
+                  autoFetchOnExpiry: get(si.request, 'auth.oauth2.autoFetchOnExpiry', true),
+                  autoRefresh: get(si.request, 'auth.oauth2.autoRefresh', true),
                 };
                 break;
             }
@@ -1050,9 +1059,11 @@ export const getEnvVars = (environment = {}) => {
 export const getFormattedCollectionOauth2Credentials = ({ oauth2Credentials = [] }) => {
   let credentialsVariables = {};
   oauth2Credentials.forEach(({ credentialsId, credentials }) => {
-    Object.entries(credentials).forEach(([key, value]) => {
-      credentialsVariables[`$oauth2.${credentialsId}.${key}`] = value;
-    });
+    if (credentials) {
+      Object.entries(credentials).forEach(([key, value]) => {
+        credentialsVariables[`$oauth2.${credentialsId}.${key}`] = value;
+      });
+    }
   });
   return credentialsVariables;
-}
+};

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -174,6 +174,9 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         request.oauth2.tokenHeaderPrefix = _interpolate(request.oauth2.tokenHeaderPrefix) || '';
         request.oauth2.tokenQueryKey = _interpolate(request.oauth2.tokenQueryKey) || '';
         request.oauth2.reuseToken = _interpolate(request.oauth2.reuseToken) || false;
+        request.oauth2.autoFetchToken = _interpolate(request.oauth2.autoFetchToken);
+        request.oauth2.autoFetchOnExpiry = _interpolate(request.oauth2.autoFetchOnExpiry);
+        request.oauth2.autoRefresh = _interpolate(request.oauth2.autoRefresh);
         break;
       case 'authorization_code':
         request.oauth2.callbackUrl = _interpolate(request.oauth2.callbackUrl) || '';
@@ -191,6 +194,9 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         request.oauth2.tokenHeaderPrefix = _interpolate(request.oauth2.tokenHeaderPrefix) || '';
         request.oauth2.tokenQueryKey = _interpolate(request.oauth2.tokenQueryKey) || '';
         request.oauth2.reuseToken = _interpolate(request.oauth2.reuseToken) || false;
+        request.oauth2.autoFetchToken = _interpolate(request.oauth2.autoFetchToken);
+        request.oauth2.autoFetchOnExpiry = _interpolate(request.oauth2.autoFetchOnExpiry);
+        request.oauth2.autoRefresh = _interpolate(request.oauth2.autoRefresh);
         break;
       case 'client_credentials':
         request.oauth2.accessTokenUrl = _interpolate(request.oauth2.accessTokenUrl) || '';
@@ -204,6 +210,9 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         request.oauth2.tokenHeaderPrefix = _interpolate(request.oauth2.tokenHeaderPrefix) || '';
         request.oauth2.tokenQueryKey = _interpolate(request.oauth2.tokenQueryKey) || '';
         request.oauth2.reuseToken = _interpolate(request.oauth2.reuseToken) || false;
+        request.oauth2.autoFetchToken = _interpolate(request.oauth2.autoFetchToken);
+        request.oauth2.autoFetchOnExpiry = _interpolate(request.oauth2.autoFetchOnExpiry);
+        request.oauth2.autoRefresh = _interpolate(request.oauth2.autoRefresh);
         break;
       default:
         break;

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -293,12 +293,14 @@ const getEnvVars = (environment = {}) => {
 const getFormattedCollectionOauth2Credentials = ({ oauth2Credentials = [] }) => {
   let credentialsVariables = {};
   oauth2Credentials.forEach(({ credentialsId, credentials }) => {
-    Object.entries(credentials).forEach(([key, value]) => {
-      credentialsVariables[`$oauth2.${credentialsId}.${key}`] = value;
-    });
+    if (credentials) {
+      Object.entries(credentials).forEach(([key, value]) => {
+        credentialsVariables[`$oauth2.${credentialsId}.${key}`] = value;
+      });
+    }
   });
   return credentialsVariables;
-}
+};
 
 
 module.exports = {

--- a/packages/bruno-electron/src/utils/request.js
+++ b/packages/bruno-electron/src/utils/request.js
@@ -103,7 +103,10 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
               tokenPlacement: get(collectionAuth, 'oauth2.tokenPlacement'),
               tokenHeaderPrefix: get(collectionAuth, 'oauth2.tokenHeaderPrefix'),
               tokenQueryKey: get(collectionAuth, 'oauth2.tokenQueryKey'),
-              reuseToken: get(collectionAuth, 'oauth2.reuseToken')
+              reuseToken: get(collectionAuth, 'oauth2.reuseToken'),
+              autoFetchToken: get(collectionAuth, 'oauth2.autoFetchToken'),
+              autoFetchOnExpiry: get(collectionAuth, 'oauth2.autoFetchOnExpiry'),
+              autoRefresh: get(collectionAuth, 'oauth2.autoRefresh')
             };
             break;
           case 'authorization_code':
@@ -123,7 +126,10 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
               tokenPlacement: get(collectionAuth, 'oauth2.tokenPlacement'),
               tokenHeaderPrefix: get(collectionAuth, 'oauth2.tokenHeaderPrefix'),
               tokenQueryKey: get(collectionAuth, 'oauth2.tokenQueryKey'),
-              reuseToken: get(collectionAuth, 'oauth2.reuseToken')
+              reuseToken: get(collectionAuth, 'oauth2.reuseToken'),
+              autoFetchToken: get(collectionAuth, 'oauth2.autoFetchToken'),
+              autoFetchOnExpiry: get(collectionAuth, 'oauth2.autoFetchOnExpiry'),
+              autoRefresh: get(collectionAuth, 'oauth2.autoRefresh')
             };
             break;
           case 'client_credentials':
@@ -139,7 +145,10 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
               tokenPlacement: get(collectionAuth, 'oauth2.tokenPlacement'),
               tokenHeaderPrefix: get(collectionAuth, 'oauth2.tokenHeaderPrefix'),
               tokenQueryKey: get(collectionAuth, 'oauth2.tokenQueryKey'),
-              reuseToken: get(collectionAuth, 'oauth2.reuseToken')
+              reuseToken: get(collectionAuth, 'oauth2.reuseToken'),
+              autoFetchToken: get(collectionAuth, 'oauth2.autoFetchToken'),
+              autoFetchOnExpiry: get(collectionAuth, 'oauth2.autoFetchOnExpiry'),
+              autoRefresh: get(collectionAuth, 'oauth2.autoRefresh')
             };
             break;
         }
@@ -198,7 +207,10 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
               tokenPlacement: get(request, 'auth.oauth2.tokenPlacement'),
               tokenHeaderPrefix: get(request, 'auth.oauth2.tokenHeaderPrefix'),
               tokenQueryKey: get(request, 'auth.oauth2.tokenQueryKey'),
-              reuseToken: get(request, 'auth.oauth2.reuseToken')
+              reuseToken: get(request, 'auth.oauth2.reuseToken'),
+              autoFetchToken: get(request, 'auth.oauth2.autoFetchToken'),
+              autoFetchOnExpiry: get(request, 'auth.oauth2.autoFetchOnExpiry'),
+              autoRefresh: get(request, 'auth.oauth2.autoRefresh')
             };
             break;
           case 'authorization_code':
@@ -218,7 +230,10 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
               tokenPlacement: get(request, 'auth.oauth2.tokenPlacement'),
               tokenHeaderPrefix: get(request, 'auth.oauth2.tokenHeaderPrefix'),
               tokenQueryKey: get(request, 'auth.oauth2.tokenQueryKey'),
-              reuseToken: get(request, 'auth.oauth2.reuseToken')
+              reuseToken: get(request, 'auth.oauth2.reuseToken'),
+              autoFetchToken: get(request, 'auth.oauth2.autoFetchToken'),
+              autoFetchOnExpiry: get(request, 'auth.oauth2.autoFetchOnExpiry'),
+              autoRefresh: get(request, 'auth.oauth2.autoRefresh')
             };
             break;
           case 'client_credentials':
@@ -234,7 +249,10 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
               tokenPlacement: get(request, 'auth.oauth2.tokenPlacement'),
               tokenHeaderPrefix: get(request, 'auth.oauth2.tokenHeaderPrefix'),
               tokenQueryKey: get(request, 'auth.oauth2.tokenQueryKey'),
-              reuseToken: get(request, 'auth.oauth2.reuseToken')
+              reuseToken: get(request, 'auth.oauth2.reuseToken'),
+              autoFetchToken: get(request, 'auth.oauth2.autoFetchToken'),
+              autoFetchOnExpiry: get(request, 'auth.oauth2.autoFetchOnExpiry'),
+              autoRefresh: get(request, 'auth.oauth2.autoRefresh')
             };
             break;
         }

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -491,6 +491,9 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     const tokenHeaderPrefixKey = _.find(auth, { name: 'token_header_prefix' });
     const tokenQueryKeyKey = _.find(auth, { name: 'token_query_key' });
     const reuseTokenKey = _.find(auth, { name: 'reuse_token' });
+    const autoFetchTokenKey = _.find(auth, { name: 'auto_fetch_token' });
+    const autoFetchOnExpiryKey = _.find(auth, { name: 'auto_fetch_on_expiry' });
+    const autoRefreshKey = _.find(auth, { name: 'auto_refresh' });
     return {
       auth: {
         oauth2:
@@ -509,7 +512,10 @@ const sem = grammar.createSemantics().addAttribute('ast', {
                 tokenPlacement: tokenPlacementKey?.value ? tokenPlacementKey.value : 'header',
                 tokenHeaderPrefix: tokenHeaderPrefixKey?.value ? tokenHeaderPrefixKey.value : 'Bearer',
                 tokenQueryKey: tokenQueryKeyKey?.value ? tokenQueryKeyKey.value : 'access_token',
-                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false
+                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false,
+                autoFetchToken: autoFetchTokenKey ? JSON.parse(autoFetchTokenKey?.value) : true,
+                autoFetchOnExpiry: autoFetchOnExpiryKey ? JSON.parse(autoFetchOnExpiryKey?.value) : true,
+                autoRefresh: autoRefreshKey ? JSON.parse(autoRefreshKey?.value) : true
               }
             : grantTypeKey?.value && grantTypeKey?.value == 'authorization_code'
             ? {
@@ -528,7 +534,10 @@ const sem = grammar.createSemantics().addAttribute('ast', {
                 tokenPlacement: tokenPlacementKey?.value ? tokenPlacementKey.value : 'header',
                 tokenHeaderPrefix: tokenHeaderPrefixKey?.value ? tokenHeaderPrefixKey.value : 'Bearer',
                 tokenQueryKey: tokenQueryKeyKey?.value ? tokenQueryKeyKey.value : 'access_token',
-                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false
+                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false,
+                autoFetchToken: autoFetchTokenKey ? JSON.parse(autoFetchTokenKey?.value) : true,
+                autoFetchOnExpiry: autoFetchOnExpiryKey ? JSON.parse(autoFetchOnExpiryKey?.value) : true,
+                autoRefresh: autoRefreshKey ? JSON.parse(autoRefreshKey?.value) : true
               }
             : grantTypeKey?.value && grantTypeKey?.value == 'client_credentials'
             ? {
@@ -543,7 +552,10 @@ const sem = grammar.createSemantics().addAttribute('ast', {
                 tokenPlacement: tokenPlacementKey?.value ? tokenPlacementKey.value : 'header',
                 tokenHeaderPrefix: tokenHeaderPrefixKey?.value ? tokenHeaderPrefixKey.value : 'Bearer',
                 tokenQueryKey: tokenQueryKeyKey?.value ? tokenQueryKeyKey.value : 'access_token',
-                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false
+                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false,
+                autoFetchToken: autoFetchTokenKey ? JSON.parse(autoFetchTokenKey?.value) : true,
+                autoFetchOnExpiry: autoFetchOnExpiryKey ? JSON.parse(autoFetchOnExpiryKey?.value) : true,
+                autoRefresh: autoRefreshKey ? JSON.parse(autoRefreshKey?.value) : true
               }
             : {}
       }

--- a/packages/bruno-lang/v2/src/collectionBruToJson.js
+++ b/packages/bruno-lang/v2/src/collectionBruToJson.js
@@ -286,6 +286,9 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     const tokenHeaderPrefixKey = _.find(auth, { name: 'token_header_prefix' });
     const tokenQueryKeyKey = _.find(auth, { name: 'token_query_key' });
     const reuseTokenKey = _.find(auth, { name: 'reuseToken' });
+    const autoFetchTokenKey = _.find(auth, { name: 'auto_fetch_token' });
+    const autoFetchOnExpiryKey = _.find(auth, { name: 'auto_fetch_on_expiry' });
+    const autoRefreshKey = _.find(auth, { name: 'auto_refresh' });
     return {
       auth: {
         oauth2:
@@ -304,7 +307,10 @@ const sem = grammar.createSemantics().addAttribute('ast', {
                 tokenPlacement: tokenPlacementKey?.value ? tokenPlacementKey.value : 'header',
                 tokenHeaderPrefix: tokenHeaderPrefixKey?.value ? tokenHeaderPrefixKey.value : 'Bearer',
                 tokenQueryKey: tokenQueryKeyKey?.value ? tokenQueryKeyKey.value : 'access_token',
-                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false
+                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false,
+                autoFetchToken: autoFetchTokenKey ? JSON.parse(autoFetchTokenKey?.value) : true,
+                autoFetchOnExpiry: autoFetchOnExpiryKey ? JSON.parse(autoFetchOnExpiryKey?.value) : true,
+                autoRefresh: autoRefreshKey ? JSON.parse(autoRefreshKey?.value) : true
               }
             : grantTypeKey?.value && grantTypeKey?.value == 'authorization_code'
             ? {
@@ -323,7 +329,10 @@ const sem = grammar.createSemantics().addAttribute('ast', {
                 tokenPlacement: tokenPlacementKey?.value ? tokenPlacementKey.value : 'header',
                 tokenHeaderPrefix: tokenHeaderPrefixKey?.value ? tokenHeaderPrefixKey.value : 'Bearer',
                 tokenQueryKey: tokenQueryKeyKey?.value ? tokenQueryKeyKey.value : 'access_token',
-                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false
+                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false,
+                autoFetchToken: autoFetchTokenKey ? JSON.parse(autoFetchTokenKey?.value) : true,
+                autoFetchOnExpiry: autoFetchOnExpiryKey ? JSON.parse(autoFetchOnExpiryKey?.value) : true,
+                autoRefresh: autoRefreshKey ? JSON.parse(autoRefreshKey?.value) : true
               }
             : grantTypeKey?.value && grantTypeKey?.value == 'client_credentials'
             ? {
@@ -338,7 +347,10 @@ const sem = grammar.createSemantics().addAttribute('ast', {
                 tokenPlacement: tokenPlacementKey?.value ? tokenPlacementKey.value : 'header',
                 tokenHeaderPrefix: tokenHeaderPrefixKey?.value ? tokenHeaderPrefixKey.value : 'Bearer',
                 tokenQueryKey: tokenQueryKeyKey?.value ? tokenQueryKeyKey.value : 'access_token',
-                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false
+                reuseToken: reuseTokenKey?.value ? JSON.parse(reuseTokenKey?.value || false) : false,
+                autoFetchToken: autoFetchTokenKey ? JSON.parse(autoFetchTokenKey?.value) : true,
+                autoFetchOnExpiry: autoFetchOnExpiryKey ? JSON.parse(autoFetchOnExpiryKey?.value) : true,
+                autoRefresh: autoRefreshKey ? JSON.parse(autoRefreshKey?.value) : true
               }
             : {}
       }

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -197,6 +197,9 @@ ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`reuse_token: ${auth?.oauth2?.reuseToken || ''}`)}
+${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken).toString()}`)}
+${indentString(`auto_fetch_on_expiry: ${(auth?.oauth2?.autoFetchToken).toString()}`)}
+${indentString(`auto_refresh: ${(auth?.oauth2?.autoRefresh).toString()}`)}
 }
 
 `;
@@ -221,6 +224,9 @@ ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`reuse_token: ${auth?.oauth2?.reuseToken || ''}`)}
+${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken).toString()}`)}
+${indentString(`auto_fetch_on_expiry: ${(auth?.oauth2?.autoFetchOnExpiry).toString()}`)}
+${indentString(`auto_refresh: ${(auth?.oauth2?.autoRefresh).toString()}`)}
 }
 
 `;
@@ -241,6 +247,9 @@ ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`reuse_token: ${auth?.oauth2?.reuseToken || ''}`)}
+${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken).toString()}`)}
+${indentString(`auto_fetch_on_expiry: ${(auth?.oauth2?.autoFetchOnExpiry).toString()}`)}
+${indentString(`auto_refresh: ${(auth?.oauth2?.autoRefresh).toString()}`)}
 }
 
 `;

--- a/packages/bruno-lang/v2/src/jsonToCollectionBru.js
+++ b/packages/bruno-lang/v2/src/jsonToCollectionBru.js
@@ -163,6 +163,9 @@ ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`reuse_token: ${auth?.oauth2?.reuseToken || ''}`)}
+${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken).toString()}`)}
+${indentString(`auto_fetch_on_expiry: ${(auth?.oauth2?.autoFetchOnExpiry).toString()}`)}
+${indentString(`auto_refresh: ${(auth?.oauth2?.autoRefresh).toString()}`)}
 }
 
 `;
@@ -187,6 +190,9 @@ ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`reuse_token: ${auth?.oauth2?.reuseToken || ''}`)}
+${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken).toString()}`)}
+${indentString(`auto_fetch_on_expiry: ${(auth?.oauth2?.autoFetchOnExpiry).toString()}`)}
+${indentString(`auto_refresh: ${(auth?.oauth2?.autoRefresh).toString()}`)}
 }
 
 `;
@@ -207,6 +213,9 @@ ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`reuse_token: ${auth?.oauth2?.reuseToken || ''}`)}
+${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken).toString()}`)}
+${indentString(`auto_fetch_on_expiry: ${(auth?.oauth2?.autoFetchOnExpiry).toString()}`)}
+${indentString(`auto_refresh: ${(auth?.oauth2?.autoRefresh).toString()}`)}
 }
 
 `;

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -241,7 +241,17 @@ const oauth2Schema = Yup.object({
     is: (val) => ['client_credentials', 'password', 'authorization_code'].includes(val),
     then: Yup.boolean().default(false),
     otherwise: Yup.boolean()
-  })
+  }),
+  autoFetchToken: Yup.boolean().when('grantType', {
+    is: (val) => ['authorization_code'].includes(val),
+    then: Yup.boolean().default(true),
+    otherwise: Yup.boolean()
+  }),
+  autoFetchOnExpiry: Yup.boolean().when('grantType', {
+    is: (val) => ['authorization_code'].includes(val),
+    then: Yup.boolean().default(true),
+    otherwise: Yup.boolean()
+  }),
 })
   .noUnknown(true)
   .strict();


### PR DESCRIPTION
# Description

Added three new options to the OAuth2 settings to control token fetching and refreshing behavior.  These options will provide more granular control over how tokens are managed, improving the user experience.

The three options to be added are:

Automatically Fetch Token:
**Functionality**: If the user doesn't have a token, a new one will be automatically fetched when they attempt to access a resource URL.

Auto Refresh Token on Expiry:
**Functionality**: If the user's token expires, it will be automatically refreshed, even if no refresh URL is provided.

Auto Refresh Token (With Refresh URL):
**Functionality**: If a refresh URL is set, it will automatically be used to refresh the token when it expires.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

https://github.com/user-attachments/assets/0e75434c-b232-4359-91d7-a0f80a6a13c4


