### PR TITLE
fix: export collection includes items

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -183,6 +183,11 @@ const Collection = ({ collection, searchText }) => {
   const requestItems = sortRequestItems(filter(collection.items, (i) => isItemARequest(i)));
   const folderItems = sortFolderItems(filter(collection.items, (i) => isItemAFolder(i)));
 
+  const handleExportCollection = () => {
+    ensureCollectionIsMounted();
+    setShowExportCollectionModal(true);
+  };
+
   return (
     <StyledWrapper className="flex flex-col">
       {showNewRequestModal && <NewRequest collection={collection} onClose={() => setShowNewRequestModal(false)} />}
@@ -271,7 +276,7 @@ const Collection = ({ collection, searchText }) => {
               className="dropdown-item"
               onClick={(e) => {
                 menuDropdownTippyRef.current.hide();
-                setShowExportCollectionModal(true);
+                handleExportCollection();
               }}
             >
               Export


### PR DESCRIPTION
# Description

This PR fixes an issue where collection items were not being included in exports when the collection was in a collapsed state in the sidebar. Previously, when exporting a collection that was collapsed in the UI, the exported file would be missing items, resulting in incomplete exports.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
