### PR TITLE
Remove scope parameter from token request when empty

### DIFF
--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -141,7 +141,7 @@ const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, fo
   if (pkce) {
     data['code_verifier'] = codeVerifier;
   }
-  if (scope) {
+  if (scope && scope.trim() !== '') {
     data.scope = scope;
   }
   requestCopy.data = qs.stringify(data);
@@ -344,7 +344,7 @@ const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, fo
   if (clientSecret && credentialsPlacement !== "basic_auth_header") {
     data.client_secret = clientSecret;
   }
-  if (scope) {
+  if (scope && scope.trim() !== '') {
     data.scope = scope;
   }
   requestCopy.data = qs.stringify(data);
@@ -515,7 +515,7 @@ const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, 
   if (clientSecret && credentialsPlacement !== "basic_auth_header") {
     data.client_secret = clientSecret;
   }
-  if (scope) {
+  if (scope && scope.trim() !== '') {
     data.scope = scope;
   }
   requestCopy.data = qs.stringify(data);


### PR DESCRIPTION
### Description

According to RFC 6749 Section 4.1.3, when requesting an access token using the Authorization Code grant type, only specific parameters should be included:
- grant_type
- code
- redirect_uri
- client_id

Currently, Bruno was sending the `scope` parameter even when it was empty or contained only whitespace, causing issues with certain OAuth2 providers.

issue: #4388

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

[JIRA](https://usebruno.atlassian.net/browse/BRU-1263)

