### PR TITLE
fix: Add overflow-x-auto to new request URL container

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -496,7 +496,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                         />
                       </div>
                     ) : null}
-                    <div id="new-request-url" className="flex px-2 items-center flex-grow input-container h-full">
+                    <div id="new-request-url" className="flex px-2 items-center flex-grow input-container h-full overflow-x-auto">
                       <SingleLineEditor
                         onPaste={handlePaste}
                         placeholder="Request URL"


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

When large request URL is pasted, the input overflows and bottom scroll bar appears. This pull request aims to fix the issue.

Before:
<img width="1195" height="476" alt="image" src="https://github.com/user-attachments/assets/253e9b6f-997e-44a5-9b88-a5fe9e6c9f3b" />

After:
<img width="970" height="485" alt="image" src="https://github.com/user-attachments/assets/d8960903-efb5-477a-bef6-10206d65c65f" />

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
