### PR TITLE
fix: params table default scroll

### DIFF
--- a/packages/bruno-app/src/components/Table/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Table/StyledWrapper.js
@@ -6,6 +6,7 @@ const StyledWrapper = styled.div`
     display: grid;
     overflow-y: hidden;
     overflow-x: auto;
+    padding: 0 1px;
 
     // for icon hover
     position: inherit;


### PR DESCRIPTION
# Description

Fix params table default scroll. Scroll bar shouldn't be visible on initial load.

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
