### PR TITLE
#1884 - Add support for text/event-stream content-type

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -5,7 +5,7 @@ import { requestUrlChanged, updateRequestMethod } from 'providers/ReduxStore/sli
 import { saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import HttpMethodSelector from './HttpMethodSelector';
 import { useTheme } from 'providers/Theme';
-import { IconDeviceFloppy, IconArrowRight, IconCode } from '@tabler/icons';
+import { IconDeviceFloppy, IconArrowRight, IconCode, IconX } from '@tabler/icons';
 import SingleLineEditor from 'components/SingleLineEditor';
 import { isMacOS } from 'utils/common/platform';
 import StyledWrapper from './StyledWrapper';
@@ -136,7 +136,14 @@ const QueryUrl = ({ item, collection, handleRun }) => {
               Save <span className="shortcut">({saveShortcut})</span>
             </span>
           </div>
-          <IconArrowRight color={theme.requestTabPanel.url.icon} strokeWidth={1.5} size={22} />
+          {
+            item.response?.hasStreamRunning ? (
+              <IconX color={theme.requestTabPanel.url.icon} strokeWidth={1.5} size={22} />
+            ) : (
+              <IconArrowRight color={theme.requestTabPanel.url.icon} strokeWidth={1.5} size={22} />
+            )
+          }
+
         </div>
       </div>
       {generateCodeItemModalOpen && (

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -8,7 +8,7 @@ import ResponsePane from 'components/ResponsePane';
 import Welcome from 'components/Welcome';
 import { findItemInCollection } from 'utils/collections';
 import { updateRequestPaneTabWidth } from 'providers/ReduxStore/slices/tabs';
-import { sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { cancelRequest, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import RequestNotFound from './RequestNotFound';
 import QueryUrl from 'components/RequestPane/QueryUrl';
 import NetworkError from 'components/ResponsePane/NetworkError';
@@ -25,6 +25,7 @@ import { produce } from 'immer';
 import CollectionOverview from 'components/CollectionSettings/Overview';
 import RequestNotLoaded from './RequestNotLoaded';
 import RequestIsLoading from './RequestIsLoading';
+import { streamDataEnded } from 'providers/ReduxStore/slices/collections';
 
 const MIN_LEFT_PANE_WIDTH = 300;
 const MIN_RIGHT_PANE_WIDTH = 350;
@@ -184,11 +185,19 @@ const RequestTabPanel = () => {
   }
 
   const handleRun = async () => {
-    dispatch(sendRequest(item, collection.uid)).catch((err) =>
-      toast.custom((t) => <NetworkError onClose={() => toast.dismiss(t.id)} />, {
-        duration: 5000
-      })
-    );
+    if (item.response?.hasStreamRunning) {
+      dispatch(cancelRequest(item.cancelTokenUid, item, collection)).catch((err) =>
+        toast.custom((t) => <NetworkError onClose={() => toast.dismiss(t.id)} />, {
+          duration: 5000
+        })
+      );
+    } else {
+      dispatch(sendRequest(item, collection.uid)).catch((err) =>
+        toast.custom((t) => <NetworkError onClose={() => toast.dismiss(t.id)} />, {
+          duration: 5000
+        })
+      );
+    }
   };
 
   return (

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -14,10 +14,10 @@ import {
   collectionUnlinkDirectoryEvent,
   collectionUnlinkEnvFileEvent,
   collectionUnlinkFileEvent,
-  processEnvUpdateEvent,
+  processEnvUpdateEvent, requestCancelled,
   runFolderEvent,
   runRequestEvent,
-  scriptEnvironmentUpdateEvent
+  scriptEnvironmentUpdateEvent, streamDataEnded, streamDataReceived
 } from 'providers/ReduxStore/slices/collections';
 import { collectionAddEnvFileEvent, openCollectionEvent, hydrateCollectionWithUiStateSnapshot } from 'providers/ReduxStore/slices/collections/actions';
 import toast from 'react-hot-toast';
@@ -173,6 +173,14 @@ const useIpcEvents = () => {
       dispatch(collectionAddOauth2CredentialsByUrl(payload));
     });
 
+    const removeHttpStreamNewDataListener = ipcRenderer.on('main:http-stream-new-data', (val) => {
+      dispatch(streamDataReceived(val));
+    });
+
+    const removeHttpStreamEndListener = ipcRenderer.on('main:http-stream-end', (val) => {
+      dispatch(requestCancelled(val));
+    });
+
     return () => {
       removeCollectionTreeUpdateListener();
       removeOpenCollectionListener();
@@ -193,6 +201,8 @@ const useIpcEvents = () => {
       removeGlobalEnvironmentsUpdatesListener();
       removeSnapshotHydrationListener();
       removeCollectionOauth2CredentialsUpdatesListener();
+      removeHttpStreamNewDataListener();
+      removeHttpStreamEndListener();
     };
   }, [isElectron]);
 };

--- a/packages/bruno-app/src/utils/network/index.js
+++ b/packages/bruno-app/src/utils/network/index.js
@@ -19,7 +19,8 @@ export const sendNetworkRequest = async (item, collection, environment, runtimeV
             status: response.status,
             statusText: response.statusText,
             duration: response.duration,
-            timeline: response.timeline
+            timeline: response.timeline,
+            hasStreamRunning: response.hasStreamRunning
           });
         })
         .catch((err) => reject(err));


### PR DESCRIPTION
# Description

This pull request adds support for text/event-stream content-type requests. I decided to try adding support for these types of request because i found a few issues requesting it, with some people saying that the only reason they didn't migrate fully from postman is the lack of this content-type support. 

If i didn't follow any standards of the project or didn't add a needed change somewhere please let me know and i will be glad to push any fixes. 

## Changes

The code changes are really simple, in summary, i just set the responseType to stream in the axios request if the accept header is set to text/event-stream, send the incoming streamed data to the front-end by listening and treat the streamed data in the response body panel.

With these changes, if the user sends a request with an accept header of text/event-stream, the right arrow icon in the URL bar will change to an X icon and the streamed data will be concatenated to the response body panel. If the user clicks the X icon, the front-end will send an event to the back-end signaling for the stream to be closed and the data will stop being streamed.

- Added boolean: item.response.hasStreamRunning, will be true if there's a steam active at the moment. This is the variable that is used to check if there's a stream active.
- packages/bruno-app/src/components/RequestPane/QueryUrl/index.js: Add icon change from arrow to X if there's a stream active.
- packages/bruno-app/src/components/RequestTabPanel/index.js: Changed the handleRun function to cancel the current request if there is a stream running (instead of starting a new request).
- packages/bruno-app/src/providers/App/useIpcEvents.js - Added two new events:

1. main:http-stream-new-data - Will be emitted from the back-end to the front-end when there's new data to the stream.
2. main:http-stream-end - Will be emitted from the back-end to the front-end when the stream has been cancelled by the host.

- packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js - Added and changed a few collection actions:

1. requestCancelled - If there's a stream active, don't set the response to null, and set the item.response.hasStreamRunning variable to null, so the front-end will reset to there being no stream running.
2. Don't set the cancelTokenUid to null when the request is created, so it can be cancelled by the user.
3. Add the streamDataReceived action, this action will be ran when the main:http-stream-new-data event is received, it will concatenate the data received in the stream with the current displayed data.

- packages/bruno-app/src/utils/network/index.js - Copy the hasStreamRunning variable from the back-end response to item.
- packages/bruno-electron/src/ipc/network/index.js:

1. Add checks for the text/event-stream accept header in the request send handler, if this header is found set the axios responseType to "stream" and set the connection header to "keep-alive", so the connection isn't lost.
2. If the header is found, the first response data will be an empty string.
3. Before returning the response in the handler, add listeners for the on data received and stream ended callbacks from the axios stream object.
4. When the data callback is received, emit a main:http-stream-new-data event to the front-end with the new data.
5. If there's a stream ended callback, check if there's still a delete token saved for that request, if there is, the event was not initiated by a user, so emit main:http-stream-end to the front-end and remove the saved delete token for that request.
6. Skip the request run if we are running a whole collection (because the event stream will never end).

### Contribution Checklist:

- [ X ] **The pull request only addresses one issue or adds one feature.**
- [ - ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
