### PR TITLE
Feat: Ensure Proper Quoting of Keys in bruToJson/jsonToBru

### DIFF
--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -56,8 +56,14 @@ const grammar = ohm.grammar(`Bru {
   // Dictionary Blocks
   dictionary = st* "{" pairlist? tagend
   pairlist = optionalnl* pair (~tagend stnl* pair)* (~tagend space)*
-  pair = st* key st* ":" st* value st*
-  key = keychar*
+  pair = st* (quoted_key | key) st* ":" st* value st*
+  disable_char = "~"
+  quote_char = "\\""
+  esc_char = "\\\\"
+  esc_quote_char = esc_char quote_char
+  quoted_key_char = ~(quote_char | esc_quote_char | nl) any
+  quoted_key = disable_char? quote_char (esc_quote_char | quoted_key_char)* quote_char
+  key = keychar+
   value = list | multilinetextblock | valuechar*
 
   // Dictionary for Assert Block
@@ -301,6 +307,14 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     res[key.ast] = value.ast ? value.ast.trim() : '';
     return res;
   },
+  esc_quote_char(_1, quote) {
+    // unescape
+    return quote.sourceString;
+  },
+  quoted_key(disabled, _1, chars, _2) {
+    // unquote
+    return (disabled ? disabled.sourceString : "") + chars.ast.join("");
+  },
   key(chars) {
     return chars.sourceString ? chars.sourceString.trim() : '';
   },
@@ -370,6 +384,9 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   multilinetextblock(_1, content, _2) {
     // Join all the content between the triple quotes and trim it
     return content.sourceString.trim();
+  },
+  _terminal(){
+    return this.sourceString;
   },
   _iter(...elements) {
     return elements.map((e) => e.ast);

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -4,6 +4,10 @@ const { indentString } = require('./utils');
 
 const enabled = (items = [], key = "enabled") => items.filter((item) => item[key]);
 const disabled = (items = [], key = "enabled") => items.filter((item) => !item[key]);
+const quoteKey = (key) => {
+  const quotableChars = [':', '"', ' ', '{', '}'];
+  return quotableChars.some(char => key.includes(char)) ? ('"' + key.replaceAll('"', '\\"') + '"') : key;
+}
 
 // remove the last line if two new lines are found
 const stripLastLine = (text) => {
@@ -121,7 +125,7 @@ const jsonToBru = (json) => {
       if (enabled(queryParams).length) {
         bru += `\n${indentString(
           enabled(queryParams)
-            .map((item) => `${item.name}: ${item.value}`)
+            .map((item) => `${quoteKey(item.name)}: ${item.value}`)
             .join('\n')
         )}`;
       }
@@ -129,7 +133,7 @@ const jsonToBru = (json) => {
       if (disabled(queryParams).length) {
         bru += `\n${indentString(
           disabled(queryParams)
-            .map((item) => `~${item.name}: ${item.value}`)
+            .map((item) => `~${quoteKey(item.name)}: ${item.value}`)
             .join('\n')
         )}`;
       }

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -19,6 +19,8 @@ params:query {
   numbers: 998877665
   "colon:parameter": is allowed
   "nested escaped \"quote\"": is allowed
+  "spaces in key": value with spaces
+  "curly{braces}": test value
   ~"disabled:colon:parameter": is allowed
   ~message: hello
 }

--- a/packages/bruno-lang/v2/tests/fixtures/request.bru
+++ b/packages/bruno-lang/v2/tests/fixtures/request.bru
@@ -17,6 +17,9 @@ get {
 params:query {
   apiKey: secret
   numbers: 998877665
+  "colon:parameter": is allowed
+  "nested escaped \"quote\"": is allowed
+  ~"disabled:colon:parameter": is allowed
   ~message: hello
 }
 

--- a/packages/bruno-lang/v2/tests/fixtures/request.json
+++ b/packages/bruno-lang/v2/tests/fixtures/request.json
@@ -37,6 +37,18 @@
       "enabled": true
     },
     {
+      "name": "spaces in key",
+      "value": "value with spaces",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name": "curly{braces}",
+      "value": "test value",
+      "type": "query",
+      "enabled": true
+    },
+    {
       "name" : "disabled:colon:parameter",
       "value" : "is allowed",
       "type": "query",

--- a/packages/bruno-lang/v2/tests/fixtures/request.json
+++ b/packages/bruno-lang/v2/tests/fixtures/request.json
@@ -25,6 +25,24 @@
       "enabled": true
     },
     {
+      "name" : "colon:parameter",
+      "value" : "is allowed",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name" : "nested escaped \"quote\"",
+      "value" : "is allowed",
+      "type": "query",
+      "enabled": true
+    },
+    {
+      "name" : "disabled:colon:parameter",
+      "value" : "is allowed",
+      "type": "query",
+      "enabled": false
+    },
+    {
       "name": "message",
       "value": "hello",
       "type": "query",


### PR DESCRIPTION
Fixes: #3037 #2810 

Main Contribution: @pietrygamat 
# Description

- Updated `bruToJson` to support quoted keys with escape handling.
- Modified `jsonToBru` to quote keys when necessary, ensuring proper formatting.
- Added new test cases in request.bru and request.json to validate quoted key functionality.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**