### PR TITLE
fix(bruno-converters): construct unique operation names for OpenAPI

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -28,9 +28,10 @@ const buildEmptyJsonBody = (bodySchema) => {
 const transformOpenapiRequestItem = (request) => {
   let _operationObject = request.operationObject;
 
-  let operationName = _operationObject.summary || _operationObject.operationId || _operationObject.description;
-  if (!operationName) {
-    operationName = `${request.method} ${request.path}`;
+  let operationName = _operationObject.operationId || `${request.method} ${request.path}`;
+  let operationNameSuffix = _operationObject.summary || _operationObject.description;
+  if (operationNameSuffix) {
+    operationName = `${operationName} - ${operationNameSuffix}`;
   }
 
   // replace OpenAPI links in path by Bruno variables


### PR DESCRIPTION


# Description

Ensures that every operation imported from an OpenAPI spec gets a unique name.

Fixes https://github.com/usebruno/bruno/issues/4062.

Currently, when the following spec is imported, only one operation is created in the Bruno collection instead of two.

```json
{
  "openapi": "3.0.1",
  "info": {
    "title": "Minimal API",
    "version": "1.0.0"
  },
  "paths": {
    "/example": {
      "get": {
        "summary": "Example operation",
        "responses": {
          "200": {
            "description": "Successful response"
          }
        }
      },
      "post": {
        "summary": "Example operation",
        "responses": {
          "201": {
            "description": "Resource created"
          }
        }
      }
    }
  }
}
```

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**