### PR TITLE
fix(bruno-electron): interpolate auth headers for GraphQL introspection request

### DIFF
--- a/packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js
@@ -1,6 +1,7 @@
 const { get, each } = require('lodash');
 const { interpolate } = require('@usebruno/common');
 const { getIntrospectionQuery } = require('graphql');
+const interpolateVars = require('./interpolate-vars');
 const { setAuthHeaders } = require('./prepare-request');
 
 const prepareGqlIntrospectionRequest = (endpoint, resolvedVars, request, collectionRoot) => {
@@ -23,7 +24,9 @@ const prepareGqlIntrospectionRequest = (endpoint, resolvedVars, request, collect
     data: JSON.stringify(queryParams)
   };
 
-  return setAuthHeaders(axiosRequest, request, collectionRoot);
+  axiosRequest = setAuthHeaders(axiosRequest, request, collectionRoot);
+
+  return interpolateVars(axiosRequest, resolvedVars);
 };
 
 const mapHeaders = (requestHeaders, collectionHeaders, resolvedVars) => {

--- a/packages/bruno-electron/tests/network/prepare-gql-introspection-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-gql-introspection-request.spec.js
@@ -29,6 +29,43 @@ describe('prepareGqlIntrospectionRequest', () => {
     expect(result.url).toBe(setup.endpoint);
   });
 
+  it('should interpolate bearer auth headers from request auth', () => {
+    const setup = createBasicSetup();
+    setup.request.auth = {
+      mode: 'bearer',
+      bearer: {
+        token: '{{AUTH_TOKEN}}'
+      }
+    };
+    const vars = {
+      AUTH_TOKEN: 'request-token'
+    };
+
+    const result = prepareGqlIntrospectionRequest(setup.endpoint, vars, setup.request, setup.collectionRoot);
+
+    expect(result.headers['Authorization']).toBe('Bearer request-token');
+  });
+
+  it('should interpolate inherited bearer auth headers', () => {
+    const setup = createBasicSetup();
+    setup.request.auth = {
+      mode: 'inherit'
+    };
+    setup.collectionRoot.request.auth = {
+      mode: 'bearer',
+      bearer: {
+        token: '{{AUTH_TOKEN}}'
+      }
+    };
+    const vars = {
+      AUTH_TOKEN: 'collection-token'
+    };
+
+    const result = prepareGqlIntrospectionRequest(setup.endpoint, vars, setup.request, setup.collectionRoot);
+
+    expect(result.headers['Authorization']).toBe('Bearer collection-token');
+  });
+
   it('should override collection headers with request headers', () => {
     const setup = createBasicSetup();
     setup.collectionRoot.request.headers = [


### PR DESCRIPTION
# Description
Fix #4921 : interpolate auth headers for GraphQL introspection request

[JIRA](https://usebruno.atlassian.net/browse/BRU-2009)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GraphQL introspection requests now support variable interpolation, allowing dynamic parameters to be processed during request preparation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->