### PR TITLE
feat: support v1 reflection for grpc server reflection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8227,12 +8227,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/google-protobuf": {
-      "version": "3.15.12",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz",
-      "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -8367,9 +8361,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
       "license": "MIT"
     },
     "node_modules/@types/lodash-es": {
@@ -8377,15 +8371,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.set": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.9.tgz",
-      "integrity": "sha512-KOxyNkZpbaggVmqbpr82N2tDVTx05/3/j0f50Es1prxrWB0XYf9p3QNxqcbWb7P1Q9wlvsUSlCFnwlPCIJ46PQ==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
@@ -15260,20 +15245,18 @@
         "node": ">= 6"
       }
     },
-    "node_modules/grpc-reflection-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/grpc-reflection-js/-/grpc-reflection-js-0.3.0.tgz",
-      "integrity": "sha512-3lhTlQluPxVgbowCXA3tAZC3RJW+GSOUkguLNYl1QffYRiutUB3RDfPkQFTcrCFJgNiIIxx+iJkr8s3uSp3zWA==",
+    "node_modules/grpc-js-reflection-client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/grpc-js-reflection-client/-/grpc-js-reflection-client-1.3.0.tgz",
+      "integrity": "sha512-eJ5/m1pXpcheSjOGExktU69WPUKnL4Su3IxGJYYYjy3/w19vE8dH7Wi46G5T92bpM0eZWftjiM5HduX8CjPq9w==",
       "license": "MIT",
       "dependencies": {
-        "@types/google-protobuf": "^3.7.2",
-        "@types/lodash.set": "^4.3.6",
-        "google-protobuf": "^3.12.2",
-        "lodash.set": "^4.3.2",
-        "protobufjs": "^7.2.2"
+        "@types/lodash": "^4.17.15",
+        "lodash": "^4.17.21",
+        "protobufjs": "^7.4.0"
       },
       "peerDependencies": {
-        "@grpc/grpc-js": "^1.0.0"
+        "@grpc/grpc-js": "^1.12.6"
       }
     },
     "node_modules/har-schema": {
@@ -18562,12 +18545,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -31964,7 +31941,8 @@
         "@grpc/proto-loader": "^0.7.15",
         "@types/qs": "^6.9.18",
         "axios": "^1.9.0",
-        "grpc-reflection-js": "^0.3.0",
+        "google-protobuf": "^3.21.4",
+        "grpc-js-reflection-client": "^1.3.0",
         "is-ip": "^5.0.1",
         "tough-cookie": "^6.0.0"
       },

--- a/packages/bruno-requests/package.json
+++ b/packages/bruno-requests/package.json
@@ -25,7 +25,7 @@
     "@grpc/proto-loader": "^0.7.15",
     "@types/qs": "^6.9.18",
     "axios": "^1.9.0",
-    "grpc-reflection-js": "^0.3.0",
+    "grpc-js-reflection-client": "^1.3.0",
     "is-ip": "^5.0.1",
     "tough-cookie": "^6.0.0"
   },

--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -1,5 +1,5 @@
 import { makeGenericClientConstructor, ChannelCredentials, Metadata } from '@grpc/grpc-js';
-import * as grpcReflection from 'grpc-reflection-js';
+import { GrpcReflection } from 'grpc-js-reflection-client';
 import * as protoLoader from '@grpc/proto-loader';
 import { generateGrpcSampleMessage } from './grpcMessageGenerator';
 import * as tls from 'tls';
@@ -564,7 +564,7 @@ class GrpcClient {
     passphrase,
     pfx,
     verifyOptions,
-    sendEvent
+    sendEvent,
   }) {
     const credentials = this.#getChannelCredentials({
       url: request.url,
@@ -573,7 +573,7 @@ class GrpcClient {
       certificateChain,
       passphrase,
       pfx,
-      verifyOptions
+      verifyOptions,
     });
     const { host, path } = getParsedGrpcUrlObject(request.url);
     const metadata = new Metadata();
@@ -582,31 +582,30 @@ class GrpcClient {
     });
 
     try {
-      const client = new grpcReflection.Client(host, credentials, {}, metadata);
+      const client = new GrpcReflection(host, credentials, {});
+      const services = await client.listServices();
+      const methods = [];
 
-      const declarations = await client.listServices();
-      const methods = await Promise.all(
-        declarations.map(async (declaration) => {
-          const fileContainingSymbol = await client.fileContainingSymbol(declaration);
-          const descriptor = fileContainingSymbol.toDescriptor('proto3');
-          const protoDefinition = protoLoader.loadFileDescriptorSetFromObject(descriptor, configOptions);
+      for (const service of services) {
+        if (service === 'grpc.reflection.v1alpha.ServerReflection') {
+          continue;
+        }
+        const m = await client.listMethods(service);
+        methods.push(...m);
+      }
 
-          const serviceDefinition = protoDefinition[declaration];
-          if (!!serviceDefinition?.format) {
-            return [];
-          }
-          const methods = Object.values(serviceDefinition);
-          methods.forEach((method) => {
-            this.methods.set(method.path, method);
-          });
-          return methods;
-        })
-      );
-
-      const methodsWithType = methods.flat().map((method) => ({
-        ...method,
-        type: this.#getMethodType(method)
-      }));
+      const methodsWithType = methods.flat().map(method => {
+        const modifiedMethod = {
+          ...method,
+          ...method.definition,
+          type: this.#getMethodType(method),
+        };
+        delete modifiedMethod.definition;
+        return modifiedMethod;
+      });
+      methodsWithType.forEach(method => {
+        this.methods.set(method.path, method);
+      });
       return methodsWithType;
     } catch (error) {
       console.error('Error in gRPC reflection:', error);
@@ -615,9 +614,6 @@ class GrpcClient {
     }
   }
 
-  /**
-   * Load methods from proto file
-   */
   async loadMethodsFromProtoFile(filePath, includeDirs = []) {
     const protoDefinition = await protoLoader.load(filePath, { ...configOptions, includeDirs });
     const methods = Object.values(protoDefinition)
@@ -688,6 +684,7 @@ class GrpcClient {
    * @returns {Object} A sample message or error
    */
   generateSampleMessage(methodPath, options = {}) {
+    console.log('generateSampleMessage', methodPath, options, this.methods);
     try {
       let method;
       


### PR DESCRIPTION
# Description
fixes: #5650
- replaced grpc-reflection-js  which only has v1alpha reflection with grpc-js-reflection-client which has support for v1 and v1alpha reflection

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
