### PR TITLE
fix h1 and h2 style (#4074)

### DIFF
--- a/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
@@ -15,14 +15,14 @@ const StyledMarkdownBodyWrapper = styled.div`
       margin: 0.67em 0;
       font-weight: var(--base-text-weight-semibold, 600);
       padding-bottom: 0.3em;
-      font-size: 1.3;
+      font-size: 1.3em;
       border-bottom: 1px solid var(--color-border-muted);
     }
 
     h2 {
       font-weight: var(--base-text-weight-semibold, 600);
       padding-bottom: 0.3em;
-      font-size: 1.2;
+      font-size: 1.2em;
       border-bottom: 1px solid var(--color-border-muted);
     }
 


### PR DESCRIPTION
# Description

Fixes #4074 4074

Before

<img width="257" alt="image" src="https://github.com/user-attachments/assets/362319ce-6acd-4267-967f-bcd72459414f" />

<img width="430" alt="image" src="https://github.com/user-attachments/assets/aef2e6dc-d04e-4a98-8b3b-5de0606d3b77" />


# After

<img width="342" alt="image" src="https://github.com/user-attachments/assets/5099f96a-9b3a-46cf-a3b6-2b7a6e8c5031" />

<img width="464" alt="image" src="https://github.com/user-attachments/assets/9fd3e710-8baf-42ad-85cc-58c1c93b568e" />


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
