### PR TITLE
fix: ensure timestamp and isoTimestamp return current time instead of random values

### DIFF
--- a/packages/bruno-common/src/utils/faker-functions.spec.ts
+++ b/packages/bruno-common/src/utils/faker-functions.spec.ts
@@ -1,10 +1,20 @@
 import { mockDataFunctions } from "./faker-functions";
 
 describe("mockDataFunctions Regex Validation", () => {
+  test("timestamp and isoTimestamp should return current time values", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const timestamp = parseInt(mockDataFunctions.timestamp());
+    const isoTimestamp = new Date(mockDataFunctions.isoTimestamp()).getTime() / 1000;
+
+    // Allow for a 2-second difference to account for test execution time
+    expect(Math.abs(timestamp - now)).toBeLessThanOrEqual(2);
+    expect(Math.abs(isoTimestamp - now)).toBeLessThanOrEqual(2);
+  });
+
   test("all values should match their expected patterns", () => {
     const patterns: Record<string, RegExp> = {
       guid: /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/,
-      timestamp: /^\d{13,}$/,
+      timestamp: /^\d{10}$/,
       isoTimestamp: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       randomUUID: /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/,
       randomAlphaNumeric: /^[\w]$/,

--- a/packages/bruno-common/src/utils/faker-functions.ts
+++ b/packages/bruno-common/src/utils/faker-functions.ts
@@ -2,8 +2,8 @@ import { faker } from '@faker-js/faker';
 
 export const mockDataFunctions = {
   guid: () => faker.string.uuid(),
-  timestamp: () => faker.date.anytime().getTime().toString(),
-  isoTimestamp: () => faker.date.anytime().toISOString(),
+  timestamp: () => Math.floor(Date.now() / 1000).toString(),
+  isoTimestamp: () => new Date().toISOString(),
   randomUUID: () => faker.string.uuid(),
   randomAlphaNumeric: () => faker.string.alphanumeric(),
   randomBoolean: () => faker.datatype.boolean(),


### PR DESCRIPTION

# Description

This PR addresses the issue where the timestamp and isoTimestamp functions were returning random values instead of the current time. The changes ensure that both functions now return the actual current time.

Closes https://github.com/usebruno/bruno/issues/4631

Changes Made:

- Updated the timestamp function to return the current Unix timestamp in seconds.
- Updated the isoTimestamp function to return the current time in ISO format.
- Added tests to verify that both functions return current time values within a 2-second window.

Before:
![Screenshot 2025-05-15 at 14 28 52](https://github.com/user-attachments/assets/560de81e-90bd-4e47-874a-4cfe6fbd58ee)

After:

![Screenshot 2025-05-15 at 14 28 39](https://github.com/user-attachments/assets/0b28c69f-dd8d-4791-9d37-8aec5335d3e3)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
