### PR TITLE
Fix: Leading dot is not allowed for collections, folders and requests

### DIFF
--- a/packages/bruno-app/src/utils/common/regex.js
+++ b/packages/bruno-app/src/utils/common/regex.js
@@ -1,6 +1,6 @@
 const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g; // replace invalid characters with hyphens
 const reservedDeviceNames = /^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])$/i;
-const firstCharacter = /^[^.\s\-<>:"/\\|?*\x00-\x1F]/; // no dot, space, hyphen and `invalidCharacters`
+const firstCharacter = /^[^\s\-<>:"/\\|?*\x00-\x1F]/; // no space, hyphen and `invalidCharacters`
 const middleCharacters = /^[^<>:"/\\|?*\x00-\x1F]*$/;   // no `invalidCharacters`
 const lastCharacter = /[^.\s<>:"/\\|?*\x00-\x1F]$/; // no dot, space and `invalidCharacters`
 
@@ -9,7 +9,7 @@ export const variableNameRegex = /^[\w-.]*$/;
 export const sanitizeName = (name) => {
     name = name
         .replace(invalidCharacters, '-') // replace invalid characters with hyphens
-        .replace(/^[.\s\-]+/, '') // remove leading dots, spaces and hyphens
+        .replace(/^[\s\-]+/, '') // remove leading spaces and hyphens
         .replace(/[.\s]+$/, ''); // remove trailing dots and spaces
     return name;
 };

--- a/packages/bruno-app/src/utils/common/regex.js
+++ b/packages/bruno-app/src/utils/common/regex.js
@@ -1,16 +1,16 @@
 const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g; // replace invalid characters with hyphens
 const reservedDeviceNames = /^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])$/i;
-const firstCharacter = /^[^.\s\-\<>:"/\\|?*\x00-\x1F]/; // no dot, space, or hyphen at start
-const middleCharacters = /^[^<>:"/\\|?*\x00-\x1F]*$/;   // no invalid characters
-const lastCharacter = /^[^.\s\-\<>:"/\\|?*\x00-\x1F]/;  // no dot or space at end, hyphen allowed
+const firstCharacter = /^[^.\s\-<>:"/\\|?*\x00-\x1F]/; // no dot, space, hyphen and `invalidCharacters`
+const middleCharacters = /^[^<>:"/\\|?*\x00-\x1F]*$/;   // no `invalidCharacters`
+const lastCharacter = /[^.\s<>:"/\\|?*\x00-\x1F]$/; // no dot, space and `invalidCharacters`
 
 export const variableNameRegex = /^[\w-.]*$/;
 
 export const sanitizeName = (name) => {
     name = name
-        .replace(invalidCharacters, '-')       // replace invalid characters with hyphens
-        .replace(/^[.\s-]+/, '')               // remove leading dots, hyphens and spaces
-        .replace(/[.\s]+$/, '');               // remove trailing dots and spaces (keep trailing hyphens)
+        .replace(invalidCharacters, '-') // replace invalid characters with hyphens
+        .replace(/^[.\s\-]+/, '') // remove leading dots, spaces and hyphens
+        .replace(/[.\s]+$/, ''); // remove trailing dots and spaces
     return name;
 };
 

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -165,7 +165,7 @@ const sanitizeName = (name) => {
   const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g;
   name = name
     .replace(invalidCharacters, '-') // replace invalid characters with hyphens
-    .replace(/^[.\s\-]+/, '') // remove leading dots, spaces and hyphens
+    .replace(/^[\s\-]+/, '') // remove leading spaces and hyphens
     .replace(/[.\s]+$/, ''); // remove trailing dots and spaces
   return name;
 };
@@ -177,7 +177,7 @@ const isWindowsOS = () => {
 const validateName = (name) => {
     const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g; // keeping this for informational purpose
     const reservedDeviceNames = /^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])$/i;
-    const firstCharacter = /^[^.\s\-<>:"/\\|?*\x00-\x1F]/; // no dot, space, hyphen and `invalidCharacters`
+    const firstCharacter = /^[^\s\-<>:"/\\|?*\x00-\x1F]/; // no space, hyphen and `invalidCharacters`
     const middleCharacters = /^[^<>:"/\\|?*\x00-\x1F]*$/;   // no `invalidCharacters`
     const lastCharacter = /[^.\s<>:"/\\|?*\x00-\x1F]$/; // no dot, space and `invalidCharacters`
     if (name.length > 255) return false;          // max name length

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -164,9 +164,9 @@ const searchForBruFiles = (dir) => {
 const sanitizeName = (name) => {
   const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g;
   name = name
-    .replace(invalidCharacters, '-')       // replace invalid characters with hyphens
-    .replace(/^[.\s]+/, '')               // remove leading dots and and spaces
-    .replace(/[.\s]+$/, '');               // remove trailing dots and spaces (keep trailing hyphens)
+    .replace(invalidCharacters, '-') // replace invalid characters with hyphens
+    .replace(/^[.\s\-]+/, '') // remove leading dots, spaces and hyphens
+    .replace(/[.\s]+$/, ''); // remove trailing dots and spaces
   return name;
 };
 
@@ -175,10 +175,11 @@ const isWindowsOS = () => {
 }
 
 const validateName = (name) => {
+    const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g; // keeping this for informational purpose
     const reservedDeviceNames = /^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])$/i;
-    const firstCharacter = /^[^.\s\-\<>:"/\\|?*\x00-\x1F]/; // no dot, space, or hyphen at start
-    const middleCharacters = /^[^<>:"/\\|?*\x00-\x1F]*$/;   // no invalid characters
-    const lastCharacter = /[^.\s]$/;  // no dot or space at end, hyphen allowed
+    const firstCharacter = /^[^.\s\-<>:"/\\|?*\x00-\x1F]/; // no dot, space, hyphen and `invalidCharacters`
+    const middleCharacters = /^[^<>:"/\\|?*\x00-\x1F]*$/;   // no `invalidCharacters`
+    const lastCharacter = /[^.\s<>:"/\\|?*\x00-\x1F]$/; // no dot, space and `invalidCharacters`
     if (name.length > 255) return false;          // max name length
 
     if (reservedDeviceNames.test(name)) return false; // windows reserved names


### PR DESCRIPTION
Closes #4350

Fixes Regression #4350: Restore dot-prefixed folder support (e.g., .bruno) as valid collection locations, broken in v1.40.0.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
