### PR TITLE
feat(markdown): add copy-to-clipboard button to code blocks in markdown

### DIFF
--- a/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
@@ -78,6 +78,34 @@ const StyledMarkdownBodyWrapper = styled.div`
         background-color: ${(props) => props.theme.bg};
       }
     }
+
+    .code-block-wrapper {
+      position: relative;
+    }
+
+    .code-block-wrapper pre {
+      padding-top: 2rem; /* Creates room for the icon inside the code block */
+    }
+
+    .copy-btn-react-root {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      z-index: 2;
+      cursor: pointer;
+      opacity: 0.7;
+      transition: opacity 0.2s ease;
+
+      &:hover {
+        opacity: 1;
+      }
+
+      svg {
+        width: 25px;
+        height: 25px;
+      }
+    }
+
   }
 `;
 

--- a/packages/bruno-app/src/components/MarkDown/index.jsx
+++ b/packages/bruno-app/src/components/MarkDown/index.jsx
@@ -1,15 +1,64 @@
 import MarkdownIt from 'markdown-it';
 import * as MarkdownItReplaceLink from 'markdown-it-replace-link';
 import StyledWrapper from './StyledWrapper';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { isValidUrl } from 'utils/url/index';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import toast from 'react-hot-toast';
+import { IconCopy } from '@tabler/icons';
+import { createRoot } from 'react-dom/client';
 
 const Markdown = ({ collectionPath, onDoubleClick, content }) => {
+  const wrapperRef = useRef();
+
   const markdownItOptions = {
     replaceLink: function (link, env) {
       return link.replace(/^\./, collectionPath);
     }
   };
+
+  const md = new MarkdownIt(markdownItOptions).use(MarkdownItReplaceLink);
+
+  // Custom renderer for fenced code blocks
+  md.renderer.rules.fence = function (tokens, idx, options, env, slf) {
+    const token = tokens[idx];
+    const code = token.content;
+    const langClass = token.info ? `language-${token.info.trim()}` : '';
+
+    return `
+      <div class="code-block-wrapper" data-copy="${encodeURIComponent(code)}">
+        <div class="code-copy-placeholder"></div>
+        <pre><code class="${langClass}">${md.utils.escapeHtml(code)}</code></pre>
+      </div>
+    `;
+  };
+
+  const htmlFromMarkdown = md.render(content || '');
+
+  useEffect(() => {
+    const wrappers = wrapperRef.current?.querySelectorAll('.code-block-wrapper');
+    wrappers?.forEach((el) => {
+      const placeholder = el.querySelector('.code-copy-placeholder');
+      const code = decodeURIComponent(el.dataset.copy || '');
+
+      if (placeholder) {
+        const button = document.createElement('div');
+        button.className = 'copy-btn-react-root';
+
+        const reactElement = (
+          <div className="copy-btn-react-root">
+            <CopyToClipboard text={code} onCopy={() => toast.success('Copied to clipboard!')}>
+              <IconCopy size={18} strokeWidth={1.5} />
+            </CopyToClipboard>
+          </div>
+        );
+
+        const root = createRoot(button);
+        root.render(reactElement);
+        placeholder.replaceWith(button);
+      }
+    });
+  }, [htmlFromMarkdown]);
 
   const handleOnClick = (event) => {
     const target = event.target;
@@ -29,13 +78,10 @@ const Markdown = ({ collectionPath, onDoubleClick, content }) => {
     }
   };
 
-  const md = new MarkdownIt(markdownItOptions).use(MarkdownItReplaceLink);
-
-  const htmlFromMarkdown = md.render(content || '');
-
   return (
     <StyledWrapper>
       <div
+        ref={wrapperRef}
         className="markdown-body"
         dangerouslySetInnerHTML={{ __html: htmlFromMarkdown }}
         onClick={handleOnClick}


### PR DESCRIPTION
## 💡 Feature: "Copy to Clipboard" Button for Code Blocks

### ✨ Description

This feature adds a "Copy to Clipboard" button to every code block rendered from Markdown. It allows users to easily copy code examples — especially useful when working with API usage snippets or tutorials.

### 🔧 Implementation

- Extended the `markdown-it` renderer to wrap fenced code blocks in a `div.code-block-wrapper` and attach a `data-copy` attribute containing the encoded code content.
- Used `useEffect` to dynamically mount a `<CopyToClipboard>` React component into a placeholder within each code block after rendering.
- Copy functionality is provided by `react-copy-to-clipboard` with visual feedback using `react-hot-toast`.
- Added scoped styles in `StyledWrapper.js`:
  - Positioning and hover effect for the copy icon
  - Top padding inside `<pre>` blocks to make room for the button

### 🔍 Preview

![Preview](URL-TO-GIF-OR-SCREENSHOT) <!-- Optional: Include a screenshot or GIF -->

### 🧪 Testing

Manually tested with Markdown files containing fenced code blocks (e.g., ```js) to ensure the button:
- is visible,
- copies content correctly,
- shows a toast confirmation on click.

### 📁 Files Changed

- `packages/bruno-app/src/components/MarkDown/index.jsx`
- `packages/bruno-app/src/components/MarkDown/StyledWrapper.js`

### 🧭 Branch Name

`feature/copy-code-button`
