### PR TITLE
refactor: Replace tag-based grouping with path-based grouping in Open…

### DIFF
--- a/packages/bruno-converters/tests/openapi/openapi-path-grouping.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-path-grouping.spec.js
@@ -1,0 +1,243 @@
+import jsyaml from 'js-yaml';
+import { describe, it, expect } from '@jest/globals';
+import openApiToBruno from '../../src/openapi/openapi-to-bruno';
+
+describe('openapi-path-based-grouping', () => {
+  it('should correctly group endpoints by path segments', async () => {
+    const openApiSpecification = jsyaml.load(openApiWithNestedPaths);
+    const brunoCollection = openApiToBruno(openApiSpecification);
+
+    expect(brunoCollection).toMatchObject(expectedNestedPathsOutput);
+  });
+});
+
+const openApiWithNestedPaths = `
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: "Path Grouping Test API"
+paths:
+  /api/users:
+    get:
+      summary: "List Users"
+      responses:
+        '200':
+          description: "Successful response"
+    post:
+      summary: "Create User"
+      responses:
+        '201':
+          description: "User created"
+  /api/users/{userId}:
+    get:
+      summary: "Get User"
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: "User found"
+  /api/users/{userId}/posts:
+    get:
+      summary: "List User Posts"
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: "Posts found"
+servers:
+  - url: "https://api.example.com"
+`;
+
+const expectedNestedPathsOutput = {
+  "name": "Path Grouping Test API",
+  "uid": "mockeduuidvalue123456",
+  "version": "1",
+  "environments": [
+    {
+      "name": "Environment 1",
+      "uid": "mockeduuidvalue123456",
+      "variables": [
+        {
+          "enabled": true,
+          "name": "baseUrl",
+          "secret": false,
+          "type": "text",
+          "uid": "mockeduuidvalue123456",
+          "value": "https://api.example.com"
+        }
+      ]
+    }
+  ],
+  "items": [
+    {
+      "name": "api",
+      "type": "folder",
+      "uid": "mockeduuidvalue123456",
+      "items": [
+        {
+          "name": "users",
+          "type": "folder",
+          "uid": "mockeduuidvalue123456",
+          "items": [
+            {
+              "name": "List Users",
+              "type": "http-request",
+              "uid": "mockeduuidvalue123456",
+              "request": {
+                "auth": {
+                  "basic": null,
+                  "bearer": null,
+                  "digest": null,
+                  "mode": "none"
+                },
+                "body": {
+                  "formUrlEncoded": [],
+                  "json": null,
+                  "mode": "none",
+                  "multipartForm": [],
+                  "text": null,
+                  "xml": null
+                },
+                "headers": [],
+                "method": "GET",
+                "params": [],
+                "script": {
+                  "res": null
+                },
+                "url": "{{baseUrl}}/api/users"
+              },
+              "seq": 1
+            },
+            {
+              "name": "Create User",
+              "type": "http-request",
+              "uid": "mockeduuidvalue123456",
+              "request": {
+                "auth": {
+                  "mode": "none",
+                  "basic": null,
+                  "bearer": null,
+                  "digest": null
+                },
+                "body": {
+                  "mode": "none",
+                  "json": null,
+                  "text": null,
+                  "xml": null,
+                  "formUrlEncoded": [],
+                  "multipartForm": []
+                },
+                "headers": [],
+                "method": "POST",
+                "params": [],
+                "script": {
+                  "res": null
+                },
+                "url": "{{baseUrl}}/api/users"
+              },
+              "seq": 2
+            },
+            {
+              "name": "{userId}",
+              "type": "folder",
+              "uid": "mockeduuidvalue123456",
+              "items": [
+                {
+                  "name": "Get User",
+                  "type": "http-request",
+                  "uid": "mockeduuidvalue123456",
+                  "request": {
+                    "auth": {
+                      "mode": "none",
+                      "basic": null,
+                      "bearer": null,
+                      "digest": null
+                    },
+                    "body": {
+                      "mode": "none",
+                      "json": null,
+                      "text": null,
+                      "xml": null,
+                      "formUrlEncoded": [],
+                      "multipartForm": []
+                    },
+                    "headers": [],
+                    "method": "GET",
+                    "params": [
+                      {
+                        "name": "userId",
+                        "value": "",
+                        "description": "",
+                        "enabled": true,
+                        "type": "path",
+                        "uid": "mockeduuidvalue123456"
+                      }
+                    ],
+                    "script": {
+                      "res": null
+                    },
+                    "url": "{{baseUrl}}/api/users/:userId"
+                  },
+                  "seq": 1
+                },
+                {
+                  "name": "posts",
+                  "type": "folder",
+                  "uid": "mockeduuidvalue123456",
+                  "items": [
+                    {
+                      "name": "List User Posts",
+                      "type": "http-request",
+                      "uid": "mockeduuidvalue123456",
+                      "request": {
+                        "auth": {
+                          "mode": "none",
+                          "basic": null,
+                          "bearer": null,
+                          "digest": null
+                        },
+                        "body": {
+                          "mode": "none",
+                          "json": null,
+                          "text": null,
+                          "xml": null,
+                          "formUrlEncoded": [],
+                          "multipartForm": []
+                        },
+                        "headers": [],
+                        "method": "GET",
+                        "params": [
+                          {
+                            "name": "userId",
+                            "value": "",
+                            "description": "",
+                            "enabled": true,
+                            "type": "path",
+                            "uid": "mockeduuidvalue123456"
+                          }
+                        ],
+                        "script": {
+                          "res": null
+                        },
+                        "url": "{{baseUrl}}/api/users/:userId/posts"
+                      },
+                      "seq": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno.spec.js
@@ -48,6 +48,9 @@ servers:
 `;
 
 const expectedOutput = {
+  "name": "Hello World OpenAPI",
+  "uid": "mockeduuidvalue123456",
+  "version": "1",
   "environments": [
     {
       "name": "Environment 1",
@@ -97,7 +100,7 @@ const expectedOutput = {
           "uid": "mockeduuidvalue123456",
         },
       ],
-      "name": "Folder1",
+      "name": "get",
       "type": "folder",
       "uid": "mockeduuidvalue123456",
     },


### PR DESCRIPTION
 Description

## Changes

### OpenAPI Converter Enhancement
- **Changed grouping strategy**: Replaced tag-based grouping with path-based grouping for better organization
  - Previously: Requests were grouped by OpenAPI tags
  - Now: Requests are grouped by URL path segments for more intuitive organization
- This change provides a more logical and hierarchical structure to imported collections

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/82488fda-9d37-4180-a980-0b6fd748e3c0