### PR TITLE
feat(url): import url encode settings from postman and insomnia

### DIFF
--- a/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
+++ b/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
@@ -157,6 +157,12 @@ const transformInsomniaRequestItem = (request, index, allRequests) => {
     brunoRequestItem.request.body.graphql = parseGraphQL(request.body.text);
   }
 
+  const settings = {
+    encodeUrl: request.settings?.encodeUrl !== false && request.settingEncodeUrl !== false, // handles v4 and v5 import
+  }
+
+  brunoRequestItem.settings = settings;
+
   return brunoRequestItem;
 };
 
@@ -200,7 +206,8 @@ const parseInsomniaV5Collection = (data) => {
             parameters: item.parameters || [],
             pathParameters: item.pathParameters || [],
             authentication: item.authentication || {},
-            body: item.body || {}
+            body: item.body || {},
+            settings: item.settings || {}
           };
           return transformInsomniaRequestItem(request, index, allItems);
         } else if (item.children && Array.isArray(item.children)) {

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -380,6 +380,12 @@ const importPostmanV2CollectionItem = (brunoParent, item, parentAuth, { useWorke
         }
       };
 
+      const settings = {
+        encodeUrl: i.protocolProfileBehavior?.disableUrlEncoding !== true
+      }
+
+      brunoRequestItem.settings = settings;
+
       brunoParent.items.push(brunoRequestItem);
 
       if (i.event) {

--- a/packages/bruno-converters/tests/insomnia/insomnia-collection-v5.spec.js
+++ b/packages/bruno-converters/tests/insomnia/insomnia-collection-v5.spec.js
@@ -4,7 +4,7 @@ import insomniaToBruno from '../../src/insomnia/insomnia-to-bruno';
 describe('insomnia-collection', () => {
   it('should correctly import a valid Insomnia v5 collection file', async () => {
     const brunoCollection = insomniaToBruno(insomniaCollection);
-    
+
     expect(brunoCollection).toMatchObject(expectedOutput)
   });
 });
@@ -59,7 +59,7 @@ collection:
         method: GET
         settings:
           renderRequestBody: true
-          encodeUrl: true
+          encodeUrl: false
           followRedirects: global
           cookies:
             send: true
@@ -113,6 +113,9 @@ const expectedOutput = {
           "seq": 1,
           "type": "http-request",
           "uid": "mockeduuidvalue123456",
+          "settings": {
+            "encodeUrl": true,
+          },
         },
       ],
       "name": "Folder1",
@@ -146,6 +149,9 @@ const expectedOutput = {
           "seq": 1,
           "type": "http-request",
           "uid": "mockeduuidvalue123456",
+          "settings": {
+            "encodeUrl": false,
+          },
         },
       ],
       "name": "Folder2",

--- a/packages/bruno-converters/tests/insomnia/insomnia-collection.spec.js
+++ b/packages/bruno-converters/tests/insomnia/insomnia-collection.spec.js
@@ -22,6 +22,7 @@ const insomniaCollection = {
       "name": "Request1",
       "method": "GET",
       "url": "https://httpbin.org/get",
+      "settingEncodeUrl": false,
       "parameters": []
     },
     {
@@ -31,6 +32,7 @@ const insomniaCollection = {
       "name": "Request2",
       "method": "GET",
       "url": "https://httpbin.org/get",
+      "settingEncodeUrl": true,
       "parameters": []
     },
     {
@@ -92,6 +94,9 @@ const expectedOutput = {
           "seq": 1,
           "type": "http-request",
           "uid": "mockeduuidvalue123456",
+          "settings": {
+            "encodeUrl": false,
+          },
         },
         {
           "name": "Request1",
@@ -118,6 +123,9 @@ const expectedOutput = {
           "seq": 2,
           "type": "http-request",
           "uid": "mockeduuidvalue123456",
+          "settings": {
+            "encodeUrl": false,
+          },
         },
       ],
       "name": "Folder1",
@@ -151,6 +159,9 @@ const expectedOutput = {
           "seq": 1,
           "type": "http-request",
           "uid": "mockeduuidvalue123456",
+          "settings": {
+            "encodeUrl": true,
+          },
         },
         {
           "name": "Request2",
@@ -177,6 +188,9 @@ const expectedOutput = {
           "seq": 2,
           "type": "http-request",
           "uid": "mockeduuidvalue123456",
+          "settings": {
+            "encodeUrl": true,
+          },
         },
       ],
       "name": "Folder2",


### PR DESCRIPTION
# Description

This PR introduces support for importing URL encode settings from Postman and Insomnia collections.
- Parses URL encoding preferences from imported Postman and Insomnia files.
- Ensures consistent request behavior when migrating projects from other API clients.

This enhancement improves compatibility and streamlines migration for users switching to Bruno from other API tools.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
