### PR TITLE
fix: update global shortcut registration just for Windows platform in Electron app

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -241,15 +241,17 @@ app.on('open-file', (event, path) => {
 });
 
 
-// Register the global shortcuts
-app.on('browser-window-focus', () => {
-  // Quick fix for Electron issue #29996: https://github.com/electron/electron/issues/29996
-  globalShortcut.register('Ctrl+=', () => {
-    mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() + 1);
+// Register the global shortcuts (Windows only)
+if (os.platform() === 'win32') {
+  app.on('browser-window-focus', () => {
+    // Quick fix for Electron issue #29996: https://github.com/electron/electron/issues/29996
+    globalShortcut.register('Ctrl+=', () => {
+      mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() + 1);
+    });
   });
-})
 
-// Disable global shortcuts when not focused
-app.on('browser-window-blur', () => {
-  globalShortcut.unregisterAll()
-})
+  // Disable global shortcuts when not focused
+  app.on('browser-window-blur', () => {
+    globalShortcut.unregisterAll();
+  });
+}


### PR DESCRIPTION
Related to: https://github.com/usebruno/bruno/issues/5703
# Description

This PR implements the refactor the use the globalShortcuts logic only for windows OS.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**