### PR TITLE
feat: Add ability to resize path parameters table

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -221,8 +221,8 @@ const QueryParams = ({ item, collection }) => {
         </div>
         <Table
           headers={[
-            { name: 'Name', accessor: 'name' },
-            { name: 'Value', accessor: 'value' }
+            { name: 'Name', accessor: 'name', width: '31%' },
+            { name: 'Value', accessor: 'value', width: '56%' }
           ]}
         >
           <tbody>


### PR DESCRIPTION
# Description

You can resize the query parameters table because it uses the Table component. But the path parameters table is a normal table. I think they should be the same.

Resolves #5949

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
