### PR TITLE
feat: add per-request SSL verification toggle (#1325, #848)

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Settings/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Settings/index.js
@@ -13,15 +13,18 @@ const Settings = ({ item, collection }) => {
   const getPropertyFromDraftOrRequest = (propertyKey) =>
     item.draft ? get(item, `draft.${propertyKey}`, {}) : get(item, propertyKey, {});
 
-  const { encodeUrl } = getPropertyFromDraftOrRequest('settings');
+  const settings = getPropertyFromDraftOrRequest('settings');
 
-  const onToggleUrlEncoding = useCallback(() => {
+  const createToggleHandler = (settingKey) => () => {
     dispatch(updateItemSettings({
       collectionUid: collection.uid,
       itemUid: item.uid,
-      settings: { encodeUrl: !encodeUrl }
+      settings: { ...settings, [settingKey]: !settings[settingKey] }
     }));
-  }, [encodeUrl, dispatch, collection.uid, item.uid]);
+  };
+
+  const onToggleUrlEncoding = useCallback(createToggleHandler('encodeUrl'), [settings, dispatch, collection.uid, item.uid]);
+  const onToggleSslVerification = useCallback(createToggleHandler('disableSslVerification'), [settings, dispatch, collection.uid, item.uid]);
 
   return (
     <div className="w-full h-full flex flex-col gap-10">
@@ -36,10 +39,17 @@ const Settings = ({ item, collection }) => {
       </div>
       <div className='flex flex-col gap-4'>
         <ToggleSelector
-          checked={encodeUrl}
+          checked={settings.encodeUrl}
           onChange={onToggleUrlEncoding}
           label="URL Encoding"
           description="Automatically encode query parameters in the URL"
+          size="medium"
+        />
+        <ToggleSelector
+          checked={settings.disableSslVerification}
+          onChange={onToggleSslVerification}
+          label="Disable SSL Certificate Verification (insecure)"
+          description="Turn off SSL/TLS certificate verification for this request only, overriding global settings"
           size="medium"
         />
       </div>

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -177,7 +177,8 @@ const QueryResult = ({ item, collection, data, dataBuffer, disableRunEventListen
 
           {error && typeof error === 'string' && error.toLowerCase().includes('self signed certificate') ? (
             <div className="mt-6 muted text-xs">
-              You can disable SSL verification in the Preferences. <br />
+              You can disable SSL verification in the request Settings tab. <br />
+              Alternatively, you can disable it globally in the Preferences. <br />
               To open the Preferences, click on the gear icon in the bottom left corner.
             </div>
           ) : null}

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -799,7 +799,8 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
         }
       },
       settings: settings ?? {
-        encodeUrl: true
+        encodeUrl: true,
+        disableSslVerification: false
       }
     };
 

--- a/packages/bruno-cli/tests/runner/prepare-request.spec.js
+++ b/packages/bruno-cli/tests/runner/prepare-request.spec.js
@@ -519,4 +519,28 @@ describe('prepare-request: prepareRequest', () => {
       });
     });
   });
+
+  it('Should properly map settings from item', () => {
+    const item = {
+      name: 'Test Request',
+      type: 'http-request',
+      request: {
+        method: 'GET',
+        headers: [],
+        params: [],
+        url: 'https://usebruno.com',
+        auth: { mode: 'none' }
+      },
+      settings: {
+        encodeUrl: true,
+        disableSslVerification: true
+      }
+    };
+
+    const result = prepareRequest(item);
+    expect(result.settings).toEqual({
+      encodeUrl: true,
+      disableSslVerification: true
+    });
+  });
 });

--- a/packages/bruno-electron/tests/network/index.spec.js
+++ b/packages/bruno-electron/tests/network/index.spec.js
@@ -1,15 +1,30 @@
-const { configureRequest } = require('../../src/ipc/network/index');
+const { configureRequest, getCertsAndProxyConfig } = require('../../src/ipc/network/index');
 
