### PR TITLE
feat: add visual indicator for GQL requests

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -109,6 +109,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   }
 
   const isGrpc = item.type === 'grpc-request';
+  const isGraphQL = item.type === 'graphql-request';
   const method = item.draft ? get(item, 'draft.request.method') : get(item, 'request.method');
 
   return (
@@ -161,8 +162,8 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
           }
         }}
       >
-        <span className="tab-method uppercase" style={{ color: isGrpc ? theme.request.grpc : getMethodColor(method), fontSize: 12 }}>
-          {isGrpc ? 'gRPC' : method}
+        <span className="tab-method uppercase" style={{ color: isGrpc ? theme.request.grpc : isGraphQL ? theme.request.graphql : getMethodColor(method), fontSize: 12 }}>
+          {isGrpc ? 'gRPC' : isGraphQL ? 'GQL' : method}
         </span>
         <span className="ml-1 tab-name" title={item.name}>
           {item.name}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/StyledWrapper.js
@@ -37,6 +37,9 @@ const Wrapper = styled.div`
   .method-grpc {
     color: ${(props) => props.theme.request.grpc};
   }
+  .method-graphql {
+    color: ${(props) => props.theme.request.graphql};
+  }
 `;
 
 export default Wrapper;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.js
@@ -8,6 +8,7 @@ const RequestMethod = ({ item }) => {
   }
 
   const isGrpc = item.type === 'grpc-request';
+  const isGraphQL = item.type === 'graphql-request';
 
   const getClassname = (method = '') => {
     method = method.toLocaleLowerCase();
@@ -20,6 +21,7 @@ const RequestMethod = ({ item }) => {
       'method-head': method === 'head',
       'method-options': method === 'options',
       'method-grpc': isGrpc,
+      'method-graphql': isGraphQL
     });
   };
 
@@ -27,7 +29,7 @@ const RequestMethod = ({ item }) => {
     <StyledWrapper>
       <div className={getClassname(item.request.method)}>
         <span className="uppercase">
-          {isGrpc ? 'grpc' : item.request.method.length > 5 ? item.request.method.substring(0, 3) : item.request.method}
+          {isGrpc ? 'grpc' : isGraphQL ? 'gql' : item.request.method.length > 5 ? item.request.method.substring(0, 3) : item.request.method}
         </span>
       </div>
     </StyledWrapper>

--- a/packages/bruno-app/src/themes/dark.js
+++ b/packages/bruno-app/src/themes/dark.js
@@ -102,7 +102,8 @@ const darkTheme = {
       options: '#d69956',
       head: '#d69956'
     },
-    grpc: '#6366f1'
+    grpc: '#6366f1',
+    graphql: '#e535ab'
   },
 
   requestTabPanel: {

--- a/packages/bruno-app/src/themes/light.js
+++ b/packages/bruno-app/src/themes/light.js
@@ -102,7 +102,8 @@ const lightTheme = {
       options: '#ca7811',
       head: '#ca7811'
     },
-    grpc: '#6366f1'
+    grpc: '#6366f1',
+    graphql: '#e535ab'
   },
 
   requestTabPanel: {


### PR DESCRIPTION
# Description

To quickly identify GraphQL requests I'd prefer them to have some indicator similar to the HTTP verbs and gRPC requests. This is added in this PR:

<img width="211" height="120" alt="image" src="https://github.com/user-attachments/assets/d28ce62d-6975-4cc4-bbcb-e6da852b3437" />

<img width="163" height="68" alt="image" src="https://github.com/user-attachments/assets/097a13ee-b82b-4001-bd55-3b8c1849a7b6" />

I've kept the timeline as is to still show the "real" requests send in there.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
