### PR TITLE
Fix: Matching Brackets pair not highlighting

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -102,6 +102,13 @@ const StyledWrapper = styled.div`
   .cm-s-default span.cm-variable {
     color: #397d13 !important;
   }
+  
+  //matching bracket fix
+  .CodeMirror-matchingbracket {
+    background: #5cc0b48c !important;
+    text-decoration:unset;
+  }
+
 `;
 
 export default StyledWrapper;


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Minor CSS changes were made in the `StyledWrapper `of the "CodeEditor" component.

### Contribution Checklist:

- [&check;] **The pull request only addresses one issue or adds one feature.**
- [&check;] **The pull request does not introduce any breaking changes**
- [&check;] **I have added screenshots or gifs to help explain the change if applicable.**
- [&check; **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [&check;] **Create an issue and link to the pull request.**


**Preview of the fix**

*Dark mode*

![Screenshot 2025-04-04 005548](https://github.com/user-attachments/assets/fda367b7-7a15-4e74-aa66-2a6a33d4e5f1)


*Light mode*

![Screenshot 2025-04-04 003742](https://github.com/user-attachments/assets/d81cf338-6fe1-4334-ae78-bf018d27ac09)

This fixes issue #4354

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
