### PR TITLE
Make autocomplete work with substrings

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/autocomplete.js
+++ b/packages/bruno-app/src/utils/codemirror/autocomplete.js
@@ -363,40 +363,45 @@ const getCurrentWordWithContext = (cm) => {
  * @returns {string[]} Array of suggestion segments
  */
 const extractNextSegmentSuggestions = (filteredHints, currentInput) => {
-  const suggestions = new Set();
-  
-  filteredHints.forEach(hint => {
-    if (!hint.toLowerCase().startsWith(currentInput.toLowerCase())) {
-      return;
-    }
-    
-    // Handle exact match case
-    if (hint.toLowerCase() === currentInput.toLowerCase()) {
-      suggestions.add(hint.substring(hint.lastIndexOf('.') + 1));
-      return;
-    }
-    
-    const inputLength = currentInput.length;
-    
-    if (currentInput.endsWith('.')) {
-      // Show next segment after the dot
-      const afterDot = hint.substring(inputLength);
-      const nextDot = afterDot.indexOf('.');
-      const segment = nextDot === -1 ? afterDot : afterDot.substring(0, nextDot);
-      suggestions.add(segment);
-    } else {
-      // Show complete current segment
-      const lastDotInInput = currentInput.lastIndexOf('.');
-      const currentSegmentStart = lastDotInInput + 1;
-      const nextDotAfterInput = hint.indexOf('.', currentSegmentStart);
-      const segment = nextDotAfterInput === -1 
-        ? hint.substring(currentSegmentStart)
-        : hint.substring(currentSegmentStart, nextDotAfterInput);
-      suggestions.add(segment);
+  const prefixMatches = new Set();
+  const substringMatches = new Set();
+
+  filteredHints.forEach((hint) => {
+    // For prefix matches, use the original progressive logic
+    if (hint.toLowerCase().startsWith(currentInput.toLowerCase())) {
+      // Handle exact match case
+      if (hint.toLowerCase() === currentInput.toLowerCase()) {
+        prefixMatches.add(hint.substring(hint.lastIndexOf('.') + 1));
+        return;
+      }
+
+      const inputLength = currentInput.length;
+
+      if (currentInput.endsWith('.')) {
+        // Show next segment after the dot
+        const afterDot = hint.substring(inputLength);
+        const nextDot = afterDot.indexOf('.');
+        const segment = nextDot === -1 ? afterDot : afterDot.substring(0, nextDot);
+        prefixMatches.add(segment);
+      } else {
+        // Show complete current segment
+        const lastDotInInput = currentInput.lastIndexOf('.');
+        const currentSegmentStart = lastDotInInput + 1;
+        const nextDotAfterInput = hint.indexOf('.', currentSegmentStart);
+        const segment =
+          nextDotAfterInput === -1
+            ? hint.substring(currentSegmentStart)
+            : hint.substring(currentSegmentStart, nextDotAfterInput);
+        prefixMatches.add(segment);
+      }
+    } else if (hint.toLowerCase().includes(currentInput.toLowerCase())) {
+      // For substring matches (search within words), suggest the complete hint
+      substringMatches.add(hint);
     }
   });
-  
-  return Array.from(suggestions).sort();
+
+  // Return prefix matches first, then substring matches
+  return [...Array.from(prefixMatches).sort(), ...Array.from(substringMatches).sort()];
 };
 
 /**
@@ -451,9 +456,9 @@ const filterHintsByContext = (categorizedHints, currentWord, context, showHintsF
   }
   
   const allowedHints = getAllowedHintsByContext(categorizedHints, context, showHintsFor);
-  
-  const filtered = allowedHints.filter(hint => {
-    return hint.toLowerCase().startsWith(currentWord.toLowerCase());
+
+  const filtered = allowedHints.filter((hint) => {
+    return hint.toLowerCase().includes(currentWord.toLowerCase());
   });
   
   const hintParts = getHintParts(filtered, currentWord);


### PR DESCRIPTION
# Description

Makes autocomplete also work with substrings so typing `Languages` for instance also suggests `Accept-Languages`. The prefix matches will be shown first (see second screenshot). 

Fixes https://github.com/usebruno/bruno/issues/5188

<img width="794" height="293" alt="image" src="https://github.com/user-attachments/assets/6d4f28fc-2c62-41ad-9c63-ed2e85b6e877" />

<img width="611" height="327" alt="image" src="https://github.com/user-attachments/assets/a704dc6d-7ffb-4caa-8c31-7515378301e6" />


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
