### PR TITLE
Fix: Inconsistent JSON parsing and formatting in `res.body` and Res-preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24447,6 +24447,7 @@
         "graphql-request": "^3.7.0",
         "httpsnippet": "^3.0.9",
         "i18next": "24.1.2",
+        "iconv-lite": "^0.6.3",
         "idb": "^7.0.0",
         "immer": "^9.0.15",
         "jsesc": "^3.0.2",

--- a/packages/bruno-app/package.json
+++ b/packages/bruno-app/package.json
@@ -36,6 +36,7 @@
     "graphql-request": "^3.7.0",
     "httpsnippet": "^3.0.9",
     "i18next": "24.1.2",
+    "iconv-lite": "^0.6.3",
     "idb": "^7.0.0",
     "immer": "^9.0.15",
     "jsesc": "^3.0.2",

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -17,14 +17,14 @@ const formatResponse = (data, mode, filter) => {
   }
 
   if (data === null) {
-    return 'null';
+    return data;
   }
 
   if (mode.includes('json')) {
     let isValidJSON = false;
 
     try {
-      isValidJSON = typeof JSON.parse(JSON.stringify(data)) === 'object'
+      isValidJSON = typeof JSON.parse(JSON.stringify(data)) === 'object';
     } catch (error) {
       console.log('Error parsing JSON: ', error.message);
     }

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -9,7 +9,7 @@ import QueryResultPreview from './QueryResultPreview';
 import StyledWrapper from './StyledWrapper';
 import { useState, useMemo, useEffect } from 'react';
 import { useTheme } from 'providers/Theme/index';
-import { uuid } from 'utils/common/index';
+import { prettifyJson, uuid } from 'utils/common/index';
 
 const formatResponse = (data, dataBuffer, mode, filter) => {
   if (data === undefined || !dataBuffer) {
@@ -33,12 +33,15 @@ const formatResponse = (data, dataBuffer, mode, filter) => {
     if (filter) {
       try {
         data = JSONPath({ path: filter, json: data });
+        return prettifyJson(JSON.stringify(data));
       } catch (e) {
         console.warn('Could not apply JSONPath filter:', e.message);
       }
     }
 
-    return safeStringifyJSON(data, true);
+    // Prettify the JSON string directly instead of parse->stringify to avoid
+    // issues like rounding numbers bigger than Number.MAX_SAFE_INTEGER etc.
+    return prettifyJson(rawData);
   }
 
   if (mode.includes('xml')) {
@@ -53,7 +56,7 @@ const formatResponse = (data, dataBuffer, mode, filter) => {
     return data;
   }
 
-  return safeStringifyJSON(data, true);
+  return prettifyJson(rawData);
 };
 
 const formatErrorMessage = (error) => {

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -184,3 +184,9 @@ export const generateUidBasedOnHash = (str) => {
 };
 
 export const stringifyIfNot = v => typeof v === 'string' ? v : String(v);
+
+export const getEncoding = (headers) => {
+  // Parse the charset from content type: https://stackoverflow.com/a/33192813
+  const charsetMatch = /charset=([^()<>@,;:"/[\]?.=\s]*)/i.exec(headers['content-type'] || '');
+  return charsetMatch?.[1];
+}

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -1,5 +1,6 @@
 import { customAlphabet } from 'nanoid';
 import xmlFormat from 'xml-formatter';
+import { format as jsoncFormat, applyEdits as jsoncApplyEdits } from 'jsonc-parser';
 
 // a customized version of nanoid without using _ and -
 export const uuid = () => {
@@ -25,6 +26,13 @@ export const waitForNextTick = () => {
     setTimeout(() => resolve(), 0);
   });
 };
+
+export const prettifyJson = (doc) => {
+  return jsoncApplyEdits(
+    doc,
+    jsoncFormat(doc, null, {insertSpaces: true, tabSize: 2})
+  );
+}
 
 export const safeParseJSON = (str) => {
   if (!str || !str.length || typeof str !== 'string') {

--- a/packages/bruno-cli/src/utils/common.js
+++ b/packages/bruno-cli/src/utils/common.js
@@ -34,14 +34,10 @@ const parseDataFromResponse = (response, disableParsingResponseJson = false) => 
     // Filter out ZWNBSP character
     // https://gist.github.com/antic183/619f42b559b78028d1fe9e7ae8a1352d
     data = data.replace(/^\uFEFF/, '');
-    
-    // If the response is a string and starts and ends with double quotes, it's a stringified JSON and should not be parsed
-    if (!disableParsingResponseJson && !(typeof data === 'string' && data.startsWith('"') && data.endsWith('"'))) {
+    if (!disableParsingResponseJson) {
       data = JSON.parse(data);
     }
-  } catch {
-
-  }
+  } catch { }
 
   return { data, dataBuffer };
 };

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -398,14 +398,10 @@ const parseDataFromResponse = (response, disableParsingResponseJson = false) => 
     // Filter out ZWNBSP character
     // https://gist.github.com/antic183/619f42b559b78028d1fe9e7ae8a1352d
     data = data.replace(/^\uFEFF/, '');
-
-    // If the response is a string and starts and ends with double quotes, it's a stringified JSON and should not be parsed
-    if ( !disableParsingResponseJson && ! (typeof data === 'string' && data.startsWith("\"") && data.endsWith("\""))) {
+    if (!disableParsingResponseJson) {
       data = JSON.parse(data);
     }
-  } catch { 
-    console.log('Failed to parse response data as JSON');
-   }
+  } catch { }
 
   return { data, dataBuffer };
 };

--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -22,6 +22,12 @@ const toNumber = (value) => {
   return Number.isInteger(num) ? parseInt(value, 10) : parseFloat(value);
 };
 
+const removeQuotes = (str) => {
+  if ((str.startsWith('"') && str.endsWith('"')) || (str.startsWith("'") && str.endsWith("'"))) {
+    return str.slice(1, -1);
+  }
+  return str;
+};
 
 const executeQuickJsVm = ({ script: externalScript, context: externalContext, scriptType = 'template-literal' }) => {
   if (!externalScript?.length || typeof externalScript !== 'string') {
@@ -38,6 +44,7 @@ const executeQuickJsVm = ({ script: externalScript, context: externalContext, sc
   if (externalScript === 'null') return null;
   if (externalScript === 'undefined') return undefined;
 
+  externalScript = removeQuotes(externalScript);
 
   const vm = QuickJSSyncContext;
 
@@ -87,6 +94,7 @@ const executeQuickJsVmAsync = async ({ script: externalScript, context: external
   if (externalScript === 'null') return null;
   if (externalScript === 'undefined') return undefined;
 
+  externalScript = removeQuotes(externalScript);
 
   try {
     const module = await newQuickJSWASMModule();

--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -35,16 +35,25 @@ const executeQuickJsVm = ({ script: externalScript, context: externalContext, sc
   }
   externalScript = externalScript?.trim();
 
-  if (!isNaN(Number(externalScript))) {
-    return Number(externalScript);
+  if(scriptType === 'template-literal') {
+    if (!isNaN(Number(externalScript))) {
+      const number = Number(externalScript);
+
+      // Check if the number is too high. Too high number might get altered, see #1000
+      if (number > Number.MAX_SAFE_INTEGER) {
+        return externalScript;
+      }
+
+      return toNumber(externalScript);
+    }
+
+    if (externalScript === 'true') return true;
+    if (externalScript === 'false') return false;
+    if (externalScript === 'null') return null;
+    if (externalScript === 'undefined') return undefined;
+
+    externalScript = removeQuotes(externalScript);
   }
-
-  if (externalScript === 'true') return true;
-  if (externalScript === 'false') return false;
-  if (externalScript === 'null') return null;
-  if (externalScript === 'undefined') return undefined;
-
-  externalScript = removeQuotes(externalScript);
 
   const vm = QuickJSSyncContext;
 
@@ -84,17 +93,6 @@ const executeQuickJsVmAsync = async ({ script: externalScript, context: external
     return externalScript;
   }
   externalScript = externalScript?.trim();
-
-  if (!isNaN(Number(externalScript))) {
-    return toNumber(externalScript);
-  }
-
-  if (externalScript === 'true') return true;
-  if (externalScript === 'false') return false;
-  if (externalScript === 'null') return null;
-  if (externalScript === 'undefined') return undefined;
-
-  externalScript = removeQuotes(externalScript);
 
   try {
     const module = await newQuickJSWASMModule();

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bru.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bru.js
@@ -189,8 +189,8 @@ const addBruShimToContext = (vm, bru) => {
     const promise = vm.newPromise();
     bru.runRequest(vm.dump(args))
       .then((response) => {
-        const { status, headers, data, dataBuffer, size } = response || {};
-        promise.resolve(marshallToVm(cleanJson({ status, headers, data, dataBuffer, size }), vm));
+        const { status, statusText, headers, data, dataBuffer, size } = response || {};
+        promise.resolve(marshallToVm(cleanJson({ status, statusText, headers, data, dataBuffer, size }), vm));
       })
       .catch((err) => {
         promise.resolve(

--- a/packages/bruno-js/src/utils.js
+++ b/packages/bruno-js/src/utils.js
@@ -85,6 +85,14 @@ const evaluateJsTemplateLiteral = (templateLiteral, context) => {
     return undefined;
   }
 
+  if (templateLiteral.startsWith('"') && templateLiteral.endsWith('"')) {
+    return templateLiteral.slice(1, -1);
+  }
+
+  if (templateLiteral.startsWith("'") && templateLiteral.endsWith("'")) {
+    return templateLiteral.slice(1, -1);
+  }
+
   if (!isNaN(templateLiteral)) {
     const number = Number(templateLiteral);
     // Check if the number is too high. Too high number might get altered, see #1000

--- a/packages/bruno-tests/collection/asserts/test-assert-combinations.bru
+++ b/packages/bruno-tests/collection/asserts/test-assert-combinations.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/asserts/test-assert-combinations.bru
+++ b/packages/bruno-tests/collection/asserts/test-assert-combinations.bru
@@ -1,0 +1,74 @@
+meta {
+  name: test-assert-combinations
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "type": "application/json",
+    "contentJSON": {
+      "string": "foo",
+      "stringWithSQuotes": "'foo'",
+      "stringWithDQuotes": "\"foo\"",
+      "number": 123,
+      "numberAsString": "123",
+      "numberAsStringWithSQuotes": "'123'",
+      "numberAsStringWithDQuotes": "\"123\"",
+      "numberAsStringWithLeadingZero": "0123",
+      "numberBig": 9007199254740992000,
+      "numberBigAsString": "9007199254740991999",
+      "null": null,
+      "nullAsString": "null",
+      "nullAsStringWithSQuotes": "'null'",
+      "nullAsStringWithDQuotes": "\"null\"",
+      "true": true,
+      "trueAsString": "true",
+      "trueAsStringWithSQuotes": "'true'",
+      "trueAsStringWithDQuotes": "\"true\"",
+      "false": false,
+      "falseAsString": "false",
+      "falseAsStringWithSQuotes": "'false'",
+      "falseAsStringWithDQuotes": "\"false\"",
+      "stringWithCurlyBraces": "{foo}",
+      "stringWithDoubleCurlyBraces": "{{foobar}}"
+    }
+  }
+}
+
+assert {
+  res.body.string: eq foo
+  res.body.string: eq 'foo'
+  res.body.string: eq "foo"
+  res.body.stringWithSQuotes: eq "'foo'"
+  res.body.stringWithDQuotes: eq '"foo"'
+  res.body.number: eq 123
+  res.body.numberAsString: eq '123'
+  res.body.numberAsString: eq "123"
+  res.body.numberAsStringWithSQuotes: eq "'123'"
+  res.body.numberAsStringWithDQuotes: eq '"123"'
+  res.body.numberAsStringWithLeadingZero: eq "0123"
+  res.body.numberBig.toString(): eq '9007199254740992000'
+  res.body.numberBigAsString: eq "9007199254740991999"
+  res.body.null: eq null
+  res.body.nullAsString: eq "null"
+  res.body.nullAsStringWithSQuotes: eq "'null'"
+  res.body.nullAsStringWithDQuotes: eq '"null"'
+  res.body.true: eq true
+  res.body.trueAsString: eq "true"
+  res.body.trueAsStringWithSQuotes: eq "'true'"
+  res.body.trueAsStringWithDQuotes: eq '"true"'
+  res.body.false: eq false
+  res.body.falseAsString: eq "false"
+  res.body.falseAsStringWithSQuotes: eq "'false'"
+  res.body.falseAsStringWithDQuotes: eq '"false"'
+  res.body.nonexistent: eq undefined
+  res.body.stringWithCurlyBraces: eq "{foo}"
+  res.body.stringWithDoubleCurlyBraces: eq "{{foobar}}"
+}

--- a/packages/bruno-tests/collection/echo/test echo any.bru
+++ b/packages/bruno-tests/collection/echo/test echo any.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test echo any
+  type: http
+  seq: 11
+}
+
+post {
+  url: http://localhost:8080/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "text/plain" },
+    "content": "hello"
+  }
+}
+
+assert {
+  res.body: eq hello
+}

--- a/packages/bruno-tests/collection/echo/test echo any.bru
+++ b/packages/bruno-tests/collection/echo/test echo any.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/echo/test echo-any image.bru
+++ b/packages/bruno-tests/collection/echo/test echo-any image.bru
@@ -1,0 +1,18 @@
+meta {
+  name: test echo-any image
+  type: http
+  seq: 12
+}
+
+post {
+  url: http://localhost:8080/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "type": "image/png",
+    "contentBase64": "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAQMAAABKLAcXAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGUExURQCqAP///59OGOoAAAABYktHRAH/Ai3eAAAAB3RJTUUH6QMHCwUNKHvFmgAAABRJREFUOMtjYBgFo2AUjIJRQE8AAAV4AAEpcbn8AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDI1LTAzLTA3VDExOjA1OjEzKzAwOjAwQkgGWgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyNS0wMy0wN1QxMTowNToxMyswMDowMDMVvuYAAAAodEVYdGRhdGU6dGltZXN0YW1wADIwMjUtMDMtMDdUMTE6MDU6MTMrMDA6MDBkAJ85AAAAAElFTkSuQmCC"
+  }
+}

--- a/packages/bruno-tests/collection/echo/test echo-any json.bru
+++ b/packages/bruno-tests/collection/echo/test echo-any json.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test echo-any json
+  type: http
+  seq: 13
+}
+
+post {
+  url: http://localhost:8080/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "type": "application/json",
+    "contentJSON": {"x": 42}
+  }
+}
+
+assert {
+  res.body.x: eq 42
+}

--- a/packages/bruno-tests/collection/echo/test echo-any json.bru
+++ b/packages/bruno-tests/collection/echo/test echo-any json.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/environments/Local.bru
+++ b/packages/bruno-tests/collection/environments/Local.bru
@@ -2,6 +2,12 @@ vars {
   host: http://localhost:8080
   bearer_auth_token: your_secret_token
   basic_auth_password: della
+  env.var1: envVar1
+  env-var2: envVar2
+  bark: {{process.env.PROC_ENV_VAR}}
+  foo: bar
+  testSetEnvVar: bruno-29653
+  echo-host: https://echo.usebruno.com
   client_id: client_id_1
   client_secret: client_secret_1
   auth_url: http://localhost:8080/api/auth/oauth2/authorization_code/authorize

--- a/packages/bruno-tests/collection/environments/Local.bru
+++ b/packages/bruno-tests/collection/environments/Local.bru
@@ -1,5 +1,6 @@
 vars {
   host: http://localhost:8080
+  httpfaker: https://www.httpfaker.org
   bearer_auth_token: your_secret_token
   basic_auth_password: della
   env.var1: envVar1

--- a/packages/bruno-tests/collection/environments/Prod.bru
+++ b/packages/bruno-tests/collection/environments/Prod.bru
@@ -1,5 +1,6 @@
 vars {
   host: https://testbench-sanity.usebruno.com
+  httpfaker: https://www.httpfaker.org
   bearer_auth_token: your_secret_token
   basic_auth_password: della
   env.var1: envVar1

--- a/packages/bruno-tests/collection/response-parsing/test JSON false response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON false response.bru
@@ -1,5 +1,5 @@
 meta {
-  name: test echo any
+  name: test JSON false response
   type: http
   seq: 11
 }
@@ -12,11 +12,11 @@ post {
 
 body:json {
   {
-    "headers": { "content-type": "text/plain" },
-    "content": "hello"
+    "headers": { "content-type": "application/json" },
+    "content": "false"
   }
 }
 
 assert {
-  res.body: eq hello
+  res.body: eq false
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON false response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON false response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON null response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON null response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test JSON null response
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "application/json" },
+    "content": "null"
+  }
+}
+
+assert {
+  res.body: eq null
+}

--- a/packages/bruno-tests/collection/response-parsing/test JSON null response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON null response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON null response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON null response.bru
@@ -1,7 +1,7 @@
 meta {
   name: test JSON null response
   type: http
-  seq: 7
+  seq: 6
 }
 
 post {

--- a/packages/bruno-tests/collection/response-parsing/test JSON number response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON number response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON number response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON number response.bru
@@ -1,5 +1,5 @@
 meta {
-  name: test echo-any json
+  name: test JSON number response
   type: http
   seq: 12
 }
@@ -12,11 +12,11 @@ post {
 
 body:json {
   {
-    "type": "application/json",
-    "contentJSON": {"x": 42}
+    "headers": { "content-type": "application/json" },
+    "content": "3.1"
   }
 }
 
 assert {
-  res.body.x: eq 42
+  res.body: eq 3.1
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test JSON response
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "application/json" },
+    "contentJSON": { "message": "hello" }
+  }
+}
+
+assert {
+  res.body.message: eq hello
+}

--- a/packages/bruno-tests/collection/response-parsing/test JSON response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON string response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON string response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON string response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON string response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test JSON string response
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "application/json" },
+    "content": "\"ok\""
+  }
+}
+
+assert {
+  res.body: eq ok
+}

--- a/packages/bruno-tests/collection/response-parsing/test JSON string response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON string response.bru
@@ -1,7 +1,7 @@
 meta {
   name: test JSON string response
   type: http
-  seq: 8
+  seq: 7
 }
 
 post {

--- a/packages/bruno-tests/collection/response-parsing/test JSON string with quotes response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON string with quotes response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test JSON string with quotes response
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "application/json" },
+    "contentJSON": "\"ok\""
+  }
+}
+
+assert {
+  res.body: eq '"ok"'
+}

--- a/packages/bruno-tests/collection/response-parsing/test JSON string with quotes response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON string with quotes response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON true response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON true response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test JSON true response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON true response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test JSON true response
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "application/json" },
+    "content": "true"
+  }
+}
+
+assert {
+  res.body: eq true
+}

--- a/packages/bruno-tests/collection/response-parsing/test JSON unsafe-int response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON unsafe-int response.bru
@@ -1,0 +1,26 @@
+meta {
+  name: test JSON unsafe-int response
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "application/json" },
+    "content": "90071992547409919876"
+  }
+}
+
+assert {
+  res.body.toString(): eq 90071992547409920000
+}
+
+docs {
+  Note: This test is not perfect, we should match the unparsed raw-response with the expected string version of the unsafe-integer
+}

--- a/packages/bruno-tests/collection/response-parsing/test JSON unsafe-int response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test JSON unsafe-int response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test binary response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test binary response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test binary response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test binary response.bru
@@ -1,0 +1,34 @@
+meta {
+  name: test binary response
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "type": "application/octet-stream",
+    "contentBase64": "+Z1P82iH1wmbILfvnhvjQVbVAktP4TzltpxYD74zNyA="
+  }
+}
+
+tests {
+  test("response matches the expectation after utf-8 decoding(needs improvement)", function () {
+    expect(res.getStatus()).to.equal(200);
+    const dataBinary = Buffer.from("+Z1P82iH1wmbILfvnhvjQVbVAktP4TzltpxYD74zNyA=", "base64"); 
+    expect(res.body).to.equal(dataBinary.toString("utf-8"));
+  });
+}
+
+docs {
+  Note:
+  
+  This test is not perfect and needs to be improved by direclty matching expected binary data with raw-response.
+  
+  Currently res.body is decoded with `utf-8` by default and looses data in the process. We need some property in `res` which gives access to raw-data/Buffer.
+}

--- a/packages/bruno-tests/collection/response-parsing/test html response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test html response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test html response
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "text/html" },
+    "content": "<h1>hello</h1>"
+  }
+}
+
+assert {
+  res.body: eq <h1>hello</h1>
+}

--- a/packages/bruno-tests/collection/response-parsing/test html response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test html response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test html response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test html response.bru
@@ -1,7 +1,7 @@
 meta {
   name: test html response
   type: http
-  seq: 6
+  seq: 5
 }
 
 post {

--- a/packages/bruno-tests/collection/response-parsing/test image response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test image response.bru
@@ -1,11 +1,11 @@
 meta {
-  name: test echo-any image
+  name: test image response
   type: http
-  seq: 12
+  seq: 3
 }
 
 post {
-  url: http://localhost:8080/api/echo/custom
+  url: {{host}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test image response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test image response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test invalid JSON response with formatting.bru
+++ b/packages/bruno-tests/collection/response-parsing/test invalid JSON response with formatting.bru
@@ -1,7 +1,7 @@
 meta {
-  name: test JSON string with quotes response
+  name: test invalid JSON response with formatting
   type: http
-  seq: 8
+  seq: 19
 }
 
 post {
@@ -13,10 +13,10 @@ post {
 body:json {
   {
     "headers": { "content-type": "application/json" },
-    "contentJSON": "\"ok\""
+    "content": "hello\n\tworld"
   }
 }
 
 assert {
-  res.body: eq '"ok"'
+  res.body: eq hello\n\tworld
 }

--- a/packages/bruno-tests/collection/response-parsing/test invalid JSON response with formatting.bru
+++ b/packages/bruno-tests/collection/response-parsing/test invalid JSON response with formatting.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test plain text response with formatting.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text response with formatting.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test plain text response with formatting.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text response with formatting.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test plain text response with formatting
+  type: http
+  seq: 18
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "text/plain" },
+    "content": "hello\n\tworld"
+  }
+}
+
+assert {
+  res.body: eq hello\n\tworld
+}

--- a/packages/bruno-tests/collection/response-parsing/test plain text response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test plain text response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text response.bru
@@ -1,7 +1,7 @@
 meta {
-  name: test echo any
+  name: test plain text response
   type: http
-  seq: 11
+  seq: 1
 }
 
 post {
@@ -20,3 +20,4 @@ body:json {
 assert {
   res.body: eq hello
 }
+

--- a/packages/bruno-tests/collection/response-parsing/test plain text utf16 response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text utf16 response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test plain text utf16 response
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "text/plain; charset=utf-16" },
+    "contentBase64": "dABoAGkAcwAgAGkAcwAgAGUAbgBjAG8AZABlAGQAIAB3AGkAdABoACAAdQB0AGYAMQA2AA=="
+  }
+}
+
+assert {
+  res.body: eq "this is encoded with utf16"
+}

--- a/packages/bruno-tests/collection/response-parsing/test plain text utf16 response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text utf16 response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test plain text utf16-be with BOM response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text utf16-be with BOM response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test plain text utf16-be with BOM response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text utf16-be with BOM response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test plain text utf16-be with BOM response
+  type: http
+  seq: 15
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "text/plain; charset=utf-16" },
+    "contentBase64": "/v8AdABoAGkAcwAgAGkAcwAgAGUAbgBjAG8AZABlAGQAIAB3AGkAdABoACAAdQB0AGYAMQA2AC0AYgBlACAAdwBpAHQAaAAgAEIATwBN"
+  }
+}
+
+assert {
+  res.body: eq "this is encoded with utf16-be with BOM"
+}

