### PR TITLE
Add editable variable tooltips

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/CodeEditorWithStore.js
+++ b/packages/bruno-app/src/components/CodeEditor/CodeEditorWithStore.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import CodeEditor from './index';
+import { useStore } from 'react-redux';
+
+/**
+ * CodeEditorWithStore - A wrapper component that provides Redux store access to CodeEditor
+ * This ensures that CodeMirror extensions like brunoVarInfo can safely access Redux
+ * without relying on global store exposure.
+ */
+const CodeEditorWithStore = (props) => {
+  const store = useStore();
+  
+  return <CodeEditor {...props} store={store} />;
+};
+
+export default CodeEditorWithStore;

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -49,7 +49,9 @@ export default class CodeEditor extends React.Component {
       tabSize: TAB_SIZE,
       mode: this.props.mode || 'application/ld+json',
       brunoVarInfo: {
-        variables
+        variables,
+        collectionUid: this.props.collection?.uid,
+        store: this.props.store
       },
       keyMap: 'sublime',
       autoCloseBrackets: true,
@@ -269,6 +271,13 @@ export default class CodeEditor extends React.Component {
 
     defineCodeMirrorBrunoVariablesMode(variables, mode, false, this.props.enableVariableHighlighting);
     this.editor.setOption('mode', 'brunovariables');
+    
+    // Update brunoVarInfo options with new variables and ensure collectionUid is preserved
+    this.editor.setOption('brunoVarInfo', {
+      variables,
+      collectionUid: this.props.collection?.uid,
+      store: this.props.store
+    });
   };
 
   _onEdit = () => {

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -29,7 +29,9 @@ class MultiLineEditor extends Component {
       placeholder: this.props.placeholder,
       mode: 'brunovariables',
       brunoVarInfo: {
-        variables
+        variables,
+        collectionUid: this.props.collection?.uid,
+        store: this.props.store
       },
       scrollbarStyle: null,
       tabindex: 0,
@@ -112,6 +114,8 @@ class MultiLineEditor extends Component {
     let variables = getAllVariables(this.props.collection, this.props.item);
     if (!isEqual(variables, this.variables)) {
       this.editor.options.brunoVarInfo.variables = variables;
+      this.editor.options.brunoVarInfo.collectionUid = this.props.collection?.uid;
+      this.editor.options.brunoVarInfo.store = this.props.store
       this.addOverlay(variables);
     }
     if (this.props.theme !== prevProps.theme && this.editor) {

--- a/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
-import CodeEditor from 'components/CodeEditor';
+import CodeEditorWithStore from 'components/CodeEditor/CodeEditorWithStore';
 import { updateRequestGraphqlVariables } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { useTheme } from 'providers/Theme';
@@ -57,7 +57,7 @@ const GraphQLVariables = ({ variables, item, collection }) => {
       >
         <IconWand size={20} strokeWidth={1.5} />
       </button>
-      <CodeEditor
+      <CodeEditorWithStore
         collection={collection}
         value={variables || ''}
         theme={displayedTheme}

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
@@ -42,7 +42,8 @@ export default class QueryEditor extends React.Component {
       mode: 'graphql',
       // mode: 'brunovariables',
       brunoVarInfo: {
-        variables: getAllVariables(this.props.collection)
+        variables: getAllVariables(this.props.collection),
+        collectionUid: this.props.collection?.uid
       },
       theme: this.props.editorTheme || 'graphiql',
       theme: this.props.theme === 'dark' ? 'monokai' : 'default',
@@ -163,6 +164,7 @@ export default class QueryEditor extends React.Component {
     let variables = getAllVariables(this.props.collection);
     if (!isEqual(variables, this.variables)) {
       this.editor.options.brunoVarInfo.variables = variables;
+      this.editor.options.brunoVarInfo.collectionUid = this.props.collection?.uid;
       this.addOverlay();
     }
     this.ignoreChangeEvent = false;

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import get from 'lodash/get';
-import CodeEditor from 'components/CodeEditor';
+import CodeEditorWithStore from 'components/CodeEditor/CodeEditorWithStore';
 import FormUrlEncodedParams from 'components/RequestPane/FormUrlEncodedParams';
 import MultipartFormParams from 'components/RequestPane/MultipartFormParams';
 import { useDispatch, useSelector } from 'react-redux';
@@ -47,7 +47,7 @@ const RequestBody = ({ item, collection }) => {
 
     return (
       <StyledWrapper className="w-full">
-        <CodeEditor
+        <CodeEditorWithStore
           collection={collection}
           item={item}
           theme={displayedTheme}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -1,4 +1,4 @@
-import CodeEditor from 'components/CodeEditor/index';
+import CodeEditorWithStore from 'components/CodeEditor/CodeEditorWithStore';
 import get from 'lodash/get';
 import { useTheme } from 'providers/Theme/index';
 import StyledWrapper from './StyledWrapper';
@@ -47,7 +47,7 @@ const CodeView = ({ language, item }) => {
         </button>
       </CopyToClipboard>
       <div className="editor-content">
-        <CodeEditor
+        <CodeEditorWithStore
           readOnly
           collection={collection}
           item={item}

--- a/packages/bruno-app/src/components/SingleLineEditor/SingleLineEditorWithStore.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/SingleLineEditorWithStore.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import SingleLineEditor from './index';
+import { useStore } from 'react-redux';
+
+/**
+ * SingleLineEditorWithStore - A wrapper component that provides Redux store access to SingleLineEditor
+ * This ensures that CodeMirror extensions like brunoVarInfo can safely access Redux
+ * without relying on global store exposure.
+ */
+const SingleLineEditorWithStore = (props) => {
+  const store = useStore();
+  
+  return <SingleLineEditor {...props} store={store} />;
+};
+
+export default SingleLineEditorWithStore;

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -47,7 +47,9 @@ class SingleLineEditor extends Component {
       theme: this.props.theme === 'dark' ? 'monokai' : 'default',
       mode: 'brunovariables',
       brunoVarInfo: {
-        variables
+        variables,
+        collectionUid: this.props.collection?.uid,
+        store: this.props.store
       },
       scrollbarStyle: null,
       tabindex: 0,
@@ -129,6 +131,8 @@ class SingleLineEditor extends Component {
     let variables = getAllVariables(this.props.collection, this.props.item);
     if (!isEqual(variables, this.variables)) {
       this.editor.options.brunoVarInfo.variables = variables;
+      this.editor.options.brunoVarInfo.collectionUid = this.props.collection?.uid;
+      this.editor.options.brunoVarInfo.store = this.props.store;
       this.addOverlay(variables);
     }
     if (this.props.theme !== prevProps.theme && this.editor) {

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -205,19 +205,154 @@ const GlobalStyle = createGlobalStyle`
   .CodeMirror-brunoVarInfo {
     color: ${(props) => props.theme.codemirror.variable.info.color};
     background: ${(props) => props.theme.codemirror.variable.info.bg};
-    border-radius: 2px;
+    border-radius: 6px;
     box-shadow: ${(props) => props.theme.codemirror.variable.info.boxShadow};
     box-sizing: border-box;
     font-size: 13px;
     line-height: 16px;
     margin: 8px -8px;
-    max-width: 800px;
+    max-width: 320px;
+    min-width: 220px;
     opacity: 0;
     overflow: hidden;
-    padding: 8px 8px;
+    padding: 12px;
     position: fixed;
     transition: opacity 0.15s;
     z-index: 50;
+    border: 1px solid ${(props) => props.theme.codemirror.border || 'rgba(0,0,0,0.1)'};
+  }
+
+  .CodeMirror-brunoVarInfo .bruno-var-info-container {
+    width: 100%;
+  }
+
+  .CodeMirror-brunoVarInfo .info-name {
+    font-weight: bold;
+    font-size: 12px;
+    margin-bottom: 6px;
+    color: ${(props) => props.theme.codemirror.variable.info.color};
+    opacity: 0.8;
+    padding: 2px 6px;
+    background: rgba(0, 122, 204, 0.1);
+    border-radius: 3px;
+    display: inline-block;
+  }
+
+  .CodeMirror-brunoVarInfo .value-container {
+    margin-bottom: 8px;
+  }
+
+  .CodeMirror-brunoVarInfo .info-description {
+    word-break: break-all;
+    max-height: 120px;
+    overflow-y: auto;
+    padding: 6px;
+    background: rgba(0, 0, 0, 0.02);
+    border-radius: 3px;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    font-family: monospace;
+  }
+
+  .CodeMirror-brunoVarInfo .edit-input {
+    font-family: monospace;
+    font-size: 13px;
+    line-height: 16px;
+    background: ${(props) => props.theme.codemirror.bg || '#fff'};
+    color: ${(props) => props.theme.codemirror.variable.info.color};
+    border: 1px solid ${(props) => props.theme.codemirror.border || '#ccc'};
+    padding: 6px;
+    border-radius: 3px;
+  }
+
+  .CodeMirror-brunoVarInfo .edit-input:focus {
+    outline: none;
+    border-color: #007acc;
+    box-shadow: 0 0 0 2px rgba(0, 122, 204, 0.2);
+  }
+
+  .CodeMirror-brunoVarInfo .button-container {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 8px;
+  }
+
+  .CodeMirror-brunoVarInfo button {
+    transition: all 0.2s ease;
+    font-size: 11px;
+    padding: 5px 10px;
+    border-radius: 4px;
+    border: none;
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .CodeMirror-brunoVarInfo button:hover {
+    opacity: 0.9;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  }
+
+  .CodeMirror-brunoVarInfo button:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  }
+
+  .CodeMirror-brunoVarInfo .edit-btn {
+    background: #007acc;
+    color: white;
+  }
+
+  .CodeMirror-brunoVarInfo .save-btn {
+    background: #28a745;
+    color: white;
+  }
+
+  .CodeMirror-brunoVarInfo .cancel-btn {
+    background: #6c757d;
+    color: white;
+  }
+
+  .CodeMirror-brunoVarInfo .edit-input {
+    width: 100%;
+  }
+
+  .CodeMirror-brunoVarInfo .edit-input.hidden {
+    display: none;
+  }
+
+  .CodeMirror-brunoVarInfo .info-description.hidden {
+    display: none;
+  }
+
+  .CodeMirror-brunoVarInfo button.hidden {
+    display: none;
+  }
+
+  .CodeMirror-brunoVarInfo button.visible {
+    display: inline-block;
+  }
+
+  .CodeMirror-brunoVarInfo .feedback-message {
+    font-size: 12px;
+    margin-top: 4px;
+  }
+
+  .CodeMirror-brunoVarInfo .feedback-message.success {
+    color: #28a745;
+  }
+
+  .CodeMirror-brunoVarInfo .feedback-message.error {
+    color: #dc3545;
+    white-space: normal;
+    word-wrap: break-word;
+  }
+
+  .CodeMirror-brunoVarInfo .read-only-info {
+    font-size: 11px;
+    color: #666;
+    margin-top: 4px;
+    font-style: italic;
   }
 
   .CodeMirror-brunoVarInfo :first-child {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -259,6 +259,15 @@ export const collectionsSlice = createSlice({
         collection.runtimeVariables = runtimeVariables;
       }
     },
+    updateRuntimeVariable: (state, action) => {
+      const { collectionUid, variableName, variableValue } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+
+      if (collection) {
+        collection.runtimeVariables = collection.runtimeVariables || {};
+        collection.runtimeVariables[variableName] = variableValue;
+      }
+    },
     processEnvUpdateEvent: (state, action) => {
       const { collectionUid, processEnvVariables } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
@@ -2346,6 +2355,7 @@ export const {
   renameItem,
   cloneItem,
   scriptEnvironmentUpdateEvent,
+  updateRuntimeVariable,
   processEnvUpdateEvent,
   requestCancelled,
   responseReceived,

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -9,33 +9,429 @@
 import { interpolate } from '@usebruno/common';
 
 let CodeMirror;
+let store;
 const SERVER_RENDERED = typeof window === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
 const { get } = require('lodash');
 
+// Dynamically import the store when not server-rendered
 if (!SERVER_RENDERED) {
   CodeMirror = require('codemirror');
+  // Import store asynchronously to avoid circular dependencies
+  import('providers/ReduxStore').then(({ default: reduxStore }) => {
+    store = reduxStore;
+  });
 
   const renderVarInfo = (token, options, cm, pos) => {
-    // Extract variable name and value based on token
     const { variableName, variableValue } = extractVariableInfo(token.string, options.variables);
 
     if (variableValue === undefined) {
       return;
     }
 
-    const into = document.createElement('div');
+    const container = createVariableInfoContainer();
+    
+    appendVariableHeader(container, variableName, options);
+    appendVariableValue(container, variableName, variableValue, options, cm);
+    
+    return container;
+  };
+
+  const createVariableInfoContainer = () => {
+    const container = document.createElement('div');
+    container.className = 'bruno-var-info-container';
+    return container;
+  };
+
+  const appendVariableHeader = (container, variableName, options) => {
+    const variableType = getVariableType(variableName, options);
+    const headerDiv = document.createElement('div');
+    headerDiv.className = 'info-name';
+    headerDiv.textContent = `${variableName} (${variableType})`;
+    container.appendChild(headerDiv);
+  };
+
+  const appendVariableValue = (container, variableName, variableValue, options, cm) => {
+    const variableType = getVariableType(variableName, options);
+    const isEditable = isVariableEditable(variableType);
+    const isMasked = isVariableMasked(variableName, options);
+    
+    const valueContainer = createValueContainer(variableValue, isMasked, isEditable);
+    container.appendChild(valueContainer);
+    
+    if (isEditable && !isMasked) {
+      const editControls = createEditControls(variableName, variableValue, options, cm, valueContainer);
+      container.appendChild(editControls);
+    } else if (!isEditable) {
+      container.appendChild(createReadOnlyInfo());
+    }
+  };
+
+  const isVariableEditable = (variableType) => {
+    return ['global', 'environment', 'runtime'].includes(variableType);
+  };
+
+  const isVariableMasked = (variableName, options) => {
+    return options?.variables?.maskedEnvVariables?.includes(variableName);
+  };
+
+  const createValueContainer = (variableValue, isMasked, isEditable) => {
+    const valueContainer = document.createElement('div');
+    valueContainer.className = 'value-container';
+    
+    const displayValue = isMasked ? '*****' : variableValue;
+    const descriptionDiv = createValueDisplay(displayValue);
+    valueContainer.appendChild(descriptionDiv);
+    
+    if (isEditable && !isMasked) {
+      const editInput = createEditInput(variableValue);
+      valueContainer.appendChild(editInput);
+    }
+    
+    return valueContainer;
+  };
+
+  const createValueDisplay = (displayValue) => {
     const descriptionDiv = document.createElement('div');
     descriptionDiv.className = 'info-description';
+    descriptionDiv.appendChild(document.createTextNode(displayValue));
+    return descriptionDiv;
+  };
 
-    if (options?.variables?.maskedEnvVariables?.includes(variableName)) {
-      descriptionDiv.appendChild(document.createTextNode('*****'));
-    } else {
-      descriptionDiv.appendChild(document.createTextNode(variableValue));
+  const createEditInput = (variableValue) => {
+    const editInput = document.createElement('input');
+    editInput.type = 'text';
+    editInput.className = 'edit-input hidden';
+    editInput.value = variableValue;
+    return editInput;
+  };
+
+  const createEditControls = (variableName, variableValue, options, cm, valueContainer) => {
+    const buttonContainer = document.createElement('div');
+    buttonContainer.className = 'button-container';
+    
+    const editButton = createButton('Edit', 'edit-btn');
+    const saveButton = createButton('Save', 'save-btn hidden');
+    const cancelButton = createButton('Cancel', 'cancel-btn hidden');
+    
+    buttonContainer.appendChild(editButton);
+    buttonContainer.appendChild(saveButton);
+    buttonContainer.appendChild(cancelButton);
+    
+    setupEditFunctionality(
+      variableName, 
+      variableValue, 
+      options, 
+      cm, 
+      valueContainer, 
+      editButton, 
+      saveButton, 
+      cancelButton
+    );
+    
+    return buttonContainer;
+  };
+
+  const createButton = (text, className) => {
+    const button = document.createElement('button');
+    button.textContent = text;
+    button.className = className;
+    return button;
+  };
+
+  const createReadOnlyInfo = () => {
+    const infoDiv = document.createElement('div');
+    infoDiv.className = 'read-only-info';
+    infoDiv.textContent = 'Read-only variable';
+    return infoDiv;
+  };
+
+  const setupEditFunctionality = (variableName, variableValue, options, cm, valueContainer, editButton, saveButton, cancelButton) => {
+    const descriptionDiv = valueContainer.querySelector('.info-description');
+    const editInput = valueContainer.querySelector('.edit-input');
+    const originalValue = variableValue;
+    
+    const editMode = createEditModeController(descriptionDiv, editInput, editButton, saveButton, cancelButton);
+    
+    setupEditEventListeners(
+      variableName, 
+      originalValue, 
+      options, 
+      cm, 
+      valueContainer, 
+      descriptionDiv, 
+      editInput, 
+      editButton, 
+      saveButton, 
+      cancelButton, 
+      editMode
+    );
+  };
+
+  const createEditModeController = (descriptionDiv, editInput, editButton, saveButton, cancelButton) => {
+    return {
+      enter: () => {
+        descriptionDiv.className = 'info-description hidden';
+        editInput.className = 'edit-input';
+        editInput.focus();
+        editInput.select();
+        
+        editButton.className = 'edit-btn hidden';
+        saveButton.className = 'save-btn visible';
+        cancelButton.className = 'cancel-btn visible';
+      },
+      
+      exit: () => {
+        descriptionDiv.className = 'info-description';
+        editInput.className = 'edit-input hidden';
+        
+        editButton.className = 'edit-btn visible';
+        saveButton.className = 'save-btn hidden';
+        cancelButton.className = 'cancel-btn hidden';
+      }
+    };
+  };
+
+  const setupEditEventListeners = (variableName, originalValue, options, cm, valueContainer, descriptionDiv, editInput, editButton, saveButton, cancelButton, editMode) => {
+    const saveValue = async () => {
+      const newValue = editInput.value;
+      try {
+        await updateVariableValue(variableName, newValue, options, cm);
+        descriptionDiv.textContent = newValue;
+        editMode.exit();
+        showFeedback(valueContainer, 'Saved!', 'success', 2000);
+      } catch (error) {
+        showFeedback(valueContainer, error.message || 'Failed to save', 'error', 4000);
+      }
+    };
+
+    const cancelEdit = () => {
+      editInput.value = originalValue;
+      editMode.exit();
+    };
+
+    editButton.addEventListener('click', (e) => {
+      e.stopPropagation();
+      editMode.enter();
+    });
+
+    saveButton.addEventListener('click', (e) => {
+      e.stopPropagation();
+      saveValue();
+    });
+
+    cancelButton.addEventListener('click', (e) => {
+      e.stopPropagation();
+      cancelEdit();
+    });
+
+    editInput.addEventListener('keydown', (e) => {
+      e.stopPropagation();
+      if (e.key === 'Enter') {
+        saveValue();
+      } else if (e.key === 'Escape') {
+        cancelEdit();
+      }
+    });
+  };
+
+  const showFeedback = (container, message, type, duration) => {
+    const feedbackMsg = document.createElement('div');
+    feedbackMsg.textContent = message;
+    feedbackMsg.className = `feedback-message ${type}`;
+    container.appendChild(feedbackMsg);
+    setTimeout(() => feedbackMsg.remove(), duration);
+  };
+
+  // Helper function to determine variable type
+  const getVariableType = (variableName, options) => {
+    // Use imported store, fallback to options.store for backward compatibility
+    const reduxStore = store || options?.store;
+    
+    if (!reduxStore) {
+      console.warn('Bruno Variable Info: Store not available for variable type detection');
+      // When store is unavailable, we can make some basic assumptions
+      if (variableName.startsWith('process.env.')) {
+        return 'process';
+      }
+      // Default to runtime for variables that appear in the variables object
+      return options?.variables?.[variableName] !== undefined ? 'runtime' : 'unknown';
+    }
+    
+    const state = reduxStore.getState();
+    const globalEnvironments = state?.globalEnvironments?.globalEnvironments;
+    const activeGlobalEnvironmentUid = state?.globalEnvironments?.activeGlobalEnvironmentUid;
+    const collections = state?.collections?.collections;
+
+    // Check global environment
+    const activeGlobalEnv = globalEnvironments?.find(env => env?.uid === activeGlobalEnvironmentUid);
+    if (activeGlobalEnv?.variables?.some(v => v.name === variableName)) {
+      return 'global';
     }
 
-    into.appendChild(descriptionDiv);
+    // Check collection environments
+    if (collections) {
+      for (const collection of collections) {
+        if (collection.activeEnvironmentUid && collection.environments) {
+          const environment = collection.environments.find(env => env.uid === collection.activeEnvironmentUid);
+          if (environment?.variables?.some(v => v.name === variableName)) {
+            return 'environment';
+          }
+        }
+      }
+    }
 
-    return into;
+    // Check collection variables
+    if (collections) {
+      for (const collection of collections) {
+        if (collection.root?.request?.vars?.req?.some(v => v.name === variableName)) {
+          return 'collection';
+        }
+      }
+    }
+
+    // Check if it's a process env variable
+    if (variableName.startsWith('process.env.')) {
+      return 'process';
+    }
+
+    return 'runtime';
+  };
+
+  // Function to update variable value
+  const updateVariableValue = async (variableName, newValue, options, cm) => {
+    validateUpdateParameters(variableName, newValue, options);
+    
+    const variableType = getVariableType(variableName, options);
+    const reduxStore = getReduxStore(options);
+    
+    if (!reduxStore) {
+      return updateRuntimeVariableWithoutStore(variableName, newValue, options, cm, variableType);
+    }
+    
+    const state = reduxStore.getState();
+    
+    switch (variableType) {
+      case 'global':
+        return updateGlobalVariable(variableName, newValue, state, reduxStore);
+      case 'environment':
+        return updateEnvironmentVariable(variableName, newValue, state, reduxStore);
+      case 'runtime':
+        return updateRuntimeVariable(variableName, newValue, options, cm, reduxStore);
+      default:
+        throw new Error(`Variable '${variableName}' not found in editable contexts. Global, environment, and runtime variables can be edited from tooltips.`);
+    }
+  };
+
+  const validateUpdateParameters = (variableName, newValue, options) => {
+    if (!variableName) {
+      throw new Error('Variable name is required');
+    }
+    if (!options?.variables) {
+      throw new Error('No variables context available');
+    }
+  };
+
+  const getReduxStore = (options) => {
+    return store || options?.store;
+  };
+
+  const updateRuntimeVariableWithoutStore = (variableName, newValue, options, cm, variableType) => {
+    if (variableType !== 'runtime' && variableType !== 'unknown') {
+      throw new Error('Redux store not available for updating global/environment variables');
+    }
+    
+    options.variables[variableName] = newValue;
+    updateCodeMirrorState(cm, options.variables);
+  };
+
+  const updateGlobalVariable = async (variableName, newValue, state, reduxStore) => {
+    const activeGlobalEnv = getActiveGlobalEnvironment(state);
+    
+    if (!activeGlobalEnv) {
+      throw new Error('No active global environment found');
+    }
+    
+    const globalVar = activeGlobalEnv.variables?.find(v => v.name === variableName);
+    if (!globalVar) {
+      throw new Error(`Global variable '${variableName}' not found`);
+    }
+    
+    const updatedVariables = updateVariableInArray(activeGlobalEnv.variables, variableName, newValue);
+    
+    const { saveGlobalEnvironment } = await import('providers/ReduxStore/slices/global-environments');
+    await reduxStore.dispatch(saveGlobalEnvironment({ 
+      environmentUid: state.globalEnvironments.activeGlobalEnvironmentUid, 
+      variables: updatedVariables 
+    }));
+  };
+
+  const updateEnvironmentVariable = async (variableName, newValue, state, reduxStore) => {
+    const collections = state?.collections?.collections;
+    if (!collections) {
+      throw new Error('No collections found');
+    }
+    
+    for (const collection of collections) {
+      const environment = getActiveEnvironment(collection);
+      if (!environment) continue;
+      
+      const envVar = environment.variables?.find(v => v.name === variableName && v.enabled);
+      if (envVar) {
+        const updatedVariables = updateVariableInArray(environment.variables, variableName, newValue);
+        
+        const { saveEnvironment } = await import('providers/ReduxStore/slices/collections/actions');
+        await reduxStore.dispatch(saveEnvironment(updatedVariables, collection.activeEnvironmentUid, collection.uid));
+        return;
+      }
+    }
+    
+    throw new Error(`Environment variable '${variableName}' not found`);
+  };
+
+  const updateRuntimeVariable = async (variableName, newValue, options, cm, reduxStore) => {
+    options.variables[variableName] = newValue;
+    updateCodeMirrorState(cm, options.variables);
+    
+    const collectionUid = options.collectionUid;
+    if (collectionUid) {
+      await dispatchRuntimeVariableUpdate(reduxStore, collectionUid, variableName, newValue);
+    }
+  };
+
+  const getActiveGlobalEnvironment = (state) => {
+    const globalEnvironments = state?.globalEnvironments?.globalEnvironments;
+    const activeGlobalEnvironmentUid = state?.globalEnvironments?.activeGlobalEnvironmentUid;
+    
+    return globalEnvironments?.find(env => env?.uid === activeGlobalEnvironmentUid);
+  };
+
+  const getActiveEnvironment = (collection) => {
+    if (!collection.activeEnvironmentUid || !collection.environments) {
+      return null;
+    }
+    
+    return collection.environments.find(env => env.uid === collection.activeEnvironmentUid);
+  };
+
+  const updateVariableInArray = (variables, variableName, newValue) => {
+    return variables.map(v => 
+      v.name === variableName ? { ...v, value: newValue } : v
+    );
+  };
+
+  const updateCodeMirrorState = (cm, variables) => {
+    if (cm?.state?.brunoVarInfo) {
+      cm.state.brunoVarInfo.options.variables = variables;
+    }
+  };
+
+  const dispatchRuntimeVariableUpdate = async (reduxStore, collectionUid, variableName, variableValue) => {
+    const { updateRuntimeVariable } = await import('providers/ReduxStore/slices/collections');
+    await reduxStore.dispatch(updateRuntimeVariable({
+      collectionUid,
+      variableName,
+      variableValue
+    }));
   };
 
   CodeMirror.defineOption('brunoVarInfo', false, function (cm, options, old) {
@@ -133,23 +529,28 @@ if (!SERVER_RENDERED) {
     const popupHeight =
       popupBox.bottom - popupBox.top + parseFloat(popupStyle.marginTop) + parseFloat(popupStyle.marginBottom);
 
-    let topPos = box.bottom;
+    // Smart positioning: try below first, then above if no space
+    let topPos = box.bottom + 5;
     if (popupHeight > window.innerHeight - box.bottom - 15 && box.top > window.innerHeight - box.bottom) {
-      topPos = box.top - popupHeight;
+      topPos = box.top - popupHeight - 5;
     }
 
+    // If still doesn't fit, position at top of viewport
     if (topPos < 0) {
-      topPos = box.bottom;
+      topPos = 10;
     }
 
-    // make popup appear on top of cursor
-    if (topPos > 70) {
-      topPos = topPos - 70;
+    // Horizontal positioning: try to center on the variable, but stay within viewport
+    let leftPos = box.left + (box.width / 2) - (popupWidth / 2);
+    
+    // Ensure it doesn't go off the left edge
+    if (leftPos < 10) {
+      leftPos = 10;
     }
-
-    let leftPos = Math.max(0, window.innerWidth - popupWidth - 15);
-    if (leftPos > box.left) {
-      leftPos = box.left;
+    
+    // Ensure it doesn't go off the right edge
+    if (leftPos + popupWidth > window.innerWidth - 10) {
+      leftPos = window.innerWidth - popupWidth - 10;
     }
 
     popup.style.opacity = 1;
@@ -164,7 +565,7 @@ if (!SERVER_RENDERED) {
 
     const onMouseOut = function () {
       clearTimeout(popupTimeout);
-      popupTimeout = setTimeout(hidePopup, 200);
+      popupTimeout = setTimeout(hidePopup, 300); // Increased timeout for better UX
     };
 
     const hidePopup = function () {


### PR DESCRIPTION
Variable tooltips now allow the user to edit the value inline

# Description

Is now possible to inline edit variable values. The tooltip also tells if the variable is a global, runtime or environment variable.

<img width="637" height="335" alt="image" src="https://github.com/user-attachments/assets/25f3545d-2cdd-494f-adbd-22bcf207dcd2" />


### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
