### PR TITLE
feat: add support for collection pinning and unpinning

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -4,10 +4,10 @@ import classnames from 'classnames';
 import { uuid } from 'utils/common';
 import filter from 'lodash/filter';
 import { useDrop, useDrag } from 'react-dnd';
-import { IconChevronRight, IconDots, IconLoader2 } from '@tabler/icons';
+import { IconChevronRight, IconDots, IconLoader2, IconPin, IconPinned } from '@tabler/icons';
 import Dropdown from 'components/Dropdown';
 import { collapseCollection } from 'providers/ReduxStore/slices/collections';
-import { mountCollection, moveCollectionAndPersist, handleCollectionItemDrop } from 'providers/ReduxStore/slices/collections/actions';
+import { mountCollection, moveCollectionAndPersist, handleCollectionItemDrop, togglePinCollection } from 'providers/ReduxStore/slices/collections/actions';
 import { useDispatch } from 'react-redux';
 import { addTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
@@ -103,6 +103,13 @@ const Collection = ({ collection, searchText }) => {
     e.preventDefault();
     ensureCollectionIsMounted();
     dispatch(collapseCollection(collection.uid));
+  }
+
+  const handlePinToggle = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    ensureCollectionIsMounted();
+    dispatch(togglePinCollection(collection.uid));
   }
 
   const handleRightClick = (event) => {
@@ -210,6 +217,18 @@ const Collection = ({ collection, searchText }) => {
           onDoubleClick={handleDoubleClick}
           onContextMenu={handleRightClick}
         >
+          <IconPin
+            size={22}
+            className={`pin-icon ${!collection.pinned ? '' : 'hidden'}`}
+            style={{ opacity: 0.2 }}
+            onClick={handlePinToggle}
+          />
+          <IconPinned
+            size={22}
+            className={`pinned-icon ${collection.pinned ? '' : 'hidden'}`}
+            style={{ color: 'red' }}
+            onClick={handlePinToggle}
+          />
           <IconChevronRight
             size={16}
             strokeWidth={2}

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -195,6 +195,27 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedCollection
     }
   });
 
+  ipcMain.handle('renderer:toggle-pin-collection', async (_, collection, collections) => {
+    try {
+      lastOpenedCollections.update(collections.map((c) => c.pathname));
+
+      const brunoJsonFilePath = path.join(collection.pathname, 'bruno.json');
+      const content = fs.readFileSync(brunoJsonFilePath, 'utf8');
+      const json = JSON.parse(content);
+
+      if (collection.pinned) {
+        json.pinned = collection.pinned;
+      } else {
+        delete json.pinned;
+      }
+
+      const newContent = await stringifyJson(json);
+      await writeFile(brunoJsonFilePath, newContent);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  });
+
   ipcMain.handle('renderer:save-folder-root', async (event, folder) => {
     try {
       const { name: folderName, root: folderRoot = {}, pathname: folderPathname } = folder;

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -384,6 +384,7 @@ const collectionSchema = Yup.object({
   uid: uidSchema,
   name: Yup.string().min(1, 'name must be at least 1 character').required('name is required'),
   items: Yup.array().of(itemSchema),
+  pinned: Yup.number(),
   activeEnvironmentUid: Yup.string()
     .length(21, 'activeEnvironmentUid must be 21 characters in length')
     .matches(/^[a-zA-Z0-9]*$/, 'uid must be alphanumeric')


### PR DESCRIPTION
# Description

Implements https://github.com/usebruno/bruno/issues/4298

This PR adds support for pinning and unpinning collections to the top of the collections sidebar by clicking the new icon to the left of the caret. A newly pinned collection moves to the top of the list. Changes are persisted as expected and reverted if IPC throws an exception. `performance.now()` was used instead of `new Date().getTime()` due to a timing precision bug using the latter (two collections can import at the exact same time value post epoch). Sort functionality is preserved, but now bifurcated between pinned and unpinned collections.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

![bruno-pins1](https://github.com/user-attachments/assets/23d8ae6b-31df-4e46-a88d-efb1263ed7a2)
![bruno-pins2](https://github.com/user-attachments/assets/337a404a-ead8-4790-ae2f-25ac08ce8977)