--- a/packages/bruno-tests/collection/response-parsing/test plain text utf16-le with BOM response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text utf16-le with BOM response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test plain text utf16-le with BOM response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text utf16-le with BOM response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test plain text utf16-le with BOM response
+  type: http
+  seq: 16
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "text/plain; charset=utf-16" },
+    "contentBase64": "//50AGgAaQBzACAAaQBzACAAZQBuAGMAbwBkAGUAZAAgAHcAaQB0AGgAIAB1AHQAZgAxADYALQBsAGUAIAB3AGkAdABoACAAQgBPAE0A"
+  }
+}
+
+assert {
+  res.body: eq "this is encoded with utf16-le with BOM"
+}

--- a/packages/bruno-tests/collection/response-parsing/test plain text utf8 with BOM response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text utf8 with BOM response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/collection/response-parsing/test plain text utf8 with BOM response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test plain text utf8 with BOM response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test plain text utf8 with BOM response
+  type: http
+  seq: 17
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "text/plain; charset=utf8" },
+    "contentBase64": "77u/dGhpcyBpcyB1dGY4IGVuY29kZWQgd2l0aCBCT00sIHdoeSBub3Q/"
+  }
+}
+
+assert {
+  res.body: eq "this is utf8 encoded with BOM, why not?"
+}

