### PR TITLE
fix: incorrectly counts running/in-progress requests

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -21,7 +21,7 @@ const getDisplayName = (fullPath, pathname, name = '') => {
 };
 
 const getTestStatus = (results) => {
-  if (!results || !results.length) return 'pass';
+  if (!results || !results.length) return 'running';
   const failed = results.filter((result) => result.status === 'fail');
   return failed.length ? 'fail' : 'pass';
 };


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
fix this issue:
 - #5221 

This pull request fixes an issue where running or in-progress requests were incorrectly counted in the test status calculation. 

Modified the test status logic so that tests which are still running and have no results are now returned as `running` instead of `pass`.

The UI that displays the test status was not modified.

#### before
- Tests that were still running were previously being counted as `passed`.

https://github.com/user-attachments/assets/cd171419-6a01-46b2-b2fb-e8c2eb729035

#### after

https://github.com/user-attachments/assets/92be7f2e-97b4-44b3-881c-9a70af5a1851


### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
