### PR TITLE
Revert "fix: add rsbuild `watchFiles` config for bruno-app `src/providers/*` path and `forceRefreshWatcher` option for collection reopening"

### DIFF
--- a/packages/bruno-app/rsbuild.config.mjs
+++ b/packages/bruno-app/rsbuild.config.mjs
@@ -18,21 +18,6 @@ export default defineConfig({
       }
     })
   ],
-  dev: {
-    watchFiles: {
-      paths: [
-        'src/providers/**',
-        'src/utils/**',
-        'src/hooks/**',
-        'src/themes/**',
-        'src/selectors/**'
-      ],
-      options: {
-        usePolling: false,
-        interval: 1000,
-      },
-    },
-  },
   source: {
     tsconfigPath: './jsconfig.json', // Specifies the path to the JavaScript/TypeScript configuration file,
     exclude: [

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -56,12 +56,7 @@ const openCollectionDialog = async (win, watcher) => {
 };
 
 const openCollection = async (win, watcher, collectionPath, options = {}) => {
-  if (!watcher.hasWatcher(collectionPath) || options.forceRefreshWatcher) {
-    if (options.forceRefreshWatcher) {
-      // the watcher is being refreshed, so we remove the existing watcher
-      // when the collection is opened again in the gui, a new watcher will be created via the `renderer:mount-collection` handler
-      watcher.removeWatcher(collectionPath);
-    }
+  if (!watcher.hasWatcher(collectionPath)) {
     try {
       let brunoConfig = await getCollectionConfigFile(collectionPath);
       const uid = generateUidBasedOnHash(collectionPath);

--- a/packages/bruno-electron/src/ipc/preferences.js
+++ b/packages/bruno-electron/src/ipc/preferences.js
@@ -28,8 +28,7 @@ const registerPreferencesIpc = (mainWindow, watcher, lastOpenedCollections) => {
       for (let collectionPath of lastOpened) {
         if (isDirectory(collectionPath)) {
           await openCollection(mainWindow, watcher, collectionPath, {
-            dontSendDisplayErrors: true,
-            forceRefreshWatcher: true
+            dontSendDisplayErrors: true
           });
         }
       }


### PR DESCRIPTION
missing implementation for handling "return to app" button interaction following application crashes.

Reverts usebruno/bruno#4766