### PR TITLE
fix: lint errors for atob/btoa redefinition

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/javascript-lint.js
+++ b/packages/bruno-app/src/utils/codemirror/javascript-lint.js
@@ -37,7 +37,8 @@ if (!SERVER_RENDERED) {
         'test': false,
         'expect': false,
         'require': false,
-        'module': false
+        'module': false,
+        'atob': true
       }
     };
     
@@ -74,6 +75,18 @@ if (!SERVER_RENDERED) {
         }
 
         return true;
+      }
+
+      /*
+       * Filter out errors due to atob/btoa redefinition
+       * 
+       * - W079: Redefinition of '{a}'
+       *   This JSHint warning triggers when a variable name conflicts with a built-in global.
+       *   We filter this for atob/btoa to allow explicit requires in Node.js environments
+       *   where these browser functions might not be available.
+       */
+      if (error.code === 'W079' && (error.a === 'atob' || error.a === 'btoa')) {
+        return false;
       }
 
       return true;


### PR DESCRIPTION
# Description

This PR fixes the JSHint lint errors (W079) that appear when using `const atob = require("atob")` or `const btoa = require("btoa")` in the editor. These errors occur because atob and btoa are built-in browser functions, but users sometimes need to explicitly require them in Node.js environments.
The solution filters out these specific redefinition warnings while preserving other lint checks, improving the developer experience when working with Base64 encoding/decoding functions.

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<img width="822" alt="image" src="https://github.com/user-attachments/assets/8fc26a81-30f3-482e-be87-4bf00eda70d6" />

