### PR TITLE
fix:5951-multipart-form-block-string

### DIFF
--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -1,6 +1,83 @@
 const stringify = require('../src/jsonToBru');
+const parse = require('../src/bruToJson');
 
 describe('jsonToBru stringify', () => {
+  describe('body:multipart-form', () => {
+    it('handles block strings with contentType annotation', () => {
+      const input = {
+        http: {
+          method: 'post',
+          url: 'https://api.example.com/upload'
+        },
+        body: {
+          mode: 'multipartForm',
+          multipartForm: [
+            {
+              name: 'json',
+              value: '{\n  "name": "Bob"\n}',
+              type: 'text',
+              enabled: true,
+              contentType: 'application/json'
+            },
+            {
+              name: 'simple',
+              value: 'text value',
+              type: 'text',
+              enabled: true,
+              contentType: 'text/plain'
+            }
+          ]
+        }
+      };
+
+      const output = stringify(input);
+
+      // Verify the output contains properly formatted block strings
+      expect(output).toContain('body:multipart-form {');
+      expect(output).toContain('json: \'\'\'');
+      expect(output).toContain('@contentType(application/json)');
+      expect(output).toContain('simple: text value @contentType(text/plain)');
+
+      // Most importantly: verify round-trip parsing works
+      const parsed = parse(output);
+      expect(parsed.body.multipartForm).toHaveLength(2);
+      expect(parsed.body.multipartForm[0].name).toBe('json');
+      expect(parsed.body.multipartForm[0].value).toBe('{\n  "name": "Bob"\n}');
+      expect(parsed.body.multipartForm[0].contentType).toBe('application/json');
+      expect(parsed.body.multipartForm[1].name).toBe('simple');
+      expect(parsed.body.multipartForm[1].value).toBe('text value');
+      expect(parsed.body.multipartForm[1].contentType).toBe('text/plain');
+    });
+
+    it('handles block strings without contentType annotation', () => {
+      const input = {
+        http: {
+          method: 'post',
+          url: 'https://api.example.com/upload'
+        },
+        body: {
+          mode: 'multipartForm',
+          multipartForm: [
+            {
+              name: 'data',
+              value: 'line1\nline2\nline3',
+              type: 'text',
+              enabled: true,
+              contentType: ''
+            }
+          ]
+        }
+      };
+
+      const output = stringify(input);
+
+      // Verify round-trip parsing works
+      const parsed = parse(output);
+      expect(parsed.body.multipartForm).toHaveLength(1);
+      expect(parsed.body.multipartForm[0].value).toBe('line1\nline2\nline3');
+    });
+  });
+
   describe('body:ws', () => {
     it('stringifies a valid bruno request | smoke', () => {
       const input = {


### PR DESCRIPTION
<h1 data-start="94" data-end="194">Fix: Multipart Form Fields with Triple-Quoted Block Strings and <code data-start="160" data-end="174">@contentType</code> Persist Correctly</h1>
<p data-start="196" data-end="214"><strong data-start="196" data-end="206">Fixes:</strong> #5951</p>
<hr data-start="216" data-end="219">
<h2 data-start="221" data-end="233">Problem</h2>
<p data-start="235" data-end="434">When users created multipart form fields using block strings (triple quotes <code data-start="311" data-end="322">'''...'''</code>) along with <code data-start="335" data-end="349">@contentType</code> annotations, the field would disappear after saving and reopening the <code data-start="420" data-end="426">.bru</code> file.</p>
<h3 data-start="436" data-end="453">Root Causes</h3>
<ol data-start="454" data-end="662">
<li data-start="454" data-end="538">
<p data-start="457" data-end="538">The parser grammar did not allow text after the closing <code data-start="513" data-end="518">'''</code> on the same line.</p>
</li>
<li data-start="539" data-end="662">
<p data-start="542" data-end="662">The <code data-start="546" data-end="560">@contentType</code> extraction regex lacked the <code data-start="589" data-end="593">/s</code> (dotall) flag, which prevented it from matching multiline content.</p>
</li>
</ol>
<hr data-start="664" data-end="667">
<h2 data-start="669" data-end="681">Example</h2>
<h3 data-start="683" data-end="723">Before (Data Lost After Save/Reload)</h3>
<pre class="overflow-visible!" data-start="724" data-end="856"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-bru"><span>body:multipart-form {
  json: '''
    {
      "name": "Bob",
      "age": 30
    }
  ''' @contentType(application/json)
}
</span></code></div></div></pre>
<h3 data-start="858" data-end="896">After This Fix (Works as Expected)</h3>
<ul data-start="897" data-end="1067">
<li data-start="897" data-end="953">
<p data-start="899" data-end="953">Field persists correctly through save/reload cycles.</p>
</li>
<li data-start="954" data-end="1017">
<p data-start="956" data-end="1017"><code data-start="956" data-end="970">@contentType</code> is properly extracted as <code data-start="996" data-end="1014">application/json</code>.</p>
</li>
<li data-start="1018" data-end="1067">
<p data-start="1020" data-end="1067">JSON content is preserved exactly as entered.</p>
</li>
</ul>
<hr data-start="1069" data-end="1072">
<h2 data-start="1074" data-end="1087">Solution</h2>
<h3 data-start="1089" data-end="1117">1. Grammar Enhancement</h3>
<p data-start="1118" data-end="1171"><strong data-start="1118" data-end="1127">File:</strong> <code data-start="1128" data-end="1169">packages/bruno-lang/v2/src/bruToJson.js</code></p>
<ul data-start="1172" data-end="1341">
<li data-start="1172" data-end="1283">
<p data-start="1174" data-end="1224">Added a new rule: <code data-start="1192" data-end="1222">multilinetextblockwithsuffix</code></p>
<ul data-start="1227" data-end="1283">
<li data-start="1227" data-end="1283">
<p data-start="1229" data-end="1283">Allows text after the closing triple quotes (<code data-start="1274" data-end="1279">'''</code>).</p>
</li>
</ul>
</li>
<li data-start="1284" data-end="1341">
<p data-start="1286" data-end="1341">Updated the <code data-start="1298" data-end="1305">value</code> rule to use the new grammar rule.</p>
</li>
</ul>
<h3 data-start="1343" data-end="1374">2. Semantic Action Update</h3>
<ul data-start="1375" data-end="1505">
<li data-start="1375" data-end="1422">
<p data-start="1377" data-end="1422">Added logic to handle the new grammar rule.</p>
</li>
<li data-start="1423" data-end="1505">
<p data-start="1425" data-end="1505">Ensures block strings with suffix annotations are parsed and stored correctly.</p>
</li>
</ul>
<h3 data-start="1507" data-end="1527">3. Regex Fixes</h3>
<p data-start="1528" data-end="1581"><strong data-start="1528" data-end="1537">File:</strong> <code data-start="1538" data-end="1579">packages/bruno-lang/v2/src/bruToJson.js</code></p>
<ul data-start="1582" data-end="1807">
<li data-start="1582" data-end="1723">
<p data-start="1584" data-end="1630">Added <code data-start="1590" data-end="1594">/s</code> (dotall) flag to regex functions:</p>
<ul data-start="1633" data-end="1723">
<li data-start="1633" data-end="1679">
<p data-start="1635" data-end="1679"><code data-start="1635" data-end="1666">multipartExtractContentType()</code> (line 216)</p>
</li>
<li data-start="1682" data-end="1723">
<p data-start="1684" data-end="1723"><code data-start="1684" data-end="1710">fileExtractContentType()</code> (line 229)</p>
</li>
</ul>
</li>
<li data-start="1724" data-end="1807">
<p data-start="1726" data-end="1807">Enables regex to match multiline patterns where the value spans multiple lines.</p>
</li>
</ul>
<hr data-start="1809" data-end="1812">
<h2 data-start="1814" data-end="1826">Testing</h2>
<p data-start="1828" data-end="1915"><strong data-start="1828" data-end="1852">New Test Cases Added</strong><br data-start="1852" data-end="1855">
<strong data-start="1855" data-end="1864">File:</strong> <code data-start="1865" data-end="1913">packages/bruno-lang/v2/tests/jsonToBru.spec.js</code></p>
<ul data-start="1916" data-end="2030">
<li data-start="1916" data-end="1971">
<p data-start="1918" data-end="1971"><code data-start="1918" data-end="1969">handles block strings with contentType annotation</code></p>
</li>
<li data-start="1972" data-end="2030">
<p data-start="1974" data-end="2030"><code data-start="1974" data-end="2028">handles block strings without contentType annotation</code></p>
</li>
</ul>
<p data-start="2032" data-end="2051"><strong data-start="2032" data-end="2049">Test Coverage</strong></p>
<ul data-start="2052" data-end="2169">
<li data-start="2052" data-end="2117">
<p data-start="2054" data-end="2117">Verified round-trip parsing (<code data-start="2083" data-end="2113">serialize → parse → validate</code>).</p>
</li>
<li data-start="2118" data-end="2169">
<p data-start="2120" data-end="2169">Ensured no data loss or formatting differences.</p>
</li>
</ul>
<p data-start="2171" data-end="2185"><strong data-start="2171" data-end="2183">Results:</strong></p>
<pre class="overflow-visible!" data-start="2186" data-end="2525"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre!"><span><span>PASS v2/tests/jsonToBru.spec.js
  jsonToBru stringify
    body:multipart-form
      ✓ </span><span><span class="hljs-keyword">handles</span></span><span> block strings </span><span><span class="hljs-keyword">with</span></span><span> contentType annotation
      ✓ </span><span><span class="hljs-keyword">handles</span></span><span> block strings without contentType annotation
    body:ws
      ✓ stringifies a valid bruno request | smoke

Test Suites: </span><span><span class="hljs-number">28</span></span><span> passed, </span><span><span class="hljs-number">28</span></span><span> total  
</span><span><span class="hljs-symbol">Tests:</span></span><span>       </span><span><span class="hljs-number">169</span></span><span> passed, </span><span><span class="hljs-number">169</span></span><span> total  
</span></span></code></div></div></pre>
<p data-start="2527" data-end="2550"><strong data-start="2527" data-end="2548">Additional Checks</strong></p>
<ul data-start="2551" data-end="2660">
<li data-start="2551" data-end="2579">
<p data-start="2553" data-end="2579">All existing tests pass.</p>
</li>
<li data-start="2580" data-end="2628">
<p data-start="2582" data-end="2628">ESLint compliant (project style maintained).</p>
</li>
<li data-start="2629" data-end="2660">
<p data-start="2631" data-end="2660">No performance degradation.</p>
</li>
</ul>
<hr data-start="2662" data-end="2665">
<h2 data-start="2667" data-end="2678">Impact</h2>
<div class="_tableContainer_1rjym_1"><div tabindex="-1" class="group _tableWrapper_1rjym_13 flex w-fit flex-col-reverse">
Category | Impact
-- | --
User Impact | Prevents data loss in multipart form fields with block strings and annotations.
Backward Compatibility | Fully backward compatible.
File Format | No changes needed for existing .bru files.
Performance | No measurable performance impact.

</div></div>
<hr data-start="2996" data-end="2999">
<h2 data-start="3001" data-end="3028">Contribution Checklist</h2>
<ul class="contains-task-list" data-start="3030" data-end="3303">
<li class="task-list-item" data-start="3030" data-end="3071">
<p data-start="3036" data-end="3071"><input disabled="" type="checkbox" checked=""> Addresses a single issue (#5951).</p>
</li>
<li data-start="3072" data-end="3111" class="task-list-item">
<p data-start="3078" data-end="3111"><input disabled="" type="checkbox" checked=""> No breaking changes introduced.</p>
</li>
<li class="task-list-item" data-start="3112" data-end="3165">
<p data-start="3118" data-end="3165"><input disabled="" type="checkbox" checked=""> Internal parser fix — no UI changes required.</p>
</li>
<li data-start="3166" data-end="3199" class="task-list-item">
<p data-start="3172" data-end="3199"><input disabled="" type="checkbox" checked=""> Tests added and verified.</p>
</li>
<li data-start="3200" data-end="3303" class="task-list-item">
<p data-start="3206" data-end="3303"><input disabled="" type="checkbox" checked=""> Follows <a data-start="3214" data-end="3300" class="decorated-link" rel="noopener" target="_new" href="https://github.com/usebruno/bruno/blob/main/contributing.md">contribution guidelines<span aria-hidden="true" class="ms-0.5 inline-block align-middle leading-none"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" data-rtl-flip="" class="block h-[0.75em] w-[0.75em] stroke-current stroke-[0.75]"><path d="M14.3349 13.3301V6.60645L5.47065 15.4707C5.21095 15.7304 4.78895 15.7304 4.52925 15.4707C4.26955 15.211 4.26955 14.789 4.52925 14.5293L13.3935 5.66504H6.66011C6.29284 5.66504 5.99507 5.36727 5.99507 5C5.99507 4.63273 6.29284 4.33496 6.66011 4.33496H14.9999L15.1337 4.34863C15.4369 4.41057 15.665 4.67857 15.665 5V13.3301C15.6649 13.6973 15.3672 13.9951 14.9999 13.9951C14.6327 13.9951 14.335 13.6973 14.3349 13.3301Z"></path></svg></span></a>.</p></li></ul>