### PR TITLE
fix: about bruno window crash

### DIFF
--- a/packages/bruno-electron/src/app/menu-template.js
+++ b/packages/bruno-electron/src/app/menu-template.js
@@ -77,14 +77,25 @@ const template = [
     submenu: [
       {
         label: 'About Bruno',
-        click: () =>
-          openAboutWindow({
+        click: () => {
+          const aboutWindow = openAboutWindow({
             product_name: 'Bruno',
             icon_path: join(__dirname, '../about/256x256.png'),
             css_path: join(__dirname, '../about/about.css'),
             homepage: 'https://www.usebruno.com/',
             package_json_dir: join(__dirname, '../..')
-          })
+          });
+
+          // Set CSP to allow inline scripts
+          aboutWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+            callback({
+              responseHeaders: {
+                ...details.responseHeaders,
+                'Content-Security-Policy': ["default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';"]
+              }
+            });
+          });
+        }
       },
       { label: 'Documentation', click: () => ipcMain.emit('main:open-docs') }
     ]


### PR DESCRIPTION
# Description

Addressing issue: https://github.com/usebruno/bruno/issues/4040, #4120 

This PR fixes issue with the About window that was causing it to crash. The window was failing to load properly due to Content Security Policy (CSP) restrictions that blocked inline scripts.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="682" alt="image" src="https://github.com/user-attachments/assets/b4d9fdab-b2d7-450d-bc35-d7921e405df2" />
