### PR TITLE
Feature: Add support for a max timeout cli flag

### DIFF
--- a/packages/bruno-cli/src/constants.js
+++ b/packages/bruno-cli/src/constants.js
@@ -25,6 +25,8 @@ const EXIT_STATUS = {
   ERROR_INCORRECT_OUTPUT_FORMAT: 9,
   // Invalid file format
   ERROR_INVALID_FILE: 10,
+  // Invalid timeout option
+  ERROR_TIMEOUT_FORMAT: 11,
   // Everything else
   ERROR_GENERIC: 255
 };


### PR DESCRIPTION
# Description

https://github.com/usebruno/bruno/issues/1249 was an attempt at adding support for timeouts in the CLI & supporting configuration for per-request timeout settings. The per-request timeout settings was handled in an upstream ticket, so this is just the cli support for timeout handling.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
