### PR TITLE
Refactor/ Remove options from `ImportCollection` for Postman collection import

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import importBrunoCollection from 'utils/importers/bruno-collection';
 import importPostmanCollection from 'utils/importers/postman-collection';
 import importInsomniaCollection from 'utils/importers/insomnia-collection';
@@ -7,14 +7,6 @@ import { toastError } from 'utils/common/error';
 import Modal from 'components/Modal';
 
 const ImportCollection = ({ onClose, handleSubmit }) => {
-  const [options, setOptions] = useState({
-    enablePostmanTranslations: {
-      enabled: true,
-      label: 'Auto translate postman scripts',
-      subLabel:
-        "When enabled, Bruno will try as best to translate the scripts from the imported collection to Bruno's format."
-    }
-  });
   const handleImportBrunoCollection = () => {
     importBrunoCollection()
       .then(({ collection }) => {
@@ -24,7 +16,7 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
   };
 
   const handleImportPostmanCollection = () => {
-    importPostmanCollection(options)
+    importPostmanCollection()
       .then(({ collection, translationLog }) => {
         handleSubmit({ collection, translationLog });
       })
@@ -46,15 +38,7 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
       })
       .catch((err) => toastError(err, 'OpenAPI v3 Import collection failed'));
   };
-  const toggleOptions = (event, optionKey) => {
-    setOptions({
-      ...options,
-      [optionKey]: {
-        ...options[optionKey],
-        enabled: !options[optionKey].enabled
-      }
-    });
-  };
+
   const CollectionButton = ({ children, className, onClick }) => {
     return (
       <button
@@ -67,6 +51,7 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
       </button>
     );
   };
+
   return (
     <Modal size="sm" title="Import Collection" hideFooter={true} handleCancel={onClose}>
       <div className="flex flex-col">
@@ -78,29 +63,13 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
           <CollectionButton onClick={handleImportOpenapiCollection}>OpenAPI V3 Spec</CollectionButton>
         </div>
         <div className="flex justify-start w-full mt-4 max-w-[450px]">
-          {Object.entries(options || {}).map(([key, option]) => (
-            <div key={key} className="relative flex items-start">
-              <div className="flex h-6 items-center">
-                <input
-                  id="comments"
-                  aria-describedby="comments-description"
-                  name="comments"
-                  type="checkbox"
-                  checked={option.enabled}
-                  onChange={(e) => toggleOptions(e, key)}
-                  className="h-3.5 w-3.5 rounded border-zinc-300 dark:ring-offset-zinc-800 bg-transparent text-indigo-600 dark:text-indigo-500 focus:ring-indigo-600 dark:focus:ring-indigo-500"
-                />
-              </div>
-              <div className="ml-2 text-sm leading-6">
-                <label htmlFor="comments" className="font-medium text-gray-900 dark:text-zinc-50">
-                  {option.label}
-                </label>
-                <p id="comments-description" className="text-zinc-500 text-xs dark:text-zinc-400">
-                  {option.subLabel}
-                </p>
-              </div>
+          <div className="relative flex items-start">
+            <div className="ml-2 text-sm leading-6">
+              <p className="text-zinc-500 text-xs dark:text-zinc-400">
+                <span className="font-bold text-red-900 dark:text-zinc-50">Note:</span> When importing Postman collections, Bruno will automatically translate pre-request and test scripts to Bruno's format.
+              </p>
             </div>
-          ))}
+          </div>
         </div>
       </div>
     </Modal>

--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -116,7 +116,7 @@ const pushTranslationLog = (type, index) => {
   translationLog[i.name][type].push(index + 1);
 };
 
-const importScriptsFromEvents = (events, requestObject, options, pushTranslationLog) => {
+const importScriptsFromEvents = (events, requestObject, pushTranslationLog) => {
   events.forEach((event) => {
     if (event.script && event.script.exec) {
       if (event.listen === 'prerequest') {
@@ -126,16 +126,10 @@ const importScriptsFromEvents = (events, requestObject, options, pushTranslation
 
         if (Array.isArray(event.script.exec) && event.script.exec.length > 0) {
           requestObject.script.req = event.script.exec
-            .map((line, index) =>
-              options.enablePostmanTranslations.enabled
-                ? postmanTranslation(line, () => pushTranslationLog('script', index))
-                : `// ${line}`
-            )
+            .map((line, index) => postmanTranslation(line, () => pushTranslationLog('script', index)))
             .join('\n');
         } else if (typeof event.script.exec === 'string') {
-          requestObject.script.req = options.enablePostmanTranslations.enabled
-            ? postmanTranslation(event.script.exec, () => pushTranslationLog('script', 0))
-            : `// ${event.script.exec}`;
+          requestObject.script.req = postmanTranslation(event.script.exec, () => pushTranslationLog('script', 0));
         } else {
           console.warn('Unexpected event.script.exec type', typeof event.script.exec);
         }
@@ -148,16 +142,10 @@ const importScriptsFromEvents = (events, requestObject, options, pushTranslation
 
         if (Array.isArray(event.script.exec) && event.script.exec.length > 0) {
           requestObject.tests = event.script.exec
-            .map((line, index) =>
-              options.enablePostmanTranslations.enabled
-                ? postmanTranslation(line, () => pushTranslationLog('test', index))
-                : `// ${line}`
-            )
+            .map((line, index) => postmanTranslation(line, () => pushTranslationLog('test', index)))
             .join('\n');
         } else if (typeof event.script.exec === 'string') {
-          requestObject.tests = options.enablePostmanTranslations.enabled
-            ? postmanTranslation(event.script.exec, () => pushTranslationLog('test', 0))
-            : `// ${event.script.exec}`;
+          requestObject.tests = postmanTranslation(event.script.exec, () => pushTranslationLog('test', 0));
         } else {
           console.warn('Unexpected event.script.exec type', typeof event.script.exec);
         }
@@ -177,7 +165,7 @@ const importCollectionLevelVariables = (variables, requestObject) => {
   requestObject.vars.req = vars;
 };
 
-const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) => {
+const importPostmanV2CollectionItem = (brunoParent, item, parentAuth) => {
   brunoParent.items = brunoParent.items || [];
   const folderMap = {};
   const requestMap = {};
@@ -219,11 +207,11 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
         }
       };
       if (i.item && i.item.length) {
-        importPostmanV2CollectionItem(brunoFolderItem, i.item, i.auth ?? parentAuth, options);
+        importPostmanV2CollectionItem(brunoFolderItem, i.item, i.auth ?? parentAuth);
       }
 
       if (i.event) {
-        importScriptsFromEvents(i.event, brunoFolderItem.root.request, options, pushTranslationLog);
+        importScriptsFromEvents(i.event, brunoFolderItem.root.request, pushTranslationLog);
       }
 
       brunoParent.items.push(brunoFolderItem);
@@ -282,16 +270,10 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
               }
               if (Array.isArray(event.script.exec) && event.script.exec.length > 0) {
                 brunoRequestItem.request.script.req = event.script.exec
-                  .map((line, index) =>
-                    options.enablePostmanTranslations.enabled
-                      ? postmanTranslation(line, () => pushTranslationLog('script', index))
-                      : `// ${line}`
-                  )
+                  .map((line, index) => postmanTranslation(line, () => pushTranslationLog('script', index)))
                   .join('\n');
               } else if (typeof event.script.exec === 'string') {
-                brunoRequestItem.request.script.req = options.enablePostmanTranslations.enabled
-                  ? postmanTranslation(event.script.exec, () => pushTranslationLog('script', 0))
-                  : `// ${event.script.exec}`;
+                brunoRequestItem.request.script.req = postmanTranslation(event.script.exec, () => pushTranslationLog('script', 0));
               } else {
                 console.warn('Unexpected event.script.exec type', typeof event.script.exec);
               }
@@ -302,16 +284,10 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
               }
               if (Array.isArray(event.script.exec) && event.script.exec.length > 0) {
                 brunoRequestItem.request.tests = event.script.exec
-                  .map((line, index) =>
-                    options.enablePostmanTranslations.enabled
-                      ? postmanTranslation(line, () => pushTranslationLog('test', index))
-                      : `// ${line}`
-                  )
+                  .map((line, index) => postmanTranslation(line, () => pushTranslationLog('test', index)))
                   .join('\n');
               } else if (typeof event.script.exec === 'string') {
-                brunoRequestItem.request.tests = options.enablePostmanTranslations.enabled
-                  ? postmanTranslation(event.script.exec, () => pushTranslationLog('test', 0))
-                  : `// ${event.script.exec}`;
+                brunoRequestItem.request.tests = postmanTranslation(event.script.exec, () => pushTranslationLog('test', 0));
               } else {
                 console.warn('Unexpected event.script.exec type', typeof event.script.exec);
               }
@@ -483,7 +459,7 @@ const searchLanguageByHeader = (headers) => {
   return contentType;
 };
 
-const importPostmanV2Collection = (collection, options) => {
+const importPostmanV2Collection = (collection) => {
   const brunoCollection = {
     name: collection.info.name,
     uid: uuid(),
@@ -511,19 +487,19 @@ const importPostmanV2Collection = (collection, options) => {
   };
 
   if (collection.event) {
-    importScriptsFromEvents(collection.event, brunoCollection.root.request, options, pushTranslationLog);
+    importScriptsFromEvents(collection.event, brunoCollection.root.request, pushTranslationLog);
   }
 
   if (collection?.variable){
     importCollectionLevelVariables(collection.variable, brunoCollection.root.request);
   }
 
-  importPostmanV2CollectionItem(brunoCollection, collection.item, collection.auth, options);
+  importPostmanV2CollectionItem(brunoCollection, collection.item, collection.auth);
 
   return brunoCollection;
 };
 
-const parsePostmanCollection = (str, options) => {
+const parsePostmanCollection = (str) => {
   return new Promise((resolve, reject) => {
     try {
       let collection = JSON.parse(str);
@@ -537,7 +513,7 @@ const parsePostmanCollection = (str, options) => {
       ];
 
       if (v2Schemas.includes(schema)) {
-        return resolve(importPostmanV2Collection(collection, options));
+        return resolve(importPostmanV2Collection(collection));
       }
 
       throw new BrunoError('Unknown postman schema');
@@ -567,11 +543,11 @@ Collections incomplete : ${Object.keys(translationLog || {}).length}` +
   }
 };
 
-const importCollection = (options) => {
+const importCollection = () => {
   return new Promise((resolve, reject) => {
     fileDialog({ accept: 'application/json' })
       .then(readFile)
-      .then((str) => parsePostmanCollection(str, options))
+      .then((str) => parsePostmanCollection(str))
       .then(transformItemsInCollection)
       .then(hydrateSeqInCollection)
       .then(validateSchema)


### PR DESCRIPTION
related to: #4252 

# Description

This PR refactors the Postman collection import logic by removing the option to disable auto-translate. 
Changes made:
 - Removed Options state
 - Removed `toggleOptions` function

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**

![image](https://github.com/user-attachments/assets/b8a8cc3d-1f2c-463f-be13-cc3052e09365)
