### PR TITLE
fix: newly created requests should be added within the directory context

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1060,8 +1060,8 @@ export const newGrpcRequest = (params) => (dispatch, getState) => {
     };
 
     // itemUid is null when we are creating a new request at the root level
-    const resolvedFilename = resolveRequestFilename(filename);
     const parentItem = itemUid ? findItemInCollection(collection, itemUid) : collection;
+    const resolvedFilename = resolveRequestFilename(filename);
 
     if (!parentItem) {
       return reject(new Error('Parent item not found'));
@@ -1130,8 +1130,8 @@ export const newWsRequest = (params) => (dispatch, getState) => {
     };
 
     // itemUid is null when we are creating a new request at the root level
-    const resolvedFilename = resolveRequestFilename(filename);
     const parentItem = itemUid ? findItemInCollection(collection, itemUid) : collection;
+    const resolvedFilename = resolveRequestFilename(filename);
 
     if (!parentItem) {
       return reject(new Error('Parent item not found'));


### PR DESCRIPTION
# Description
[Jira](https://usebruno.atlassian.net/browse/BRU-1975)

https://github.com/user-attachments/assets/dea0c060-2f11-4dc0-93bd-02068d9ae470

When we create grpc or ws request from 3 dots of any directory, the request should get added to the directory itself, but currently it is getting added to collection root itself

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
