### PR TITLE
adding req getTags methods

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/autocomplete.js
+++ b/packages/bruno-app/src/utils/codemirror/autocomplete.js
@@ -27,6 +27,7 @@ const STATIC_API_HINTS = {
     'req.setTimeout(timeout)',
     'req.getExecutionMode()',
     'req.getName()',
+    'req.getTags()',
     'req.disableParsingResponseJson()',
     'req.onFail(function(err) {})',
   ],

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -39,6 +39,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
     url: request.url,
     headers: headers,
     name: item.name,
+    tags: item.tags || [],
     pathParams: request.params?.filter((param) => param.type === 'path'),
     settings: item.settings,
     responseType: 'arraybuffer'

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -343,6 +343,7 @@ const prepareRequest = async (item, collection = {}, abortController) => {
     url,
     headers,
     name: item.name,
+    tags: item.tags || [],
     pathParams: request.params?.filter((param) => param.type === 'path'),
     settings,
     responseType: 'arraybuffer'

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -18,6 +18,7 @@ class BrunoRequest {
     this.headers = req.headers;
     this.timeout = req.timeout;
     this.name = req.name;
+    this.tags = req.tags || [];
     /**
      * We automatically parse the JSON body if the content type is JSON
      * This is to make it easier for the user to access the body directly
@@ -188,6 +189,14 @@ class BrunoRequest {
 
   getName() {
     return this.req.name;
+  }
+
+  /**
+   * Get the tags associated with this request
+   * @returns {Array<string>} Array of tag strings
+   */
+  getTags() {
+    return this.req.tags || [];
   }
 }
 

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-request.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-request.js
@@ -9,6 +9,7 @@ const addBrunoRequestShimToContext = (vm, req) => {
   const body = marshallToVm(req.getBody(), vm);
   const timeout = marshallToVm(req.getTimeout(), vm);
   const name = marshallToVm(req.getName(), vm);
+  const tags = marshallToVm(req.getTags(), vm);
 
   vm.setProp(reqObject, 'url', url);
   vm.setProp(reqObject, 'method', method);
@@ -16,6 +17,7 @@ const addBrunoRequestShimToContext = (vm, req) => {
   vm.setProp(reqObject, 'body', body);
   vm.setProp(reqObject, 'timeout', timeout);
   vm.setProp(reqObject, 'name', name);
+  vm.setProp(reqObject, 'tags', tags);
 
   url.dispose();
   method.dispose();
@@ -23,6 +25,7 @@ const addBrunoRequestShimToContext = (vm, req) => {
   body.dispose();
   timeout.dispose();
   name.dispose();
+  tags.dispose();
 
   let getUrl = vm.newFunction('getUrl', function () {
     return marshallToVm(req.getUrl(), vm);
@@ -125,6 +128,12 @@ const addBrunoRequestShimToContext = (vm, req) => {
   });
   vm.setProp(reqObject, 'getExecutionMode', getExecutionMode);
   getExecutionMode.dispose();
+
+  let getTags = vm.newFunction('getTags', function () {
+    return marshallToVm(req.getTags(), vm);
+  });
+  vm.setProp(reqObject, 'getTags', getTags);
+  getTags.dispose();
 
   vm.setProp(vm.global, 'req', reqObject);
   reqObject.dispose();

--- a/packages/bruno-tests/collection/scripting/api/req/getTags.bru
+++ b/packages/bruno-tests/collection/scripting/api/req/getTags.bru
@@ -1,0 +1,33 @@
+meta {
+  name: getTags
+  type: http
+  seq: 11
+  tags: [
+    api
+    test
+    tags
+  ]
+}
+
+post {
+  url: {{host}}/api/echo/json
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  // Test getTags() function
+  const tags = req.getTags();
+  bru.setVar('request-tags', tags);
+}
+
+tests {
+  test("req.getTags() should return array of tags", function() {
+    const tags = bru.getVar('request-tags');
+    expect(tags).to.be.an('array');
+    expect(tags).to.include('api');
+    expect(tags).to.include('test');
+    expect(tags).to.include('tags');
+    expect(tags.length).to.be.equal(3);
+  });
+}


### PR DESCRIPTION
# Description

Add support for `tags` ~~and `metadata`~~ with the `req` object while scripting.

Easily leverage this information to better create scripting logic for differing scenarios. 

Examples:
- Pre-request: if a specific tag is present -> skip the request when using the runner
- Post-request: if a specific tag is present -> set the next request to x
- Test scripts: does the request contain x tags -> pass

### Screenshots
**Request Tags**
<img width="682" height="250" alt="image" src="https://github.com/user-attachments/assets/5d3793ca-cb47-40a5-ab9d-1e23e17b09aa" />

**Tests with Valid Tags and Metadata Passing**

<img width="1176" height="361" alt="image" src="https://github.com/user-attachments/assets/b57a5117-5660-4b1e-994e-462c26da2e16" />

**Tests with Invalid Tags Failing**

<img width="1176" height="335" alt="image" src="https://github.com/user-attachments/assets/0071cd89-5dc7-4d7f-8e9f-e9cda2808a9b" />

**req.getTag() in Script**
<img width="525" height="294" alt="image" src="https://github.com/user-attachments/assets/5e990a82-a4d2-4ffb-ad23-9c9b47ee4cf8" />
<img width="525" height="206" alt="image" src="https://github.com/user-attachments/assets/2d2da3b9-4054-4c61-b9bd-006101a5c814" />

~~**req.getMetadata() in Script**~~





### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
 - https://github.com/usebruno/bruno/issues/5689 

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
