### PR TITLE
fix: Reorder items when deleting request or directory

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js
@@ -3,7 +3,7 @@ import Modal from 'components/Modal';
 import { isItemAFolder } from 'utils/tabs';
 import { useDispatch } from 'react-redux';
 import { closeTabs } from 'providers/ReduxStore/slices/tabs';
-import { deleteItem } from 'providers/ReduxStore/slices/collections/actions';
+import { deleteItem, reorderDirectoryItems } from 'providers/ReduxStore/slices/collections/actions';
 import { recursivelyGetAllItemUids } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 
@@ -11,7 +11,8 @@ const DeleteCollectionItem = ({ onClose, item, collectionUid }) => {
   const dispatch = useDispatch();
   const isFolder = isItemAFolder(item);
   const onConfirm = () => {
-    dispatch(deleteItem(item.uid, collectionUid)).then(() => {
+    dispatch(deleteItem(item.uid, collectionUid)).then(({ parentDirectory }) => {
+      dispatch(reorderDirectoryItems(parentDirectory, item.uid));
 
       if (isFolder) {
         // close all tabs that belong to the folder


### PR DESCRIPTION
closes: #5721 

# Description

This PR implements the process of re-compute the sequential order of requests (queries) / directories (folders) in a directory / collection when an item is deleted.<br>
This fixes the issue that adding a request / directory make the new item going physically between two items or even have the same sequential order as another item in the same folder.

Before / After example below :smile:

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Before
1. Creating 4 requests :
![before 1](https://github.com/user-attachments/assets/8b2f85c9-671f-44e2-9267-e888af699a2f)
2. Deleting the second and third items. (the fouth keeps its order)
![before 2](https://github.com/user-attachments/assets/6cba3734-7c08-40cd-bba0-8cd36145ad9a)
![before 3](https://github.com/user-attachments/assets/838fad5d-ef5f-4584-be94-00189e2f4a60)
3. Inserting a request results in having its order equals to 3 (count 2 + 1).<br>
It will be added between the two others...
![before 4](https://github.com/user-attachments/assets/01fd2f8a-3e03-40b7-a8c6-54ef219fa257)

### After
1. Creating 4 requests :
![after 1](https://github.com/user-attachments/assets/d80c99f9-ff3a-40a6-beb0-6ce001a6aaa7)
2. Deleting the second and third as well. We can see the orders **re-computed each time**
![after 2](https://github.com/user-attachments/assets/8ae38658-e1f6-4e9f-b43a-1ee1d32b67bf)
![after 3](https://github.com/user-attachments/assets/918ccf52-fb16-4315-8e70-acc31e2753d8)
3. Adding a request goes at the good level, after the others.
![after 4](https://github.com/user-attachments/assets/0f7b745c-46e4-422a-8bfa-3e67b845f29e)