### PR TITLE
feat: add select/deselect all functionality for request parameters

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
@@ -8,7 +8,8 @@ import {
   addFormUrlEncodedParam,
   updateFormUrlEncodedParam,
   deleteFormUrlEncodedParam,
-  moveFormUrlEncodedParam
+  moveFormUrlEncodedParam,
+  updateRequestBody
 } from 'providers/ReduxStore/slices/collections';
 import MultiLineEditor from 'components/MultiLineEditor';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
@@ -77,18 +78,59 @@ const FormUrlEncodedParams = ({ item, collection }) => {
     );
   };
 
+  const handleToggleAllParams = () => {
+    const hasEnabledParams = params && params.some((param) => param.enabled);
+    const updatedParams = params ? params.map((param) => ({
+      ...param,
+      enabled: !hasEnabledParams
+    })) : [];
+    
+    dispatch(updateRequestBody({ 
+      collectionUid: collection.uid, 
+      itemUid: item.uid, 
+      content: updatedParams,
+      mode: 'formUrlEncoded'
+    }));
+  };
+
   return (
     <StyledWrapper className="w-full">
       <Table
         headers={[
           { name: 'Key', accessor: 'key', width: '40%' },
           { name: 'Value', accessor: 'value', width: '46%' },
-          { name: '', accessor: '', width: '14%' }
+          { 
+            name: '', 
+            accessor: '', 
+            width: '14%',
+            renderHeader: () => {
+              const hasEnabledParams = params && params.some((param) => param.enabled);
+              const allEnabled = params && params.length > 0 && params.every((param) => param.enabled);
+              const someEnabled = hasEnabledParams && !allEnabled;
+              
+              return (
+                <div className="flex items-center justify-center">
+                  <input
+                    type="checkbox"
+                    checked={allEnabled}
+                    ref={(input) => {
+                      if (input) {
+                        input.indeterminate = someEnabled;
+                      }
+                    }}
+                    onChange={handleToggleAllParams}
+                    disabled={!params || params.length === 0}
+                    title={allEnabled ? "Deselect all" : "Select all"}
+                  />
+                </div>
+              );
+            }
+          }
         ]}
       >
         <ReorderTable updateReorderedItem={handleParamDrag}>
           {params && params.length
-            ? params.map((param, index) => {
+            ? params.map((param) => {
               return (
                 <tr key={param.uid} data-uid={param.uid}>
                   <td className='flex relative'>

--- a/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
@@ -168,7 +168,7 @@ const FormUrlEncodedParams = ({ item, collection }) => {
                     />
                   </td>
                   <td>
-                    <div className="flex items-center">
+                    <div className="flex items-center justify-center">
                       <input
                         type="checkbox"
                         checked={param.enabled}

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -8,7 +8,8 @@ import {
   addMultipartFormParam,
   updateMultipartFormParam,
   deleteMultipartFormParam,
-  moveMultipartFormParam
+  moveMultipartFormParam,
+  updateRequestBody
 } from 'providers/ReduxStore/slices/collections';
 import MultiLineEditor from 'components/MultiLineEditor';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
@@ -95,6 +96,21 @@ const MultipartFormParams = ({ item, collection }) => {
     );
   };
 
+  const handleToggleAllParams = () => {
+    const hasEnabledParams = params && params.some((param) => param.enabled);
+    const updatedParams = params ? params.map((param) => ({
+      ...param,
+      enabled: !hasEnabledParams
+    })) : [];
+    
+    dispatch(updateRequestBody({ 
+      collectionUid: collection.uid, 
+      itemUid: item.uid, 
+      content: updatedParams,
+      mode: 'multipartForm'
+    }));
+  };
+
   return (
     <StyledWrapper className="w-full">
       <Table
@@ -102,12 +118,38 @@ const MultipartFormParams = ({ item, collection }) => {
           { name: 'Key', accessor: 'key', width: '29%' },
           { name: 'Value', accessor: 'value', width: '29%' },
           { name: 'Content-Type', accessor: 'content-type', width: '28%' },
-          { name: '', accessor: '', width: '14%' }
+          { 
+            name: '', 
+            accessor: '', 
+            width: '14%',
+            renderHeader: () => {
+              const hasEnabledParams = params && params.some((param) => param.enabled);
+              const allEnabled = params && params.length > 0 && params.every((param) => param.enabled);
+              const someEnabled = hasEnabledParams && !allEnabled;
+              
+              return (
+                <div className="flex items-center justify-center">
+                  <input
+                    type="checkbox"
+                    checked={allEnabled}
+                    ref={(input) => {
+                      if (input) {
+                        input.indeterminate = someEnabled;
+                      }
+                    }}
+                    onChange={handleToggleAllParams}
+                    disabled={!params || params.length === 0}
+                    title={allEnabled ? "Deselect all" : "Select all"}
+                  />
+                </div>
+              );
+            }
+          }
         ]}
       >
         <ReorderTable updateReorderedItem={handleParamDrag}>
           {params && params.length
-            ? params.map((param, index) => {
+            ? params.map((param) => {
               return (
                 <tr key={param.uid} className='w-full' data-uid={param.uid}>
                   <td className="flex relative">

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -226,7 +226,7 @@ const MultipartFormParams = ({ item, collection }) => {
                     />
                   </td>
                   <td>
-                    <div className="flex items-center">
+                    <div className="flex items-center justify-center">
                       <input
                         type="checkbox"
                         checked={param.enabled}

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 import InfoTip from 'components/InfoTip';
 import { IconTrash } from '@tabler/icons';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import {
   addQueryParam,
@@ -126,6 +126,17 @@ const QueryParams = ({ item, collection }) => {
     dispatch(setQueryParams({ collectionUid: collection.uid, itemUid: item.uid, params: paramsWithType }));
   };
 
+  const handleToggleAllParams = () => {
+    const hasEnabledParams = queryParams.some((param) => param.enabled);
+    const updatedParams = queryParams.map((param) => ({
+      ...param,
+      enabled: !hasEnabledParams
+    }));
+    
+    const allParams = [...updatedParams, ...pathParams];
+    dispatch(setQueryParams({ collectionUid: collection.uid, itemUid: item.uid, params: allParams }));
+  };
+
   if (isBulkEditMode) {
     return (
       <StyledWrapper className="w-full mt-3">
@@ -148,12 +159,38 @@ const QueryParams = ({ item, collection }) => {
           headers={[
             { name: 'Name', accessor: 'name', width: '31%' },
             { name: 'Path', accessor: 'path', width: '56%' },
-            { name: '', accessor: '', width: '13%' }
+            { 
+              name: '', 
+              accessor: '', 
+              width: '13%',
+              renderHeader: () => {
+                const hasEnabledParams = queryParams.some((param) => param.enabled);
+                const allEnabled = queryParams.length > 0 && queryParams.every((param) => param.enabled);
+                const someEnabled = hasEnabledParams && !allEnabled;
+                
+                return (
+                  <div className="flex items-center justify-center">
+                    <input
+                      type="checkbox"
+                      checked={allEnabled}
+                      ref={(input) => {
+                        if (input) {
+                          input.indeterminate = someEnabled;
+                        }
+                      }}
+                      onChange={handleToggleAllParams}
+                      disabled={queryParams.length === 0}
+                      title={allEnabled ? "Deselect all" : "Select all"}
+                    />
+                  </div>
+                );
+              }
+            }
           ]}
         >
           <ReorderTable updateReorderedItem={handleQueryParamDrag}>
             {queryParams && queryParams.length
-              ? queryParams.map((param, index) => (
+              ? queryParams.map((param) => (
                   <tr key={param.uid} data-uid={param.uid}>
                     <td className="flex relative">
                       <input

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -87,6 +87,16 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
     dispatch(setRequestHeaders({ collectionUid: collection.uid, itemUid: item.uid, headers: newHeaders }));
   };
 
+  const handleToggleAllHeaders = () => {
+    const hasEnabledHeaders = headers.some((header) => header.enabled);
+    const updatedHeaders = headers.map((header) => ({
+      ...header,
+      enabled: !hasEnabledHeaders
+    }));
+    
+    dispatch(setRequestHeaders({ collectionUid: collection.uid, itemUid: item.uid, headers: updatedHeaders }));
+  };
+
   if (isBulkEditMode) {
     return (
       <StyledWrapper className="w-full mt-3">
@@ -107,7 +117,33 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
         headers={[
           { name: 'Key', accessor: 'key', width: '34%' },
           { name: 'Value', accessor: 'value', width: '46%' },
-          { name: '', accessor: '', width: '20%' }
+          { 
+            name: '', 
+            accessor: '', 
+            width: '20%',
+            renderHeader: () => {
+              const hasEnabledHeaders = headers.some((header) => header.enabled);
+              const allEnabled = headers.length > 0 && headers.every((header) => header.enabled);
+              const someEnabled = hasEnabledHeaders && !allEnabled;
+              
+              return (
+                <div className="flex items-center justify-center">
+                  <input
+                    type="checkbox"
+                    checked={allEnabled}
+                    ref={(input) => {
+                      if (input) {
+                        input.indeterminate = someEnabled;
+                      }
+                    }}
+                    onChange={handleToggleAllHeaders}
+                    disabled={headers.length === 0}
+                    title={allEnabled ? "Deselect all" : "Select all"}
+                  />
+                </div>
+              );
+            }
+          }
         ]}
       >
         <ReorderTable updateReorderedItem={handleHeaderDrag}>

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -196,7 +196,7 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
                       />
                     </td>
                     <td>
-                      <div className="flex items-center">
+                      <div className="flex items-center justify-center">
                         <input
                           type="checkbox"
                           checked={header.enabled}

--- a/packages/bruno-app/src/components/Table/index.js
+++ b/packages/bruno-app/src/components/Table/index.js
@@ -89,9 +89,9 @@ const Table = ({ minColumnWidth = 1, headers = [], children }) => {
         <table ref={tableRef} className="inherit">
           <thead>
             <tr>
-              {columns.map(({ ref, name }, i) => (
-                <th ref={ref} key={name} title={name}>
-                  <span>{name}</span>
+              {columns.map(({ ref, name, renderHeader }, i) => (
+                <th ref={ref} key={name} title={typeof renderHeader === 'function' ? undefined : name}>
+                  {typeof renderHeader === 'function' ? renderHeader() : <span>{name}</span>}
                   <div
                     className="resizer absolute cursor-col-resize w-[4px] right-[-2px] top-0 z-10 opacity-50 hover:bg-blue-500 active:bg-blue-500"
                     onMouseDown={handleMouseDown(i)}


### PR DESCRIPTION
### Description

When working with API requests that have multiple parameters, headers, or form fields, users often need to quickly enable or disable all items at once for testing purposes.
Currently, users must individually check or uncheck each parameter, which can be time-consuming when dealing with requests that have many fields.

This PR introduces select/deselect all functionality for request parameters.  Users can now use a checkbox in the header row to quickly select or deselect all parameters in:
  - Query Parameters
  - Request Headers
  - Form URL-Encoded Parameters
  - Multipart Form Parameters

The header checkbox intelligently shows three states:
  - ✅ Checked: All parameters are enabled
  - ⬜ Unchecked: No parameters are enabled
  - ➖ Indeterminate: Some parameters are enabled (partial selection)

### Evidence

https://github.com/user-attachments/assets/337ea3a0-2d06-4d3f-9da5-726858def25e

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** Related with #5439 

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
