### PR TITLE
fix: to run collection a left click was needed

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -51,6 +51,7 @@ const Collection = ({ collection, searchText }) => {
   });
 
   const handleRun = () => {
+    ensureCollectionIsMounted();
     dispatch(
       addTab({
         uid: uuid(),


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
As explained on #5181, to run a collection it is needed to collapse or open the collection from the sidebar. This happens because when a collection is opened its items are not loaded by default. It can stay the same but ensuring the collection is mounted when the "Run" item is clicked in the dropdown menu.

The solution looks like this in the UI:

![bruno run collection](https://github.com/user-attachments/assets/34fa74ac-bd08-41f4-80ba-af41aa1565b8)


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
