### PR TITLE
fix: graphQL documentation theme

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/StyledWrapper.js
@@ -63,7 +63,8 @@ const StyledWrapper = styled.div`
   }
 
   div.graphql-docs-explorer-container {
-    background: white;
+    background: ${(props) => props.theme.requestTabPanel.graphqlDocsExplorer.bg};
+    color: ${(props) => props.theme.requestTabPanel.graphqlDocsExplorer.color};
     outline: none;
     box-shadow: rgb(0 0 0 / 15%) 0px 0px 8px;
     position: absolute;
@@ -71,6 +72,14 @@ const StyledWrapper = styled.div`
     z-index: 2000;
     width: 350px;
     height: 100%;
+
+    .doc-explorer-contents,
+    .doc-explorer,
+    .search-box > input,
+    .search-box-clear {
+      background-color: ${(props) => props.theme.requestTabPanel.graphqlDocsExplorer.bg};
+      color: ${(props) => props.theme.requestTabPanel.graphqlDocsExplorer.color};
+    }
 
     div.doc-explorer-title {
       text-align: left;

--- a/packages/bruno-app/src/themes/dark.js
+++ b/packages/bruno-app/src/themes/dark.js
@@ -94,7 +94,7 @@ const darkTheme = {
       // customize these colors if needed
       patch: '#d69956',
       options: '#d69956',
-      head: '#d69956',
+      head: '#d69956'
     },
     grpc: '#6366f1'
   },
@@ -134,6 +134,10 @@ const darkTheme = {
           color: '#ccc'
         }
       }
+    },
+    graphqlDocsExplorer: {
+      bg: '#1e1e1e',
+      color: '#d4d4d4'
     }
   },
 

--- a/packages/bruno-app/src/themes/light.js
+++ b/packages/bruno-app/src/themes/light.js
@@ -131,6 +131,10 @@ const lightTheme = {
           color: 'rgb(75 85 99)'
         }
       }
+    },
+    graphqlDocsExplorer: {
+      bg: '#fff',
+      color: 'rgb(52, 52, 52)'
     }
   },
 


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fix for GraphQL documentation tab theme. 

Before-
<img width="1913" height="1018" alt="image" src="https://github.com/user-attachments/assets/8c878607-7383-4521-bd03-5ec2f1279634" />

After-
<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/5eb0a70f-1418-4b20-9ce5-b42cb0988b9f" />


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
