### PR TITLE
fix: Param Table UI Breaks on resize

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -147,8 +147,8 @@ const QueryParams = ({ item, collection }) => {
         <Table
           headers={[
             { name: 'Name', accessor: 'name', width: '31%' },
-            { name: 'Path', accessor: 'path', width: '56%' },
-            { name: '', accessor: '', width: '13%' }
+            { name: 'Path', accessor: 'path', width: 'calc(69% - 3.5625rem)' },
+            { name: '', accessor: '', width: '3.5rem' }
           ]}
         >
           <ReorderTable updateReorderedItem={handleQueryParamDrag}>


### PR DESCRIPTION
# Description

resolves #5011 


https://github.com/user-attachments/assets/ccc51a5b-2ed6-4b85-810b-33a3ed62912b

Yes, I saw the other PR as well, but it doesn't address the root issue, i.e. the input & icon widths are fixed, so we can't contain them into a column with width in % which changes with screen size, so using "rem" should be the right move.


