### PR TITLE
feat: extend cli auth for inherit and request

### DIFF
--- a/packages/bruno-cli/tests/runner/prepare-request.spec.js
+++ b/packages/bruno-cli/tests/runner/prepare-request.spec.js
@@ -150,6 +150,92 @@ describe('prepare-request: prepareRequest', () => {
       });
     });
 
+    describe('AWS v4 Authentication', () => {
+      it('If collection auth is AWS v4', () => {
+        collection.root.request.auth = {
+          mode: 'awsv4',
+          awsv4: {
+            accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+            secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+            sessionToken: 'session-token',
+            service: 's3',
+            region: 'us-west-2',
+            profileName: 'default'
+          }
+        };
+
+        const result = prepareRequest(item, collection);
+        const expected = {
+          accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+          secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+          sessionToken: 'session-token',
+          service: 's3',
+          region: 'us-west-2',
+          profileName: 'default'
+        };
+        expect(result.awsv4config).toEqual(expected);
+      });
+    });
+
+    describe('NTLM Authentication', () => {
+      it('If collection auth is NTLM', () => {
+        collection.root.request.auth = {
+          mode: 'ntlm',
+          ntlm: {
+            username: 'testUser',
+            password: 'testPass123',
+            domain: 'testDomain'
+          }
+        };
+
+        const result = prepareRequest(item, collection);
+        const expected = {
+          username: 'testUser',
+          password: 'testPass123',
+          domain: 'testDomain'
+        };
+        expect(result.ntlmConfig).toEqual(expected);
+      });
+    });
+
+    describe('WSSE Authentication', () => {
+      it('If collection auth is WSSE', () => {
+        collection.root.request.auth = {
+          mode: 'wsse',
+          wsse: {
+            username: 'testUser',
+            password: 'testPass123'
+          }
+        };
+
+        const result = prepareRequest(item, collection);
+        expect(result.headers).toHaveProperty('X-WSSE');
+        expect(result.headers['X-WSSE']).toContain('UsernameToken Username="testUser"');
+        expect(result.headers['X-WSSE']).toContain('PasswordDigest="');
+        expect(result.headers['X-WSSE']).toContain('Nonce="');
+        expect(result.headers['X-WSSE']).toContain('Created="');
+      });
+    });
+
+    describe('Digest Authentication', () => {
+      it('If collection auth is digest auth', () => {
+        collection.root.request.auth = {
+          mode: 'digest',
+          digest: {
+            username: 'testUser',
+            password: 'testPass123'
+          }
+        };
+
+        const result = prepareRequest(item, collection);
+        const expected = {
+          username: 'testUser',
+          password: 'testPass123'
+        };
+        expect(result.digestConfig).toEqual(expected);
+      });
+    });
+
     describe('No Authentication', () => {
       it('If request does not have auth configured', () => {
         delete item.request.auth;


### PR DESCRIPTION
# Description

Fixed authentication inheritance for AWS v4, NTLM, and WSSE authentication types, and added direct API key authentication support for requests.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Fixes: https://github.com/usebruno/bruno/issues/3688
