### PR TITLE
Use pre interpolated vars in report

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -108,6 +108,7 @@ const runSingleRequest = async function (
     }
 
     // interpolate variables inside request
+    const origReq = JSON.parse(JSON.stringify(request));
     interpolateVars(request, envVariables, runtimeVariables, processEnvVars);
 
     if (!protocolRegex.test(request.url)) {
@@ -363,10 +364,10 @@ const runSingleRequest = async function (
             filename: filename
           },
           request: {
-            method: request.method,
-            url: request.url,
-            headers: request.headers,
-            data: request.data
+            method: origReq.method,
+            url: origReq.url,
+            headers: origReq.headers,
+            data: origReq.data
           },
           response: {
             status: null,
@@ -498,10 +499,10 @@ const runSingleRequest = async function (
         filename: filename
       },
       request: {
-        method: request.method,
-        url: request.url,
-        headers: request.headers,
-        data: request.data
+        method: origReq.method,
+        url: origReq.url,
+        headers: origReq.headers,
+        data: origReq.data
       },
       response: {
         status: response.status,


### PR DESCRIPTION
# Description

A proposed quick fix for https://github.com/usebruno/bruno/issues/2186

Which just output the original request template before interpolation to the result.html
So the secrets are not exposed.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

![image](https://github.com/user-attachments/assets/d704aee0-7907-482d-8e48-6e83b97786dc)


Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
