### PR TITLE
Added type-check for  $ref as object property instead of component reference

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -217,6 +217,10 @@ const resolveRefs = (spec, components = spec?.components, cache = new Map()) => 
   if ('$ref' in spec) {
     const refPath = spec.$ref;
 
+    if (typeof refPath === 'object') {
+      return "";
+    }
+
     if (cache.has(refPath)) {
       return cache.get(refPath);
     }


### PR DESCRIPTION
# Description

- Added type-check as object for `$ref` property in `open-api-specs`

https://github.com/user-attachments/assets/e67e50d6-1f2c-485f-8a7b-85b052017bc9


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
