### PR TITLE
Feat: Update serialization logic for `application/x-www-form-urlencoded` body type

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -330,7 +330,7 @@ const runSingleRequest = async function (
 
     // stringify the request url encoded params
     if (request.headers['content-type'] === 'application/x-www-form-urlencoded') {
-      request.data = qs.stringify(request.data);
+      request.data = qs.stringify(request.data, { arrayFormat: "repeat" });
     }
 
     if (request?.headers?.['content-type'] === 'multipart/form-data') {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -454,7 +454,7 @@ const registerNetworkIpc = (mainWindow) => {
 
     // stringify the request url encoded params
     if (request.headers['content-type'] === 'application/x-www-form-urlencoded') {
-      request.data = qs.stringify(request.data);
+      request.data = qs.stringify(request.data, { arrayFormat: "repeat" });
     }
 
     if (request.headers['content-type'] === 'multipart/form-data') {

--- a/packages/bruno-tests/collection/url-serialization/1. Duplicate Keys.bru
+++ b/packages/bruno-tests/collection/url-serialization/1. Duplicate Keys.bru
@@ -1,0 +1,29 @@
+meta {
+  name: 1. Duplicate Keys
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  tags: frontend
+  tags: api
+  user: john
+}
+
+script:post-response {
+  console.log(res.getBody());
+  
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql("tags=frontend&tags=api&user=john");
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/10. Key with Space.bru
+++ b/packages/bruno-tests/collection/url-serialization/10. Key with Space.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 10. Key with Space
+  type: http
+  seq: 10
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  full-name: Alice Doe
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('full-name=Alice%20Doe');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/11. Unicode Key and Value.bru
+++ b/packages/bruno-tests/collection/url-serialization/11. Unicode Key and Value.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 11. Unicode Key and Value
+  type: http
+  seq: 11
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  ключ: значение
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(JSON.stringify(res.getBody())).to.include('%D0%BA%D0%BB%D1%8E%D1%87=%D0%B7%D0%BD%D0%B0%D1%87%D0%B5%D0%BD%D0%B8%D0%B5');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/12. Empty Key and Value.bru
+++ b/packages/bruno-tests/collection/url-serialization/12. Empty Key and Value.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 12. Empty Key and Value
+  type: http
+  seq: 12
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  : 
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('=');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/2. Special Characters.bru
+++ b/packages/bruno-tests/collection/url-serialization/2. Special Characters.bru
@@ -1,0 +1,31 @@
+meta {
+  name: 2. Special Characters
+  type: http
+  seq: 2
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  query: hello world!
+  city: New York
+}
+
+script:post-response {
+  // test('Response body matches expected value', function () {
+  //     expect(JSON.stringify(res.getBody())).to.eql('query=hello+world%21&city=New+York');
+  // });
+  
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('query=hello%20world%21&city=New%20York');
+  });
+  
+}

--- a/packages/bruno-tests/collection/url-serialization/3. Empty Values.bru
+++ b/packages/bruno-tests/collection/url-serialization/3. Empty Values.bru
@@ -1,0 +1,26 @@
+meta {
+  name: 3. Empty Values
+  type: http
+  seq: 3
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  username: 
+  token: abc123
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('username=&token=abc123');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/4. Multiple Duplicate Fields.bru
+++ b/packages/bruno-tests/collection/url-serialization/4. Multiple Duplicate Fields.bru
@@ -1,0 +1,27 @@
+meta {
+  name: 4. Multiple Duplicate Fields
+  type: http
+  seq: 4
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  id: 1
+  id: 2
+  id: 3
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('id=1&id=2&id=3');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/5. Non-ASCII Characters.bru
+++ b/packages/bruno-tests/collection/url-serialization/5. Non-ASCII Characters.bru
@@ -1,0 +1,26 @@
+meta {
+  name: 5. Non-ASCII Characters
+  type: http
+  seq: 5
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  name: Jöhn
+  city: São Paulo
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.include('name=J%C3%B6hn&city=S%C3%A3o%20Paulo');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/6. Field With Equals Sign.bru
+++ b/packages/bruno-tests/collection/url-serialization/6. Field With Equals Sign.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 6. Field With Equals Sign
+  type: http
+  seq: 6
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  data: a=b&c=d
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('data=a%3Db%26c%3Dd');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/7. Field With Ampersand.bru
+++ b/packages/bruno-tests/collection/url-serialization/7. Field With Ampersand.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 7. Field With Ampersand
+  type: http
+  seq: 7
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  note: Tom & Jerry
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('note=Tom%20%26%20Jerry');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/8. Field With Plus.bru
+++ b/packages/bruno-tests/collection/url-serialization/8. Field With Plus.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 8. Field With Plus
+  type: http
+  seq: 8
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  sum: 1+1=2
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('sum=1%2B1%3D2');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/9. Encoded Reserved Characters.bru
+++ b/packages/bruno-tests/collection/url-serialization/9. Encoded Reserved Characters.bru
@@ -1,0 +1,25 @@
+meta {
+  name: 9. Encoded Reserved Characters
+  type: http
+  seq: 9
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: formUrlEncoded
+  auth: none
+}
+
+headers {
+  Content-Type: application/x-www-form-urlencoded
+}
+
+body:form-urlencoded {
+  path: /home/user?arg=value
+}
+
+script:post-response {
+  test('Response body matches expected value', function () {
+      expect(res.getBody()).to.eql('path=%2Fhome%2Fuser%3Farg%3Dvalue');
+  });
+}

--- a/packages/bruno-tests/collection/url-serialization/folder.bru
+++ b/packages/bruno-tests/collection/url-serialization/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: url-serialization
+  seq: 13
+}
+
+auth {
+  mode: inherit
+}


### PR DESCRIPTION
# Description

This PR updates the serialization logic for requests with the `application/x-www-form-urlencoded` content type. The change addresses an issue where array-like data structures were being incorrectly serialized.

#### **Issue**

Previously, data such as:

```plaintext
IND: India  
IND: Bharat  
AUS: Australia
```

was being serialized as:

```plaintext
IND%5B0%5D=India&IND%5B1%5D=Bharat&AUS=Australia
```

This format is not ideal or widely supported.

#### **Solution**

The serialization logic has been updated using:

```js
qs.stringify(request.data, { arrayFormat: "repeat" })
```

With this change, the data is now properly serialized as:

```plaintext
IND=India&IND=Bharat&AUS=Australia
```

#### **Changes Included**

1. Updated URL serialization logic in **Bruno App**
2. Updated URL serialization logic in **Bruno CLI**
3. Added test cases for URL serialization

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Before:
![image](https://github.com/user-attachments/assets/9b6b8daa-d012-4bf9-8002-c2b14039f178)

After:
![image](https://github.com/user-attachments/assets/c5699864-0627-4aef-8a43-c2fc95161101)
