### PR TITLE
Update: readme.md installation instructions via Apt (#5411)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,9 +94,9 @@ flatpak install com.usebruno.Bruno
 
 # On Linux via Apt
 sudo mkdir -p /etc/apt/keyrings
-sudo apt update && sudo apt install gpg
+sudo apt update && sudo apt install gpg curl
 sudo gpg --list-keys
-sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/bruno.gpg --keyserver keyserver.ubuntu.com --recv-keys 9FA6017ECABE0266
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x9FA6017ECABE0266" | gpg --dearmor | sudo tee /etc/apt/keyrings/bruno.gpg > /dev/null
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/bruno.gpg] http://debian.usebruno.com/ bruno stable" | sudo tee /etc/apt/sources.list.d/bruno.list
 sudo apt update && sudo apt install bruno
 ```


### PR DESCRIPTION
# Description

This PR updates the Debian (Trixie) installation instructions in the README.md.
The current method using gpg --recv-keys fails on Debian 13 with:

```pgsql
gpg: no valid OpenPGP data found
``` 
I replaced it with the curl | gpg --dearmor method which works correctly on Debian 13 and is consistent with modern Debian/Ubuntu packaging practices.

https://github.com/usebruno/bruno/issues/5411


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**