### PR TITLE
Refactor: Remove use of `globalShortcut` for minimize/hide to avoid hijacking system shortcuts

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -174,13 +174,7 @@ app.on('ready', async () => {
     mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() + 1);
   });
 
-  globalShortcut.register('CommandOrControl+M', () => {
-    mainWindow.minimize();
-  });
 
-  globalShortcut.register('CommandOrControl+H', () => {
-    mainWindow.minimize();
-  });
 
   mainWindow.webContents.on('did-finish-load', async () => {
     let ogSend = mainWindow.webContents.send;


### PR DESCRIPTION
fixes: https://github.com/usebruno/bruno/issues/5450

# Description

Recently, we added Electron’s `globalShortcut` to register `CmdOrCtrl+M` and `CmdOrCtrl+H`. However, `globalShortcut` works system-wide, which caused Bruno to intercept these key combinations even when other applications were in focus. As a result, the shortcuts were hijacked and other apps lost their native behavior (e.g., `Cmd+M` to minimize the active app in macOS).

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**