### PR TITLE
fix: update global env in collection runner

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -526,6 +526,8 @@ const registerNetworkIpc = (mainWindow) => {
         mainWindow.webContents.send('main:global-environment-variables-update', {
           globalEnvironmentVariables: result.globalEnvironmentVariables
         });
+
+        collection.globalEnvironmentVariables = result.globalEnvironmentVariables;
       }
 
       if (result?.error) {
@@ -763,6 +765,8 @@ const registerNetworkIpc = (mainWindow) => {
         mainWindow.webContents.send('main:global-environment-variables-update', {
           globalEnvironmentVariables: testResults.globalEnvironmentVariables
         });
+
+        collection.globalEnvironmentVariables = testResults.globalEnvironmentVariables;
       }
 
       return {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1280,6 +1280,8 @@ const registerNetworkIpc = (mainWindow) => {
               mainWindow.webContents.send('main:global-environment-variables-update', {
                 globalEnvironmentVariables: testResults.globalEnvironmentVariables
               });
+              
+              collection.globalEnvironmentVariables = testResults.globalEnvironmentVariables;
             }
           } catch (error) {
             mainWindow.webContents.send('main:run-folder-event', {


### PR DESCRIPTION
# Description

Addressing issue https://github.com/usebruno/bruno/issues/4100

This PR fixes an issue where global environment variables set using `bru.setGlobalEnvVar()`  in test scripts were not being saved correctly during a collection run.

### What was the issue?
- When running multiple requests in a collection, if a test script updated a global environment variable, the next request didn't see the updated value.
- This issue only happened with test scripts. Pre-request and post-response scripts were already working fine.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines]**
- [x] **Create an issue and link to the pull request.**

https://github.com/user-attachments/assets/be35dfea-53b2-43c3-bb32-215f6af575f2