### PR TITLE
Bugfix/5823-request-save-not-working-in-response-tab

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
@@ -4,7 +4,7 @@ import { get } from 'lodash';
 import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateResponsePaneScrollPosition } from 'providers/ReduxStore/slices/tabs';
-import { sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { saveRequest, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { Document, Page } from 'react-pdf';
 import 'pdfjs-dist/build/pdf.worker';
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
@@ -85,6 +85,8 @@ const QueryResultPreview = ({
     );
   };
 
+  const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
+
   switch (previewTab?.mode) {
     case 'preview-web': {
       const webViewSrc = data.replace('<head>', `<head><base href="${item.requestSent?.url || ''}">`);
@@ -128,6 +130,7 @@ const QueryResultPreview = ({
           theme={displayedTheme}
           onRun={onRun}
           onScroll={onScroll}
+          onSave={onSave}
           value={formattedData}
           mode={mode}
           initialScroll={focusedTab.responsePaneScrollPosition || 0}


### PR DESCRIPTION
# Description
Fixes #5823 

I added the missing event handler for `onSave` in `QueryResultPreview` and passed it as a prop to `CodeEditor`. It saves the request when the focus is on the Response tab.

https://github.com/user-attachments/assets/ac3aed03-a055-479c-a454-a2ffedb7fc7b




### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
