### PR TITLE
Fix(app): remove redundant ipcRenderer.invoke call

### DIFF
--- a/packages/bruno-app/src/utils/network/grpc-event-listeners.js
+++ b/packages/bruno-app/src/utils/network/grpc-event-listeners.js
@@ -13,8 +13,6 @@ const useGrpcEventListeners = () => {
       return () => {};
     }
 
-    ipcRenderer.invoke('renderer:ready');
-
     // Handle gRPC requestSent event
     const removeGrpcRequestSentListener = ipcRenderer.on('grpc:request', (requestId, collectionUid, eventData) => {
 

--- a/packages/bruno-app/src/utils/network/ws-event-listeners.js
+++ b/packages/bruno-app/src/utils/network/ws-event-listeners.js
@@ -13,8 +13,6 @@ const useWsEventListeners = () => {
       return () => {};
     }
 
-    ipcRenderer.invoke('renderer:ready');
-
     // Handle WebSocket requestSent event
     const removeWsRequestSentListener = ipcRenderer.on('main:ws:request', (requestId, collectionUid, eventData) => {
       dispatch(runWsRequestEvent({


### PR DESCRIPTION
# Description

Copy pasting the `useIPC` has caused  duplicate invocations for when the renderer is ready, this PR removes the duplicate calls

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
