### PR TITLE
feat: expand/collapse collection and folders on name click

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -483,7 +483,9 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
             <div className="ml-1 flex w-full h-full items-center overflow-hidden">
               <CollectionItemIcon item={item} />
               <span className="item-name" title={item.name}>
-                {item.name}
+                <span className={isFolder ? 'hover:underline' : ''} onClick={isFolder ? handleFolderCollapse : undefined}>
+                  {item.name}
+                </span>
               </span>
             </div>
           </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -264,7 +264,9 @@ const Collection = ({ collection, searchText }) => {
             onDoubleClick={handleCollectionDoubleClick}
           />
           <div className="ml-1 w-full" id="sidebar-collection-name" title={collection.name}>
-            {collection.name}
+            <span className="hover:underline" onClick={handleCollectionCollapse}>
+              {collection.name}
+            </span>
           </div>
           {isLoading ? <IconLoader2 className="animate-spin mx-1" size={18} strokeWidth={1.5} /> : null}
         </div>


### PR DESCRIPTION
# Description

This PR addresses issue #6137. 

Currently, users are required to click the small arrow/chevron icon to expand or collapse Collections and Folders. This change improves the UX by allowing users to click the **text name** of the Collection or Folder to toggle the expand/collapse state as well.

**Key Changes:**
- Modified `Collection/index.js` (Root Collection) and `CollectionItem/index.js` (Sub-folders).
- Added `onClick` handlers to the text elements to trigger the toggle action.
- Added `hover:underline` style to the text to indicate interactivity.
- **Preserved existing behavior:** Clicking the empty space (row background) to the right of the text still opens the **Settings** tab, ensuring no functionality is lost.
- **Requests:** Logic ensures that clicking a Request item name still opens the request tab, not the collapse action.

### Demo


https://github.com/user-attachments/assets/144e9311-7196-4868-880d-09908fd57e7d



### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**