### PR TITLE
add process.env variable support to GraphQL introspection

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -333,6 +333,7 @@ const fetchGqlSchemaHandler = async (event, endpoint, environment, _request, col
     const runtimeVars = collection.runtimeVariables;
 
     // Precedence: runtimeVars > requestVariables > folderVars > envVars > collectionVariables > globalEnvironmentVars
+    const processEnvVars = getProcessEnvVars(collection.uid);
     const resolvedVars = merge(
       {},
       globalEnvironmentVars,
@@ -340,7 +341,14 @@ const fetchGqlSchemaHandler = async (event, endpoint, environment, _request, col
       envVars,
       folderVars,
       requestVariables,
-      runtimeVars
+      runtimeVars,
+      {
+        process: {
+          env: {
+            ...processEnvVars
+          }
+        }
+      }
     );
 
     const collectionRoot = get(collection, 'root', {});
@@ -355,7 +363,6 @@ const fetchGqlSchemaHandler = async (event, endpoint, environment, _request, col
     }
 
     const collectionPath = collection.pathname;
-    const processEnvVars = getProcessEnvVars(collection.uid);
 
     const axiosInstance = await configureRequest(
       collection.uid,

--- a/packages/bruno-electron/tests/network/prepare-gql-introspection-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-gql-introspection-request.spec.js
@@ -63,4 +63,32 @@ describe('prepareGqlIntrospectionRequest', () => {
     expect(result.headers['Content-Type']).toBe('application/json');
   });
 
+  it('should handle process.env variables in endpoint URL', () => {
+    const setup = createBasicSetup();
+    setup.endpoint = 'https://{{process.env.API_HOST}}/graphql';
+    const vars = {
+      process: {
+        env: {
+          API_HOST: 'api.example.com'
+        }
+      }
+    };
+
+    const result = prepareGqlIntrospectionRequest(setup.endpoint, vars, setup.request, setup.collectionRoot);
+
+    expect(result.url).toBe('https://api.example.com/graphql');
+    expect(result.method).toBe('POST');
+  });
+
+  it('should handle missing process.env variables gracefully', () => {
+    const setup = createBasicSetup();
+    setup.request.headers = [
+      { name: 'X-API-Key', value: '{{process.env.MISSING_VAR}}', enabled: true }
+    ];
+
+    const result = prepareGqlIntrospectionRequest(setup.endpoint, {}, setup.request, setup.collectionRoot);
+
+    expect(result.headers['X-API-Key']).toBe('{{process.env.MISSING_VAR}}');
+  });
+
 });


### PR DESCRIPTION
Fixes a bug where GraphQL introspection requests would fail when using `{{process.env.VAR_NAME}}`. The URL interpolation was working, but the introspection request itself wasn't properly handling process environment variables.
Mentioned here https://github.com/usebruno/bruno/issues/3861#issuecomment-3013121195

https://github.com/user-attachments/assets/f91aa553-0a4d-469f-9828-763db7fa580c



https://github.com/user-attachments/assets/199acf16-f886-4032-8748-bee578c69919


Contribution Checklist:

- [x] The pull request only addresses one issue or adds one feature.
- [ ] The pull request does not introduce any breaking changes
- [ ] I have added screenshots or gifs to help explain the change if applicable.
- [ ] I have read the contribution guidelines.
- [ ] Create an issue and link to the pull request.