### PR TITLE
 in directory name then error is not visible if show file system is false

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewFolder/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewFolder/index.js
@@ -108,7 +108,9 @@ const NewFolder = ({ collectionUid, item, onClose }) => {
             {formik.touched.folderName && formik.errors.folderName ? (
               <div className="text-red-500">{formik.errors.folderName}</div>
             ) : null}
-
+            {!showFilesystemName && !isEditing && formik.touched.folderName && !formik.errors.folderName && formik.errors.directoryName ? (
+              <div className="text-red-500">{formik.errors.directoryName}</div>
+            ) : null}
             {showFilesystemName && (
               <div className="mt-4">
                 <div className="flex items-center justify-between">


### PR DESCRIPTION
# Description
bugfix: if error is in directory name then error is not visible if show file system is false

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
#### Error screenshot
![Screenshot 2025-05-07 091904](https://github.com/user-attachments/assets/69e3e343-9814-4416-b6fd-a9288413535c)
![image](https://github.com/user-attachments/assets/a7d90bb8-0045-4b46-b9d8-1b62f8123a5f)

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
