### PR TITLE
feat: enhance OpenAPI example extraction to support all example formats

### DIFF
--- a/packages/bruno-converters/tests/openapi/openapi-with-examples.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-with-examples.spec.js
@@ -53,7 +53,7 @@ describe('OpenAPI with Examples', () => {
     const createUserRequest = brunoCollection.items.find((item) => item.name === 'Create a new user');
     expect(createUserRequest).toBeDefined();
     expect(createUserRequest.examples).toBeDefined();
-    expect(createUserRequest.examples).toHaveLength(2);
+    expect(createUserRequest.examples).toHaveLength(4); // 2 response + 2 request body examples
 
     // Check response examples
     const createdExample = createUserRequest.examples.find((ex) => ex.name === 'User Created');
@@ -65,6 +65,25 @@ describe('OpenAPI with Examples', () => {
       name: 'John Doe',
       email: 'john@example.com',
       created_at: '2023-01-01T00:00:00Z'
+    });
+
+    // Check request body examples
+    const validUserExample = createUserRequest.examples.find((ex) => ex.name === 'Valid User');
+    expect(validUserExample).toBeDefined();
+    expect(validUserExample.request).toBeDefined();
+    expect(validUserExample.request.body.mode).toBe('json');
+    expect(JSON.parse(validUserExample.request.body.json)).toEqual({
+      name: 'John Doe',
+      email: 'john@example.com'
+    });
+
+    const invalidUserExample = createUserRequest.examples.find((ex) => ex.name === 'Invalid User');
+    expect(invalidUserExample).toBeDefined();
+    expect(invalidUserExample.request).toBeDefined();
+    expect(invalidUserExample.request.body.mode).toBe('json');
+    expect(JSON.parse(invalidUserExample.request.body.json)).toEqual({
+      name: '',
+      email: 'invalid-email'
     });
   });
 


### PR DESCRIPTION
# Description

- Add support for content.example (singular) in responses
- Add support for schema.example in responses
- Add support for property-level examples in schemas
- Add support for array item examples
- Add request body example extraction (examples, example, schema.example, property-level)
- Implement priority ordering: examples > example > schema.example > property examples
- Add getBodyModeFromContentType helper for request body examples
- Update tests to verify request body example extraction

This makes the OpenAPI importer much more robust and able to extract examples regardless of how they are defined in the OpenAPI specification.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
