### PR TITLE
feat: Allow to configure which tab is opened by default (instead of "Params")

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
@@ -34,7 +34,7 @@ const RequestsNotLoaded = ({ collection }) => {
         addTab({
           uid: item.uid,
           collectionUid: collection.uid,
-          requestPaneTab: getDefaultRequestPaneTab(item)
+          requestPaneTab: getDefaultRequestPaneTab({ type: item.type, preferences })
         })
       );
       return;

--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -26,6 +26,7 @@ const General = ({ close }) => {
     }),
     storeCookies: Yup.boolean(),
     sendCookies: Yup.boolean(),
+    defaultRequestTab: Yup.string().oneOf(['params', 'body', 'headers', 'auth', 'vars', 'script', 'assert', 'tests', 'docs']),
     timeout: Yup.mixed()
       .transform((value, originalValue) => {
         return originalValue === '' ? undefined : value;
@@ -51,7 +52,8 @@ const General = ({ close }) => {
       },
       timeout: preferences.request.timeout,
       storeCookies: get(preferences, 'request.storeCookies', true),
-      sendCookies: get(preferences, 'request.sendCookies', true)
+      sendCookies: get(preferences, 'request.sendCookies', true),
+      defaultRequestTab: get(preferences, 'request.defaultRequestTab', 'params')
     },
     validationSchema: preferencesSchema,
     onSubmit: async (values) => {
@@ -79,7 +81,8 @@ const General = ({ close }) => {
           },
           timeout: newPreferences.timeout,
           storeCookies: newPreferences.storeCookies,
-          sendCookies: newPreferences.sendCookies
+          sendCookies: newPreferences.sendCookies,
+          defaultRequestTab: newPreferences.defaultRequestTab
         }
       })
     )
@@ -232,6 +235,27 @@ const General = ({ close }) => {
         {formik.touched.timeout && formik.errors.timeout ? (
           <div className="text-red-500">{formik.errors.timeout}</div>
         ) : null}
+        <div className="flex flex-col mt-6">
+          <label className="block select-none" htmlFor="defaultRequestTab">
+            Default Request Tab
+          </label>
+          <select
+            name="defaultRequestTab"
+            className="block textbox mt-2 w-48"
+            onChange={formik.handleChange}
+            value={formik.values.defaultRequestTab}
+          >
+            <option value="params">Params</option>
+            <option value="body">Body</option>
+            <option value="headers">Headers</option>
+            <option value="auth">Auth</option>
+            <option value="vars">Vars</option>
+            <option value="script">Script</option>
+            <option value="assert">Assert</option>
+            <option value="tests">Tests</option>
+            <option value="docs">Docs</option>
+          </select>
+        </div>
         <div className="mt-10">
           <button type="submit" className="submit btn btn-sm btn-secondary">
             Save

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -4,7 +4,7 @@ import * as Yup from 'yup';
 import toast from 'react-hot-toast';
 import { uuid } from 'utils/common';
 import Modal from 'components/Modal';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { newEphemeralHttpRequest } from 'providers/ReduxStore/slices/collections';
 import { newHttpRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
@@ -17,6 +17,7 @@ import { IconCaretDown } from '@tabler/icons';
 
 const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
   const dispatch = useDispatch();
+  const preferences = useSelector((state) => state.app.preferences);
   const inputRef = useRef();
   const {
     brunoConfig: { presets: collectionPresets = {} }
@@ -127,7 +128,7 @@ const NewRequest = ({ collection, item, isEphemeral, onClose }) => {
               addTab({
                 uid: uid,
                 collectionUid: collection.uid,
-                requestPaneTab: getDefaultRequestPaneTab({ type: values.requestType })
+                requestPaneTab: getDefaultRequestPaneTab({ type: values.requestType, preferences })
               })
             );
             onClose();

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -827,14 +827,16 @@ export const areItemsTheSameExceptSeqUpdate = (_item1, _item2) => {
   return isEqual(item1, item2);
 };
 
-export const getDefaultRequestPaneTab = (item) => {
-  if (item.type === 'http-request') {
-    return 'params';
+export const getDefaultRequestPaneTab = ({ type, preferences }) => {
+  // Use user's preference or default to 'params'
+  if (type === 'http-request') {
+    return preferences?.request?.defaultRequestTab || 'params';
   }
 
-  if (item.type === 'graphql-request') {
-    return 'query';
+  if (type === 'graphql-request') {
+  return 'query';
   }
+  return 'params';
 };
 
 export const getGlobalEnvironmentVariables = ({ globalEnvironments, activeGlobalEnvironmentUid }) => {


### PR DESCRIPTION
# Description

- This PR fixes the issue #4200
- Added a prompt in Bruno Preferences which allows the user to select which request Tab he wants to redirect everytime he creates a new field.
- Added a `type` preference which checks if there is a user preference and if not then redirects to `params` by default

## Screenshot

<img width="802" alt="Screenshot 2025-03-14 at 6 42 22 PM" src="https://github.com/user-attachments/assets/51840d79-e385-4612-8736-2dcb19822f2b" />


### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
