### PR TITLE
fix: Add null check for collection root in snippet generator #5029

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -27,7 +27,8 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
 
     // Add auth headers if needed
     if (request.auth && request.auth.mode !== 'none') {
-      const authHeaders = getAuthHeaders(collection.root.request.auth, request.auth);
+      const collectionAuth = collection?.root?.request?.auth || null;
+      const authHeaders = getAuthHeaders(collectionAuth, request.auth);
       headers = [...headers, ...authHeaders];
     }
 


### PR DESCRIPTION
# Description

Generate code now correctly interpolates token and basic auth header
### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="799" alt="Screenshot 2025-07-03 at 16 21 32" src="https://github.com/user-attachments/assets/4d019773-7db9-42ba-84c2-3e8a22908ff2" />
<img width="801" alt="Screenshot 2025-07-03 at 16 22 48" src="https://github.com/user-attachments/assets/3f78ad2c-fefc-4dac-9418-014f21a4feed" />
