### PR TITLE
OAuth: Allow the authorizeUrl to be a subpath of the callbackUrl

### DIFF
--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -1,16 +1,14 @@
 const { BrowserWindow } = require('electron');
 const { preferencesUtil } = require('../../store/preferences');
 
-const matchesCallbackUrl = (url, authorizeUrl, callbackUrl) => {
-  if (!url) {
-    return false;
-  }
-
-  if (url.href.startsWith(authorizeUrl.href)) {
-    return false;
-  }
-
-  return url.href.startsWith(callbackUrl.href);
+const matchesCallbackUrl = (url, callbackUrl) => {
+  const removeTrailingSlashRegex = /\/$/;
+  return url
+    && url.origin === callbackUrl.origin
+    && url.pathname.replace(removeTrailingSlashRegex, '') === callbackUrl.pathname.replace(removeTrailingSlashRegex, '')
+    && url.username === callbackUrl.username
+    && url.password === callbackUrl.password
+    && url.search.startsWith(callbackUrl.search);
 };
 
 const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
@@ -125,7 +123,7 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session }) => {
       // Handle redirects as needed
 
       // Check if redirect is to the callback URL and contains an authorization code
-      if (matchesCallbackUrl(new URL(url), new URL(authorizeUrl), new URL(callbackUrl))) {
+      if (matchesCallbackUrl(new URL(url), new URL(callbackUrl))) {
         finalUrl = url;
         window.close();
       }

--- a/packages/bruno-electron/tests/network/authorize-user.spec.js
+++ b/packages/bruno-electron/tests/network/authorize-user.spec.js
@@ -4,38 +4,83 @@ describe('matchesCallbackUrl', () => {
   const testCases = [
     { url: 'https://random-url/endpoint', expected: false },
     { url: 'https://random-url/endpoint?code=abcd', expected: false },
+    { url: 'https://callback.url', expected: false },
+    { url: 'https://callback.url/', expected: false },
+    { url: 'https://callback.url/?code=abcd', expected: false },
+    { url: 'https://callback.url/endpoint', expected: true },
+    { url: 'https://callback.url/endpoint/', expected: true },
     { url: 'https://callback.url/endpoint?code=abcd', expected: true },
     { url: 'https://callback.url/endpoint/?code=abcd', expected: true },
+
+    // authorizeUrl that is subpath of the callbackUrl should not be matched
+    { url: 'https://callback.url/endpoint/auth', expected: false },
+    { url: 'https://callback.url/endpoint/auth?response_type=code&client_id=test', expected: false },
+    { url: 'https://callback.url/endpoint-something', expected: false },
+    { url: 'https://callback.url/endpoint-auth', expected: false },
+
     { url: 'https://callback.url/random-endpoint/?code=abcd', expected: false }
   ];
 
   it.each(testCases)('$url - should be $expected', ({ url, expected }) => {
-    const callBackUrl = 'https://callback.url/endpoint';
-    const authorizeUrl = 'https://login.example.com/openid-connect/auth'
+    let callbackUrl = 'https://callback.url/endpoint';
 
-    const actual = matchesCallbackUrl(new URL(url), new URL(authorizeUrl), new URL(callBackUrl));
+    let actual = matchesCallbackUrl(new URL(url), new URL(callbackUrl));
 
     expect(actual).toBe(expected);
   });
 
-  it('should allow authorizeUrl to be a subpath of the callBackUrl', () => {
-    const callBackUrl = 'https://some-app.example.com';
-    const authorizeUrl = `${callBackUrl}/auth/protocol/openid-connect/auth`;
-    expect(authorizeUrl.startsWith(callBackUrl)).toBeTruthy();
-    
-    // When the authorizeUrl is currently opened, do not match this as the callBackUrl
-    let url = authorizeUrl;
-    let actual = matchesCallbackUrl(new URL(url), new URL(authorizeUrl), new URL(callBackUrl));
-    expect(actual).toBeFalsy();
-    
-    // Also not the authorizeUrl with some parameters
-    url = `${authorizeUrl}?response_type=code&client_id=test`;
-    actual = matchesCallbackUrl(new URL(url), new URL(authorizeUrl), new URL(callBackUrl));
-    expect(actual).toBeFalsy();
+  const testCasesModifiedCallback = [
+    {
+      callbackUrl: 'https://callback.url',
+      url: 'https://callback.url',
+      expected: true
+    },
+    {
+      callbackUrl: 'https://callback.url',
+      url: 'https://callback.url/',
+      expected: true
+    },
+    {
+      callbackUrl: 'https://callback.url/',
+      url: 'https://callback.url',
+      expected: true
+    },
+    {
+      callbackUrl: 'https://callback.url/endpoint?something=1&another=2',
+      url: 'https://callback.url/endpoint',
+      expected: false
+    },
+    {
+      callbackUrl: 'https://callback.url/endpoint?something=1&another=2',
+      url: 'https://callback.url/endpoint?something=1&another=2',
+      expected: true
+    },
+    {
+      callbackUrl: 'https://callback.url/endpoint?something=1&another=2',
+      // appended extra search params should be allowed
+      url: 'https://callback.url/endpoint?something=1&another=2&code=abcd',
+      expected: true
+    },
+    {
+      callbackUrl: 'https://user:pass@callback.url/endpoint',
+      url: 'https://callback.url/endpoint',
+      expected: false
+    },
+    {
+      callbackUrl: 'https://user:pass@callback.url/endpoint',
+      url: 'https://user:otherpass@callback.url/endpoint',
+      expected: false
+    },
+    {
+      callbackUrl: 'https://user:pass@callback.url/endpoint',
+      url: 'https://user:pass@callback.url/endpoint?code=123',
+      expected: true
+    }
+  ];
 
-    // Now the real callBackUrl is opened in the browser window
-    url = callBackUrl;
-    actual = matchesCallbackUrl(new URL(url), new URL(authorizeUrl), new URL(callBackUrl));
-    expect(actual).toBeTruthy();
+  it.each(testCasesModifiedCallback)('$url - should be $expected with callbackUrl $callbackUrl', ({ callbackUrl, url, expected }) => {
+    let actual = matchesCallbackUrl(new URL(url), new URL(callbackUrl));
+
+    expect(actual).toBe(expected);
   });
 });


### PR DESCRIPTION
# Description

First of all: Thanks for this nice tool :)
This is a little bugfix, to allow an OAuth authorizeUrl to be a subpath of the callbackUrl.

We have the following scenario:

- App = CallbackUrl running on `https://apigateway-something.mycompany.dev`
- Keycloak = AuthorizeUrl running on `https://apigateway-something.mycompany.dev/auth/realms/my-realm/protocol/openid-connect/auth`

So the special case is here, that the authorizeUrl is a subpath of the callbackUrl.

In `packages/bruno-electron/src/ipc/network/authorize-user-in-window.js` -> `window.webContents.on('did-navigate', ...)` this causes the OAuth process to run `window.close()` to early. It directly closes, when opening authorizeUrl, because it thinks, authorizeUrl is already the callbackUrl.  
In fact, the user does not even see the window, because it directly closes.

As we see here, authorizeUrl is called, then directly the tokenUrl. Normally there should be another call in between, which is the 302 redirect.

![image](https://github.com/user-attachments/assets/d656f07e-9aac-4235-8210-1c819ff04073)


This PR fixes this, by adding another check, that ensures, that the window does not directly close, in that situation.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
