### PR TITLE
Feat/ Set default names for folders and requests in Postman collection importer (fixes: #4277)

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -185,7 +185,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
 
   each(item, (i) => {
     if (isItemAFolder(i)) {
-      const baseFolderName = i.name;
+      const baseFolderName = i.name || 'Untitled Folder';
       let folderName = baseFolderName;
       let count = 1;
 
@@ -236,7 +236,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
           return;
         }
 
-        const baseRequestName = i.name;
+        const baseRequestName = i.name || 'Untitled Request';
         let requestName = baseRequestName;
         let count = 1;
 
@@ -485,7 +485,7 @@ const searchLanguageByHeader = (headers) => {
 
 const importPostmanV2Collection = (collection, options) => {
   const brunoCollection = {
-    name: collection.info.name,
+    name: collection.info.name || 'New Collection',
     uid: uuid(),
     version: '1',
     items: [],
@@ -493,7 +493,7 @@ const importPostmanV2Collection = (collection, options) => {
     root: {
       docs: collection.info.description || '',
       meta: {
-        name: collection.info.name
+        name: collection.info.name || 'New Collection'
       },
       request: {
         auth: {

--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -485,7 +485,7 @@ const searchLanguageByHeader = (headers) => {
 
 const importPostmanV2Collection = (collection, options) => {
   const brunoCollection = {
-    name: collection.info.name || 'New Collection',
+    name: collection.info.name || 'Untitled Collection',
     uid: uuid(),
     version: '1',
     items: [],
@@ -493,7 +493,7 @@ const importPostmanV2Collection = (collection, options) => {
     root: {
       docs: collection.info.description || '',
       meta: {
-        name: collection.info.name || 'New Collection'
+        name: collection.info.name || 'Untitled Collection'
       },
       request: {
         auth: {


### PR DESCRIPTION
fixes: #4277 

# Description

This PR introduces a logic where a Postman collection with an empty name, an empty folder name, or an empty request name will receive default names and be added to the import, ensuring a successful import. With this, users can import the collection and change the names afterward instead of creating the names first and then importing it into Bruno.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**