### PR TITLE
Include globalEnvironmentVariables in runPostResponseVars result

### DIFF
--- a/packages/bruno-js/src/runtime/vars-runtime.js
+++ b/packages/bruno-js/src/runtime/vars-runtime.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const Bru = require('../bru');
 const BrunoRequest = require('../bruno-request');
 const { evaluateJsExpression, createResponseParser } = require('../utils');
+const { cleanJson } = require('../utils');
 
 const { executeQuickJsVm } = require('../sandbox/quickjs');
 
@@ -25,12 +26,16 @@ class VarsRuntime {
 
   runPostResponseVars(vars, request, response, envVariables, runtimeVariables, collectionPath, processEnvVars) {
     const requestVariables = request?.requestVariables || {};
+    const globalEnvironmentVariables = request?.globalEnvironmentVariables || {};
+    const oauth2CredentialVariables = request?.oauth2CredentialVariables || {};
+    const collectionVariables = request?.collectionVariables || {};
+    const folderVariables = request?.folderVariables || {};
     const enabledVars = _.filter(vars, (v) => v.enabled);
     if (!enabledVars.length) {
       return;
     }
 
-    const bru = new Bru(envVariables, runtimeVariables, processEnvVars, undefined, requestVariables);
+    const bru = new Bru(envVariables, runtimeVariables, processEnvVars, undefined, collectionVariables, folderVariables, requestVariables, globalEnvironmentVariables, oauth2CredentialVariables);
     const req = new BrunoRequest(request);
     const res = createResponseParser(response);
 
@@ -68,6 +73,7 @@ class VarsRuntime {
     return {
       envVariables,
       runtimeVariables,
+      globalEnvironmentVariables: cleanJson(globalEnvironmentVariables),
       error
     };
   }


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Fixes issue https://github.com/usebruno/bruno/issues/4491

In the runPostResponseVars
1. The `Bru` constructor wasn't receiving all variables
2. The result object from `runPostResponseVars` wasn't properly including global environment variables