### PR TITLE
handle options in getBody for QuickJS VM

### DIFF
--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-request.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-request.js
@@ -75,9 +75,10 @@ const addBrunoRequestShimToContext = (vm, req) => {
   vm.setProp(reqObject, 'setHeader', setHeader);
   setHeader.dispose();
 
-  let getBody = vm.newFunction('getBody', function () {
-    return marshallToVm(req.getBody(), vm);
+  let getBody = vm.newFunction('getBody', function (options) {
+    return marshallToVm(req.getBody(vm.dump(options)), vm);
   });
+  
   vm.setProp(reqObject, 'getBody', getBody);
   getBody.dispose();
 


### PR DESCRIPTION
This PR fixes an inconsistency in the `getBody` function behavior between Developer Mode and QuickJS VM environments. 

### Changes Made:
- Added support for options in `getBody` function for QuickJS VM

### Testing:
- Verified `getBody({ raw: true })` works in both Developer Mode and QuickJS VM
- Tested with various body types (JSON, text, etc.)

### Related Issue:
#3992 - Add possibility to see actual raw body in scripts (req.body.raw)

### Without Changes:
When try to get body passing raw option as true 

`const requestBody = req.getBody({ raw: true });`

![Screenshot 2025-05-07 at 14 28 26](https://github.com/user-attachments/assets/fa68728c-cab1-4177-ac0a-a5d8e73ebe0d)

### WIth Changes:
![image](https://github.com/user-attachments/assets/117a5454-c6e4-4dca-8486-f496abe9910a)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
