### PR TITLE
File Count Logic for Proper Collection Mount Loading

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -19,7 +19,7 @@ import { isItemAFolder, isItemARequest } from 'utils/collections';
 import RenameCollection from './RenameCollection';
 import StyledWrapper from './StyledWrapper';
 import CloneCollection from './CloneCollection';
-import { areItemsLoading, findItemInCollection } from 'utils/collections';
+import { getItemsLoadStats } from 'utils/collections';
 import { scrollToTheActiveTab } from 'utils/tabs';
 import ShareCollection from 'components/ShareCollection/index';
 
@@ -31,9 +31,10 @@ const Collection = ({ collection, searchText }) => {
   const [showShareCollectionModal, setShowShareCollectionModal] = useState(false);
   const [showRemoveCollectionModal, setShowRemoveCollectionModal] = useState(false);
   const dispatch = useDispatch();
-  const isLoading = areItemsLoading(collection);
+  const { total: itemsLoadingCount } = getItemsLoadStats(collection);
   const collectionRef = useRef(null);
-
+  const totalFilesCount = collection.totalFilesCount;
+  
   const menuDropdownTippyRef = useRef();
   const onMenuDropdownCreate = (ref) => (menuDropdownTippyRef.current = ref);
   const MenuIcon = forwardRef((props, ref) => {
@@ -217,7 +218,11 @@ const Collection = ({ collection, searchText }) => {
           <div className="ml-1 w-full" id="sidebar-collection-name">
             {collection.name}
           </div>
-          {isLoading ? <IconLoader2 className="animate-spin mx-1" size={18} strokeWidth={1.5} /> : null}
+          <div className="flex items-center">
+            {totalFilesCount && itemsLoadingCount !== totalFilesCount ? (
+                <IconLoader2 className="animate-spin mx-1" size={18} strokeWidth={1.5} />
+            ) : null}
+          </div>
         </div>
         <div className="collection-actions">
           <Dropdown onCreate={onMenuDropdownCreate} icon={<MenuIcon />} placement="bottom-start">

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1232,8 +1232,14 @@ export const mountCollection = ({ collectionUid, collectionPathname, brunoConfig
   dispatch(updateCollectionMountStatus({ collectionUid, mountStatus: 'mounting' }));
   return new Promise(async (resolve, reject) => {
     callIpc('renderer:mount-collection', { collectionUid, collectionPathname, brunoConfig })
-      .then(() => dispatch(updateCollectionMountStatus({ collectionUid, mountStatus: 'mounted' })))
-      .then(resolve)
+      .then((result) => {
+        dispatch(updateCollectionMountStatus({ 
+          collectionUid, 
+          mountStatus: 'mounted',
+          totalFilesCount: result?.filesCount
+        }));
+        resolve();
+      })
       .catch(() => {
         dispatch(updateCollectionMountStatus({ collectionUid, mountStatus: 'unmounted' }));
         reject();

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -62,6 +62,9 @@ export const collectionsSlice = createSlice({
         if (action.payload.mountStatus) {
           collection.mountStatus = action.payload.mountStatus;
         }
+        if (action.payload.totalFilesCount) {
+          collection.totalFilesCount = action.payload.totalFilesCount;
+        }
       }
     },
     setCollectionSecurityConfig: (state, action) => {

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -139,7 +139,7 @@ export const areItemsLoading = (folder) => {
 
 export const getItemsLoadStats = (folder) => {
   let loadingCount = 0;
-  let flattenedItems = flattenItems(folder.items);
+  let flattenedItems = flattenItems(folder.items)?.filter(i => i?.type !== 'folder');
   flattenedItems?.forEach(i => {
     if(i?.loading) {
       loadingCount += 1;

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -955,6 +955,8 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
       (maxFileSize > MAX_SINGLE_FILE_SIZE_IN_COLLECTION_IN_MB);
 
     watcher.addWatcher(mainWindow, collectionPathname, collectionUid, brunoConfig, false, shouldLoadCollectionAsync);
+    
+    return {filesCount};
   });
 
   ipcMain.handle('renderer:show-in-folder', async (event, filePath) => {

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -212,7 +212,7 @@ const getCollectionStats = async (directoryPath) => {
       const fullPath = path.join(directory, entry.name);
 
       if (entry.isDirectory()) {
-        if (['node_modules', '.git'].includes(entry.name)) {
+        if (['node_modules', '.git', 'environments'].includes(entry.name)) {
           return;
         }
 
@@ -220,6 +220,11 @@ const getCollectionStats = async (directoryPath) => {
       }
 
       if (path.extname(fullPath) === '.bru') {
+        // Skip folder.bru and collection.bru files in stats calculation
+        if (entry.name === 'folder.bru' || entry.name === 'collection.bru') {
+          return;
+        }
+        
         const stats = await fsPromises.stat(fullPath);
         size += stats?.size;
         if (maxFileSize < stats?.size) {


### PR DESCRIPTION
# Description

This PR enhances the file count logic to ensure that the loading indicator for collection mounting is displayed correctly. The updated logic ensures a smoother and more accurate loading experience while the collection is being loaded.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
