### PR TITLE
fix: ensure protocolVersion is a number in WebSocket options

### DIFF
--- a/packages/bruno-requests/src/ws/ws-client.js
+++ b/packages/bruno-requests/src/ws/ws-client.js
@@ -67,7 +67,11 @@ class WsClient {
       };
 
       if (protocolVersion) {
-        wsOptions.protocolVersion = protocolVersion;
+        // Force convert to number since `ws` doesn't do it for you
+        const asNumber = Number(protocolVersion);
+        if (!isNaN(asNumber)) {
+          wsOptions.protocolVersion = asNumber;
+        }
       }
 
       const wsConnection = new ws.WebSocket(parsedUrl.fullUrl, protocols, wsOptions);

--- a/tests/websockets/fixtures/collection/ws-test-request-with-subproto.bru
+++ b/tests/websockets/fixtures/collection/ws-test-request-with-subproto.bru
@@ -13,6 +13,7 @@ ws {
 headers {
   Sec-WebSocket-Protocol: soap
   Sec-WebSocket-Protocol: mqtt
+  Sec-WebSocket-Version: 13
 }
 
 body:ws {


### PR DESCRIPTION
# Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2118)

Force convert the protocol version since `ws` doesn't convert a stringified  representation of the `protocolVersion`

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
