### PR TITLE
Feature/set map support for logging

### DIFF
--- a/packages/bruno-js/src/sandbox/node-vm/console.js
+++ b/packages/bruno-js/src/sandbox/node-vm/console.js
@@ -1,0 +1,102 @@
+/**
+ * Gets the type tag of a value using Object.prototype.toString
+ * This works across VM context boundaries unlike instanceof
+ * @param {*} value - The value to check
+ * @returns {string} The type tag (e.g., 'Set', 'Map', 'Array', 'Object')
+ */
+function getTypeTag(value) {
+  return Object.prototype.toString.call(value).slice(8, -1);
+}
+
+/**
+ * Transforms a value, converting Set and Map to a special format for display
+ * Uses Object.prototype.toString for cross-context type detection
+ * @param {*} value - The value to transform
+ * @param {WeakSet} seen - Set of already visited objects for circular ref detection
+ * @returns {*} Transformed value with Set/Map converted to __brunoType format
+ */
+function transformValue(value, seen = new WeakSet()) {
+  // Return primitives as-is
+  if (value === null || value === undefined || typeof value !== 'object' && typeof value !== 'function') {
+    return value;
+  }
+
+  // Circular reference check for objects
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+  }
+
+  const typeTag = getTypeTag(value);
+
+  if (typeTag === 'Set') {
+    return {
+      __brunoType: 'Set',
+      __brunoValue: Array.from(value).map((item) => transformValue(item, seen))
+    };
+  }
+
+  if (typeTag === 'Map') {
+    return {
+      __brunoType: 'Map',
+      __brunoValue: Array.from(value.entries()).map(([k, v]) => [
+        transformValue(k, seen),
+        transformValue(v, seen)
+      ])
+    };
+  }
+
+  if (typeTag === 'Array') {
+    return value.map((item) => transformValue(item, seen));
+  }
+
+  if (typeTag === 'Object') {
+    const transformed = {};
+    for (const [key, val] of Object.entries(value)) {
+      transformed[key] = transformValue(val, seen);
+    }
+    return transformed;
+  }
+
+  // Handle functions - show clean wrapper
+  if (typeTag === 'Function' || typeof value === 'function') {
+    const name = value.name || 'anonymous';
+    return `function ${name}() {\n    [native code]\n}`;
+  }
+
+  // Handle other built-in types (Date, RegExp, Error, etc.) - convert to string representation
+  try {
+    return value?.toString?.() ?? String(value);
+  } catch {
+    return `[${typeTag}]`;
+  }
+}
+
+/**
+ * Wraps a console object to add Set/Map support for logging
+ * @param {Object} originalConsole - The original console object
+ * @returns {Object} Wrapped console with Set/Map transformation
+ */
+function wrapConsoleWithSerializers(originalConsole) {
+  if (!originalConsole) return originalConsole;
+
+  const methodsToWrap = ['log', 'debug', 'info', 'warn', 'error'];
+  const wrappedConsole = { ...originalConsole };
+
+  for (const method of methodsToWrap) {
+    if (typeof originalConsole[method] === 'function') {
+      wrappedConsole[method] = (...args) => {
+        const transformedArgs = args.map((arg) => transformValue(arg));
+        originalConsole[method](...transformedArgs);
+      };
+    }
+  }
+
+  return wrappedConsole;
+}
+
+module.exports = {
+  wrapConsoleWithSerializers
+};

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -4,6 +4,7 @@ const path = require('node:path');
 const { get } = require('lodash');
 const lodash = require('lodash');
 const { mixinTypedArrays } = require('../mixins/typed-arrays');
