### PR TITLE
Fix snippet generation for curl when a binary file is set.

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -46,7 +46,7 @@ const CodeView = ({ language, item }) => {
     );
   } catch (e) {
     console.error(e);
-    snippet = 'Error generating code snippet';
+    snippet = 'Error generating code snippet: ' + e;
   }
 
   return (

--- a/packages/bruno-app/src/utils/codegenerator/har.js
+++ b/packages/bruno-app/src/utils/codegenerator/har.js
@@ -36,7 +36,11 @@ const createHeaders = (request, headers) => {
       value: header.value
     }));
 
-  const contentType = createContentType(request.body?.mode);
+  let contentType = createContentType(request.body?.mode);
+  // Override contentType when a binary file is set
+  if (request.body?.mode == "file") {
+    contentType = request.body[request.body.mode].filter((param) => param.selected)[0].contentType
+  }
   if (contentType !== '' && !enabledHeaders.some((header) => header.name === 'content-type')) {
     enabledHeaders.push({ name: 'content-type', value: contentType });
   }
@@ -94,13 +98,10 @@ const createPostData = (body, type) => {
           }))
       };
     case 'file':
+      let selected = body[body.mode].filter((param) => param.selected)[0]
       return {
-        mimeType: body[body.mode].filter((param) => param.enabled)[0].contentType,
-        params: body[body.mode]
-          .filter((param) => param.selected)
-          .map((param) => ({
-            value: param.filePath,
-          }))
+        mimeType: selected.contentType,
+        text: "@" + selected.filePath
       };
     default:
       return {


### PR DESCRIPTION
# Description

Since files are selected and not enabled, the current code produces an "Error generating code snippet" error when one is set while exporting a snippet.

![Screenshot from 2025-03-11 22-36-24](https://github.com/user-attachments/assets/7b8fac4d-1985-4774-8f12-dd0751b77cab)

![Screenshot from 2025-03-11 22-36-44](https://github.com/user-attachments/assets/9035f364-7fe0-4f83-b20f-f4428301098c)

httpsnippet does not directly support --data "@..." when being passed filepath, so we need to trick it with a formated "text" parameter.

Add the error being sent by httpsnippet to the UI, so that other issues can be easier debugged.

Related to #1584.

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**
