### PR TITLE
Feat: add xdg-portal version override for Linux

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const isDev = require('electron-is-dev');
+const os = require('os');
 
 if (isDev) {
   if(!fs.existsSync(path.join(__dirname, '../../bruno-js/src/sandbox/bundle-browser-rollup.js'))) {
@@ -19,6 +20,14 @@ if (isDev && process.env.ELECTRON_USER_DATA_PATH) {
     + `\t${app.getPath("userData")} -> ${process.env.ELECTRON_USER_DATA_PATH}`);
 
   app.setPath('userData', process.env.ELECTRON_USER_DATA_PATH);
+}
+
+// Command line switches
+if (os.platform() === 'linux') {
+  // Use portal version 4 that supports current_folder option
+  // to address https://github.com/usebruno/bruno/issues/5471
+  // Runtime sets the default version to 3, refs https://github.com/electron/electron/pull/44426
+  app.commandLine.appendSwitch('xdg-portal-required-version', '4');
 }
 
 const menuTemplate = require('./app/menu-template');


### PR DESCRIPTION
fixes: https://github.com/usebruno/bruno/issues/5471

# Description

This PR implements the feature of overriding the `xdg-portal` version to `4` since `version=3` causing issues on the File Selector. A similar solution has been implemented in [microsoft/vscode](https://github.com/microsoft/vscode/commit/f94b27000c8423c19a96528d09b518c2cbb60860). 

Reference: https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-350

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
