### PR TITLE
feat(cli): add support for environment file input in run command

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -106,6 +106,10 @@ const builder = async (yargs) => {
       describe: 'Environment variables',
       type: 'string'
     })
+    .option('env-file', {
+      describe: 'Path to environment file (.bru) - can be absolute or relative path',
+      type: 'string'
+    })
     .option('env-var', {
       describe: 'Overwrite a single environment variable, multiple usages possible',
       type: 'string'
@@ -175,6 +179,7 @@ const builder = async (yargs) => {
     })
     .example('$0 run request.bru', 'Run a request')
     .example('$0 run request.bru --env local', 'Run a request with the environment set to local')
+    .example('$0 run request.bru --env-file env.bru', 'Run a request with the environment from env.bru file')
     .example('$0 run folder', 'Run all requests in a folder')
     .example('$0 run folder -r', 'Run all requests in a folder recursively')
     .example('$0 run --reporter-skip-all-headers', 'Run all requests in a folder recursively with omitted headers from the reporter output')
@@ -224,6 +229,7 @@ const handler = async function (argv) {
       ignoreTruststore,
       disableCookies,
       env,
+      envFile,
       envVar,
       insecure,
       r: recursive,
@@ -294,19 +300,28 @@ const handler = async function (argv) {
     const runtimeVariables = {};
     let envVars = {};
 
-    if (env) {
-      const envFile = path.join(collectionPath, 'environments', `${env}.bru`);
-      const envPathExists = await exists(envFile);
+    if (env && envFile) {
+      console.error(chalk.red(`Cannot use both --env and --env-file options together`));
+      process.exit(constants.EXIT_STATUS.ERROR_MALFORMED_ENV_OVERRIDE);
+    }
 
-      if (!envPathExists) {
-        console.error(chalk.red(`Environment file not found: `) + chalk.dim(`environments/${env}.bru`));
+    if (envFile || env) {
+      const envFilePath = envFile
+        ? path.resolve(collectionPath, envFile)
+        : path.join(collectionPath, 'environments', `${env}.bru`);
+
+      const envFileExists = await exists(envFilePath);
+      if (!envFileExists) {
+        const errorPath = envFile || `environments/${env}.bru`;
+        console.error(chalk.red(`Environment file not found: `) + chalk.dim(errorPath));
+
         process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
       }
 
-      const envBruContent = fs.readFileSync(envFile, 'utf8');
+      const envBruContent = fs.readFileSync(envFilePath, 'utf8').replace(/\r\n/g, '\n');
       const envJson = bruToEnvJson(envBruContent);
       envVars = getEnvVars(envJson);
-      envVars.__name__ = env;
+      envVars.__name__ = envFile ? path.basename(envFilePath, '.bru') : env;
     }
 
     if (envVar) {


### PR DESCRIPTION
Jira: [BRU-1210](https://usebruno.atlassian.net/browse/BRU-1210)

# Description

This PR adds support for `.bru` files by allowing both relative and absolute paths. This enables us to attach environments via the CLI from anywhere in the filesystem.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Demo:
Absolute path:
![image](https://github.com/user-attachments/assets/622d5dd3-de33-4c45-b5c4-ff03950f87d4)

Relative Path:
![image](https://github.com/user-attachments/assets/eff4e5e9-fa17-4564-8919-c53dede4e46f)
