### PR TITLE
Fix: Missing bruno-requests module in `setup.js` and `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25212,6 +25212,7 @@
         "@usebruno/common": "0.1.0",
         "@usebruno/js": "0.12.0",
         "@usebruno/lang": "0.12.0",
+        "@usebruno/requests": "^0.1.0",
         "@usebruno/vm2": "^3.9.13",
         "aws4-axios": "^3.3.0",
         "axios": "^1.8.3",

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -75,6 +75,7 @@ async function setup() {
     execCommand('npm run build:bruno-query', 'Building bruno-query');
     execCommand('npm run build:bruno-common', 'Building bruno-common');
     execCommand('npm run build:bruno-converters', 'Building bruno-converters');
+    execCommand('npm run build:bruno-requests', 'Building bruno-requests');
 
     // Bundle JS sandbox libraries
     execCommand(


### PR DESCRIPTION
Closes #4488

without this I couldn't get started with local dev `npm run setup`
