### PR TITLE
Bugfix: Add cheerio and xml2js modules to post-response scripts

### DIFF
--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -283,6 +283,8 @@ class ScriptRuntime {
           axios,
           'node-fetch': fetch,
           'crypto-js': CryptoJS,
+          'xml2js': xml2js,
+          cheerio,
           ...whitelistedModules,
           fs: allowScriptFilesystemAccess ? fs : undefined,
           'node-vault': NodeVault

--- a/packages/bruno-tests/collection/scripting/inbuilt modules/cheerio/cheerio.bru
+++ b/packages/bruno-tests/collection/scripting/inbuilt modules/cheerio/cheerio.bru
@@ -25,6 +25,17 @@ script:pre-request {
   bru.setVar("cheerio-test-html", $.html());
 }
 
+script:post-response {
+  const cheerio = require('cheerio');
+
+  const $ = cheerio.load('<h2 class="title">Hello world</h2>');
+
+  $('h2.title').text('Hello there!');
+  $('h2').addClass('welcome');
+
+  bru.setVar("cheerio-test-html", $.html());
+}
+
 tests {
   const cheerio = require('cheerio');
   

--- a/packages/bruno-tests/collection/scripting/inbuilt modules/cheerio/cheerio.bru
+++ b/packages/bruno-tests/collection/scripting/inbuilt modules/cheerio/cheerio.bru
@@ -19,10 +19,10 @@ script:pre-request {
   
   const $ = cheerio.load('<h2 class="title">Hello world</h2>');
   
-  $('h2.title').text('Hello there!');
+  $('h2.title').text('Hello pre-request!');
   $('h2').addClass('welcome');
   
-  bru.setVar("cheerio-test-html", $.html());
+  bru.setVar("cheerio-test-pre-request", $.html());
 }
 
 script:post-response {
@@ -30,18 +30,24 @@ script:post-response {
 
   const $ = cheerio.load('<h2 class="title">Hello world</h2>');
 
-  $('h2.title').text('Hello there!');
+  $('h2.title').text('Hello post-response!');
   $('h2').addClass('welcome');
 
-  bru.setVar("cheerio-test-html", $.html());
+  bru.setVar("cheerio-test-post-response", $.html());
 }
 
 tests {
   const cheerio = require('cheerio');
   
-  test("cheerio html - from scripts", function() {
-    const expected = '<html><head></head><body><h2 class="title welcome">Hello there!</h2></body></html>';
-    const html = bru.getVar('cheerio-test-html');
+  test("cheerio html - from pre request script", function() {
+    const expected = '<html><head></head><body><h2 class="title welcome">Hello pre-request!</h2></body></html>';
+    const html = bru.getVar('cheerio-test-pre-request');
+    expect(html).to.eql(expected);
+  });
+
+  test("cheerio html - from post response script", function() {
+    const expected = '<html><head></head><body><h2 class="title welcome">Hello post-response!</h2></body></html>';
+    const html = bru.getVar('cheerio-test-post-response');
     expect(html).to.eql(expected);
   });
   

--- a/packages/bruno-tests/collection/scripting/inbuilt modules/xml2js/xml2js.bru
+++ b/packages/bruno-tests/collection/scripting/inbuilt modules/xml2js/xml2js.bru
@@ -18,6 +18,14 @@ script:pre-request {
   });
 }
 
+script:post-response {
+  var parseString = require('xml2js').parseString;
+  var xml = "<root>Hello xml2js!</root>"
+  parseString(xml, function (err, result) {
+     bru.setVar("xml2js-test-result", result);
+  });
+}
+
 tests {
   var parseString = require('xml2js').parseString;
   

--- a/packages/bruno-tests/collection/scripting/inbuilt modules/xml2js/xml2js.bru
+++ b/packages/bruno-tests/collection/scripting/inbuilt modules/xml2js/xml2js.bru
@@ -12,28 +12,36 @@ get {
 
 script:pre-request {
   var parseString = require('xml2js').parseString;
-  var xml = "<root>Hello xml2js!</root>"
+  var xml = "<root>Hello xml2js - pre request!</root>"
   parseString(xml, function (err, result) {
-     bru.setVar("xml2js-test-result", result); 
+     bru.setVar("xml2js-test-result-pre-request", result); 
   });
 }
 
 script:post-response {
   var parseString = require('xml2js').parseString;
-  var xml = "<root>Hello xml2js!</root>"
+  var xml = "<root>Hello xml2js - post response!</root>"
   parseString(xml, function (err, result) {
-     bru.setVar("xml2js-test-result", result);
+     bru.setVar("xml2js-test-result-post-response", result);
   });
 }
 
 tests {
   var parseString = require('xml2js').parseString;
   
-  test("xml2js parseString in scripts", function() {
+  test("xml2js parseString in scripts - pre request", function() {
     const expected = {
-      root: 'Hello xml2js!'
+      root: 'Hello xml2js - pre request!'
     };
-    const result = bru.getVar('xml2js-test-result');
+    const result = bru.getVar('xml2js-test-result-pre-request');
+    expect(result).to.eql(expected);
+  });
+
+  test("xml2js parseString in scripts - post response", function() {
+    const expected = {
+      root: 'Hello xml2js - post response!'
+    };
+    const result = bru.getVar('xml2js-test-result-post-response');
     expect(result).to.eql(expected);
   });
   


### PR DESCRIPTION
# Description

Addresses #4515: #3976 introduced cheerio and xml2js modules to be used within scripts and tests. Unfortunately they forgot to add the modules to the post-response script runtime, so it is not available there. 
This PR adds these modules + expands the existing tests

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
