### PR TITLE
fix: include unsaved changes in generate code

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/auth-utils.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/auth-utils.js
@@ -21,7 +21,7 @@ export const resolveInheritedAuth = (item, collection) => {
     ...(item.draft?.request || {})
   };
 
-  const authMode = mergedRequest?.auth?.mode;
+  const authMode = mergedRequest.auth.mode;
 
   // If auth is not inherit or no auth defined, return the merged request as is
   if (!authMode || authMode !== 'inherit') {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -27,7 +27,7 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
 
     // Add auth headers if needed
     if (request.auth && request.auth.mode !== 'none') {
-      const authHeaders = getAuthHeaders(collection?.root?.request?.auth, request.auth);
+      const authHeaders = getAuthHeaders(collection.root.request.auth, request.auth);
       headers = [...headers, ...authHeaders];
     }
 


### PR DESCRIPTION
# Description

This PR fixes an issue where unsaved changes to a request (such as edits to the body, headers, or other fields) were not reflected in the generated code snippet. Previously, if a user made changes but did not save the request, the code generator would ignore those unsaved edits, leading to confusion and incorrect code output.

[JIRA](https://usebruno.atlassian.net/browse/BRU-1273)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/8ca656a8-3a72-4383-b5d0-0b49252f0e17
