### PR TITLE
Fix: The Generate Code feature shows "error generating code snippet" message when no environment is selected.

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -2,6 +2,7 @@ import { buildHarRequest } from 'utils/codegenerator/har';
 import { getAuthHeaders } from 'utils/codegenerator/auth';
 import { getAllVariables, getTreePathFromCollectionToItem } from 'utils/collections/index';
 import { interpolateHeaders, interpolateBody } from './interpolation';
+import { fullyDecodeURI } from 'utils/url/index';
 
 // Merge headers from collection, folders, and request
 const mergeHeaders = (collection, request, requestTreePath) => {
@@ -68,6 +69,7 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
         request.body = interpolateBody(request.body, variables);
       }
     }
+    request.url = encodeURI(fullyDecodeURI(request.url))
 
     // Build HAR request
     const harRequest = buildHarRequest({

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -156,3 +156,16 @@ export const interpolateUrlPathParams = (url, params) => {
 
   return `${uri.origin}${basePath}${uri?.search || ''}`;
 };
+
+function isEncodedURI(uri) {
+  uri = uri || '';
+  return uri !== decodeURIComponent(uri);
+}
+
+export function fullyDecodeURI(uri) {
+  while (isEncodedURI(uri)) {
+    uri = decodeURIComponent(uri);
+  }
+
+  return uri;
+}


### PR DESCRIPTION
The current fix decodes the URL until no encoding exists (this is to prevent any prior multiple encodings) and encodes the URL one time.
Ticket: https://usebruno.atlassian.net/browse/BRU-2095

# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
