### PR TITLE
fix: query params not loaded while creating new request from curl

### DIFF
--- a/packages/bruno-app/src/utils/curl/index.js
+++ b/packages/bruno-app/src/utils/curl/index.js
@@ -79,7 +79,7 @@ export const getRequestFromCurlCommand = (curlCommand, requestType = 'http-reque
       }
     }
     return {
-      url: request.url,
+      url: request.raw_url,
       method: request.method,
       body,
       headers: headers,


### PR DESCRIPTION
# Description
closes: #4385 

before:

https://github.com/user-attachments/assets/0e6e5119-9710-40ce-8367-184c84e73dad


after:

https://github.com/user-attachments/assets/d3937ee5-0a83-471d-bbb2-35e8f850d0e0



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
