### PR TITLE
Save cookies on redirect response

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -546,6 +546,10 @@ const runSingleRequest = async function (
         err.response.dataBuffer = dataBuffer;
         response = err.response;
 
+        if (!options.disableCookies) {
+          saveCookies(request.url, err.response.headers);
+        }
+
         // Prevents the duration on leaking to the actual result
         responseTime = response.headers.get('request-duration');
         response.headers.delete('request-duration');

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1417,6 +1417,10 @@ const registerNetworkIpc = (mainWindow) => {
                 error.response.data = data;
                 error.response.dataBuffer = dataBuffer;
 
+                if (preferencesUtil.shouldStoreCookies()) {
+                  saveCookies(request.url, error.response.headers);
+                }
+
                 timeEnd = Date.now();
                 response = {
                   status: error.response.status,


### PR DESCRIPTION
# Description

When the response is a redirect (e.g. 302) the set-cookie headers were not processed. 

This problem happened in the collection runner and the CLI.

Let me know if the change is too naive

Are there any automated tests I can add?

Fixes #5658 

### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie management for error responses. When cookie storage is enabled, the application now properly persists cookies received from failed HTTP requests. This enhancement ensures consistent session handling across both successful and unsuccessful API calls, providing more reliable authentication and session state management for users working with HTTP error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->