### PR TITLE
fix(dev): add filestore src to dev hot reload watchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "setup": "node ./scripts/setup.js",
     "watch:converters": "npm run watch --workspace=packages/bruno-converters",
     "dev": "concurrently --kill-others \"npm run dev:web\" \"npm run dev:electron\"",
+    "watch": "npm run dev:watch",
     "dev:watch": "node ./scripts/dev-hot-reload.js",
     "dev:web": "npm run dev --workspace=packages/bruno-app",
     "build:web": "npm run build --workspace=packages/bruno-app",

--- a/scripts/dev-hot-reload.js
+++ b/scripts/dev-hot-reload.js
@@ -171,6 +171,11 @@ function startDevelopment() {
       prefixColor: 'gray'
     },
     {
+      command: 'npm run watch --workspace=packages/bruno-filestore',
+      name: 'filestore',
+      prefixColor: '#FA8072'
+    },
+    {
       command: 'npm run dev:web',
       name: 'react',
       prefixColor: 'cyan'


### PR DESCRIPTION
### Description

Add filestore src to dev hot reload watchers and add a short `watch` command to run `dev:watch`. `Dev:watch` shall be removed later.

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
