### PR TITLE
Fix: infinite recursion in buildEmptyJsonBody

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -7,14 +7,22 @@ const ensureUrl = (url) => {
   return url.replace(/([^:])\/{2,}/g, '$1/');
 };
 
-const buildEmptyJsonBody = (bodySchema) => {
+const buildEmptyJsonBody = (bodySchema, visited = new Map()) => {
+  // Check for circular references
+  if (visited.has(bodySchema)) {
+    return {};
+  }
+
+  // Add this schema to visited map
+  visited.set(bodySchema, true);
+
   let _jsonBody = {};
   each(bodySchema.properties || {}, (prop, name) => {
     if (prop.type === 'object') {
-      _jsonBody[name] = buildEmptyJsonBody(prop);
+      _jsonBody[name] = buildEmptyJsonBody(prop, visited);
     } else if (prop.type === 'array') {
       if (prop.items && prop.items.type === 'object') {
-        _jsonBody[name] = [buildEmptyJsonBody(prop.items)];
+        _jsonBody[name] = [buildEmptyJsonBody(prop.items, visited)];
       } else {
         _jsonBody[name] = [];
       }

--- a/packages/bruno-converters/tests/openapi/openapi-circular-references.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-circular-references.spec.js
@@ -3,22 +3,19 @@ import openApiToBruno from '../../src/openapi/openapi-to-bruno';
 
 describe('openapi-circular-references', () => {
   it('should handle simple circular references in schema correctly', async () => {
-    const circularRefsData = JSON.parse(circularRefsJson);
     const brunoCollection = openApiToBruno(circularRefsData);
     
     expect(brunoCollection).toMatchObject(circularRefsOutput);
   });
 
   it('should handle complex circular reference chains correctly', async () => {
-    const complexCircularRefsData = JSON.parse(complexCircularRefsJson);
-    
     const brunoCollection = openApiToBruno(complexCircularRefsData);
     
     expect(brunoCollection).toMatchObject(circularRefsOutput);
   });
 });
 
-const circularRefsJson = `{
+const circularRefsData = {
   "components": {
     "schemas": {
       "schema_1": {
@@ -88,10 +85,10 @@ const circularRefsJson = `{
     }
   },
   "servers": [{ "url": "https://echo.usebruno.com" }]
-}`;
+};
 
 // More complex circular reference test with a longer chain
-const complexCircularRefsJson = `{
+const complexCircularRefsData = {
   "components": {
     "schemas": {
       "schema_1": {
@@ -211,7 +208,7 @@ const complexCircularRefsJson = `{
     }
   },
   "servers": [{ "url": "https://echo.usebruno.com" }]
-}`;
+};
 
 const circularRefsOutput = {
   "environments": [

--- a/packages/bruno-converters/tests/openapi/openapi-circular-references.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-circular-references.spec.js
@@ -12,26 +12,9 @@ describe('openapi-circular-references', () => {
   it('should handle complex circular reference chains correctly', async () => {
     const complexCircularRefsData = JSON.parse(complexCircularRefsJson);
     
-    // This should not throw a maximum call stack error
     const brunoCollection = openApiToBruno(complexCircularRefsData);
     
-    // Verify basic structure of the collection
-    expect(brunoCollection).toHaveProperty('name', 'circular reference openapi sample json spec');
-    expect(brunoCollection).toHaveProperty('items');
-    expect(brunoCollection).toHaveProperty('environments');
-    
-    // Verify the POST endpoint was converted correctly
-    const requestItem = brunoCollection.items.find(item => 
-      item.type === 'http-request' && 
-      item.request.method === 'POST'
-    );
-    
-    expect(requestItem).toBeDefined();
-    expect(requestItem.request.body.mode).toBe('json');
-    
-    // The JSON body should be defined and parseable
-    expect(requestItem.request.body.json).toBeDefined();
-    expect(() => JSON.parse(requestItem.request.body.json)).not.toThrow();
+    expect(brunoCollection).toMatchObject(circularRefsOutput);
   });
 });
 

--- a/packages/bruno-converters/tests/openapi/openapi-circular-references.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-circular-references.spec.js
@@ -1,0 +1,268 @@
+import { describe, it, expect } from '@jest/globals';
+import openApiToBruno from '../../src/openapi/openapi-to-bruno';
+
+describe('openapi-circular-references', () => {
+  it('should handle simple circular references in schema correctly', async () => {
+    const circularRefsData = JSON.parse(circularRefsJson);
+    const brunoCollection = openApiToBruno(circularRefsData);
+    
+    expect(brunoCollection).toMatchObject(circularRefsOutput);
+  });
+
+  it('should handle complex circular reference chains correctly', async () => {
+    const complexCircularRefsData = JSON.parse(complexCircularRefsJson);
+    
+    // This should not throw a maximum call stack error
+    const brunoCollection = openApiToBruno(complexCircularRefsData);
+    
+    // Verify basic structure of the collection
+    expect(brunoCollection).toHaveProperty('name', 'circular reference openapi sample json spec');
+    expect(brunoCollection).toHaveProperty('items');
+    expect(brunoCollection).toHaveProperty('environments');
+    
+    // Verify the POST endpoint was converted correctly
+    const requestItem = brunoCollection.items.find(item => 
+      item.type === 'http-request' && 
+      item.request.method === 'POST'
+    );
+    
+    expect(requestItem).toBeDefined();
+    expect(requestItem.request.body.mode).toBe('json');
+    
+    // The JSON body should be defined and parseable
+    expect(requestItem.request.body.json).toBeDefined();
+    expect(() => JSON.parse(requestItem.request.body.json)).not.toThrow();
+  });
+});
+
+const circularRefsJson = `{
+  "components": {
+    "schemas": {
+      "schema_1": {
+        "additionalProperties": false,
+        "description": "schema_1",
+        "properties": {
+          "conditions": {
+            "$ref": "#/components/schemas/schema_1"
+          }
+        },
+        "type": "object"
+      },
+      "schema_2": {
+        "additionalProperties": false,
+        "description": "schema_2",
+        "properties": {
+          "conditionGroup": {
+            "description": "nested schema_1",
+            "items": { "$ref": "#/components/schemas/schema_1" },
+            "type": "array"
+          },
+          "operation": {
+            "description": "operation",
+            "enum": ["ANY", "ALL"],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "circular reference openapi sample json spec",
+    "title": "circular reference openapi sample json spec",
+    "version": "0.1"
+  },
+  "openapi": "3.0.1",
+  "paths": {
+    "/": {
+      "post": {
+        "deprecated": false,
+        "description": "echo ping api",
+        "operationId": "echo ping",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/schema_1"
+              }
+            }
+          },
+          "description": "echo ping api",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": "ping"
+              }
+            },
+            "description": "Returned if the request is successful."
+          }
+        }
+      }
+    }
+  },
+  "servers": [{ "url": "https://echo.usebruno.com" }]
+}`;
+
+// More complex circular reference test with a longer chain
+const complexCircularRefsJson = `{
+  "components": {
+    "schemas": {
+      "schema_1": {
+        "additionalProperties": false,
+        "description": "schema_1",
+        "properties": {
+          "conditionGroup": {
+            "description": "nested schema_1",
+            "items": { "$ref": "#/components/schemas/schema_2" },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "schema_2": {
+        "additionalProperties": false,
+        "description": "schema_2",
+        "properties": {
+          "conditionGroup": {
+            "description": "nested schema_2",
+            "items": { "$ref": "#/components/schemas/schema_3" },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "schema_3": {
+        "additionalProperties": false,
+        "description": "schema_3",
+        "properties": {
+          "conditionGroup": {
+            "description": "nested schema_3",
+            "items": { "$ref": "#/components/schemas/schema_4" },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "schema_4": {
+        "additionalProperties": false,
+        "description": "schema_4",
+        "properties": {
+          "conditionGroup": {
+            "description": "nested schema_4",
+            "items": { "$ref": "#/components/schemas/schema_5" },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "schema_5": {
+        "additionalProperties": false,
+        "description": "schema_4",
+        "properties": {
+          "conditionGroup": {
+            "description": "nested schema_5",
+            "items": { "$ref": "#/components/schemas/schema_1" },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "schema_6": {
+        "additionalProperties": false,
+        "description": "schema_3",
+        "properties": {
+          "conditionGroup": {
+            "description": "nested schema_3",
+            "items": { "$ref": "#/components/schemas/schema_1" },
+            "type": "array"
+          },
+          "operation": {
+            "description": "operation",
+            "enum": ["ANY", "ALL"],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "circular reference openapi sample json spec",
+    "title": "circular reference openapi sample json spec",
+    "version": "0.1"
+  },
+  "openapi": "3.0.1",
+  "paths": {
+    "/": {
+      "post": {
+        "deprecated": false,
+        "description": "echo ping api",
+        "operationId": "echo ping",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/schema_1"
+              }
+            }
+          },
+          "description": "echo ping api",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": "ping"
+              }
+            },
+            "description": "Returned if the request is successful."
+          }
+        }
+      }
+    }
+  },
+  "servers": [{ "url": "https://echo.usebruno.com" }]
+}`;
+
+const circularRefsOutput = {
+  "environments": [
+    {
+      "name": "Environment 1",
+      "variables": [
+        {
+          "enabled": true,
+          "name": "baseUrl",
+          "secret": false,
+          "type": "text",
+          "value": "https://echo.usebruno.com",
+        },
+      ],
+    },
+  ],
+  "items": [
+    {
+      "name": "echo ping",
+      "type": "http-request",
+      "request": {
+        "url": "{{baseUrl}}/",
+        "method": "POST",
+        "auth": {
+          "mode": "none",
+        },
+        "headers": [],
+        "params": [],
+        "body": {
+          "mode": "json",
+        }
+      },
+    },
+  ],
+  "name": "circular reference openapi sample json spec",
+  "version": "1",
+}; 

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-circular-references.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-circular-references.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import openApiToBruno from '../../src/openapi/openapi-to-bruno';
+import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
 
 describe('openapi-circular-references', () => {
   it('should handle simple circular references in schema correctly', async () => {

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-to-bruno.spec.js
@@ -1,6 +1,6 @@
 import jsyaml from 'js-yaml';
 import { describe, it, expect } from '@jest/globals';
-import openApiToBruno from '../../src/openapi/openapi-to-bruno';
+import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
 
 describe('openapi-collection', () => {
   it('should correctly import a valid OpenAPI file', async () => {


### PR DESCRIPTION
# Description

Fixed a issue in the OpenAPI to Bruno converter where circular references in JSON schemas would cause a "Maximum callstack size exceeded" error. Added a visited Map parameter to the `buildEmptyJsonBody` function to track already processed schemas and prevent infinite recursion when handling complex nested structures. This fix ensures that OpenAPI specifications with circular references can be properly imported without crashing.

[JIRA](https://usebruno.atlassian.net/browse/BRU-1054)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
