### PR TITLE
rename query table value from path to value

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -147,7 +147,7 @@ const QueryParams = ({ item, collection }) => {
         <Table
           headers={[
             { name: 'Name', accessor: 'name', width: '31%' },
-            { name: 'Path', accessor: 'path', width: '56%' },
+            { name: 'Value', accessor: 'path', width: '56%' },
             { name: '', accessor: '', width: '13%' }
           ]}
         >


### PR DESCRIPTION
# Description

- Rename `Path` to `Value` in the Query Params table.
- File changed: `packages/bruno-app/src/components/RequestPane/QueryParams/index.js`

Screenshot:

<img width="1144" height="676" alt="image" src="https://github.com/user-attachments/assets/46e73ce3-7646-426d-9052-0c984f3d02d1" />



