### PR TITLE
fix: fixing tests using locale on numbers

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseSize/ResponseSize.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseSize/ResponseSize.spec.js
@@ -76,35 +76,39 @@ describe('ResponseSize', () => {
     });
 
     it('should handle exactly 1024 bytes as size', () => {
-      renderWithTheme(<ResponseSize size={1024} />);
+      const size = 1024;
+      renderWithTheme(<ResponseSize size={size} />);
       const element = screen.getByText(/1024B/);
       expect(element).toBeInTheDocument();
       expect(element.textContent).toMatch(/^1024B$/);
-      expect(element).toHaveAttribute('title', '1,024B');
+      expect(element).toHaveAttribute('title', `${size.toLocaleString()}B`);
     });
 
     it('should render kilobytes when size is greater than 1024', () => {
-      renderWithTheme(<ResponseSize size={1500} />);
+      const size = 1500;
+      renderWithTheme(<ResponseSize size={size} />);
       const element = screen.getByText(/1\.46KB/);
       expect(element).toBeInTheDocument();
       expect(element.textContent).toMatch(/^\d+\.\d+KB$/);
-      expect(element).toHaveAttribute('title', '1,500B');
+      expect(element).toHaveAttribute('title', `${size.toLocaleString()}B`);
     });
 
     it('should handle large size numbers', () => {
-      renderWithTheme(<ResponseSize size={10240} />);
+      const size = 10240;
+      renderWithTheme(<ResponseSize size={size} />);
       const element = screen.getByText(/10\.0KB/);
       expect(element).toBeInTheDocument();
       expect(element.textContent).toMatch(/^\d+\.\d+KB$/);
-      expect(element).toHaveAttribute('title', '10,240B');
+      expect(element).toHaveAttribute('title', `${size.toLocaleString()}B`);
     });
 
     it('should handle decimal size numbers', () => {
-      renderWithTheme(<ResponseSize size={1126.5} />);
+      const size = 1126.5;
+      renderWithTheme(<ResponseSize size={size} />);
       const element = screen.getByText(/1\.10KB/);
       expect(element).toBeInTheDocument();
       expect(element.textContent).toMatch(/^\d+\.\d+KB$/);
-      expect(element).toHaveAttribute('title', '1,126.5B');
+      expect(element).toHaveAttribute('title', `${size.toLocaleString()}B`);
     });
   });
 });


### PR DESCRIPTION
fixes #5732 

# Description

This PR fixes 4 tests that were failing if the user testing was on a different locale than `EN`.

File `packages/bruno-app/src/components/ResponsePane/ResponseSize.spec.js`, the following tests :
- "should handle exactly 1024 bytes as size"
- "should render kilobytes when size is greater than 1024"
- "should handle large size numbers"
- "should handle decimal size numbers"

Because these tests directly use locale dependent **magic strings** :

![Issue 1 - problem](https://github.com/user-attachments/assets/04b4732d-42f9-45f8-8881-160a4df78dbe)
![Issue 2 - test fails](https://github.com/user-attachments/assets/5c86a067-ba31-4697-9242-62ddfbafb4ab)

This string is computed in the `ResponseSize` component using the method `number.toLocaleString()`
This method documentation says :

![Issue 3 - documentation](https://github.com/user-attachments/assets/b1c526f3-5314-4d5f-99bf-a4f0e4b9346f)

Because these tests seem to "just" check if the title is set, computing the "locale string" in the test before the assertion is acceptable **(won't break the nature of the test)** and will works for everybody.

Before / After example below :smile:

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

### Before

![After 1 - the problem](https://github.com/user-attachments/assets/1093a76a-5d44-4ea4-93a4-2c4a870e9259)

### After

![After 2 - resolution](https://github.com/user-attachments/assets/2bcd82c6-d004-4ae9-9b29-8fad04261c36)


