### PR TITLE
fix: modify brunoToPostman function to include tests in event section

### DIFF
--- a/packages/bruno-converters/tests/bruno/bruno-to-postman-with-tests.spec.js
+++ b/packages/bruno-converters/tests/bruno/bruno-to-postman-with-tests.spec.js
@@ -1,0 +1,293 @@
+import { brunoToPostman } from '../../src/postman/bruno-to-postman';
+
+describe('Bruno to Postman Converter with Tests and Scripts', () => {
+  const brunoCollection = {
+    name: 'Script and Tests Collection',
+    version: '1',
+    items: [
+      {
+        name: 'Request With Scripts and Tests',
+        type: 'http',
+        filename: 'request-with-scripts.bru',
+        seq: 1,
+        settings: {
+          encodeUrl: true,
+          timeout: 0
+        },
+        tags: [],
+        examples: [],
+        request: {
+          url: 'https://echo.usebruno.com',
+          method: 'POST',
+          headers: [],
+          params: [],
+          body: {
+            mode: 'json',
+            json: '{\n  "location": "root-request"\n}',
+            formUrlEncoded: [],
+            multipartForm: [],
+            file: []
+          },
+          script: {
+            req: 'console.log("root-request script line 1");\nconsole.log("root-request script line 2")',
+            res: 'console.log("root-request script line 1");\nconsole.log("root-request script line 2")'
+          },
+          vars: {},
+          assertions: [],
+          tests: 'test("Status code is 200", () => {\n    expect(res.status).to.eql(200);\n});\ntest("Body is not empty", () => {\n    expect(res.text).not.to.eql("");\n});',
+          docs: '',
+          auth: {
+            mode: 'none'
+          }
+        }
+      },
+      {
+        type: 'folder',
+        name: 'Scripts Folder',
+        filename: 'scripts-folder',
+        seq: 2,
+        examples: [],
+        root: {
+          request: {
+            auth: {
+              mode: 'none'
+            },
+            script: {
+              req: 'console.log("scripts-folder script line 1");\nconsole.log("scripts-folder script line 2")',
+              res: 'console.log("scripts-folder script line 1");\nconsole.log("scripts-folder script line 2")'
+            },
+            tests: 'test("Status code is 200", () => {\n    expect(res.status).to.eql(200);\n});\ntest("Body is not empty", () => {\n    expect(res.text).not.to.eql("");\n});'
+          },
+          meta: {
+            name: 'Scripts Folder',
+            seq: 2
+          }
+        },
+        items: [
+          {
+            type: 'http',
+            name: 'Request In Scripts Folder',
+            filename: 'scripts-folder-echo.bru',
+            seq: 1,
+            settings: {
+              encodeUrl: true,
+              timeout: 0
+            },
+            tags: [],
+            examples: [],
+            request: {
+              url: 'https://echo.usebruno.com',
+              method: 'POST',
+              headers: [],
+              params: [],
+              body: {
+                mode: 'json',
+                json: '{\n  "location": "folder-request"\n}',
+                formUrlEncoded: [],
+                multipartForm: [],
+                file: []
+              },
+              script: {
+                req: 'console.log("scripts-folder-request script line 1");\nconsole.log("scripts-folder-request script line 2")',
+                res: 'console.log("scripts-folder-request script line 1");\nconsole.log("scripts-folder-request script line 2")'
+              },
+              vars: {},
+              assertions: [],
+              tests: 'test("Status code is 200", () => {\n    expect(res.status).to.eql(200);\n});\ntest("Body is not empty", () => {\n    expect(res.text).not.to.eql("");\n});',
+              docs: '',
+              auth: {
+                mode: 'none'
+              }
+            }
+          },
+          {
+            type: 'folder',
+            name: 'Scripts Inner Folder',
+            filename: 'scripts-inner-folder',
+            seq: 2,
+            examples: [],
+            root: {
+              request: {
+                auth: {
+                  mode: 'none'
+                },
+                script: {
+                  req: 'console.log("scripts-inner-folder script line 1");\nconsole.log("scripts-inner-folder script line 2")',
+                  res: 'console.log("scripts-inner-folder script line 1");\nconsole.log("scripts-inner-folder script line 2")'
+                },
+                tests: 'test("Status code is 200", () => {\n    expect(res.status).to.eql(200);\n});\ntest("Body is not empty", () => {\n    expect(res.text).not.to.eql("");\n});'
+              },
+              meta: {
+                name: 'Scripts Inner Folder',
+                seq: 2
+              }
+            },
+            items: [
+              {
+                type: 'http',
+                name: 'Request In Scripts Inner Folder',
+                filename: 'scripts-inner-folder-echo.bru',
+                seq: 2,
+                settings: {
+                  encodeUrl: true,
+                  timeout: 0
+                },
+                tags: [],
+                examples: [],
+                request: {
+                  url: 'https://echo.usebruno.com',
+                  method: 'POST',
+                  headers: [],
+                  params: [],
+                  body: {
+                    mode: 'json',
+                    json: '{\n  "location": "inner-folder-request"\n}',
+                    formUrlEncoded: [],
+                    multipartForm: [],
+                    file: []
+                  },
+                  script: {
+                    req: 'console.log("scripts-inner-folder-request script line 1");\nconsole.log("scripts-inner-folder-request script line 2")',
+                    res: 'console.log("scripts-inner-folder-request script line 1");\nconsole.log("scripts-inner-folder-request script line 2")'
+                  },
+                  vars: {},
+                  assertions: [],
+                  tests: 'test("Status code is 200", () => {\n    expect(res.status).to.eql(200);\n});\ntest("Body is not empty", () => {\n    expect(res.text).not.to.eql("");\n});',
+                  docs: '',
+                  auth: {
+                    mode: 'none'
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    environments: [],
+    root: {
+      request: {
+        script: {
+          req: 'console.log("root-request script line 1");\nconsole.log("root-request script line 2")',
+          res: 'console.log("root-request script line 1");\nconsole.log("root-request script line 2")'
+        },
+        tests: 'test("Status code is 200", () => {\n    expect(res.status).to.eql(200);\n});\ntest("Body is not empty", () => {\n    expect(res.text).not.to.eql("");\n});'
+      }
+    },
+    brunoConfig: {
+      version: '1',
+      name: 'Script and Tests Collection',
+      type: 'collection',
+      ignore: [
+        'node_modules',
+        '.git'
+      ],
+      size: 0.0020351409912109375,
+      filesCount: 6
+    }
+  };
+
+  it('should convert Bruno request scripts and tests to Postman event scripts', () => {
+    const postmanCollection = brunoToPostman(brunoCollection);
+    // Root request events
+    const rootRequest = postmanCollection.item.find((i) => i.name === 'Request With Scripts and Tests');
+    const rootPre = rootRequest.event.find((e) => e.listen === 'prerequest');
+    const rootTest = rootRequest.event.find((e) => e.listen === 'test');
+    expect(rootPre).toBeDefined();
+    expect(rootTest).toBeDefined();
+    expect(rootPre.script.exec).toEqual([
+      'console.log("root-request script line 1");',
+      'console.log("root-request script line 2")'
+    ]);
+    expect(rootTest.script.exec).toEqual([
+      'console.log("root-request script line 1");',
+      'console.log("root-request script line 2")',
+      '',
+      '// Tests',
+      'test("Status code is 200", () => {',
+      '    expect(res.status).to.eql(200);',
+      '});',
+      'test("Body is not empty", () => {',
+      '    expect(res.text).not.to.eql("");',
+      '});'
+    ]);
+  });
+
+  it('should convert Bruno folder scripts and tests to Postman event scripts', () => {
+    const postmanCollection = brunoToPostman(brunoCollection);
+    // Folder events
+    const folder = postmanCollection.item.find((i) => i.name === 'Scripts Folder');
+    const folderPre = folder.event.find((e) => e.listen === 'prerequest');
+    const folderTest = folder.event.find((e) => e.listen === 'test');
+    expect(folderPre).toBeDefined();
+    expect(folderTest).toBeDefined();
+    expect(folderPre.script.exec).toEqual([
+      'console.log("scripts-folder script line 1");',
+      'console.log("scripts-folder script line 2")'
+    ]);
+    expect(folderTest.script.exec).toEqual([
+      'console.log("scripts-folder script line 1");',
+      'console.log("scripts-folder script line 2")',
+      '',
+      '// Tests',
+      'test("Status code is 200", () => {',
+      '    expect(res.status).to.eql(200);',
+      '});',
+      'test("Body is not empty", () => {',
+      '    expect(res.text).not.to.eql("");',
+      '});'
+    ]);
+  });
+
+  it('should convert Bruno inner folder scripts and tests to Postman event scripts', () => {
+    const postmanCollection = brunoToPostman(brunoCollection);
+    const folder = postmanCollection.item.find((i) => i.name === 'Scripts Folder');
+    // Inner folder events
+    const innerFolder = folder.item.find((i) => i.name === 'Scripts Inner Folder');
+    const innerFolderPre = innerFolder.event.find((e) => e.listen === 'prerequest');
+    const innerFolderTest = innerFolder.event.find((e) => e.listen === 'test');
+    expect(innerFolderPre).toBeDefined();
+    expect(innerFolderTest).toBeDefined();
+    expect(innerFolderPre.script.exec).toEqual([
+      'console.log("scripts-inner-folder script line 1");',
+      'console.log("scripts-inner-folder script line 2")'
+    ]);
+    expect(innerFolderTest.script.exec).toEqual([
+      'console.log("scripts-inner-folder script line 1");',
+      'console.log("scripts-inner-folder script line 2")',
+      '',
+      '// Tests',
+      'test("Status code is 200", () => {',
+      '    expect(res.status).to.eql(200);',
+      '});',
+      'test("Body is not empty", () => {',
+      '    expect(res.text).not.to.eql("");',
+      '});'
+    ]);
+  });
+
+  it('should convert Bruno collection scripts and tests to Postman event scripts', () => {
+    const postmanCollection = brunoToPostman(brunoCollection);
+    // Collection events
+    const collectionPre = postmanCollection.event.find((e) => e.listen === 'prerequest');
+    const collectionTest = postmanCollection.event.find((e) => e.listen === 'test');
+    expect(collectionPre).toBeDefined();
+    expect(collectionTest).toBeDefined();
+    expect(collectionPre.script.exec).toEqual([
+      'console.log("root-request script line 1");',
+      'console.log("root-request script line 2")'
+    ]);
+    expect(collectionTest.script.exec).toEqual([
+      'console.log("root-request script line 1");',
+      'console.log("root-request script line 2")',
+      '',
+      '// Tests',
+      'test("Status code is 200", () => {',
+      '    expect(res.status).to.eql(200);',
+      '});',
+      'test("Body is not empty", () => {',
+      '    expect(res.text).not.to.eql("");',
+      '});'
+    ]);
+  });
+});


### PR DESCRIPTION
# Description
Updated `brunoToPostman` to include test scripts in the Postman test event section during conversion. 
[JIRA](https://usebruno.atlassian.net/browse/BRU-1154)
Fixes: https://github.com/usebruno/bruno/issues/6103

**Changes:**
- Modified `generateEventSection` in `packages/bruno-converters/src/postman/bruno-to-postman.js` to handle test blocks from Bruno collections.
- Added support for reading test blocks from:
  - Request level: `item.tests`
  - Folder level: `item.root.request.tests`
  - Collection level: `item.request.tests`
- Updated the test event generation logic to combine response scripts (`scriptBlock.res`) with test blocks (`testsBlock`) when creating the Postman test event.
- Added a comment marker (`// Tests`) to distinguish test code from response scripts in the generated Postman collection.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
