### PR TITLE
oauth2 fixes

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -50,6 +50,7 @@ import { sendCollectionOauth2Request as _sendCollectionOauth2Request } from 'uti
 import { getGlobalEnvironmentVariables } from 'utils/collections/index';
 import { findCollectionByPathname, findEnvironmentInCollectionByName } from 'utils/collections/index';
 import { sanitizeName } from 'utils/common/regex';
+import { safeParseJSON, safeStringifyJSON } from 'utils/common/index';
 
 export const renameCollection = (newName, collectionUid) => (dispatch, getState) => {
   const state = getState();
@@ -1281,7 +1282,7 @@ export const fetchOauth2Credentials = (payload) => async (dispatch, getState) =>
             url,
             collectionUid,
             credentialsId,
-            debugInfo,
+            debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)),
             folderUid: folderUid || null,
             itemUid: !folderUid ? itemUid : null
           })
@@ -1304,7 +1305,7 @@ export const refreshOauth2Credentials = (payload) => async (dispatch, getState) 
             url,
             collectionUid,
             credentialsId,
-            debugInfo,
+            debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)),
             folderUid: folderUid || null,
             itemUid: !folderUid ? itemUid : null
           })

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -902,16 +902,6 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
     }
   });
 
-  ipcMain.handle('renderer:get-stored-oauth2-credentials', async (event, collectionUid, url, credentialsId) => {
-    try {
-      const oauth2Store = new Oauth2Store();
-      const credentials = oauth2Store.getCredentialsForCollection({ collectionUid, url, credentialsId });
-      return { credentials, collectionUid, url };
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  });
-
   ipcMain.handle('renderer:fetch-oauth2-credentials', async (event, { itemUid, request, collection }) => {
     try {
         if (request.oauth2) {

--- a/packages/bruno-electron/src/store/oauth2.js
+++ b/packages/bruno-electron/src/store/oauth2.js
@@ -118,6 +118,7 @@ class Oauth2Store {
     try {
       let oauth2DataForCollection = this.getOauth2DataOfCollection({ collectionUid, url });
       let credentials = oauth2DataForCollection?.credentials?.find(c => (c?.url == url) && (c?.credentialsId == credentialsId));
+      if (!credentials?.data) return null;
       let decryptedCredentialsData = safeParseJSON(decryptString(credentials?.data));
       return decryptedCredentialsData;
     } catch (err) {


### PR DESCRIPTION
~ removed unused `renderer:get-stored-oauth2-credentials` ipc event handler
~ serialize debugInfo data
~ validation before the decrypt step when oauth2 credentials data are not present