### PR TITLE
Fix import post response scripts as the same

### DIFF
--- a/packages/bruno-tests/collection/ping.bru
+++ b/packages/bruno-tests/collection/ping.bru
@@ -11,5 +11,35 @@ get {
 }
 
 script:pre-request {
-  bru.runner.stopExecution();
+  test("prereq:tests", () => {
+    expect(false).to.equal(false);
+    expect(true).to.equal(true);
+  });
+}
+
+script:post-response {
+  test("postres:response should be valid ping message", () => {
+    expect(res.status).to.equal(200);
+    expect(res.body).to.equal('pong');
+    expect(res.headers['content-type']).to.exist;
+  });
+  
+  test("postres:response time should be reasonable", () => {
+    expect(res.responseTime).to.be.below(1000);
+    expect(res.responseTime).to.be.a('number');
+  });
+  
+}
+
+tests {
+  test("test:response should be valid ping message", () => {
+    expect(res.status).to.equal(200);
+    expect(res.body).to.equal('pong');
+    expect(res.headers['content-type']).to.exist;
+  });
+  
+  test("test:response time should be reasonable", () => {
+    expect(res.responseTime).to.be.below(1000);
+    expect(res.responseTime).to.be.a('number');
+  });
 }


### PR DESCRIPTION
# Description
Bruno used to import post response scripts from pm as tests rather than post response scripts, we will now star importing them as post response scripts, 
- Additionally we will support tests in post res and pre res  scripts
- The test results section will now show combined results of tests from pre-request scripts, post-request scripts, tests,
- Tests should support in safe mode too

<img width="631" alt="Screenshot 2025-03-04 at 2 15 03 PM" src="https://github.com/user-attachments/assets/e87d5074-752c-4227-a600-94920c1cdb89" />


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
