### PR TITLE
fix: add optional chaining to `content-type` header retrieval in `postman-to-bruno.js`

### DIFF
--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -751,7 +751,7 @@ const searchLanguageByHeader = (headers) => {
 };
 
 const getBodyTypeFromContentTypeHeader = (headers) => {
-  const contentTypeHeader = headers.find((header) => header.key.toLowerCase() === 'content-type');
+  const contentTypeHeader = headers?.find((header) => header?.key?.toLowerCase() === 'content-type');
   if (contentTypeHeader) {
     const contentType = contentTypeHeader.value?.toLowerCase();
     if (contentType?.includes('application/json')) {


### PR DESCRIPTION

fixes: https://github.com/usebruno/bruno/issues/6127

# Description

This PR implements the logic for adding object chaining to expect null values for the `Content-Type` header. Since Postman's direct export gives `null` if the `Content-Type` header is not explicitly mentioned, and if we try to import that into Postman and export it again, the `Content-Type` header is represented as `[]`
### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**