### PR TITLE
feat: show final request variables under request vars tab

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Vars/FinalVarsTable/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Vars/FinalVarsTable/index.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import get from 'lodash/get';
+import { findEnvironmentInCollection, getTreePathFromCollectionToItem } from 'utils/collections';
+
+const FinalVarsTable = ({ item, collection }) => {
+  // Get the complete variable resolution hierarchy
+  const getResolvedVariables = () => {
+    const requestTreePath = getTreePathFromCollectionToItem(collection, item);
+    
+    // Start with environment variables
+    const activeEnvironment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
+    const envVars = new Map();
+    if (activeEnvironment) {
+      activeEnvironment.variables.forEach(envVar => {
+        if (envVar.enabled) {
+          envVars.set(envVar.name, {
+            value: envVar.value,
+            source: `Environment: ${activeEnvironment.name}`,
+            type: 'environment'
+          });
+        }
+      });
+    }
+
+    // Add collection variables
+    const collectionVars = get(collection, 'root.request.vars.req', []);
+    collectionVars.forEach(_var => {
+      if (_var.enabled) {
+        envVars.set(_var.name, {
+          value: _var.value,
+          source: 'Collection',
+          type: 'collection'
+        });
+      }
+    });
+
+    // Add folder variables (walking up the tree)
+    for (let i of requestTreePath) {
+      if (i.type === 'folder') {
+        const folderVars = get(i, 'root.request.vars.req', []);
+        folderVars.forEach(_var => {
+          if (_var.enabled) {
+            envVars.set(_var.name, {
+              value: _var.value,
+              source: `Folder: ${i.name}`,
+              type: 'folder'
+            });
+          }
+        });
+      }
+    }
+
+    // Add request variables (highest priority)
+    const requestVars = item.draft ? get(item, 'draft.request.vars.req', []) : get(item, 'request.vars.req', []);
+    requestVars.forEach(_var => {
+      if (_var.enabled) {
+        envVars.set(_var.name, {
+          value: _var.value,
+          source: 'Request',
+          type: 'request'
+        });
+      }
+    });
+
+    return Array.from(envVars, ([name, data]) => ({
+      name,
+      value: data.value,
+      source: data.source,
+      type: data.type
+    }));
+  };
+
+  const finalVars = getResolvedVariables();
+
+  const getTypeColor = (type) => {
+    switch (type) {
+      case 'environment': return 'text-green-600';
+      case 'collection': return 'text-blue-600';
+      case 'folder': return 'text-yellow-600';
+      case 'request': return 'text-purple-600';
+      default: return 'text-gray-600';
+    }
+  };
+
+  if (!finalVars || finalVars.length === 0) {
+    return (
+      <div>
+        <div className="text-gray-500 text-sm italic">No variables available</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="border-b">
+            <th className="text-left text-xs font-medium text-gray-700 py-2 px-1">Name</th>
+            <th className="text-left text-xs font-medium text-gray-700 py-2 px-1">Value</th>
+            <th className="text-left text-xs font-medium text-gray-700 py-2 px-1">Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {finalVars.map((variable, index) => (
+            <tr key={`${variable.name}-${index}`} className="border-b border-gray-100 hover:bg-gray-50">
+              <td className="py-2 px-1 text-xs font-mono">{variable.name}</td>
+              <td className="py-2 px-1 text-xs font-mono break-all">{variable.value}</td>
+              <td className={`py-2 px-1 text-xs ${getTypeColor(variable.type)}`}>
+                {variable.source}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default FinalVarsTable;

--- a/packages/bruno-app/src/components/RequestPane/Vars/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Vars/index.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import get from 'lodash/get';
 import VarsTable from './VarsTable';
+import FinalVarsTable from './FinalVarsTable';
 import StyledWrapper from './StyledWrapper';
 
 const Vars = ({ item, collection }) => {
+  const [showFinalVars, setShowFinalVars] = React.useState(false);
   const requestVars = item.draft ? get(item, 'draft.request.vars.req') : get(item, 'request.vars.req');
   const responseVars = item.draft ? get(item, 'draft.request.vars.res') : get(item, 'request.vars.res');
 
@@ -16,6 +18,19 @@ const Vars = ({ item, collection }) => {
       <div>
         <div className="mt-1 mb-1 title text-xs">Post Response</div>
         <VarsTable item={item} collection={collection} vars={responseVars} varType="response" />
+      </div>
+      <hr/>
+      <div>
+        <div className="mt-2 mb-1 flex items-center justify-between mb-2">
+          <div className="title text-xs">Final Variables (All Sources)</div>
+          <button
+            className="text-xs text-blue-600 hover:text-blue-800 underline"
+            onClick={() => setShowFinalVars(!showFinalVars)}
+          >
+            {showFinalVars ? 'Hide' : 'Show'}
+          </button>
+        </div>
+        {showFinalVars && <FinalVarsTable item={item} collection={collection} />}
       </div>
     </StyledWrapper>
   );


### PR DESCRIPTION


# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
In the Request → Variables tab, display a table with:

resolves #5456  

Variable Name – effective name used in the request
Value – resolved final value after applying precedence
Source – origin of the variable (Collection, Folder, Request, or Environment)
Notes:
2. Precedence: Request > Folder > Collection > Environment
3. View updates automatically when request or environment context changes

<img width="935" height="1071" alt="Screenshot 2025-08-30 at 12 10 48 AM" src="https://github.com/user-attachments/assets/b9e8b797-6be7-47d6-b3a1-00c7f06cf7fb" />



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
