### PR TITLE
added free resizing

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -86,21 +86,20 @@ app.on('ready', async () => {
   const { maximized, x, y, width, height } = loadWindowState();
 
   mainWindow = new BrowserWindow({
-    x,
-    y,
-    width,
-    height,
-    minWidth: 1000,
-    minHeight: 640,
-    show: false,
-    webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: true,
-      preload: path.join(__dirname, 'preload.js'),
-      webviewTag: true
-    },
-    title: 'Bruno',
-    icon: path.join(__dirname, 'about/256x256.png')
+      width: 375,
+      height: 667,
+      minWidth: 320,
+      minHeight: 480,
+      resizable: true,
+      show: false,
+      webPreferences: {
+        nodeIntegration: true,
+        contextIsolation: true,
+        preload: path.join(__dirname, 'preload.js'),
+        webviewTag: true
+      },
+      title: 'Bruno',
+      icon: path.join(__dirname, 'about/256x256.png')
     // we will bring this back
     // see https://github.com/usebruno/bruno/issues/440
     // autoHideMenuBar: true


### PR DESCRIPTION
# Description

When programming and having multiple windows open at the same time, Bruno did not allow the window to be resized as the user wanted.

### Contribution Checklist:

- [ Yes] **The pull request only addresses one issue or adds one feature.**
- [Yes ] **The pull request does not introduce any breaking changes**
- [It doesn't change much ] **I have added screenshots or gifs to help explain the change if applicable.**
- [Yes ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
