### PR TITLE
Add: API Key auth in code generator

### DIFF
--- a/packages/bruno-app/src/utils/codegenerator/auth.js
+++ b/packages/bruno-app/src/utils/codegenerator/auth.js
@@ -24,6 +24,22 @@ export const getAuthHeaders = (collectionRootAuth, requestAuth) => {
           value: `Bearer ${get(auth, 'bearer.token', '')}`
         }
       ];
+    case 'apikey':
+      const apiKeyAuth = get(auth, 'apikey', {});
+      const key = get(apiKeyAuth, 'key', '');
+      const value = get(apiKeyAuth, 'value', '');
+      const placement = get(apiKeyAuth, 'placement', 'header');
+
+      if (placement === 'header') {
+        return [
+          {
+            enabled: true,
+            name: key,
+            value: value
+          }
+        ];
+      }
+      return [];
     default:
       return [];
   }

--- a/packages/bruno-app/src/utils/codegenerator/har.js
+++ b/packages/bruno-app/src/utils/codegenerator/har.js
@@ -44,13 +44,25 @@ const createHeaders = (request, headers) => {
   return enabledHeaders;
 };
 
-const createQuery = (queryParams = []) => {
-  return queryParams
+const createQuery = (queryParams = [], request) => {
+  const params = queryParams
     .filter((param) => param.enabled && param.type === 'query')
     .map((param) => ({
       name: param.name,
       value: param.value
     }));
+
+  if (request?.auth?.mode === 'apikey' && 
+      request?.auth?.apikey?.placement === 'queryparams' && 
+      request?.auth?.apikey?.key && 
+      request?.auth?.apikey?.value) {
+    params.push({
+      name: request.auth.apikey.key,
+      value: request.auth.apikey.value
+    });
+  }
+
+  return params;
 };
 
 const createPostData = (body, type) => {
@@ -117,7 +129,7 @@ export const buildHarRequest = ({ request, headers, type }) => {
     httpVersion: 'HTTP/1.1',
     cookies: [],
     headers: createHeaders(request, headers),
-    queryString: createQuery(request.params),
+    queryString: createQuery(request.params, request),
     postData: createPostData(request.body, type),
     headersSize: 0,
     bodySize: 0,


### PR DESCRIPTION
# Description

Issue: #3405 

Implemented API key support in the code generator with the ability to place the key in both headers and query parameters.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="1159" alt="Screenshot 2025-03-19 at 5 20 58 PM" src="https://github.com/user-attachments/assets/294a0223-f5fb-4889-8078-b45c3701d6ed" />


Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
