### PR TITLE
Add Support for Multiple Import Styles in Bruno Converters

### DIFF
--- a/packages/bruno-converters/package.json
+++ b/packages/bruno-converters/package.json
@@ -5,6 +5,13 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist",
     "src",

--- a/packages/bruno-converters/src/index.js
+++ b/packages/bruno-converters/src/index.js
@@ -1,5 +1,26 @@
-export { default as postmanToBruno } from './postman/postman-to-bruno.js';
-export { default as postmanToBrunoEnvironment } from './postman/postman-env-to-bruno-env.js';
-export { default as brunoToPostman } from './postman/bruno-to-postman.js';
-export { default as openApiToBruno } from './openapi/openapi-to-bruno.js';
-export { default as insomniaToBruno } from './insomnia/insomnia-to-bruno.js';
+import postmanToBruno from './postman/postman-to-bruno.js';
+import postmanToBrunoEnvironment from './postman/postman-env-to-bruno-env.js';
+import brunoToPostman from './postman/bruno-to-postman.js';
+import openApiToBruno from './openapi/openapi-to-bruno.js';
+import insomniaToBruno from './insomnia/insomnia-to-bruno.js';
+
+// Create the default export object
+const converters = {
+  postmanToBruno,
+  postmanToBrunoEnvironment,
+  brunoToPostman,
+  openApiToBruno,
+  insomniaToBruno
+};
+
+// Export as default
+export default converters;
+
+// Export named exports
+export {
+  postmanToBruno,
+  postmanToBrunoEnvironment,
+  brunoToPostman,
+  openApiToBruno,
+  insomniaToBruno
+};


### PR DESCRIPTION
# Description

- Modified `src/index.js` to support both default and named exports
- Added proper exports configuration in `package.json`
- Updated build configuration to handle both CommonJS and ESM formats

## Details

- Added support for three import styles:
  1. Default Import:
     ```javascript
     import brunoConverters from "@usebruno/converters";
     const { insomniaToBruno } = brunoConverters;
     ```
  2. Named Import:
     ```javascript
     import { insomniaToBruno } from "@usebruno/converters";
     ```
  3. CommonJS:
     ```javascript
     const { insomniaToBruno } = require("@usebruno/converters");
     ```

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
