### PR TITLE
add explicit HTTP agents with keepAlive to `bru.sendRequest` axios request config

### DIFF
--- a/packages/bruno-requests/src/network/axios-instance.ts
+++ b/packages/bruno-requests/src/network/axios-instance.ts
@@ -1,4 +1,6 @@
 import { default as axios, AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import http from 'node:http';
+import https from 'node:https';
 
 /**
  * 
@@ -25,6 +27,8 @@ type ModifiedAxiosResponse = AxiosResponse & {
 }
 
 const baseRequestConfig: Partial<AxiosRequestConfig> = {
+  httpAgent: new http.Agent({ keepAlive: true }),
+  httpsAgent: new https.Agent({ keepAlive: true }),
   transformRequest: function transformRequest(data: any, headers: AxiosRequestHeaders) {
     const contentType = headers.getContentType() || '';
     const hasJSONContentType = contentType.includes('json');


### PR DESCRIPTION
# Description

Added http.Agent and https.Agent with keepAlive: true to the base axios request configuration for `bru.sendRequest` api

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
