### PR TITLE
fix: normalize certificate paths in collection export and import

### DIFF
--- a/packages/bruno-app/src/utils/collections/export.js
+++ b/packages/bruno-app/src/utils/collections/export.js
@@ -1,6 +1,7 @@
 import * as FileSaver from 'file-saver';
 import get from 'lodash/get';
 import each from 'lodash/each';
+import { normalizePath } from 'utils/common/path';
 
 export const deleteUidsInItems = (items) => {
   each(items, (item) => {
@@ -62,6 +63,16 @@ export const deleteSecretsInEnvs = (envs) => {
   });
 };
 
+function normalizeCertPathsInCollection(collection) {
+  if (collection.clientCertificates && Array.isArray(collection.clientCertificates.certs)) {
+    collection.clientCertificates.certs.forEach(cert => {
+      if (cert.pfxFilePath) cert.pfxFilePath = normalizePath(cert.pfxFilePath);
+      if (cert.certFilePath) cert.certFilePath = normalizePath(cert.certFilePath);
+      if (cert.keyFilePath) cert.keyFilePath = normalizePath(cert.keyFilePath);
+    });
+  }
+}
+
 export const exportCollection = (collection) => {
   // delete uids
   delete collection.uid;
@@ -73,6 +84,7 @@ export const exportCollection = (collection) => {
   deleteUidsInEnvs(collection.environments);
   deleteSecretsInEnvs(collection.environments);
   transformItem(collection.items);
+  normalizeCertPathsInCollection(collection);
 
   const fileName = `${collection.name}.json`;
   const fileBlob = new Blob([JSON.stringify(collection, null, 2)], { type: 'application/json' });

--- a/packages/bruno-app/src/utils/common/path.js
+++ b/packages/bruno-app/src/utils/common/path.js
@@ -10,3 +10,7 @@ const isWindowsOS = () => {
 const brunoPath = isWindowsOS() ? path.win32 : path.posix;
 
 export default brunoPath;
+
+export function normalizePath(p) {
+  return p ? p.replace(/\\\\|\\/g, '/') : p;
+}


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fixes: #4869 (Path is not OS safe)
Added a normalizePath utility to ensure all certificate file paths in collections use forward slashes (/), making them OS-safe and cross-platform.
Applied normalizePath during collection export to prevent new exports from containing OS-specific paths (e.g., Windows backslashes).
### Contribution Checklist:

- [x] *The pull request only addresses one issue or adds one feature.*
- [x] *The pull request does not introduce any breaking changes*
- [ ] *I have added screenshots or gifs to help explain the change if applicable.*
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] *Create an issue and link to the pull request.*

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.