### PR TITLE
fix: strip newlines from query param

### DIFF
--- a/packages/bruno-common/src/utils/url/index.ts
+++ b/packages/bruno-common/src/utils/url/index.ts
@@ -12,11 +12,14 @@ interface ExtractQueryParamsOptions {
 }
 
 function buildQueryString(paramsArray: QueryParam[], { encode = false }: BuildQueryStringOptions = {}): string {
+  const strip = (str: string) => str.replace(/\r?\n/g, '');
   return paramsArray
     .filter(({ name }) => typeof name === 'string' && name.trim().length > 0)
     .map(({ name, value }) => {
-      const finalName = encode ? encodeURIComponent(name) : name;
-      const finalValue = encode ? encodeURIComponent(value ?? '') : (value ?? '');
+      const rawName = strip(name);
+      const rawValue = strip(value ?? '');
+      const finalName = encode ? encodeURIComponent(rawName) : rawName;
+      const finalValue = encode ? encodeURIComponent(rawValue) : rawValue;
 
       return finalValue ? `${finalName}=${finalValue}` : finalName;
     })

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -5,6 +5,9 @@ const { indentString } = require('./utils');
 const enabled = (items = [], key = "enabled") => items.filter((item) => item[key]);
 const disabled = (items = [], key = "enabled") => items.filter((item) => !item[key]);
 
+// For query params and URL we just remove real line breaks (join lines)
+const stripNewlines = (value) => (typeof value === 'string' ? value.replace(/\r?\n/g, '') : value);
+
 // remove the last line if two new lines are found
 const stripLastLine = (text) => {
   if (!text || !text.length) return text;
@@ -57,7 +60,7 @@ const jsonToBru = (json) => {
 
   if (http && http.method) {
     bru += `${http.method} {
-  url: ${http.url}`;
+  url: ${stripNewlines(http.url)}`;
 
     if (http.body && http.body.length) {
       bru += `
@@ -84,7 +87,7 @@ const jsonToBru = (json) => {
       if (enabled(queryParams).length) {
         bru += `\n${indentString(
           enabled(queryParams)
-            .map((item) => `${item.name}: ${item.value}`)
+            .map((item) => `${stripNewlines(item.name)}: ${stripNewlines(item.value)}`)
             .join('\n')
         )}`;
       }
@@ -92,7 +95,7 @@ const jsonToBru = (json) => {
       if (disabled(queryParams).length) {
         bru += `\n${indentString(
           disabled(queryParams)
-            .map((item) => `~${item.name}: ${item.value}`)
+            .map((item) => `~${stripNewlines(item.name)}: ${stripNewlines(item.value)}`)
             .join('\n')
         )}`;
       }


### PR DESCRIPTION
# Description

Removes line-breaks from query names & values (and the URL) so multi-line inputs are flattened, preventing malformed .bru files and draft-URL mismatches.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/0273af6e-063e-486e-a47c-ed8a4fe4a1f8