### PR TITLE
fix: restore pre/post request scripts in GraphQL introspection (regression from #4661)

### DIFF
--- a/packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js
@@ -20,7 +20,9 @@ const prepareGqlIntrospectionRequest = (endpoint, resolvedVars, request, collect
       Accept: 'application/json',
       'Content-Type': 'application/json'
     },
-    data: JSON.stringify(queryParams)
+    data: JSON.stringify(queryParams),
+    script: request.script,
+    vars: request.vars
   };
 
   return setAuthHeaders(axiosRequest, request, collectionRoot);


### PR DESCRIPTION
# Description

This PR fixes a regression introduced in #4661, where the execution of pre-request and post-request scripts was skipped during GraphQL introspection. The missing logic has been restored to ensure scripts run as expected.

Jira: [BRU-1092](https://usebruno.atlassian.net/browse/BRU-1092)


https://github.com/user-attachments/assets/f83af52d-9423-41a3-9545-7a6123adde03


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