-describe('index: configureRequest', () => {
-  it("Should add 'http://' to the URL if no protocol is specified", async () => {
-    const request = { method: 'GET', url: 'test-domain', body: {} };
-    await configureRequest(null, request, null, null, null, null);
-    expect(request.url).toEqual('http://test-domain');
+describe('index', () => {
+  describe('index: configureRequest', () => {
+    it("Should add 'http://' to the URL if no protocol is specified", async () => {
+      const request = { method: 'GET', url: 'test-domain', body: {} };
+      await configureRequest(null, request, null, null, null, null);
+      expect(request.url).toEqual('http://test-domain');
+    });
+    it("Should NOT add 'http://' to the URL if a protocol is specified", async () => {
+      const request = { method: 'GET', url: 'ftp://test-domain', body: {} };
+      await configureRequest(null, request, null, null, null, null);
+      expect(request.url).toEqual('ftp://test-domain');
+    });
   });
-
-  it("Should NOT add 'http://' to the URL if a protocol is specified", async () => {
-    const request = { method: 'GET', url: 'ftp://test-domain', body: {} };
-    await configureRequest(null, request, null, null, null, null);
-    expect(request.url).toEqual('ftp://test-domain');
-  });
+  describe('index: getCertsAndProxyConfig', () => {
+    it('Should configure rejectUnauthorized to be false when disableSslVerification is true', async () => {
+      const request = { method: 'GET', url: 'https://test-domain', settings: { disableSslVerification: true } };
+      const { httpsAgentRequestFields } = await getCertsAndProxyConfig({
+        request,
+        collectionUid: null,
+        envVars: {},
+        runtimeVariables: {},
+        processEnvVars: {},
+        collectionPath: null
+      });
+      expect(httpsAgentRequestFields.rejectUnauthorized).toBe(false);
+    });
+  })
 });

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -361,7 +361,8 @@ const itemSchema = Yup.object({
     then: (schema) => schema.required('request is required when item-type is request')
   }),
   settings: Yup.object({
-    encodeUrl: Yup.boolean().nullable()
+    encodeUrl: Yup.boolean().nullable(),
+    disableSslVerification: Yup.boolean().nullable()
   })
     .noUnknown(true)
     .strict()

--- a/packages/bruno-schema/src/collections/index.spec.js
+++ b/packages/bruno-schema/src/collections/index.spec.js
@@ -62,6 +62,10 @@ describe('Collection Schema Validation', () => {
             body: {
               mode: 'none'
             }
+          },
+          settings: {
+            encodeUrl: true,
+            disableSslVerification: null
           }
         }
       ]


### PR DESCRIPTION
# Description

Add ability to disable SSL certificate verification at the individual request level, overriding global SSL settings.
resolves #1325, resolves #848
Note: in #848 they requested adding `req.disableSslVerification()`. I also implemented that, but I think that just adding the toggle is good enough to address their issue.  
Let me know if you want me to add back `req.disableSslVerification()` and if you want to add support in .bru files and what the flag name should be (this also relates to issue #3496)

Changes:
* Add SSL verification toggle in RequestPane Settings with clear labeling as "insecure"
* Toggle allows users to disable SSL verification per request with descriptive text
* Ensure request-level setting takes precedence over global preferences
* Add test coverage for SSL verification configuration
* Tested manually using https://self-signed.badssl.com/ to verify SSL bypass functionality

Functionality:
* When `disableSslVerification` is `true`: SSL verification is disabled
* When `disableSslVerification` is `false/null`: Uses global SSL settings
* Setting is stored at item level and properly transferred through request pipeline

Images:
When the flag is disabled - we now have a new error message:

<img width="1225" height="399" alt="image" src="https://github.com/user-attachments/assets/36e0d737-1238-4161-a261-93f4b903e552" />

And when enabled, the request works:

<img width="1385" height="530" alt="image" src="https://github.com/user-attachments/assets/992a00de-22ab-4cee-aacd-2f061b01fd7a" />


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