--- a/packages/bruno-tests/collection/response-parsing/test xml response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test xml response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: test xml response
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{host}}/api/echo/custom
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "headers": { "content-type": "application/xml" },
+    "content": "<message>hello</message>"
+  }
+}
+
+assert {
+  res.body: eq <message>hello</message>
+}

--- a/packages/bruno-tests/collection/response-parsing/test xml response.bru
+++ b/packages/bruno-tests/collection/response-parsing/test xml response.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/api/echo/custom
+  url: {{httpfaker}}/api/echo/custom
   body: json
   auth: none
 }

--- a/packages/bruno-tests/src/echo/index.js
+++ b/packages/bruno-tests/src/echo/index.js
@@ -48,4 +48,30 @@ router.get('/iso-enc', (req, res) => {
   return res.send(Buffer.from(responseText, 'latin1'));
 });
 
+router.post("/custom", (req, res) => {
+  const { headers, content, contentBase64, contentJSON, type } = req.body || {};
+
+  res._headers = {};
+
+  if (type) {
+    res.setHeader('Content-Type', type);
+  }
+
+  if (headers && typeof headers === 'object') {
+    Object.entries(headers).forEach(([key, value]) => {
+      res.setHeader(key, value);
+    });
+  }
+
+  if (contentBase64) {
+    res.write(Buffer.from(contentBase64, 'base64'));
+  } else if (contentJSON !== undefined) {
+    res.write(JSON.stringify(contentJSON));
+  } else if (content !== undefined) {
+    res.write(content);
+  }
+
+  return res.end();
+});
+
 module.exports = router;

