### PR TITLE
feat: remember last collection import location

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -23,6 +23,9 @@ const initialState = {
     },
     font: {
       codeFont: 'default'
+    },
+    import: {
+      lastCollectionLocation: ''
     }
   },
   generateCode: {

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -40,6 +40,9 @@ const defaultPreferences = {
   },
   layout: {
     responsePaneOrientation: 'horizontal'
+  },
+  import: {
+    lastCollectionLocation: ''
   }
 };
 
@@ -75,6 +78,9 @@ const preferencesSchema = Yup.object().shape({
   }),
   layout: Yup.object({
     responsePaneOrientation: Yup.string().oneOf(['horizontal', 'vertical'])
+  }),
+  import: Yup.object({
+    lastCollectionLocation: Yup.string().max(1024).nullable()
   })
 });
 
@@ -157,6 +163,9 @@ const preferencesUtil = {
   },
   getResponsePaneOrientation: () => {
     return get(getPreferences(), 'layout.responsePaneOrientation', 'horizontal');
+  },
+  getLastImportCollectionLocation: () => {
+    return get(getPreferences(), 'import.lastCollectionLocation', '');
   },
   getSystemProxyEnvVariables: () => {
     const { http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, no_proxy, NO_PROXY } = process.env;


### PR DESCRIPTION
# Description

This PR adds the ability to remember the last used import collection location after one was selected, making it easier to import collections successively.

Solves https://github.com/usebruno/bruno/issues/222

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
