### PR TITLE
fix: update stylistic rules in ESLint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,11 +37,11 @@ module.exports = runESMImports().then(() => defineConfig([
         indent: 2,
         quotes: 'single',
         semi: true,
-        arrowParens: false,
         jsx: true,
       }).rules,
+      '@stylistic/comma-dangle': ['error', 'never'],
       '@stylistic/brace-style': ['error', '1tbs', { allowSingleLine: true }],
-      '@stylistic/arrow-parens': ['error', 'as-needed'],
+      '@stylistic/arrow-parens': ['error', 'always'],
       '@stylistic/curly-newline': ['error', {
         multiline: true,
         minElements: 2,


### PR DESCRIPTION
# Description

- Added 'comma-dangle' rule to disallow trailing commas.
- Changed 'arrow-parens' rule to require parentheses for arrow functions.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
