### PR TITLE
fix: Add null safety checks in GlobalSearchModal

### DIFF
--- a/packages/bruno-app/src/components/GlobalSearchModal/index.js
+++ b/packages/bruno-app/src/components/GlobalSearchModal/index.js
@@ -70,7 +70,7 @@ const GlobalSearchModal = ({ isOpen, onClose }) => {
       const flattenedItems = flattenItems(collection.items);
       flattenedItems.forEach(item => {
         const itemPath = getItemPath(item, collection, findParentItemInCollection);
-        const itemPathLower = itemPath?.toLowerCase();
+        const itemPathLower = itemPath.toLowerCase();
 
         if (isItemARequest(item)) {
           const nameMatch = searchTerms.every(term => (item.name || '').toLowerCase().includes(term));

--- a/packages/bruno-app/src/components/GlobalSearchModal/index.js
+++ b/packages/bruno-app/src/components/GlobalSearchModal/index.js
@@ -73,6 +73,7 @@ const GlobalSearchModal = ({ isOpen, onClose }) => {
         const itemPathLower = itemPath.toLowerCase();
 
         if (isItemARequest(item)) {
+          // add an optional check for the item name to prevent a crash if it doesn’t exist.
           const nameMatch = searchTerms.every(term => (item.name || '').toLowerCase().includes(term));
           const urlMatch = searchTerms.every(term => (item.request?.url || '').toLowerCase().includes(term));
           const pathMatch = enablePathMatch && searchTerms.every(term => itemPathLower.includes(term));

--- a/packages/bruno-app/src/components/GlobalSearchModal/index.js
+++ b/packages/bruno-app/src/components/GlobalSearchModal/index.js
@@ -70,10 +70,10 @@ const GlobalSearchModal = ({ isOpen, onClose }) => {
       const flattenedItems = flattenItems(collection.items);
       flattenedItems.forEach(item => {
         const itemPath = getItemPath(item, collection, findParentItemInCollection);
-        const itemPathLower = itemPath.toLowerCase();
+        const itemPathLower = itemPath?.toLowerCase();
 
         if (isItemARequest(item)) {
-          const nameMatch = searchTerms.every(term => item.name.toLowerCase().includes(term));
+          const nameMatch = searchTerms.every(term => (item.name || '').toLowerCase().includes(term));
           const urlMatch = searchTerms.every(term => (item.request?.url || '').toLowerCase().includes(term));
           const pathMatch = enablePathMatch && searchTerms.every(term => itemPathLower.includes(term));
 


### PR DESCRIPTION
# Description

This PR adds optional chaining operators (`?.`) to the GlobalSearchModal component to prevent app crash if request name is not there

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
