### PR TITLE
bug/improve-handling-of -Inherit-for-folders-and-requests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
-# .husky/pre-commit
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged

--- a/packages/bruno-app/src/components/FolderSettings/AuthMode/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/AuthMode/index.js
@@ -48,6 +48,15 @@ const AuthMode = ({ collection, folder }) => {
             className="dropdown-item"
             onClick={() => {
               dropdownTippyRef.current.hide();
+              onModeChange('inherit');
+            }}
+          >
+            Inherit
+          </div>
+          <div
+            className="dropdown-item"
+            onClick={() => {
+              dropdownTippyRef.current.hide();
               onModeChange('none');
             }}
           >

--- a/packages/bruno-app/src/components/RequestPane/Auth/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/index.js
@@ -42,7 +42,7 @@ const Auth = ({ item, collection }) => {
     for (let i of [...requestTreePath].reverse()) {
       if (i.type === 'folder') {
         const folderAuth = get(i, 'root.request.auth');
-        if (folderAuth && folderAuth.mode && folderAuth.mode !== 'none' && folderAuth.mode !== 'inherit') {
+        if (folderAuth && folderAuth.mode && folderAuth.mode !== 'inherit') {
           effectiveSource = {
             type: 'folder',
             name: i.name,

--- a/packages/bruno-converters/package.json
+++ b/packages/bruno-converters/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "test": "node --experimental-vm-modules $(npx which jest) --colors --collectCoverage",
+    "test": "jest --colors --collectCoverage",
     "prebuild": "npm run clean",
     "build": "rollup -c",
     "watch": "rollup -c -w",

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -2,7 +2,7 @@ import get from 'lodash/get';
 import { validateSchema, transformItemsInCollection, hydrateSeqInCollection, uuid } from '../common';
 import each from 'lodash/each';
 import postmanTranslation from './postman-translations';
-import { invalidVariableCharacterRegex } from '../constants/index';  
+import { invalidVariableCharacterRegex } from '../constants/index';
 
 const parseGraphQLRequest = (graphqlSource) => {
   try {
@@ -45,7 +45,7 @@ const convertV21Auth = (array) => {
 
 const constructUrlFromParts = (url) => {
   if (!url) return '';
-  
+
   const { protocol = 'http', host, path, port, query, hash } = url || {};
   const hostStr = Array.isArray(host) ? host.filter(Boolean).join('.') : host || '';
   const pathStr = Array.isArray(path) ? path.filter(Boolean).join('/') : path || '';
@@ -53,9 +53,9 @@ const constructUrlFromParts = (url) => {
   const queryStr =
     query && Array.isArray(query) && query.length > 0
       ? `?${query
-          .filter((q) => q && q.key)
-          .map((q) => `${q.key}=${q.value || ''}`)
-          .join('&')}`
+        .filter((q) => q && q.key)
+        .map((q) => `${q.key}=${q.value || ''}`)
+        .join('&')}`
       : '';
   const urlStr = `${protocol}://${hostStr}${portStr}${pathStr ? `/${pathStr}` : ''}${queryStr}`;
   return urlStr;
@@ -86,31 +86,31 @@ const constructUrl = (url) => {
   return '';
 };
 
-const importScriptsFromEvents = (events, requestObject) => {
-  events.forEach((event) => {
+const importScriptsFromEvents = (postmanEvents, brunoRequestObject) => {
+  postmanEvents.forEach((event) => {
     if (event.script && event.script.exec) {
       if (event.listen === 'prerequest') {
-        if (!requestObject.script) {
-          requestObject.script = {};
+        if (!brunoRequestObject.script) {
+          brunoRequestObject.script = {};
         }
 
         if (event.script.exec && event.script.exec.length > 0) {
-          requestObject.script.req = postmanTranslation(event.script.exec)
+          brunoRequestObject.script.req = postmanTranslation(event.script.exec)
         } else {
-          requestObject.script.req = '';
+          brunoRequestObject.script.req = '';
           console.warn('Unexpected event.script.exec type', typeof event.script.exec);
         }
       }
 
       if (event.listen === 'test') {
-        if (!requestObject.tests) {
-          requestObject.tests = {};
+        if (!brunoRequestObject.tests) {
+          brunoRequestObject.tests = {};
         }
 
         if (event.script.exec && event.script.exec.length > 0) {
-          requestObject.tests = postmanTranslation(event.script.exec)
+          brunoRequestObject.tests = postmanTranslation(event.script.exec)
         } else {
-          requestObject.tests = '';
+          brunoRequestObject.tests = '';
           console.warn('Unexpected event.script.exec type', typeof event.script.exec);
         }
       }
@@ -118,128 +118,152 @@ const importScriptsFromEvents = (events, requestObject) => {
   });
 };
 
-const importCollectionLevelVariables = (variables, requestObject) => {
-  const vars = variables.map((v) => ({
+const importCollectionLevelVariables = (postmanVariables, brunoRequestObject) => {
+  const vars = postmanVariables.map((v) => ({
     uid: uuid(),
     name: v.key.replace(invalidVariableCharacterRegex, '_'),
     value: v.value,
     enabled: true
   }));
 
-  requestObject.vars.req = vars;
+  brunoRequestObject.vars.req = vars;
 };
 
-const processAuth = (auth, requestObject) => {
-  if (!auth || !auth.type || auth.type === 'noauth') {
+const processAuth = (postmanAuth, brunoRequestObject, collection = false) => {
+  // As of 14/05/2025
+  // When collections are set to "No Auth" in Postman, the postmanAuth object is null.
+  // When folders and requests are set to "No Auth" in Postman, the postmanAuth object is present.
+  // When folders and requests are set to "Inherit" in Postman, the postmanAuth object is null.
+
+  // Handle collection-specific "No Auth"
+  if (collection && (!postmanAuth || !postmanAuth.type || postmanAuth.type === 'noauth')) {
+    brunoRequestObject.auth.mode = 'none';
     return;
   }
 
-  let authValues = auth[auth.type];
-  if (Array.isArray(authValues)) {
-    authValues = convertV21Auth(authValues);
+  // Handle "Inherit Auth" (typically for non-collections when postmanAuth is null)
+  if (!postmanAuth) {
+    brunoRequestObject.auth.mode = 'inherit';
+    return;
   }
 
-  if (auth.type === 'basic') {
-    requestObject.auth.mode = 'basic';
-    requestObject.auth.basic = {
-      username: authValues.username || '',
-      password: authValues.password || ''
-    };
-  } else if (auth.type === 'bearer') {
-    requestObject.auth.mode = 'bearer';
-    requestObject.auth.bearer = {
-      token: authValues.token || ''
-    };
-  } else if (auth.type === 'awsv4') {
-    requestObject.auth.mode = 'awsv4';
-    requestObject.auth.awsv4 = {
-      accessKeyId: authValues.accessKey || '',
-      secretAccessKey: authValues.secretKey || '',
-      sessionToken: authValues.sessionToken || '',
-      service: authValues.service || '',
-      region: authValues.region || '',
-      profileName: ''
-    };
-  } else if (auth.type === 'apikey') {
-    requestObject.auth.mode = 'apikey';
-    requestObject.auth.apikey = {
-      key: authValues.key || '',
-      value: authValues.value?.toString() || '', // Convert the value to a string as Postman's schema does not rigidly define the type of it,
-      placement: 'header' //By default we are placing the apikey values in headers!
-    };
-  } else if (auth.type === 'digest') {
-    requestObject.auth.mode = 'digest';
-    requestObject.auth.digest = {
-      username: authValues.username || '',
-      password: authValues.password || ''
-    };
-  } else if (auth.type === 'oauth2') {
-    const findValueUsingKey = (key) => {
-      return authValues[key] || '';
-    };
-    const oauth2GrantTypeMaps = {
-      authorization_code_with_pkce: 'authorization_code',
-      authorization_code: 'authorization_code',
-      client_credentials: 'client_credentials',
-      password_credentials: 'password_credentials'
-    };
-    const grantType = oauth2GrantTypeMaps[findValueUsingKey('grant_type')] || 'authorization_code';
+  // Handle explicit "No Auth"
+  if (postmanAuth.type === 'noauth') {
+    brunoRequestObject.auth.mode = 'none';
+    return;
+  }
 
-    requestObject.auth.mode = 'oauth2';
-    if (grantType === 'authorization_code') {
-      requestObject.auth.oauth2 = {
-        grantType: 'authorization_code',
-        authorizationUrl: findValueUsingKey('authUrl'),
-        callbackUrl: findValueUsingKey('redirect_uri'),
-        accessTokenUrl: findValueUsingKey('accessTokenUrl'),
-        refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
-        clientId: findValueUsingKey('clientId'),
-        clientSecret: findValueUsingKey('clientSecret'),
-        scope: findValueUsingKey('scope'),
-        state: findValueUsingKey('state'),
-        pkce: Boolean(findValueUsingKey('grant_type') == 'authorization_code_with_pkce'),
-        tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
-        credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
+  let pmAuthValues = postmanAuth[postmanAuth.type];
+  if (Array.isArray(pmAuthValues)) {
+    pmAuthValues = convertV21Auth(pmAuthValues);
+  }
+
+  brunoRequestObject.auth.mode = postmanAuth.type; // Set the mode based on Postman's auth type
+
+  switch (postmanAuth.type) {
+    case 'basic':
+      brunoRequestObject.auth.basic = {
+        username: pmAuthValues.username || '',
+        password: pmAuthValues.password || ''
       };
-    } else if (grantType === 'password_credentials') {
-      requestObject.auth.oauth2 = {
-        grantType: 'password',
-        accessTokenUrl: findValueUsingKey('accessTokenUrl'),
-        refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
-        username: findValueUsingKey('username'),
-        password: findValueUsingKey('password'),
-        clientId: findValueUsingKey('clientId'),
-        clientSecret: findValueUsingKey('clientSecret'),
-        scope: findValueUsingKey('scope'),
-        state: findValueUsingKey('state'),
-        tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
-        credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
+      break;
+    case 'bearer':
+      brunoRequestObject.auth.bearer = {
+        token: pmAuthValues.token || ''
       };
-    } else if (grantType === 'client_credentials') {
-      requestObject.auth.oauth2 = {
-        grantType: 'client_credentials',
-        accessTokenUrl: findValueUsingKey('accessTokenUrl'),
-        refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
-        clientId: findValueUsingKey('clientId'),
-        clientSecret: findValueUsingKey('clientSecret'),
-        scope: findValueUsingKey('scope'),
-        state: findValueUsingKey('state'),
-        tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
-        credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
+      break;
+    case 'awsv4':
+      brunoRequestObject.auth.awsv4 = {
+        accessKeyId: pmAuthValues.accessKey || '',
+        secretAccessKey: pmAuthValues.secretKey || '',
+        sessionToken: pmAuthValues.sessionToken || '',
+        service: pmAuthValues.service || '',
+        region: pmAuthValues.region || '',
+        profileName: ''
       };
-    }
-  } else {
-    console.warn('Unexpected auth.type', auth.type);
+      break;
+    case 'apikey':
+      brunoRequestObject.auth.apikey = {
+        key: pmAuthValues.key || '',
+        value: pmAuthValues.value?.toString() || '', // Convert the value to a string as Postman's schema does not rigidly define the type of it,
+        placement: 'header' //By default we are placing the apikey values in headers!
+      };
+      break;
+    case 'digest':
+      brunoRequestObject.auth.digest = {
+        username: pmAuthValues.username || '',
+        password: pmAuthValues.password || ''
+      };
+      break;
+    case 'oauth2':
+      _processOAuth2Auth(pmAuthValues, brunoRequestObject.auth);
+      break;
+    default:
+      console.warn('Unexpected postmanAuth.type:', postmanAuth.type, '- Mode set, but no specific config generated.');
+      break;
   }
 };
 
-const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, { useWorkers = false } = {}, scriptMap)=> {
+const _processOAuth2Auth = (pmAuthValues, targetAuthObject) => {
+  const getValue = (key) => pmAuthValues[key] || '';
+
+  // Maps Postman's grant_type to the grantType string expected in the target object
+  const oauth2GrantTypeMaps = {
+    authorization_code_with_pkce: 'authorization_code',
+    authorization_code: 'authorization_code',
+    client_credentials: 'client_credentials',
+    password_credentials: 'password_credentials'
+  };
+
+  const postmanGrantType = getValue('grant_type');
+  const targetGrantType = oauth2GrantTypeMaps[postmanGrantType] || 'authorization_code'; // Default
+
+  // Common properties for all OAuth2 grant types
+  const baseOAuth2Config = {
+    grantType: targetGrantType,
+    accessTokenUrl: getValue('accessTokenUrl'),
+    refreshTokenUrl: getValue('refreshTokenUrl'),
+    clientId: getValue('clientId'),
+    clientSecret: getValue('clientSecret'),
+    scope: getValue('scope'),
+    state: getValue('state'),
+    tokenPlacement: getValue('addTokenTo') === 'header' ? 'header' : 'url',
+    credentialsPlacement: getValue('client_authentication') === 'body' ? 'body' : 'basic_auth_header'
+  };
+
+  switch (targetGrantType) {
+    case 'authorization_code':
+      targetAuthObject.oauth2 = {
+        ...baseOAuth2Config,
+        authorizationUrl: getValue('authUrl'),
+        callbackUrl: getValue('redirect_uri'),
+        pkce: postmanGrantType === 'authorization_code_with_pkce',
+      };
+      break;
+    case 'password_credentials':
+      targetAuthObject.oauth2 = {
+        ...baseOAuth2Config,
+        username: getValue('username'),
+        password: getValue('password'),
+      };
+      break;
+    case 'client_credentials':
+      targetAuthObject.oauth2 = baseOAuth2Config;
+      break;
+    default:
+      console.warn('Unexpected OAuth2 grant type after mapping:', targetGrantType);
+      targetAuthObject.oauth2 = baseOAuth2Config; // Fallback to base
+      break;
+  }
+};
+
+const importPostmanV2CollectionItem = (brunoParent, postmanItem, { useWorkers = false } = {}, scriptMap) => {
   brunoParent.items = brunoParent.items || [];
   const folderMap = {};
   const requestMap = {};
   const requestMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE']
 
-  item.forEach((i, index) => {
+  postmanItem.forEach((i, index) => {
     if (isItemAFolder(i)) {
       const baseFolderName = i.name || 'Untitled Folder';
       let folderName = baseFolderName;
@@ -282,19 +306,14 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, { useWorke
       brunoParent.items.push(brunoFolderItem);
 
       // Folder level auth
-      if (i.auth) {
-        processAuth(i.auth, brunoFolderItem.root.request);
-      } else if (parentAuth) {
-        // Inherit parent auth if folder doesn't define its own
-        processAuth(parentAuth, brunoFolderItem.root.request);
-      }
+      processAuth(i.auth, brunoFolderItem.root.request);
 
       if (i.item && i.item.length) {
-         importPostmanV2CollectionItem(brunoFolderItem, i.item, i.auth ?? parentAuth, { useWorkers }, scriptMap);
+        importPostmanV2CollectionItem(brunoFolderItem, i.item, { useWorkers }, scriptMap);
       }
 
       if (i.event) {
-        if(useWorkers) {
+        if (useWorkers) {
           scriptMap.set(brunoFolderItem.uid, {
             events: i.event,
             request: brunoFolderItem.root.request
@@ -327,7 +346,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, { useWorke
         uid: uuid(),
         name: requestName,
         type: 'http-request',
-        seq: index + 1, 
+        seq: index + 1,
         request: {
           url: url,
           method: i?.request?.method?.toUpperCase(),
@@ -357,8 +376,8 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, { useWorke
       brunoParent.items.push(brunoRequestItem);
 
       if (i.event) {
-        if(useWorkers) {
-            scriptMap.set(brunoRequestItem.uid, {
+        if (useWorkers) {
+          scriptMap.set(brunoRequestItem.uid, {
             events: i.event,
             request: brunoRequestItem.request
           });
@@ -468,9 +487,8 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, { useWorke
         });
       });
 
-      // Handle request-level auth or inherit from parent
-      const auth = i.request.auth ?? parentAuth;
-      processAuth(auth, brunoRequestItem.request);
+      // Request-level auth
+      processAuth(i.request.auth, brunoRequestItem.request);
 
       each(get(i, 'request.url.query'), (param) => {
         brunoRequestItem.request.params.push({
@@ -504,7 +522,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, { useWorke
   });
 };
 
-  
+
 const searchLanguageByHeader = (headers) => {
   let contentType;
   each(headers, (header) => {
@@ -520,17 +538,17 @@ const searchLanguageByHeader = (headers) => {
   return contentType;
 };
 
-const importPostmanV2Collection = async (collection, { useWorkers = false }) => {
+const importPostmanV2Collection = async (postmanCollection, { useWorkers = false }) => {
   const brunoCollection = {
-    name: collection.info.name || 'Untitled Collection',
+    name: postmanCollection.info.name || 'Untitled Collection',
     uid: uuid(),
     version: '1',
     items: [],
     environments: [],
     root: {
-      docs: collection.info.description || '',
+      docs: postmanCollection.info.description || '',
       meta: {
-        name: collection.info.name || 'Untitled Collection'
+        name: postmanCollection.info.name || 'Untitled Collection'
       },
       request: {
         auth: {
@@ -550,28 +568,28 @@ const importPostmanV2Collection = async (collection, { useWorkers = false }) => 
     }
   };
 
-  if (collection.event) {
-    importScriptsFromEvents(collection.event, brunoCollection.root.request);
+  if (postmanCollection.event) {
+    importScriptsFromEvents(postmanCollection.event, brunoCollection.root.request);
   }
 
-  if (collection?.variable) {
-    importCollectionLevelVariables(collection.variable, brunoCollection.root.request);
+  if (postmanCollection?.variable) {
+    importCollectionLevelVariables(postmanCollection.variable, brunoCollection.root.request);
   }
 
   // Collection level auth
-  processAuth(collection.auth, brunoCollection.root.request);
+  processAuth(postmanCollection.auth, brunoCollection.root.request, true);
 
   // Create a single scriptMap for all items
   const scriptMap = useWorkers ? new Map() : null;
-  
-  importPostmanV2CollectionItem(brunoCollection, collection.item, collection.auth, { useWorkers }, scriptMap);
-  
+
+  importPostmanV2CollectionItem(brunoCollection, postmanCollection.item, { useWorkers }, scriptMap);
+
   // Process all scripts in a single call at the top level
   if (useWorkers && scriptMap && scriptMap.size > 0) {
     try {
-      const { default: scriptTranslationWorker } = await import('../workers/postman-translator-worker');    
+      const { default: scriptTranslationWorker } = await import('../workers/postman-translator-worker');
       const translatedScripts = await scriptTranslationWorker(scriptMap);
-      
+
       // Apply translated scripts to all items in the collection
       const applyScriptsToItems = (items) => {
         items.forEach(item => {
@@ -584,14 +602,14 @@ const importPostmanV2Collection = async (collection, { useWorkers = false }) => 
               if (!item.root.request.tests) {
                 item.root.request.tests = '';
               }
-              
+
               const script = translatedScripts.get(item.uid).request?.script?.req;
               const tests = translatedScripts.get(item.uid).request?.tests;
-              
+
               item.root.request.script.req = script && script.length > 0 ? script : '';
               item.root.request.tests = tests && tests.length > 0 ? tests : '';
             }
-            
+
             // Recursively apply to nested items
             if (item.items && item.items.length > 0) {
               applyScriptsToItems(item.items);
@@ -604,33 +622,33 @@ const importPostmanV2Collection = async (collection, { useWorkers = false }) => 
               if (!item.request.tests) {
                 item.request.tests = '';
               }
-              
+
               const script = translatedScripts.get(item.uid).request?.script?.req;
               const tests = translatedScripts.get(item.uid).request?.tests;
-              
+
               item.request.script.req = script && script.length > 0 ? script : '';
               item.request.tests = tests && tests.length > 0 ? tests : '';
             }
           }
         });
       };
-      
+
       applyScriptsToItems(brunoCollection.items);
-      
+
     } catch (error) {
       console.error('Error in script translation worker:', error);
     } finally {
       scriptMap.clear();
     }
   }
-  
+
   return brunoCollection;
 };
 
 
-const parsePostmanCollection = async (collection, { useWorkers = false }) => {
+const parsePostmanCollection = async (postmanCollection, { useWorkers = false }) => {
   try {
-    let schema = get(collection, 'info.schema');
+    let schema = get(postmanCollection, 'info.schema');
 
     let v2Schemas = [
       'https://schema.getpostman.com/json/collection/v2.0.0/collection.json',
@@ -640,7 +658,7 @@ const parsePostmanCollection = async (collection, { useWorkers = false }) => {
     ];
 
     if (v2Schemas.includes(schema)) {
-      return await importPostmanV2Collection(collection, { useWorkers });
+      return await importPostmanV2Collection(postmanCollection, { useWorkers });
     }
 
     throw new Error('Unsupported Postman schema version. Only Postman Collection v2.0 and v2.1 are supported.');

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/collection-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/collection-auth.spec.js
@@ -2,7 +2,48 @@ import { describe, it, expect } from '@jest/globals';
 import postmanToBruno from '../../../src/postman/postman-to-bruno';
 
 describe('Collection Authentication', () => {
-  it('should handle basic auth at collection level', async() => {
+  it('should handle no auth at collection level (when auth property is absent)', async () => {
+    const postmanCollection = {
+      info: {
+        name: 'Collection level no auth',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [],
+      event: [
+        {
+          listen: 'prerequest',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        },
+        {
+          listen: 'test',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+    // console.log('result', JSON.stringify(result, null, 2));
+
+    expect(result.root.request.auth).toEqual({
+      mode: 'none',
+      basic: null,
+      bearer: null,
+      awsv4: null,
+      apikey: null,
+      oauth2: null,
+      digest: null
+    });
+  });
+
+  it('should handle basic auth at collection level', async () => {
     const postmanCollection = {
       info: {
         name: 'Collection level basic auth',
@@ -61,7 +102,7 @@ describe('Collection Authentication', () => {
     });
   });
 
-  it('should handle bearer token auth at collection level', async() => {
+  it('should handle bearer token auth at collection level', async () => {
     const postmanCollection = {
       info: {
         name: 'Collection level bearer token',
@@ -112,9 +153,9 @@ describe('Collection Authentication', () => {
       oauth2: null,
       digest: null
     });
-  }); 
+  });
 
-  it('should handle API key auth at collection level', async() => {
+  it('should handle API key auth at collection level', async () => {
     const postmanCollection = {
       info: {
         name: 'Collection level api key',
@@ -173,7 +214,7 @@ describe('Collection Authentication', () => {
     });
   });
 
-  it('should handle digest auth at collection level', async() => {
+  it('should handle digest auth at collection level', async () => {
     const postmanCollection = {
       info: {
         name: 'Collection level digest auth',

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/folder-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/folder-auth.spec.js
@@ -2,7 +2,130 @@ import { describe, it, expect } from '@jest/globals';
 import postmanToBruno from '../../../src/postman/postman-to-bruno';
 
 describe('Folder Authentication', () => {
-  it('should handle basic auth at folder level', async() => {
+  it('should handle "Inherit Auth" at folder level (auth property absent)', async () => {
+    const postmanCollection = {
+      info: {
+        name: 'Folder Inherit Auth',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'Inheriting Folder',
+          items: []
+        }
+      ],
+      auth: {
+        type: 'basic',
+        basic: [
+          {
+            key: 'password',
+            value: 'testpass',
+            type: 'string'
+          },
+          {
+            key: 'username',
+            value: 'testuser',
+            type: 'string'
+          }
+        ]
+      },
+      event: [
+        {
+          listen: 'prerequest',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        },
+        {
+          listen: 'test',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    expect(result.items[0].root.request.auth).toEqual({
+      mode: 'inherit',
+      basic: null,
+      bearer: null,
+      awsv4: null,
+      apikey: null,
+      oauth2: null,
+      digest: null
+    });
+  });
+
+  it('should handle explicit "No Auth" at folder level', async () => {
+    const postmanCollection = {
+      info: {
+        name: 'Folder No Auth',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'No Auth Folder',
+          item: [],
+          auth: {
+            type: 'noauth'
+          }
+        }
+      ],
+      auth: {
+        type: 'basic',
+        basic: [
+          {
+            key: 'password',
+            value: 'testpass',
+            type: 'string'
+          },
+          {
+            key: 'username',
+            value: 'testuser',
+            type: 'string'
+          }
+        ]
+      },
+      event: [
+        {
+          listen: 'prerequest',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        },
+        {
+          listen: 'test',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    expect(result.items[0].root.request.auth).toEqual({
+      mode: 'none',
+      basic: null,
+      bearer: null,
+      awsv4: null,
+      apikey: null,
+      oauth2: null,
+      digest: null
+    });
+  });
+
+  it('should handle basic auth at folder level', async () => {
     const postmanCollection = {
       info: {
         name: 'Folder level basic auth',
@@ -65,7 +188,7 @@ describe('Folder Authentication', () => {
     });
   });
 
-  it('should handle bearer token auth at folder level', async() => {
+  it('should handle bearer token auth at folder level', async () => {
     const postmanCollection = {
       info: {
         name: 'Folder level bearer token',
@@ -120,7 +243,7 @@ describe('Folder Authentication', () => {
     });
   });
 
-  it('should handle API key auth at folder level', async() => {
+  it('should handle API key auth at folder level', async () => {
     const postmanCollection = {
       info: {
         name: 'Folder level API key',
@@ -180,7 +303,7 @@ describe('Folder Authentication', () => {
     });
   });
 
-  it('should handle digest auth at folder level', async() => {
+  it('should handle digest auth at folder level', async () => {
     const postmanCollection = {
       info: {
         name: 'Folder level digest auth',

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/request-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/request-auth.spec.js
@@ -2,7 +2,9 @@ import { describe, it, expect } from '@jest/globals';
 import postmanToBruno from '../../../src/postman/postman-to-bruno';
 
 describe('Request Authentication', () => {
-  it('should handle basic auth at request level', async() => {
+
+
+  it('should handle basic auth at request level', async () => {
     const postmanCollection = {
       info: {
         name: 'Request Auth Collection',
@@ -42,7 +44,7 @@ describe('Request Authentication', () => {
     });
   });
 
-  it('should inherit folder auth when request has no auth', async() => {
+  it('should inherit folder auth when request has no auth', async () => {
     const postmanCollection = {
       info: {
         name: 'Inherit Request Auth Collection',
@@ -71,11 +73,9 @@ describe('Request Authentication', () => {
     const result = await postmanToBruno(postmanCollection);
 
     expect(result.items[0].items[0].request.auth).toEqual({
-      mode: 'bearer',
+      mode: 'inherit',
       basic: null,
-      bearer: {
-        token: 'foldertoken'
-      },
+      bearer: null,
       awsv4: null,
       apikey: null,
       oauth2: null,
@@ -83,31 +83,113 @@ describe('Request Authentication', () => {
     });
   });
 
-  it('should override folder auth with request auth', async() => {
+  it('should handle "Inherit Auth" for request (auth property absent, inherits from folder)', async () => {
     const postmanCollection = {
       info: {
-        name: 'Override Request Auth Collection',
+        name: 'Request Inherit Auth from Folder',
         schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
       },
       item: [
         {
           name: 'Auth Folder',
-          auth: {
-            type: 'basic',
-            basic: [
-              { key: 'username', value: 'folderuser' },
-              { key: 'password', value: 'folderpass' }
-            ]
+          auth: { // Folder has auth
+            type: 'bearer',
+            bearer: [{ key: 'token', value: 'foldertoken' }]
           },
           item: [
             {
-              name: 'Override Auth Request',
+              name: 'Inheriting Request',
+              request: {
+                method: 'GET',
+                url: 'https://api.example.com/test'
+                // auth property is ABSENT for this request, meaning "Inherit auth from parent"
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    expect(result.items[0].items[0].request.auth).toEqual({
+      mode: 'inherit',
+      basic: null,
+      bearer: null, // It should NOT have the folder's token directly here after import
+      awsv4: null,
+      apikey: null,
+      oauth2: null,
+      digest: null
+    });
+  });
+
+  it('should handle "Inherit Auth" for request (auth property absent, inherits from collection if folder also inherits)', async () => {
+    const postmanCollection = {
+      info: {
+        name: 'Request Inherit Auth from Collection',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      auth: { // Collection has auth
+        type: 'basic',
+        basic: [
+
+          { key: 'username', value: 'requestuser' },
+          { key: 'password', value: 'requestpass' }
+        ]
+      },
+      item: [
+        {
+          name: 'Inheriting Folder',
+          // auth property is ABSENT for this folder
+          item: [
+            {
+              name: 'Inheriting Request',
+              request: {
+                method: 'GET',
+                url: 'https://api.example.com/test'
+                // auth property is ABSENT for this request
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    // Check folder first
+    expect(result.items[0].root.request.auth).toEqual({
+      mode: 'inherit',
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+    // Then check request
+    expect(result.items[0].items[0].request.auth).toEqual({
+      mode: 'inherit',
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+  });
+
+  it('should handle explicit "No Auth" at request level', async () => {
+    const postmanCollection = {
+      info: {
+        name: 'Request No Auth',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'Auth Folder', // Parent folder might have auth
+          auth: {
+            type: 'bearer',
+            bearer: [{ key: 'token', value: 'foldertoken' }]
+          },
+          item: [
+            {
+              name: 'Explicit No Auth Request',
               request: {
                 method: 'GET',
                 url: 'https://api.example.com/test',
-                auth: {
-                  type: 'bearer',
-                  bearer: [{ key: 'token', value: 'requesttoken' }]
+                auth: { // Request explicitly set to "No Auth"
+                  type: 'noauth'
                 }
               }
             }
@@ -119,16 +201,195 @@ describe('Request Authentication', () => {
     const result = await postmanToBruno(postmanCollection);
 
     expect(result.items[0].items[0].request.auth).toEqual({
-      mode: 'bearer',
+      mode: 'none', // <<<< KEY CHECK
       basic: null,
-      bearer: {
-        token: 'requesttoken'
-      },
+      bearer: null,
       awsv4: null,
       apikey: null,
       oauth2: null,
       digest: null
     });
   });
-  
+
+  it('should handle "Inherit Auth" for a request nested under multiple inheriting folders', async () => {
+    const postmanCollection = {
+      info: {
+        name: 'Multi-Level Inherit Auth',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      auth: { // Collection level auth
+        type: 'basic',
+        basic: [
+          { key: 'username', value: 'collectionUser' },
+          { key: 'password', value: 'collectionPass' }
+        ]
+      },
+      item: [
+        {
+          name: 'Folder Level 1 (Inherit)',
+          // auth property is ABSENT for this folder, meaning "Inherit"
+          item: [
+            {
+              name: 'Folder Level 2 (Inherit)',
+              // auth property is ABSENT for this folder, meaning "Inherit"
+              item: [
+                {
+                  name: 'Deeply Nested Request (Inherit)',
+                  request: {
+                    method: 'GET',
+                    url: 'https://api.example.com/deep'
+                    // auth property is ABSENT for this request, meaning "Inherit"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    // Check Folder Level 1
+    expect(result.items[0].root.request.auth).toEqual({
+      mode: 'inherit',
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+
+    // Check Folder Level 2
+    expect(result.items[0].items[0].root.request.auth).toEqual({
+      mode: 'inherit',
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+
+    // Check the Request
+    expect(result.items[0].items[0].items[0].request.auth).toEqual({
+      mode: 'inherit',
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+  });
+
+  it('should handle "Inherit Auth" where an intermediate folder has explicit auth', async () => {
+    const postmanCollection = {
+      info: {
+        name: 'Multi-Level Inherit with Override',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      auth: { // Collection level auth
+        type: 'basic',
+        basic: [
+          { key: 'username', value: 'collectionUser' },
+          { key: 'password', value: 'collectionPass' }
+        ]
+      },
+      item: [
+        {
+          name: 'Folder Level 1 (Explicit Bearer)',
+          auth: { // This folder has its own auth
+            type: 'bearer',
+            bearer: [{ key: 'token', value: 'folder1Token' }]
+          },
+          item: [
+            {
+              name: 'Folder Level 2 (Inherit from Folder 1)',
+              // auth property is ABSENT for this folder, meaning "Inherit"
+              item: [
+                {
+                  name: 'Deeply Nested Request (Inherit from Folder 1 via Folder 2)',
+                  request: {
+                    method: 'GET',
+                    url: 'https://api.example.com/deep_override'
+                    // auth property is ABSENT for this request, meaning "Inherit"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    // Check Folder Level 1
+    expect(result.items[0].root.request.auth).toEqual({
+      mode: 'bearer',
+      basic: null,
+      bearer: { token: 'folder1Token' }, // Explicitly set
+      awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+
+    // Check Folder Level 2
+    expect(result.items[0].items[0].root.request.auth).toEqual({
+      mode: 'inherit', // Inherits from Folder 1
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+
+    // Check the Request
+    expect(result.items[0].items[0].items[0].request.auth).toEqual({
+      mode: 'inherit', // Inherits from Folder 1
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+  });
+
+  it('should handle "Inherit Auth" where an intermediate folder has explicit "No Auth"', async () => {
+    const postmanCollection = {
+      info: {
+        name: 'Multi-Level Inherit with No Auth Stop',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      auth: { // Collection level auth
+        type: 'basic',
+        basic: [
+          { key: 'username', value: 'collectionUser' },
+          { key: 'password', value: 'collectionPass' }
+        ]
+      },
+      item: [
+        {
+          name: 'Folder Level 1 (Explicit No Auth)',
+          auth: { // This folder is explicitly "No Auth"
+            type: 'noauth'
+          },
+          item: [
+            {
+              name: 'Folder Level 2 (Inherit from Folder 1 - so No Auth)',
+              // auth property is ABSENT for this folder, meaning "Inherit"
+              item: [
+                {
+                  name: 'Deeply Nested Request (Inherit from Folder 1 via Folder 2 - so No Auth)',
+                  request: {
+                    method: 'GET',
+                    url: 'https://api.example.com/deep_no_auth_stop'
+                    // auth property is ABSENT for this request, meaning "Inherit"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    // Check Folder Level 1
+    expect(result.items[0].root.request.auth).toEqual({
+      mode: 'none', // Explicitly "No Auth"
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+
+    // Check Folder Level 2
+    expect(result.items[0].items[0].root.request.auth).toEqual({
+      mode: 'inherit', // Inherits from Folder 1
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+
+    // Check the Request
+    expect(result.items[0].items[0].items[0].request.auth).toEqual({
+      mode: 'inherit', // Inherits from Folder 1
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null
+    });
+  });
+
 });


### PR DESCRIPTION
Pull request resolves issue [Postman Importer: Improve Handling of "Inherit" for Folders and Requests](https://github.com/usebruno/bruno/issues/4664) bug.


**Key Changes:**

1. UI: Added "Inherit from Collection" Auth Option for Folders
    - Folders in Bruno can now explicitly be set to "Inherit from Collection" in their Auth tab.
    - This addresses a gap where folders previously lacked a distinct "inherit" state separate from "No Auth."
    
![image](https://github.com/user-attachments/assets/406d92c0-545d-40c7-8797-38bfb58e5019)

2. Importer: Correctly Map Postman's "Inherit Auth"
    - Modified the Postman importer (packages/bruno-converters).
    - When a Postman folder or request has its auth property omitted (indicating "Inherit auth from parent" in Postman), it is now imported into Bruno with its authentication mode set to "Inherit."
    - This prevents parent auth from being incorrectly hardcoded onto child items that should be inheriting.
3. Request Pane Logic: Allow "No Auth" to be Inherited Correctly
    - Ensured that if a parent item (collection or folder) is set to "No Auth," child items set to "Inherit Auth" will correctly inherit this "No Auth" state, matching Postman's behavior.
    - Previously, "No Auth" on a Bruno folder would break the inheritance chain differently.

**Unit Tests:**

- Added new unit tests to _collection-auth.spec.js_, _folder-auth.spec.js_, and _request-auth.spec.js_ within packages/bruno-converters to cover these scenarios, including:
    - Collection "No Auth."
    - Folder/Request "Inherit Auth" (absent auth property).
    - Folder/Request explicit "No Auth" (type: "noauth").
    - Multi-level inheritance scenarios.

