### PR TITLE
Bugfix/newlines break bru files

### DIFF
--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -77,6 +77,7 @@ export const normalizeFileName = (name) => {
   }
 
   // First normalize spacing chars like tabs and newlines to normal spaces.
+  // Otherwise line breaks in the name will make it into .bru files which prevents files from showing up in the app.
   const invalidWhitespaceChars = /\r\n|\r|\n|\t/g;
   let formattedName = name.replace(invalidWhitespaceChars, ' ');
 

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -76,8 +76,12 @@ export const normalizeFileName = (name) => {
     return name;
   }
 
+  // First normalize spacing chars like tabs and newlines to normal spaces.
+  const invalidWhitespaceChars = /\r\n|\r|\n|\t/g;
+  let formattedName = name.replace(invalidWhitespaceChars, ' ');
+
   const validChars = /[^\w\s-]/g;
-  const formattedName = name.replace(validChars, '-');
+  formattedName = formattedName.replace(validChars, '-');
 
   return formattedName;
 };


### PR DESCRIPTION
# Description

This PR addresses #4137 by replacing new lines and tabs with spaces during file name normalization process.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**