### PR TITLE
Fix: removed scope from token request as per RFC standard

### DIFF
--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -58,7 +58,6 @@ const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, fo
     clientId,
     clientSecret,
     callbackUrl,
-    scope,
     pkce,
     credentialsPlacement,
     authorizationUrl,
@@ -140,9 +139,6 @@ const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, fo
   }
   if (pkce) {
     data['code_verifier'] = codeVerifier;
-  }
-  if (scope) {
-    data.scope = scope;
   }
   requestCopy.data = qs.stringify(data);
   requestCopy.url = url;


### PR DESCRIPTION
# Description

This relates to bug #4388 and removes the `scope` parameter from the token request. Currently these requests may be rejected by standard compliant identity providers. Significantly limiting the utility of the authorization feature in Bruno.
