### PR TITLE
Feature/devtools slider resizable

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/RequestDetailsPanel/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/RequestDetailsPanel/index.js
@@ -153,7 +153,7 @@ const NetworkTab = ({ response }) => {
   );
 };
 
-const RequestDetailsPanel = () => {
+const RequestDetailsPanel = ({ style }) => {
   const dispatch = useDispatch();
   const { selectedRequest } = useSelector(state => state.logs);
   const collections = useSelector(state => state.collections.collections);
@@ -189,15 +189,15 @@ const RequestDetailsPanel = () => {
   };
 
   return (
-    <StyledWrapper>
+    <StyledWrapper style={style}>
       <div className="panel-header">
         <div className="panel-title">
           <IconFileText size={16} strokeWidth={1.5} />
           <span>Request Details</span>
           <span className="request-time">({formatTime(selectedRequest.timestamp)})</span>
         </div>
-        
-        <button 
+
+        <button
           className="close-button"
           onClick={handleClose}
           title="Close details panel"
@@ -207,23 +207,23 @@ const RequestDetailsPanel = () => {
       </div>
 
       <div className="panel-tabs">
-        <button 
+        <button
           className={`tab-button ${activeTab === 'request' ? 'active' : ''}`}
           onClick={() => setActiveTab('request')}
         >
           <IconArrowRight size={14} strokeWidth={1.5} />
           Request
         </button>
-        
-        <button 
+
+        <button
           className={`tab-button ${activeTab === 'response' ? 'active' : ''}`}
           onClick={() => setActiveTab('response')}
         >
           <IconFileText size={14} strokeWidth={1.5} />
           Response
         </button>
-        
-        <button 
+
+        <button
           className={`tab-button ${activeTab === 'network' ? 'active' : ''}`}
           onClick={() => setActiveTab('network')}
         >

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -25,6 +25,14 @@ const initialState = {
     font: {
       codeFont: 'default'
     },
+    beta: {
+      grpc: false
+    },
+    devTools: {
+      network: {
+        detailsWidth: null
+      }
+    },
     general: {
       defaultCollectionLocation: ''
     }


### PR DESCRIPTION
# Description

## Summary
Adds a draggable divider to the DevTools Network tab that allows users to resize the Request Details panel width. The width preference persists across sessions and includes keyboard accessibility and smart defaults.

## Motivation
The Request Details panel in DevTools Network tab previously had a fixed width (40% of viewport, clamped to 400-600px), which didn't accommodate different screen sizes or user workflows. Users with larger monitors wanted more space to view request/response details, while those with smaller screens needed to maximize the network request list area.

<img width="1428" height="371" alt="image" src="https://github.com/user-attachments/assets/7e935982-814d-4ea8-afce-e42c06e35c42" />

## Changes

### Features Added

- **Resizable divider** between Network request list and Request Details panel
- **Width range**: 400px (min) to 1000px (max)
- **Persistent preferences**: Width saved to user preferences and restored on app restart
- **Keyboard navigation**: 
  - Arrow Left/Right: Adjust width by 8px
  - Shift + Arrow Left/Right: Adjust width by 24px
- **Double-click toggle**: Quickly switch between max (1000px) and min (400px) width
- **Smart default**: Defaults to 33% of container width when no saved preference exists
- **Accessibility**: Full ARIA attributes (`role="separator"`, `aria-orientation="vertical"`, `tabIndex={0}`)

### Files Modified

- `packages/bruno-app/src/components/Devtools/Console/index.js` (+110 lines)
  - Added resizable divider component with drag handlers
  - Implemented keyboard navigation
  - Added width persistence via Redux preferences
  - Container-based width calculation for accurate defaults
  
- `packages/bruno-app/src/components/Devtools/Console/RequestDetailsPanel/index.js` (+1 line)
  - Accept optional `style` prop for dynamic width
  
- `packages/bruno-app/src/providers/ReduxStore/slices/app.js` (+5 lines)
  - Added `devTools.network.detailsWidth` preference field

## Technical Details

### Implementation Highlights

1. **Drag behavior**: Uses window-level event listeners to handle dragging outside component bounds
2. **State management**: Uses `useRef` to track latest width during drag to ensure accurate persistence
3. **Layout calculation**: Uses `useLayoutEffect` to compute default width from actual container dimensions (not window width) for pixel-perfect defaults
4. **Cleanup**: Properly removes event listeners on unmount to prevent memory leaks

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
 - https://github.com/usebruno/bruno/issues/5468

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### GIFs
![devtool-slider-add](https://github.com/user-attachments/assets/e6f4cdda-3dcb-4c27-9bc4-bbfc56dc09f3)

**Features**
- Drag slider to resize request details pane
- double click to minimize, double click to maximize
- resized pane persists after closing and reopening requests / dev tools