### PR TITLE
fix: reimplement payload serialization for `x-www-form-encoded` 

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -333,7 +333,9 @@ const runSingleRequest = async function (
       name => name.toLowerCase() === 'content-type'
     );
     if (contentTypeHeader && request.headers[contentTypeHeader] === 'application/x-www-form-urlencoded') {
-      request.data = qs.stringify(request.data, { arrayFormat: 'repeat' });
+      if (typeof request.data === 'object') {
+        request.data = qs.stringify(request.data, { arrayFormat: 'repeat' });
+      }
     }
 
     if (contentTypeHeader && request.headers[contentTypeHeader] === 'multipart/form-data') {

--- a/packages/bruno-cli/src/utils/form-data.js
+++ b/packages/bruno-cli/src/utils/form-data.js
@@ -5,20 +5,14 @@ const path = require('path');
 
 /**
  * @param {Array.<object>} params The request body Array
- * @returns {object} Returns an obj with repeating key as an array of values
- * {item: 2, item: 3, item1: 4} becomes {item: [2,3], item1: 4}
+ * @returns {string} Returns a order respecting standard compliant string of form encoded values
  */
 const buildFormUrlEncodedPayload = (params) => {
-  return params.reduce((acc, p) => {
-    if (!acc[p.name]) {
-      acc[p.name] = p.value;
-    } else if (Array.isArray(acc[p.name])) {
-      acc[p.name].push(p.value);
-    } else {
-      acc[p.name] = [acc[p.name], p.value];
-    }
-    return acc;
-  }, {});
+  const resultParams = new URLSearchParams();
+  for (const param of params) {
+    resultParams.append(param.name, param.value);
+  }
+  return resultParams.toString();
 };
 
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -408,7 +408,9 @@ const registerNetworkIpc = (mainWindow) => {
 
     // stringify the request url encoded params
     if (request.headers['content-type'] === 'application/x-www-form-urlencoded') {
-      request.data = qs.stringify(request.data, { arrayFormat: 'repeat' });
+      if (typeof request.data === 'object') {
+        request.data = qs.stringify(request.data, { arrayFormat: 'repeat' });
+      }
     }
 
     if (request.headers['content-type'] === 'multipart/form-data') {

--- a/packages/bruno-electron/src/utils/form-data.js
+++ b/packages/bruno-electron/src/utils/form-data.js
@@ -5,20 +5,14 @@ const path = require('path');
 
 /**
  * @param {Array.<object>} params The request body Array
- * @returns {object} Returns an obj with repeating key as an array of values
- * {item: 2, item: 3, item1: 4} becomes {item: [2,3], item1: 4}
+ * @returns {string} Returns a order respecting standard compliant string of form encoded values
  */
 const buildFormUrlEncodedPayload = (params) => {
-  return params.reduce((acc, p) => {
-    if (!acc[p.name]) {
-      acc[p.name] = p.value;
-    } else if (Array.isArray(acc[p.name])) {
-      acc[p.name].push(p.value);
-    } else {
-      acc[p.name] = [acc[p.name], p.value];
-    }
-    return acc;
-  }, {});
+  const resultParams = new URLSearchParams();
+  for (const param of params) {
+    resultParams.append(param.name, param.value);
+  }
+  return resultParams.toString();
 };
 
 

--- a/packages/bruno-electron/tests/network/prepare-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-request.spec.js
@@ -23,7 +23,7 @@ describe('prepare-request: prepareRequest', () => {
 
     it('should handle single key-value pair', () => {
       const requestObj = [{ name: 'item', value: 2 }];
-      const expected = { item: 2 };
+      const expected = 'item=2';
       const result = buildFormUrlEncodedPayload(requestObj);
       expect(result).toEqual(expected);
     });
@@ -33,7 +33,7 @@ describe('prepare-request: prepareRequest', () => {
         { name: 'item1', value: 2 },
         { name: 'item2', value: 3 }
       ];
-      const expected = { item1: 2, item2: 3 };
+      const expected = 'item1=2&item2=3';
       const result = buildFormUrlEncodedPayload(requestObj);
       expect(result).toEqual(expected);
     });
@@ -43,7 +43,7 @@ describe('prepare-request: prepareRequest', () => {
         { name: 'item', value: 2 },
         { name: 'item', value: 3 }
       ];
-      const expected = { item: [2, 3] };
+      const expected = 'item=2&item=3';
       const result = buildFormUrlEncodedPayload(requestObj);
       expect(result).toEqual(expected);
     });
@@ -54,7 +54,7 @@ describe('prepare-request: prepareRequest', () => {
         { name: 'item2', value: 3 },
         { name: 'item1', value: 4 }
       ];
-      const expected = { item1: [2, 4], item2: 3 };
+      const expected = 'item1=2&item2=3&item1=4';
       const result = buildFormUrlEncodedPayload(requestObj);
       expect(result).toEqual(expected);
     });


### PR DESCRIPTION
# Description

Fixes: #5237

Re-implements the utility `buildFormUrlEncodedPayload` to return a serialised form encoded string instead of an object to avoid loosing the order of values

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
