### PR TITLE
fix(curl-parser): curl commands with url without protocol

### DIFF
--- a/packages/bruno-app/src/utils/curl/parse-curl.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.js
@@ -312,7 +312,22 @@ const isURL = (arg) => {
   if (typeof arg !== 'string') {
     return false;
   }
-  return !!URL.parse(arg || '').host;
+
+  // First try to parse as a regular URL (with protocol)
+  if (URL.parse(arg || '').host) {
+    return true;
+  }
+
+  // Check if it looks like a domain without protocol
+  // This regex matches domain patterns like:
+  // - example.com
+  // - sub.example.com
+  // - example.com/path
+  // - example.com/path?query=value
+  // Must contain at least one dot to be considered a domain
+  const DOMAIN_PATTERN = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\/[^\s]*)?(\?[^\s]*)?$/;
+
+  return DOMAIN_PATTERN.test(arg);
 };
 
 /**
@@ -320,8 +335,9 @@ const isURL = (arg) => {
  * Handles shell-quote operator objects and query parameter patterns
  */
 const isURLFragment = (arg) => {
+  // If it's a glob pattern that looks like a URL, treat it as a complete URL
   if (arg && typeof arg === 'object' && arg.op === 'glob') {
-    return !!URL.parse(arg.pattern || '').host;
+    return isURL(arg.pattern);
   }
   if (arg && typeof arg === 'object' && arg.op === '&') {
     return true;
@@ -341,7 +357,13 @@ const setURL = (request, url) => {
   const urlString = getUrlString(url);
   if (!urlString) return;
 
-  const newUrl = request.url ? request.url + urlString : urlString;
+  // Add default protocol if none is present
+  let processedUrl = urlString;
+  if (!request.url && !urlString.match(/^[a-zA-Z]+:\/\//)) {
+    processedUrl = 'https://' + urlString;
+  }
+
+  const newUrl = request.url ? request.url + processedUrl : processedUrl;
 
   const { url: formattedUrl, queries, urlWithoutQuery } = parseUrl(newUrl);
 


### PR DESCRIPTION
## Description

When importing a cURL command whose URL lacks a protocol (e.g., curl example.com/api), we now default to https:// before parsing.

The parser previously failed to parse such commands. Defaulting to HTTPS makes the import reliable and secure-by-default.

Notes
- No change if a scheme is present (http:// or https://).
- Users can still switch the scheme after import if needed.

Resolves: https://github.com/usebruno/bruno/issues/5366 

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