+const { wrapConsoleWithSerializers } = require('./console');
 
 class ScriptError extends Error {
   constructor(error, script) {
@@ -47,8 +48,8 @@ async function runScriptInNodeVm({
 
     // Create script context with all necessary variables
     const scriptContext = {
-      // Bruno context
-      console: context.console,
+      // Bruno context (wrap console with Set/Map support)
+      console: wrapConsoleWithSerializers(context.console),
       req: context.req,
       res: context.res,
       bru: context.bru,

--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -164,54 +164,6 @@ const executeQuickJsVmAsync = async ({ script: externalScript, context: external
           fn.apply();
         }
 
-        // Override console.log to handle Sets and Maps properly
-        const originalConsoleLog = console.log;
-        console.log = function(...args) {
-          const processedArgs = args.map(arg => {
-            if (arg instanceof Set) {
-              return {
-                __brunoType: 'Set',
-                __brunoValue: Array.from(arg),
-                size: arg.size
-              };
-            }
-            if (arg instanceof Map) {
-              return {
-                __brunoType: 'Map',
-                __brunoValue: Array.from(arg.entries()),
-                size: arg.size
-              };
-            }
-            return arg;
-          });
-          return originalConsoleLog.apply(this, processedArgs);
-        };
-
-        // Also override other console methods
-        ['debug', 'info', 'warn', 'error'].forEach(method => {
-          const originalMethod = console[method];
-          console[method] = function(...args) {
-            const processedArgs = args.map(arg => {
-              if (arg instanceof Set) {
-                return {
-                  __brunoType: 'Set',
-                  __brunoValue: Array.from(arg),
-                  size: arg.size
-                };
-              }
-              if (arg instanceof Map) {
-                return {
-                  __brunoType: 'Map',
-                  __brunoValue: Array.from(arg.entries()),
-                  size: arg.size
-                };
-              }
-              return arg;
-            });
-            return originalMethod.apply(this, processedArgs);
-          };
-        });
-
         await bru.sleep(0);
         try {
           ${externalScript}

--- a/packages/bruno-js/src/sandbox/quickjs/shims/console.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/console.js
@@ -2,150 +2,121 @@ const addConsoleShimToContext = (vm, console) => {
   if (!console) return;
 
   // Helper function to convert QuickJS values to native values with Set/Map support
-  const dumpWithSetMapSupport = arg => {
+  const dumpWithSerializers = (arg) => {
+    // Track all handles for centralized disposal
+    let nameProp, constructorProp, constructorNameProp, toStringFn, toStringResult;
+    let arrayFn, fromFn, arrayResult;
+
     try {
-      // First try to dump normally
-      const dumped = vm.dump(arg);
+      const argType = vm.typeof(arg);
 
-      // Check if it's a Set by trying to access Set-specific properties
-      if (vm.typeof(arg) === 'object' && arg !== vm.null && arg !== vm.undefined) {
-        // Try to get the constructor name
-        const constructorProp = vm.getProp(arg, 'constructor');
-        if (constructorProp) {
-          const constructorNameProp = vm.getProp(constructorProp, 'name');
-          if (constructorNameProp) {
-            const constructorName = vm.dump(constructorNameProp);
-            constructorNameProp.dispose();
-
-            if (constructorName === 'Set') {
-              // It's a Set, convert to our special format
-              const sizeProp = vm.getProp(arg, 'size');
-              const size = sizeProp ? vm.dump(sizeProp) : 0;
-              sizeProp?.dispose();
-
-              // Get values by calling values() method
-              const valuesFn = vm.getProp(arg, 'values');
-              if (valuesFn) {
-                const valuesIterator = vm.callFunction(valuesFn, arg);
-                const values = [];
-
-                // Try to extract values (this is a simplified approach)
-                try {
-                  // For now, we'll use a different approach - convert via Array.from
-                  const arrayFromFn = vm.getProp(vm.global, 'Array');
-                  if (arrayFromFn) {
-                    const fromFn = vm.getProp(arrayFromFn, 'from');
-                    if (fromFn) {
-                      const arrayResult = vm.callFunction(fromFn, arrayFromFn, arg);
-                      const arrayValues = vm.dump(arrayResult);
-                      arrayResult.dispose();
-                      fromFn.dispose();
-
-                      constructorProp.dispose();
-                      valuesFn.dispose();
-                      valuesIterator?.dispose();
-                      arrayFromFn.dispose();
-
-                      return {
-                        __brunoType: 'Set',
-                        __brunoValue: arrayValues,
-                        size: size,
-                      };
-                    }
-                    fromFn?.dispose();
-                  }
-                  arrayFromFn?.dispose();
-                } catch (e) {
-                  // Fallback to empty array
-                }
-
-                valuesFn.dispose();
-                valuesIterator?.dispose();
-
-                return {
-                  __brunoType: 'Set',
-                  __brunoValue: values,
-                  size: size,
-                };
-              }
-            } else if (constructorName === 'Map') {
-              // It's a Map, convert to our special format
-              const sizeProp = vm.getProp(arg, 'size');
-              const size = sizeProp ? vm.dump(sizeProp) : 0;
-              sizeProp?.dispose();
-
-              // Try to convert via Array.from
-              try {
-                const arrayFromFn = vm.getProp(vm.global, 'Array');
-                if (arrayFromFn) {
-                  const fromFn = vm.getProp(arrayFromFn, 'from');
-                  if (fromFn) {
-                    const arrayResult = vm.callFunction(fromFn, arrayFromFn, arg);
-                    const arrayValues = vm.dump(arrayResult);
-                    arrayResult.dispose();
-                    fromFn.dispose();
-                    arrayFromFn.dispose();
-
-                    constructorProp.dispose();
-
-                    return {
-                      __brunoType: 'Map',
-                      __brunoValue: arrayValues,
-                      size: size,
-                    };
-                  }
-                  fromFn?.dispose();
-                }
-                arrayFromFn?.dispose();
-              } catch (e) {
-                // Fallback
-              }
-
-              constructorProp.dispose();
-
-              return {
-                __brunoType: 'Map',
-                __brunoValue: [],
-                size: size,
-              };
-            }
-          }
-          constructorNameProp?.dispose();
-        }
-        constructorProp?.dispose();
+      // Early return for primitives (string, number, boolean, undefined, null)
+      if (arg == null || arg === vm.null || arg === vm.undefined) {
+        return vm.dump(arg);
       }
 
-      return dumped;
+      if (argType !== 'object' && argType !== 'function') {
+        return vm.dump(arg);
+      }
+
+      // Handle functions - show clean wrapper
+      if (argType === 'function') {
+        nameProp = vm.getProp(arg, 'name');
+        const name = nameProp ? vm.dump(nameProp) || 'anonymous' : 'anonymous';
+        return `function ${name}() {\n    [native code]\n}`;
+      }
+
+      // Try to get the constructor name to detect Set/Map
+      constructorProp = vm.getProp(arg, 'constructor');
+      if (!constructorProp) {
+        return vm.dump(arg);
+      }
+
+      let constructorName = null;
+      constructorNameProp = vm.getProp(constructorProp, 'name');
+      if (constructorNameProp) {
+        constructorName = vm.dump(constructorNameProp);
+      }
+
+      // Handle Date, RegExp, Error - call toString()
+      if (constructorName === 'Date' || constructorName === 'RegExp' || constructorName?.endsWith?.('Error')) {
+        toStringFn = vm.getProp(arg, 'toString');
+        if (toStringFn) {
+          toStringResult = vm.callFunction(toStringFn, arg);
+          if (toStringResult.error) {
+            return vm.dump(arg);
+          }
+          return vm.dump(toStringResult.value);
+        }
+      }
+
+      // If not a Set or Map, use standard dump
+      if (constructorName !== 'Set' && constructorName !== 'Map') {
+        return vm.dump(arg);
+      }
+
+      // Convert Set or Map to array via Array.from
+      arrayFn = vm.getProp(vm.global, 'Array');
+      if (!arrayFn) {
+        return vm.dump(arg);
+      }
+
+      fromFn = vm.getProp(arrayFn, 'from');
+      if (!fromFn) {
+        return vm.dump(arg);
+      }
+
+      arrayResult = vm.callFunction(fromFn, arrayFn, arg);
+      if (arrayResult.error) {
+        return vm.dump(arg);
+      }
+
+      return {
+        __brunoType: constructorName,
+        __brunoValue: vm.dump(arrayResult.value)
+      };
     } catch (e) {
       // Fallback to normal dump
       return vm.dump(arg);
+    } finally {
+      // Centralized handle disposal - dispose all handles regardless of success or error
+      nameProp?.dispose();
+      constructorProp?.dispose();
+      constructorNameProp?.dispose();
+      toStringFn?.dispose();
+      toStringResult?.value?.dispose();
+      toStringResult?.error?.dispose();
+      arrayFn?.dispose();
+      fromFn?.dispose();
+      arrayResult?.value?.dispose();
+      arrayResult?.error?.dispose();
     }
   };
 
   const consoleHandle = vm.newObject();
 
   const logHandle = vm.newFunction('log', (...args) => {
-    const nativeArgs = args.map(dumpWithSetMapSupport);
+    const nativeArgs = args.map(dumpWithSerializers);
     console?.log?.(...nativeArgs);
   });
 
   const debugHandle = vm.newFunction('debug', (...args) => {
-    const nativeArgs = args.map(dumpWithSetMapSupport);
+    const nativeArgs = args.map(dumpWithSerializers);
     console?.debug?.(...nativeArgs);
   });
 
   const infoHandle = vm.newFunction('info', (...args) => {
-    const nativeArgs = args.map(dumpWithSetMapSupport);
+    const nativeArgs = args.map(dumpWithSerializers);
     console?.info?.(...nativeArgs);
   });
 
   const warnHandle = vm.newFunction('warn', (...args) => {
-    const nativeArgs = args.map(dumpWithSetMapSupport);
+    const nativeArgs = args.map(dumpWithSerializers);
     console?.warn?.(...nativeArgs);
   });
 
   const errorHandle = vm.newFunction('error', (...args) => {
-    const nativeArgs = args.map(dumpWithSetMapSupport);
+    const nativeArgs = args.map(dumpWithSerializers);
     console?.error?.(...nativeArgs);
   });
 


### PR DESCRIPTION
# Description

This PR improves the display of JavaScript Map and Set objects in Bruno's developer console to match Postman's cleaner, more user-friendly implementation.

[JIRA](https://usebruno.atlassian.net/browse/BRU-2092)

# Changes

### Map Display Improvements
- ✅ Removed `[[Map]]` wrapper property
- ✅ Display Map entries directly at top level with `=>` notation (e.g., `"key =>": "value"`)
- ✅ Removed `size` property from display
- ✅ Added "Map" type label for clarity
- ✅ Collapse by default for cleaner console output

### Set Display Improvements
- ✅ Removed `[[Set]]` wrapper property
- ✅ Display Set values directly at top level with numeric indices (0, 1, 2, ...)
- ✅ Removed `size` property from display
- ✅ Added "Set" type label for clarity
- ✅ Collapse by default for cleaner console output

## Implementation Details

### Modified Function: `transformBrunoTypes()`
- Enhanced to support metadata tracking via optional `returnMetadata` parameter
- Returns `{ data, metadata }` when metadata is requested
- Metadata includes type information ('Map', 'Set', etc.)

### Modified Function: `formatMessage()`
- Uses metadata to determine display name and collapse behavior
- Sets `name` prop to 'Map' or 'Set' for type identification
- Sets `collapsed` prop to `true` for Maps and Sets (collapse by default)
- Maintains `collapsed={1}` for regular objects (collapse at depth 1)

## Testing

Tested with post-response script logging Set and Map objects:
- ✅ Sets display with numeric indices at top level
- ✅ Maps display with `=>` notation at top level
- ✅ Both collapse by default
- ✅ Type labels clearly identify object types
- ✅ Expandable/collapsible UI works correctly

## Demo 
![set - maps console log update](https://github.com/user-attachments/assets/76ba11f0-c7c9-4055-a6d0-f2874b8be7df)

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
 - https://github.com/usebruno/bruno/issues/6040

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pretty-printing of Set and Map across sandboxes and the in-app log viewer for clearer, compact output.
  * Enhanced sandbox consoles now serialize Set/Map/Function/undefined for consistent logs.

* **Bug Fixes**
  * Improved handling of circular references to prevent render/logging errors.

* **Improvements**
  * Bruno-type-aware rendering with sensible collapse/summary behavior for complex objects.

* **Other**
  * Minor timing adjustment to in-VM async execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->