### PR TITLE
chore: extract ts support for aslant from feat/websocket-engine

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,9 +16,16 @@ module.exports = runESMImports().then(() => defineConfig([
       'diff': fixupPluginRules(eslintPluginDiff),
       '@stylistic': stylistic,
     },
+    languageOptions: {
+      parser: require('@typescript-eslint/parser'),
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
     files: [
       './eslint.config.js',
-      'tests/**/*.spec.{ts,js}',
+      'tests/**/*.{ts,js}',
       'packages/bruno-app/**/*.{js,jsx,ts}',
       'packages/bruno-app/src/test-utils/mocks/codemirror.js',
       'packages/bruno-cli/**/*.js',


### PR DESCRIPTION
# Description

Fix the typescript support for all files being used in eslint, the parser overrides later in the rules doesn't seem to be flaky so this a forced addition

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
