### PR TITLE
Support for Odata style path params

### DIFF
--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -111,6 +111,12 @@ describe('Url Utils - parsePathParams', () => {
       { name: 'postId', value: '' }
     ]);
   });
+
+  it('should parse path param inside parentheses and quotes', () => {
+    const params = parsePathParams("https://example.com/ExchangeRates(':ExchangeRateOID')");
+    expect(params).toEqual([{ name: 'ExchangeRateOID', value: '' }]);
+  });
+
 });
 
 describe('Url Utils - splitOnFirst', () => {

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -91,7 +91,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         request.data = request?.data?.map(d => ({
           ...d,
           value: _interpolate(d?.value)
-        }));   
+        }));
       } catch (err) {}
     }
   } else {
@@ -119,12 +119,17 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .split('/')
       .filter((path) => path !== '')
       .map((path) => {
-        if (path[0] !== ':') {
-          return '/' + path;
+        const paramRegex = /[:](\w+)/g;
+        const matches = path.match(paramRegex);
+        if (matches) {
+          const paramName = matches[0].slice(1); // Remove the : prefix
+          const existingPathParam = request.pathParams.find(param => param.name === paramName);
+          if (!existingPathParam) {
+            return '/' + path;
+          }
+          return '/' + path.replace(':' + paramName, existingPathParam.value);
         } else {
-          const name = path.slice(1);
-          const existingPathParam = request?.pathParams?.find((param) => param.type === 'path' && param.name === name);
-          return existingPathParam ? '/' + existingPathParam.value : '';
+          return '/' + path + "hej";
         }
       })
       .join('');
@@ -200,7 +205,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
   if (request.ntlmConfig) {
     request.ntlmConfig.username = _interpolate(request.ntlmConfig.username) || '';
     request.ntlmConfig.password = _interpolate(request.ntlmConfig.password) || '';
-    request.ntlmConfig.domain = _interpolate(request.ntlmConfig.domain) || '';    
+    request.ntlmConfig.domain = _interpolate(request.ntlmConfig.domain) || '';
   }
 
   if(request?.auth) delete request.auth;


### PR DESCRIPTION
# Description

THe odata request format adds path parameters in url that isn't added directly after the slash: https://www.odata.org/documentation/odata-version-2-0/uri-conventions/

This PR adds support for this by using a regex to parse path params from the url.
![image](https://github.com/user-attachments/assets/ec91eaab-02e8-419d-918b-d23a9ab5b9b4)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
