### PR TITLE
Fix folder vars invalid style in script section

### DIFF
--- a/packages/bruno-app/src/components/FolderSettings/Script/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/index.js
@@ -49,6 +49,7 @@ const Script = ({ collection, folder }) => {
         <CodeEditor
           collection={collection}
           value={requestScript || ''}
+          item={folder}
           theme={displayedTheme}
           onEdit={onRequestScriptEdit}
           mode="javascript"
@@ -62,6 +63,7 @@ const Script = ({ collection, folder }) => {
         <CodeEditor
           collection={collection}
           value={responseScript || ''}
+          item={folder}
           theme={displayedTheme}
           onEdit={onResponseScriptEdit}
           mode="javascript"


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fix a visual issue. Inside a folder script folder variables are visualized red like they are invalid to use on the script.
Fixes a visual issue where variables inside a script folder are displayed in red, indicating they are invalid.

## What it does
Passes the `folder` as the `item` to the `CodeEditor` component. This change allows the `CodeEditor` component to properly recognize and utilize folder-specific variables.

----
Before:
<img width="378" alt="Screenshot 2025-04-05 at 12 32 53 AM" src="https://github.com/user-attachments/assets/1a69c917-def7-4b09-b5f5-53449be9eaf6" />

After:
<img width="378" alt="Screenshot 2025-04-05 at 12 34 16 AM" src="https://github.com/user-attachments/assets/6e51f399-4975-41da-95e8-a604600c8bb7" />


### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
