### PR TITLE
add: skip request number in runner summary

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -101,6 +101,9 @@ export default function RunnerResults({ collection }) {
   const failedRequests = items.filter((item) => {
     return (item.status !== 'error' && item.testStatus === 'fail') || item.assertionStatus === 'fail';
   });
+  const skippedRequests = items.filter((item) => {
+    return item.status === 'skipped';
+  });
 
   let isCollectionLoading = areItemsLoading(collection);
 
@@ -159,7 +162,7 @@ export default function RunnerResults({ collection }) {
           ref={runnerBodyRef}
         >
           <div className="pb-2 font-medium test-summary">
-            Total Requests: {items.length}, Passed: {passedRequests.length}, Failed: {failedRequests.length}
+            Total Requests: {items.length}, Passed: {passedRequests.length}, Failed: {failedRequests.length}, Skipped: {skippedRequests.length}
           </div>
           {runnerInfo?.statusText ? 
             <div className="pb-2 font-medium danger">


### PR DESCRIPTION
# Description

Added "Skipped" requests count to the test summary in the Runner Results component. This improves the visibility of test execution status by clearly displaying how many requests were skipped alongside the existing counts for passed and failed requests.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="807" alt="image" src="https://github.com/user-attachments/assets/23cb0abd-9785-4cec-8286-beb77383fd58" />
