### PR TITLE
Expose bruno-runner as runtime library

### DIFF
--- a/packages/bruno-cli/LIBRARY_USAGE.md
+++ b/packages/bruno-cli/LIBRARY_USAGE.md
@@ -1,0 +1,446 @@
+# Bruno Runner Library
+
+The Bruno Runner has been refactored to provide a clean library interface that can be called externally by other applications multiple times. This allows you to programmatically execute Bruno collections from your own Node.js applications.
+
+## Installation
+
+The Bruno Runner library is part of the `@usebruno/cli` package:
+
+```bash
+npm install @usebruno/cli
+```
+
+## Basic Usage
+
+### Simple Function-based API (Original)
+
+```javascript
+const { runCollection } = require('@usebruno/cli/src/runner/bruno-runner');
+
+async function runMyCollection() {
+  try {
+    const result = await runCollection({
+      collectionPath: '/path/to/your/bruno/collection',
+      paths: ['./'],
+      recursive: true
+    });
+
+    console.log(`Executed ${result.summary.totalRequests} requests`);
+    console.log(`Passed: ${result.summary.passedRequests}`);
+    console.log(`Failed: ${result.summary.failedRequests}`);
+    console.log(`Total time: ${result.totalTime}ms`);
+
+    return result;
+  } catch (error) {
+    console.error('Collection run failed:', error.message);
+    throw error;
+  }
+}
+```
+
+### Event-based API (Newman-like Events)
+
+```javascript
+const { BrunoRunner } = require('@usebruno/cli/src/runner/bruno-runner');
+
+async function runMyCollectionWithEvents() {
+  const runner = new BrunoRunner();
+
+  // Listen for start event
+  runner.on('start', (data) => {
+    console.log('🚀 Collection started');
+    console.log(`Collection Path: ${data.options.collectionPath}`);
+    console.log(`Timestamp: ${data.timestamp}`);
+  });
+
+  // Listen for item events (each request)
+  runner.on('item', (data) => {
+    console.log(`📋 Request: ${data.item.name}`);
+    console.log(`Progress: ${data.index + 1}/${data.total}`);
+    console.log(`Status: ${data.result.error ? 'FAILED' : 'PASSED'}`);
+    if (data.result.response) {
+      console.log(`Response Time: ${data.result.response.responseTime}ms`);
+      console.log(`Status Code: ${data.result.response.status}`);
+    }
+  });
+
+  // Listen for done event
+  runner.on('done', (data) => {
+    console.log('✅ Collection completed');
+    console.log(`Duration: ${data.duration}ms`);
+    if (data.error) {
+      console.log(`Error: ${data.error}`);
+    } else {
+      console.log(`Total Requests: ${data.summary.totalRequests}`);
+      console.log(`Passed: ${data.summary.passedRequests}`);
+      console.log(`Failed: ${data.summary.failedRequests}`);
+    }
+  });
+
+  try {
+    const result = await runner.run({
+      collectionPath: '/path/to/your/bruno/collection',
+      paths: ['./'],
+      recursive: true
+    });
+
+    return result;
+  } catch (error) {
+    console.error('Collection run failed:', error.message);
+    throw error;
+  }
+}
+```
+
+## Events API
+
+The `BrunoRunner` class extends Node.js `EventEmitter` and provides Newman-like events during collection execution.
+
+### Available Events
+
+#### `start`
+Emitted when the collection run begins.
+
+**Event Data:**
+```
+{
+  timestamp: Date,        // When the run started
+  options: Object        // The options passed to runner.run()
+}
+```
+
+#### `item`
+Emitted after each request is completed.
+
+**Event Data:**
+```
+{
+  timestamp: Date,        // When the request completed
+  item: {                // Information about the request
+    name: string,         // Request name
+    pathname: string,     // Request file path
+    request: Object       // Request configuration
+  },
+  result: {              // Request execution result
+    error: string|null,   // Error message if request failed
+    response: {           // Response details (if successful)
+      status: number,     // HTTP status code
+      responseTime: number, // Response time in milliseconds
+      headers: Object,    // Response headers
+      data: any          // Response body
+    },
+    testResults: Array,   // Test execution results
+    assertionResults: Array, // Assertion results
+    runtime: number       // Total execution time
+  },
+  index: number,         // Current request index (0-based)
+  total: number          // Total number of requests
+}
+```
+
+#### `done`
+Emitted when the collection run completes (success or failure).
+
+**Event Data:**
+```
+{
+  timestamp: Date,        // When the run completed
+  duration: number,       // Total run duration in milliseconds
+  error: string|null,     // Error message if run failed
+  summary: {             // Run summary (null if error occurred)
+    totalRequests: number,
+    passedRequests: number,
+    failedRequests: number,
+    skippedRequests: number,
+    errorRequests: number,
+    totalAssertions: number,
+    passedAssertions: number,
+    failedAssertions: number,
+    totalTests: number,
+    passedTests: number,
+    failedTests: number
+  },
+  results: Array,        // Detailed results for each request
+  totalTime: number      // Total response time across all requests
+}
+```
+
+## API Reference
+
+### `runCollection(options)`
+
+Executes a Bruno collection with the specified options.
+
+**Parameters:**
+- `options` (Object): Configuration options for the runner
+
+**Returns:**
+- `Promise<Object>`: Results object containing summary, results, and totalTime
+
+#### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `paths` | `string[]` | `['./']` | Paths to run (files or directories) |
+| `collectionPath` | `string` | `process.cwd()` | Path to the collection directory |
+| `recursive` | `boolean` | `false` | Run recursively through directories |
+| `env` | `string` | `undefined` | Environment name to use |
+| `envFile` | `string` | `undefined` | Path to environment file |
+| `envVar` | `string\|string[]` | `undefined` | Environment variable overrides (format: "name=value") |
+| `testsOnly` | `boolean` | `false` | Only run requests with tests |
+| `bail` | `boolean` | `false` | Stop on first failure |
+| `sandbox` | `string` | `'developer'` | JavaScript sandbox type ('developer' or 'safe') |
+| `insecure` | `boolean` | `false` | Allow insecure connections |
+| `disableCookies` | `boolean` | `false` | Disable cookie handling |
+| `noproxy` | `boolean` | `false` | Disable proxy settings |
+| `cacert` | `string` | `undefined` | Path to CA certificate |
+| `ignoreTruststore` | `boolean` | `false` | Ignore default truststore |
+| `clientCertConfig` | `string` | `undefined` | Path to client certificate config |
+| `delay` | `number` | `undefined` | Delay between requests in milliseconds |
+| `reporterSkipAllHeaders` | `boolean` | `false` | Skip all headers in results |
+| `reporterSkipHeaders` | `string[]` | `[]` | Skip specific headers in results |
+| `generateReports` | `Object` | `undefined` | Report generation configuration |
+
+#### Report Generation Configuration
+
+The `generateReports` option allows you to generate various report formats directly from the library:
+
+```
+{
+  generateReports: {
+    json: '/path/to/output.json',      // Generate JSON report
+    junit: '/path/to/output.xml',      // Generate JUnit XML report
+    html: '/path/to/output.html'       // Generate HTML report
+  }
+}
+```
+
+**Supported Report Formats:**
+- `json`: Structured JSON report with summary and detailed results
+- `junit`: JUnit XML format compatible with CI/CD systems
+- `html`: Interactive HTML report for browser viewing
+
+**Note:** The output directories must exist before generating reports. The library will not create directories automatically.
+
+#### Return Object
+
+```
+{
+  summary: {
+    totalRequests: number,
+    passedRequests: number,
+    failedRequests: number,
+    skippedRequests: number,
+    errorRequests: number,
+    totalAssertions: number,
+    passedAssertions: number,
+    failedAssertions: number,
+    totalTests: number,
+    passedTests: number,
+    failedTests: number,
+    totalPreRequestTests: number,
+    passedPreRequestTests: number,
+    failedPreRequestTests: number,
+    totalPostResponseTests: number,
+    passedPostResponseTests: number,
+    failedPostResponseTests: number
+  },
+  results: Array<Object>, // Detailed results for each request
+  totalTime: number // Total execution time in milliseconds
+}
+```
+
+## Advanced Usage Examples
+
+### Environment Variables
+
+```javascript
+const result = await runCollection({
+  collectionPath: '/path/to/collection',
+  env: 'production',
+  envVar: ['API_KEY=secret123', 'BASE_URL=https://api.example.com']
+});
+```
+
+### Custom Configuration
+
+```javascript
+const result = await runCollection({
+  collectionPath: '/path/to/collection',
+  paths: ['auth/', 'users/'],
+  recursive: true,
+  testsOnly: true,
+  bail: true,
+  sandbox: 'safe',
+  delay: 1000,
+  reporterSkipHeaders: ['Authorization', 'Cookie']
+});
+```
+
+### Report Generation
+
+```javascript
+// Generate multiple report formats
+const result = await runCollection({
+  collectionPath: '/path/to/collection',
+  recursive: true,
+  generateReports: {
+    json: './reports/results.json',
+    junit: './reports/results.xml',
+    html: './reports/results.html'
+  }
+});
+
+// Generate only JSON report
+const result2 = await runCollection({
+  collectionPath: '/path/to/collection',
+  recursive: true,
+  generateReports: {
+    json: './test-results.json'
+  }
+});
+
+// CI/CD with JUnit report
+const result3 = await runCollection({
+  collectionPath: process.env.COLLECTION_PATH,
+  env: process.env.TEST_ENV,
+  bail: true,
+  generateReports: {
+    junit: './reports/junit-results.xml'
+  }
+});
+```
+
+### Multiple Collections
+
+```javascript
+const collections = [
+  '/path/to/collection1',
+  '/path/to/collection2',
+  '/path/to/collection3'
+];
+
+for (const collectionPath of collections) {
+  const result = await runCollection({
+    collectionPath,
+    recursive: true
+  });
+
+  console.log(`Collection ${collectionPath}: ${result.summary.totalRequests} requests`);
+}
+```
+
+### Integration with Testing Frameworks
+
+```javascript
+// Jest example
+describe('API Tests', () => {
+  test('should run Bruno collection successfully', async () => {
+    const result = await runCollection({
+      collectionPath: './tests/api-collection',
+      recursive: true,
+      bail: true
+    });
+
+    expect(result.summary.failedRequests).toBe(0);
+    expect(result.summary.errorRequests).toBe(0);
+    expect(result.summary.totalRequests).toBeGreaterThan(0);
+  });
+});
+```
+
+### CI/CD Integration
+
+```javascript
+// CI/CD pipeline example
+async function runApiTests() {
+  try {
+    const result = await runCollection({
+      collectionPath: process.env.COLLECTION_PATH,
+      env: process.env.TEST_ENV,
+      bail: true,
+      recursive: true
+    });
+
+    if (result.summary.failedRequests > 0 || result.summary.errorRequests > 0) {
+      console.error('API tests failed');
+      process.exit(1);
+    }
+
+    console.log('All API tests passed');
+    return result;
+  } catch (error) {
+    console.error('Failed to run API tests:', error.message);
+    process.exit(1);
+  }
+}
+```
+
+## Error Handling
+
+The library throws descriptive errors for various failure scenarios:
+
+```javascript
+try {
+  const result = await runCollection(options);
+} catch (error) {
+  if (error.message.includes('Collection not found')) {
+    // Handle missing collection
+  } else if (error.message.includes('Environment file not found')) {
+    // Handle missing environment
+  } else if (error.message.includes('Too many jumps')) {
+    // Handle infinite loop detection
+  } else {
+    // Handle other errors
+  }
+}
+```
+
+## Differences from CLI
+
+When using the library:
+- No console output for request execution (except delay messages)
+- Optional file output generation via `generateReports` option
+- No process.exit() calls
+- Returns structured data instead of printing summaries
+- Throws errors instead of exiting with error codes
+
+## Migration from CLI
+
+If you were previously using the CLI programmatically via child processes:
+
+**Before:**
+```javascript
+const { exec } = require('child_process');
+
+exec('bru run collection/ --env prod', (error, stdout, stderr) => {
+  // Parse stdout for results
+});
+```
+
+**After:**
+```javascript
+const { runCollection } = require('@usebruno/cli/src/runner/bruno-runner');
+
+const result = await runCollection({
+  collectionPath: 'collection/',
+  env: 'prod'
+});
+// Use structured result object
+```
+
+## Performance Considerations
+
+- The library can be called multiple times without performance degradation
+- Each call creates a fresh execution context
+- Memory usage is cleaned up after each run
+- Consider using connection pooling for high-frequency usage
+
+## Compatibility
+
+- Node.js 14+ required
+- Same Bruno collection format as CLI
+- All CLI features supported including report generation
+- Environment variables and configuration work identically
+
+For more examples, see the `example-library-usage.js` file in the package directory.

