### PR TITLE
feat: expand search to include request URL

### DIFF
--- a/packages/bruno-app/src/utils/collections/search.js
+++ b/packages/bruno-app/src/utils/collections/search.js
@@ -3,7 +3,12 @@ import filter from 'lodash/filter';
 import find from 'lodash/find';
 
 export const doesRequestMatchSearchText = (request, searchText = '') => {
-  return request?.name?.toLowerCase().includes(searchText.toLowerCase());
+  const searchItems = [
+    request?.name ?? '',
+    request?.request?.url ?? '',
+  ];
+
+  return searchItems.join('').toLowerCase().includes(searchText.toLowerCase());
 };
 
 export const doesFolderHaveItemsMatchSearchText = (item, searchText = '') => {


### PR DESCRIPTION
# Description

This PR extends the request search functionality by including the request URL in the search criteria. Previously, only the request name was used to match against the search text. With this change, users will be able to find requests by matching either the name or the URL, which makes it easier to locate requests in large collections, especially when request names are not descriptive.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.  
#5078**

<details>
<summary>
Screenshots
</summary>
<img width="984" height="552" alt="image" src="https://github.com/user-attachments/assets/9fb04ee1-4cf9-4b37-a5a9-4ac418d41515" />

<img width="995" height="499" alt="image" src="https://github.com/user-attachments/assets/20da185c-04ab-4445-ba18-46e980bd826f" />
</details>




