### PR TITLE
Fix: Resize the tab for the requests

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/StyledWrapper.js
@@ -17,7 +17,6 @@ const Wrapper = styled.div`
 
     li {
       display: inline-flex;
-      max-width: 150px;
       border: 1px solid transparent;
       list-style: none;
       padding-top: 8px;


### PR DESCRIPTION
# Description

Fix issue: #4886 

Before
![image](https://github.com/user-attachments/assets/eb7be097-376b-4eb8-8ff7-968ef93c54fb)

After
![image](https://github.com/user-attachments/assets/8120349d-be0d-4ceb-897d-f20fcaff290b)

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
