### PR TITLE
feat: add proxy .pac file resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12456,6 +12456,111 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
+      "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/degenerator/node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/degenerator/node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/degenerator/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/degenerator/node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/degenerator/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/degenerator/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -16214,6 +16319,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ip": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -19468,6 +19580,16 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/new-github-issue-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/new-github-issue-url/-/new-github-issue-url-0.2.1.tgz",
@@ -19922,6 +20044,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
+      "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^2.2.0",
+        "ip": "^1.1.5",
+        "netmask": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -29624,6 +29761,8 @@
         "babel-jest": "^29.7.0",
         "is-ip": "^5.0.1",
         "moment": "^2.29.4",
+        "node-fetch": "^2.6.7",
+        "pac-resolver": "^4.1.0",
         "rollup": "3.29.5",
         "rollup-plugin-dts": "^5.0.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",

--- a/packages/bruno-app/src/components/Preferences/ProxySettings/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/index.js
@@ -17,7 +17,7 @@ const ProxySettings = ({ close }) => {
   console.log(preferences);
 
   const proxySchema = Yup.object({
-    mode: Yup.string().oneOf(['off', 'on', 'system']),
+    mode: Yup.string().oneOf(['off', 'on', 'system', 'pac']),
     protocol: Yup.string().required().oneOf(['http', 'https', 'socks4', 'socks5']),
     hostname: Yup.string()
       .when('enabled', {
@@ -52,7 +52,8 @@ const ProxySettings = ({ close }) => {
         })
       })
       .optional(),
-    bypassProxy: Yup.string().optional().max(1024)
+    bypassProxy: Yup.string().optional().max(1024),
+    pacUrl: Yup.string().optional().url('Specify a valid PAC URL').max(2048)
   });
 
   const formik = useFormik({
@@ -61,6 +62,7 @@ const ProxySettings = ({ close }) => {
       protocol: preferences.proxy.protocol || 'http',
       hostname: preferences.proxy.hostname || '',
       port: preferences.proxy.port || 0,
+      pacUrl: preferences.proxy.pacUrl || '',
       auth: {
         enabled: preferences.proxy.auth ? preferences.proxy.auth.enabled || false : false,
         username: preferences.proxy.auth ? preferences.proxy.auth.username || '' : '',
@@ -104,6 +106,7 @@ const ProxySettings = ({ close }) => {
       protocol: preferences.proxy.protocol || 'http',
       hostname: preferences.proxy.hostname || '',
       port: preferences.proxy.port || '',
+      pacUrl: preferences.proxy.pacUrl || '',
       auth: {
         enabled: preferences.proxy.auth ? preferences.proxy.auth.enabled || false : false,
         username: preferences.proxy.auth ? preferences.proxy.auth.username || '' : '',
@@ -153,10 +156,25 @@ const ProxySettings = ({ close }) => {
                 name="mode"
                 value="system"
                 checked={formik.values.mode === 'system'}
-                onChange={formik.handleChange}
+                onChange={(e) => {
+                  formik.setFieldValue('mode', 'system');
+                }}
                 className="mr-1 cursor-pointer"
               />
               System Proxy
+            </label>
+            <label className="flex items-center ml-4 cursor-pointer">
+              <input
+                type="radio"
+                name="mode"
+                value="pac"
+                checked={formik.values.mode === 'pac'}
+                onChange={(e) => {
+                  formik.setFieldValue('mode', 'pac');
+                }}
+                className="mr-1 cursor-pointer"
+              />
+              PAC
             </label>
           </div>
         </div>
@@ -361,6 +379,31 @@ const ProxySettings = ({ close }) => {
               />
               {formik.touched.bypassProxy && formik.errors.bypassProxy ? (
                 <div className="ml-3 text-red-500">{formik.errors.bypassProxy}</div>
+              ) : null}
+            </div>
+          </>
+        ) : null}
+        {formik?.values?.mode === 'pac' ? (
+          <>
+            <div className="mb-3 flex items-center">
+              <label className="settings-label" htmlFor="pacUrl">
+                PAC URL
+              </label>
+              <input
+                id="pacUrl"
+                type="text"
+                name="pacUrl"
+                className="block textbox"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck="false"
+                onChange={formik.handleChange}
+                value={formik.values.pacUrl || ''}
+                placeholder="https://example.com/proxy.pac"
+              />
+              {formik.touched.pacUrl && formik.errors.pacUrl ? (
+                <div className="ml-3 text-red-500">{formik.errors.pacUrl}</div>
               ) : null}
             </div>
           </>

--- a/packages/bruno-common/package.json
+++ b/packages/bruno-common/package.json
@@ -52,7 +52,9 @@
     "rollup-plugin-dts": "^5.0.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "node-fetch": "^2.6.7",
+    "pac-resolver": "^4.1.0"
   },
   "overrides": {
     "rollup": "3.29.5"

--- a/packages/bruno-common/src/net/pac-resolver.js
+++ b/packages/bruno-common/src/net/pac-resolver.js
@@ -1,0 +1,110 @@
+const pac = require('pac-resolver');
+const fetch = require('node-fetch');
+
+// Prefer native/global AbortController when available, otherwise try to use
+// fetch-provided AbortController or fall back to the 'abort-controller' package.
+let AbortController = globalThis.AbortController || (fetch && fetch.AbortController) || null;
+if (!AbortController) {
+  try {
+    // this package may not be installed in all environments
+    // requiring it is best-effort — if it fails we'll use a safe noop fallback below
+     
+    AbortController = require('abort-controller');
+  } catch (e) {
+    AbortController = null;
+  }
+}
+const crypto = require('crypto');
+
+// Simple in-memory cache for compiled resolvers
+const CACHE = new Map();
+
+function hash(input) {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+async function downloadPac(pacUrl, timeoutMs = 5000) {
+  console.log(`Starting download of PAC from ${pacUrl} with timeout ${timeoutMs}ms`);
+  // create a real AbortController when possible; otherwise provide a noop
+  // controller so code can call `abort()` without throwing.
+  let controller;
+  if (AbortController) {
+    controller = new AbortController();
+  } else if (fetch && fetch.AbortController) {
+    controller = new fetch.AbortController();
+  } else {
+    controller = { signal: undefined, abort: () => { } };
+  }
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(pacUrl, { signal: controller.signal });
+    clearTimeout(id);
+    if (!res.ok) throw new Error(`Failed to fetch PAC (${res.status})`);
+    return await res.text();
+  } catch (err) {
+    clearTimeout(id);
+    throw err;
+  }
+}
+
+async function getPacResolver({ pacUrl, opts = {} }) {
+  /**
+  * Get a resolver for a pacUrl.
+  * Returns { resolve(url): Promise<string[]>, dispose(): void }
+  */
+
+  // 5 minutes default cache TTL
+  const cacheTtlMs = opts.cacheTtlMs || 5 * 60 * 1000;
+
+  if (!pacUrl) {
+    throw new Error('pacUrl must be provided');
+  }
+
+  if (pacUrl) {
+    const key = `url:${pacUrl}`;
+    const now = Date.now();
+    const cached = CACHE.get(key);
+    if (cached && now - cached.ts < cacheTtlMs) {
+      return cached.wrapper;
+    }
+
+    // download
+    const script = await downloadPac(pacUrl, opts.timeoutMs || 5000);
+    const resolverFn = pac(script);
+    const wrapper = createWrapper(resolverFn);
+    CACHE.set(key, { wrapper, ts: Date.now() });
+    return wrapper;
+  }
+}
+
+function createWrapper(resolverFn) {
+  return {
+    resolve: async (url) => {
+      try {
+        const u = new URL(url);
+        const host = u.hostname;
+        // resolverFn(url, host) => returns string like 'PROXY x:8080; DIRECT'
+        const out = await resolverFn(url, host);
+        if (!out || typeof out !== 'string') return [];
+        return out.split(';').map(s => s.trim()).filter(Boolean);
+      } catch (err) {
+        throw err;
+      }
+    },
+    dispose: () => {
+      // noop for now — cache eviction handled globally
+    }
+  };
+}
+
+function clearCache(keyPrefix) {
+  if (!keyPrefix) {
+    CACHE.clear();
+    return;
+  }
+  for (const key of Array.from(CACHE.keys())) {
+    if (key.startsWith(keyPrefix)) CACHE.delete(key);
+  }
+}
+
+module.exports = { getPacResolver, clearCache, _CACHE: CACHE };

--- a/packages/bruno-common/test/pac-resolver.test.js
+++ b/packages/bruno-common/test/pac-resolver.test.js
@@ -1,0 +1,106 @@
+
+describe('pac-resolver wrapper', () => {
+  beforeEach(() => {
+    // reset module cache so mocks apply per-test
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    // ensure cache is cleared between tests
+    const { clearCache } = require('../src/net/pac-resolver');
+    clearCache();
+    jest.clearAllMocks();
+  });
+
+  test('throws when pacUrl is not provided', async () => {
+    const { getPacResolver } = require('../src/net/pac-resolver');
+    await expect(getPacResolver({})).rejects.toThrow('pacUrl must be provided');
+  });
+
+  test('downloads PAC and returns resolver that splits directives', async () => {
+    // Mock node-fetch to return a successful response with script text
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true, text: async () => 'function FindProxyForURL(url, host) { return "PROXY p.example:8080; DIRECT"; }' });
+    jest.doMock('node-fetch', () => mockFetch);
+
+    // Mock pac-resolver to return a resolver function based on the script
+    const pacMock = jest.fn((script) => {
+      return async (url, host) => {
+        // return the string format expected by the wrapper
+        return 'PROXY p.example:8080; DIRECT';
+      };
+    });
+    jest.doMock('pac-resolver', () => pacMock);
+
+    const { getPacResolver } = require('../src/net/pac-resolver');
+
+    const pacUrl = 'http://example.com/proxy.pac';
+    const wrapper = await getPacResolver({ pacUrl });
+
+    expect(typeof wrapper.resolve).toBe('function');
+    const directives = await wrapper.resolve('http://foo.example/');
+    expect(directives).toEqual(['PROXY p.example:8080', 'DIRECT']);
+
+    // pac-resolver should have been called with the script text
+    expect(pacMock).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(pacUrl, expect.any(Object));
+  });
+
+  test('caches resolver and returns same wrapper on repeated calls', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true, text: async () => 'script' });
+    jest.doMock('node-fetch', () => mockFetch);
+
+    const pacMock = jest.fn((script) => {
+      return async (url, host) => 'DIRECT';
+    });
+    jest.doMock('pac-resolver', () => pacMock);
+
+    const { getPacResolver, _CACHE } = require('../src/net/pac-resolver');
+
+    const pacUrl = 'http://example.com/proxy.pac';
+    const w1 = await getPacResolver({ pacUrl });
+    const w2 = await getPacResolver({ pacUrl });
+
+    expect(w1).toBe(w2);
+    expect(_CACHE.size).toBeGreaterThan(0);
+    expect(pacMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('createWrapper returns empty array for non-string resolver output', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true, text: async () => 'script' });
+    jest.doMock('node-fetch', () => mockFetch);
+
+    const pacMock = jest.fn((script) => {
+      return async (url, host) => null; // simulate invalid return
+    });
+    jest.doMock('pac-resolver', () => pacMock);
+
+    const { getPacResolver } = require('../src/net/pac-resolver');
+    const wrapper = await getPacResolver({ pacUrl: 'http://example.com/proxy.pac' });
+    const out = await wrapper.resolve('http://example.com/');
+    expect(out).toEqual([]);
+  });
+
+  test('clearCache clears entries by prefix and entirely', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true, text: async () => 'script' });
+    jest.doMock('node-fetch', () => mockFetch);
+
+    const pacMock = jest.fn((script) => async (url, host) => 'DIRECT');
+    jest.doMock('pac-resolver', () => pacMock);
+
+    const { getPacResolver, _CACHE, clearCache } = require('../src/net/pac-resolver');
+    await getPacResolver({ pacUrl: 'http://one/pac' });
+    await getPacResolver({ pacUrl: 'http://two/pac' });
+
+    expect(_CACHE.size).toBeGreaterThanOrEqual(2);
+
+    // clear only keys starting with url:http://one
+    clearCache('url:http://one');
+    for (const key of Array.from(_CACHE.keys())) {
+      expect(key.startsWith('url:http://one')).toBe(false);
+    }
+
+    // clear all
+    clearCache();
+    expect(_CACHE.size).toBe(0);
+  });
+});

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -175,8 +175,8 @@ function makeAxiosInstance({
     };
 
     try {
-      // Now call setupProxyAgents and pass the timeline
-      setupProxyAgents({
+      // Now call setupProxyAgents and pass the timeline (async - may perform PAC resolution)
+      await setupProxyAgents({
         requestConfig: config,
         proxyMode: proxyMode, // 'on', 'off', or 'system', depending on your settings
         proxyConfig: proxyConfig,
@@ -243,7 +243,7 @@ function makeAxiosInstance({
       response.timeline = timeline;
       return response;
     },
-    (error) => {
+    async (error) => {
       const config = error.config;
       const timeline = config?.metadata?.timeline || [];
       timeline?.push({
@@ -383,7 +383,7 @@ function makeAxiosInstance({
           }
 
           try { 
-            setupProxyAgents({
+            await setupProxyAgents({
               requestConfig,
               proxyMode,
               proxyConfig,

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -36,7 +36,8 @@ const defaultPreferences = {
       username: '',
       password: ''
     },
-    bypassProxy: ''
+    bypassProxy: '',
+    pacUrl: ''
   },
   layout: {
     responsePaneOrientation: 'horizontal'
@@ -71,10 +72,11 @@ const preferencesSchema = Yup.object().shape({
     codeFontSize: Yup.number().min(1).max(32).nullable()
   }),
   proxy: Yup.object({
-    mode: Yup.string().oneOf(['off', 'on', 'system']),
+    mode: Yup.string().oneOf(['off', 'on', 'system', 'pac']),
     protocol: Yup.string().oneOf(['http', 'https', 'socks4', 'socks5']),
     hostname: Yup.string().max(1024),
     port: Yup.number().min(1).max(65535).nullable(),
+    pacUrl: Yup.string().optional().max(2048).nullable(),
     auth: Yup.object({
       enabled: Yup.boolean(),
       username: Yup.string().max(1024),

--- a/packages/bruno-electron/test/proxy-util.test.js
+++ b/packages/bruno-electron/test/proxy-util.test.js
@@ -1,0 +1,47 @@
+const jestClearModules = () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+};
+
+describe('proxy-util minimal tests', () => {
+  beforeEach(() => jestClearModules());
+  afterEach(() => jestClearModules());
+
+  test('shouldUseProxy respects wildcard bypass', () => {
+    const { shouldUseProxy } = require('../src/utils/proxy-util');
+    const url = 'http://example.com';
+    expect(shouldUseProxy(url, '*')).toBe(false);
+  });
+
+  test('setupProxyAgents handles PAC directive PROXY and sets agents', async () => {
+    const path = require('path');
+    const pacResolverPath = path.resolve(__dirname, '..', '..', 'bruno-common', 'src', 'net', 'pac-resolver');
+    jest.doMock(pacResolverPath, () => ({
+      getPacResolver: async () => ({
+        resolve: async () => ['PROXY p.example:8080', 'DIRECT'],
+        dispose: () => {}
+      }),
+      clearCache: () => {}
+    }));
+
+    const { setupProxyAgents } = require('../src/utils/proxy-util');
+
+    const requestConfig = { url: 'http://example.com/resource' };
+    const timeline = [];
+
+    await setupProxyAgents({
+      requestConfig,
+      proxyMode: 'pac',
+      proxyConfig: { pacUrl: 'http://pac' },
+      httpsAgentRequestFields: {},
+      interpolationOptions: {},
+      timeline
+    });
+
+    // Ensure httpsAgent was set by PAC handling
+    expect(requestConfig.httpsAgent).toBeDefined();
+    // timeline should contain info about PAC directives
+    const hasPacInfo = timeline.some((t) => t.type === 'info' && /PAC directives/.test(t.message));
+    expect(hasPacInfo).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

This PR adds support for using .pac proxy configuration files in Bruno.
It allows users to define a PAC file to dynamically resolve which proxy or host should be used for each request.

Below, an updated image of the new screen with the PAC url function
<img width="1274" height="760" alt="image" src="https://github.com/user-attachments/assets/2a47886c-d1b7-4573-a8d7-f10067d23786" />

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md) and [also this one on the blog](https://blog.usebruno.com/contributing-to-bruno).**
- [x] **Create an issue and link to the pull request.** 

### Resolve issues
Resolves #5980 