### PR TITLE
fix: export for folder level auth

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -387,7 +387,12 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
         };
 
         let { request, meta, docs } = si?.root || {};
-        let { headers, script = {}, vars = {}, tests } = request || {};
+        let { auth, headers, script = {}, vars = {}, tests } = request || {};
+
+        // folder level auth
+        if (auth?.mode) {
+          di.root.request.auth = auth;
+        }
 
         // folder level headers
         if (headers?.length) {
@@ -1084,4 +1089,3 @@ export const calculateDraggedItemNewPathname = ({ draggedItem, targetItem, dropT
 };
 
 // item sequence utils - END
-


### PR DESCRIPTION
# Description

This PR fixes the correct export of folder-level authentication in the Bruno collection.

[JIRA](https://usebruno.atlassian.net/browse/BRU-1299)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/236429d5-3f71-4b9b-a979-9cd3e80fbb58