### PR TITLE
feat: Collapsible Interface for Pre / Post Request scripts

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Script/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Script/StyledWrapper.js
@@ -5,10 +5,55 @@ const StyledWrapper = styled.div`
 
   div.CodeMirror {
     height: inherit;
+    min-height: 200px;
   }
 
   div.title {
     color: var(--color-tab-inactive);
+    font-weight: 500;
+  }
+
+  .script-section {
+    border: 1px solid ${props => props.theme.input.border};
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    overflow: hidden;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .script-header {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    background: transparent;
+    cursor: pointer;
+    font-weight: 500;
+    border: none;
+    width: 100%;
+
+    &:hover {
+      background-color: ${props => props.theme.plainGrid.hoverBg};
+    }
+
+    .chevron-icon {
+      color: var(--color-tab-inactive);
+    }
+  }
+
+  .script-content {
+    padding: 1rem;
+    border-top: 1px solid ${props => props.theme.input.border};
+  }
+
+  .script-editor-container {
+    height: 50vh;
+    min-height: 300px;
+    max-height: 600px;
+    display: flex;
+    flex-direction: column;
   }
 `;
 

--- a/packages/bruno-app/src/components/CollectionSettings/Script/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Script/StyledWrapper.js
@@ -2,6 +2,9 @@ import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
   max-width: 800px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   div.CodeMirror {
     height: inherit;
@@ -18,9 +21,21 @@ const StyledWrapper = styled.div`
     border-radius: 4px;
     margin-bottom: 0.5rem;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
 
     &:last-child {
       margin-bottom: 0;
+    }
+
+    /* When collapsed, take minimal space */
+    &.collapsed {
+      flex: 0 0 auto;
+    }
+
+    /* When expanded, take all available space */
+    &.expanded {
+      flex: 1;
     }
   }
 
@@ -46,14 +61,21 @@ const StyledWrapper = styled.div`
   .script-content {
     padding: 1rem;
     border-top: 1px solid ${props => props.theme.input.border};
+    flex: 1;
+    display: flex;
+    flex-direction: column;
   }
 
   .script-editor-container {
-    height: 50vh;
-    min-height: 300px;
-    max-height: 600px;
+    flex: 1;
+    min-height: 200px;
     display: flex;
     flex-direction: column;
+
+    div.CodeMirror {
+      flex-direction: column !important;
+      flex: 1;
+    }
   }
 `;
 

--- a/packages/bruno-app/src/components/CollectionSettings/Script/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Script/index.js
@@ -16,7 +16,7 @@ const Script = ({ collection }) => {
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
 
-  // State for collapsible sections - both start expanded
+  // State for collapsible sections - start expanded by default
   const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(true);
   const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(true);
 
@@ -48,8 +48,9 @@ const Script = ({ collection }) => {
         Write pre and post-request scripts that will run before and after any request in this collection is sent.
       </div>
 
-      {/* Pre Request Section */}
-      <div className="script-section">
+      <div className="flex flex-col flex-1">
+        {/* Pre Request Section */}
+        <div className={`script-section ${isPreRequestExpanded ? 'expanded' : 'collapsed'}`}>
         <div className="script-header" onClick={() => setIsPreRequestExpanded(!isPreRequestExpanded)}>
           <div className="title text-xs">Pre Request</div>
           <IconChevronDown
@@ -79,8 +80,8 @@ const Script = ({ collection }) => {
         )}
       </div>
 
-      {/* Post Response Section */}
-      <div className="script-section">
+        {/* Post Response Section */}
+        <div className={`script-section ${isPostResponseExpanded ? 'expanded' : 'collapsed'}`}>
         <div className="script-header" onClick={() => setIsPostResponseExpanded(!isPostResponseExpanded)}>
           <div className="title text-xs">Post Response</div>
           <IconChevronDown
@@ -108,6 +109,7 @@ const Script = ({ collection }) => {
             </div>
           </div>
         )}
+        </div>
       </div>
 
       <div className="mt-12">

--- a/packages/bruno-app/src/components/CollectionSettings/Script/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Script/index.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
+import { IconChevronDown } from '@tabler/icons';
 import CodeEditor from 'components/CodeEditor';
 import { updateCollectionRequestScript, updateCollectionResponseScript } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionRoot } from 'providers/ReduxStore/slices/collections/actions';
@@ -14,6 +15,10 @@ const Script = ({ collection }) => {
 
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
+
+  // State for collapsible sections - both start expanded
+  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(true);
+  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(true);
 
   const onRequestScriptEdit = (value) => {
     dispatch(
@@ -42,33 +47,67 @@ const Script = ({ collection }) => {
       <div className="text-xs mb-4 text-muted">
         Write pre and post-request scripts that will run before and after any request in this collection is sent.
       </div>
-      <div className="flex-1 mt-2">
-        <div className="mb-1 title text-xs">Pre Request</div>
-        <CodeEditor
-          collection={collection}
-          value={requestScript || ''}
-          theme={displayedTheme}
-          onEdit={onRequestScriptEdit}
-          mode="javascript"
-          onSave={handleSave}
-          font={get(preferences, 'font.codeFont', 'default')}
-          fontSize={get(preferences, 'font.codeFontSize')}
-          showHintsFor={['req', 'bru']}
-        />
+
+      {/* Pre Request Section */}
+      <div className="script-section">
+        <div className="script-header" onClick={() => setIsPreRequestExpanded(!isPreRequestExpanded)}>
+          <div className="title text-xs">Pre Request</div>
+          <IconChevronDown
+            className="w-4 h-4 ml-auto chevron-icon"
+            style={{
+              transform: `rotate(${isPreRequestExpanded ? '180deg' : '0deg'})`,
+              transition: 'transform 0.2s ease-in-out',
+            }}
+          />
+        </div>
+        {isPreRequestExpanded && (
+          <div className="script-content">
+            <div className="script-editor-container">
+              <CodeEditor
+                collection={collection}
+                value={requestScript || ''}
+                theme={displayedTheme}
+                onEdit={onRequestScriptEdit}
+                mode="javascript"
+                onSave={handleSave}
+                font={get(preferences, 'font.codeFont', 'default')}
+                fontSize={get(preferences, 'font.codeFontSize')}
+                showHintsFor={['req', 'bru']}
+              />
+            </div>
+          </div>
+        )}
       </div>
-      <div className="flex-1 mt-6">
-        <div className="mt-1 mb-1 title text-xs">Post Response</div>
-        <CodeEditor
-          collection={collection}
-          value={responseScript || ''}
-          theme={displayedTheme}
-          onEdit={onResponseScriptEdit}
-          mode="javascript"
-          onSave={handleSave}
-          font={get(preferences, 'font.codeFont', 'default')}
-          fontSize={get(preferences, 'font.codeFontSize')}
-          showHintsFor={['req', 'res', 'bru']}
-        />
+
+      {/* Post Response Section */}
+      <div className="script-section">
+        <div className="script-header" onClick={() => setIsPostResponseExpanded(!isPostResponseExpanded)}>
+          <div className="title text-xs">Post Response</div>
+          <IconChevronDown
+            className="w-4 h-4 ml-auto chevron-icon"
+            style={{
+              transform: `rotate(${isPostResponseExpanded ? '180deg' : '0deg'})`,
+              transition: 'transform 0.2s ease-in-out',
+            }}
+          />
+        </div>
+        {isPostResponseExpanded && (
+          <div className="script-content">
+            <div className="script-editor-container">
+              <CodeEditor
+                collection={collection}
+                value={responseScript || ''}
+                theme={displayedTheme}
+                onEdit={onResponseScriptEdit}
+                mode="javascript"
+                onSave={handleSave}
+                font={get(preferences, 'font.codeFont', 'default')}
+                fontSize={get(preferences, 'font.codeFontSize')}
+                showHintsFor={['req', 'res', 'bru']}
+              />
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="mt-12">

--- a/packages/bruno-app/src/components/FolderSettings/Script/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/StyledWrapper.js
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
   div.CodeMirror {
     height: inherit;
     min-height: 200px;
@@ -16,6 +20,9 @@ const StyledWrapper = styled.div`
     border-radius: 4px;
     margin-bottom: 0.5rem;
     overflow: hidden;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
 
     &:last-child {
       margin-bottom: 0;
@@ -44,14 +51,21 @@ const StyledWrapper = styled.div`
   .script-content {
     padding: 1rem;
     border-top: 1px solid ${props => props.theme.input.border};
+    flex: 1;
+    display: flex;
+    flex-direction: column;
   }
 
   .script-editor-container {
-    height: 50vh;
-    min-height: 300px;
-    max-height: 600px;
+    flex: 1;
+    min-height: 200px;
     display: flex;
     flex-direction: column;
+
+    div.CodeMirror {
+      flex-direction: column !important;
+      flex: 1;
+    }
   }
 `;
 

--- a/packages/bruno-app/src/components/FolderSettings/Script/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/StyledWrapper.js
@@ -3,10 +3,55 @@ import styled from 'styled-components';
 const StyledWrapper = styled.div`
   div.CodeMirror {
     height: inherit;
+    min-height: 200px;
   }
 
   div.title {
     color: var(--color-tab-inactive);
+    font-weight: 500;
+  }
+
+  .script-section {
+    border: 1px solid ${props => props.theme.input.border};
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    overflow: hidden;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .script-header {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    background: transparent;
+    cursor: pointer;
+    font-weight: 500;
+    border: none;
+    width: 100%;
+
+    &:hover {
+      background-color: ${props => props.theme.plainGrid.hoverBg};
+    }
+
+    .chevron-icon {
+      color: var(--color-tab-inactive);
+    }
+  }
+
+  .script-content {
+    padding: 1rem;
+    border-top: 1px solid ${props => props.theme.input.border};
+  }
+
+  .script-editor-container {
+    height: 50vh;
+    min-height: 300px;
+    max-height: 600px;
+    display: flex;
+    flex-direction: column;
   }
 `;
 

--- a/packages/bruno-app/src/components/FolderSettings/Script/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/StyledWrapper.js
@@ -20,12 +20,21 @@ const StyledWrapper = styled.div`
     border-radius: 4px;
     margin-bottom: 0.5rem;
     overflow: hidden;
-    flex: 1;
     display: flex;
     flex-direction: column;
 
     &:last-child {
       margin-bottom: 0;
+    }
+
+    /* When collapsed, take minimal space */
+    &.collapsed {
+      flex: 0 0 auto;
+    }
+
+    /* When expanded, take all available space */
+    &.expanded {
+      flex: 1;
     }
   }
 

--- a/packages/bruno-app/src/components/FolderSettings/Script/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/index.js
@@ -16,9 +16,9 @@ const Script = ({ collection, folder }) => {
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
 
-  // State for collapsible sections - start collapsed to test functionality
-  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(false);
-  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(false);
+  // State for collapsible sections - start expanded by default
+  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(true);
+  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(true);
 
   const onRequestScriptEdit = (value) => {
     dispatch(

--- a/packages/bruno-app/src/components/FolderSettings/Script/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/index.js
@@ -16,9 +16,9 @@ const Script = ({ collection, folder }) => {
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
 
-  // State for collapsible sections - both start expanded
-  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(true);
-  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(true);
+  // State for collapsible sections - start collapsed to test functionality
+  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(false);
+  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(false);
 
   const onRequestScriptEdit = (value) => {
     dispatch(
@@ -50,8 +50,9 @@ const Script = ({ collection, folder }) => {
         Pre and post-request scripts that will run before and after any request inside this folder is sent.
       </div>
 
-      {/* Pre Request Section */}
-      <div className="script-section">
+      <div className="flex flex-col flex-1">
+        {/* Pre Request Section */}
+        <div className="script-section">
         <div className="script-header" onClick={() => setIsPreRequestExpanded(!isPreRequestExpanded)}>
           <div className="title text-xs">Pre Request</div>
           <IconChevronDown
@@ -81,8 +82,8 @@ const Script = ({ collection, folder }) => {
         )}
       </div>
 
-      {/* Post Response Section */}
-      <div className="script-section">
+        {/* Post Response Section */}
+        <div className="script-section">
         <div className="script-header" onClick={() => setIsPostResponseExpanded(!isPostResponseExpanded)}>
           <div className="title text-xs">Post Response</div>
           <IconChevronDown
@@ -110,6 +111,7 @@ const Script = ({ collection, folder }) => {
             </div>
           </div>
         )}
+        </div>
       </div>
 
       <div className="mt-12">

--- a/packages/bruno-app/src/components/FolderSettings/Script/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/index.js
@@ -52,7 +52,7 @@ const Script = ({ collection, folder }) => {
 
       <div className="flex flex-col flex-1">
         {/* Pre Request Section */}
-        <div className="script-section">
+        <div className={`script-section ${isPreRequestExpanded ? 'expanded' : 'collapsed'}`}>
         <div className="script-header" onClick={() => setIsPreRequestExpanded(!isPreRequestExpanded)}>
           <div className="title text-xs">Pre Request</div>
           <IconChevronDown
@@ -83,7 +83,7 @@ const Script = ({ collection, folder }) => {
       </div>
 
         {/* Post Response Section */}
-        <div className="script-section">
+        <div className={`script-section ${isPostResponseExpanded ? 'expanded' : 'collapsed'}`}>
         <div className="script-header" onClick={() => setIsPostResponseExpanded(!isPostResponseExpanded)}>
           <div className="title text-xs">Post Response</div>
           <IconChevronDown

--- a/packages/bruno-app/src/components/FolderSettings/Script/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/index.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
+import { IconChevronDown } from '@tabler/icons';
 import CodeEditor from 'components/CodeEditor';
 import { updateFolderRequestScript, updateFolderResponseScript } from 'providers/ReduxStore/slices/collections';
 import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions';
@@ -14,6 +15,10 @@ const Script = ({ collection, folder }) => {
 
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
+
+  // State for collapsible sections - both start expanded
+  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(true);
+  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(true);
 
   const onRequestScriptEdit = (value) => {
     dispatch(
@@ -44,33 +49,67 @@ const Script = ({ collection, folder }) => {
       <div className="text-xs mb-4 text-muted">
         Pre and post-request scripts that will run before and after any request inside this folder is sent.
       </div>
-      <div className="flex flex-col flex-1 mt-2 gap-y-2">
-        <div className="title text-xs">Pre Request</div>
-        <CodeEditor
-          collection={collection}
-          value={requestScript || ''}
-          theme={displayedTheme}
-          onEdit={onRequestScriptEdit}
-          mode="javascript"
-          onSave={handleSave}
-          font={get(preferences, 'font.codeFont', 'default')}
-          fontSize={get(preferences, 'font.codeFontSize')}
-          showHintsFor={['req', 'bru']}
-        />
+
+      {/* Pre Request Section */}
+      <div className="script-section">
+        <div className="script-header" onClick={() => setIsPreRequestExpanded(!isPreRequestExpanded)}>
+          <div className="title text-xs">Pre Request</div>
+          <IconChevronDown
+            className="w-4 h-4 ml-auto chevron-icon"
+            style={{
+              transform: `rotate(${isPreRequestExpanded ? '180deg' : '0deg'})`,
+              transition: 'transform 0.2s ease-in-out',
+            }}
+          />
+        </div>
+        {isPreRequestExpanded && (
+          <div className="script-content">
+            <div className="script-editor-container">
+              <CodeEditor
+                collection={collection}
+                value={requestScript || ''}
+                theme={displayedTheme}
+                onEdit={onRequestScriptEdit}
+                mode="javascript"
+                onSave={handleSave}
+                font={get(preferences, 'font.codeFont', 'default')}
+                fontSize={get(preferences, 'font.codeFontSize')}
+                showHintsFor={['req', 'bru']}
+              />
+            </div>
+          </div>
+        )}
       </div>
-      <div className="flex flex-col flex-1 mt-2 gap-y-2">
-        <div className="title text-xs">Post Response</div>
-        <CodeEditor
-          collection={collection}
-          value={responseScript || ''}
-          theme={displayedTheme}
-          onEdit={onResponseScriptEdit}
-          mode="javascript"
-          onSave={handleSave}
-          font={get(preferences, 'font.codeFont', 'default')}
-          fontSize={get(preferences, 'font.codeFontSize')}
-          showHintsFor={['req', 'res', 'bru']}
-        />
+
+      {/* Post Response Section */}
+      <div className="script-section">
+        <div className="script-header" onClick={() => setIsPostResponseExpanded(!isPostResponseExpanded)}>
+          <div className="title text-xs">Post Response</div>
+          <IconChevronDown
+            className="w-4 h-4 ml-auto chevron-icon"
+            style={{
+              transform: `rotate(${isPostResponseExpanded ? '180deg' : '0deg'})`,
+              transition: 'transform 0.2s ease-in-out',
+            }}
+          />
+        </div>
+        {isPostResponseExpanded && (
+          <div className="script-content">
+            <div className="script-editor-container">
+              <CodeEditor
+                collection={collection}
+                value={responseScript || ''}
+                theme={displayedTheme}
+                onEdit={onResponseScriptEdit}
+                mode="javascript"
+                onSave={handleSave}
+                font={get(preferences, 'font.codeFont', 'default')}
+                fontSize={get(preferences, 'font.codeFontSize')}
+                showHintsFor={['req', 'res', 'bru']}
+              />
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="mt-12">

--- a/packages/bruno-app/src/components/RequestPane/Script/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/StyledWrapper.js
@@ -1,12 +1,61 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
   div.CodeMirror {
     height: inherit;
+    min-height: 200px;
   }
 
   div.title {
     color: var(--color-tab-inactive);
+    font-weight: 500;
+  }
+
+  .script-section {
+    border: 1px solid ${props => props.theme.input.border};
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    overflow: hidden;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .script-header {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    background: transparent;
+    cursor: pointer;
+    font-weight: 500;
+    border: none;
+    width: 100%;
+
+    &:hover {
+      background-color: ${props => props.theme.plainGrid.hoverBg};
+    }
+
+    .chevron-icon {
+      color: var(--color-tab-inactive);
+    }
+  }
+
+  .script-content {
+    padding: 1rem;
+    border-top: 1px solid ${props => props.theme.input.border};
+  }
+
+  .script-editor-container {
+    height: 50vh;
+    min-height: 300px;
+    max-height: 600px;
+    display: flex;
+    flex-direction: column;
   }
 `;
 

--- a/packages/bruno-app/src/components/RequestPane/Script/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/StyledWrapper.js
@@ -20,6 +20,9 @@ const StyledWrapper = styled.div`
     border-radius: 4px;
     margin-bottom: 0.5rem;
     overflow: hidden;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
 
     &:last-child {
       margin-bottom: 0;
@@ -48,14 +51,21 @@ const StyledWrapper = styled.div`
   .script-content {
     padding: 1rem;
     border-top: 1px solid ${props => props.theme.input.border};
+    flex: 1;
+    display: flex;
+    flex-direction: column;
   }
 
   .script-editor-container {
-    height: 50vh;
-    min-height: 300px;
-    max-height: 600px;
+    flex: 1;
+    min-height: 200px;
     display: flex;
     flex-direction: column;
+
+    div.CodeMirror {
+      flex-direction: column !important;
+      flex: 1;
+    }
   }
 `;
 

--- a/packages/bruno-app/src/components/RequestPane/Script/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/StyledWrapper.js
@@ -20,12 +20,21 @@ const StyledWrapper = styled.div`
     border-radius: 4px;
     margin-bottom: 0.5rem;
     overflow: hidden;
-    flex: 1;
     display: flex;
     flex-direction: column;
 
     &:last-child {
       margin-bottom: 0;
+    }
+
+    /* When collapsed, take minimal space */
+    &.collapsed {
+      flex: 0 0 auto;
+    }
+
+    /* When expanded, take all available space */
+    &.expanded {
+      flex: 1;
     }
   }
 

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
+import { IconChevronDown } from '@tabler/icons';
 import CodeEditor from 'components/CodeEditor';
 import { updateRequestScript, updateResponseScript } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
@@ -14,6 +15,10 @@ const Script = ({ item, collection }) => {
 
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
+
+  // State for collapsible sections - both start expanded
+  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(true);
+  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(true);
 
   const onRequestScriptEdit = (value) => {
     dispatch(
@@ -39,36 +44,69 @@ const Script = ({ item, collection }) => {
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
 
   return (
-    <StyledWrapper className="w-full flex flex-col">
-      <div className="flex flex-col flex-1 mt-2 gap-y-2">
-        <div className="title text-xs">Pre Request</div>
-        <CodeEditor
-          collection={collection}
-          value={requestScript || ''}
-          theme={displayedTheme}
-          font={get(preferences, 'font.codeFont', 'default')}
-          fontSize={get(preferences, 'font.codeFontSize')}
-          onEdit={onRequestScriptEdit}
-          mode="javascript"
-          onRun={onRun}
-          onSave={onSave}
-          showHintsFor={['req', 'bru']}
-        />
+    <StyledWrapper className="w-full flex flex-col h-full">
+      {/* Pre Request Section */}
+      <div className="script-section">
+        <div className="script-header" onClick={() => setIsPreRequestExpanded(!isPreRequestExpanded)}>
+          <div className="title text-xs">Pre Request</div>
+          <IconChevronDown
+            className="w-4 h-4 ml-auto chevron-icon"
+            style={{
+              transform: `rotate(${isPreRequestExpanded ? '180deg' : '0deg'})`,
+              transition: 'transform 0.2s ease-in-out',
+            }}
+          />
+        </div>
+        {isPreRequestExpanded && (
+          <div className="script-content">
+            <div className="script-editor-container">
+              <CodeEditor
+                collection={collection}
+                value={requestScript || ''}
+                theme={displayedTheme}
+                font={get(preferences, 'font.codeFont', 'default')}
+                fontSize={get(preferences, 'font.codeFontSize')}
+                onEdit={onRequestScriptEdit}
+                mode="javascript"
+                onRun={onRun}
+                onSave={onSave}
+                showHintsFor={['req', 'bru']}
+              />
+            </div>
+          </div>
+        )}
       </div>
-      <div className="flex flex-col flex-1 mt-2 gap-y-2">
-        <div className="title text-xs">Post Response</div>
-        <CodeEditor
-          collection={collection}
-          value={responseScript || ''}
-          theme={displayedTheme}
-          font={get(preferences, 'font.codeFont', 'default')}
-          fontSize={get(preferences, 'font.codeFontSize')}
-          onEdit={onResponseScriptEdit}
-          mode="javascript"
-          onRun={onRun}
-          onSave={onSave}
-          showHintsFor={['req', 'res', 'bru']}
-        />
+
+      {/* Post Response Section */}
+      <div className="script-section">
+        <div className="script-header" onClick={() => setIsPostResponseExpanded(!isPostResponseExpanded)}>
+          <div className="title text-xs">Post Response</div>
+          <IconChevronDown
+            className="w-4 h-4 ml-auto chevron-icon"
+            style={{
+              transform: `rotate(${isPostResponseExpanded ? '180deg' : '0deg'})`,
+              transition: 'transform 0.2s ease-in-out',
+            }}
+          />
+        </div>
+        {isPostResponseExpanded && (
+          <div className="script-content">
+            <div className="script-editor-container">
+              <CodeEditor
+                collection={collection}
+                value={responseScript || ''}
+                theme={displayedTheme}
+                font={get(preferences, 'font.codeFont', 'default')}
+                fontSize={get(preferences, 'font.codeFontSize')}
+                onEdit={onResponseScriptEdit}
+                mode="javascript"
+                onRun={onRun}
+                onSave={onSave}
+                showHintsFor={['req', 'res', 'bru']}
+              />
+            </div>
+          </div>
+        )}
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -16,9 +16,9 @@ const Script = ({ item, collection }) => {
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
 
-  // State for collapsible sections - both start expanded
-  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(true);
-  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(true);
+  // State for collapsible sections - start collapsed to test functionality
+  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(false);
+  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(false);
 
   const onRequestScriptEdit = (value) => {
     dispatch(
@@ -45,8 +45,9 @@ const Script = ({ item, collection }) => {
 
   return (
     <StyledWrapper className="w-full flex flex-col h-full">
-      {/* Pre Request Section */}
-      <div className="script-section">
+      <div className="flex flex-col flex-1">
+        {/* Pre Request Section */}
+        <div className="script-section">
         <div className="script-header" onClick={() => setIsPreRequestExpanded(!isPreRequestExpanded)}>
           <div className="title text-xs">Pre Request</div>
           <IconChevronDown
@@ -107,6 +108,7 @@ const Script = ({ item, collection }) => {
             </div>
           </div>
         )}
+      </div>
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -47,7 +47,7 @@ const Script = ({ item, collection }) => {
     <StyledWrapper className="w-full flex flex-col h-full">
       <div className="flex flex-col flex-1">
         {/* Pre Request Section */}
-        <div className="script-section">
+        <div className={`script-section ${isPreRequestExpanded ? 'expanded' : 'collapsed'}`}>
         <div className="script-header" onClick={() => setIsPreRequestExpanded(!isPreRequestExpanded)}>
           <div className="title text-xs">Pre Request</div>
           <IconChevronDown
@@ -79,7 +79,7 @@ const Script = ({ item, collection }) => {
       </div>
 
       {/* Post Response Section */}
-      <div className="script-section">
+        <div className={`script-section ${isPostResponseExpanded ? 'expanded' : 'collapsed'}`}>
         <div className="script-header" onClick={() => setIsPostResponseExpanded(!isPostResponseExpanded)}>
           <div className="title text-xs">Post Response</div>
           <IconChevronDown

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -16,9 +16,9 @@ const Script = ({ item, collection }) => {
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
 
-  // State for collapsible sections - start collapsed to test functionality
-  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(false);
-  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(false);
+  // State for collapsible sections - start expanded by default
+  const [isPreRequestExpanded, setIsPreRequestExpanded] = useState(true);
+  const [isPostResponseExpanded, setIsPostResponseExpanded] = useState(true);
 
   const onRequestScriptEdit = (value) => {
     dispatch(


### PR DESCRIPTION
# Description

## Overview
This PR introduces a UX improvement to the Script tabs across Collections, Folders, and Requests by implementing collapsible sections with intelligent space management. Providing maximum real estate to Bruno users that are heavily utilizing scripting - without having to leave the Bruno UI.

**Related GH Issues**
- https://github.com/usebruno/bruno/issues/5619
- https://github.com/usebruno/bruno/issues/5467

### ✨ Features Added

#### 🔄 Collapsible Script Sections
- **Interactive Headers**: Click-to-toggle functionality for Pre Request and Post Response sections
- **Visual Feedback**: Rotating chevron icons indicate expanded/collapsed state with smooth transitions
- **Independent Control**: Each section can be expanded/collapsed independently
- **Intuitive Design**: Clean, consistent interface across all Script tabs

#### 📏 Intelligent Space Utilization
- **Dynamic Flex Layout**: Collapsed sections take minimal space (`flex: 0 0 auto`)
- **Expanded Optimization**: Expanded sections utilize all available space (`flex: 1`)
- **Real Estate Maximization**: When one section is collapsed, the other expands to fill the freed space
- **Responsive Design**: Optimal space usage regardless of section states

#### 🎨 Enhanced User Experience
- **Expanded by Default**: Both sections start expanded for immediate script access
- **Smooth Animations**: 200ms transition effects for professional feel
- **Consistent Behavior**: Uniform functionality across all three contexts:
  - Collection Settings → Script
  - Folder Settings → Script  
  - Individual Request → Script

![scripts-expandable-sections](https://github.com/user-attachments/assets/502abe5f-88a6-4116-97ac-b9b8c9c28596)

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
