### PR TITLE
Setting default param value if specified on openapi schema

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -186,7 +186,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set()) => {
       brunoRequestItem.request.params.push({
         uid: uuid(),
         name: param.name,
-        value: '',
+        value: param?.schema?.default != null ? param?.schema?.default : '',
         description: param.description || '',
         enabled: param.required,
         type: 'query'
@@ -195,7 +195,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set()) => {
       brunoRequestItem.request.params.push({
         uid: uuid(),
         name: param.name,
-        value: '',
+        value: param?.schema?.default != null ? param?.schema?.default : '',
         description: param.description || '',
         enabled: param.required,
         type: 'path'
@@ -204,7 +204,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set()) => {
       brunoRequestItem.request.headers.push({
         uid: uuid(),
         name: param.name,
-        value: '',
+        value: param?.schema?.default != null ? param?.schema?.default : '',
         description: param.description || '',
         enabled: param.required
       });

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-to-bruno.spec.js
@@ -116,6 +116,85 @@ servers:
     expect(result.name).toBe('Untitled Collection');
   });
 
+  it('should set default value on a query param if specified', () => {
+    const openApiWithDefaultParamValues = `
+openapi: '3.0.0'
+paths:
+  /get:
+    get:
+      summary: 'Request'
+      operationId: 'getRequest'
+      parameters:
+        - name: status
+          in: query
+          description: Status values
+          schema:
+            type: string
+            default: value2
+            enum:
+              - value1
+              - value2
+              - value3
+      responses:
+        '200':
+          description: 'OK'
+servers:
+  - url: 'https://example.com'
+`;
+    const result = openApiToBruno(openApiWithDefaultParamValues);
+    expect(result.items[0].request.params[0].value).toBe('value2');
+  });
+
+  it('should set default value on a header param if specified', () => {
+    const openApiWithDefaultParamValues = `
+openapi: '3.0.0'
+paths:
+  /get:
+    get:
+      summary: 'Request'
+      operationId: 'getRequest'
+      parameters:
+        - name: header1
+          in: header
+          description: header1
+          schema:
+            type: string
+            default: my-test-value
+      responses:
+        '200':
+          description: 'OK'
+servers:
+  - url: 'https://example.com'
+`;
+    const result = openApiToBruno(openApiWithDefaultParamValues);
+    expect(result.items[0].request.headers[0].value).toBe('my-test-value');
+  });
+
+  it('should set default value on a path param if specified', () => {
+    const openApiWithDefaultParamValues = `
+openapi: '3.0.0'
+paths:
+  /get:
+    get:
+      summary: 'Request'
+      operationId: 'getRequest'
+      parameters:
+        - name: path1
+          in: path
+          description: path1
+          schema:
+            type: integer
+            default: '123'
+      responses:
+        '200':
+          description: 'OK'
+servers:
+  - url: 'https://example.com'
+`;
+    const result = openApiToBruno(openApiWithDefaultParamValues);
+    expect(result.items[0].request.params[0].value).toBe('123');
+  });
+
   describe('authentication inheritance', () => {
     it('should set auth mode to inherit when no security is defined', () => {
       const openApiWithoutSecurity = `


### PR DESCRIPTION
fixes: #5866 

# Description

This is a fix to [issue-5866](https://github.com/usebruno/bruno/issues/5866).
As described in the issue: "When importing an OpenAPI 3.0 specification ..., Bruno does not import or prefill default parameter values defined in the schema."
After checking out the code, what I found was that in the method transformOpenapiRequestItem, from openapi-to-bruno.js, when it is creating the request.params array of parameters, it always set the value to ''.
<img width="622" height="418" alt="image" src="https://github.com/user-attachments/assets/c47dda1a-635a-4540-b418-d3df9f0a1cda" />

So I simply added the default value if it is set. Like so:
<img width="715" height="403" alt="Captura de tela de 2025-11-06 17-03-54" src="https://github.com/user-attachments/assets/525bf1c2-baf5-43ba-a5ce-c0c6a02f4c51" />

I also added tests for the cases.

The only thing I am wondering is if it really makes sense to expect default values for parameters in the path or in the headers, since it is not mentioned in the [documentation](https://swagger.io/docs/specification/v3_0/describing-parameters/), session "Default Parameter Values".

Besides that, I also found out that bruno throws a Invalid Schema error if I try to set a default integer parameter withou quotes, like this:

parameters:
        - name: path1
          in: path
          description: path1
          schema:
            type: integer
            default: 123

<img width="681" height="205" alt="Captura de tela de 2025-11-06 17-11-13" src="https://github.com/user-attachments/assets/d063292d-d929-49f8-9e1b-c036121355cd" />

Is this behavior correct, or should I raise an issue for it too? Because the example shown in the same documentation I've linked earlier has an integer parameter without quotes.


### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
