### PR TITLE
feat: apply modified dataBuffer to the response

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -942,21 +942,6 @@ const registerNetworkIpc = (mainWindow) => {
         await runPostScripts();
       }
 
-      // Regenerate dataBuffer from response.data only if res.setBody() was called
-      // This ensures dataBuffer matches the potentially modified response.data from res.setBody()
-      let finalDataBuffer;
-      if (response._setBodyCalled) {
-        if (response.data === null || response.data === undefined) {
-          finalDataBuffer = Buffer.from('');
-        } else if (typeof response.data === 'string') {
-          finalDataBuffer = Buffer.from(response.data);
-        } else {
-          finalDataBuffer = Buffer.from(safeStringifyJSON(response.data) || '');
-        }
-      } else {
-        finalDataBuffer = response.dataBuffer;
-      }
-
       return {
         status: response.status,
         statusText: response.statusText,
@@ -964,8 +949,8 @@ const registerNetworkIpc = (mainWindow) => {
         data: response.data,
         stream: isResponseStream ? axiosDataStream : null,
         cancelTokenUid: cancelTokenUid,
-        dataBuffer: finalDataBuffer.toString('base64'),
-        size: Buffer.byteLength(finalDataBuffer),
+        dataBuffer: response.dataBuffer.toString('base64'),
+        size: Buffer.byteLength(response.dataBuffer),
         duration: responseTime ?? 0,
         url: response.request ? response.request.protocol + '//' + response.request.host + response.request.path : null,
         timeline: response.timeline

--- a/packages/bruno-js/src/bruno-response.js
+++ b/packages/bruno-js/src/bruno-response.js
@@ -55,7 +55,20 @@ class BrunoResponse {
     const clonedData = _.cloneDeep(data);
     this.res.data = clonedData;
     this.body = clonedData;
-    this.res._setBodyCalled = true;
+
+    // Update dataBuffer to match the modified body
+    if (clonedData === null || clonedData === undefined) {
+      this.res.dataBuffer = Buffer.from('');
+    } else if (typeof clonedData === 'string') {
+      this.res.dataBuffer = Buffer.from(clonedData);
+    } else {
+      // For objects, stringify them
+      try {
+        this.res.dataBuffer = Buffer.from(JSON.stringify(clonedData));
+      } catch (e) {
+        this.res.dataBuffer = Buffer.from('');
+      }
+    }
   }
 
   // TODO: Refactor: dataBuffer size calculation should be handled in a shared utility so it can be passed and reused across the application


### PR DESCRIPTION
fixes: #6003, #6133

# Description

This PR implements a feature that applies the `dataBuffer` to the final return, ensuring that the response edited with `res.setBody` is actually set in the response

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:
<img width="2426" height="1058" alt="image" src="https://github.com/user-attachments/assets/00f6e1d0-4e13-4e20-b5c6-d01d8a3c56e4" />


After:
<img width="2404" height="996" alt="image" src="https://github.com/user-attachments/assets/3d50324b-814f-4cde-b1a4-3337f50c3bfe" />
