### PR TITLE
Fix countSearchResults for regular expressions

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -427,8 +427,16 @@ export default class CodeEditor extends React.Component {
     const searchInput = document.querySelector('.CodeMirror-search-field');
 
     if (searchInput && searchInput.value.length > 0) {
-      // Escape special characters in search input to prevent RegExp crashes. Fixes #3051
-      const text = new RegExp(escapeRegExp(searchInput.value), 'gi');
+      let text;
+      // CoreMirror5 allows the user to use /re/ syntax for regexp search, so we handle both cases
+      if (searchInput.value.at(0) == "/" && searchInput.value.at(-1) == "/" && searchInput.value.length >= 3) {
+        try {
+          text = new RegExp(searchInput.value.slice(1, -1), "g")
+        } catch {}
+      } else {        
+        // Escape special characters in search input to prevent RegExp crashes. Fixes #3051
+        text = new RegExp(escapeRegExp(searchInput.value), 'gi');
+      }
       const matches = this.editor.getValue().match(text);
       count = matches ? matches.length : 0;
     }


### PR DESCRIPTION
Fixes #4659 

# Description

Currently the editor incorrectly shows "0 results" always when searching with a /regex/. This is because the search logic used to find matches is implemented in CodeMirror, and it supports /regex/ search, but the search result counter is implemented in Bruno, and it's search implementation doesn't support regexes.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
