### PR TITLE
fix: handle falsy values in Postman environment and collection variables

### DIFF
--- a/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
+++ b/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
@@ -6,10 +6,10 @@ const isSecret = (type) => {
   return type === 'secret';
 };
 
-const importPostmanEnvironmentVariables = (brunoEnvironment, values) => {
+const importPostmanEnvironmentVariables = (brunoEnvironment, values = []) => {
   brunoEnvironment.variables = brunoEnvironment.variables || [];
 
-  each(values, (i) => {
+  each(values.filter(i => !(i.key == null && i.value == null)), (i) => {
     const brunoEnvironmentVariable = {
       uid: uuid(),
       name: (i.key ?? '').replace(invalidVariableCharacterRegex, '_'),

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -119,7 +119,7 @@ const importScriptsFromEvents = (events, requestObject) => {
 };
 
 const importCollectionLevelVariables = (variables, requestObject) => {
-  const vars = variables.map((v) => ({
+  const vars = variables.filter(v => !(v.key == null && v.value == null)).map((v) => ({
     uid: uuid(),
     name: (v.key ?? '').replace(invalidVariableCharacterRegex, '_'),
     value: v.value ?? '',

--- a/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
@@ -100,13 +100,6 @@ describe('postmanToBrunoEnvironment Function', () => {
           enabled: true,
           secret: false,
           uid: "mockeduuidvalue123456",
-        },
-        {
-          name: '',
-          value: '',
-          enabled: true,
-          secret: false,
-          uid: "mockeduuidvalue123456",
         }
       ],
     };
@@ -132,5 +125,24 @@ describe('postmanToBrunoEnvironment Function', () => {
     await expect(postmanToBrunoEnvironment(invalidBrunoEnvironment)).rejects.toThrow(
       'Unable to parse the postman environment json file'
     );
+  });
+
+  it("should handle empty variables", async () => {
+    const collectionWithEmptyVars = {
+      "name": "My Environment",
+      "values": []
+    };
+
+    const brunoCollection = await postmanToBrunoEnvironment(collectionWithEmptyVars);
+    expect(brunoCollection.variables).toEqual([]);
+  });
+
+  it("should handle undefined variables", async () => {
+    const collectionWithUndefinedVars = {
+      "name": "My Environment",
+    };
+
+    const brunoCollection = await postmanToBrunoEnvironment(collectionWithUndefinedVars);
+    expect(brunoCollection.variables).toEqual([]);
   });
 });

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
@@ -55,14 +55,23 @@ describe('postman-collection', () => {
         name: '',
         value: '',
         enabled: true
-      },
-      {
-        uid: "mockeduuidvalue123456",
-        name: '',
-        value: '',
-        enabled: true
       }
     ]);
+  });
+
+  it("should handle empty variables", async () => {
+    const collectionWithEmptyVars = {
+      "info": {
+        "_postman_id": "7f91bbd8-cb97-41ac-8d0b-e1fcd8bb4ce9",
+        "name": "collection with falsy vars",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+      },
+      "variable": [],
+      "item": []
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithEmptyVars);
+    expect(brunoCollection.root.request.vars.req).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Fixes #4904 
Jira [ticket ](https://usebruno.atlassian.net/browse/BRU-1239)

* Updated the `postman-env-to-bruno-env` and `postman-to-bruno` converters to handle cases where variable keys or values are falsy, ensuring they default to empty strings.
* Added unit tests to verify the correct handling of falsy values in both environment and collection variables.

# Description


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
