### PR TITLE
Fix: OAuth2 Token Scope Handling and Optional Client Secret

### DIFF
--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -259,15 +259,13 @@ const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, fo
     redirect_uri: callbackUrl,
     client_id: clientId,
   };
-  if (clientSecret && credentialsPlacement !== "basic_auth_header") {
+  if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== "basic_auth_header") {
     data.client_secret = clientSecret;
   }
   if (pkce) {
     data['code_verifier'] = codeVerifier;
   }
-  if (scope && scope.trim() !== '') {
-    data.scope = scope;
-  }
+
   axiosRequestConfig.data = qs.stringify(data);
   axiosRequestConfig.url = url;
   axiosRequestConfig.responseType = 'arraybuffer';
@@ -360,15 +358,6 @@ const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, fo
     };
   }
 
-  if (!clientSecret) {
-    return {
-      error: 'Client Secret is required for OAuth2 client credentials flow',
-      credentials: null,
-      url,
-      credentialsId
-    };
-  }
-
   if (!forceFetch) {
     const storedCredentials = getStoredOauth2Credentials({ collectionUid, url, credentialsId });
 
@@ -427,14 +416,14 @@ const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, fo
     'content-type': 'application/x-www-form-urlencoded',
     'Accept': 'application/json',
   };
-  if (credentialsPlacement === "basic_auth_header") {
+  if (credentialsPlacement === "basic_auth_header" && clientSecret && clientSecret.trim() !== '') {
     axiosRequestConfig.headers['Authorization'] = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
   }
   const data = {
     grant_type: 'client_credentials',
     client_id: clientId,
   };
-  if (clientSecret && credentialsPlacement !== "basic_auth_header") {
+  if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== "basic_auth_header") {
     data.client_secret = clientSecret;
   }
   if (scope && scope.trim() !== '') {
@@ -568,7 +557,7 @@ const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, 
     'content-type': 'application/x-www-form-urlencoded',
     'Accept': 'application/json',
   };
-  if (credentialsPlacement === "basic_auth_header") {
+  if (credentialsPlacement === "basic_auth_header" && clientSecret && clientSecret.trim() !== '') {
     axiosRequestConfig.headers['Authorization'] = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
   }
   const data = {
@@ -577,7 +566,7 @@ const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, 
     password,
     client_id: clientId,
   };
-  if (clientSecret && credentialsPlacement !== "basic_auth_header") {
+  if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== "basic_auth_header") {
     data.client_secret = clientSecret;
   }
   if (scope && scope.trim() !== '') {
@@ -613,7 +602,7 @@ const refreshOauth2Token = async ({ requestCopy, collectionUid, certsAndProxyCon
       client_id: clientId,
       refresh_token: credentials.refresh_token,
     };
-    if (clientSecret) {
+    if (clientSecret && clientSecret.trim() !== '') {
       data.client_secret = clientSecret;
     }
     let axiosRequestConfig = {};


### PR DESCRIPTION
### Description

This PR addresses the following issues: #5171 and #4388.

Fixes included:
**Scope parameter handling:** The scope parameter was incorrectly required during the /token exchange call.
**Client secret requirement:** The client_secret is mandatory for OAuth2 flow, which is incorrect.

[Jira](https://usebruno.atlassian.net/browse/BRU-1425)

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
