### PR TITLE
fix: Add null checks and fallbacks to `Bruno-to-Postman` converter to…

### DIFF
--- a/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
+++ b/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
@@ -371,4 +371,124 @@ describe('brunoToPostman null checks and fallbacks', () => {
     const result = brunoToPostman(simpleCollection);
     expect(result.item[0].item).toEqual([]);
   });
+
+  it('should handle null or undefined auth object', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: null
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection);
+    expect(result.item[0].request.auth).toEqual({ type: 'noauth' });
+  });
+
+  it('should handle missing token in bearer auth', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: {
+              mode: 'bearer',
+              bearer: { token: null }
+            }
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection);
+    expect(result.item[0].request.auth).toEqual({
+      type: 'bearer',
+      bearer: {
+        key: 'token',
+        value: '',
+        type: 'string'
+      }
+    });
+  });
+
+  it('should handle missing username/password in basic auth', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: {
+              mode: 'basic',
+              basic: { username: null, password: undefined }
+            }
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection);
+    expect(result.item[0].request.auth).toEqual({
+      type: 'basic',
+      basic: [
+        {
+          key: 'password',
+          value: '',
+          type: 'string'
+        },
+        {
+          key: 'username',
+          value: '',
+          type: 'string'
+        }
+      ]
+    });
+  });
+
+  it('should handle missing key/value in apikey auth', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: {
+              mode: 'apikey',
+              apikey: { key: null, value: undefined }
+            }
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection);
+    expect(result.item[0].request.auth).toEqual({
+      type: 'apikey',
+      apikey: [
+        {
+          key: 'key',
+          value: '',
+          type: 'string'
+        },
+        {
+          key: 'value',
+          value: '',
+          type: 'string'
+        }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
# Description

This PR adds null checks and fallbacks to the Bruno-to-Postman converter to prevent crashes when exporting collections with incomplete data.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
