### PR TITLE
Fix: Made `reporter-skip-headers` option case-insensitive in bruno-cli

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -513,9 +513,11 @@ const handler = async function (argv) {
       }
 
       const deleteHeaderIfExists = (headers, header) => {
-        if (headers && headers[header]) {
-          delete headers[header];
-        }
+        Object.keys(headers).forEach((key) => {
+          if (key.toLowerCase() === header.toLowerCase()) {
+            delete headers[key];
+          }
+        });
       };
 
       if (reporterSkipHeaders?.length) {


### PR DESCRIPTION
# Description

- Fix: Made `reporter-skip-headers` option case-insensitive in bruno-cli

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
