### PR TITLE
feat: add stop request button in api url bar

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -5,7 +5,7 @@ import { requestUrlChanged, updateRequestMethod } from 'providers/ReduxStore/sli
 import { cancelRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import HttpMethodSelector from './HttpMethodSelector';
 import { useTheme } from 'providers/Theme';
-import { IconDeviceFloppy, IconArrowRight, IconCode, IconPlayerStop } from '@tabler/icons';
+import { IconDeviceFloppy, IconArrowRight, IconCode, IconSquareRoundedX } from '@tabler/icons';
 import SingleLineEditor from 'components/SingleLineEditor';
 import { isMacOS } from 'utils/common/platform';
 import { hasRequestChanges } from 'utils/collections';
@@ -156,7 +156,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
           </div>
 
           {isLoading ? (
-            <IconPlayerStop
+            <IconSquareRoundedX
               color={theme.requestTabPanel.url.icon}
               strokeWidth={1.5}
               size={22}


### PR DESCRIPTION
# Description

This PR introduces the following changes to fix issue (#5971):

- Adds a Stop Request button in the URL bar

Refer to the attached recording below on how this new feature behaves. 

https://github.com/user-attachments/assets/db620268-db14-476b-b46a-ee9069372432


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