--- a/packages/bruno-cli/example-library-usage.js
+++ b/packages/bruno-cli/example-library-usage.js
@@ -1,0 +1,170 @@
+const { runCollection, BrunoRunner } = require('./src/runner/bruno-runner');
+const path = require('path');
+
+/**
+ * Example of using Bruno Runner as a library
+ * This demonstrates how external applications can use Bruno programmatically
+ */
+
+async function exampleUsage() {
+  try {
+    console.log('=== Bruno Runner Library Example ===\n');
+
+    // Example 1: Basic usage
+    console.log('Example 1: Basic collection run');
+    const testCollectionPath = path.join(__dirname, 'tests/runner/fixtures/collection-json-from-pathname/collection');
+    const basicOptions = {
+      collectionPath: testCollectionPath, // Use test collection
+      paths: ['./'], // Run all requests in collection
+      recursive: true
+    };
+
+    console.log('Running with options:', JSON.stringify(basicOptions, null, 2));
+
+    try {
+      const result1 = await runCollection(basicOptions);
+      console.log('✅ Basic run completed successfully');
+      console.log(`   - Total requests: ${result1.summary.totalRequests}`);
+      console.log(`   - Passed: ${result1.summary.passedRequests}`);
+      console.log(`   - Failed: ${result1.summary.failedRequests}`);
+      console.log(`   - Total time: ${result1.totalTime}ms\n`);
+    } catch (error) {
+      console.log('ℹ️  Basic run failed (expected if no .bru files in current directory)');
+      console.log(`   Error: ${error.message}\n`);
+    }
+
+    // Example 2: Advanced usage with multiple options
+    console.log('Example 2: Advanced configuration');
+    const advancedOptions = {
+      collectionPath: testCollectionPath,
+      paths: ['./'],
+      recursive: true,
+      testsOnly: false,
+      bail: false,
+      sandbox: 'developer',
+      insecure: false,
+      disableCookies: false,
+      delay: 500, // 500ms delay between requests
+      reporterSkipAllHeaders: false,
+      reporterSkipHeaders: ['Authorization', 'Cookie']
+    };
+
+    console.log('Running with advanced options:', JSON.stringify(advancedOptions, null, 2));
+
+    try {
+      const result2 = await runCollection(advancedOptions);
+      console.log('✅ Advanced run completed successfully');
+      console.log(`   - Total requests: ${result2.summary.totalRequests}`);
+      console.log(`   - Total time: ${result2.totalTime}ms\n`);
+    } catch (error) {
+      console.log('ℹ️  Advanced run failed (expected if no .bru files in current directory)');
+      console.log(`   Error: ${error.message}\n`);
+    }
+
+    // Example 3: Multiple runs (demonstrating reusability)
+    console.log('Example 3: Multiple runs to demonstrate reusability');
+
+    for (let i = 1; i <= 3; i++) {
+      console.log(`Run ${i}:`);
+      try {
+        const result = await runCollection({
+          collectionPath: testCollectionPath,
+          paths: ['./'],
+          recursive: true
+        });
+        console.log(`   ✅ Run ${i} completed - ${result.summary.totalRequests} requests processed`);
+      } catch (error) {
+        console.log(`   ℹ️  Run ${i} failed: ${error.message}`);
+      }
+    }
+
+    // Example 4: Report generation
+    console.log('\nExample 4: Report generation');
+
+    try {
+      const result4 = await runCollection({
+        collectionPath: testCollectionPath,
+        paths: ['./'],
+        recursive: true,
+        generateReports: {
+          json: './example-results.json',
+          html: './example-results.html'
+        }
+      });
+      console.log('✅ Report generation completed successfully');
+      console.log(`   - Generated JSON and HTML reports`);
+      console.log(`   - Total requests: ${result4.summary.totalRequests}`);
+
+      // Clean up generated files
+      const fs = require('fs');
+      try {
+        if (fs.existsSync('./example-results.json')) fs.unlinkSync('./example-results.json');
+        if (fs.existsSync('./example-results.html')) fs.unlinkSync('./example-results.html');
+        console.log('   - Cleaned up example report files');
+      } catch (cleanupError) {
+        console.log('   - Note: Could not clean up example files');
+      }
+    } catch (error) {
+      console.log('ℹ️  Report generation failed (expected if no .bru files in current directory)');
+      console.log(`   Error: ${error.message}`);
+    }
+
+    // Example 5: Event-based API (Newman-like events)
+    console.log('\nExample 5: Event-based API with Newman-like events');
+
+    const runner = new BrunoRunner();
+
+    // Set up event listeners
+    runner.on('start', (data) => {
+      console.log('🚀 Collection started');
+      console.log(`   Collection Path: ${data.options.collectionPath}`);
+    });
+
+    runner.on('item', (data) => {
+      console.log(`📋 Request completed: ${data.item.name}`);
+      console.log(`   Progress: ${data.index + 1}/${data.total}`);
+      console.log(`   Status: ${data.result.error ? 'FAILED' : 'PASSED'}`);
+      if (data.result.response) {
+        console.log(`   Response Time: ${data.result.response.responseTime}ms`);
+      }
+    });
+
+    runner.on('done', (data) => {
+      console.log('✅ Collection completed');
+      console.log(`   Duration: ${data.duration}ms`);
+      if (data.summary) {
+        console.log(`   Total Requests: ${data.summary.totalRequests}`);
+        console.log(`   Passed: ${data.summary.passedRequests}`);
+        console.log(`   Failed: ${data.summary.failedRequests}`);
+      }
+    });
+
+    try {
+      const result5 = await runner.run({
+        collectionPath: testCollectionPath,
+        paths: ['./'],
+        recursive: true
+      });
+      console.log('✅ Event-based run completed successfully');
+    } catch (error) {
+      console.log('ℹ️  Event-based run failed (expected if no .bru files in current directory)');
+      console.log(`   Error: ${error.message}`);
+    }
+
+    console.log('\n=== Library Usage Examples Complete ===');
+    console.log('The Bruno Runner library can be called multiple times from external applications!');
+    console.log('It now supports report generation in JSON, JUnit, and HTML formats!');
+    console.log('It also supports Newman-like events for real-time monitoring!');
+
+  } catch (error) {
+    console.error('❌ Example failed:', error.message);
+    process.exit(1);
+  }
+}
+
+// Run the example
+if (require.main === module) {
+  exampleUsage();
+}
+
+module.exports = { exampleUsage };

