### PR TITLE
bruno-lang: Change the default request auth mode from "none" to "inherit"

### DIFF
--- a/packages/bruno-lang/v2/src/collectionBruToJson.js
+++ b/packages/bruno-lang/v2/src/collectionBruToJson.js
@@ -163,7 +163,7 @@ const sem = grammar.createSemantics().addAttribute('ast', {
 
     return {
       auth: {
-        mode: auth ? auth.mode : 'none'
+        mode: auth ? auth.mode : 'inherit'
       }
     };
   },


### PR DESCRIPTION
# Description

Although this was updated in !3436, the default auth mode is still set to none when importing the OpenAPI. To fix this—and to keep broToJson and the client in sync—we’re also changing the default auth mode in collectionBruToJson inside bru-lang to inherit.

### Contribution Checklist:

- [v] **The pull request only addresses one issue or adds one feature.**
- [v] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [v] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [v] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