--- a/packages/bruno-tests/src/index.js
+++ b/packages/bruno-tests/src/index.js
@@ -10,12 +10,19 @@ const multipartRouter = require('./multipart');
 const app = new express();
 const port = process.env.PORT || 8080;
 
-app.use(express.raw({type: '*/*', limit: '100mb'}));
 app.use(cors());
+
+const saveRawBody = (req, res, buf) => {
+  req.rawBuffer = Buffer.from(buf);
+  req.rawBody = buf.toString();
+};
+
+app.use(bodyParser.json({ verify: saveRawBody }));
+app.use(bodyParser.urlencoded({ extended: true, verify: saveRawBody }));
+app.use(bodyParser.text({ verify: saveRawBody }));
 app.use(xmlParser());
-app.use(bodyParser.text());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.raw({ type: '*/*', limit: '100mb', verify: saveRawBody }));
+
 formDataParser.init(app, express);
 
 app.use('/api/auth', authRouter);


### PR DESCRIPTION
Closes #4046
Closes #3761
Closes #2273
Related Issues #3758, #3594, #3558
Related PRs #3805 #3706 #3676 #2272 


Some of the Issues mentioned above have already been worked on and fixed but we had to re-look them and fix the root-cause and had to revert some of those changes.

This PR fixes
- Inconsistencies in parsing and formatting the JSON response where anything other than `typeof data === "object"` is considered a not a valid JSON which includes string, numbers, boolean and also `null`.
- Wrong interpretation of string wrapped in quotes in of RHS input of Assert table. They are supposed to be still plain strings, instead they were interpreted as string containing quotes.
- For the Response-preview, format the JSON string/raw-response without parsing(`JSON.parse`) to preserve the precession of numbers bigger than `Number.MAX_SAFE_INTEGER`.
This is just to make sure that the exact response given by the server is shown in the preview. The `res.body/res.getBody()` will still have the parsed data and precession will be lost anyway for those numbers
- Inconsistencies in response-preview formatting for invalid-JSON response while the `content-type` is still `application/json`

Also, added test requests with Asserts and Test scripts to validate the above across older versions and to check for any regressions.
|||
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/1d8be869-789a-43a5-9688-de7dd1b49b70) | ![image](https://github.com/user-attachments/assets/58568d89-2391-4759-ae9f-4ceaa1b39e1f) |

