### PR TITLE
feat(Markdown): override normalizing on whitespace in markdown editor

### DIFF
--- a/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MarkDown/StyledWrapper.js
@@ -78,6 +78,14 @@ const StyledMarkdownBodyWrapper = styled.div`
         background-color: ${(props) => props.theme.bg};
       }
     }
+
+    p {
+      white-space: pre-wrap;
+    }
+
+    div {
+      white-space: pre-wrap;
+    }
   }
 `;
 

--- a/packages/bruno-app/src/components/MarkDown/index.jsx
+++ b/packages/bruno-app/src/components/MarkDown/index.jsx
@@ -6,6 +6,9 @@ import { isValidUrl } from 'utils/url/index';
 
 const Markdown = ({ collectionPath, onDoubleClick, content }) => {
   const markdownItOptions = {
+    html: true,
+    breaks: true,
+    linkify: true,
     replaceLink: function (link, env) {
       return link.replace(/^\./, collectionPath);
     }


### PR DESCRIPTION
fixes: https://github.com/usebruno/bruno/issues/5714

# Description

This PR implements the feature of overriding the whitespace normalizing in markdown preview

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**