### PR TITLE
fix: environment display in HTML report

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -655,6 +655,9 @@ const handler = async function (argv) {
     const totalTime = results.reduce((acc, res) => acc + res.response.responseTime, 0);
     console.log(chalk.dim(chalk.grey(`Ran all requests - ${totalTime} ms`)));
 
+    // Extract environment name from envVars if available
+    const environmentName = envVars?.__name__ || null;
+
     const formatKeys = Object.keys(formats);
     if (formatKeys && formatKeys.length > 0) {
       const outputJson = {
@@ -665,7 +668,7 @@ const handler = async function (argv) {
       const reporters = {
         'json': (path) => fs.writeFileSync(path, JSON.stringify(outputJson, null, 2)),
         'junit': (path) => makeJUnitOutput(results, path),
-        'html': (path) => makeHtmlOutput(outputJson, path, runCompletionTime),
+        html: (path) => makeHtmlOutput(outputJson, path, runCompletionTime, environmentName)
       }
 
       for (const formatter of Object.keys(formats))

--- a/packages/bruno-cli/src/reporters/html.js
+++ b/packages/bruno-cli/src/reporters/html.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const { generateHtmlReport } = require('@usebruno/common/runner');
 const { CLI_VERSION } = require('../constants');
 
-const makeHtmlOutput = async (results, outputPath, runCompletionTime) => {
+const makeHtmlOutput = async (results, outputPath, runCompletionTime, environment = null) => {
   let runnerResults = results;
   if (!results) {
     runnerResults = [];
@@ -16,9 +16,7 @@ const makeHtmlOutput = async (results, outputPath, runCompletionTime) => {
   } else if (Array.isArray(results)) {
     runnerResults = results;
   }
-  
-  const environment = runnerResults.length > 0 ? runnerResults[0].environment : null;
-  
+
   const htmlString = generateHtmlReport({ 
     runnerResults: runnerResults,
     version: `usebruno v${CLI_VERSION}`,

--- a/packages/bruno-cli/tests/reporters/html.spec.js
+++ b/packages/bruno-cli/tests/reporters/html.spec.js
@@ -1,0 +1,73 @@
+const { describe, it, expect } = require('@jest/globals');
+const fs = require('fs');
+
+const mockGenerateHtmlReport = jest.fn(() => '<html>Mock HTML</html>');
+
+jest.mock('@usebruno/common/runner', () => ({
+  generateHtmlReport: mockGenerateHtmlReport
+}));
+
+const makeHtmlOutput = require('../../src/reporters/html');
+
+describe('makeHtmlOutput', () => {
+  let writeFileSyncSpy;
+
+  beforeEach(() => {
+    mockGenerateHtmlReport.mockClear();
+    writeFileSyncSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should pass environment parameter to generateHtmlReport when provided', async () => {
+    const mockResults = {
+      results: [],
+      summary: {
+        totalRequests: 0,
+        passedRequests: 0,
+        failedRequests: 0,
+        errorRequests: 0,
+        skippedRequests: 0,
+        totalAssertions: 0,
+        passedAssertions: 0,
+        failedAssertions: 0,
+        totalTests: 0,
+        passedTests: 0,
+        failedTests: 0
+      }
+    };
+
+    await makeHtmlOutput(mockResults, '/tmp/test.html', '2024-01-15T14:30:45.123Z', 'production');
+
+    expect(mockGenerateHtmlReport).toHaveBeenCalledWith(expect.objectContaining({
+      environment: 'production'
+    }));
+  });
+
+  it('should pass null environment when not provided', async () => {
+    const mockResults = {
+      results: [],
+      summary: {
+        totalRequests: 0,
+        passedRequests: 0,
+        failedRequests: 0,
+        errorRequests: 0,
+        skippedRequests: 0,
+        totalAssertions: 0,
+        passedAssertions: 0,
+        failedAssertions: 0,
+        totalTests: 0,
+        passedTests: 0,
+        failedTests: 0
+      }
+    };
+
+    await makeHtmlOutput(mockResults, '/tmp/test.html', '2024-01-15T14:30:45.123Z');
+
+    expect(mockGenerateHtmlReport).toHaveBeenCalledWith(expect.objectContaining({
+      environment: null
+    }));
+  });
+});


### PR DESCRIPTION
[BRU-1906](https://usebruno.atlassian.net/browse/BRU-1906)

- Extract the environment name from `envVars.__name__` in the run command and pass it to the HTML reporter
- Updated `makeHtmlOutput` to accept and use the environment parameter
- Removed the fallback `runnerResults[0].environment` check as the environment is never stored in the `runnerResults` structure, so the fallback would always return `undefined`