### PR TITLE
Allowing the timestamp dynamic variable to have a format parameter.

### DIFF
--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -8,6 +8,21 @@ const pathFoundInVariables = (path, obj) => {
   return value !== undefined;
 };
 
+const checkMockVariable = (word) => {
+  // The word must start with a $ for it to be a mock variable.
+  if (!word.startsWith('$')) { return false; }
+
+  // The work can have a pipe followed by a parameter, for example a format string for a timestamp.
+  const indexOfPipe = word.indexOf('|');
+
+  // If it has a pipe, just get everything up to the pipe, and make sure that name exists.
+  if (indexOfPipe >= 1) { word = word.substring(1, indexOfPipe).trim(); }
+  else { word = word.substring(1); }
+
+  // Check that we have a mock data function by that name.
+  return mockDataFunctions.hasOwnProperty(word);
+};
+
 /**
  * Defines a custom CodeMirror mode for Bruno variables highlighting.
  * This function creates a specialized mode that can highlight both Bruno template
@@ -31,7 +46,7 @@ export const defineCodeMirrorBrunoVariablesMode = (_variables, mode, highlightPa
             if (ch === '}' && stream.peek() === '}') {
               stream.eat('}');
               // Check if it's a mock variable (starts with $) and exists in mockDataFunctions
-              const isMockVariable = word.startsWith('$') && mockDataFunctions.hasOwnProperty(word.substring(1));
+              const isMockVariable = checkMockVariable(word);
               const found = isMockVariable || pathFoundInVariables(word, variables);
               const status = found ? 'valid' : 'invalid';
               const randomClass = `random-${(Math.random() + 1).toString(36).substring(9)}`;

--- a/packages/bruno-common/src/interpolate/index.spec.ts
+++ b/packages/bruno-common/src/interpolate/index.spec.ts
@@ -536,6 +536,49 @@ describe('interpolate - mock variable interpolation', () => {
   });
 });
 
+describe('interpolate - formatted timestamp handling', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-10-21T19:22:40.123Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return a formatted date of when a format parameter of yyyyMMDDHHmmss is specified in the timestamp mock variable', () => {
+    const inputString = '{ "formattedTimestamp": "{{$timestamp|yyyyMMDDHHmmss}}" }';
+    const result = interpolate(inputString, {}, {});
+
+    // Test that it replaced the value with a formatted value.
+    expect(result).toBe('{ "formattedTimestamp": "20241021192240" }');
+  })
+
+  it('should return a formatted date of when a format parameter of MMM Do, YYYY is specified in the timestamp mock variable', () => {
+    const inputString = '{ "formattedTimestamp": "{{$timestamp|MMM Do, YYYY}}" }';
+    const result = interpolate(inputString, {}, {});
+
+    // Test that it replaced the value with a formatted value.
+    expect(result).toBe('{ "formattedTimestamp": "Oct 21st, 2024" }');
+  })
+
+  it('should return the plain timestamp when no pipe is included', () => {
+    const inputString = '{ "formattedTimestamp": "{{$timestamp}}" }';
+    const result = interpolate(inputString, {}, {});
+
+    // Test that it replaced the value with a formatted value.
+    expect(result).toBe('{ "formattedTimestamp": "1729538560" }');
+  })
+
+  it('should return the plain timestamp when a pipe is included, but no format string', () => {
+    const inputString = '{ "formattedTimestamp": "{{$timestamp|}}" }';
+    const result = interpolate(inputString, {}, {});
+
+    // Test that it replaced the value with a formatted value.
+    expect(result).toBe('{ "formattedTimestamp": "1729538560" }');
+  })
+});
+
 describe('interpolate - Date() handling', () => {
   it('should interpolate Date() using JSON.stringify', () => {
     const inputString = 'Date is {{date}}';

--- a/packages/bruno-common/src/interpolate/index.ts
+++ b/packages/bruno-common/src/interpolate/index.ts
@@ -25,9 +25,16 @@ const interpolate = (
 
   const { escapeJSONStrings } = options;
 
-  const patternRegex = /\{\{\$(\w+)\}\}/g;
-  str = str.replace(patternRegex, (match, keyword) => {
-    let replacement = mockDataFunctions[keyword as keyof typeof mockDataFunctions]?.();
+  // Pattern breakdown:
+  // \{\{ - start with {{
+  // \$(\w+) - match a keyword for a dynamic variable
+  // (?:\s*\|\s*([^}]+))? - match an optional parameter followed by |
+  // \}\} - end with }}
+  // A simple example: {{$randomFirstName}}
+  // With a parameter: {{$timestamp|yyyyMMDD}}
+  const patternRegex = /\{\{\$(\w+)(?:\s*\|\s*([^}]+)?)?\}\}/g;
+  str = str.replace(patternRegex, (match, keyword, keywordParameter) => {
+    let replacement = mockDataFunctions[keyword as keyof typeof mockDataFunctions]?.(keywordParameter);
 
     if (replacement === undefined) return match;
     replacement = String(replacement);

--- a/packages/bruno-common/src/utils/faker-functions.spec.ts
+++ b/packages/bruno-common/src/utils/faker-functions.spec.ts
@@ -13,9 +13,11 @@ describe("mockDataFunctions Regex Validation", () => {
   test("timestamp and isoTimestamp should return mocked time values", () => {
     const expectedTimestamp = '1704067200'; 
     const expectedIsoTimestamp = '2024-01-01T00:00:00.000Z';
+    const expectedFormattedTimestamp = '20240101000000';
 
     expect(mockDataFunctions.timestamp()).toBe(expectedTimestamp);
     expect(mockDataFunctions.isoTimestamp()).toBe(expectedIsoTimestamp);
+    expect(mockDataFunctions.timestamp("yyyyMMDDHHmmss")).toBe(expectedFormattedTimestamp);
   });
 
   test("all values should match their expected patterns", () => {

--- a/packages/bruno-common/src/utils/faker-functions.ts
+++ b/packages/bruno-common/src/utils/faker-functions.ts
@@ -1,8 +1,12 @@
 import { faker } from '@faker-js/faker';
+import moment from 'moment';
 
 export const mockDataFunctions = {
   guid: () => faker.string.uuid(),
-  timestamp: () => Math.floor(Date.now() / 1000).toString(),
+  timestamp: (format?: string) => { 
+    if (!format) { return Math.floor(Date.now() / 1000).toString() }
+    else { return moment.utc().format(format); }
+  },
   isoTimestamp: () => new Date().toISOString(),
   randomUUID: () => faker.string.uuid(),
   randomNanoId: () => faker.string.nanoid(),


### PR DESCRIPTION
# Description

This enhances the dynamic variables by allowing you to add a pipe followed by a parameter defining how that variable is generated. Then we implement that for the $timestamp variable. If $timestamp is specified by itself, its behavior is the same, but now you could also specify $timestamp|yyyyMMDD to get a timestamp that looks like 20251021. Any format string supported by moment is supported.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
Closes #5861 

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
