### PR TITLE
Variables tooltips

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -277,10 +277,17 @@ export default class CodeEditor extends React.Component {
         }
       }
       return found;
-    });
-    if (editor) {
+    });    if (editor) {
       editor.setOption('lint', this.props.mode && editor.getValue().trim().length > 0 ? this.lintOptions : false);
       editor.on('change', this._onEdit);
+      
+      // Setup variable highlighting and tooltips
+      let variables = getAllVariables(this.props.collection, this.props.item);
+      this.variables = variables;
+      
+      // Enable brunoVarInfo for variable tooltips
+      editor.setOption('brunoVarInfo', { variables });
+      
       this.addOverlay();
     }
     if (this.props.mode == 'javascript') {
@@ -304,7 +311,6 @@ export default class CodeEditor extends React.Component {
       });
     }
   }
-
   componentDidUpdate(prevProps) {
     // Ensure the changes caused by this update are not interpreted as
     // user-input changes which could otherwise result in an infinite
@@ -325,7 +331,13 @@ export default class CodeEditor extends React.Component {
     if (this.editor) {
       let variables = getAllVariables(this.props.collection, this.props.item);
       if (!isEqual(variables, this.variables)) {
+        this.variables = variables;
         this.addOverlay();
+        
+        // Update the brunoVarInfo option with the new variables
+        if (this.editor.getOption('brunoVarInfo')) {
+          this.editor.setOption('brunoVarInfo', { variables });
+        }
       }
     }
 
@@ -360,7 +372,6 @@ export default class CodeEditor extends React.Component {
       />
     );
   }
-
   addOverlay = () => {
     const mode = this.props.mode || 'application/ld+json';
     let variables = getAllVariables(this.props.collection, this.props.item);
@@ -368,6 +379,9 @@ export default class CodeEditor extends React.Component {
 
     defineCodeMirrorBrunoVariablesMode(variables, mode, false, this.props.enableVariableHighlighting);
     this.editor.setOption('mode', 'brunovariables');
+    
+    // Enable the brunoVarInfo option with the variables
+    this.editor.setOption('brunoVarInfo', { variables });
   };
 
   _onEdit = () => {

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -277,7 +277,9 @@ export default class CodeEditor extends React.Component {
         }
       }
       return found;
-    });    if (editor) {
+    });    
+    
+    if (editor) {
       editor.setOption('lint', this.props.mode && editor.getValue().trim().length > 0 ? this.lintOptions : false);
       editor.on('change', this._onEdit);
       

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -201,11 +201,10 @@ const GlobalStyle = createGlobalStyle`
     .cm-variable-invalid {
       color: ${(props) => props.theme.codemirror.variable.invalid};
     }
-  }
-  .CodeMirror-brunoVarInfo {
+  }  .CodeMirror-brunoVarInfo {
     color: ${(props) => props.theme.codemirror.variable.info.color};
     background: ${(props) => props.theme.codemirror.variable.info.bg};
-    border-radius: 2px;
+    border-radius: 4px;
     box-shadow: ${(props) => props.theme.codemirror.variable.info.boxShadow};
     box-sizing: border-box;
     font-size: 13px;
@@ -214,10 +213,30 @@ const GlobalStyle = createGlobalStyle`
     max-width: 800px;
     opacity: 0;
     overflow: hidden;
-    padding: 8px 8px;
+    padding: 10px 12px;
     position: fixed;
     transition: opacity 0.15s;
     z-index: 50;
+    border: 1px solid ${(props) => props.theme.codemirror.border};
+  }
+  
+  .CodeMirror-brunoVarInfo .info-name {
+    margin-bottom: 4px;
+    color: ${(props) => props.theme.codemirror.variable.valid};
+  }
+  
+  .CodeMirror-brunoVarInfo .info-status {
+    margin-bottom: 6px;
+    font-size: 12px;
+  }
+  
+  .CodeMirror-brunoVarInfo .info-description {
+    padding-top: 2px;
+    border-top: 1px solid ${(props) => props.theme.codemirror.border};
+    max-height: 300px;
+    overflow-y: auto;
+    font-family: monospace;
+    word-break: break-all;
   }
 
   .CodeMirror-brunoVarInfo :first-child {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -6,8 +6,6 @@
  *  LICENSE file at https://github.com/graphql/codemirror-graphql/tree/v0.8.3
  */
 
-import { interpolate } from '@usebruno/common';
-
 let CodeMirror;
 const SERVER_RENDERED = typeof window === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
 const { get } = require('lodash');
@@ -21,21 +19,20 @@ if (!SERVER_RENDERED) {
     }
 
     // Extract variable name from different formats
-    let variableName;
-    let variableValue;
+    let variableName = str;
 
-    if (str.startsWith('{{')) {
+    // path variables comes with brackets
+    if (str.startsWith('{{'))
       variableName = str.replace('{{', '').replace('}}', '').trim();
-      variableValue = interpolate(get(options.variables, variableName), options.variables);
-    } else if (str.startsWith('/:')) {
+
+    if (str.startsWith('/:'))
       variableName = str.replace('/:', '').trim();
-      variableValue =
-        options.variables && options.variables.pathParams ? options.variables.pathParams[variableName] : undefined;
-    }
+
+    let variableValue = options.variables[variableName] || undefined;
 
     // Create container
     const into = document.createElement('div');
-    
+
     // Add variable name (common for both defined and undefined cases)
     const nameDiv = document.createElement('div');
     nameDiv.className = 'info-name';
@@ -54,7 +51,7 @@ if (!SERVER_RENDERED) {
       // Add formatted value for defined variables
       const descriptionDiv = document.createElement('div');
       descriptionDiv.className = 'info-description';
-      
+
       let displayValue;
       if (options?.variables?.maskedEnvVariables?.includes(variableName)) {
         displayValue = '*****'; // Mask sensitive values
@@ -67,14 +64,13 @@ if (!SERVER_RENDERED) {
       } else {
         displayValue = variableValue;
       }
-      
+
       descriptionDiv.appendChild(document.createTextNode(displayValue));
       into.appendChild(descriptionDiv);
     }
 
     return into;
   };
-
   CodeMirror.defineOption('brunoVarInfo', false, function (cm, options, old) {
     if (old && old !== CodeMirror.Init) {
       const oldOnMouseOver = cm.state.brunoVarInfo.onMouseOver;
@@ -139,7 +135,7 @@ if (!SERVER_RENDERED) {
     CodeMirror.on(document, 'mousemove', onMouseMove);
     CodeMirror.on(cm.getWrapperElement(), 'mouseout', onMouseOut);
   }
-
+  
   function onMouseHover(cm, box) {
     const pos = cm.coordsChar({
       left: (box.left + box.right) / 2,
@@ -177,12 +173,12 @@ if (!SERVER_RENDERED) {
 
     if (topPos < 0) {
       topPos = box.bottom;
-    }    
-    
+    }
+
     // make popup appear higher above the cursor to allow selection of the variable
     // Apply a larger offset to ensure the tooltip doesn't overlap with the cursor
     topPos = topPos - 90;
-    
+
     // Ensure the tooltip doesn't go off-screen at the top
     if (topPos < 10) {
       topPos = 10;

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -177,11 +177,15 @@ if (!SERVER_RENDERED) {
 
     if (topPos < 0) {
       topPos = box.bottom;
-    }
-
-    // make popup appear on top of cursor
-    if (topPos > 70) {
-      topPos = topPos - 70;
+    }    
+    
+    // make popup appear higher above the cursor to allow selection of the variable
+    // Apply a larger offset to ensure the tooltip doesn't overlap with the cursor
+    topPos = topPos - 90;
+    
+    // Ensure the tooltip doesn't go off-screen at the top
+    if (topPos < 10) {
+      topPos = 10;
     }
 
     let leftPos = Math.max(0, window.innerWidth - popupWidth - 15);


### PR DESCRIPTION
Add logic and style to show tooltips for variables when they are hovered with the mouse

# Description

Bruno was missing the capability to show the value of a variable when the user hovers with the mouse. This is a very convenient way to, for example, quickly check what value is passed into a payload

![image](https://github.com/user-attachments/assets/bedeceb1-6c88-49f1-bb22-e23e496ad5cf)


### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
