### PR TITLE
feat(cli): ignore and skip invalid `.bru` file

### DIFF
--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -44,13 +44,23 @@ const createCollectionJsonFromPathname = (collectionPath) => {
         if (path.extname(filePath) !== '.bru') continue;
 
         // get the request item
-        const bruContent = fs.readFileSync(filePath, 'utf8');
-        const requestItem = parseRequest(bruContent);
-        currentDirItems.push({
-          name: file,
-          pathname: filePath,
-          ...requestItem
-        });
+        try {
+          const bruContent = fs.readFileSync(filePath, 'utf8');
+          const requestItem = parseRequest(bruContent);
+          currentDirItems.push({
+            name: file,
+            pathname: filePath,
+            ...requestItem
+          });
+        } catch (err) {
+          // Log warning for invalid .bru file but continue processing
+          console.warn(chalk.yellow(`Warning: Skipping invalid file ${filePath}\nError: ${err.message}`));
+          // Track skipped files for later reporting
+          if (!global.brunoSkippedFiles) {
+            global.brunoSkippedFiles = [];
+          }
+          global.brunoSkippedFiles.push({ path: filePath, error: err.message });
+        }
       }
     }
     let currentDirFolderItems = currentDirItems?.filter((iter) => iter.type === 'folder');


### PR DESCRIPTION
fixes: https://github.com/usebruno/bruno/issues/5710
related to: https://github.com/usebruno/bruno/issues/5685

# Description

This PR implements the logic for ignoring, skipping, and reporting invalid `.bru` files in the collection. This solves the issue where invalid files prevent the collection from running properly.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:
<img width="1282" height="258" alt="image" src="https://github.com/user-attachments/assets/05bddf9b-a372-4b72-a748-6e65a83b0066" />

After:
<img width="1648" height="574" alt="image" src="https://github.com/user-attachments/assets/1759aa7f-1e2c-408f-ab82-064b39be858b" />
