### PR TITLE
Add support for integer and boolean in OpenAPI to Bruno converter

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -27,6 +27,10 @@ const buildEmptyJsonBody = (bodySchema, visited = new Map()) => {
       } else {
         _jsonBody[name] = [];
       }
+    } else if (prop.type === 'integer') {
+      _jsonBody[name] = 0;
+    } else if (prop.type === 'boolean') {
+      _jsonBody[name] = false;
     } else {
       _jsonBody[name] = '';
     }


### PR DESCRIPTION
# Description

Fixes #4733

This adds integer and boolean support to the OpenAPI to Bruno converter.

We are frustrated that all properties of a body object are strings, it makes it hard for users to infer what a value should be.

Previously:

```
body:json {
  {
    "name": "",
    "description": "",
    "age": "",
    "enabled": ""
  }
}
```

With this change:

```
body:json {
  {
    "name": "",
    "description": "",
    "age": 0,
    "enabled": false
  }
}
```

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
