### PR TITLE
Implement cross-collection item drop functionality in collections sidebar

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
@@ -143,6 +143,18 @@ const Wrapper = styled.div`
         color: white;
       }
     }
+
+    /* Cross-collection drop indicator - same as folder drop */
+    &.cross-collection-drop {
+      background-color: ${(props) => props.theme.dragAndDrop.hoverBg};
+      border: ${(props) => props.theme.dragAndDrop.borderStyle} ${(props) => props.theme.dragAndDrop.border};
+      border-radius: 4px;
+      
+      &::before,
+      &::after {
+        opacity: 0;
+      }
+    }
   }
 
   &.is-sidebar-dragging .collection-item-name {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
@@ -104,6 +104,15 @@ const Wrapper = styled.div`
     box-shadow: 0 0 0 2px ${(props) => props.theme.dragAndDrop.hoverBg};
   }
 
+  .collection-name.cross-collection-drop {
+    border: ${(props) => props.theme.dragAndDrop.borderStyle} ${(props) => props.theme.dragAndDrop.border};
+    border-radius: 4px;
+    background-color: ${(props) => props.theme.dragAndDrop.hoverBg};
+    margin: -2px;
+    transition: ${(props) => props.theme.dragAndDrop.transition};
+    box-shadow: 0 0 0 2px ${(props) => props.theme.dragAndDrop.hoverBg};
+  }
+
   #sidebar-collection-name {
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
[Jira ticket](https://usebruno.atlassian.net/browse/BRU-1399) 
Fixes #3320 

- Added `handleCrossCollectionItemDrop` action to manage item moves between collections.
- Updated drag-and-drop logic in `Collection` and `CollectionItem` components to differentiate between within-collection and cross-collection moves.
- Enhanced styling for cross-collection drop indicators in `StyledWrapper` components.
- Adjusted item properties during drag to include source collection information for accurate handling.

# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
