### PR TITLE
fix: store redirect cookies under initial request domain

### DIFF
--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -111,7 +111,7 @@ function makeAxiosInstance({ requestMaxRedirects = 5, disableCookies } = {}) {
           }
 
           if (!disableCookies){
-            saveCookies(redirectUrl, error.response.headers);
+            saveCookies(error.config.url, error.response.headers);
           }
 
           const requestConfig = createRedirectConfig(error, redirectUrl);

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -297,7 +297,7 @@ function makeAxiosInstance({
           }
 
           if (preferencesUtil.shouldStoreCookies()) {
-            saveCookies(redirectUrl, error.response.headers);
+            saveCookies(error.config.url, error.response.headers);
           }
 
           // Create a new request config for the redirect

--- a/packages/bruno-tests/collection/redirects/Redirect Cookie Save.bru
+++ b/packages/bruno-tests/collection/redirects/Redirect Cookie Save.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Redirect Cookie Save
+  type: http
+  seq: 3
+}
+
+get {
+  url: https://0d453eaa-76dc-45c1-a93c-0138e8b77d62.mock.pstmn.io/redirect
+  body: none
+  auth: none
+}
+
+tests {
+  const jar = bru.cookies.jar()
+  
+  const cookieData = await jar.getCookie(
+    "https://0d453eaa-76dc-45c1-a93c-0138e8b77d62.mock.pstmn.io",
+    "foo"
+  );
+  
+  test("should store redirect cookie under initial request domain", function () {
+    expect(cookieData).to.not.be.undefined;
+    expect(cookieData.key).to.equal("foo");
+    expect(cookieData.value).to.equal("bar");
+  });
+  
+  
+  jar.clear();
+}


### PR DESCRIPTION
# Description

Fix incorrect cookie domain assignment on HTTP redirects.

[JIRA](https://usebruno.atlassian.net/browse/BRU-1426)

[Issue](https://github.com/usebruno/bruno/issues/5268)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/91867f2e-330e-4863-9b82-23516da96c35
