### PR TITLE
Remove welcome sandbox modal and set Safe Mode as default for new collections

### DIFF
--- a/packages/bruno-app/src/components/SecuritySettings/JsSandboxMode/index.js
+++ b/packages/bruno-app/src/components/SecuritySettings/JsSandboxMode/index.js
@@ -6,7 +6,7 @@ import JsSandboxModeModal from '../JsSandboxModeModal';
 import StyledWrapper from './StyledWrapper';
 
 const JsSandboxMode = ({ collection }) => {
-  const jsSandboxMode = collection?.securityConfig?.jsSandboxMode;
+  const jsSandboxMode = collection?.securityConfig?.jsSandboxMode || 'safe';
   const dispatch = useDispatch();
 
   const viewSecuritySettings = () => {
@@ -37,7 +37,6 @@ const JsSandboxMode = ({ collection }) => {
           Developer Mode
         </div>
       )}
-      {!jsSandboxMode ? <JsSandboxModeModal collection={collection} /> : null}
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1140,9 +1140,14 @@ export const openCollectionEvent = (uid, pathname, brunoConfig) => (dispatch, ge
 
   return new Promise((resolve, reject) => {
     ipcRenderer.invoke('renderer:get-collection-security-config', pathname).then((securityConfig) => {
+      // Set default security config if none exists
+      const defaultSecurityConfig = securityConfig && Object.keys(securityConfig).length > 0 
+        ? securityConfig 
+        : { jsSandboxMode: 'safe' };
+      
       collectionSchema
         .validate(collection)
-        .then(() => dispatch(_createCollection({ ...collection, securityConfig })))
+        .then(() => dispatch(_createCollection({ ...collection, securityConfig: defaultSecurityConfig })))
         .then(resolve)
         .catch(reject);
     });


### PR DESCRIPTION
# Description

Removes the mandatory sandbox mode selection modal that appears when opening new collections for the first time. New collections now automatically default to Safe Mode without requiring user interaction.

## Changes Made
- **Modified** `JsSandboxMode` component to default to 'safe' mode 
- **Updated** collection opening logic to set default security config for new collections
- **Removed** conditional modal rendering that forced users to choose sandbox mode

## New Implementations
1. New collections open without sandbox modal
2. Safe Mode is automatically selected for new collections
3. Existing collections retain their current sandbox settings
4. Security settings can still be accessed and modified

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

https://github.com/user-attachments/assets/b09de510-e9b1-4162-89a1-8dc236bb5cc8


