### PR TITLE
feat: auto-focus on newly added row input fields

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Headers/index.js
@@ -16,6 +16,8 @@ import StyledWrapper from './StyledWrapper';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
 import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
 import BulkEditor from 'components/BulkEditor/index';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
+
 const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
 
 const Headers = ({ collection }) => {
@@ -23,6 +25,7 @@ const Headers = ({ collection }) => {
   const { storedTheme } = useTheme();
   const headers = get(collection, 'root.request.headers', []);
   const [isBulkEditMode, setIsBulkEditMode] = useState(false);
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const toggleBulkEditMode = () => {
     setIsBulkEditMode(!isBulkEditMode);
@@ -33,11 +36,9 @@ const Headers = ({ collection }) => {
   };
 
   const addHeader = () => {
-    dispatch(
-      addCollectionHeader({
-        collectionUid: collection.uid
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addCollectionHeader, {
+      collectionUid: collection.uid
+    });
   };
 
   const handleSave = () => dispatch(saveCollectionRoot(collection.uid));
@@ -110,6 +111,7 @@ const Headers = ({ collection }) => {
                   <tr key={header.uid}>
                     <td>
                       <SingleLineEditor
+                        ref={inputRef(header.uid)}
                         value={header.name}
                         theme={storedTheme}
                         onSave={handleSave}

--- a/packages/bruno-app/src/components/CollectionSettings/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Vars/VarsTable/index.js
@@ -14,18 +14,18 @@ import {
   deleteCollectionVar,
   updateCollectionVar
 } from 'providers/ReduxStore/slices/collections/index';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
 
 const VarsTable = ({ collection, vars, varType }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const addVar = () => {
-    dispatch(
-      addCollectionVar({
-        collectionUid: collection.uid,
-        type: varType
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addCollectionVar, {
+      collectionUid: collection.uid,
+      type: varType
+    });
   };
 
   const onSave = () => dispatch(saveCollectionRoot(collection.uid));
@@ -110,6 +110,7 @@ const VarsTable = ({ collection, vars, varType }) => {
                         spellCheck="false"
                         value={_var.name}
                         className="mousetrap"
+                        ref={inputRef(_var.uid)}
                         onChange={(e) => handleVarChange(e, _var, 'name')}
                       />
                     </td>

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
@@ -17,12 +17,14 @@ import { Tooltip } from 'react-tooltip';
 import SensitiveFieldWarning from 'components/SensitiveFieldWarning';
 import { getGlobalEnvironmentVariables, flattenItems, isItemARequest } from 'utils/collections';
 import { sensitiveFields } from './constants';
+import { useParamAddAutoFocusIntent } from 'hooks/useParamAddAutoFocusIntent';
 
 const EnvironmentVariables = ({ environment, collection, setIsModified, originalEnvironmentVariables, onClose }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
   const addButtonRef = useRef(null);
   const { globalEnvironments, activeGlobalEnvironmentUid } = useSelector((state) => state.globalEnvironments);
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   let _collection = cloneDeep(collection);
   
@@ -130,8 +132,11 @@ const EnvironmentVariables = ({ environment, collection, setIsModified, original
   };
 
   const addVariable = () => {
+    const newItemUid = uuid();
+    uidSetter(newItemUid);
+
     const newVariable = {
-      uid: uuid(),
+      uid: newItemUid,
       name: '',
       value: '',
       type: 'text',
@@ -207,6 +212,7 @@ const EnvironmentVariables = ({ environment, collection, setIsModified, original
                       id={`${index}.name`}
                       name={`${index}.name`}
                       value={variable.name}
+                      ref={inputRef(variable.uid)}
                       onChange={formik.handleChange}
                     />
                     <ErrorMessage name={`${index}.name`} />

--- a/packages/bruno-app/src/components/FolderSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/index.js
@@ -11,6 +11,8 @@ import StyledWrapper from './StyledWrapper';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
 import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
 import BulkEditor from 'components/BulkEditor/index';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
+
 const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
 
 const Headers = ({ collection, folder }) => {
@@ -18,6 +20,7 @@ const Headers = ({ collection, folder }) => {
   const { storedTheme } = useTheme();
   const headers = get(folder, 'root.request.headers', []);
   const [isBulkEditMode, setIsBulkEditMode] = useState(false);
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const toggleBulkEditMode = () => {
     setIsBulkEditMode(!isBulkEditMode);
@@ -28,12 +31,10 @@ const Headers = ({ collection, folder }) => {
   };
 
   const addHeader = () => {
-    dispatch(
-      addFolderHeader({
-        collectionUid: collection.uid,
-        folderUid: folder.uid
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addFolderHeader, {
+      collectionUid: collection.uid,
+      folderUid: folder.uid
+    });
   };
 
   const handleSave = () => dispatch(saveFolderRoot(collection.uid, folder.uid));
@@ -108,6 +109,7 @@ const Headers = ({ collection, folder }) => {
                   <tr key={header.uid}>
                     <td>
                       <SingleLineEditor
+                        ref={inputRef(header.uid)}
                         value={header.name}
                         theme={storedTheme}
                         onSave={handleSave}

--- a/packages/bruno-app/src/components/FolderSettings/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Vars/VarsTable/index.js
@@ -10,19 +10,19 @@ import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
 import { addFolderVar, deleteFolderVar, updateFolderVar } from 'providers/ReduxStore/slices/collections/index';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
 
 const VarsTable = ({ folder, collection, vars, varType }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const addVar = () => {
-    dispatch(
-      addFolderVar({
-        collectionUid: collection.uid,
-        folderUid: folder.uid,
-        type: varType
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addFolderVar, {
+      collectionUid: collection.uid,
+      folderUid: folder.uid,
+      type: varType
+    });
   };
 
   const onSave = () => dispatch(saveFolderRoot(collection.uid, folder.uid));
@@ -109,6 +109,7 @@ const VarsTable = ({ folder, collection, vars, varType }) => {
                         spellCheck="false"
                         value={_var.name}
                         className="mousetrap"
+                        ref={inputRef(_var.uid)}
                         onChange={(e) => handleVarChange(e, _var, 'name')}
                       />
                     </td>

--- a/packages/bruno-app/src/components/GlobalEnvironments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
+++ b/packages/bruno-app/src/components/GlobalEnvironments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
@@ -13,12 +13,14 @@ import toast from 'react-hot-toast';
 import { saveGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import { Tooltip } from 'react-tooltip';
 import { getGlobalEnvironmentVariables } from 'utils/collections';
+import { useParamAddAutoFocusIntent } from 'hooks/useParamAddAutoFocusIntent';
 
 const EnvironmentVariables = ({ environment, setIsModified, originalEnvironmentVariables, collection }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
   const addButtonRef = useRef(null);
   const { globalEnvironments, activeGlobalEnvironmentUid } = useSelector(state => state.globalEnvironments);
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   let _collection = cloneDeep(collection);
 
@@ -83,8 +85,11 @@ const EnvironmentVariables = ({ environment, setIsModified, originalEnvironmentV
   };
 
   const addVariable = () => {
+    const newItemUid = uuid();
+    uidSetter(newItemUid);
+
     const newVariable = {
-      uid: uuid(),
+      uid: newItemUid,
       name: '',
       value: '',
       type: 'text',
@@ -144,6 +149,7 @@ const EnvironmentVariables = ({ environment, setIsModified, originalEnvironmentV
                       autoCapitalize="off"
                       spellCheck="false"
                       className="mousetrap"
+                      ref={inputRef(variable.uid)}
                       id={`${index}.name`}
                       name={`${index}.name`}
                       value={variable.name}

--- a/packages/bruno-app/src/components/RequestPane/Assertions/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/index.js
@@ -9,18 +9,18 @@ import StyledWrapper from './StyledWrapper';
 import Table from 'components/Table/index';
 import ReorderTable from 'components/ReorderTable/index';
 import { moveAssertion } from 'providers/ReduxStore/slices/collections/index';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
 
 const Assertions = ({ item, collection }) => {
   const dispatch = useDispatch();
   const assertions = item.draft ? get(item, 'draft.request.assertions') : get(item, 'request.assertions');
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const handleAddAssertion = () => {
-    dispatch(
-      addAssertion({
-        itemUid: item.uid,
-        collectionUid: collection.uid
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addAssertion, {
+      itemUid: item.uid,
+      collectionUid: collection.uid
+    });
   };
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
@@ -86,7 +86,8 @@ const Assertions = ({ item, collection }) => {
               return (
                 <tr key={assertion.uid} data-uid={assertion.uid}>
                   <td className='flex relative'>
-                    <input
+                      <input
+                        ref={inputRef(assertion.uid)}
                       type="text"
                       autoComplete="off"
                       autoCorrect="off"

--- a/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
@@ -15,19 +15,19 @@ import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collection
 import StyledWrapper from './StyledWrapper';
 import ReorderTable from 'components/ReorderTable/index';
 import Table from 'components/Table/index';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
 
 const FormUrlEncodedParams = ({ item, collection }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
   const params = item.draft ? get(item, 'draft.request.body.formUrlEncoded') : get(item, 'request.body.formUrlEncoded');
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const addParam = () => {
-    dispatch(
-      addFormUrlEncodedParam({
-        itemUid: item.uid,
-        collectionUid: collection.uid
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addFormUrlEncodedParam, {
+      itemUid: item.uid,
+      collectionUid: collection.uid
+    });
   };
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
@@ -92,7 +92,8 @@ const FormUrlEncodedParams = ({ item, collection }) => {
               return (
                 <tr key={param.uid} data-uid={param.uid}>
                   <td className='flex relative'>
-                    <input
+                      <input
+                        ref={inputRef(param.uid)}
                       type="text"
                       autoComplete="off"
                       autoCorrect="off"

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -16,32 +16,30 @@ import StyledWrapper from './StyledWrapper';
 import FilePickerEditor from 'components/FilePickerEditor';
 import Table from 'components/Table/index';
 import ReorderTable from 'components/ReorderTable/index';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
 
 const MultipartFormParams = ({ item, collection }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
   const params = item.draft ? get(item, 'draft.request.body.multipartForm') : get(item, 'request.body.multipartForm');
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const addParam = () => {
-    dispatch(
-      addMultipartFormParam({
-        itemUid: item.uid,
-        collectionUid: collection.uid,
-        type: 'text',
-        value: ''
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addMultipartFormParam, {
+      itemUid: item.uid,
+      collectionUid: collection.uid,
+      type: 'text',
+      value: ''
+    });
   };
 
   const addFile = () => {
-    dispatch(
-      addMultipartFormParam({
-        itemUid: item.uid,
-        collectionUid: collection.uid,
-        type: 'file',
-        value: []
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addMultipartFormParam, {
+      itemUid: item.uid,
+      collectionUid: collection.uid,
+      type: 'file',
+      value: []
+    });
   };
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
@@ -111,7 +109,8 @@ const MultipartFormParams = ({ item, collection }) => {
               return (
                 <tr key={param.uid} className='w-full' data-uid={param.uid}>
                   <td className="flex relative">
-                    <input
+                      <input
+                        ref={inputRef(param.uid)}
                       type="text"
                       autoComplete="off"
                       autoCorrect="off"

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -20,6 +20,7 @@ import StyledWrapper from './StyledWrapper';
 import Table from 'components/Table/index';
 import ReorderTable from 'components/ReorderTable';
 import BulkEditor from '../../BulkEditor';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
 
 const QueryParams = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -27,16 +28,15 @@ const QueryParams = ({ item, collection }) => {
   const params = item.draft ? get(item, 'draft.request.params') : get(item, 'request.params');
   const queryParams = params.filter((param) => param.type === 'query');
   const pathParams = params.filter((param) => param.type === 'path');
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
   
   const [isBulkEditMode, setIsBulkEditMode] = useState(false);
 
   const handleAddQueryParam = () => {
-    dispatch(
-      addQueryParam({
-        itemUid: item.uid,
-        collectionUid: collection.uid
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addQueryParam, {
+      itemUid: item.uid,
+      collectionUid: collection.uid
+    });
   };
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
@@ -79,7 +79,6 @@ const QueryParams = ({ item, collection }) => {
 
   const handlePathParamChange = (e, data) => {
     let value = e.target.value;
-
     let pathParam = cloneDeep(data);
 
     if (pathParam['value'] === value) {
@@ -164,6 +163,7 @@ const QueryParams = ({ item, collection }) => {
                         spellCheck="false"
                         value={param.name}
                         className="mousetrap"
+                        ref={inputRef(param.uid)}
                         onChange={(e) => handleQueryParamChange(e, param, 'name')}
                       />
                     </td>

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -13,6 +13,7 @@ import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
 import Table from 'components/Table/index';
 import ReorderTable from 'components/ReorderTable/index';
 import BulkEditor from '../../BulkEditor';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
 
 const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
 
@@ -22,14 +23,13 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
   const headers = item.draft ? get(item, 'draft.request.headers') : get(item, 'request.headers');
   
   const [isBulkEditMode, setIsBulkEditMode] = useState(false);
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const addHeader = () => {
-    dispatch(
-      addRequestHeader({
-        itemUid: item.uid,
-        collectionUid: collection.uid
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addRequestHeader, {
+      itemUid: item.uid,
+      collectionUid: collection.uid
+    });
   };
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
@@ -117,6 +117,7 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
                   <tr key={header.uid} data-uid={header.uid}>
                     <td className='flex relative'>
                       <SingleLineEditor
+                        ref={inputRef(header.uid)}
                         value={header.name}
                         theme={storedTheme}
                         onSave={onSave}

--- a/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
@@ -12,19 +12,19 @@ import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
 import Table from 'components/Table/index';
 import ReorderTable from 'components/ReorderTable/index';
+import { useParamAddAutoFocusIntent, addWithAutoFocus } from 'hooks/useParamAddAutoFocusIntent';
 
 const VarsTable = ({ item, collection, vars, varType }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
+  const { uidSetter, inputRef } = useParamAddAutoFocusIntent();
 
   const handleAddVar = () => {
-    dispatch(
-      addVar({
-        type: varType,
-        itemUid: item.uid,
-        collectionUid: collection.uid
-      })
-    );
+    addWithAutoFocus(uidSetter, dispatch, addVar, {
+      collectionUid: collection.uid,
+      itemUid: item.uid,
+      type: varType
+    });
   };
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
@@ -118,6 +118,7 @@ const VarsTable = ({ item, collection, vars, varType }) => {
                         spellCheck="false"
                         value={_var.name}
                         className="mousetrap"
+                        ref={inputRef(_var.uid)}
                         onChange={(e) => handleVarChange(e, _var, 'name')}
                       />
                     </td>

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -24,6 +24,11 @@ class SingleLineEditor extends Component {
     };
   }
 
+  focus = () => {
+    if (!this.editor) return;
+    this.editor.focus();
+  };
+
   componentDidMount() {
     // Initialize CodeMirror as a single line editor
     /** @type {import("codemirror").Editor} */

--- a/packages/bruno-app/src/hooks/useParamAddAutoFocusIntent/index.js
+++ b/packages/bruno-app/src/hooks/useParamAddAutoFocusIntent/index.js
@@ -1,0 +1,23 @@
+import { useState, useCallback } from 'react';
+import { uuid } from 'utils/common';
+
+export function useParamAddAutoFocusIntent() {
+  const [pending, setPending] = useState(null);
+
+  const uidSetter = useCallback((id) => setPending(id), []);
+  const inputRef = useCallback((id) => (el) => {
+    if (!el) return;
+    if (pending !== id) return;
+    el.focus();
+    setPending(null);
+  },
+  [pending]);
+
+  return { uidSetter, inputRef };
+}
+
+export function addWithAutoFocus(uidSetter, dispatch, actionMethod, payload) {
+  const uid = uuid();
+  uidSetter(uid);
+  dispatch(actionMethod({ ...payload, paramUid: uid }));
+}

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -849,9 +849,10 @@ export const collectionsSlice = createSlice({
           if (!item.draft) {
             item.draft = cloneDeep(item);
           }
+
           item.draft.request.params = item.draft.request.params || [];
           item.draft.request.params.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             name: '',
             value: '',
             description: '',
@@ -1043,7 +1044,7 @@ export const collectionsSlice = createSlice({
           }
           item.draft.request.headers = item.draft.request.headers || [];
           item.draft.request.headers.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             name: '',
             value: '',
             description: '',
@@ -1181,7 +1182,7 @@ export const collectionsSlice = createSlice({
           }
           item.draft.request.body.formUrlEncoded = item.draft.request.body.formUrlEncoded || [];
           item.draft.request.body.formUrlEncoded.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             name: '',
             value: '',
             description: '',
@@ -1261,7 +1262,7 @@ export const collectionsSlice = createSlice({
           }
           item.draft.request.body.multipartForm = item.draft.request.body.multipartForm || [];
           item.draft.request.body.multipartForm.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             type: action.payload.type,
             name: '',
             value: action.payload.value,
@@ -1601,7 +1602,7 @@ export const collectionsSlice = createSlice({
           }
           item.draft.request.assertions = item.draft.request.assertions || [];
           item.draft.request.assertions.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             name: '',
             value: '',
             enabled: true
@@ -1681,7 +1682,7 @@ export const collectionsSlice = createSlice({
             item.draft.request.vars = item.draft.request.vars || {};
             item.draft.request.vars.req = item.draft.request.vars.req || [];
             item.draft.request.vars.req.push({
-              uid: uuid(),
+              uid: action.payload.paramUid ?? uuid(),
               name: '',
               value: '',
               local: false,
@@ -1691,7 +1692,7 @@ export const collectionsSlice = createSlice({
             item.draft.request.vars = item.draft.request.vars || {};
             item.draft.request.vars.res = item.draft.request.vars.res || [];
             item.draft.request.vars.res.push({
-              uid: uuid(),
+              uid: action.payload.paramUid ?? uuid(),
               name: '',
               value: '',
               local: false,
@@ -1867,7 +1868,7 @@ export const collectionsSlice = createSlice({
       if (folder) {
         const headers = get(folder, 'root.request.headers', []);
         headers.push({
-          uid: uuid(),
+          uid: action.payload.paramUid ?? uuid(),
           name: '',
           value: '',
           description: '',
@@ -1907,7 +1908,7 @@ export const collectionsSlice = createSlice({
         if (type === 'request') {
           const vars = get(folder, 'root.request.vars.req', []);
           vars.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             name: '',
             value: '',
             enabled: true
@@ -1916,7 +1917,7 @@ export const collectionsSlice = createSlice({
         } else if (type === 'response') {
           const vars = get(folder, 'root.request.vars.res', []);
           vars.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             name: '',
             value: '',
             enabled: true
@@ -2037,7 +2038,7 @@ export const collectionsSlice = createSlice({
       if (collection) {
         const headers = get(collection, 'root.request.headers', []);
         headers.push({
-          uid: uuid(),
+          uid: action.payload.paramUid ?? uuid(),
           name: '',
           value: '',
           description: '',
@@ -2076,7 +2077,7 @@ export const collectionsSlice = createSlice({
         if (type === 'request') {
           const vars = get(collection, 'root.request.vars.req', []);
           vars.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             name: '',
             value: '',
             enabled: true
@@ -2085,7 +2086,7 @@ export const collectionsSlice = createSlice({
         } else if (type === 'response') {
           const vars = get(collection, 'root.request.vars.res', []);
           vars.push({
-            uid: uuid(),
+            uid: action.payload.paramUid ?? uuid(),
             name: '',
             value: '',
             enabled: true


### PR DESCRIPTION
# Description
This feature aims to improve the UX of adding new variables/params/headers by focusing on the newly added key input field, so that the user doesn't have to take another couple of steps (move the mouse, click on the field; get annoying pretty fast when you are working with multiple fields, multiple times) to working on the new field.

https://github.com/user-attachments/assets/f1351535-68bc-4c4e-9def-e38630029221

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (already existing ticket)

