### PR TITLE
fix: added word-break for bruno-modal-card

### DIFF
--- a/packages/bruno-app/src/components/Modal/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Modal/StyledWrapper.js
@@ -40,6 +40,7 @@ const Wrapper = styled.div`
     flex-grow: 0;
     margin: 3vh 10vw;
     margin-top: 50px;
+    word-break: break-word;
 
     &.modal-sm {
       min-width: 300px;


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Added word-break CSS property to fix modal text wrapping issue.
Fixes: #5873

<img width="975" height="428" alt="Captura de Tela 2025-10-24 às 09 49 32" src="https://github.com/user-attachments/assets/8135f741-7190-43aa-a88d-fec1ad31b6ce" />

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
