### PR TITLE
handle oauth2 timeline response, remove dataBuffer from debugInfo obj

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Request/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Request/index.js
@@ -3,8 +3,11 @@ import BodyBlock from "../Common/Body/index";
 import { safeStringifyJSONIfNotString } from "utils/common/index";
 
 const Request = ({ collection, request, item, width }) => {
-  const { url, headers, data, error } = request || {};  
-  const dataBuffer = Buffer.from(safeStringifyJSONIfNotString(data))?.toString('base64');
+  let { url, headers, data, dataBuffer, error } = request || {};  
+  if (!dataBuffer) {
+    dataBuffer = Buffer.from(safeStringifyJSONIfNotString(data))?.toString('base64');
+  }
+
   return (
     <div>
       {/* Method and URL */}

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Request/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Request/index.js
@@ -1,6 +1,20 @@
 import Headers from "../Common/Headers/index";
 import BodyBlock from "../Common/Body/index";
-import { safeStringifyJSONIfNotString } from "utils/common/index";
+
+const safeStringifyJSONIfNotString = (obj) => {
+  if (obj === null || obj === undefined) return '';
+
+  if (typeof obj === 'string') {
+    return obj;
+  }
+
+  try {
+    return JSON.stringify(obj);
+  } catch (e) {
+    return '[Unserializable Object]';
+  }
+};
+
 
 const Request = ({ collection, request, item, width }) => {
   let { url, headers, data, dataBuffer, error } = request || {};  

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Request/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Request/index.js
@@ -1,9 +1,10 @@
 import Headers from "../Common/Headers/index";
 import BodyBlock from "../Common/Body/index";
+import { safeStringifyJSONIfNotString } from "utils/common/index";
 
 const Request = ({ collection, request, item, width }) => {
-  const { url, headers, data, dataBuffer, error } = request || {};  
-
+  const { url, headers, data, error } = request || {};  
+  const dataBuffer = Buffer.from(safeStringifyJSONIfNotString(data))?.toString('base64');
   return (
     <div>
       {/* Method and URL */}

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Response/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Response/index.js
@@ -1,7 +1,20 @@
 import BodyBlock from "../Common/Body/index";
 import Headers from "../Common/Headers/index";
 import Status from "../Common/Status/index";
-import { safeStringifyJSONIfNotString } from "utils/common/index";
+
+const safeStringifyJSONIfNotString = (obj) => {
+  if (obj === null || obj === undefined) return '';
+
+  if (typeof obj === 'string') {
+    return obj;
+  }
+
+  try {
+    return JSON.stringify(obj);
+  } catch (e) {
+    return '[Unserializable Object]';
+  }
+};
 
 const Response = ({ collection, response, item, width }) => {
   let { status, statusCode, statusText, dataBuffer, headers, data, error } = response || {};

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Response/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Response/index.js
@@ -1,10 +1,11 @@
 import BodyBlock from "../Common/Body/index";
 import Headers from "../Common/Headers/index";
 import Status from "../Common/Status/index";
+import { safeStringifyJSONIfNotString } from "utils/common/index";
 
 const Response = ({ collection, response, item, width }) => {
-  const { status, statusCode, statusText, headers, data, dataBuffer, error } = response || {};
-
+  const { status, statusCode, statusText, headers, data, error } = response || {};
+  const dataBuffer = Buffer.from(safeStringifyJSONIfNotString(data))?.toString('base64');
   return (
     <div>
     {/* Status */}

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Response/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Response/index.js
@@ -4,8 +4,11 @@ import Status from "../Common/Status/index";
 import { safeStringifyJSONIfNotString } from "utils/common/index";
 
 const Response = ({ collection, response, item, width }) => {
-  const { status, statusCode, statusText, headers, data, error } = response || {};
-  const dataBuffer = Buffer.from(safeStringifyJSONIfNotString(data))?.toString('base64');
+  let { status, statusCode, statusText, dataBuffer, headers, data, error } = response || {};
+  if (!dataBuffer) {
+    dataBuffer = Buffer.from(safeStringifyJSONIfNotString(data))?.toString('base64');
+  }
+
   return (
     <div>
     {/* Status */}

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1282,7 +1282,7 @@ export const fetchOauth2Credentials = (payload) => async (dispatch, getState) =>
             url,
             collectionUid,
             credentialsId,
-            debugInfo,
+            debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)),
             folderUid: folderUid || null,
             itemUid: !folderUid ? itemUid : null
           })
@@ -1305,7 +1305,7 @@ export const refreshOauth2Credentials = (payload) => async (dispatch, getState) 
             url,
             collectionUid,
             credentialsId,
-            debugInfo,
+            debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)),
             folderUid: folderUid || null,
             itemUid: !folderUid ? itemUid : null
           })

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -190,3 +190,17 @@ export const getEncoding = (headers) => {
   const charsetMatch = /charset=([^()<>@,;:"/[\]?.=\s]*)/i.exec(headers?.['content-type'] || '');
   return charsetMatch?.[1];
 }
+
+export const safeStringifyJSONIfNotString = (obj) => {
+  if (obj === null || obj === undefined) return '';
+
+  if (typeof obj === 'string') {
+    return obj;
+  }
+
+  try {
+    return JSON.stringify(obj);
+  } catch (e) {
+    return '[Unserializable Object]';
+  }
+};

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -190,17 +190,3 @@ export const getEncoding = (headers) => {
   const charsetMatch = /charset=([^()<>@,;:"/[\]?.=\s]*)/i.exec(headers?.['content-type'] || '');
   return charsetMatch?.[1];
 }
-
-export const safeStringifyJSONIfNotString = (obj) => {
-  if (obj === null || obj === undefined) return '';
-
-  if (typeof obj === 'string') {
-    return obj;
-  }
-
-  try {
-    return JSON.stringify(obj);
-  } catch (e) {
-    return '[Unserializable Object]';
-  }
-};

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -275,7 +275,6 @@ function makeAxiosInstance({
               statusText: error.response.statusText,
               headers: error.response.headers,
               data: errorResponseData?.toString?.(),
-              dataBuffer: dataBuffer,
               size: Buffer.byteLength(dataBuffer),
               duration: error.response.headers.get('request-duration') ?? 0,
               timeline: error.response.timeline
@@ -363,7 +362,6 @@ function makeAxiosInstance({
             statusText: error.response.statusText,
             headers: error.response.headers,
             data: errorResponseData?.toString?.(),
-            dataBuffer: dataBuffer,
             size: Buffer.byteLength(dataBuffer),
             duration: error.response.headers.get('request-duration') ?? 0,
             timeline

--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -158,7 +158,6 @@ const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, fo
         url: config.url,
         headers: config.headers,
         data: requestData,
-        dataBuffer: Buffer.from(requestData),
         timestamp: Date.now(),
       };
       return config;
@@ -220,14 +219,12 @@ const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, fo
         method: axiosRequestInfo?.method,
         headers: axiosRequestInfo?.headers || {},
         data: axiosRequestInfo?.data,
-        dataBuffer: axiosRequestInfo?.dataBuffer,
         error: null
       },
       response: {
         url: axiosResponseInfo?.url,
         headers: axiosResponseInfo?.headers,
         data: parsedResponseData,
-        dataBuffer: axiosResponseInfo?.data,
         status: axiosResponseInfo?.status,
         statusText: axiosResponseInfo?.statusText,
         error: axiosResponseInfo?.error,
@@ -386,7 +383,6 @@ const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, fo
         url: config.url,
         headers: config.headers,
         data: requestData,
-        dataBuffer: Buffer.from(requestData),
         timestamp: Date.now(),
       };
       return config;
@@ -442,14 +438,12 @@ const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, fo
         method: axiosRequestInfo?.method,
         headers: axiosRequestInfo?.headers || {},
         data: axiosRequestInfo?.data,
-        dataBuffer: axiosRequestInfo?.dataBuffer,
         error: null
       },
       response: {
         url: axiosResponseInfo.url,
         headers: axiosResponseInfo?.headers,
         data: parsedResponseData,
-        dataBuffer: axiosResponseInfo?.data,
         status: axiosResponseInfo?.status,
         statusText: axiosResponseInfo?.statusText,
         timeline: axiosResponseInfo?.timeline,
@@ -576,7 +570,6 @@ const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, 
         url: config.url,
         headers: config.headers,
         data: requestData,
-        dataBuffer: Buffer.from(requestData),
         timestamp: Date.now(),
       };
       return config;
@@ -631,14 +624,12 @@ const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, 
         method: axiosRequestInfo?.method,
         headers: axiosRequestInfo?.headers || {},
         data: axiosRequestInfo?.data,
-        dataBuffer: axiosRequestInfo?.dataBuffer,
         error: null
       },
       response: {
         url: axiosResponseInfo?.url,
         headers: axiosResponseInfo?.headers,
         data: parsedResponseData,
-        dataBuffer: axiosResponseInfo?.data,
         status: axiosResponseInfo?.status,
         statusText: axiosResponseInfo?.statusText,
         timeline: axiosResponseInfo?.timeline,
@@ -697,7 +688,6 @@ const refreshOauth2Token = async (requestCopy, collectionUid) => {
         url: config.url,
         headers: config.headers,
         data: requestData,
-        dataBuffer: Buffer.from(requestData),
         timestamp: Date.now(),
       };
       return config;
@@ -755,14 +745,12 @@ const refreshOauth2Token = async (requestCopy, collectionUid) => {
           method: axiosRequestInfo?.method,
           headers: axiosRequestInfo?.headers || {},
           data: axiosRequestInfo?.data,
-          dataBuffer: axiosRequestInfo?.dataBuffer,
           error: null
         },
         response: {
           url: axiosResponseInfo?.url,
           headers: axiosResponseInfo?.headers,
           data: parsedResponseData,
-          dataBuffer: axiosResponseInfo?.data,
           status: axiosResponseInfo?.status,
           statusText: axiosResponseInfo?.statusText,
           timeline: axiosResponseInfo?.timeline,


### PR DESCRIPTION
remove dataBuffer from debugInfo timeline objects since its directly derived from request/response data at all times and can be created directly in the ui comp.
[only for request not from the sendRequest flow]