### PR TITLE
feat: add  function in bruno converters package

### DIFF
--- a/packages/bruno-converters/readme.md
+++ b/packages/bruno-converters/readme.md
@@ -44,6 +44,27 @@ import { openApiToBruno } from '@usebruno/converters';
 const brunoCollection = openApiToBruno(openApiSpecification);
 ```
 
+### Convert YAML to JSON
+
+```javascript
+import { yamlToJson } from '@usebruno/converters';
+
+// Convert YAML string to JSON object
+const yamlString = `
+name: Example
+version: 1.0
+items:
+  - id: 1
+    title: Item 1
+  - id: 2
+    title: Item 2
+`;
+
+const jsonObject = yamlToJson(yamlString);
+console.log(jsonObject);
+// Output: { name: 'Example', version: 1.0, items: [ { id: 1, title: 'Item 1' }, { id: 2, title: 'Item 2' } ] }
+```
+
 ## Example 
 
 ```bash copy

--- a/packages/bruno-converters/src/index.js
+++ b/packages/bruno-converters/src/index.js
@@ -4,3 +4,4 @@ export { default as brunoToPostman } from './postman/bruno-to-postman.js';
 export { default as openApiToBruno } from './openapi/openapi-to-bruno.js';
 export { default as insomniaToBruno } from './insomnia/insomnia-to-bruno.js';
 export { default as postmanTranslation } from './postman/postman-translations.js';
+export { yamlToJson } from './utils';

--- a/packages/bruno-converters/src/utils/index.js
+++ b/packages/bruno-converters/src/utils/index.js
@@ -1,0 +1,1 @@
+export { default as yamlToJson } from './yamlToJson'; 

--- a/packages/bruno-converters/src/utils/yamlToJson.js
+++ b/packages/bruno-converters/src/utils/yamlToJson.js
@@ -1,0 +1,12 @@
+const jsyaml = require('js-yaml');
+
+
+const yamlToJson = (yamlString) => {
+  try {
+    return jsyaml.load(yamlString);
+  } catch (err) {
+    throw new Error(`Failed to parse YAML: ${err.message}`);
+  }
+};
+
+export default yamlToJson; 

--- a/packages/bruno-converters/tests/utils/yamlToJson.test.js
+++ b/packages/bruno-converters/tests/utils/yamlToJson.test.js
@@ -1,0 +1,62 @@
+import yamlToJson from '../../src/utils/yamlToJson';
+
+describe('yamlToJson', () => {
+  test('should convert simple YAML to JSON object', () => {
+    const yaml = `
+name: Test
+version: 1.0
+enabled: true
+`;
+    
+    const result = yamlToJson(yaml);
+    
+    expect(result).toEqual({
+      name: 'Test',
+      version: 1.0,
+      enabled: true
+    });
+  });
+
+  test('should convert complex YAML to JSON object', () => {
+    const yaml = `
+collection:
+  name: API Tests
+  version: 2.1
+  items:
+    - name: Get Users
+      method: GET
+      url: https://api.example.com/users
+    - name: Create User
+      method: POST
+      url: https://api.example.com/users
+      body:
+        mode: raw
+        raw: '{"name": "John", "email": "john@example.com"}'
+`;
+    
+    const result = yamlToJson(yaml);
+    
+    expect(result).toEqual({
+      collection: {
+        name: 'API Tests',
+        version: 2.1,
+        items: [
+          {
+            name: 'Get Users',
+            method: 'GET',
+            url: 'https://api.example.com/users'
+          },
+          {
+            name: 'Create User',
+            method: 'POST',
+            url: 'https://api.example.com/users',
+            body: {
+              mode: 'raw',
+              raw: '{"name": "John", "email": "john@example.com"}'
+            }
+          }
+        ]
+      }
+    });
+  });
+}); 


### PR DESCRIPTION
# Description

Added YAML to JSON conversion functionality to the `@usebruno/converters` package to simplify handling OpenAPI specifications in YAML format. This addresses the issue where users needed to install additional YAML parsing libraries when using the converters package outside of the Bruno application.

```js
const { openApiToBruno, yamlToJson } = require('@usebruno/converters');

const yamlString = fs.readFileSync('openapi-spec.yaml', 'utf8');
const jsonSpec = yamlToJson(yamlString);
const brunoCollection = openApiToBruno(jsonSpec);

const brunoCollection = openApiToBruno(yamlToJson(yamlString));
```

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

