### PR TITLE
feat: add draggable tabs component

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
@@ -1,27 +1,17 @@
 import React from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
-const DraggableTab = ({ id, moveTab, index, children, className }) => {
+const DraggableTab = ({ id, onMoveTab, index, children, className }) => {
   const ref = React.useRef(null);
 
-  const [{ handlerId }, drop] = useDrop({
+  const [{ handlerId, isOver }, drop] = useDrop({
     accept: 'tab',
-    hover(item) {
-      if (item.id === id) return;
-      const dragIndex = item.index;
-      const hoverIndex = index;
-      if (dragIndex === hoverIndex) {
-        return;
-      }
-      moveTab(item.id, id);
-      item.index = id;
-    },
-    canDrop: (draggedItem) => {
-      return draggedItem.index !== index;
+    hover(item, monitor) {
+      onMoveTab(item.id, id);
     },
     collect: (monitor) => ({
-      isOver: monitor.isOver(),
-      handlerId: monitor.getHandlerId()
+      handlerId: monitor.getHandlerId(),
+      isOver: monitor.isOver()
     })
   });
 
@@ -44,7 +34,7 @@ const DraggableTab = ({ id, moveTab, index, children, className }) => {
     <li
       className={className}
       ref={ref}
-      style={{ opacity: isDragging ? 0 : 1 }}
+      style={{ opacity: isDragging || isOver ? 0 : 1 }}
       data-handler-id={handlerId}
     >
       {children}

--- a/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useDrag, useDrop } from 'react-dnd';
+
+const DraggableTab = ({ id, moveTab, index, children, className }) => {
+  const ref = React.useRef(null);
+
+  const [{ handlerId }, drop] = useDrop({
+    accept: 'tab',
+    hover(item) {
+      if (item.id === id) return;
+      const dragIndex = item.index;
+      const hoverIndex = index;
+      if (dragIndex === hoverIndex) {
+        return;
+      }
+      moveTab(item.id, id);
+      item.index = id;
+    },
+    canDrop: (draggedItem) => {
+      return draggedItem.index !== index;
+    },
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      handlerId: monitor.getHandlerId()
+    })
+  });
+
+  const [{ isDragging }, drag] = useDrag({
+    type: 'tab',
+    item: () => {
+      return { id, index };
+    },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging()
+    }),
+    options: {
+      dropEffect: 'move'
+    }
+  });
+
+  drag(drop(ref));
+
+  return (
+    <li
+      className={className}
+      ref={ref}
+      style={{ opacity: isDragging ? 0 : 1 }}
+      data-handler-id={handlerId}
+    >
+      {children}
+    </li>
+  );
+};
+
+export default DraggableTab;

--- a/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
-const DraggableTab = ({ id, onMoveTab, index, children, className }) => {
+const DraggableTab = ({ id, onMoveTab, index, children, className, onClick }) => {
   const ref = React.useRef(null);
 
   const [{ handlerId, isOver }, drop] = useDrop({
@@ -34,7 +34,9 @@ const DraggableTab = ({ id, onMoveTab, index, children, className }) => {
     <li
       className={className}
       ref={ref}
+      role="tab"
       style={{ opacity: isDragging || isOver ? 0 : 1 }}
+      onClick={onClick}
       data-handler-id={handlerId}
     >
       {children}

--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -15,8 +15,6 @@ const RequestTabs = () => {
   const dispatch = useDispatch();
   const tabsRef = useRef();
   const [newRequestModalOpen, setNewRequestModalOpen] = useState(false);
-  const [draggedTabUid, setDraggedTabUid] = useState(null);
-  const [dragOverTabUid, setDragOverTabUid] = useState(null);
   const tabs = useSelector((state) => state.tabs.tabs);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const collections = useSelector((state) => state.collections.collections);
@@ -27,40 +25,8 @@ const RequestTabs = () => {
   const getTabClassname = (tab, index) => {
     return classnames('request-tab select-none', {
       active: tab.uid === activeTabUid,
-      'last-tab': tabs && tabs.length && index === tabs.length - 1,
-      'dragged': tab.uid === draggedTabUid,
-      'drag-over': tab.uid === dragOverTabUid && draggedTabUid !== null
+      'last-tab': tabs && tabs.length && index === tabs.length - 1
     });
-  };
-
-  const handleDragStart = (e, tab) => {
-    setDraggedTabUid(tab.uid);
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('text/plain', tab.uid);
-  };
-
-  const handleDragOver = (e, tab) => {
-    e.preventDefault();
-    setDragOverTabUid(tab.uid);
-  };
-
-  const handleDrop = (e, targetTab) => {
-    e.preventDefault();
-    setDragOverTabUid(null);
-    const sourceUid = draggedTabUid;
-    setDraggedTabUid(null);
-    if (!sourceUid || sourceUid === targetTab.uid) {
-      return;
-    }
-    dispatch(reorderTabs({
-      sourceUid,
-      targetUid: targetTab.uid
-    }));
-  };
-
-  const handleDragEnd = () => {
-    setDraggedTabUid(null);
-    setDragOverTabUid(null);
   };
 
   const handleClick = (tab) => {
@@ -145,7 +111,7 @@ const RequestTabs = () => {
                         key={tab.uid}
                         id={tab.uid}
                         index={index}
-                        moveTab={(source, target) => {
+                        onMoveTab={(source, target) => {
                           dispatch(reorderTabs({
                             sourceUid: source,
                             targetUid: target

--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -9,6 +9,7 @@ import NewRequest from 'components/Sidebar/NewRequest';
 import CollectionToolBar from './CollectionToolBar';
 import RequestTab from './RequestTab';
 import StyledWrapper from './StyledWrapper';
+import DraggableTab from './DraggableTab';
 
 const RequestTabs = () => {
   const dispatch = useDispatch();
@@ -52,8 +53,8 @@ const RequestTabs = () => {
       return;
     }
     dispatch(reorderTabs({
-        sourceUid,
-        targetUid: targetTab.uid
+      sourceUid,
+      targetUid: targetTab.uid
     }));
   };
 
@@ -140,16 +141,19 @@ const RequestTabs = () => {
               {collectionRequestTabs && collectionRequestTabs.length
                 ? collectionRequestTabs.map((tab, index) => {
                     return (
-                      <li
+                      <DraggableTab
                         key={tab.uid}
+                        id={tab.uid}
+                        index={index}
+                        moveTab={(source, target) => {
+                          dispatch(reorderTabs({
+                            sourceUid: source,
+                            targetUid: target
+                          }));
+                        }}
                         className={getTabClassname(tab, index)}
                         role="tab"
                         onClick={() => handleClick(tab)}
-                        draggable
-                        onDragStart={(e) => handleDragStart(e, tab)}
-                        onDragOver={(e) => handleDragOver(e, tab)}
-                        onDrop={(e) => handleDrop(e, tab)}
-                        onDragEnd={() => handleDragEnd}
                       >
                         <RequestTab
                           collectionRequestTabs={collectionRequestTabs}
@@ -159,7 +163,7 @@ const RequestTabs = () => {
                           collection={activeCollection}
                           folderUid={tab.folderUid}
                         />
-                      </li>
+                      </DraggableTab>
                     );
                   })
                 : null}

--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -118,7 +118,6 @@ const RequestTabs = () => {
                           }));
                         }}
                         className={getTabClassname(tab, index)}
-                        role="tab"
                         onClick={() => handleClick(tab)}
                       >
                         <RequestTab


### PR DESCRIPTION
# Description

Replaces the UI from #5413 to use `react-dnd` instead since the codebase already uses it for movement in other places. 


https://github.com/user-attachments/assets/973984e0-eded-41bc-b08b-55b146399878



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
