### PR TITLE
fix: remove global flag from TEMPLATE_VAR_PATTERN to avoid falsey matches

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index.js
@@ -19,7 +19,6 @@ const TEMPLATE_VAR_PATTERN = /\{\{([^}]+)\}\}/;
 const validateURLWithVars = (url) => {
   const isValid = isValidUrl(url);
   const hasMissingInterpolations = TEMPLATE_VAR_PATTERN.test(url);
-  TEMPLATE_VAR_PATTERN.lastIndex = 0;
   return isValid && !hasMissingInterpolations;
 };
 


### PR DESCRIPTION
# Description

Fixes a bug in Generate Code where it fails for every alternate test since the `lastIndex` is at the end of the tested string. 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
