### PR TITLE
feat: make tabs reorderable

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -4,27 +4,65 @@ import filter from 'lodash/filter';
 import classnames from 'classnames';
 import { IconChevronRight, IconChevronLeft } from '@tabler/icons';
 import { useSelector, useDispatch } from 'react-redux';
-import { focusTab } from 'providers/ReduxStore/slices/tabs';
+import { focusTab, reorderTabs } from 'providers/ReduxStore/slices/tabs';
 import NewRequest from 'components/Sidebar/NewRequest';
 import CollectionToolBar from './CollectionToolBar';
 import RequestTab from './RequestTab';
 import StyledWrapper from './StyledWrapper';
 
+
 const RequestTabs = () => {
   const dispatch = useDispatch();
   const tabsRef = useRef();
   const [newRequestModalOpen, setNewRequestModalOpen] = useState(false);
+  const [draggedTabUid, setDraggedTabUid] = useState(null);
+  const [dragOverTabUid, setDragOverTabUid] = useState(null);
   const tabs = useSelector((state) => state.tabs.tabs);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const collections = useSelector((state) => state.collections.collections);
   const leftSidebarWidth = useSelector((state) => state.app.leftSidebarWidth);
   const screenWidth = useSelector((state) => state.app.screenWidth);
 
+
   const getTabClassname = (tab, index) => {
     return classnames('request-tab select-none', {
       active: tab.uid === activeTabUid,
-      'last-tab': tabs && tabs.length && index === tabs.length - 1
+      'last-tab': tabs && tabs.length && index === tabs.length - 1,
+      'dragged': tab.uid === draggedTabUid,
+      'drag-over': tab.uid === dragOverTabUid && draggedTabUid !== null
     });
+  };
+
+  const handleDragStart = (e, tab) => {
+    setDraggedTabUid(tab.uid);
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', tab.uid);
+  };
+
+  const handleDragOver = (e, tab) => {
+    e.preventDefault();
+    setDragOverTabUid(tab.uid);
+  };
+
+  const handleDrop = (e, targetTab) => {
+    e.preventDefault();
+    setDragOverTabUid(null);
+    const sourceUid = draggedTabUid;
+    setDraggedTabUid(null);
+    if (!sourceUid || sourceUid === targetTab.uid) {
+      return;
+    }
+    dispatch(
+      reorderTabs({
+        sourceUid,
+        targetUid: targetTab.uid
+      })
+    );
+  };
+
+  const handleDragEnd = () => {
+    setDraggedTabUid(null);
+    setDragOverTabUid(null);
   };
 
   const handleClick = (tab) => {
@@ -109,6 +147,11 @@ const RequestTabs = () => {
                         className={getTabClassname(tab, index)}
                         role="tab"
                         onClick={() => handleClick(tab)}
+                        draggable={true}
+                        onDragStart={e => handleDragStart(e, tab)}
+                        onDragOver={e => handleDragOver(e, tab)}
+                        onDrop={e => handleDrop(e, tab)}
+                        onDragEnd={handleDragEnd}
                       >
                         <RequestTab
                           collectionRequestTabs={collectionRequestTabs}

--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -13,7 +13,7 @@ import {
   saveFolderRoot
 } from 'providers/ReduxStore/slices/collections/actions';
 import { findCollectionByUid, findItemInCollection } from 'utils/collections';
-import { closeTabs, switchTab } from 'providers/ReduxStore/slices/tabs';
+import { closeTabs, reorderTabs, switchTab } from 'providers/ReduxStore/slices/tabs';
 import { getKeyBindingsForActionAllOS } from './keyMappings';
 
 export const HotkeysContext = React.createContext();
@@ -223,6 +223,32 @@ export const HotkeysProvider = (props) => {
       Mousetrap.unbind([...getKeyBindingsForActionAllOS('closeAllTabs')]);
     };
   }, [activeTabUid, tabs, collections, dispatch]);
+
+  // Move tab left
+  useEffect(() => {
+    Mousetrap.bind([...getKeyBindingsForActionAllOS('moveTabLeft')], (e) => {
+      console.log('move tab left');
+      dispatch(reorderTabs({ direction: -1 }));
+      return false; // this stops the event bubbling
+    });
+
+    return () => {
+      Mousetrap.unbind([...getKeyBindingsForActionAllOS('moveTabLeft')]);
+    };
+  }, [dispatch]);
+
+  // Move tab right
+  useEffect(() => {
+    Mousetrap.bind([...getKeyBindingsForActionAllOS('moveTabRight')], (e) => {
+      console.log('move tab right');
+      dispatch(reorderTabs({ direction: 1 }));
+      return false; // this stops the event bubbling
+    });
+
+    return () => {
+      Mousetrap.unbind([...getKeyBindingsForActionAllOS('moveTabRight')]);
+    };
+  }, [dispatch]);
 
   const currentCollection = getCurrentCollection();
 

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -20,6 +20,16 @@ const KeyMapping = {
     windows: 'ctrl+pagedown',
     name: 'Switch to Next Tab'
   },
+  moveTabLeft: {
+    mac: 'command+shift+pageup',
+    windows: 'ctrl+shift+pageup',
+    name: 'Move Tab Left'
+  },
+  moveTabRight: {
+    mac: 'command+shift+pagedown',
+    windows: 'ctrl+shift+pagedown',
+    name: 'Move Tab Right'
+  },
   closeAllTabs: { mac: 'command+shift+w', windows: 'ctrl+shift+w', name: 'Close All Tabs' }
 };
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -1,5 +1,4 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { findIndex } from 'lodash';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
 import last from 'lodash/last';