--- a/packages/bruno-cli/src/index.js
+++ b/packages/bruno-cli/src/index.js
@@ -2,6 +2,7 @@ const yargs = require('yargs');
 const chalk = require('chalk');
 
 const { CLI_EPILOGUE, CLI_VERSION } = require('./constants');
+const { BrunoRunner, runCollection } = require('./runner/bruno-runner');
 
 const printBanner = () => {
   console.log(chalk.yellow(`Bru CLI ${CLI_VERSION}`));
@@ -26,5 +27,7 @@ const run = async () => {
 };
 
 module.exports = {
-  run
+  run,
+  BrunoRunner,
+  runCollection,
 };

--- a/packages/bruno-cli/src/runner/bruno-runner.js
+++ b/packages/bruno-cli/src/runner/bruno-runner.js
@@ -1,0 +1,476 @@
+const fs = require('fs');
+const path = require('path');
+const { EventEmitter } = require('events');
+const { forOwn, cloneDeep } = require('lodash');
+const { getRunnerSummary } = require('@usebruno/common/runner');
+const { exists } = require('../utils/filesystem');
+const { runSingleRequest } = require('./run-single-request');
+const { bruToEnvJson, getEnvVars, getOptions } = require('../utils/bru');
+const { dotenvToJson } = require('@usebruno/lang');
+const constants = require('../constants');
+const { findItemInCollection, createCollectionJsonFromPathname, getCallStack } = require('../utils/collection');
+const { BrunoError } = require('../utils/bruno-error');
+const makeJUnitOutput = require('../reporters/junit');
+const makeHtmlOutput = require('../reporters/html');
+
+/**
+ * Core Bruno Runner Library
+ * Provides programmatic access to Bruno collection execution
+ */
+
+const getJsSandboxRuntime = (sandbox) => {
+  return sandbox === 'safe' ? 'quickjs' : 'vm2';
+};
+
+/**
+ * Bruno Runner class that extends EventEmitter to provide Newman-like events
+ * Emits: 'start', 'item', 'done' events
+ */
+class BrunoRunner extends EventEmitter {
+  constructor() {
+    super();
+  }
+
+  /**
+   * Run Bruno collection with event emission
+   * @param {Object} options - Configuration options for the runner
+   * @returns {Promise<Object>} Results object with summary and detailed results
+   */
+  async run(options = {}) {
+    const startTime = Date.now();
+
+    // Emit start event
+    this.emit('start', {
+      timestamp: new Date(),
+      options: { ...options }
+    });
+
+    try {
+      const result = await this._runCollectionInternal(options);
+
+      // Emit done event
+      this.emit('done', {
+        timestamp: new Date(),
+        duration: Date.now() - startTime,
+        summary: result.summary,
+        results: result.results,
+        totalTime: result.totalTime
+      });
+
+      return result;
+    } catch (error) {
+      // Emit done event even on error
+      this.emit('done', {
+        timestamp: new Date(),
+        duration: Date.now() - startTime,
+        error: error.message || error,
+        summary: null,
+        results: [],
+        totalTime: 0
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Internal method that contains the original runCollection logic
+   * @param {Object} options - Configuration options
+   * @returns {Promise<Object>} Results object
+   */
+  async _runCollectionInternal(options = {}) {
+    // This will contain the original runCollection logic
+    // We'll move it here in the next step
+    return await runCollectionOriginal(options, this);
+  }
+}
+
+/**
+ * Original run collection logic with optional event emission
+ * @param {Object} options - Configuration options for the runner
+ * @param {EventEmitter} eventEmitter - Optional event emitter for item events
+ * @returns {Promise<Object>} Results object with summary and detailed results
+ */
+const runCollectionOriginal = async (options = {}, eventEmitter = null) => {
+  let {
+    paths,
+    collectionPath = process.cwd(),
+    recursive = false,
+    env,
+    envFile,
+    envVar,
+    testsOnly = false,
+    bail = false,
+    sandbox = 'developer',
+    insecure = false,
+    disableCookies = false,
+    noproxy = false,
+    cacert,
+    ignoreTruststore = false,
+    clientCertConfig,
+    delay,
+    reporterSkipAllHeaders = false,
+    reporterSkipHeaders = [],
+    generateReports
+  } = options;
+
+  if (!paths || !paths.length) {
+    paths = ['./'];
+    recursive = true;
+  }
+
+  try {
+    let collection = createCollectionJsonFromPathname(collectionPath);
+    const { root: collectionRoot, brunoConfig } = collection;
+
+    // Handle client certificate configuration
+    if (clientCertConfig) {
+      const clientCertConfigExists = await exists(clientCertConfig);
+      if (!clientCertConfigExists) {
+        throw new BrunoError(`Client Certificate Config file "${clientCertConfig}" does not exist.`, constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
+      }
+
+      const clientCertConfigFileContent = fs.readFileSync(clientCertConfig, 'utf8');
+      let clientCertConfigJson;
+
+      try {
+        clientCertConfigJson = JSON.parse(clientCertConfigFileContent);
+      } catch (err) {
+        throw new BrunoError(`Failed to parse Client Certificate Config JSON: ${err.message}`, constants.EXIT_STATUS.ERROR_GENERIC);
+      }
+
+      if (clientCertConfigJson?.enabled && Array.isArray(clientCertConfigJson?.certs)) {
+        if (brunoConfig.clientCertificates) {
+          brunoConfig.clientCertificates.certs.push(...clientCertConfigJson.certs);
+        } else {
+          brunoConfig.clientCertificates = { certs: clientCertConfigJson.certs };
+        }
+      }
+    }
+
+    const runtimeVariables = {};
+    let envVars = {};
+
+    if (env && envFile) {
+      throw new BrunoError(`Cannot use both env and envFile options together`, constants.EXIT_STATUS.ERROR_MALFORMED_ENV_OVERRIDE);
+    }
+
+    // Handle environment variables
+    if (envFile || env) {
+      const envFilePath = envFile
+        ? path.resolve(collectionPath, envFile)
+        : path.join(collectionPath, 'environments', `${env}.bru`);
+
+      const envFileExists = await exists(envFilePath);
+      if (!envFileExists) {
+        const errorPath = envFile || `environments/${env}.bru`;
+        throw new BrunoError(`Environment file not found: ${errorPath}`, constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
+      }
+
+      const envBruContent = fs.readFileSync(envFilePath, 'utf8').replace(/\r\n/g, '\n');
+      const envJson = bruToEnvJson(envBruContent);
+      envVars = getEnvVars(envJson);
+      envVars.__name__ = envFile ? path.basename(envFilePath, '.bru') : env;
+    }
+
+    // Handle environment variable overrides
+    if (envVar) {
+      let processVars;
+      if (typeof envVar === 'string') {
+        processVars = [envVar];
+      } else if (typeof envVar === 'object' && Array.isArray(envVar)) {
+        processVars = envVar;
+      } else {
+        throw new BrunoError(`overridable environment variables not parsable: use name=value`, constants.EXIT_STATUS.ERROR_MALFORMED_ENV_OVERRIDE);
+      }
+      if (processVars && Array.isArray(processVars)) {
+        for (const value of processVars.values()) {
+          const match = value.match(/^([^=]+)=(.*)$/);
+          if (!match) {
+            throw new BrunoError(`Overridable environment variable not correct: use name=value - presented: ${value}`, constants.EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE);
+          }
+          envVars[match[1]] = match[2];
+        }
+      }
+    }
+
+    // Setup options
+    const runnerOptions = getOptions();
+    if (bail) runnerOptions['bail'] = true;
+    if (insecure) runnerOptions['insecure'] = true;
+    if (disableCookies) runnerOptions['disableCookies'] = true;
+    if (noproxy) runnerOptions['noproxy'] = true;
+
+    if (cacert && cacert.length) {
+      if (insecure) {
+        console.warn(`Ignoring the cacert option since insecure connections are enabled`);
+      } else {
+        const pathExists = await exists(cacert);
+        if (pathExists) {
+          runnerOptions['cacert'] = cacert;
+        } else {
+          throw new BrunoError(`Cacert File ${cacert} does not exist`, constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
+        }
+      }
+    }
+    runnerOptions['ignoreTruststore'] = ignoreTruststore;
+
+    // Load .env file at root of collection if it exists
+    const dotEnvPath = path.join(collectionPath, '.env');
+    const dotEnvExists = await exists(dotEnvPath);
+    const processEnvVars = { ...process.env };
+
+    if (dotEnvExists) {
+      const content = fs.readFileSync(dotEnvPath, 'utf8');
+      const jsonData = dotenvToJson(content);
+      forOwn(jsonData, (value, key) => {
+        processEnvVars[key] = value;
+      });
+    }
+
+    // Resolve and validate paths
+    const resolvedPaths = paths.map(p => path.resolve(collectionPath, p));
+    for (const resolvedPath of resolvedPaths) {
+      const pathExists = await exists(resolvedPath);
+      if (!pathExists) {
+        throw new BrunoError(`Path not found: ${resolvedPath}`, constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
+      }
+    }
+
+    // Get request items
+    let requestItems = getCallStack(resolvedPaths, collection, { recursive });
+
+    // Filter for tests only if requested
+    if (testsOnly) {
+      requestItems = requestItems.filter((iter) => {
+        const requestHasTests = iter.request?.tests;
+        const requestHasActiveAsserts = iter.request?.assertions.some((x) => x.enabled) || false;
+        return requestHasTests || requestHasActiveAsserts;
+      });
+    }
+
+    const runtime = getJsSandboxRuntime(sandbox);
+
+    // Create function to run single request by pathname
+    const runSingleRequestByPathname = async (relativeItemPathname) => {
+      return new Promise(async (resolve, reject) => {
+        let itemPathname = path.join(collectionPath, relativeItemPathname);
+        if (itemPathname && !itemPathname?.endsWith('.bru')) {
+          itemPathname = `${itemPathname}.bru`;
+        }
+        const requestItem = cloneDeep(findItemInCollection(collection, itemPathname));
+        if (requestItem) {
+          const res = await runSingleRequest(
+            requestItem,
+            collectionPath,
+            runtimeVariables,
+            envVars,
+            processEnvVars,
+            brunoConfig,
+            collectionRoot,
+            runtime,
+            collection,
+            runSingleRequestByPathname
+          );
+          resolve(res?.response);
+        }
+        reject(`bru.runRequest: invalid request path - ${itemPathname}`);
+      });
+    };
+
+    // Execute requests
+    let results = [];
+    let currentRequestIndex = 0;
+    let nJumps = 0;
+
+    while (currentRequestIndex < requestItems.length) {
+      const requestItem = cloneDeep(requestItems[currentRequestIndex]);
+      const { pathname } = requestItem;
+
+      const start = process.hrtime();
+      const result = await runSingleRequest(
+        requestItem,
+        collectionPath,
+        runtimeVariables,
+        envVars,
+        processEnvVars,
+        brunoConfig,
+        collectionRoot,
+        runtime,
+        collection,
+        runSingleRequestByPathname
+      );
+
+      // Handle delay between requests
+      const isLastRun = currentRequestIndex === requestItems.length - 1;
+      const isValidDelay = !Number.isNaN(delay) && delay > 0;
+      if (isValidDelay && !isLastRun) {
+        console.log(`Waiting for ${delay}ms or ${(delay/1000).toFixed(3)}s before next request.`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+
+      if (Number.isNaN(delay) && !isLastRun) {
+        console.log(`Ignoring delay because it's not a valid number.`);
+      }
+
+      const itemResult = {
+        ...result,
+        runtime: process.hrtime(start)[0] + process.hrtime(start)[1] / 1e9,
+        suitename: pathname.replace('.bru', '')
+      };
+
+      results.push(itemResult);
+
+      // Emit item event if eventEmitter is provided
+      if (eventEmitter) {
+        eventEmitter.emit('item', {
+          timestamp: new Date(),
+          item: {
+            name: requestItem.name,
+            pathname: pathname,
+            request: requestItem.request
+          },
+          result: itemResult,
+          index: currentRequestIndex,
+          total: requestItems.length
+        });
+      }
+
+      // Process reporter options
+      if (reporterSkipAllHeaders) {
+        results.forEach((result) => {
+          result.request.headers = {};
+          result.response.headers = {};
+        });
+      }
+
+      const deleteHeaderIfExists = (headers, header) => {
+        Object.keys(headers).forEach((key) => {
+          if (key.toLowerCase() === header.toLowerCase()) {
+            delete headers[key];
+          }
+        });
+      };
+
+      if (reporterSkipHeaders?.length) {
+        results.forEach((result) => {
+          if (result.request?.headers) {
+            reporterSkipHeaders.forEach((header) => {
+              deleteHeaderIfExists(result.request.headers, header);
+            });
+          }
+          if (result.response?.headers) {
+            reporterSkipHeaders.forEach((header) => {
+              deleteHeaderIfExists(result.response.headers, header);
+            });
+          }
+        });
+      }
+
+      // Handle bail option
+      if (bail) {
+        const requestFailure = result?.error && !result?.skipped;
+        const testFailure = result?.testResults?.find((iter) => iter.status === 'fail');
+        const assertionFailure = result?.assertionResults?.find((iter) => iter.status === 'fail');
+        const preRequestTestFailure = result?.preRequestTestResults?.find((iter) => iter.status === 'fail');
+        const postResponseTestFailure = result?.postResponseTestResults?.find((iter) => iter.status === 'fail');
+        if (requestFailure || testFailure || assertionFailure || preRequestTestFailure || postResponseTestFailure) {
+          break;
+        }
+      }
+
+      // Handle flow control (next request)
+      const nextRequestName = result?.nextRequestName;
+
+      if (result?.shouldStopRunnerExecution) {
+        break;
+      }
+
+      if (nextRequestName !== undefined) {
+        nJumps++;
+        if (nJumps > 10000) {
+          throw new BrunoError(`Too many jumps, possible infinite loop`, constants.EXIT_STATUS.ERROR_INFINITE_LOOP);
+        }
+        if (nextRequestName === null) {
+          break;
+        }
+        const nextRequestIdx = requestItems.findIndex((iter) => iter.name === nextRequestName);
+        if (nextRequestIdx >= 0) {
+          currentRequestIndex = nextRequestIdx;
+        } else {
+          throw new BrunoError("Could not find request with name '" + nextRequestName + "'", constants.EXIT_STATUS.ERROR_GENERIC);
+        }
+      } else {
+        currentRequestIndex++;
+      }
+    }
+
+    // Generate summary
+    const summary = getRunnerSummary(results);
+    const totalTime = results.reduce((acc, res) => acc + res.response.responseTime, 0);
+
+    // Handle report generation
+    if (generateReports && Object.keys(generateReports).length > 0) {
+      const outputJson = {
+        summary,
+        results
+      };
+
+      const reporters = {
+        'json': (path) => fs.writeFileSync(path, JSON.stringify(outputJson, null, 2)),
+        'junit': (path) => makeJUnitOutput(results, path),
+        'html': (path) => makeHtmlOutput(outputJson, path),
+      };
+
+      for (const formatter of Object.keys(generateReports)) {
+        const reportPath = generateReports[formatter];
+        const reporter = reporters[formatter];
+
+        // Skip formatters lacking an output path
+        if (!reportPath || reportPath.length === 0) {
+          continue;
+        }
+
+        const outputDir = path.dirname(reportPath);
+        const outputDirExists = await exists(outputDir);
+        if (!outputDirExists) {
+          throw new BrunoError(`Output directory ${outputDir} does not exist`, constants.EXIT_STATUS.ERROR_MISSING_OUTPUT_DIR);
+        }
+
+        if (!reporter) {
+          throw new BrunoError(`Reporter ${formatter} does not exist`, constants.EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT);
+        }
+
+        reporter(reportPath);
+      }
+    }
+
+    return {
+      summary,
+      results,
+      totalTime
+    };
+
+  } catch (err) {
+    // If the error is already a BrunoError, preserve its exit code
+    if (err instanceof BrunoError) {
+      throw err;
+    }
+    // Otherwise, wrap it in a BrunoError with generic exit code
+    throw new BrunoError(`Bruno Runner Error: ${err.message}`, constants.EXIT_STATUS.ERROR_GENERIC);
+  }
+};
+
+/**
+ * Backward compatible runCollection function
+ * Run Bruno collection with the provided options (maintains original API)
+ * @param {Object} options - Configuration options for the runner
+ * @returns {Promise<Object>} Results object with summary and detailed results
+ */
+const runCollection = async (options = {}) => {
+  return await runCollectionOriginal(options);
+};
+
+module.exports = {
+  runCollection,
+  BrunoRunner
+};

--- a/packages/bruno-cli/src/utils/bruno-error.js
+++ b/packages/bruno-cli/src/utils/bruno-error.js
@@ -1,0 +1,19 @@
+/**
+ * Custom error class for Bruno Runner that carries exit status codes
+ */
+class BrunoError extends Error {
+  constructor(message, exitCode = null) {
+    super(message);
+    this.name = 'BrunoError';
+    this.exitCode = exitCode;
+    
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, BrunoError);
+    }
+  }
+}
+
+module.exports = {
+  BrunoError
+};

--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -6,11 +6,11 @@ const { jsonToBruV2, envJsonToBruV2, jsonToCollectionBru } = require('@usebruno/
 const { sanitizeName } = require('./filesystem');
 const { bruToJson, collectionBruToJson } = require('./bru');
 const constants = require('../constants');
-const chalk = require('chalk');
+const { BrunoError } = require('./bruno-error');
 
 const createCollectionJsonFromPathname = (collectionPath) => {
   const environmentsPath = path.join(collectionPath, `environments`);
-    
+
   // get the collection bruno json config [<collection-path>/bruno.json]
   const brunoConfig = getCollectionBrunoJsonConfig(collectionPath);
 
@@ -30,7 +30,7 @@ const createCollectionJsonFromPathname = (collectionPath) => {
       if (stats.isDirectory()) {
         if (filePath === environmentsPath) continue;
         if (filePath.startsWith('.git') || filePath.startsWith('node_modules')) continue;
-        
+
         // get the folder root
         let folderItem = { name: file, pathname: filePath, type: 'folder', items: traverse(filePath) }
         const folderBruJson = getFolderRoot(filePath);
@@ -80,8 +80,7 @@ const getCollectionBrunoJsonConfig = (dir) => {
   const brunoJsonPath = path.join(dir, 'bruno.json');
   const brunoJsonExists = fs.existsSync(brunoJsonPath);
   if (!brunoJsonExists) {
-    console.error(chalk.red(`You can run only at the root of a collection`));
-    process.exit(constants.EXIT_STATUS.ERROR_NOT_IN_COLLECTION);
+    throw new BrunoError(`You can run only at the root of a collection`, constants.EXIT_STATUS.ERROR_NOT_IN_COLLECTION);
   }
 
   const brunoConfigFile = fs.readFileSync(brunoJsonPath, 'utf8');
@@ -409,7 +408,7 @@ const createCollectionFromBrunoObject = async (collection, dirPath) => {
     type: 'collection',
     ignore: ['node_modules', '.git']
   };
-  
+
   fs.writeFileSync(
     path.join(dirPath, 'bruno.json'), 
     JSON.stringify(brunoConfig, null, 2)

--- a/packages/bruno-cli/tests/runner/collection-json-from-pathname.spec.js
+++ b/packages/bruno-cli/tests/runner/collection-json-from-pathname.spec.js
@@ -1,16 +1,23 @@
-const path = require("node:path");
+const path = require("path");
 const { describe, it, expect } = require('@jest/globals');
 const constants = require('../../src/constants');
 const { createCollectionJsonFromPathname } = require('../../src/utils/collection');
+const { BrunoError } = require('../../src/utils/bruno-error');
 
 describe('create collection json from pathname', () => {
   it("should throw an error when the pathname is not a valid bruno collection root", () => {
     const invalidCollectionPathname = path.join(__dirname, './fixtures/collection-invalid');
-    jest.spyOn(console, 'error').mockImplementation(() => { });
-    let mockProcessExit = jest.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(code); });
-    try { createCollectionJsonFromPathname(invalidCollectionPathname); } catch { }
-    expect(mockProcessExit).toHaveBeenCalledWith(constants.EXIT_STATUS.ERROR_NOT_IN_COLLECTION);
-    jest.restoreAllMocks();
+
+    expect(() => {
+      createCollectionJsonFromPathname(invalidCollectionPathname);
+    }).toThrow(BrunoError);
+
+    try {
+      createCollectionJsonFromPathname(invalidCollectionPathname);
+    } catch (error) {
+      expect(error).toBeInstanceOf(BrunoError);
+      expect(error.exitCode).toBe(constants.EXIT_STATUS.ERROR_NOT_IN_COLLECTION);
+    }
   })
 
   it("creates a bruno collection json from the collection bru files", () => {


### PR DESCRIPTION
# Description

Currently bruno can only be used as cli, when running in CI / CD this means we will have to start the node process, parse the grammer and load everytime which can be wasteful.

In our setup basically we have written code over the existing newman library where we get collections to run from a queue and run it over the entire stack. This is possible because we are using newman as a library, but bruno doesn't provide such functionality and we have to start a new node process everytime. 

The idea here is to separate the code for running bruno collections from cli and allow the users to use both as per their desire or even to write custom logic if they intend to.

The API is more or less like `newman` so folks have familiarity, there are 2 APIs:
* a method which returns result as promise when the collection run is complete
* an event emitter where one can listen events from bruno runner when a collection is started, done or when an item is being processed

We tried this in our CI / CD pipeline and it surely does perform better than starting new node process.

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
