### PR TITLE
Oauth2 refresh token call fixes

### DIFF
--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -696,8 +696,7 @@ const refreshOauth2Token = async ({ requestCopy, collectionUid, certsAndProxyCon
         requests: [], // No sub-requests in this context
       };
       debugInfo.data.push(axiosMainRequest);
-
-      if (parsedResponseData?.error) {
+      if (!parsedResponseData || parsedResponseData?.error) {
         clearOauth2Credentials({ collectionUid, url, credentialsId });
         return { collectionUid, url, credentials: null, credentialsId, debugInfo }; 
       }

--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -625,6 +625,7 @@ const refreshOauth2Token = async ({ requestCopy, collectionUid, certsAndProxyCon
     requestCopy.data = qs.stringify(data);
     requestCopy.url = url;
     requestCopy.responseType = 'arraybuffer';
+    let debugInfo = { data: [] };
     try {
       const { proxyMode, proxyConfig, httpsAgentRequestFields, interpolationOptions } = certsAndProxyConfig;
       const axiosInstance = makeAxiosInstance({ proxyMode, proxyConfig, httpsAgentRequestFields, interpolationOptions });


### PR DESCRIPTION
# Description

This PR resolves two related issues in the OAuth2 refresh token flow:

- **Avoids duplicate entries** in the network logs when making refresh token calls.
- **Clears stored token credentials** if the refresh token call fails

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
