### PR TITLE
add: cookie functions to Bruno scripts

### DIFF
--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -34,6 +34,10 @@ const replacements = {
   'pm\\.execution\\.skipRequest': 'bru.runner.skipRequest',
   'pm\\.execution\\.setNextRequest\\(null\\)': 'bru.runner.stopExecution()',
   'pm\\.execution\\.setNextRequest\\(\'null\'\\)': 'bru.runner.stopExecution()',
+
+  'pm\\.cookies\\.get\\(': 'bru.cookies.get(',
+  'pm\\.cookies\\.has\\(': 'bru.cookies.has(',
+  'pm\\.cookies\\.toObject\\(\\)': 'bru.cookies.get()',
 };
 
 const extendedReplacements = Object.keys(replacements).reduce((acc, key) => {

--- a/packages/bruno-converters/tests/postman/postman-translations/postman-cookies.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/postman-cookies.spec.js
@@ -1,0 +1,39 @@
+const { default: postmanTranslation } = require("../../../src/postman/postman-translations");
+
+describe('postmanTranslations - cookies commands', () => {
+  test('should handle cookies commands', () => {
+    const inputScript = `
+      const sessionCookie = pm.cookies.get('sessionId');
+      
+      if (pm.cookies.has('token')) {
+        console.log('Token cookie exists');
+      }
+      
+      const allCookies = pm.cookies.toObject();
+      
+      pm.test('Cookie is present', function() {
+        pm.expect(pm.cookies.has('JSESSIONID')).to.be.true;
+      });
+      
+      const authCookie = pm.cookies.get('auth');
+      const userCookie = pm.cookies.get('user');
+    `;
+    const expectedOutput = `
+      const sessionCookie = bru.cookies.get('sessionId');
+      
+      if (bru.cookies.has('token')) {
+        console.log('Token cookie exists');
+      }
+      
+      const allCookies = bru.cookies.get();
+      
+      test('Cookie is present', function() {
+        expect(bru.cookies.has('JSESSIONID')).to.be.true;
+      });
+      
+      const authCookie = bru.cookies.get('auth');
+      const userCookie = bru.cookies.get('user');
+    `;
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
+});

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -25,6 +25,31 @@ class Bru {
         this.nextRequest = nextRequest;
       }
     };
+    
+    // Add cookies API
+    this.cookies = {
+      // Get all cookies as an object or get a specific cookie by name
+      get: (name) => {
+        if (typeof this._cookiesObj !== 'object') {
+          return name ? null : {};
+        }
+        
+        if (name) {
+          return this._cookiesObj[name] || null;
+        }
+        
+        return { ...this._cookiesObj };
+      },
+      
+      // Check if a cookie with the given name exists
+      has: (name) => {
+        if (typeof this._cookiesObj !== 'object' || !name) {
+          return false;
+        }
+        
+        return Object.prototype.hasOwnProperty.call(this._cookiesObj, name);
+      }
+    };
   }
 
   _interpolate = (str) => {

--- a/packages/bruno-js/src/runtime/assert-runtime.js
+++ b/packages/bruno-js/src/runtime/assert-runtime.js
@@ -268,6 +268,60 @@ class AssertRuntime {
     const req = new BrunoRequest(request);
     const res = createResponseParser(response);
 
+    // Parse cookies from request headers and attach to bru context
+    if (request?.headers) {
+      const cookieHeader = Object.entries(request.headers).find(([key]) => key.toLowerCase() === 'cookie');
+      if (cookieHeader && cookieHeader[1]) {
+        const cookieString = cookieHeader[1];
+        const cookiesObj = {};
+        
+        // Parse cookie string to object
+        cookieString.split(';').forEach(cookie => {
+          const [name, ...valueParts] = cookie.trim().split('=');
+          if (name) {
+            cookiesObj[name] = valueParts.join('=');
+          }
+        });
+        
+        // Attach to bru object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+
+    // Also check for Set-Cookie in response headers and add those cookies
+    if (response?.headers) {
+      const setCookieHeaders = [];
+      
+      // Check for Set-Cookie in headers
+      if (response.headers['set-cookie']) {
+        if (Array.isArray(response.headers['set-cookie'])) {
+          setCookieHeaders.push(...response.headers['set-cookie']);
+        } else {
+          setCookieHeaders.push(response.headers['set-cookie']);
+        }
+      }
+      
+      // If there are Set-Cookie headers, parse and add to cookies object
+      if (setCookieHeaders.length > 0) {
+        const cookiesObj = bru._cookiesObj || {};
+        
+        setCookieHeaders.forEach(setCookieHeader => {
+          if (typeof setCookieHeader === 'string' && setCookieHeader.length) {
+            const [cookiePair] = setCookieHeader.split(';');
+            if (cookiePair) {
+              const [name, ...valueParts] = cookiePair.trim().split('=');
+              if (name) {
+                cookiesObj[name] = valueParts.join('=');
+              }
+            }
+          }
+        });
+        
+        // Update the cookies object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+
     const bruContext = {
       bru,
       req,

--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -86,6 +86,60 @@ class TestRuntime {
       .map((acr) => (acr.startsWith('/') ? acr : path.join(collectionPath, acr)))
       .value();
 
+    // Parse cookies from request headers and attach to bru context
+    if (request?.headers) {
+      const cookieHeader = Object.entries(request.headers).find(([key]) => key.toLowerCase() === 'cookie');
+      if (cookieHeader && cookieHeader[1]) {
+        const cookieString = cookieHeader[1];
+        const cookiesObj = {};
+        
+        // Parse cookie string to object
+        cookieString.split(';').forEach(cookie => {
+          const [name, ...valueParts] = cookie.trim().split('=');
+          if (name) {
+            cookiesObj[name] = valueParts.join('=');
+          }
+        });
+        
+        // Attach to bru object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+
+    // Also check for Set-Cookie in response headers and add those cookies
+    if (response?.headers) {
+      const setCookieHeaders = [];
+      
+      // Check for Set-Cookie in headers
+      if (response.headers['set-cookie']) {
+        if (Array.isArray(response.headers['set-cookie'])) {
+          setCookieHeaders.push(...response.headers['set-cookie']);
+        } else {
+          setCookieHeaders.push(response.headers['set-cookie']);
+        }
+      }
+      
+      // If there are Set-Cookie headers, parse and add to cookies object
+      if (setCookieHeaders.length > 0) {
+        const cookiesObj = bru._cookiesObj || {};
+        
+        setCookieHeaders.forEach(setCookieHeader => {
+          if (typeof setCookieHeader === 'string' && setCookieHeader.length) {
+            const [cookiePair] = setCookieHeader.split(';');
+            if (cookiePair) {
+              const [name, ...valueParts] = cookiePair.trim().split('=');
+              if (name) {
+                cookiesObj[name] = valueParts.join('=');
+              }
+            }
+          }
+        });
+        
+        // Update the cookies object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+
     const whitelistedModules = {};
 
     for (let module of moduleWhitelist) {

--- a/packages/bruno-js/src/runtime/vars-runtime.js
+++ b/packages/bruno-js/src/runtime/vars-runtime.js
@@ -34,6 +34,60 @@ class VarsRuntime {
     const req = new BrunoRequest(request);
     const res = createResponseParser(response);
 
+    // Parse cookies from request headers and attach to bru context
+    if (request?.headers) {
+      const cookieHeader = Object.entries(request.headers).find(([key]) => key.toLowerCase() === 'cookie');
+      if (cookieHeader && cookieHeader[1]) {
+        const cookieString = cookieHeader[1];
+        const cookiesObj = {};
+        
+        // Parse cookie string to object
+        cookieString.split(';').forEach(cookie => {
+          const [name, ...valueParts] = cookie.trim().split('=');
+          if (name) {
+            cookiesObj[name] = valueParts.join('=');
+          }
+        });
+        
+        // Attach to bru object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+
+    // Also check for Set-Cookie in response headers and add those cookies
+    if (response?.headers) {
+      const setCookieHeaders = [];
+      
+      // Check for Set-Cookie in headers
+      if (response.headers['set-cookie']) {
+        if (Array.isArray(response.headers['set-cookie'])) {
+          setCookieHeaders.push(...response.headers['set-cookie']);
+        } else {
+          setCookieHeaders.push(response.headers['set-cookie']);
+        }
+      }
+      
+      // If there are Set-Cookie headers, parse and add to cookies object
+      if (setCookieHeaders.length > 0) {
+        const cookiesObj = bru._cookiesObj || {};
+        
+        setCookieHeaders.forEach(setCookieHeader => {
+          if (typeof setCookieHeader === 'string' && setCookieHeader.length) {
+            const [cookiePair] = setCookieHeader.split(';');
+            if (cookiePair) {
+              const [name, ...valueParts] = cookiePair.trim().split('=');
+              if (name) {
+                cookiesObj[name] = valueParts.join('=');
+              }
+            }
+          }
+        });
+        
+        // Update the cookies object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+
     const bruContext = {
       bru,
       req,

--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -60,6 +60,60 @@ const executeQuickJsVm = ({ script: externalScript, context: externalContext, sc
   try {
     const { bru, req, res, ...variables } = externalContext;
 
+    // Parse cookies from request and response if available
+    if (bru && req && req.headers) {
+      const cookieHeader = Object.entries(req.headers).find(([key]) => key.toLowerCase() === 'cookie');
+      if (cookieHeader && cookieHeader[1]) {
+        const cookieString = cookieHeader[1];
+        const cookiesObj = {};
+        
+        // Parse cookie string to object
+        cookieString.split(';').forEach(cookie => {
+          const [name, ...valueParts] = cookie.trim().split('=');
+          if (name) {
+            cookiesObj[name] = valueParts.join('=');
+          }
+        });
+        
+        // Attach to bru object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+    
+    // Also check for Set-Cookie in response headers
+    if (bru && res && res.headers) {
+      const setCookieHeaders = [];
+      
+      // Check for Set-Cookie in headers
+      if (res.headers['set-cookie']) {
+        if (Array.isArray(res.headers['set-cookie'])) {
+          setCookieHeaders.push(...res.headers['set-cookie']);
+        } else {
+          setCookieHeaders.push(res.headers['set-cookie']);
+        }
+      }
+      
+      // If there are Set-Cookie headers, parse and add to cookies object
+      if (setCookieHeaders.length > 0) {
+        const cookiesObj = bru._cookiesObj || {};
+        
+        setCookieHeaders.forEach(setCookieHeader => {
+          if (typeof setCookieHeader === 'string' && setCookieHeader.length) {
+            const [cookiePair] = setCookieHeader.split(';');
+            if (cookiePair) {
+              const [name, ...valueParts] = cookiePair.trim().split('=');
+              if (name) {
+                cookiesObj[name] = valueParts.join('=');
+              }
+            }
+          }
+        });
+        
+        // Update the cookies object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+
     bru && addBruShimToContext(vm, bru);
     req && addBrunoRequestShimToContext(vm, req);
     res && addBrunoResponseShimToContext(vm, res);
@@ -141,6 +195,60 @@ const executeQuickJsVmAsync = async ({ script: externalScript, context: external
     );
 
     const { bru, req, res, test, __brunoTestResults, console: consoleFn } = externalContext;
+
+    // Parse cookies from request and response if available
+    if (bru && req && req.headers) {
+      const cookieHeader = Object.entries(req.headers).find(([key]) => key.toLowerCase() === 'cookie');
+      if (cookieHeader && cookieHeader[1]) {
+        const cookieString = cookieHeader[1];
+        const cookiesObj = {};
+        
+        // Parse cookie string to object
+        cookieString.split(';').forEach(cookie => {
+          const [name, ...valueParts] = cookie.trim().split('=');
+          if (name) {
+            cookiesObj[name] = valueParts.join('=');
+          }
+        });
+        
+        // Attach to bru object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
+    
+    // Also check for Set-Cookie in response headers
+    if (bru && res && res.headers) {
+      const setCookieHeaders = [];
+      
+      // Check for Set-Cookie in headers
+      if (res.headers['set-cookie']) {
+        if (Array.isArray(res.headers['set-cookie'])) {
+          setCookieHeaders.push(...res.headers['set-cookie']);
+        } else {
+          setCookieHeaders.push(res.headers['set-cookie']);
+        }
+      }
+      
+      // If there are Set-Cookie headers, parse and add to cookies object
+      if (setCookieHeaders.length > 0) {
+        const cookiesObj = bru._cookiesObj || {};
+        
+        setCookieHeaders.forEach(setCookieHeader => {
+          if (typeof setCookieHeader === 'string' && setCookieHeader.length) {
+            const [cookiePair] = setCookieHeader.split(';');
+            if (cookiePair) {
+              const [name, ...valueParts] = cookiePair.trim().split('=');
+              if (name) {
+                cookiesObj[name] = valueParts.join('=');
+              }
+            }
+          }
+        });
+        
+        // Update the cookies object
+        bru._cookiesObj = cookiesObj;
+      }
+    }
 
     bru && addBruShimToContext(vm, bru);
     req && addBrunoRequestShimToContext(vm, req);


### PR DESCRIPTION
# Description

Added cookie helper functions to Bruno scripts via the `bru.cookies` API. This provides similar functionality to Postman's `pm.cookies` API, making it easier for users to work with cookies in their scripts.

## Features added:
- `bru.cookies.get()` - Returns all cookies as an object
- `bru.cookies.get("cookieName")` - Gets a specific cookie by name
- `bru.cookies.has("cookieName")` - Checks if a specific cookie exists

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
