### PR TITLE
feat: adding a preview dialogue for long environment names

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
@@ -24,6 +24,7 @@ const EnvironmentListContent = ({
                   key={env.uid}
                   className={`dropdown-item ${env.uid === activeEnvironmentUid ? 'active' : ''}`}
                   onClick={() => onEnvironmentSelect(env)}
+                  title={env.name.length > 20 ? env.name : undefined}
                 >
                   <span className="max-w-32 truncate no-wrap">{env.name}</span>
                 </div>

--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
@@ -14,6 +14,7 @@ import CreateEnvironment from '../EnvironmentSettings/CreateEnvironment';
 import ImportEnvironment from '../EnvironmentSettings/ImportEnvironment';
 import CreateGlobalEnvironment from 'components/GlobalEnvironments/EnvironmentSettings/CreateEnvironment';
 import ImportGlobalEnvironment from 'components/GlobalEnvironments/EnvironmentSettings/ImportEnvironment';
+import ToolHint from 'components/ToolHint';
 import StyledWrapper from './StyledWrapper';
 
 const EnvironmentSelector = ({ collection }) => {
@@ -123,7 +124,25 @@ const EnvironmentSelector = ({ collection }) => {
           <>
             <div className="flex items-center">
               <IconDatabase size={14} strokeWidth={1.5} className="env-icon" />
-              <span className="env-text max-w-24 truncate no-wrap">{activeCollectionEnvironment.name}</span>
+              <span
+                id={`collection-env-${activeCollectionEnvironment.uid}`}
+                className="env-text max-w-24 truncate no-wrap"
+              >
+                {activeCollectionEnvironment.name}
+              </span>
+              {activeCollectionEnvironment.name.length > 15 && (
+                <ToolHint
+                  text={activeCollectionEnvironment.name}
+                  toolhintId={`collection-env-${activeCollectionEnvironment.uid}`}
+                  place="bottom"
+                  tooltipStyle={{
+                    maxWidth: '300px',
+                    wordWrap: 'break-word',
+                    whiteSpace: 'normal',
+                    zIndex: 10000,
+                  }}
+                />
+              )}
             </div>
             {activeGlobalEnvironment && <span className="env-separator">|</span>}
           </>
@@ -131,7 +150,25 @@ const EnvironmentSelector = ({ collection }) => {
         {activeGlobalEnvironment && (
           <div className="flex items-center">
             <IconWorld size={14} strokeWidth={1.5} className="env-icon" />
-            <span className="env-text max-w-24 truncate no-wrap">{activeGlobalEnvironment.name}</span>
+            <span
+              id={`global-env-${activeGlobalEnvironment.uid}`}
+              className="env-text max-w-24 truncate no-wrap"
+            >
+              {activeGlobalEnvironment.name}
+            </span>
+            {activeGlobalEnvironment.name.length > 15 && (
+              <ToolHint
+                text={activeGlobalEnvironment.name}
+                toolhintId={`global-env-${activeGlobalEnvironment.uid}`}
+                place="bottom"
+                tooltipStyle={{
+                  maxWidth: '300px',
+                  wordWrap: 'break-word',
+                  whiteSpace: 'normal',
+                  zIndex: 10000,
+                }}
+              />
+            )}
           </div>
         )}
       </>

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
@@ -110,15 +110,36 @@ const EnvironmentList = ({ selectedEnvironment, setSelectedEnvironment, collecti
             {environments &&
               environments.length &&
               environments.map((env) => (
-                <ToolHint key={env.uid} text={env.name} toolhintId={env.uid} place="right">
+                env.name.length > 20 ? (
+                  <ToolHint
+                    key={env.uid}
+                    text={env.name}
+                    toolhintId={env.uid}
+                    place="left"
+                    tooltipStyle={{
+                      maxWidth: '300px',
+                      wordWrap: 'break-word',
+                      whiteSpace: 'normal',
+                      zIndex: 10002,
+                    }}
+                  >
+                    <div
+                      id={env.uid}
+                      className={selectedEnvironment.uid === env.uid ? 'environment-item active' : 'environment-item'}
+                      onClick={() => handleEnvironmentClick(env)} // Use handleEnvironmentClick to handle clicks
+                    >
+                      <span className="break-all">{env.name}</span>
+                    </div>
+                  </ToolHint>
+                ) : (
                   <div
-                    id={env.uid}
+                    key={env.uid}
                     className={selectedEnvironment.uid === env.uid ? 'environment-item active' : 'environment-item'}
                     onClick={() => handleEnvironmentClick(env)} // Use handleEnvironmentClick to handle clicks
                   >
                       <span className="break-all">{env.name}</span>
                   </div>
-                </ToolHint>
+                )
               ))}
             <div className="btn-create-environment" onClick={() => handleCreateEnvClick()}>
               + <span>Create</span>

--- a/packages/bruno-app/src/components/GlobalEnvironments/EnvironmentSettings/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/GlobalEnvironments/EnvironmentSettings/EnvironmentList/index.js
@@ -113,15 +113,36 @@ const EnvironmentList = ({ environments, activeEnvironmentUid, selectedEnvironme
             {environments &&
               environments.length &&
               environments.map((env) => (
-                <ToolHint key={env.uid} text={env.name} toolhintId={env.uid} place="right">
+                env.name.length > 20 ? (
+                  <ToolHint
+                    key={env.uid}
+                    text={env.name}
+                    toolhintId={env.uid}
+                    place="left"
+                    tooltipStyle={{
+                      maxWidth: '300px',
+                      wordWrap: 'break-word',
+                      whiteSpace: 'normal',
+                      zIndex: 10002,
+                    }}
+                  >
+                    <div
+                      id={env.uid}
+                      className={selectedEnvironment.uid === env.uid ? 'environment-item active' : 'environment-item'}
+                      onClick={() => handleEnvironmentClick(env)} // Use handleEnvironmentClick to handle click
+                    >
+                      <span className="break-all">{env.name}</span>
+                    </div>
+                  </ToolHint>
+                ) : (
                   <div
-                    id={env.uid}
+                    key={env.uid}
                     className={selectedEnvironment.uid === env.uid ? 'environment-item active' : 'environment-item'}
                     onClick={() => handleEnvironmentClick(env)} // Use handleEnvironmentClick to handle click
                   >
                       <span className="break-all">{env.name}</span>
                   </div>
-                </ToolHint>
+                )
               ))}
             <div className="btn-create-environment" onClick={() => handleCreateEnvClick()}>
               + <span>Create</span>


### PR DESCRIPTION
# Description

Long environment names may exist for many reasons (naming conventions, unique IDs, etc.).

Bruno truncates these names but if the best identifying information for my environment is towards the end of the name - I have to open the configure dialogue and look for the specific place and order that environment exists in my listing. This breaks my flow when in the Bruno app.

We are adding preview dialogues for long, truncated environment names:
- Collection Environment names
- Global Environment names
- Word-wrapping environment name previews on the configure menu


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
 - **Issue** : https://github.com/usebruno/bruno/issues/5701 

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

### Screenshots / GIF

**Active Environments**
<img width="322" height="102" alt="image" src="https://github.com/user-attachments/assets/13338ecd-8837-421f-9604-a2f76396c4fb" />
<img width="336" height="145" alt="image" src="https://github.com/user-attachments/assets/ba697f3d-bd05-434a-8f0f-8ca91ac9cdcd" />


**Environment Selector**
<img width="350" height="354" alt="image" src="https://github.com/user-attachments/assets/4b36b21f-52c5-4bb6-91ac-b089d30e843a" />

**Global Selector**
<img width="350" height="307" alt="image" src="https://github.com/user-attachments/assets/d83c62e4-776d-4a20-b2a7-cde8292a9e47" />

**Configure Environment Menus**
<img width="1242" height="681" alt="image" src="https://github.com/user-attachments/assets/9b8d42f3-2367-42a1-8c60-c46ef7c7a243" />
<img width="1233" height="668" alt="image" src="https://github.com/user-attachments/assets/10886ea0-baae-4cfe-8d8b-445d9519a9c0" />
