### PR TITLE
fix: vaiable name highlight with dot in property name

### DIFF
--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -8,6 +8,22 @@ if (!SERVER_RENDERED) {
 }
 
 const pathFoundInVariables = (path, obj) => {
+  if (path.includes('.')) {
+    const parts = path.split('.');
+    const firstPart = parts[0];
+    
+    if (obj && typeof obj === 'object' && firstPart in obj) {
+      const firstObj = obj[firstPart];
+    
+      if (firstObj && typeof firstObj === 'object') {
+        const remainingPath = parts.slice(1).join('.');
+        if (Object.prototype.hasOwnProperty.call(firstObj, remainingPath)) {
+          return true;
+        }
+      }
+    }
+  }
+  
   const value = get(obj, path);
   return value !== undefined;
 };


### PR DESCRIPTION
# Description

This PR fixes an issue where property names containing dots (e.g., 'want.attention') within variable objects were incorrectly highlighted as invalid (red color) in the editor, even when they existed in the variable object.

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/da7c70aa-9075-4cac-be33-c2814de6ebab" />
