### PR TITLE
feat: Add translations for legacy Postman request.* APIs

### DIFF
--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -35,11 +35,23 @@ const replacements = {
   'pm\\.response\\.status': 'res.statusText',
   'pm\\.response\\.headers': 'res.getHeaders()',
   "tests\\['([^']+)'\\]\\s*=\\s*([^;]+);": 'test("$1", function() { expect(Boolean($2)).to.be.true; });',
+
+  // Supported Postman request translations:
+  // - pm.request.url / request.url     -> req.getUrl()
+  // - pm.request.method / request.method -> req.getMethod()
+  // - pm.request.headers / request.headers -> req.getHeaders()
+  // - pm.request.body / request.body   -> req.getBody()
+  // - pm.info.requestName / request.name -> req.getName()
   'pm\\.request\\.url': 'req.getUrl()',
   'pm\\.request\\.method': 'req.getMethod()',
   'pm\\.request\\.headers': 'req.getHeaders()',
   'pm\\.request\\.body': 'req.getBody()',
   'pm\\.info\\.requestName': 'req.getName()',
+  'request\\.url': 'req.getUrl()',
+  'request\\.method': 'req.getMethod()',
+  'request\\.headers': 'req.getHeaders()',
+  'request\\.body': 'req.getBody()',
+  'request\\.name': 'req.getName()',
   // deprecated translations
   'postman\\.setEnvironmentVariable\\(': 'bru.setEnvVar(',
   'postman\\.getEnvironmentVariable\\(': 'bru.getEnvVar(',

--- a/packages/bruno-converters/src/utils/jscode-shift-translator.js
+++ b/packages/bruno-converters/src/utils/jscode-shift-translator.js
@@ -76,11 +76,18 @@ const simpleTranslations = {
   // Info
   'pm.info.requestName': 'req.getName()',
 
-  // Request properties
+  // Request properties (pm.request.*)
   'pm.request.url': 'req.getUrl()',
   'pm.request.method': 'req.getMethod()',
   'pm.request.headers': 'req.getHeaders()',
   'pm.request.body': 'req.getBody()',
+
+  // Legacy/global request object (request.*)
+  'request.url': 'req.getUrl()',
+  'request.method': 'req.getMethod()',
+  'request.headers': 'req.getHeaders()',
+  'request.body': 'req.getBody()',
+  'request.name': 'req.getName()',
  
   // Response properties
   'pm.response.json': 'res.getBody',

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-translations/postman-request.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-translations/postman-request.spec.js
@@ -26,4 +26,20 @@ describe('postmanTranslations - request commands', () => {
     `;
     expect(postmanTranslation(inputScript)).toBe(expectedOutput);
   });
+
+  test('should handle legacy request object without pm prefix', () => {
+    const inputScript = `
+      const url = request.url;
+      const method = request.method;
+      const body = request.body;
+      const name = request.name;
+    `;
+    const expectedOutput = `
+      const url = req.getUrl();
+      const method = req.getMethod();
+      const body = req.getBody();
+      const name = req.getName();
+    `;
+    expect(postmanTranslation(inputScript)).toBe(expectedOutput);
+  });
 }); 

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/request.test.js
@@ -105,4 +105,20 @@ describe('Request Translation', () => {
         expect(translatedCode).toContain('bru.setVar("lastRequestBody", JSON.stringify(requestData));');
         expect(translatedCode).toContain('bru.setEnvVar("lastContentType", contentType);');
     });
+
+  it('should translate legacy request.* properties', () => {
+    const code = `
+        const url = request.url;
+        const method = request.method;
+        const body = request.body;
+        const name = request.name;
+        `;
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe(`
+        const url = req.getUrl();
+        const method = req.getMethod();
+        const body = req.getBody();
+        const name = req.getName();
+        `);
+  });
 }); 


### PR DESCRIPTION
[BRU-502](https://usebruno.atlassian.net/browse/BRU-502)
Fixes: https://github.com/usebruno/bruno/issues/3506

Supported mappings:
`request.url` → `req.getUrl()`
`request.method` → `req.getMethod()`
`request.headers` → `req.getHeaders()`
`request.body` → `req.getBody()`
`request.name` → `req.getName()`