### PR TITLE
fix(request): prettify JSON with variables

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -8,7 +8,7 @@ import { humanizeRequestBodyMode } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import { updateRequestBody } from 'providers/ReduxStore/slices/collections/index';
 import { toastError } from 'utils/common/error';
-import { format, applyEdits } from 'jsonc-parser';
+import { prettifyJSON } from 'utils/common';
 import xmlFormat from 'xml-formatter';
 
 const RequestBodyMode = ({ item, collection }) => {
@@ -39,8 +39,7 @@ const RequestBodyMode = ({ item, collection }) => {
   const onPrettify = () => {
     if (body?.json && bodyMode === 'json') {
       try {
-        const edits = format(body.json, undefined, { tabSize: 2, insertSpaces: true });
-        const prettyBodyJson = applyEdits(body.json, edits);
+        const prettyBodyJson = prettifyJSON(body.json);
         dispatch(
           updateRequestBody({
             content: prettyBodyJson,

--- a/packages/bruno-app/src/utils/common/index.spec.js
+++ b/packages/bruno-app/src/utils/common/index.spec.js
@@ -1,6 +1,14 @@
 const { describe, it, expect } = require('@jest/globals');
 
-import { normalizeFileName, startsWith, humanizeDate, relativeDate, getContentType, formatSize } from './index';
+import {
+  normalizeFileName,
+  startsWith,
+  humanizeDate,
+  relativeDate,
+  getContentType,
+  formatSize,
+  prettifyJSON
+} from './index';
 
 describe('common utils', () => {
   describe('normalizeFileName', () => {
@@ -182,6 +190,32 @@ describe('common utils', () => {
       expect(formatSize(null)).toBe('0B');
       expect(formatSize(undefined)).toBe('0B');
       expect(formatSize(NaN)).toBe('0B');
+    });
+  });
+
+  describe('prettifyJSON', () => {
+    it('should prettify a standard JSON string', () => {
+      const input = '{"key":"value","number":123}';
+      const expected = '{\n  "key": "value",\n  "number": 123\n}';
+      expect(prettifyJSON(input)).toBe(expected);
+    });
+
+    it('should handle JSON with a Bruno variable as a value', () => {
+      const input = '{"id":{{request_id}}}';
+      const expected = '{\n  "id": {{request_id}}\n}';
+      expect(prettifyJSON(input)).toBe(expected);
+    });
+
+    it('should handle JSON with a Bruno variable inside a string value', () => {
+      const input = '{"url":"https://example.com/{{path}}"}';
+      const expected = '{\n  "url": "https://example.com/{{path}}"\n}';
+      expect(prettifyJSON(input)).toBe(expected);
+    });
+
+    it('should return the original string for invalid JSON', () => {
+      const input = '{"key":"value",';
+      const expected = '{\n  "key": "value",';
+      expect(prettifyJSON(input)).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
# Description

  This pull request addresses issue #3019 by fixing the JSON prettifying functionality.

  The previous implementation using jsonc-parser would break when the JSON body contained Bruno's template variables (e.g., {{variable}}).


  This change introduces a new prettifyJSON utility that safely handles these variables by:
   1. Temporarily replacing all {{...}} variables with a unique placeholder.
   2. Formatting the JSON string.
   3. Restoring the original {{...}} variables from the placeholders.

  Unit tests have been added to cover the new functionality, including cases with and without variables.

## Visual Comparison
|before|after|
|--|--|
|![before](https://github.com/user-attachments/assets/9906598a-c3d6-47c1-becc-d5241dc4ec54)|![after](https://github.com/user-attachments/assets/237e04bd-2a30-4b7c-960e-6febaf0bcec1)|

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
