### PR TITLE
Fix/ Support `res.statusText` in safe mode and add `getStatus()` API

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -31,6 +31,7 @@ if (!SERVER_RENDERED) {
     'res.body',
     'res.responseTime',
     'res.getStatus()',
+    'res.getStatusText()',
     'res.getHeader(name)',
     'res.getHeaders()',
     'res.getBody()',

--- a/packages/bruno-js/src/bruno-response.js
+++ b/packages/bruno-js/src/bruno-response.js
@@ -21,6 +21,10 @@ class BrunoResponse {
     return this.res ? this.res.status : null;
   }
 
+  getStatusText() {
+    return this.res ? this.res.statusText : null;
+  }
+
   getHeader(name) {
     return this.res && this.res.headers ? this.res.headers[name] : null;
   }

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.js
@@ -6,11 +6,13 @@ const addBrunoResponseShimToContext = (vm, res) => {
   });
 
   const status = marshallToVm(res?.status, vm);
+  const statusText = marshallToVm(res?.statusText, vm);
   const headers = marshallToVm(res?.headers, vm);
   const body = marshallToVm(res?.body, vm);
   const responseTime = marshallToVm(res?.responseTime, vm);
 
   vm.setProp(resFn, 'status', status);
+  vm.setProp(resFn, 'statusText', statusText);
   vm.setProp(resFn, 'headers', headers);
   vm.setProp(resFn, 'body', body);
   vm.setProp(resFn, 'responseTime', responseTime);
@@ -19,6 +21,13 @@ const addBrunoResponseShimToContext = (vm, res) => {
   headers.dispose();
   body.dispose();
   responseTime.dispose();
+  statusText.dispose();
+
+  let getStatusText = vm.newFunction('getStatusText', function () {
+    return marshallToVm(res.getStatusText(), vm);
+  });
+  vm.setProp(resFn, 'getStatusText', getStatusText);
+  getStatusText.dispose();
 
   let getStatus = vm.newFunction('getStatus', function () {
     return marshallToVm(res.getStatus(), vm);

--- a/packages/bruno-tests/collection/scripting/api/res/getStatusText.bru
+++ b/packages/bruno-tests/collection/scripting/api/res/getStatusText.bru
@@ -1,0 +1,23 @@
+meta {
+  name: getStatusText
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+assert {
+  res.statusText: eq OK
+  res.body: eq pong
+}
+
+tests {
+  test("res.getStatusText()", function() {
+    const statusText = res.getStatusText()
+    expect(statusText).to.equal('OK');
+  });
+}


### PR DESCRIPTION
# Description

This PR implements the `res.getStatus()` API feature and adds support for `res.statusText` in safemode
### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**