### PR TITLE
Bugfix/global shortcut unfocused

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -169,12 +169,6 @@ app.on('ready', async () => {
     return { action: 'deny' };
   });
   
-  // Quick fix for Electron issue #29996: https://github.com/electron/electron/issues/29996
-  globalShortcut.register('Ctrl+=', () => {
-    mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() + 1);
-  });
-
-
 
   mainWindow.webContents.on('did-finish-load', async () => {
     let ogSend = mainWindow.webContents.send;
@@ -218,3 +212,17 @@ app.on('window-all-closed', app.quit);
 app.on('open-file', (event, path) => {
   openCollection(mainWindow, collectionWatcher, path);
 });
+
+
+// Register the global shortcuts
+app.on('browser-window-focus', () => {
+  // Quick fix for Electron issue #29996: https://github.com/electron/electron/issues/29996
+  globalShortcut.register('Ctrl+=', () => {
+    mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() + 1);
+  });
+})
+
+// Disable global shortcuts when not focused
+app.on('browser-window-blur', () => {
+  globalShortcut.unregisterAll()
+})


### PR DESCRIPTION
# Prevent Global Shortcuts from Bruno from triggering when not focused

- I moved the globalShortcuts down to prevent the [problem](https://github.com/electron/electron/issues/8491) using the [solution](https://github.com/electron/electron/issues/8491#issuecomment-1002515761) presented.
- This closes the #5489 issue.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


