### PR TITLE
fix: enable mask editor function

### DIFF
--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -94,6 +94,8 @@ class SingleLineEditor extends Component {
   _enableMaskedEditor = (enabled) => {
     if (typeof enabled !== 'boolean') return;
 
+    this.ignoreChangeEvent = true;
+
     console.log('Enabling masked editor: ' + enabled);
     if (enabled == true) {
       if (!this.maskedEditor) this.maskedEditor = new MaskedEditor(this.editor, '*');
@@ -102,6 +104,8 @@ class SingleLineEditor extends Component {
       this.maskedEditor?.disable();
       this.maskedEditor = null;
     }
+
+    this.ignoreChangeEvent = false;
   };
 
   _onEdit = () => {


### PR DESCRIPTION
# Description

Fix the `_enableMaskedEditor` function so that the draft state does not appear in the Auth tab when it is saved.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
