### PR TITLE
Fix/keybinding issues

### DIFF
--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -5,10 +5,10 @@ const KeyMapping = {
   newRequest: { mac: 'command+b', windows: 'ctrl+b', name: 'New Request' },
   closeTab: { mac: 'command+w', windows: 'ctrl+w', name: 'Close Tab' },
   openPreferences: { mac: 'command+,', windows: 'ctrl+,', name: 'Open Preferences' },
-  minimizeWindow: {
-    mac: 'command+Shift+Q',
-    windows: 'control+Shift+Q',
-    name: 'Minimize Window'
+  closeBruno: {
+    mac: 'command+Q',
+    windows: 'ctrl+shift+q',
+    name: 'Close Bruno'
   },
   switchToPreviousTab: {
     mac: 'command+pageup',

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -11,7 +11,7 @@ if (isDev) {
 }
 
 const { format } = require('url');
-const { BrowserWindow, app, session, Menu, ipcMain } = require('electron');
+const { BrowserWindow, app, session, Menu, globalShortcut, ipcMain } = require('electron');
 const { setContentSecurityPolicy } = require('electron-util');
 
 const menuTemplate = require('./app/menu-template');
@@ -159,6 +159,13 @@ app.on('ready', async () => {
     }
     return { action: 'deny' };
   });
+  
+  // Quick fix for Electron issue #29996: https://github.com/electron/electron/issues/29996
+  globalShortcut.register('Ctrl+=', () => {
+    mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() + 1);
+  });
+
+
 
   // register all ipc handlers
   registerNetworkIpc(mainWindow);

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -165,7 +165,17 @@ app.on('ready', async () => {
     mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() + 1);
   });
 
+  globalShortcut.register('CommandOrControl+M', () => {
+    if (mainWindow) {
+      mainWindow.minimize();
+    }
+  });
 
+  globalShortcut.register('CommandOrControl+H', () => {
+    if (mainWindow) {
+      mainWindow.minimize();
+    }
+  });
 
   // register all ipc handlers
   registerNetworkIpc(mainWindow);

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -141,7 +141,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       // Change new name of collection
       let brunoConfig = JSON.parse(content);
       brunoConfig.name = collectionName;
-      const cont = await stringifyJson(json);
+      const cont = await stringifyJson(brunoConfig);
 
       // write the bruno.json to new dir
       await writeFile(path.join(dirPath, 'bruno.json'), cont);


### PR DESCRIPTION
fixes: #4108 

# Description

This PR implements support for adding global shortcuts to fix **Ctrl + Plus (+)** for zooming on Windows. It also properly updates the key mapping page to use **Close Bruno** instead of **Minimize Bruno**, and introduces support for minimizing the window with **Ctrl + M** and **Ctrl + H** instead of **Win + H**.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**