### PR TITLE
Feat: hide menubar for about window in menu template (fixes: #4280)

### DIFF
--- a/packages/bruno-electron/src/app/menu-template.js
+++ b/packages/bruno-electron/src/app/menu-template.js
@@ -82,6 +82,8 @@ const template = [
           const aboutWindow = new BrowserWindow({
             width: 350,
             height: 250,
+            menuBarVisible: false,
+            autoHideMenuBar: true,
             webPreferences: {
               nodeIntegration: true,
             },


### PR DESCRIPTION
fixes: #4280 

# Description

This PR implements the logic to hide the menu bar for the "About Bruno" window by default. If users need the menu bar, they can press Alt to toggle its visibility

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**