### PR TITLE
Update wording for clarification. Add tooltip.

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -55,7 +55,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, collectionName }) => 
           <div className="mt-2">{collectionName}</div>
           <>
             <label htmlFor="collectionLocation" className="block font-semibold mt-3">
-              Location
+              Storage Location
             </label>
             <input
               id="collection-location"
@@ -71,6 +71,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, collectionName }) => 
               onChange={e => {
                 formik.setFieldValue('collectionLocation', e.target.value);
               }}
+              title="Local path where the imported collection will be stored."
             />
           </>
           {formik.touched.collectionLocation && formik.errors.collectionLocation ? (
@@ -78,7 +79,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, collectionName }) => 
           ) : null}
 
           <div className="mt-1">
-            <span className="text-link cursor-pointer hover:underline" onClick={browse}>
+            <span className="text-link cursor-pointer hover:underline" onClick={browse} title="Select the directory where the collection should be stored.">
               Browse
             </span>
           </div>


### PR DESCRIPTION
# Description
When using Bruno for the first time and importing an OpenAPI config file I was confused by the prompt to provide a "Location" after selecting the json. This PR simply changes "Location" in the front end to "Storage Location" and ads a tooltip displayed when hovering above the "Browse".

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="726" alt="Screenshot 2025-05-25 at 15 36 11" src="https://github.com/user-attachments/assets/9c25ba79-f489-42ee-9f5d-1f7f03533433" />

Addresses #4760