### PR TITLE
feat: Implement key escaping for Bruno query parameters

### DIFF
--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -40,7 +40,9 @@ const grammar = ohm.grammar(`Bru {
   stnl = st | nl
   tagend = nl "}"
   optionalnl = ~tagend nl
-  keychar = ~(tagend | st | nl | ":") any
+  keychar = esc_keychar | unesc_keychar
+  esc_keychar = esc_char (":" | "\\x22" | "{" | "}" | " " | esc_char)
+  unesc_keychar = ~(tagend | st | nl | ":" | "\\x22" | "{" | "}" | " " | esc_char) any
   valuechar = ~(nl | tagend) any
 
    // Multiline text block surrounded by '''
@@ -51,8 +53,10 @@ const grammar = ohm.grammar(`Bru {
   dictionary = st* "{" pairlist? tagend
   pairlist = optionalnl* pair (~tagend stnl* pair)* (~tagend space)*
   pair = st* key st* ":" st* value st*
-  key = keychar*
-  value = list | multilinetextblock | valuechar*
+  disable_char = "~"
+  esc_char = "\\\\"
+  key = keychar+
+  value = multilinetextblock | valuechar*
 
   // Dictionary for Assert Block
   assertdictionary = st* "{" assertpairlist? tagend
@@ -282,8 +286,50 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     res[key.ast] = value.ast ? value.ast.trim() : '';
     return res;
   },
+
+  /**
+   * Handles escaped characters in parameter keys (e.g., \:, \", \{, \}, \ )
+   *
+   * When the grammar encounters a backslash followed by a special character:
+   * - Input: "\:" in .bru file
+   * - _1 = "\" (the escape character - discarded)
+   * - char = ":" (the character being escaped - this is what we want)
+   * - Output: ":" (unescaped character for use in HTTP requests)
+   *
+   * This ensures that escaped sequences like "test\:param" become "test:param"
+   * in the final JSON representation sent to the server.
+   */
+  esc_keychar(_1, char) {
+    return char.sourceString; // Return only the escaped character, not the backslash
+  },
+
+  /**
+   * Handles regular (unescaped) characters in parameter keys
+   *
+   * For normal characters that don't need escaping (letters, numbers, etc.):
+   * - Input: "a", "1", "-", etc.
+   * - Output: Same character as-is
+   *
+   * These characters can be used directly without any transformation.
+   */
+  unesc_keychar(char) {
+    return char.sourceString; // Return the character as-is
+  },
+
+  /**
+   * Combines all characters (escaped and unescaped) to form the final parameter key
+   *
+   * The grammar splits a key like "test\:param\{foo\}" into individual characters:
+   * - chars.ast = ["t", "e", "s", "t", ":", "p", "a", "r", "a", "m", "{", "f", "o", "o", "}"]
+   *
+   * This function:
+   * 1. Joins all characters together: "test:param{foo}"
+   * 2. Trims whitespace from the result
+   *
+   * The result is the final key name that will be used in HTTP requests.
+   */
   key(chars) {
-    return chars.sourceString ? chars.sourceString.trim() : '';
+    return chars.ast.join('').trim(); // Combine all characters and remove whitespace
   },
   value(chars) {
     if (chars.ctorName === 'list') {
@@ -344,6 +390,9 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   },
   tagend(_1, _2) {
     return '';
+  },
+  _terminal(){
+    return this.sourceString;
   },
   _iter(...elements) {
     return elements.map((e) => e.ast);

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -5,6 +5,16 @@ const { indentString } = require('./utils');
 const enabled = (items = [], key = "enabled") => items.filter((item) => item[key]);
 const disabled = (items = [], key = "enabled") => items.filter((item) => !item[key]);
 
+const escapeKey = (key) => {
+  return key
+    .replaceAll('\\', '\\\\')  // Escape backslashes first
+    .replaceAll(':', '\\:')
+    .replaceAll('"', '\\"')
+    .replaceAll('{', '\\{')
+    .replaceAll('}', '\\}')
+    .replaceAll(' ', '\\ ');
+}
+
 // remove the last line if two new lines are found
 const stripLastLine = (text) => {
   if (!text || !text.length) return text;
@@ -84,7 +94,7 @@ const jsonToBru = (json) => {
       if (enabled(queryParams).length) {
         bru += `\n${indentString(
           enabled(queryParams)
-            .map((item) => `${item.name}: ${item.value}`)
+            .map((item) => `${escapeKey(item.name)}: ${item.value}`)
             .join('\n')
         )}`;
       }
@@ -92,7 +102,7 @@ const jsonToBru = (json) => {
       if (disabled(queryParams).length) {
         bru += `\n${indentString(
           disabled(queryParams)
-            .map((item) => `~${item.name}: ${item.value}`)
+            .map((item) => `~${escapeKey(item.name)}: ${item.value}`)
             .join('\n')
         )}`;
       }

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -17,6 +17,17 @@ get {
 params:query {
   apiKey: secret
   numbers: 998877665
+  simple: normal parameter
+  colon\:parameter: has colon in name
+  space\ parameter: has space in name
+  quote\"parameter: has quote in name
+  brace\{parameter\}: has braces in name
+  backslash\\parameter: has literal backslash
+  multiple\:special\{chars\}: multiple special characters
+  complex\ \"test\"\ param\:with\{many\}special\ chars: kitchen sink test
+  ~disabled\:colon\:parameter: is disabled
+  ~disabled\ space\ param: disabled with space
+  ~edge\"case\\\{with\}\:all: all special chars together
   ~message: hello
 }
 
@@ -63,7 +74,7 @@ auth:oauth2 {
   callback_url: http://localhost:8080/api/auth/oauth2/authorization_code/callback
   authorization_url: http://localhost:8080/api/auth/oauth2/authorization_code/authorize
   access_token_url: http://localhost:8080/api/auth/oauth2/authorization_code/token
-  refresh_token_url: 
+  refresh_token_url:
   client_id: client_id_1
   client_secret: client_secret_1
   scope: read write

--- a/packages/bruno-lang/v2/tests/fixtures/request.json
+++ b/packages/bruno-lang/v2/tests/fixtures/request.json
@@ -25,6 +25,72 @@
       "enabled": true
     },
     {
+      "name": "simple",
+      "value": "normal parameter",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "colon:parameter",
+      "value": "has colon in name",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "space parameter",
+      "value": "has space in name",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "quote\"parameter",
+      "value": "has quote in name",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "brace{parameter}",
+      "value": "has braces in name",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "backslash\\parameter",
+      "value": "has literal backslash",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "multiple:special{chars}",
+      "value": "multiple special characters",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "complex \"test\" param:with{many}special chars",
+      "value": "kitchen sink test",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "disabled:colon:parameter",
+      "value": "is disabled",
+      "type": "query",
+      "enabled": false
+    },
+    {
+      "name": "disabled space param",
+      "value": "disabled with space",
+      "type": "query",
+      "enabled": false
+    },
+    {
+      "name": "edge\"case\\{with}:all",
+      "value": "all special chars together",
+      "type": "query",
+      "enabled": false
+    },
+    {
       "name": "message",
       "value": "hello",
       "type": "query",


### PR DESCRIPTION
# Description

- Replaced quoting with escaping for query parameter keys containing special characters: ':'\, '\"', '{', '}' or space.
- Refactored bruToJson and jsonToBru to consistently escape keys with special characters.
- Introduced escapeKey function to handle key escaping.
- .bru files now support storing keys with escaped characters, including the double-quote (e.g., \\\"`).
- Updated test fixtures to reflect the new escaping logic.

Fixes #3037
Fixes #2810
Fixes #2878

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**