### PR TITLE
fix: handle empty script.exec cases in postman collection importer

### DIFF
--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -126,11 +126,11 @@ const importScriptsFromEvents = (events, requestObject, options, pushTranslation
 
         if (Array.isArray(event.script.exec)) {
           if (event.script.exec.length > 0) {
-          requestObject.script.req = event.script.exec
-            .map((line, index) =>
-              options.enablePostmanTranslations.enabled
-                ? postmanTranslation(line, () => pushTranslationLog('script', index))
-                : `// ${line}`
+            requestObject.script.req = event.script.exec
+              .map((line, index) =>
+                options.enablePostmanTranslations.enabled
+                  ? postmanTranslation(line, () => pushTranslationLog('script', index))
+                  : `// ${line}`
               )
               .join('\n');
           } else {
@@ -290,13 +290,13 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
               }
               if (Array.isArray(event.script.exec)) {
                 if (event.script.exec.length > 0) {
-                brunoRequestItem.request.script.req = event.script.exec
-                  .map((line, index) =>
-                    options.enablePostmanTranslations.enabled
-                      ? postmanTranslation(line, () => pushTranslationLog('script', index))
-                      : `// ${line}`
-                  )
-                  .join('\n');
+                  brunoRequestItem.request.script.req = event.script.exec
+                    .map((line, index) =>
+                      options.enablePostmanTranslations.enabled
+                        ? postmanTranslation(line, () => pushTranslationLog('script', index))
+                        : `// ${line}`
+                    )
+                    .join('\n');
                 } else {
                   brunoRequestItem.request.script.req = '';
                 }

--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -124,14 +124,18 @@ const importScriptsFromEvents = (events, requestObject, options, pushTranslation
           requestObject.script = {};
         }
 
-        if (Array.isArray(event.script.exec) && event.script.exec.length > 0) {
+        if (Array.isArray(event.script.exec)) {
+          if (event.script.exec.length > 0) {
           requestObject.script.req = event.script.exec
             .map((line, index) =>
               options.enablePostmanTranslations.enabled
                 ? postmanTranslation(line, () => pushTranslationLog('script', index))
                 : `// ${line}`
-            )
-            .join('\n');
+              )
+              .join('\n');
+          } else {
+            requestObject.script.req = '';
+          }
         } else if (typeof event.script.exec === 'string') {
           requestObject.script.req = options.enablePostmanTranslations.enabled
             ? postmanTranslation(event.script.exec, () => pushTranslationLog('script', 0))
@@ -146,14 +150,18 @@ const importScriptsFromEvents = (events, requestObject, options, pushTranslation
           requestObject.tests = {};
         }
 
-        if (Array.isArray(event.script.exec) && event.script.exec.length > 0) {
-          requestObject.tests = event.script.exec
-            .map((line, index) =>
-              options.enablePostmanTranslations.enabled
+        if (Array.isArray(event.script.exec)) {
+          if (event.script.exec.length > 0) {
+            requestObject.tests = event.script.exec
+              .map((line, index) =>
+                options.enablePostmanTranslations.enabled
                 ? postmanTranslation(line, () => pushTranslationLog('test', index))
                 : `// ${line}`
-            )
-            .join('\n');
+              )
+              .join('\n');
+          } else {
+            requestObject.tests = '';
+          }
         } else if (typeof event.script.exec === 'string') {
           requestObject.tests = options.enablePostmanTranslations.enabled
             ? postmanTranslation(event.script.exec, () => pushTranslationLog('test', 0))
@@ -280,7 +288,8 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
               if (!brunoRequestItem.request.script) {
                 brunoRequestItem.request.script = {};
               }
-              if (Array.isArray(event.script.exec) && event.script.exec.length > 0) {
+              if (Array.isArray(event.script.exec)) {
+                if (event.script.exec.length > 0) {
                 brunoRequestItem.request.script.req = event.script.exec
                   .map((line, index) =>
                     options.enablePostmanTranslations.enabled
@@ -288,6 +297,9 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
                       : `// ${line}`
                   )
                   .join('\n');
+                } else {
+                  brunoRequestItem.request.script.req = '';
+                }
               } else if (typeof event.script.exec === 'string') {
                 brunoRequestItem.request.script.req = options.enablePostmanTranslations.enabled
                   ? postmanTranslation(event.script.exec, () => pushTranslationLog('script', 0))
@@ -300,7 +312,8 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
               if (!brunoRequestItem.request.tests) {
                 brunoRequestItem.request.tests = {};
               }
-              if (Array.isArray(event.script.exec) && event.script.exec.length > 0) {
+              if (Array.isArray(event.script.exec)) {
+                if (event.script.exec.length > 0) {
                 brunoRequestItem.request.tests = event.script.exec
                   .map((line, index) =>
                     options.enablePostmanTranslations.enabled
@@ -308,6 +321,9 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, options) =
                       : `// ${line}`
                   )
                   .join('\n');
+                } else {
+                  brunoRequestItem.request.tests = '';
+                }
               } else if (typeof event.script.exec === 'string') {
                 brunoRequestItem.request.tests = options.enablePostmanTranslations.enabled
                   ? postmanTranslation(event.script.exec, () => pushTranslationLog('test', 0))


### PR DESCRIPTION
fixes: #4379 

# Description

This PR updates the `importScriptsFromEvents` and `importPostmanV2CollectionItem` functions to properly handle cases where `event.script.exec` is an empty array. Now, if `exec` is empty, `requestObject.script.req` and `requestObject.tests` are set to empty strings instead of being thrown as an error.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**