### PR TITLE
Fix global env issue on bulk import

### DIFF
--- a/packages/bruno-app/src/components/GlobalEnvironments/EnvironmentSettings/ImportEnvironment/index.js
+++ b/packages/bruno-app/src/components/GlobalEnvironments/EnvironmentSettings/ImportEnvironment/index.js
@@ -25,12 +25,7 @@ const ImportEnvironment = ({ onClose }) => {
                 }
           )
           .map((environment) => {
-            let variables = environment?.variables?.map(v => ({
-              ...v,
-              uid: uuid(),
-              type: 'text'
-            }));
-            dispatch(addGlobalEnvironment({ name: environment.name, variables }))
+            dispatch(addGlobalEnvironment({ name: environment.name, variables: environment.variables }))
               .then(() => {
                 toast.success('Global Environment imported successfully');
               })

--- a/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
+++ b/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
@@ -15,6 +15,7 @@ const importPostmanEnvironmentVariables = (brunoEnvironment, values = []) => {
       name: (i.key ?? '').replace(invalidVariableCharacterRegex, '_'),
       value: i.value ?? '',
       enabled: i.enabled,
+      type: 'text',
       secret: isSecret(i.type)
     };
 

--- a/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
@@ -32,6 +32,7 @@ describe('postmanToBrunoEnvironment Function', () => {
           value: 'value1',
           enabled: true,
           secret: false,
+          type: 'text',
           uid: "mockeduuidvalue123456",
         },
         {
@@ -39,6 +40,7 @@ describe('postmanToBrunoEnvironment Function', () => {
           value: 'value2',
           enabled: false,
           secret: true,
+          type: 'text',
           uid: "mockeduuidvalue123456",
         },
       ],
@@ -85,6 +87,7 @@ describe('postmanToBrunoEnvironment Function', () => {
           value: '',
           enabled: true,
           secret: false,
+          type: 'text',
           uid: "mockeduuidvalue123456",
         },
         {
@@ -92,6 +95,7 @@ describe('postmanToBrunoEnvironment Function', () => {
           value: '',
           enabled: true,
           secret: false,
+          type: 'text',
           uid: "mockeduuidvalue123456",
         },
         {
@@ -99,7 +103,8 @@ describe('postmanToBrunoEnvironment Function', () => {
           value: '',
           enabled: true,
           secret: false,
-          uid: "mockeduuidvalue123456",
+          type: 'text',
+          uid: "mockeduuidvalue123456"
         }
       ],
     };


### PR DESCRIPTION
# Description

This PR fixes issue where postman environment import were missing "type" attributes when imported via data dump

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
