### PR TITLE
fix: restore text selection and copy in read-only CodeEditor - Issue #5982

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -2,12 +2,6 @@ import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
   &.read-only {
-    div.CodeMirror .CodeMirror-lines {
-      user-select: none !important;
-      -webkit-user-select: none !important;
-      -ms-user-select: none !important;
-    }
-
     div.CodeMirror .CodeMirror-cursor {
       display: none !important;
     }

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -63,7 +63,7 @@ export default class CodeEditor extends React.Component {
       foldGutter: true,
       gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter', 'CodeMirror-lint-markers'],
       lint: this.lintOptions,
-      readOnly: this.props.readOnly ? 'nocursor' : false,
+      readOnly: !!this.props.readOnly,
       scrollbarStyle: 'overlay',
       theme: this.props.theme === 'dark' ? 'monokai' : 'default',
       extraKeys: {
@@ -246,7 +246,7 @@ export default class CodeEditor extends React.Component {
     }
 
     if (this.props.readOnly !== prevProps.readOnly && this.editor) {
-      this.editor.setOption('readOnly', this.props.readOnly ? 'nocursor' : false);
+      this.editor.setOption('readOnly', !!this.props.readOnly);
     }
 
     this.ignoreChangeEvent = false;


### PR DESCRIPTION
# Description

Changed CodeMirror readOnly option from 'nocursor' to boolean true to allow text selection while maintaining read-only behavior. Removed CSS rules that prevented text selection (user-select: none) in read-only mode.

This restores the ability to copy text from the Response panel using Ctrl+C or right-click context menu, which was broken in nightly builds after v2.13.2.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] Solve Issue https://github.com/usebruno/bruno/issues/5982


