### PR TITLE
fix(oauth2): always send client id if set

### DIFF
--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -259,10 +259,10 @@ const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, fo
     code: authorizationCode,
     redirect_uri: callbackUrl,
   };
-  if (credentialsPlacement !== "basic_auth_header") {
+  if (clientId && clientId.trim() !== '') {
     data.client_id = clientId;
   }
-  if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== "basic_auth_header") {
+  if (clientSecret && clientSecret.trim() !== '') {
     data.client_secret = clientSecret;
   }
   if (pkce) {
@@ -456,7 +456,7 @@ const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, fo
   const data = {
     grant_type: 'client_credentials',
   };
-  if (credentialsPlacement !== "basic_auth_header") {
+  if (clientId && clientId.trim() !== '') {
     data.client_id = clientId;
   }
   if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== "basic_auth_header") {
@@ -605,10 +605,10 @@ const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, 
     username,
     password,
   };
-  if (credentialsPlacement !== "basic_auth_header") {
+  if (clientId && clientId.trim() !== '') {
     data.client_id = clientId;
   }
-  if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== "basic_auth_header") {
+  if (clientSecret && clientSecret.trim() !== '') {
     data.client_secret = clientSecret;
   }
   if (scope && scope.trim() !== '') {
@@ -646,10 +646,10 @@ const refreshOauth2Token = async ({ requestCopy, collectionUid, certsAndProxyCon
       grant_type: 'refresh_token',
       refresh_token: credentials.refresh_token,
     };
-    if (credentialsPlacement !== "basic_auth_header") {
+    if (clientId && clientId.trim() !== '') {
       data.client_id = clientId;
     }
-    if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== "basic_auth_header") {
+    if (clientSecret && clientSecret.trim() !== '') {
       data.client_secret = clientSecret;
     }
     let axiosRequestConfig = {};

--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -459,7 +459,7 @@ const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, fo
   if (clientId && clientId.trim() !== '') {
     data.client_id = clientId;
   }
-  if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== "basic_auth_header") {
+  if (clientSecret && clientSecret.trim() !== '') {
     data.client_secret = clientSecret;
   }
   if (scope && scope.trim() !== '') {


### PR DESCRIPTION
# Description

<img width="706" height="961" alt="image" src="https://github.com/user-attachments/assets/19caef5c-9a08-46de-8a5e-28ea77243521" />

I am using Password Grant using OAuth. Since the last Update this has been broken as when the credential placement is header the client_id is not send anymore.

We require a client_id for password grant, so I changed it to send it always when it's set.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
