### PR TITLE
fix(digest-auth): fix Digest Auth when no QOP is set

### DIFF
--- a/packages/bruno-requests/src/auth/digestauth-helper.js
+++ b/packages/bruno-requests/src/auth/digestauth-helper.js
@@ -92,21 +92,36 @@ export function addDigestInterceptor(axiosInstance, request) {
         const uri = new URL(request.url, request.baseURL || 'http://localhost').pathname; // Handle relative URLs
         const HA1 = md5(`${username}:${authDetails.realm}:${password}`);
         const HA2 = md5(`${request.method}:${uri}`);
-        const response = md5(
-          `${HA1}:${authDetails.nonce}:${nonceCount}:${cnonce}:auth:${HA2}`
-        );
+
+        let response;
+        if (authDetails.qop && authDetails.qop.toLowerCase().includes('auth')) {
+          console.debug("Using QOP 'auth' for Digest Authentication");
+          response = md5(
+            `${HA1}:${authDetails.nonce}:${nonceCount}:${cnonce}:auth:${HA2}`
+          );
+        } else {
+          console.debug("No QOP specified, using simple digest");
+          response = md5(
+            `${HA1}:${authDetails.nonce}:${HA2}`
+          );
+        }
 
         const headerFields = [
           `username="${username}"`,
           `realm="${authDetails.realm}"`,
           `nonce="${authDetails.nonce}"`,
           `uri="${uri}"`,
-          `qop="auth"`,
-          `algorithm="${authDetails.algorithm}"`,
           `response="${response}"`,
-          `nc="${nonceCount}"`,
-          `cnonce="${cnonce}"`,
         ];
+
+        if (authDetails.qop && authDetails.qop.toLowerCase().includes('auth')) {
+          headerFields.push(
+            `qop="auth"`,
+            `algorithm="${authDetails.algorithm}"`,
+            `nc="${nonceCount}"`,
+            `cnonce="${cnonce}"`,
+          );
+        }
 
         if (authDetails.opaque) {
           headerFields.push(`opaque="${authDetails.opaque}"`);


### PR DESCRIPTION
I found the issue in #5378 and fixed it. I tested it against my Prusa Printer and an Apache digest Auth to get both worlds working.

# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

