### PR TITLE
fix: request timer reset while switching tabs

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Overlay/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Overlay/index.js
@@ -17,7 +17,7 @@ const ResponseLoadingOverlay = ({ item, collection }) => {
       <div className="overlay">
         <div style={{ marginBottom: 15, fontSize: 26 }}>
           <div style={{ display: 'inline-block', fontSize: 20, marginLeft: 5, marginRight: 5 }}>
-            <StopWatch requestTimestamp={item?.requestSent?.timestamp} />
+            <StopWatch itemUid={item.uid} />
           </div>
         </div>
         <IconRefresh size={24} className="loading-icon" />

--- a/packages/bruno-app/src/components/StopWatch/index.js
+++ b/packages/bruno-app/src/components/StopWatch/index.js
@@ -1,27 +1,29 @@
 import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 
-const StopWatch = () => {
-  const [milliseconds, setMilliseconds] = useState(0);
-
-  const tickInterval = 100;
-  const tick = () => {
-    setMilliseconds(_milliseconds => _milliseconds + tickInterval);
-  };
-
+const StopWatch = ({ itemUid }) => {
+  const [currentTime, setCurrentTime] = useState(Date.now());
+  
+  const startTime = useSelector(state => 
+    state.collections.requestStartTimes[itemUid]
+  );
+  
   useEffect(() => {
-    let timerID = setInterval(() => {
-      tick()
-    }, tickInterval);
-    return () => {
-      clearTimeout(timerID);
-    };
-  }, []);
-
-  if (milliseconds < 250) {
-    return 'Loading...';
-  }
-
-  let seconds = milliseconds / 1000;
+    if (!startTime) return;
+    
+    const intervalId = setInterval(() => {
+      setCurrentTime(Date.now());
+    }, 100);
+    
+    return () => clearInterval(intervalId);
+  }, [startTime]);
+  
+  if (!startTime) return <span>Loading...</span>;
+  
+  const elapsedTime = currentTime - startTime;
+  if (elapsedTime < 250) return <span>Loading...</span>;
+  
+  const seconds = elapsedTime / 1000;
   return <span>{seconds.toFixed(1)}s</span>;
 };
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -37,7 +37,8 @@ import {
   resetRunResults,
   responseReceived,
   updateLastAction,
-  setCollectionSecurityConfig
+  setCollectionSecurityConfig,
+  setRequestStartTime
 } from './index';
 
 import { each } from 'lodash';
@@ -221,6 +222,11 @@ export const sendRequest = (item, collectionUid) => (dispatch, getState) => {
   const state = getState();
   const { globalEnvironments, activeGlobalEnvironmentUid } = state.globalEnvironments;  
   const collection = findCollectionByUid(state.collections.collections, collectionUid);
+
+  dispatch(setRequestStartTime({
+    itemUid: item.uid,
+    timestamp: Date.now()
+  }));
 
   return new Promise((resolve, reject) => {
     if (!collection) {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -23,7 +23,8 @@ import path from 'node:path';
 
 const initialState = {
   collections: [],
-  collectionSortOrder: 'default'
+  collectionSortOrder: 'default',
+  requestStartTimes: {}
 };
 
 export const collectionsSlice = createSlice({
@@ -277,6 +278,7 @@ export const collectionsSlice = createSlice({
           item.cancelTokenUid = null;
         }
       }
+      delete state.requestStartTimes[itemUid];
     },
     responseReceived: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
@@ -289,6 +291,7 @@ export const collectionsSlice = createSlice({
           item.cancelTokenUid = null;
         }
       }
+      delete state.requestStartTimes[action.payload.itemUid];
     },
     responseCleared: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
@@ -1992,7 +1995,25 @@ export const collectionsSlice = createSlice({
           set(folder, 'root.docs', action.payload.docs);
         }
       }
+    },
+    setRequestStartTime: (state, action) => {
+      const { itemUid, timestamp } = action.payload;
+      state.requestStartTimes[itemUid] = timestamp;
+    },
+    clearRequestStartTime: (state, action) => {
+      const { itemUid } = action.payload;
+      delete state.requestStartTimes[itemUid];
     }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(responseReceived, (state, action) => {
+      const { itemUid } = action.payload;
+      delete state.requestStartTimes[itemUid];
+    });
+    builder.addCase(requestCancelled, (state, action) => {
+      const { itemUid } = action.payload;
+      delete state.requestStartTimes[itemUid];
+    });
   }
 });
 
@@ -2097,7 +2118,9 @@ export const {
   resetCollectionRunner,
   updateRequestDocs,
   updateFolderDocs,
-  moveCollection
+  moveCollection,
+  setRequestStartTime,
+  clearRequestStartTime
 } = collectionsSlice.actions;
 
 export default collectionsSlice.reducer;


### PR DESCRIPTION
# Description

This PR fixes an issue where the request execution timer would reset when switching between tabs. Previously, when a user initiated a request with a pre-script delay (e.g., await (new Promise(r => setTimeout(r, 10000)));), and then navigated to another tab before returning, the timer would restart from zero instead of showing the actual time.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
