### PR TITLE
Fix representation of OAuth token (OIDC Token) to support UTF-8 values

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2TokenViewer/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2TokenViewer/index.js
@@ -12,12 +12,15 @@ const TokenSection = ({ title, token }) => {
   const [decodedToken, setDecodedToken] = useState(null);
   const [copied, setCopied] = useState(false);
 
+  const base64Decode = base64EncodedString =>
+    new TextDecoder().decode(Uint8Array.from(atob(base64EncodedString), m => m.charCodeAt(0)));
+
   useEffect(() => {
     if (token) {
       try {
         const parts = token.split('.');
         if (parts.length === 3) {
-          const payload = JSON.parse(atob(parts[1]));
+          const payload = JSON.parse(base64Decode(parts[1]));
           setDecodedToken(payload);
         }
       } catch (err) {


### PR DESCRIPTION
# Description

As described in [issue 5157](https://github.com/usebruno/bruno/issues/5157) Bruno has issues displaying umlauts/Unicode characters in the Decoded Payload of OAuth Tokens. The issue comes from just passing the payload base64 string to window.atob(...).

Additional steps are required to make sure Unicode characters are supported. This PR remedies this.

Note 1:
I have been confused by the Branching of the contributions. Let me know if I have to do something different, please.

Note 2:
The changes I made do work, I have tested them with my values. I do not know if this is the best available solution for this case.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
