### PR TITLE
Refactor: Remove `normalizeNewlines` function and update tests to preserve newline types

### DIFF
--- a/packages/bruno-lang/v2/src/envToJson.js
+++ b/packages/bruno-lang/v2/src/envToJson.js
@@ -153,7 +153,7 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   },
   multilinetextblock(_1, content, _2) {
     return content.ast
-      .split('\n')
+      .split(/\r\n|\r|\n/)
       .map((line) => line.slice(indentLevel)) // Remove 4-space indentation
       .join('\n')
       .trim();

--- a/packages/bruno-lang/v2/src/utils.js
+++ b/packages/bruno-lang/v2/src/utils.js
@@ -7,6 +7,7 @@ const safeParseJson = (json) => {
   }
 };
 
+// TODO: implement proper handling of newlines with \r\n, \r, \n
 
 const indentString = (str) => {
   if (!str || !str.length) {

--- a/packages/bruno-lang/v2/src/utils.js
+++ b/packages/bruno-lang/v2/src/utils.js
@@ -7,21 +7,13 @@ const safeParseJson = (json) => {
   }
 };
 
-const normalizeNewlines = (str) => {
-  if (!str || typeof str !== 'string') {
-    return str || '';
-  }
-
-  // "\r\n" is windows, "\r" is old mac, "\n" is linux
-  return str.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-};
 
 const indentString = (str) => {
   if (!str || !str.length) {
     return str || '';
   }
 
-  return normalizeNewlines(str)
+  return str
     .split('\n')
     .map((line) => '  ' + line)
     .join('\n');
@@ -32,7 +24,7 @@ const outdentString = (str) => {
     return str || '';
   }
 
-  return normalizeNewlines(str)
+  return str
     .split('\n')
     .map((line) => line.replace(/^  /, ''))
     .join('\n');
@@ -56,7 +48,6 @@ const getValueString = (value) => {
 
 module.exports = {
   safeParseJson,
-  normalizeNewlines,
   indentString,
   outdentString,
   getValueString

--- a/packages/bruno-lang/v2/src/utils.js
+++ b/packages/bruno-lang/v2/src/utils.js
@@ -7,7 +7,6 @@ const safeParseJson = (json) => {
   }
 };
 
-// TODO: implement proper handling of newlines with \r\n, \r, \n
 
 const indentString = (str) => {
   if (!str || !str.length) {
@@ -15,7 +14,7 @@ const indentString = (str) => {
   }
 
   return str
-    .split('\n')
+    .split(/\r\n|\r|\n/)
     .map((line) => '  ' + line)
     .join('\n');
 };
@@ -26,7 +25,7 @@ const outdentString = (str) => {
   }
 
   return str
-    .split('\n')
+    .split(/\r\n|\r|\n/)
     .map((line) => line.replace(/^  /, ''))
     .join('\n');
 };

--- a/packages/bruno-lang/v2/tests/utils.spec.js
+++ b/packages/bruno-lang/v2/tests/utils.spec.js
@@ -9,8 +9,8 @@ describe('getValueString', () => {
     expect(getValueString('line1\nline2\nline3')).toBe("'''\n  line1\n  line2\n  line3\n'''");
   });
 
-  it('preserves different newline types', () => {
-    expect(getValueString('line1\r\nline2\rline3\nline4')).toBe('\'\'\'\n  line1\r\n  line2\rline3\n  line4\n\'\'\'');
+  it('normalizes different newline types', () => {
+    expect(getValueString('line1\r\nline2\rline3\nline4')).toBe('\'\'\'\n  line1\n  line2\n  line3\n  line4\n\'\'\'');
   });
 
   it('returns empty string for empty/null/undefined', () => {

--- a/packages/bruno-lang/v2/tests/utils.spec.js
+++ b/packages/bruno-lang/v2/tests/utils.spec.js
@@ -9,8 +9,8 @@ describe('getValueString', () => {
     expect(getValueString('line1\nline2\nline3')).toBe("'''\n  line1\n  line2\n  line3\n'''");
   });
 
-  it('normalizes different newline types', () => {
-    expect(getValueString('line1\r\nline2\rline3\nline4')).toBe("'''\n  line1\n  line2\n  line3\n  line4\n'''");
+  it('preserves different newline types', () => {
+    expect(getValueString('line1\r\nline2\rline3\nline4')).toBe('\'\'\'\n  line1\r\n  line2\rline3\n  line4\n\'\'\'');
   });
 
   it('returns empty string for empty/null/undefined', () => {


### PR DESCRIPTION
Jira: BRU-1937
fixes: #5670

# Description

This PR implements the logic for removing the forced `normalizeNewLines` since it is interfering with the existing CRLF.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**