### PR TITLE
update the grpc tagline

### DIFF
--- a/packages/bruno-app/src/components/Preferences/Beta/index.js
+++ b/packages/bruno-app/src/components/Preferences/Beta/index.js
@@ -79,7 +79,7 @@ const Beta = ({ close }) => {
             <h2 className="text-lg font-semibold">Beta Features</h2>
           </div>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 text-wrap">
-            Beta features are experimental previews that may change before full release. Try them and <a href="https://github.com/usebruno/bruno/discussions/5447" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:text-blue-600 underline">share feedback</a>.
+            Beta features are experimental previews that may change before full release. Try them and share feedback.
           </p>
         </div>
 
@@ -98,6 +98,16 @@ const Beta = ({ close }) => {
                 <label className="block ml-2 select-none font-medium" htmlFor={feature.id}>
                   {feature.label}
                 </label>
+                {feature.id === 'grpc' && (
+                  <a 
+                    href="https://github.com/usebruno/bruno/discussions/5447" 
+                    target="_blank" 
+                    rel="noopener noreferrer" 
+                    className="ml-2 text-xs text-blue-500 hover:text-blue-600 underline"
+                  >
+                    Share feedback
+                  </a>
+                )}
               </div>
               <div className="beta-feature-description ml-6 text-xs text-gray-500 dark:text-gray-400">
                 {feature.description}

--- a/packages/bruno-app/src/components/Preferences/Beta/index.js
+++ b/packages/bruno-app/src/components/Preferences/Beta/index.js
@@ -79,7 +79,7 @@ const Beta = ({ close }) => {
             <h2 className="text-lg font-semibold">Beta Features</h2>
           </div>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 text-wrap">
-            Enable beta features, these features may be unstable or incomplete.
+            Beta features are experimental previews that may change before full release. Try them and <a href="https://github.com/usebruno/bruno/discussions/5447" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:text-blue-600 underline">share feedback</a>.
           </p>
         </div>
 


### PR DESCRIPTION
# Description

Update the gRPC tagline:
> Beta features are experimental previews that may change before full release. Try them and [share feedback](https://github.com/usebruno/bruno/discussions/5447).

File changed: `src/components/Preferences/Beta/index.js`

<img width="1976" height="1240" alt="image" src="https://github.com/user-attachments/assets/9094607b-609e-4377-aea6-81d2986f6f09" />

