### PR TITLE
Added Support for Absolute Path Reference in bru.runner.setNextRequest()

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1236,7 +1236,13 @@ const registerNetworkIpc = (mainWindow) => {
             if (nextRequestName === null) {
               break;
             }
-            const nextRequestIdx = folderRequests.findIndex((request) => request.name === nextRequestName);
+            const nextRequestIdx = folderRequests.findIndex((request) => {
+              if (nextRequestName.includes('.bru')) {
+                return request.pathname.includes(nextRequestName)
+              }
+              return request.name === nextRequestName
+            }
+            );
             if (nextRequestIdx >= 0) {
               currentRequestIndex = nextRequestIdx;
             } else {


### PR DESCRIPTION
# Description
[JIRA](https://usebruno.atlassian.net/browse/BRU-1137) 

- Added Support for Absolute Path Reference in `bru.runner.setNextRequest()`
- Added intellisense for better UX, by providing `sub-path` suggestions for all collection requests

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
