### PR TITLE
Fix: Allow empty `dataBuffer` to support responses with content-length: (fixes: #4480)

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -13,7 +13,7 @@ import { useTheme } from 'providers/Theme/index';
 import { getEncoding, uuid } from 'utils/common/index';
 
 const formatResponse = (data, dataBuffer, encoding, mode, filter) => {
-  if (data === undefined || !dataBuffer || !mode) {
+  if (data === undefined || !mode) {
     return '';
   }
 


### PR DESCRIPTION
fixes: #4480

## Description

This PR removes the logic that checks for the presence of `dataBuffer` content, allowing support for empty `dataBuffer` when Content-Length is 0.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**