### PR TITLE
fix: Delete extra error popup

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -577,7 +577,6 @@ export const renameItem =
 
       const renameName = async () => {
         return ipcRenderer.invoke('renderer:rename-item-name', { itemPath: item.pathname, newName }).catch((err) => {
-          toast.error('Failed to rename the item name');
           console.error(err);
           throw new Error('Failed to rename the item name');
         });
@@ -596,7 +595,6 @@ export const renameItem =
         return ipcRenderer
           .invoke('renderer:rename-item-filename', { oldPath: item.pathname, newPath, newName, newFilename })
           .catch((err) => {
-            toast.error('Failed to rename the file');
             console.error(err);
             throw new Error('Failed to rename the file');
           });


### PR DESCRIPTION
closes: #5845 

# Description

When renaming a request / folder with an already existing name, Bruno won't let this happen. But it will send two popups instead of one to the user.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

## Before

I have this example situation.<br>
I want to rename "TEST 2" into "TEST", already existing.

![error 1](https://github.com/user-attachments/assets/b0542248-ad32-4a09-b2f8-45f805996d64)

When I rename it, I have two popups instead of one.

![error 2](https://github.com/user-attachments/assets/b673eadc-6599-4207-9a1b-06ccba8a1061)

## After

This PR removes one of the two popups, keeping the one coming from the thrown error.

![correction 1](https://github.com/user-attachments/assets/6957b935-8a93-4bd7-8d28-2a3c10788ac6)

Resulting in this behavior :

![correction 2](https://github.com/user-attachments/assets/fb9f10e3-a573-426b-ad8b-ca9a3c01c4d1)
