### PR TITLE
fix: log previously unnoticed error when parsing .bru files

### DIFF
--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -274,6 +274,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
         win.webContents.send('main:collection-tree-updated', 'addFile', file);
         
       } catch (error) {
+        win.webContents.send('main:display-error', `Failed to parse request file:${pathname} reason:${error?.message}`);
         console.error(error);
       } finally {
         watcher.markFileAsProcessed(win, collectionUid, pathname);


### PR DESCRIPTION
# Description

I faced an issue where if I paste a JSON/ or any text with a new line character in the request params and saved the file, the next time the collection would refresh, the request would not be shown.

This error adds a toast message when a .bru file fails to be parsed.

<img width="1470" height="956" alt="Screenshot 2025-07-31 at 12 10 52 AM" src="https://github.com/user-attachments/assets/9f8e6557-b292-4216-84c6-dfd8660efec0" />

There was an error in a previous version where if I imported curl with new line in the request params, the same issue was occurring. But that seems to have been fixed now as the path undergoes URL encoding after import. But the previously imported requests are present in the file system silently failing when bruno tries to open it. With this PR, user will now get a toast message for those incorrectly encoded files.

[Issue](https://github.com/usebruno/bruno/issues/1771) - While it doesn't solve this issue, the user might be shown clearer information on which file fails to parse.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
