### PR TITLE
fix: Ignore empty header on Auth API Key(Header) to prevent sending request error

### DIFF
--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -61,10 +61,9 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         break;
       case 'apikey':
         const apiKeyAuth = get(collectionAuth, 'apikey');
+        if (apiKeyAuth.key.length === 0) break;
         if (apiKeyAuth.placement === 'header') {
-          if (apiKeyAuth.key.length > 0) {
-            axiosRequest.headers[apiKeyAuth.key] = apiKeyAuth.value;
-          }
+          axiosRequest.headers[apiKeyAuth.key] = apiKeyAuth.value;
         } else if (apiKeyAuth.placement === 'queryparams') {
           // If the API key authentication is set and its placement is 'queryparams', add it to the axios request object. This will be used in the configureRequest function to append the API key to the query parameters of the request URL.
           axiosRequest.apiKeyAuthValueForQueryParams = apiKeyAuth;
@@ -249,10 +248,9 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         break;
       case 'apikey':
         const apiKeyAuth = get(request, 'auth.apikey');
+        if (apiKeyAuth.key.length === 0) break;
         if (apiKeyAuth.placement === 'header') {
-          if (apiKeyAuth.key.length > 0) {
-            axiosRequest.headers[apiKeyAuth.key] = apiKeyAuth.value;
-          }
+          axiosRequest.headers[apiKeyAuth.key] = apiKeyAuth.value;
         } else if (apiKeyAuth.placement === 'queryparams') {
           // If the API key authentication is set and its placement is 'queryparams', add it to the axios request object. This will be used in the configureRequest function to append the API key to the query parameters of the request URL.
           axiosRequest.apiKeyAuthValueForQueryParams = apiKeyAuth;


### PR DESCRIPTION
# Description

Empty header in Auth API Key is ignored to prevent sending request error. (https://github.com/usebruno/bruno/issues/4991)

Before:
<img width="814" alt="image" src="https://github.com/user-attachments/assets/357e4d9d-ecde-4fb3-8b9a-c531ffccfacc" />


After:
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/816b8b15-e8a2-4eb5-9266-8000ff0bd72b" />

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
