### PR TITLE
Update digest authentication test cases with new URLs and credentials

### DIFF
--- a/packages/bruno-tests/collection/auth/digest/Digest Auth 200.bru
+++ b/packages/bruno-tests/collection/auth/digest/Digest Auth 200.bru
@@ -5,14 +5,14 @@ meta {
 }
 
 get {
-  url: https://httpbin.org/digest-auth/auth/foo/passwd
+  url: https://www.httpfaker.org/api/auth/digest/auth/admin/password
   body: none
   auth: digest
 }
 
 auth:digest {
-  username: foo
-  password: passwd
+  username: admin
+  password: password
 }
 
 assert {

--- a/packages/bruno-tests/collection/auth/digest/Digest Auth 401.bru
+++ b/packages/bruno-tests/collection/auth/digest/Digest Auth 401.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: https://httpbin.org/digest-auth/auth/foo/passw
+  url: https://www.httpfaker.org/api/auth/digest/auth/admin/badpassword
   body: none
   auth: digest
 }


### PR DESCRIPTION
### Description

Update digest tests to use httpfaker.org instead of httbin.org
The latter has been flaky many times.