### PR TITLE
fix: handle undefined bearer token to send an empty string instead

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -47,7 +47,7 @@ const prepareRequest = (item = {}, collection = {}) => {
     }
 
     if (collectionAuth.mode === 'bearer') {
-      axiosRequest.headers['Authorization'] = `Bearer ${get(collectionAuth, 'bearer.token')}`;
+      axiosRequest.headers['Authorization'] = `Bearer ${get(collectionAuth, 'bearer.token', '')}`;
     }
 
     if (collectionAuth.mode === 'apikey') {
@@ -174,7 +174,7 @@ const prepareRequest = (item = {}, collection = {}) => {
     }
 
     if (request.auth.mode === 'bearer') {
-      axiosRequest.headers['Authorization'] = `Bearer ${get(request, 'auth.bearer.token')}`;
+      axiosRequest.headers['Authorization'] = `Bearer ${get(request, 'auth.bearer.token', '')}`;
     }
 
     if (request.auth.mode === 'wsse') {

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -27,7 +27,7 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         };
         break;
       case 'bearer':
-        axiosRequest.headers['Authorization'] = `Bearer ${get(collectionAuth, 'bearer.token')}`;
+        axiosRequest.headers['Authorization'] = `Bearer ${get(collectionAuth, 'bearer.token', '')}`;
         break;
       case 'digest':
         axiosRequest.digestConfig = {
@@ -152,7 +152,7 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         };
         break;
       case 'bearer':
-        axiosRequest.headers['Authorization'] = `Bearer ${get(request, 'auth.bearer.token')}`;
+        axiosRequest.headers['Authorization'] = `Bearer ${get(request, 'auth.bearer.token', '')}`;
         break;
       case 'digest':
         axiosRequest.digestConfig = {


### PR DESCRIPTION
# Description
Fixes Issue #4780 
[Jira ticket](https://usebruno.atlassian.net/jira/software/projects/BRU/boards/1/backlog?selectedIssue=BRU-1204&atlOrigin=eyJpIjoiNzllNTMxNGNlZDI2NDAwZThiYmIxZWZjYjY2NTMyYWIiLCJwIjoiaiJ9)

When auth is selected and but no values are given to the input, the request is sending "Bearer undefined" 

## Before
<img width="409" alt="Screenshot 2025-06-13 at 2 14 22 PM" src="https://github.com/user-attachments/assets/0f6ed7db-4115-4779-8b94-ea8020a7566c" />

## After
<img width="411" alt="Screenshot 2025-06-13 at 2 14 35 PM" src="https://github.com/user-attachments/assets/e7cfc5dd-9ea2-41f3-b9a9-07548fc83c82" />


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
