### PR TITLE
ca certs updates and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9942,16 +9942,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -14299,13 +14289,6 @@
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
       "license": "MIT"
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -18565,28 +18548,6 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
-    },
-    "node_modules/macos-export-certificate-and-key": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.2.4.tgz",
-      "integrity": "sha512-y5QZEywlBNKd+EhPZ1Hz1FmDbbeQKtuVHJaTlawdl7vXw9bi/4tJB2xSMwX4sMVcddy3gbQ8K0IqXAi2TpDo2g==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^4.3.0"
-      }
-    },
-    "node_modules/macos-export-certificate-and-key/node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/magic-string": {
       "version": "0.27.0",
@@ -24873,16 +24834,6 @@
         "jscat": "bundle.js"
       }
     },
-    "node_modules/system-ca": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/system-ca/-/system-ca-2.0.1.tgz",
-      "integrity": "sha512-9ZDV9yl8ph6Op67wDGPr4LykX86usE9x3le+XZSHfVMiiVJ5IRgmCWjLgxyz35ju9H3GDIJJZm4ogAeIfN5cQQ==",
-      "license": "Apache-2.0",
-      "optionalDependencies": {
-        "macos-export-certificate-and-key": "^1.2.0",
-        "win-export-certificate-and-key": "^2.1.0"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -26358,28 +26309,6 @@
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/win-export-certificate-and-key": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-2.1.0.tgz",
-      "integrity": "sha512-WeMLa/2uNZcS/HWGKU2G1Gzeh3vHpV/UFvwLhJLKxPHYFAbubxxVcJbqmPXaqySWK1Ymymh16zKK5WYIJ3zgzA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^3.1.0"
-      }
-    },
-    "node_modules/win-export-certificate-and-key/node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -31929,7 +31858,6 @@
         "axios": "^1.9.0",
         "grpc-reflection-js": "^0.3.0",
         "is-ip": "^5.0.1",
-        "system-ca": "^2.0.1",
         "tough-cookie": "^6.0.0"
       },
       "devDependencies": {

--- a/packages/bruno-requests/package.json
+++ b/packages/bruno-requests/package.json
@@ -27,7 +27,6 @@
     "axios": "^1.9.0",
     "grpc-reflection-js": "^0.3.0",
     "is-ip": "^5.0.1",
-    "system-ca": "^2.0.1",
     "tough-cookie": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/bruno-requests/rollup.config.js
+++ b/packages/bruno-requests/rollup.config.js
@@ -39,6 +39,6 @@ module.exports = [
       typescript({ tsconfig: './tsconfig.json' }),
       terser(),
     ],
-    external: ['axios', 'qs', 'system-ca']
+    external: ['axios', 'qs']
   }
 ];

--- a/packages/bruno-requests/src/utils/ca-cert.ts
+++ b/packages/bruno-requests/src/utils/ca-cert.ts
@@ -1,5 +1,4 @@
-import { systemCertsAsync, Options as SystemCAOptions } from 'system-ca';
-import { rootCertificates } from 'node:tls';
+import * as tls from 'node:tls';
 import * as fs from 'node:fs';
 
 type T_CACertificatesOptions = {
@@ -19,11 +18,11 @@ type T_CACertificatesResult = {
 
 let systemCertsCache: string[] | undefined;
 
-async function getSystemCerts(systemCAOpts: SystemCAOptions = {}): Promise<string[]> {
+async function getSystemCerts(): Promise<string[]> {
   if (systemCertsCache) return systemCertsCache;
 
   try {
-    systemCertsCache = await systemCertsAsync(systemCAOpts);
+    systemCertsCache = tls.getCACertificates('system');
 
     return systemCertsCache;
   } catch (error) {
@@ -131,7 +130,7 @@ const getCACertificates = async ({ caCertFilePath, shouldKeepDefaultCerts = true
         caCertificatesCount.system = systemCerts.length;
 
         // get root certs
-        rootCerts = [...rootCertificates];
+        rootCerts = [...tls.rootCertificates];
         caCertificatesCount.root = rootCerts.length;
       }
     } else {
@@ -140,7 +139,7 @@ const getCACertificates = async ({ caCertFilePath, shouldKeepDefaultCerts = true
       caCertificatesCount.system = systemCerts.length;
 
       // get root certs
-      rootCerts = [...rootCertificates];
+      rootCerts = [...tls.rootCertificates];
       caCertificatesCount.root = rootCerts.length;
     }
 


### PR DESCRIPTION
We decided to not use `system-ca` as it wa.s resulting in issues during build. For now, we'll use nodejs `tls.getCACertificates("system")` api.