### PR TITLE
fix collapse behaviour and enhance collection component with focused state

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -194,12 +194,14 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
           type: 'folder-settings',
         })
       );
-      dispatch(
-        collectionFolderClicked({
-          itemUid: item.uid,
-          collectionUid: collectionUid
-        })
-      );
+      if(item.collapsed) {
+        dispatch(
+          collectionFolderClicked({
+            itemUid: item.uid,
+            collectionUid: collectionUid
+          })
+        );
+      }
     }
   };
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
@@ -41,6 +41,7 @@ const Wrapper = styled.div`
     }
 
     &:hover {
+      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
       .collection-actions {
         .dropdown {
           div[aria-expanded='false'] {
@@ -83,6 +84,14 @@ const Wrapper = styled.div`
       margin-bottom: -2px;
       background: transparent;
       transition: ${(props) => props.theme.dragAndDrop.transition};
+    }
+
+    &.collection-focused-in-tab {
+      background: ${(props) => props.theme.sidebar.collection.item.bg};
+
+      &:hover {
+        background: ${(props) => props.theme.sidebar.collection.item.bg} !important;
+      }
     }
   }
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -8,7 +8,7 @@ import { IconChevronRight, IconDots, IconLoader2 } from '@tabler/icons';
 import Dropdown from 'components/Dropdown';
 import { collapseCollection } from 'providers/ReduxStore/slices/collections';
 import { mountCollection, moveCollectionAndPersist, handleCollectionItemDrop } from 'providers/ReduxStore/slices/collections/actions';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { addTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
 import NewFolder from 'components/Sidebar/NewFolder';
@@ -16,6 +16,7 @@ import CollectionItem from './CollectionItem';
 import RemoveCollection from './RemoveCollection';
 import { doesCollectionHaveItemsMatchingSearchText } from 'utils/collections/search';
 import { isItemAFolder, isItemARequest } from 'utils/collections';
+import { isTabForItemActive } from 'src/selectors/tab';
 
 import RenameCollection from './RenameCollection';
 import StyledWrapper from './StyledWrapper';
@@ -35,6 +36,8 @@ const Collection = ({ collection, searchText }) => {
   const dispatch = useDispatch();
   const isLoading = areItemsLoading(collection);
   const collectionRef = useRef(null);
+  
+  const isCollectionFocused = useSelector(isTabForItemActive({ itemUid: collection.uid }));
   
   const menuDropdownTippyRef = useRef();
   const onMenuDropdownCreate = (ref) => (menuDropdownTippyRef.current = ref);
@@ -81,7 +84,9 @@ const Collection = ({ collection, searchText }) => {
     
     ensureCollectionIsMounted();
 
-    dispatch(collapseCollection(collection.uid));
+    if(collection.collapsed) {
+      dispatch(collapseCollection(collection.uid));
+    }
   
     if(!isChevronClick) {
       dispatch(
@@ -170,7 +175,8 @@ const Collection = ({ collection, searchText }) => {
   }
 
   const collectionRowClassName = classnames('flex py-1 collection-name items-center', {
-      'item-hovered': isOver
+      'item-hovered': isOver,
+      'collection-focused-in-tab': isCollectionFocused
     });
 
   // we need to sort request items by seq property


### PR DESCRIPTION


https://github.com/user-attachments/assets/d39cea34-b099-40b5-889f-8e1c617b85f9

# Description
Jira - [ticket](https://usebruno.atlassian.net/browse/BRU-1217?atlOrigin=eyJpIjoiOGE4OTc0OTc3MjI3NGY0YWFhMWEzYjYwM2MzY2JhMTkiLCJwIjoiaiJ9)

Fixes #4832 

- Added `useSelector` to determine if a collection is focused in the active tab.
- Updated dispatch logic to collapse collections only when they are already collapsed.
- Enhanced styling for focused collections in the sidebar to improve user experience.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
