### PR TITLE
Fix: postman collection fails when auth object missing auth values

### DIFF
--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -11,7 +11,8 @@ const AUTH_TYPES = Object.freeze({
   APIKEY: 'apikey',
   DIGEST: 'digest',
   OAUTH2: 'oauth2',
-  NOAUTH: 'noauth'
+  NOAUTH: 'noauth',
+  NONE: 'none'
 });
 
 const parseGraphQLRequest = (graphqlSource) => {
@@ -139,7 +140,7 @@ const importCollectionLevelVariables = (variables, requestObject) => {
   requestObject.vars.req = vars;
 };
 
-const processAuth = (auth, requestObject) => {
+export const processAuth = (auth, requestObject) => {
   if (!auth || !auth.type || auth.type === AUTH_TYPES.NOAUTH) {
     return;
   }
@@ -148,6 +149,7 @@ const processAuth = (auth, requestObject) => {
 
   if(!authValues) {
     console.warn('Unexpected auth.type, auth object doesn\'t have the key', auth.type);
+    requestObject.auth.mode = AUTH_TYPES.NONE;
     return;
   }
 
@@ -252,6 +254,7 @@ const processAuth = (auth, requestObject) => {
       }
       break;
     default:
+      requestObject.auth.mode = AUTH_TYPES.NONE;
       console.warn('Unexpected auth.type', auth.type);
   }
 };
@@ -690,6 +693,5 @@ const postmanToBruno = async (postmanCollection, { useWorkers = false } = {}) =>
     throw new Error(`Import collection failed: ${err.message}`);
   }
 };
-
 
 export default postmanToBruno;

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -4,6 +4,16 @@ import each from 'lodash/each';
 import postmanTranslation from './postman-translations';
 import { invalidVariableCharacterRegex } from '../constants/index';  
 
