### PR TITLE
Added option to customize `userData` path on dev mode

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -98,6 +98,16 @@ npm run dev:electron
 npm run dev
 ```
 
+#### Customize Electron `userData` path
+If `ELECTRON_APP_NAME` env-variable is present and its development mode, then the `appName` and `userData` path is modified accordingly.
+
+e.g.
+```sh
+ELECTRON_APP_NAME=bruno-dev npm run dev:electron
+```
+
+> This doesn't change the name of the window or the names in lot of other places, only the name used by Electron internally.
+
 ### Troubleshooting
 
 You might encounter a `Unsupported platform` error when you run `npm install`. To fix this, you will need to delete `node_modules` and `package-lock.json` and run `npm install`. This should install all the necessary packages needed to run the app.

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -14,6 +14,18 @@ const { format } = require('url');
 const { BrowserWindow, app, session, Menu, ipcMain } = require('electron');
 const { setContentSecurityPolicy } = require('electron-util');
 
+if (isDev && process.env.ELECTRON_APP_NAME) {
+  const appName = process.env.ELECTRON_APP_NAME;
+  const userDataPath = path.join(app.getPath("appData"), appName);
+
+  console.log("`ELECTRON_APP_NAME` found, overriding `appName` and `userData` path: \n"
+    + `\t${app.getName()} -> ${appName}\n`
+    + `\t${app.getPath("userData")} -> ${userDataPath}`);
+
+  app.setName(appName);
+  app.setPath("userData", userDataPath);
+}
+
 const menuTemplate = require('./app/menu-template');
 const { openCollection } = require('./app/collections');
 const LastOpenedCollections = require('./store/last-opened-collections');


### PR DESCRIPTION
If `ELECTRON_APP_NAME` env-variable is present and its dev env, then the `appName` and `userData` path is modified accordingly.

e.g.
```sh
ELECTRON_APP_NAME=bruno-dev npm run dev:electron
```

Note: This doesn't change the name of the window or the names in lot of other places, only the name used by Electron internally.