### PR TITLE
Fix: Prevent --bail option from treating skipped requests as failures

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -729,7 +729,7 @@ const handler = async function (argv) {
 
       // bail if option is set and there is a failure
       if (bail) {
-        const requestFailure = result?.error;
+        const requestFailure = result?.error && !result?.skipped;
         const testFailure = result?.testResults?.find((iter) => iter.status === 'fail');
         const assertionFailure = result?.assertionResults?.find((iter) => iter.status === 'fail');
         if (requestFailure || testFailure || assertionFailure) {


### PR DESCRIPTION
# Description

Addressing issue: https://github.com/usebruno/bruno/issues/4155

This PR fixes an issue with the --bail option in the Bruno CLI where skipped requests were being treated as failures. When using` bru.runner.skipRequest()` in a pre-request script, the CLI would abort the entire run if the --bail flag was used, even though skipping a request is not a failure condition.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
