### PR TITLE
fix: runner result scroll

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -165,9 +165,9 @@ export default function RunnerResults({ collection }) {
           </button>
         )}
       </div>
-      <div className="flex flex-row gap-4">
+      <div className="flex flex-row gap-4 h-[calc(100vh_-_12rem)] max-h-[calc(100vh_-_12rem)]">
         <div
-          className="flex flex-col flex-1 overflow-y-auto h-[calc(100vh_-_12rem)] max-h-[calc(100vh_-_12rem)] w-full"
+          className="flex flex-col flex-1 overflow-y-auto w-full"
           ref={runnerBodyRef}
         >
           <div className="pb-2 font-medium test-summary">
@@ -315,7 +315,7 @@ export default function RunnerResults({ collection }) {
           ) : null}
         </div>
         {selectedItem ? (
-          <div className="flex flex-1 w-[50%]">
+          <div className="flex flex-1 w-[50%] overflow-y-auto">
             <div className="flex flex-col w-full overflow-auto">
               <div className="flex items-center px-3 mb-4 font-medium">
                 <span className="mr-2">{selectedItem.displayName}</span>


### PR DESCRIPTION
# Description

Scrolling inside the Response pane now moves only the response content. The rest of the Runner stays still.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

https://github.com/user-attachments/assets/9206b084-5e50-47eb-b4a7-8d4076ee59f3