### PR TITLE
Cache proxy agents by hostname to speed up subsequent requests

### DIFF
--- a/packages/bruno-electron/src/utils/map-cache.js
+++ b/packages/bruno-electron/src/utils/map-cache.js
@@ -24,10 +24,6 @@ class MapCache {
     this.cache.set(key, { value, timestamp: new Date() });
   }
 
-  has(key) {
-    return this.cache.has(key);
-  }
-
   delete(key) {
     return this.cache.delete(key);
   }

--- a/packages/bruno-electron/src/utils/map-cache.js
+++ b/packages/bruno-electron/src/utils/map-cache.js
@@ -1,0 +1,40 @@
+/**
+ * A simple in-memory cache with TTL (time-to-live) functionality.
+ * Each entry in the cache expires after a specified duration.
+ */
+class MapCache {
+  constructor(ttl = 60000) {
+    this.cache = new Map();
+    this.ttl = ttl;
+  }
+
+  get(key) {
+    if (new Date() - this.cache.get(key)?.timestamp > this.ttl) {
+      this.cache.delete(key);
+      return undefined;
+    }
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key, value) {
+    this.cache.set(key, { value, timestamp: new Date() });
+  }
+
+  has(key) {
+    return this.cache.has(key);
+  }
+
+  delete(key) {
+    return this.cache.delete(key);
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}
+
+module.exports = MapCache;

--- a/packages/bruno-electron/src/utils/map-cache.js
+++ b/packages/bruno-electron/src/utils/map-cache.js
@@ -9,12 +9,12 @@ class MapCache {
   }
 
   get(key) {
-    if (new Date() - this.cache.get(key)?.timestamp > this.ttl) {
-      this.cache.delete(key);
-      return undefined;
-    }
     const entry = this.cache.get(key);
     if (!entry) {
+      return undefined;
+    }
+    if (new Date() - entry.timestamp > this.ttl) {
+      this.cache.delete(key);
       return undefined;
     }
     return entry.value;

--- a/packages/bruno-electron/src/utils/proxy-util.js
+++ b/packages/bruno-electron/src/utils/proxy-util.js
@@ -364,7 +364,7 @@ function setupProxyAgents({
         requestConfig.httpsAgent = getCachedProxyAgent(agentCacheKey, new TimelineSocksProxyAgent({ proxy: proxyUri, ...tlsOptions }, timeline));
       } else {
         const TimelineHttpsProxyAgent = createTimelineAgentClass(PatchedHttpsProxyAgent);
-        requestConfig.httpAgent = new HttpProxyAgent(proxyUri); // For http, no need for timeline
+        requestConfig.httpAgent = getCachedProxyAgent(agentCacheKey, new HttpProxyAgent(proxyUri));
         requestConfig.httpsAgent = getCachedProxyAgent(agentCacheKey, new TimelineHttpsProxyAgent({ proxy: proxyUri, ...tlsOptions }, timeline));
       }
     } else {

--- a/packages/bruno-electron/src/utils/tests/map-cache.spec.js
+++ b/packages/bruno-electron/src/utils/tests/map-cache.spec.js
@@ -1,0 +1,65 @@
+const MapCache = require('../map-cache');
+
+describe('MapCache', () => {
+  jest.useFakeTimers();
+
+  let cache;
+
+  beforeEach(() => {
+    cache = new MapCache(1000); // 1 second TTL for testing
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('should set and get values correctly', () => {
+    cache.set('key1', 'value1');
+    expect(cache.get('key1')).toBe('value1');
+  });
+
+  it('should return undefined for non-existent keys', () => {
+    expect(cache.get('nonExistentKey')).toBeUndefined();
+  });
+
+  it('should delete keys correctly', () => {
+    cache.set('key2', 'value2');
+    expect(cache.get('key2')).toBe('value2');
+    cache.delete('key2');
+    expect(cache.get('key2')).toBeUndefined();
+  });
+
+  it('should clear all entries correctly', () => {
+    cache.set('key3', 'value3');
+    cache.set('key4', 'value4');
+    expect(cache.get('key3')).toBe('value3');
+    expect(cache.get('key4')).toBe('value4');
+    cache.clear();
+    expect(cache.get('key3')).toBeUndefined();
+    expect(cache.get('key4')).toBeUndefined();
+  });
+
+  it('should expire entries after TTL', () => {
+    cache.set('key5', 'value5');
+    expect(cache.get('key5')).toBe('value5');
+    jest.advanceTimersByTime(1001); // Advance time by just over 1 second
+    expect(cache.get('key5')).toBeUndefined();
+  });
+
+  it('should not expire entries before TTL', () => {
+    cache.set('key6', 'value6');
+    expect(cache.get('key6')).toBe('value6');
+    jest.advanceTimersByTime(500); // Advance time by half a second
+    expect(cache.get('key6')).toBe('value6');
+  });
+
+  it('should reset TTL on set', () => {
+    cache.set('key7', 'value7');
+    jest.advanceTimersByTime(800); // Advance time by 0.8 seconds
+    cache.set('key7', 'value7Updated'); // Reset TTL
+    jest.advanceTimersByTime(300); // Advance time by 0.3 seconds (total 1.1 seconds from first set)
+    expect(cache.get('key7')).toBe('value7Updated'); // Should still exist
+    jest.advanceTimersByTime(701); // Advance time by another 0.7 seconds (total 2 seconds from first set)
+    expect(cache.get('key7')).toBeUndefined(); // Should be expired now
+  });
+});


### PR DESCRIPTION
# Description

Fixes #5574

All requests go through proxy agents (http, https, sock, etc.). For each request, a new agent instance is created. This PR caches agents by hostname for a limited time (5 minutes) so that all requests to the same host within that time will reuse the same proxy agent.

In my testing, I'm seeing 3-4x speed ups.

https://github.com/user-attachments/assets/e501d086-a73d-4672-920e-d9c21a42a92f

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
