### PR TITLE
feat: add context menu support for all tabs

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import CloseTabIcon from './CloseTabIcon';
 import { IconVariable, IconSettings, IconRun, IconFolder, IconShieldLock } from '@tabler/icons';
+import { TabContextMenu } from 'components/TabContextMenu/index';
 
-const SpecialTab = ({ handleCloseClick, type, tabName, handleDoubleClick }) => {
+const SpecialTab = ({ handleCloseClick, type, tabName, handleDoubleClick, tabIndex }) => {
+  const dropdownTippyRef = useRef();
+  const onDropdownCreate = (ref) => (dropdownTippyRef.current = ref);
+
   const getTabInfo = (type, tabName) => {
     switch (type) {
       case 'collection-settings': {
@@ -27,7 +31,7 @@ const SpecialTab = ({ handleCloseClick, type, tabName, handleDoubleClick }) => {
             <IconShieldLock size={18} strokeWidth={1.5} className="text-yellow-600" />
             <span className="ml-1">Security</span>
           </>
-        )
+        );
       }
       case 'folder-settings': {
         return (
@@ -56,9 +60,26 @@ const SpecialTab = ({ handleCloseClick, type, tabName, handleDoubleClick }) => {
     }
   };
 
+  const handleRightClick = (_event) => {
+    const menuDropdown = dropdownTippyRef.current;
+    if (!menuDropdown) {
+      return;
+    }
+
+    if (menuDropdown.state.isShown) {
+      menuDropdown.hide();
+    } else {
+      menuDropdown.show();
+    }
+  };
+
   return (
     <>
-      <div className="flex items-center tab-label pl-2">{getTabInfo(type, tabName)}</div>
+      <div className="flex items-center tab-label pl-2" onContextMenu={handleRightClick}>
+        {getTabInfo(type, tabName)}
+        <TabContextMenu onDropdownCreate={onDropdownCreate} tabIndex={tabIndex} dropdownTippyRef={dropdownTippyRef} />
+      </div>
+
       <div className="flex px-2 close-icon-container" onClick={(e) => handleCloseClick(e)}>
         <CloseTabIcon />
       </div>

--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -111,7 +111,6 @@ const RequestTabs = () => {
                         onClick={() => handleClick(tab)}
                       >
                         <RequestTab
-                          collectionRequestTabs={collectionRequestTabs}
                           tabIndex={index}
                           key={tab.uid}
                           tab={tab}

--- a/packages/bruno-app/src/components/TabContextMenu/index.js
+++ b/packages/bruno-app/src/components/TabContextMenu/index.js
@@ -1,0 +1,140 @@
+import { saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { closeTabs } from 'providers/ReduxStore/slices/tabs';
+import { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { findItemInCollection, flattenItems } from 'utils/collections/index';
+import NewRequest from 'components/Sidebar/NewRequest/index';
+import CloneCollectionItem from 'components/Sidebar/Collections/Collection/CollectionItem/CloneCollectionItem/index';
+import Dropdown from 'components/Dropdown';
+import { Fragment } from 'react';
+
+export function TabContextMenu({ onDropdownCreate, tabIndex, collection, dropdownTippyRef }) {
+  const [showCloneRequestModal, setShowCloneRequestModal] = useState(false);
+  const [showAddNewRequestModal, setShowAddNewRequestModal] = useState(false);
+  const tabs = useSelector((state) => state.tabs.tabs);
+  const dispatch = useDispatch();
+
+  const currentTabItem = tabs[tabIndex];
+  const currentTabItemUid = currentTabItem?.uid;
+  const isRequest = collection ? true : false;
+  const requestItem = isRequest && findItemInCollection(collection, currentTabItemUid);
+
+  const totalTabs = tabs.length || 0;
+  const hasLeftTabs = tabIndex !== 0;
+  const hasRightTabs = totalTabs > tabIndex + 1;
+  const hasOtherTabs = totalTabs > 1;
+
+  async function handleCloseTab(event, closingTabUid) {
+    event.stopPropagation();
+    dropdownTippyRef.current.hide();
+
+    if (!currentTabItemUid) {
+      return;
+    }
+
+    try {
+      // silently save unsaved changes before closing the request tab
+      if (isRequest && collection) {
+        const item = findItemInCollection(collection, currentTabItemUid);
+        dispatch(saveRequest(item.uid, collection.uid, true));
+      }
+      dispatch(closeTabs({ tabUids: [closingTabUid] }));
+    } catch (err) {}
+  }
+
+  function handleCloseOtherTabs(event) {
+    dropdownTippyRef.current.hide();
+
+    const otherTabs = tabs.filter((_, index) => index !== tabIndex);
+    otherTabs.forEach((tab) => handleCloseTab(event, tab.uid));
+  }
+
+  function handleCloseTabsToTheLeft(event) {
+    dropdownTippyRef.current.hide();
+
+    const leftTabs = tabs.filter((_, index) => index < tabIndex);
+    leftTabs.forEach((tab) => handleCloseTab(event, tab.uid));
+  }
+
+  function handleCloseTabsToTheRight(event) {
+    dropdownTippyRef.current.hide();
+
+    const rightTabs = tabs.filter((_, index) => index > tabIndex);
+    rightTabs.forEach((tab) => handleCloseTab(event, tab.uid));
+  }
+
+  function handleCloseSavedTabs(event) {
+    event.stopPropagation();
+
+    const items = flattenItems(collection?.items);
+    const savedTabs = items?.filter?.((item) => !item.draft);
+    const savedTabIds = savedTabs?.map((item) => item.uid) || [];
+    dispatch(closeTabs({ tabUids: savedTabIds }));
+  }
+
+  function handleCloseAllTabs(event) {
+    tabs.forEach((tab) => handleCloseTab(event, tab.uid));
+  }
+
+  return (
+    <Fragment>
+      {showAddNewRequestModal && (
+        <NewRequest collection={collection} onClose={() => setShowAddNewRequestModal(false)} />
+      )}
+
+      {showCloneRequestModal && (
+        <CloneCollectionItem
+          item={requestItem}
+          collection={collection}
+          onClose={() => setShowCloneRequestModal(false)}
+        />
+      )}
+
+      <Dropdown onCreate={onDropdownCreate} icon={<span></span>} placement="bottom-start">
+        {isRequest && (
+          <>
+            <button
+              className="dropdown-item w-full"
+              onClick={() => {
+                dropdownTippyRef.current.hide();
+                setShowAddNewRequestModal(true);
+              }}
+            >
+              New Request
+            </button>
+            <button
+              className="dropdown-item w-full"
+              onClick={() => {
+                dropdownTippyRef.current.hide();
+                setShowCloneRequestModal(true);
+              }}
+            >
+              Clone Request
+            </button>
+          </>
+        )}
+
+        <button className="dropdown-item w-full" onClick={(e) => handleCloseTab(e, currentTabItemUid)}>
+          Close
+        </button>
+        <button disabled={!hasOtherTabs} className="dropdown-item w-full" onClick={handleCloseOtherTabs}>
+          Close Others
+        </button>
+        <button disabled={!hasLeftTabs} className="dropdown-item w-full" onClick={handleCloseTabsToTheLeft}>
+          Close to the Left
+        </button>
+        <button disabled={!hasRightTabs} className="dropdown-item w-full" onClick={handleCloseTabsToTheRight}>
+          Close to the Right
+        </button>
+        {isRequest && (
+          <button className="dropdown-item w-full" onClick={handleCloseSavedTabs}>
+            Close Saved
+          </button>
+        )}
+        <button className="dropdown-item w-full" onClick={handleCloseAllTabs}>
+          Close All
+        </button>
+      </Dropdown>
+    </Fragment>
+  );
+}

--- a/packages/bruno-app/src/components/TabContextMenu/index.js
+++ b/packages/bruno-app/src/components/TabContextMenu/index.js
@@ -35,8 +35,7 @@ export function TabContextMenu({ onDropdownCreate, tabIndex, collection, dropdow
     try {
       // silently save unsaved changes before closing the request tab
       if (isRequest && collection) {
-        const item = findItemInCollection(collection, currentTabItemUid);
-        dispatch(saveRequest(item.uid, collection.uid, true));
+        dispatch(saveRequest(currentTabItemUid, collection.uid, true));
       }
       dispatch(closeTabs({ tabUids: [closingTabUid] }));
     } catch (err) {}

--- a/packages/bruno-app/src/components/TabContextMenu/index.js
+++ b/packages/bruno-app/src/components/TabContextMenu/index.js
@@ -16,8 +16,8 @@ export function TabContextMenu({ onDropdownCreate, tabIndex, collection, dropdow
 
   const currentTabItem = tabs[tabIndex];
   const currentTabItemUid = currentTabItem?.uid;
-  const isRequest = collection ? true : false;
-  const requestItem = isRequest ? findItemInCollection(collection, currentTabItemUid) : null;
+  const isRequestTab = collection ? true : false;
+  const requestItem = isRequestTab ? findItemInCollection(collection, currentTabItemUid) : null;
 
   const totalTabs = tabs.length || 0;
   const hasLeftTabs = tabIndex !== 0;
@@ -34,7 +34,7 @@ export function TabContextMenu({ onDropdownCreate, tabIndex, collection, dropdow
 
     try {
       // silently save unsaved changes before closing the request tab
-      if (isRequest && collection) {
+      if (isRequestTab && collection) {
         dispatch(saveRequest(currentTabItemUid, collection.uid, true));
       }
       dispatch(closeTabs({ tabUids: [closingTabUid] }));
@@ -90,7 +90,7 @@ export function TabContextMenu({ onDropdownCreate, tabIndex, collection, dropdow
       )}
 
       <Dropdown onCreate={onDropdownCreate} icon={<span></span>} placement="bottom-start">
-        {isRequest && (
+        {isRequestTab && (
           <>
             <button
               className="dropdown-item w-full"
@@ -125,7 +125,7 @@ export function TabContextMenu({ onDropdownCreate, tabIndex, collection, dropdow
         <button disabled={!hasRightTabs} className="dropdown-item w-full" onClick={handleCloseTabsToTheRight}>
           Close to the Right
         </button>
-        {isRequest && (
+        {isRequestTab && (
           <button className="dropdown-item w-full" onClick={handleCloseSavedTabs}>
             Close Saved
           </button>

--- a/packages/bruno-app/src/components/TabContextMenu/index.js
+++ b/packages/bruno-app/src/components/TabContextMenu/index.js
@@ -17,7 +17,7 @@ export function TabContextMenu({ onDropdownCreate, tabIndex, collection, dropdow
   const currentTabItem = tabs[tabIndex];
   const currentTabItemUid = currentTabItem?.uid;
   const isRequest = collection ? true : false;
-  const requestItem = isRequest && findItemInCollection(collection, currentTabItemUid);
+  const requestItem = isRequest ? findItemInCollection(collection, currentTabItemUid) : null;
 
   const totalTabs = tabs.length || 0;
   const hasLeftTabs = tabIndex !== 0;


### PR DESCRIPTION
# Description
Added context menu support for all tabs.

- With this change `close all`, `close to the left`, `close to the right`, `close others` options will effect all the open tabs not just request tabs.
- `close saved`, `new request` and `clone request` is only available on request tabs



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**




https://github.com/user-attachments/assets/f97bc5bd-4253-4f39-b193-6078cbec4c79

