### PR TITLE
feat: decode msgpack response type to JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5636,6 +5636,15 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.1.tgz",
+      "integrity": "sha512-DnBpqkMOUGayNVKyTLlkM6ILmU/m/+VUxGkuQlPQVAcvreLz5jn1OlQnWd8uHKL/ZSiljpM12rjRhr51VtvJUQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@n1ru4l/push-pull-async-iterable-iterator": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-3.2.0.tgz",
@@ -9114,7 +9123,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
@@ -9137,7 +9145,6 @@
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
       "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "*",
@@ -9148,7 +9155,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -27562,7 +27568,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -28645,6 +28651,7 @@
       "license": "MIT",
       "dependencies": {
         "@fontsource/inter": "^5.0.15",
+        "@msgpack/msgpack": "^3.1.1",
         "@prantlf/jsonlint": "^16.0.0",
         "@reduxjs/toolkit": "^1.8.0",
         "@tabler/icons": "^1.46.0",

--- a/packages/bruno-app/jest.setup.js
+++ b/packages/bruno-app/jest.setup.js
@@ -1,3 +1,8 @@
+// Polyfill TextEncoder/TextDecoder for jsdom (required by @msgpack/msgpack)
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
 jest.mock('nanoid', () => {
   return {
     nanoid: () => {}

--- a/packages/bruno-app/package.json
+++ b/packages/bruno-app/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.0.15",
+    "@msgpack/msgpack": "^3.1.1",
     "@prantlf/jsonlint": "^16.0.0",
     "@reduxjs/toolkit": "^1.8.0",
     "@tabler/icons": "^1.46.0",

--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -117,6 +117,8 @@ export const getCodeMirrorModeBasedOnContentType = (contentType, body) => {
     return 'application/xml';
   } else if (contentType.includes('yaml')) {
     return 'application/yaml';
+  } else if (contentType.includes('msgpack')) {
+    return 'application/msgpack';
   } else {
     return 'application/text';
   }

--- a/packages/bruno-app/src/utils/common/format-response.spec.js
+++ b/packages/bruno-app/src/utils/common/format-response.spec.js
@@ -99,6 +99,31 @@ describe('formatResponse', () => {
     });
   });
 
+  describe('msgpack mode', () => {
+    it('should decode msgpack data and return a formatted string', () => {
+      const dataBuffer = Buffer.from([0x81, 0xa3, 0x66, 0x6f, 0x6f, 0xa3, 0x62, 0x61, 0x72]);
+      const result = formatResponse(null, dataBuffer.toString('base64'), 'msgpack');
+      expect(result).toBe(`{
+  "foo": "bar"
+}`);
+    });
+
+    it('should show raw data when invalid msgpack', () => {
+      const dataBuffer = Buffer.from([0x81, 0xa3, 0x66, 0x6f, 0x6f]);
+      const result = formatResponse(null, dataBuffer.toString('base64'), 'msgpack');
+      expect(result).toBe('��foo');
+    });
+
+    it('should show raw UTF-8 data when invalid msgpack for large responses', () => {
+      const invalidMsgpackData = 'This is invalid msgpack: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua';
+      const largeBuffer = createLargeBase64Buffer(invalidMsgpackData);
+      const result = formatResponse(null, largeBuffer, 'msgpack', undefined, 100);
+
+      expect(typeof result).toBe('string');
+      expect(result).toContain('Lorem ipsum');
+    });
+  });
+
   describe('other modes', () => {
     it('should handle string data for non-JSON/XML modes', () => {
       const data = 'plain text content';

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -6,6 +6,7 @@ import { format, applyEdits } from 'jsonc-parser';
 import { patternHasher } from '@usebruno/common/utils';
 import prettierFormat from 'prettier/standalone';
 import parserBabel from 'prettier/parser-babel';
+import { decode } from '@msgpack/msgpack';
 
 export const isPlaywright = () => {
   return typeof window !== 'undefined' && window.isPlaywright === true;
@@ -324,6 +325,22 @@ export const formatResponse = (data, dataBufferString, mode, filter, bufferThres
       return parsed;
     }
     return safeStringifyJSON(parsed, true);
+  }
+
+  if (mode.includes('msgpack')) {
+    try {
+      const decodedData = decode(Buffer.from(dataBufferString, 'base64'));
+      return safeStringifyJSON(decodedData, true);
+    } catch (error) {
+      console.warn('Error decoding msgpack data:', error);
+      // Fallback to showing the raw UTF-8 decoded data
+      try {
+        const fallbackData = Buffer.from(dataBufferString, 'base64').toString('utf-8');
+        return fallbackData || 'Error decoding msgpack data';
+      } catch (fallbackError) {
+        return 'Error decoding msgpack data';
+      }
+    }
   }
 
   if (mode.includes('html')) {


### PR DESCRIPTION
Fixes: #372 

# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Decodes a msgpack response to JSON.

Useful links:

- https://msgpack.org/
- https://www.npmjs.com/package/@msgpack/msgpack

Open to any comments/suggestions.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MessagePack responses are decoded and shown as formatted JSON.
* **Bug Fixes / Improvements**
  * Invalid MessagePack now falls back to raw/UTF‑8 display.
  * Improved runtime compatibility for MessagePack decoding in the app and test environment.
* **Tests**
  * Added unit tests covering valid MessagePack decoding, invalid data fallback, and large-response handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->