### PR TITLE
feat: add `req.getName` api

### DIFF
--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -26,6 +26,7 @@ const replacements = {
   'pm\\.request\\.method': 'req.getMethod()',
   'pm\\.request\\.headers': 'req.getHeaders()',
   'pm\\.request\\.body': 'req.getBody()',
+  'pm\\.info\\.requestName': 'req.getName()',
   // deprecated translations
   'postman\\.setEnvironmentVariable\\(': 'bru.setEnvVar(',
   'postman\\.getEnvironmentVariable\\(': 'bru.getEnvVar(',

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-translations/postman-request.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-translations/postman-request.spec.js
@@ -7,6 +7,7 @@ describe('postmanTranslations - request commands', () => {
       const requestMethod = pm.request.method;
       const requestHeaders = pm.request.headers;
       const requestBody = pm.request.body;
+      const requestName = pm.info.requestName;
 
       pm.test('Request method is POST', function() {
         pm.expect(pm.request.method).to.equal('POST');
@@ -17,6 +18,7 @@ describe('postmanTranslations - request commands', () => {
       const requestMethod = req.getMethod();
       const requestHeaders = req.getHeaders();
       const requestBody = req.getBody();
+      const requestName = req.getName();
 
       test('Request method is POST', function() {
         expect(req.getMethod()).to.equal('POST');

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -301,6 +301,7 @@ const prepareRequest = async (item, collection = {}, abortController) => {
     method: request.method,
     url,
     headers,
+    name: item.name,
     pathParams: request?.params?.filter((param) => param.type === 'path'),
     responseType: 'arraybuffer'
   };

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -17,7 +17,7 @@ class BrunoRequest {
     this.method = req.method;
     this.headers = req.headers;
     this.timeout = req.timeout;
-
+    this.name = req.name;
     /**
      * We automatically parse the JSON body if the content type is JSON
      * This is to make it easier for the user to access the body directly
@@ -176,6 +176,10 @@ class BrunoRequest {
 
   getExecutionMode() {
     return this.req.__bruno__executionMode;
+  }
+
+  getName() {
+    return this.req.name;
   }
 }
 

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-request.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-request.js
@@ -8,18 +8,21 @@ const addBrunoRequestShimToContext = (vm, req) => {
   const headers = marshallToVm(req.getHeaders(), vm);
   const body = marshallToVm(req.getBody(), vm);
   const timeout = marshallToVm(req.getTimeout(), vm);
+  const name = marshallToVm(req.getName(), vm);
 
   vm.setProp(reqObject, 'url', url);
   vm.setProp(reqObject, 'method', method);
   vm.setProp(reqObject, 'headers', headers);
   vm.setProp(reqObject, 'body', body);
   vm.setProp(reqObject, 'timeout', timeout);
+  vm.setProp(reqObject, 'name', name);
 
   url.dispose();
   method.dispose();
   headers.dispose();
   body.dispose();
   timeout.dispose();
+  name.dispose();
 
   let getUrl = vm.newFunction('getUrl', function () {
     return marshallToVm(req.getUrl(), vm);
@@ -44,6 +47,12 @@ const addBrunoRequestShimToContext = (vm, req) => {
   });
   vm.setProp(reqObject, 'getAuthMode', getAuthMode);
   getAuthMode.dispose();
+
+  let getName = vm.newFunction('getName', function () {
+    return marshallToVm(req.getName(), vm);
+  });
+  vm.setProp(reqObject, 'getName', getName);
+  getName.dispose();
 
   let setMethod = vm.newFunction('setMethod', function (method) {
     req.setMethod(vm.dump(method));


### PR DESCRIPTION
# Description

Added support for converting Postman's `pm.info.requestName` to Bruno's `req.getName()` in the request scripts. This change helps maintain compatibility when importing Postman collections that use request names in their scripts.

## Changes made:
1. Added getName() method to BrunoRequest class
2. Added translation mapping from pm.info.requestName to req.getName()
3. Updated tests to verify the translation works correctly

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
