### PR TITLE
fix: consider request execution errors as `CLI Tests` workflow failure

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -617,7 +617,7 @@ const handler = async function (argv) {
       }
     }
 
-    if (summary.failedAssertions + summary.failedTests + summary.failedRequests > 0) {
+    if ((summary.failedAssertions + summary.failedTests + summary.failedRequests > 0) || (summary?.errorRequests > 0)) {
       process.exit(constants.EXIT_STATUS.ERROR_FAILED_COLLECTION);
     }
   } catch (err) {


### PR DESCRIPTION
# Description

[jira](https://usebruno.atlassian.net/browse/BRU-1167)

for tests/assertions failure, process exits with an error code:

<img width="448" alt="failed_requests" src="https://github.com/user-attachments/assets/a4be6ce7-9344-4dcc-a31e-6e35be894b76" />

for errored requests, process does not exits with an error code:

<img width="433" alt="error_requests" src="https://github.com/user-attachments/assets/7097bbf4-3d77-47ed-bb1d-f914b1f3b028" />


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
