### PR TITLE
fix: push event only if `exec` has content

### DIFF
--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -178,15 +178,18 @@ export const brunoToPostman = (collection) => {
         exec.push(...testsBlock.split('\n'));
       }
 
-      eventArray.push({
-        listen: 'test',
-        script: {
-          type: 'text/javascript',
-          packages: {},
-          requests: {},
-          exec: exec
-        }
-      });
+      // Only push the event if exec has content
+      if (exec.length > 0) {
+        eventArray.push({
+          listen: 'test',
+          script: {
+            type: 'text/javascript',
+            packages: {},
+            requests: {},
+            exec: exec
+          }
+        });
+      }
     }
     return eventArray;
   };


### PR DESCRIPTION
fixes: #6103 

# Description

This PR implements a fix for pushing the event when exec has content. This resolves the issue and properly adds the tests for the postman export

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


v2.13.2:

<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/2806c73f-17fe-466e-90ec-2c79c34f1707" />

v2.14.2:
<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/0aa25551-1904-468d-b0ef-6b620af26f9a" />

The current fix:
<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/81233641-2b98-4975-9bb9-1c7e1e93deda" />