+const AUTH_TYPES = Object.freeze({
+  BASIC: 'basic',
+  BEARER: 'bearer',
+  AWSV4: 'awsv4',
+  APIKEY: 'apikey',
+  DIGEST: 'digest',
+  OAUTH2: 'oauth2',
+  NOAUTH: 'noauth'
+});
+
 const parseGraphQLRequest = (graphqlSource) => {
   try {
     let queryResultObject = {
@@ -130,106 +140,119 @@ const importCollectionLevelVariables = (variables, requestObject) => {
 };
 
 const processAuth = (auth, requestObject) => {
-  if (!auth || !auth.type || auth.type === 'noauth') {
+  if (!auth || !auth.type || auth.type === AUTH_TYPES.NOAUTH) {
     return;
   }
 
   let authValues = auth[auth.type];
+
+  if(!authValues) {
+    console.warn('Unexpected auth.type, auth object doesn\'t have the key', auth.type);
+    return;
+  }
+
   if (Array.isArray(authValues)) {
     authValues = convertV21Auth(authValues);
   }
 
-  if (auth.type === 'basic') {
-    requestObject.auth.mode = 'basic';
-    requestObject.auth.basic = {
-      username: authValues.username || '',
-      password: authValues.password || ''
-    };
-  } else if (auth.type === 'bearer') {
-    requestObject.auth.mode = 'bearer';
-    requestObject.auth.bearer = {
-      token: authValues.token || ''
-    };
-  } else if (auth.type === 'awsv4') {
-    requestObject.auth.mode = 'awsv4';
-    requestObject.auth.awsv4 = {
-      accessKeyId: authValues.accessKey || '',
-      secretAccessKey: authValues.secretKey || '',
-      sessionToken: authValues.sessionToken || '',
-      service: authValues.service || '',
-      region: authValues.region || '',
-      profileName: ''
-    };
-  } else if (auth.type === 'apikey') {
-    requestObject.auth.mode = 'apikey';
-    requestObject.auth.apikey = {
-      key: authValues.key || '',
-      value: authValues.value?.toString() || '', // Convert the value to a string as Postman's schema does not rigidly define the type of it,
-      placement: 'header' //By default we are placing the apikey values in headers!
-    };
-  } else if (auth.type === 'digest') {
-    requestObject.auth.mode = 'digest';
-    requestObject.auth.digest = {
-      username: authValues.username || '',
-      password: authValues.password || ''
-    };
-  } else if (auth.type === 'oauth2') {
-    const findValueUsingKey = (key) => {
-      return authValues[key] || '';
-    };
-    const oauth2GrantTypeMaps = {
-      authorization_code_with_pkce: 'authorization_code',
-      authorization_code: 'authorization_code',
-      client_credentials: 'client_credentials',
-      password_credentials: 'password_credentials'
-    };
-    const grantType = oauth2GrantTypeMaps[findValueUsingKey('grant_type')] || 'authorization_code';
+  switch (auth.type) {
+    case AUTH_TYPES.BASIC:
+      requestObject.auth.mode = AUTH_TYPES.BASIC;
+      requestObject.auth.basic = {
+        username: authValues.username || '',
+        password: authValues.password || ''
+      };
+      break;
+    case AUTH_TYPES.BEARER:
+      requestObject.auth.mode = AUTH_TYPES.BEARER;
+      requestObject.auth.bearer = {
+        token: authValues.token || ''
+      };
+      break;
+    case AUTH_TYPES.AWSV4:
+      requestObject.auth.mode = AUTH_TYPES.AWSV4;
+      requestObject.auth.awsv4 = {
+        accessKeyId: authValues.accessKey || '',
+        secretAccessKey: authValues.secretKey || '',
+        sessionToken: authValues.sessionToken || '',
+        service: authValues.service || '',
+        region: authValues.region || '',
+        profileName: ''
+      };
+      break;
+    case AUTH_TYPES.APIKEY:
+      requestObject.auth.mode = AUTH_TYPES.APIKEY;
+      requestObject.auth.apikey = {
+        key: authValues.key || '',
+        value: authValues.value?.toString() || '', // Convert the value to a string as Postman's schema does not rigidly define the type of it,
+        placement: 'header' //By default we are placing the apikey values in headers!
+      };
+      break;
+    case AUTH_TYPES.DIGEST:
+      requestObject.auth.mode = AUTH_TYPES.DIGEST;
+      requestObject.auth.digest = {
+        username: authValues.username || '',
+        password: authValues.password || ''
+      };
+      break;
+    case AUTH_TYPES.OAUTH2:
+      const findValueUsingKey = (key) => {
+        return authValues[key] || '';
+      };
+      const oauth2GrantTypeMaps = {
+        authorization_code_with_pkce: 'authorization_code',
+        authorization_code: 'authorization_code',
+        client_credentials: 'client_credentials',
+        password_credentials: 'password_credentials'
+      };
+      const grantType = oauth2GrantTypeMaps[findValueUsingKey('grant_type')] || 'authorization_code';
 
-    requestObject.auth.mode = 'oauth2';
-    if (grantType === 'authorization_code') {
-      requestObject.auth.oauth2 = {
-        grantType: 'authorization_code',
-        authorizationUrl: findValueUsingKey('authUrl'),
-        callbackUrl: findValueUsingKey('redirect_uri'),
-        accessTokenUrl: findValueUsingKey('accessTokenUrl'),
-        refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
-        clientId: findValueUsingKey('clientId'),
-        clientSecret: findValueUsingKey('clientSecret'),
-        scope: findValueUsingKey('scope'),
-        state: findValueUsingKey('state'),
-        pkce: Boolean(findValueUsingKey('grant_type') == 'authorization_code_with_pkce'),
-        tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
-        credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
-      };
-    } else if (grantType === 'password_credentials') {
-      requestObject.auth.oauth2 = {
-        grantType: 'password',
-        accessTokenUrl: findValueUsingKey('accessTokenUrl'),
-        refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
-        username: findValueUsingKey('username'),
-        password: findValueUsingKey('password'),
-        clientId: findValueUsingKey('clientId'),
-        clientSecret: findValueUsingKey('clientSecret'),
-        scope: findValueUsingKey('scope'),
-        state: findValueUsingKey('state'),
-        tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
-        credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
-      };
-    } else if (grantType === 'client_credentials') {
-      requestObject.auth.oauth2 = {
-        grantType: 'client_credentials',
-        accessTokenUrl: findValueUsingKey('accessTokenUrl'),
-        refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
-        clientId: findValueUsingKey('clientId'),
-        clientSecret: findValueUsingKey('clientSecret'),
-        scope: findValueUsingKey('scope'),
-        state: findValueUsingKey('state'),
-        tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
-        credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
-      };
-    }
-  } else {
-    console.warn('Unexpected auth.type', auth.type);
+      requestObject.auth.mode = AUTH_TYPES.OAUTH2;
+      if (grantType === 'authorization_code') {
+        requestObject.auth.oauth2 = {
+          grantType: 'authorization_code',
+          authorizationUrl: findValueUsingKey('authUrl'),
+          callbackUrl: findValueUsingKey('redirect_uri'),
+          accessTokenUrl: findValueUsingKey('accessTokenUrl'),
+          refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
+          clientId: findValueUsingKey('clientId'),
+          clientSecret: findValueUsingKey('clientSecret'),
+          scope: findValueUsingKey('scope'),
+          state: findValueUsingKey('state'),
+          pkce: Boolean(findValueUsingKey('grant_type') == 'authorization_code_with_pkce'),
+          tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
+          credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
+        };
+      } else if (grantType === 'password_credentials') {
+        requestObject.auth.oauth2 = {
+          grantType: 'password',
+          accessTokenUrl: findValueUsingKey('accessTokenUrl'),
+          refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
+          username: findValueUsingKey('username'),
+          password: findValueUsingKey('password'),
+          clientId: findValueUsingKey('clientId'),
+          clientSecret: findValueUsingKey('clientSecret'),
+          scope: findValueUsingKey('scope'),
+          state: findValueUsingKey('state'),
+          tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
+          credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
+        };
+      } else if (grantType === 'client_credentials') {
+        requestObject.auth.oauth2 = {
+          grantType: 'client_credentials',
+          accessTokenUrl: findValueUsingKey('accessTokenUrl'),
+          refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
+          clientId: findValueUsingKey('clientId'),
+          clientSecret: findValueUsingKey('clientSecret'),
+          scope: findValueUsingKey('scope'),
+          state: findValueUsingKey('state'),
+          tokenPlacement: findValueUsingKey('addTokenTo') == 'header' ? 'header' : 'url',
+          credentialsPlacement: findValueUsingKey('client_authentication') == 'body' ? 'body' : 'basic_auth_header'
+        };
+      }
+      break;
+    default:
+      console.warn('Unexpected auth.type', auth.type);
   }
 };
 

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/collection-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/collection-auth.spec.js
@@ -235,4 +235,92 @@ describe('Collection Authentication', () => {
       }
     });
   });
+
+  it('should handle missing auth values when auth.type exists', async() => {
+    const postmanCollection = {
+      info: {
+        name: 'Collection with missing auth values',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [],
+      auth: {
+        type: 'basic'
+        // Missing basic auth values
+      },
+      event: [
+        {
+          listen: 'prerequest',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        },
+        {
+          listen: 'test',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    expect(result.root.request.auth).toEqual({
+      mode: 'none',
+      basic: null,
+      bearer: null,
+      awsv4: null,
+      apikey: null,
+      oauth2: null,
+      digest: null
+    });
+  });
+
+  it('should handle missing auth values for different auth types', async() => {
+    const postmanCollection = {
+      info: {
+        name: 'Collection with missing auth values for different types',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [],
+      auth: {
+        type: 'bearer'
+        // Missing bearer token
+      },
+      event: [
+        {
+          listen: 'prerequest',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        },
+        {
+          listen: 'test',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            exec: ['']
+          }
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    expect(result.root.request.auth).toEqual({
+      mode: 'none',
+      basic: null,
+      bearer: null,
+      awsv4: null,
+      apikey: null,
+      oauth2: null,
+      digest: null
+    });
+  });
 });

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/folder-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/folder-auth.spec.js
@@ -244,4 +244,53 @@ describe('Folder Authentication', () => {
       digest: { username: 'digest user', password: 'digest pass' }
     });
   });
+
+  it('should handle missing auth values in folder level auth', async() => {
+    const postmanCollection = {
+      info: {
+        name: 'Folder with missing auth values',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'folder',
+          item: [],
+          auth: {
+            type: 'basic'
+            // Missing basic values
+          },
+          event: [
+            {
+              listen: 'prerequest',
+              script: {
+                type: 'text/javascript',
+                packages: {},
+                exec: ['']
+              }
+            },
+            {
+              listen: 'test',
+              script: {
+                type: 'text/javascript',
+                packages: {},
+                exec: ['']
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    expect(result.items[0].root.request.auth).toEqual({
+      mode: 'none',
+      basic: null,
+      bearer: null,
+      awsv4: null,
+      apikey: null,
+      oauth2: null,
+      digest: null
+    });
+  });
 });

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
@@ -1,0 +1,398 @@
+const { processAuth } = require("../../../src/postman/postman-to-bruno");
+
+
+describe('processAuth', () => {
+  let requestObject;
+
+  beforeEach(() => {
+    requestObject = {
+      auth: {
+        mode: 'none',
+        basic: null,
+        bearer: null,
+        awsv4: null,
+        apikey: null,
+        oauth2: null,
+        digest: null
+      }
+    };
+  });
+
+  it('should handle no auth', () => {
+    processAuth(null, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+
+  it('should handle noauth type', () => {
+    processAuth({ type: 'noauth' }, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+
+  it('should handle basic auth', () => {
+    const auth = {
+      type: 'basic',
+      basic: [
+        { key: 'username', value: 'testuser', type: 'string' },
+        { key: 'password', value: 'testpass', type: 'string' }
+      ]
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('basic');
+    expect(requestObject.auth.basic).toEqual({
+      username: 'testuser',
+      password: 'testpass'
+    });
+  });
+
+  it('should handle basic auth with missing values', () => {
+    const auth = {
+      type: 'basic',
+      basic: {}
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('basic');
+    expect(requestObject.auth.basic).toEqual({
+      username: '',
+      password: ''
+    });
+  });
+
+  it('should handle basic auth with missing basic key', () => {
+    const auth = {
+      type: 'basic'
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+
+  it('should handle bearer auth', () => {
+    const auth = {
+      type: 'bearer',
+      bearer: {
+        token: 'test-token'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('bearer');
+    expect(requestObject.auth.bearer).toEqual({
+      token: 'test-token'
+    });
+  });
+
+  it('should handle bearer auth with missing values', () => {
+    const auth = {
+      type: 'bearer',
+      bearer: {}
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('bearer');
+    expect(requestObject.auth.bearer).toEqual({
+      token: ''
+    });
+  });
+
+  it('should handle bearer auth with missing bearer key', () => {
+    const auth = {
+      type: 'bearer'
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+
+  it('should handle awsv4 auth', () => {
+    const auth = {
+      type: 'awsv4',
+      awsv4: {
+        accessKey: 'test-access-key',
+        secretKey: 'test-secret-key',
+        sessionToken: 'test-session-token',
+        service: 'test-service',
+        region: 'test-region'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('awsv4');
+    expect(requestObject.auth.awsv4).toEqual({
+      accessKeyId: 'test-access-key',
+      secretAccessKey: 'test-secret-key',
+      sessionToken: 'test-session-token',
+      service: 'test-service',
+      region: 'test-region',
+      profileName: ''
+    });
+  });
+
+  it('should handle awsv4 auth with missing values', () => {
+    const auth = {
+      type: 'awsv4',
+      awsv4: {}
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('awsv4');
+    expect(requestObject.auth.awsv4).toEqual({
+      accessKeyId: '',
+      secretAccessKey: '',
+      sessionToken: '',
+      service: '',
+      region: '',
+      profileName: ''
+    });
+  });
+
+  it('should handle awsv4 auth with missing awsv4 key', () => {
+    const auth = {
+      type: 'awsv4'
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+
+  it('should handle apikey auth', () => {
+    const auth = {
+      type: 'apikey',
+      apikey: {
+        key: 'test-key',
+        value: 'test-value'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('apikey');
+    expect(requestObject.auth.apikey).toEqual({
+      key: 'test-key',
+      value: 'test-value',
+      placement: 'header'
+    });
+  });
+
+  it('should handle apikey auth with missing values', () => {
+    const auth = {
+      type: 'apikey',
+      apikey: {}
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('apikey');
+    expect(requestObject.auth.apikey).toEqual({
+      key: '',
+      value: '',
+      placement: 'header'
+    });
+  });
+
+  it('should handle apikey auth with missing apikey key', () => {
+    const auth = {
+      type: 'apikey'
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+
+  it('should handle digest auth', () => {
+    const auth = {
+      type: 'digest',
+      digest: {
+        username: 'testuser',
+        password: 'testpass'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('digest');
+    expect(requestObject.auth.digest).toEqual({
+      username: 'testuser',
+      password: 'testpass'
+    });
+  });
+
+  it('should handle digest auth with missing values', () => {
+    const auth = {
+      type: 'digest',
+      digest: {}
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('digest');
+    expect(requestObject.auth.digest).toEqual({
+      username: '',
+      password: ''
+    });
+  });
+
+  it('should handle digest auth with missing digest key', () => {
+    const auth = {
+      type: 'digest'
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+
+  it('should handle oauth2 auth with authorization_code grant type', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'authorization_code',
+        authUrl: 'https://auth.example.com',
+        redirect_uri: 'https://callback.example.com',
+        accessTokenUrl: 'https://token.example.com',
+        refreshTokenUrl: 'https://refresh.example.com',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        scope: 'test-scope',
+        state: 'test-state',
+        addTokenTo: 'header',
+        client_authentication: 'body'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('oauth2');
+    expect(requestObject.auth.oauth2).toEqual({
+      grantType: 'authorization_code',
+      authorizationUrl: 'https://auth.example.com',
+      callbackUrl: 'https://callback.example.com',
+      accessTokenUrl: 'https://token.example.com',
+      refreshTokenUrl: 'https://refresh.example.com',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      scope: 'test-scope',
+      state: 'test-state',
+      pkce: false,
+      tokenPlacement: 'header',
+      credentialsPlacement: 'body'
+    });
+  });
+
+  it('should handle oauth2 auth with password_credentials grant type', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'password_credentials',
+        accessTokenUrl: 'https://token.example.com',
+        refreshTokenUrl: 'https://refresh.example.com',
+        username: 'testuser',
+        password: 'testpass',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        scope: 'test-scope',
+        state: 'test-state',
+        addTokenTo: 'header',
+        client_authentication: 'body'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('oauth2');
+    expect(requestObject.auth.oauth2).toEqual({
+      grantType: 'password',
+      accessTokenUrl: 'https://token.example.com',
+      refreshTokenUrl: 'https://refresh.example.com',
+      username: 'testuser',
+      password: 'testpass',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      scope: 'test-scope',
+      state: 'test-state',
+      tokenPlacement: 'header',
+      credentialsPlacement: 'body'
+    });
+  });
+
+  it('should handle oauth2 auth with client_credentials grant type', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'client_credentials',
+        accessTokenUrl: 'https://token.example.com',
+        refreshTokenUrl: 'https://refresh.example.com',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        scope: 'test-scope',
+        state: 'test-state',
+        addTokenTo: 'header',
+        client_authentication: 'body'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('oauth2');
+    expect(requestObject.auth.oauth2).toEqual({
+      grantType: 'client_credentials',
+      accessTokenUrl: 'https://token.example.com',
+      refreshTokenUrl: 'https://refresh.example.com',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      scope: 'test-scope',
+      state: 'test-state',
+      tokenPlacement: 'header',
+      credentialsPlacement: 'body'
+    });
+  });
+
+  it('should handle oauth2 auth with missing values', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {}
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('oauth2');
+    expect(requestObject.auth.oauth2).toEqual({
+      grantType: 'authorization_code',
+      authorizationUrl: '',
+      callbackUrl: '',
+      accessTokenUrl: '',
+      refreshTokenUrl: '',
+      clientId: '',
+      clientSecret: '',
+      scope: '',
+      state: '',
+      pkce: false,
+      tokenPlacement: 'url',
+      credentialsPlacement: 'basic_auth_header'
+    });
+  });
+
+  it('should handle oauth2 auth with missing oauth2 key', () => {
+    const auth = {
+      type: 'oauth2'
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+
+  it('should handle oauth2 auth with authorization_code_with_pkce grant type', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'authorization_code_with_pkce',
+        authUrl: 'https://auth.example.com',
+        redirect_uri: 'https://callback.example.com',
+        accessTokenUrl: 'https://token.example.com',
+        refreshTokenUrl: 'https://refresh.example.com',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        scope: 'test-scope',
+        state: 'test-state',
+        addTokenTo: 'header',
+        client_authentication: 'body'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('oauth2');
+    expect(requestObject.auth.oauth2).toEqual({
+      grantType: 'authorization_code',
+      authorizationUrl: 'https://auth.example.com',
+      callbackUrl: 'https://callback.example.com',
+      accessTokenUrl: 'https://token.example.com',
+      refreshTokenUrl: 'https://refresh.example.com',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      scope: 'test-scope',
+      state: 'test-state',
+      pkce: true,
+      tokenPlacement: 'header',
+      credentialsPlacement: 'body'
+    });
+  });
+
+  it('should handle unknown auth type', () => {
+    const auth = {
+      type: 'unknown'
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('none');
+  });
+});

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/request-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/request-auth.spec.js
@@ -130,5 +130,37 @@ describe('Request Authentication', () => {
       digest: null
     });
   });
-  
+
+  it('should handle missing basic auth values in request level', async() => {
+    const postmanCollection = {
+      info: {
+        name: 'Missing Auth Request Collection',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'Missing Auth Request',
+          request: {
+            method: 'GET',
+            url: 'https://api.example.com/test',
+            auth: {
+              type: 'basic'
+            }
+          }
+        }
+      ]
+    };
+
+    const result = await postmanToBruno(postmanCollection);
+
+    expect(result.items[0].request.auth).toEqual({
+      mode: 'none',
+      basic: null,
+      bearer: null,
+      awsv4: null,
+      apikey: null,
+      oauth2: null,
+      digest: null
+    });
+  });
 });


### PR DESCRIPTION
# Description
[Jira ticket](https://usebruno.atlassian.net/jira/software/projects/BRU/boards/1/backlog?selectedIssue=BRU-1174&atlOrigin=eyJpIjoiYjE3NTNlN2E4ZTdjNDc0ZWFhM2VkOWYyOTZhNjcxZDYiLCJwIjoiaiJ9)

Postman collection with missing auth values is failing to get imported also it doesn't show any error while it is failing. this happens when user has selected a auth mode for a request, folder, collection but didn't provide any data related to it. this results in an auth object

```js
auth : {
 type : "bearer"
}
```
Yet we went on to check for "bearer" key within auth object, which resulted in the failure.

## Fix
 If any of the auth object doesn't have the necessary values to go with, basically the auth object is missing keys like "bearer", "apikey", we will default to auth mode to be "none". also we will return from there when such an event happens

Current behaviour

https://github.com/user-attachments/assets/7e1b6afa-f126-4cd7-8800-35ded91292fb

Post Fix behaviour

https://github.com/user-attachments/assets/6bc207ae-7315-4b75-b523-9b8814cb8d4b





<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
