### PR TITLE
fix: header key variables not interpolating with capital letters

### DIFF
--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -194,7 +194,7 @@ const prepareRequest = async (item, collection = {}, abortController) => {
   const scriptFlow = collection?.brunoConfig?.scripts?.flow ?? 'sandwich';
   const requestTreePath = getTreePathFromCollectionToItem(collection, item);
   if (requestTreePath && requestTreePath.length > 0) {
-    mergeHeaders(collection, request, requestTreePath);
+    contentTypeDefined = mergeHeaders(collection, request, requestTreePath);
     mergeScripts(collection, request, requestTreePath, scriptFlow);
     mergeVars(collection, request, requestTreePath);
     request.globalEnvironmentVariables = collection?.globalEnvironmentVariables;

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -194,7 +194,7 @@ const prepareRequest = async (item, collection = {}, abortController) => {
   const scriptFlow = collection?.brunoConfig?.scripts?.flow ?? 'sandwich';
   const requestTreePath = getTreePathFromCollectionToItem(collection, item);
   if (requestTreePath && requestTreePath.length > 0) {
-    contentTypeDefined = mergeHeaders(collection, request, requestTreePath);
+    mergeHeaders(collection, request, requestTreePath);
     mergeScripts(collection, request, requestTreePath, scriptFlow);
     mergeVars(collection, request, requestTreePath);
     request.globalEnvironmentVariables = collection?.globalEnvironmentVariables;

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -13,7 +13,6 @@ const mergeHeaders = (collection, request, requestTreePath) => {
     if (header.enabled) {
       if (header?.name?.toLowerCase?.() === 'content-type') {
         headers.set('content-type', header.value);
-        contentTypeDefined = true;
       } else {
         headers.set(header.name, header.value);
       }

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -48,7 +48,6 @@ const mergeHeaders = (collection, request, requestTreePath) => {
   }
 
   request.headers = Array.from(headers, ([name, value]) => ({ name, value, enabled: true }));
-  return contentTypeDefined;
 };
 
 const mergeVars = (collection, request, requestTreePath) => {

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -7,13 +7,16 @@ const os = require('os');
 
 const mergeHeaders = (collection, request, requestTreePath) => {
   let headers = new Map();
+  let contentTypeDefined = false;
 
   let collectionHeaders = get(collection, 'root.request.headers', []);
   collectionHeaders.forEach((header) => {
     if (header.enabled) {
-      headers.set(header.name?.toLowerCase?.(), header.value);
-      if (header?.name?.toLowerCase() === 'content-type') {
+      if (header?.name?.toLowerCase?.() === 'content-type') {
+        headers.set('content-type', header.value);
         contentTypeDefined = true;
+      } else {
+        headers.set(header.name, header.value);
       }
     }
   });
@@ -23,20 +26,29 @@ const mergeHeaders = (collection, request, requestTreePath) => {
       let _headers = get(i, 'root.request.headers', []);
       _headers.forEach((header) => {
         if (header.enabled) {
-          headers.set(header.name?.toLowerCase?.(), header.value);
+          if (header.name.toLowerCase() === 'content-type') {
+            headers.set('content-type', header.value);
+          } else {
+            headers.set(header.name, header.value);
+          }
         }
       });
     } else {
       const _headers = i?.draft ? get(i, 'draft.request.headers', []) : get(i, 'request.headers', []);
       _headers.forEach((header) => {
         if (header.enabled) {
-          headers.set(header.name?.toLowerCase?.(), header.value);
+          if (header.name.toLowerCase() === 'content-type') {
+            headers.set('content-type', header.value);
+          } else {
+            headers.set(header.name, header.value);
+          }
         }
       });
     }
   }
 
   request.headers = Array.from(headers, ([name, value]) => ({ name, value, enabled: true }));
+  return contentTypeDefined;
 };
 
 const mergeVars = (collection, request, requestTreePath) => {

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -7,7 +7,6 @@ const os = require('os');
 
 const mergeHeaders = (collection, request, requestTreePath) => {
   let headers = new Map();
-  let contentTypeDefined = false;
 
   let collectionHeaders = get(collection, 'root.request.headers', []);
   collectionHeaders.forEach((header) => {


### PR DESCRIPTION
# Description

This PR fixes issue #4052 where header key variables containing capital letters were not being properly interpolated in version 1.39. The issue occurred because header names were being converted to lowercase during the merging process, which prevented variable interpolation from working correctly for header keys with capital letters

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/1bd766fe-cc33-401b-9f28-6c5f99ae08e7" />