@@ -170,6 +169,33 @@ export const tabsSlice = createSlice({
       } else{
         console.error("Tab not found!")
       }
+    },
+    reorderTabs: (state, action) => {
+      const { direction, sourceUid, targetUid } = action.payload;
+      const tabs = state.tabs;
+
+      let sourceIdx, targetIdx;
+      if (direction) {
+        sourceIdx = tabs.findIndex(t => t.uid === state.activeTabUid);
+        if (sourceIdx < 0) {
+          return;
+        }
+        targetIdx = sourceIdx + (direction === -1 ? -1 : 1);
+      } else {
+        sourceIdx = tabs.findIndex(t => t.uid === sourceUid);
+        targetIdx = tabs.findIndex(t => t.uid === targetUid);
+      }
+
+      const sourceBoundary = sourceIdx < 0;
+      const targetBoundary = targetIdx < 0 || targetIdx >= tabs.length;
+      if (sourceBoundary || sourceIdx === targetIdx  || targetBoundary) {
+        return;
+      }
+
+      const [moved] = tabs.splice(sourceIdx, 1);
+      tabs.splice(targetIdx, 0, moved);
+
+      state.tabs = tabs;
     }
   }
 });
@@ -183,7 +209,8 @@ export const {
   updateResponsePaneTab,
   closeTabs,
   closeAllCollectionTabs,
-  makeTabPermanent
+  makeTabPermanent,
+  reorderTabs
 } = tabsSlice.actions;
 
 export default tabsSlice.reducer;


### PR DESCRIPTION
# Description

Adds support for reordering tabs via drag-n-drop and hotkeys.

https://github.com/user-attachments/assets/8ba728c6-9be6-4a51-ad74-9485ab51bf11

As a Mac user i personally find the tab keybindings odd since `pagedown`/`pageup` requires me to press `fn+down`/`fn+up` so 4 keys in total. (Changing this might be a breaking change though)

Next Tab: `cmd+pageup` (should rather be `cmd+opt+right`, like in Chrome)
Previous Tab: `cmd+pagedown` (should rather be `cmd+opt+left`, like in Chrome)
Move Tab Left: `cmd+shift+pageup` (should be `cmd+shift+left`)
Move Tab Right: `cmd+shift+pagedown` (should be `cmd+shift+right`)

Fixes #4551 and addresses functionality from PR #4621 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
