### PR TITLE
Fix: Remove unwanted transitive `devDependencies` of `electron-store`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16507,9 +16507,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
+      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==",
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stringify-safe": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
     "prepare": "husky install"
   },
   "overrides": {
-    "rollup": "3.29.5"
+    "rollup": "3.29.5",
+    "electron-store": {
+      "conf": {
+        "json-schema-typed": "8.0.1"
+      }
+    }
   }
 }


### PR DESCRIPTION
There were few transitive `devDependencies` of `electron-store` -> `conf` which were sketchy.
Although those will never gets installed in any case, its better not to have them in the first place.

A better option is to upgrade `electron-store` itself to latest where its fixed, but they moved to ESM-only and we cannot upgrade easily. 