### PR TITLE
fix: improve file upload handling in prepare-request to use streaming

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -314,7 +314,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
         }
 
         try {
-          // Large files (>20MB) can cause "JavaScript heap out of memory" errors when loaded entirely into memory.
+          // Large files can cause "JavaScript heap out of memory" errors when loaded entirely into memory.
           if (isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)) {
             // For large files: Use streaming to avoid memory issues
             axiosRequest.data = fs.createReadStream(filePath);

--- a/packages/bruno-cli/src/utils/filesystem.js
+++ b/packages/bruno-cli/src/utils/filesystem.js
@@ -158,6 +158,22 @@ const validateName = (name) => {
   );
 };
 
+/**
+ * Checks if a file is larger than a given threshold.
+ * @param {string} filePath - The path to the file.
+ * @param {number} threshold - The threshold in bytes. Default is 10MB.
+ * @returns {boolean} True if the file is larger than the threshold, false otherwise.
+ */
+const isLargeFile = (filePath, threshold = 10 * 1024 * 1024) => {
+  if (!isFile(filePath)) {
+    throw new Error(`File ${filePath} is not a file`);
+  }
+
+  const size = fs.statSync(filePath).size;
+
+  return size > threshold;
+};
+
 module.exports = {
   exists,
   isSymbolicLink,
@@ -173,5 +189,6 @@ module.exports = {
   stripExtension,
   getSubDirectories,
   sanitizeName,
-  validateName
+  validateName,
+  isLargeFile
 };

--- a/packages/bruno-cli/tests/runner/prepare-request.spec.js
+++ b/packages/bruno-cli/tests/runner/prepare-request.spec.js
@@ -538,7 +538,7 @@ describe('prepare-request: prepareRequest', () => {
       jest.restoreAllMocks();
     });
 
-    it('uses readFileSync for small files', async () => {
+    it('should use readFileSync to read small files', async () => {
       const fileContent = Buffer.from('small file content');
       filesystemUtils.isLargeFile.mockReturnValue(false);
       readFileSyncSpy.mockReturnValue(fileContent);
@@ -569,7 +569,7 @@ describe('prepare-request: prepareRequest', () => {
       expect(createReadStreamSpy).not.toHaveBeenCalled();
     });
 
-    it('uses createReadStream for large files', async () => {
+    it('should use createReadStream to read large files', async () => {
       const mockStream = { pipe: jest.fn() };
       filesystemUtils.isLargeFile.mockReturnValue(true);
       createReadStreamSpy.mockReturnValue(mockStream);

--- a/packages/bruno-cli/tests/utils/filesystem.spec.js
+++ b/packages/bruno-cli/tests/utils/filesystem.spec.js
@@ -1,0 +1,50 @@
+const { isLargeFile } = require('../../src/utils/filesystem');
+const fs = require('fs-extra');
+
+describe('isLargeFile', () => {
+  let existsSyncSpy;
+  let lstatSyncSpy;
+  let statSyncSpy;
+
+  beforeEach(() => {
+    existsSyncSpy = jest.spyOn(fs, 'existsSync');
+    lstatSyncSpy = jest.spyOn(fs, 'lstatSync');
+    statSyncSpy = jest.spyOn(fs, 'statSync');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return false when file size is below default threshold (10MB)', () => {
+    existsSyncSpy.mockReturnValue(true);
+    lstatSyncSpy.mockReturnValue({ isFile: () => true });
+    statSyncSpy.mockReturnValue({ size: 5 * 1024 * 1024 }); // 5MB
+
+    expect(isLargeFile('/path/small.bin')).toBe(false);
+  });
+
+  it('should return true when file size is above default threshold (10MB)', () => {
+    existsSyncSpy.mockReturnValue(true);
+    lstatSyncSpy.mockReturnValue({ isFile: () => true });
+    statSyncSpy.mockReturnValue({ size: 15 * 1024 * 1024 }); // 15MB
+
+    expect(isLargeFile('/path/large.bin')).toBe(true);
+  });
+
+  it('should respect custom threshold (args true or false)', () => {
+    existsSyncSpy.mockReturnValue(true);
+    lstatSyncSpy.mockReturnValue({ isFile: () => true });
+    statSyncSpy.mockReturnValue({ size: 50 });
+
+    expect(isLargeFile('/path/file.bin', 100)).toBe(false); // 50 < 100
+    expect(isLargeFile('/path/file.bin', 10)).toBe(true); // 50 > 10
+  });
+
+  it('should throw on invalid values (not a file)', () => {
+    existsSyncSpy.mockReturnValue(false);
+    lstatSyncSpy.mockReturnValue({ isFile: () => false });
+
+    expect(() => isLargeFile('/path/not-a-file.bin')).toThrow('File /path/not-a-file.bin is not a file');
+  });
+});

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -401,7 +401,7 @@ const prepareRequest = async (item, collection = {}, abortController) => {
         }
   
         try {
-          // Large files (>20MB) can cause "JavaScript heap out of memory" errors when loaded entirely into memory.
+          // Large files can cause "JavaScript heap out of memory" errors when loaded entirely into memory.
           if (isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)) {
             // For large files: Use streaming to avoid memory issues
             axiosRequest.data = fs.createReadStream(filePath);

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -1,10 +1,13 @@
 const { get, each, filter, find } = require('lodash');
 const decomment = require('decomment');
 const crypto = require('node:crypto');
-const fs = require('node:fs/promises');
+const fs = require('node:fs');
 const { getTreePathFromCollectionToItem, mergeHeaders, mergeScripts, mergeVars, getFormattedCollectionOauth2Credentials, mergeAuth } = require('../../utils/collection');
 const { buildFormUrlEncodedPayload } = require('../../utils/form-data');
 const path = require('node:path');
+const { isLargeFile } = require('../../utils/filesystem');
+
+const STREAMING_FILE_SIZE_THRESHOLD = 20 * 1024 * 1024; // 20MB
 
 const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
   const collectionAuth = get(collectionRoot, 'request.auth');
@@ -398,8 +401,14 @@ const prepareRequest = async (item, collection = {}, abortController) => {
         }
   
         try {
-          const fileContent = await fs.readFile(filePath);
-          axiosRequest.data = fileContent;
+          // Large files (>20MB) can cause "JavaScript heap out of memory" errors when loaded entirely into memory.
+          if (isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)) {
+            // For large files: Use streaming to avoid memory issues
+            axiosRequest.data = fs.createReadStream(filePath);
+          } else {
+            // For smaller files: Use synchronous read for better performance
+            axiosRequest.data = fs.readFileSync(filePath);
+          }
         } catch (error) {
           console.error('Error reading file:', error);
         }

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -343,6 +343,21 @@ const getPaths = async (source) => {
   return paths;
 }
 
+/**
+ * Checks if a file is larger than a given threshold.
+ * @param {string} filePath - The path to the file.
+ * @param {number} threshold - The threshold in bytes. Default is 10MB.
+ * @returns {boolean} True if the file is larger than the threshold, false otherwise.
+ */
+const isLargeFile = (filePath, threshold = 10 * 1024 * 1024) => {
+  if (!isFile(filePath)) {
+    throw new Error(`File ${filePath} is not a file`);
+  }
+
+  const size = fs.statSync(filePath).size;
+
+  return size > threshold;
+};
 
 module.exports = {
   isValidPathname,
@@ -373,5 +388,6 @@ module.exports = {
   safeWriteFileSync,
   copyPath,
   removePath,
-  getPaths
+  getPaths,
+  isLargeFile
 };

--- a/packages/bruno-electron/src/utils/filesystem.test.js
+++ b/packages/bruno-electron/src/utils/filesystem.test.js
@@ -45,7 +45,7 @@ describe('isLargeFile', () => {
     jest.restoreAllMocks();
   });
 
-  it('returns false when file size is below default threshold (10MB)', () => {
+  it('should return false when file size is below default threshold (10MB)', () => {
     existsSyncSpy.mockReturnValue(true);
     lstatSyncSpy.mockReturnValue({ isFile: () => true });
     statSyncSpy.mockReturnValue({ size: 5 * 1024 * 1024 }); // 5MB
@@ -53,7 +53,7 @@ describe('isLargeFile', () => {
     expect(isLargeFile('/path/small.bin')).toBe(false);
   });
 
-  it('returns true when file size is above default threshold (10MB)', () => {
+  it('should return true when file size is above default threshold (10MB)', () => {
     existsSyncSpy.mockReturnValue(true);
     lstatSyncSpy.mockReturnValue({ isFile: () => true });
     statSyncSpy.mockReturnValue({ size: 15 * 1024 * 1024 }); // 15MB
@@ -61,7 +61,7 @@ describe('isLargeFile', () => {
     expect(isLargeFile('/path/large.bin')).toBe(true);
   });
 
-  it('respects custom threshold (args true or false)', () => {
+  it('should respect custom threshold (args true or false)', () => {
     existsSyncSpy.mockReturnValue(true);
     lstatSyncSpy.mockReturnValue({ isFile: () => true });
     statSyncSpy.mockReturnValue({ size: 50 });
@@ -70,11 +70,11 @@ describe('isLargeFile', () => {
     expect(isLargeFile('/path/file.bin', 10)).toBe(true); // 50 > 10
   });
 
-  it('throws on invalid values (not a file)', () => {
+  it('should throw on invalid values (not a file)', () => {
     existsSyncSpy.mockReturnValue(false);
     lstatSyncSpy.mockReturnValue({ isFile: () => false });
 
-    expect(() => isLargeFile('/path/not-a-file.bin')).toThrow('is not a file');
+    expect(() => isLargeFile('/path/not-a-file.bin')).toThrow('File /path/not-a-file.bin is not a file');
   });
 });
 


### PR DESCRIPTION
[JIRA](https://usebruno.atlassian.net/browse/BRU-1773)
Fixes: https://github.com/usebruno/bruno/issues/5340

Bruno crashes with a "JavaScript heap out of memory" error when uploading large files (e.g., 367MB MP4 files) in file body mode. The issue occurs because the entire file is loaded into memory using `fs.readFile()`.

### Fix:
- **Small files (≤100MB)**: Use `fs.readFileSync()` for better performance
- **Large files (>100MB)**: Use `fs.createReadStream()` for streaming upload to prevent memory overflow