### PR TITLE
fix: crash double-click handling for collection and collection item

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -217,6 +217,12 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     );
   };
 
+  const handleFolderDoubleClick = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    // Prevent the parent's double-click handler from firing
+  };
+
   const handleRightClick = (event) => {
     const _menuDropdown = dropdownTippyRef.current;
     if (_menuDropdown) {
@@ -358,6 +364,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
                   className={iconClassName}
                   style={{ color: 'rgb(160 160 160)' }}
                   onClick={handleFolderCollapse}
+                   onDoubleClick={handleFolderDoubleClick}
                 />
               ) : null}
             </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -111,6 +111,12 @@ const Collection = ({ collection, searchText }) => {
     dispatch(toggleCollection(collection.uid));
   }
 
+  const handleCollectionDoubleClick = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    // Prevent the parent's double-click handler from firing
+  };
+
   const handleRightClick = (event) => {
     const _menuDropdown = menuDropdownTippyRef.current;
     if (_menuDropdown) {
@@ -223,6 +229,7 @@ const Collection = ({ collection, searchText }) => {
             className={`chevron-icon ${iconClassName}`}
             style={{ width: 16, minWidth: 16, color: 'rgb(160 160 160)' }}
             onClick={handleCollectionCollapse}
+             onDoubleClick={handleCollectionDoubleClick}
           />
           <div className="ml-1 w-full" id="sidebar-collection-name">
             {collection.name}


### PR DESCRIPTION
The app crashes when we click on the folder item, collection item. for this fix, i have handled double clicks for collection and collection item, and stopping the propagation!

# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
