### PR TITLE
Switch GraphQL variables code editor to json linting

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
@@ -64,7 +64,7 @@ const GraphQLVariables = ({ variables, item, collection }) => {
         font={get(preferences, 'font.codeFont', 'default')}
         fontSize={get(preferences, 'font.codeFontSize')}
         onEdit={onEdit}
-        mode="javascript"
+        mode="application/json"
         onRun={onRun}
         onSave={onSave}
         enableVariableHighlighting={true}


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
This PR addresses a small bug in the GraphQL variables code editor where it is incorrectly linting against javascript instead of json. This causes an incorrect warning to be rendered when using Bruno variables without quotes.

Closes #4755 

#### Before Change:
Allowed JS syntax to not get caught by linter and unquoted Bruno vars to have issues.
<img width="443" alt="Screenshot 2025-05-23 at 11 24 17 AM" src="https://github.com/user-attachments/assets/505ee5f3-7e17-4db9-8258-a169af8c0382" />
<img width="475" alt="Screenshot 2025-05-23 at 11 24 26 AM" src="https://github.com/user-attachments/assets/595ef2b8-f6a8-4376-9c2a-c4f50e844adb" />

#### After change:
Properly complains about js variable and no longer complains about unquoted variable.
<img width="448" alt="Screenshot 2025-05-23 at 11 24 46 AM" src="https://github.com/user-attachments/assets/ecfebd1f-8e7f-492a-8a4b-b86474d1a1a1" />
<img width="485" alt="Screenshot 2025-05-23 at 11 24 51 AM" src="https://github.com/user-attachments/assets/3d48a479-f812-410a-af94-d6db6428999e" />



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
