### PR TITLE
fix: sanitize end of item names on cli openapi import

### DIFF
--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -395,7 +395,7 @@ const createCollectionFromBrunoObject = async (collection, dirPath) => {
 
     for (const env of collection.environments) {
       const content = await envJsonToBruV2(env);
-      const filename = sanitizeName(`${env.name}.bru`);
+      const filename = `${sanitizeName(env.name)}.bru`;
       fs.writeFileSync(path.join(envDirPath, filename), content);
     }
   }
@@ -439,7 +439,7 @@ const processCollectionItems = async (items = [], currentPath) => {
       }
     } else if (['http-request', 'graphql-request'].includes(item.type)) {
       // Create request file
-      let sanitizedFilename = sanitizeName(item?.filename || `${item.name}.bru`);
+      let sanitizedFilename = sanitizeName(item?.filename || item.name);
       if (!sanitizedFilename.endsWith('.bru')) {
         sanitizedFilename += '.bru';
       }


### PR DESCRIPTION
# Description

Fix bug #4716: cli openapi import does not sanitize end of item names

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

