### PR TITLE
Added json copy button to response pane

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseCopy/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseCopy/StyledWrapper.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  font-size: 0.8125rem;
+  color: ${(props) => props.theme.requestTabPanel.responseStatus};
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/ResponsePane/ResponseCopy/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseCopy/index.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { IconCopy } from '@tabler/icons';
+import StyledWrapper from './StyledWrapper';
+import toast from 'react-hot-toast';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+
+const ResponseCopy = ({ item }) => {
+  const response = item.response || {};
+
+  const getResponseText = () => {
+    return JSON.stringify(response.data, null, 2);
+  };
+
+  return (
+    <StyledWrapper className="ml-2 flex items-center">
+      <CopyToClipboard
+        className="copy-to-clipboard"
+        text={getResponseText()}
+        onCopy={() => toast.success('Copied to clipboard!')}
+      >
+        <button title="Copy response" disabled={!response.dataBuffer}>
+          <IconCopy size={16} strokeWidth={1.5} />
+        </button>
+      </CopyToClipboard>
+    </StyledWrapper>
+  );
+};
+export default ResponseCopy;

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -17,6 +17,7 @@ import ScriptError from './ScriptError';
 import ScriptErrorIcon from './ScriptErrorIcon';
 import StyledWrapper from './StyledWrapper';
 import ResponseSave from 'src/components/ResponsePane/ResponseSave';
+import ResponseCopy from 'src/components/ResponsePane/ResponseCopy';
 import ResponseClear from 'src/components/ResponsePane/ResponseClear';
 import SkippedRequest from './SkippedRequest';
 import ClearTimeline from './ClearTimeline/index';
@@ -28,7 +29,7 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
   const isLoading = ['queued', 'sending'].includes(item.requestState);
   const [showScriptErrorCard, setShowScriptErrorCard] = useState(false);
 
-  const requestTimeline = ([...(collection.timeline || [])]).filter(obj => {
+  const requestTimeline = [...(collection.timeline || [])].filter((obj) => {
     if (obj.itemUid === item.uid) return true;
   });
 
@@ -70,7 +71,7 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
         return <ResponseHeaders headers={response.headers} />;
       }
       case 'timeline': {
-        return <Timeline collection={collection} item={item} width={rightPaneWidth}  />;
+        return <Timeline collection={collection} item={item} width={rightPaneWidth} />;
       }
       case 'tests': {
         return <TestResults results={item.testResults} assertionResults={item.assertionResults} />;
@@ -122,7 +123,7 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
   };
 
   const responseHeadersCount = typeof response.headers === 'object' ? Object.entries(response.headers).length : 0;
-  
+
   const hasScriptError = item?.preRequestScriptErrorMessage || item?.postResponseScriptErrorMessage;
 
   return (
@@ -144,16 +145,14 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
         {!isLoading ? (
           <div className="flex flex-grow justify-end items-center">
             {hasScriptError && !showScriptErrorCard && (
-              <ScriptErrorIcon 
-                itemUid={item.uid} 
-                onClick={() => setShowScriptErrorCard(true)} 
-              />
+              <ScriptErrorIcon itemUid={item.uid} onClick={() => setShowScriptErrorCard(true)} />
             )}
-            {focusedTab?.responsePaneTab === "timeline" ? (
+            {focusedTab?.responsePaneTab === 'timeline' ? (
               <ClearTimeline item={item} collection={collection} />
-            ) : (item?.response && !item?.response?.error) ? (
+            ) : item?.response && !item?.response?.error ? (
               <>
                 <ResponseClear item={item} collection={collection} />
+                <ResponseCopy item={item} />
                 <ResponseSave item={item} />
                 <StatusCode status={response.status} />
                 <ResponseTime duration={response.duration} />
@@ -164,22 +163,17 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
         ) : null}
       </div>
       <section
-        className={`flex flex-col flex-grow relative pl-3 pr-4 ${focusedTab.responsePaneTab === 'response' ? '' : 'mt-4'}`}
+        className={`flex flex-col flex-grow relative pl-3 pr-4 ${
+          focusedTab.responsePaneTab === 'response' ? '' : 'mt-4'
+        }`}
       >
         {isLoading ? <Overlay item={item} collection={collection} /> : null}
         {hasScriptError && showScriptErrorCard && (
-          <ScriptError 
-            item={item} 
-            onClose={() => setShowScriptErrorCard(false)} 
-          />
+          <ScriptError item={item} onClose={() => setShowScriptErrorCard(false)} />
         )}
         {!item?.response ? (
-          focusedTab?.responsePaneTab === "timeline" && requestTimeline?.length ? (
-            <Timeline
-              collection={collection}
-              item={item}
-              width={rightPaneWidth}
-            />
+          focusedTab?.responsePaneTab === 'timeline' && requestTimeline?.length ? (
+            <Timeline collection={collection} item={item} width={rightPaneWidth} />
           ) : null
         ) : (
           <>{getTabPanel(focusedTab.responsePaneTab)}</>


### PR DESCRIPTION
# Description

Adds a button to copy HTTP response data to clipboard in the response panel. Works on all HTTP requests and follows the same pattern as the existing [`ResponseSave`](https://github.com/usebruno/bruno/blob/main/packages/bruno-app/src/components/ResponsePane/ResponseSave/index.js) button by disabling when no dataBuffer is available. Uses the same CopyToClipboard implementation as the existing [`CodeView`](https://github.com/usebruno/bruno/blob/main/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js) component.

### Contribution Checklist:

- [✔] **The pull request only addresses one issue or adds one feature.**
- [✔] **The pull request does not introduce any breaking changes**
- [✔] **I have added screenshots or gifs to help explain the change if applicable.**
- [✔] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [✔] **Create an issue and link to the pull request.**

### Screenshot:
![electron_Hi65MwIVps](https://github.com/user-attachments/assets/1dd13074-b867-4cee-815c-bd1f2493ef5c)

### Copy Result:
```json
[
  {
    "id": 305,
    "title": "Axiom",
    "category": "Software",
    "route": {
      "light": "https://svgl.app/library/axiom-light.svg",
      "dark": "https://svgl.app/library/axiom-dark.svg"
    },
    "wordmark": {
      "light": "https://svgl.app/library/axiom-wordmark-light.svg",
      "dark": "https://svgl.app/library/axiom-wordmark-dark.svg"
    },
    "url": "https://axiom.co/"
  }
]
```

