### PR TITLE
feat: add UI font family and size customization

### DIFF
--- a/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
@@ -84,7 +84,7 @@ const StyledWrapper = styled.div`
   }
 
   .bruno-search-bar, .bruno-search-bar input {
-    font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important;
+    font-family: ${(props) => props.theme.uiFont || 'Inter'}, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important;
   }
 
   .cm-search-line-highlight {

--- a/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
@@ -52,7 +52,7 @@ const StyledWrapper = styled.div`
     }
 
     pre {
-      font-family: Inter, sans-serif !important;
+      font-family: ${(props) => props.theme.uiFont || 'Inter'}, sans-serif !important;
       font-weight: 400;
     }
 

--- a/packages/bruno-app/src/components/Preferences/Display/Font/index.js
+++ b/packages/bruno-app/src/components/Preferences/Display/Font/index.js
@@ -11,6 +11,8 @@ const Font = ({ close }) => {
 
   const [codeFont, setCodeFont] = useState(get(preferences, 'font.codeFont', 'default'));
   const [codeFontSize, setCodeFontSize] = useState(get(preferences, 'font.codeFontSize', '14'));
+  const [uiFont, setUiFont] = useState(get(preferences, 'font.uiFont', 'Inter'));
+  const [uiFontSize, setUiFontSize] = useState(get(preferences, 'font.uiFontSize', '14'));
 
   const handleCodeFontChange = (event) => {
     setCodeFont(event.target.value);
@@ -22,13 +24,25 @@ const Font = ({ close }) => {
     setCodeFontSize(clampedSize);
   };
 
+  const handleUiFontChange = (event) => {
+    setUiFont(event.target.value);
+  };
+
+  const handleUiFontSizeChange = (event) => {
+    // Restrict to min/max value
+    const clampedSize = Math.max(1, Math.min(event.target.value, 32));
+    setUiFontSize(clampedSize);
+  };
+
   const handleSave = () => {
     dispatch(
       savePreferences({
         ...preferences,
         font: {
           codeFont,
-          codeFontSize
+          codeFontSize,
+          uiFont,
+          uiFontSize
         }
       })
     ).then(() => {
@@ -41,31 +55,60 @@ const Font = ({ close }) => {
 
   return (
     <StyledWrapper>
-      <div className="flex flex-row gap-2 w-full">
-        <div className="w-4/5">
-          <label className="block">Code Editor Font</label>
-          <input
-            type="text"
-            className="block textbox mt-2 w-full"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck="false"
-            onChange={handleCodeFontChange}
-            defaultValue={codeFont}
-          />
+      <div className="flex flex-col gap-6 w-full">
+        <div className="flex flex-row gap-2 w-full">
+          <div className="w-4/5">
+            <label className="block">UI Font</label>
+            <input
+              type="text"
+              className="block textbox mt-2 w-full"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck="false"
+              onChange={handleUiFontChange}
+              defaultValue={uiFont}
+            />
+          </div>
+          <div className="w-1/5">
+            <label className="block">Font Size</label>
+            <input
+              type="number"
+              className="block textbox mt-2 w-full"
+              autoComplete="off"
+              autoCorrect="off"
+              inputMode="numeric"
+              onChange={handleUiFontSizeChange}
+              defaultValue={uiFontSize}
+            />
+          </div>
         </div>
-        <div className="w-1/5">
-          <label className="block">Font Size</label>
-          <input
-            type="number"
-            className="block textbox mt-2 w-full"
-            autoComplete="off"
-            autoCorrect="off"
-            inputMode="numeric"
-            onChange={handleCodeFontSizeChange}
-            defaultValue={codeFontSize}
-          />
+        <div className="flex flex-row gap-2 w-full">
+          <div className="w-4/5">
+            <label className="block">Code Editor Font</label>
+            <input
+              type="text"
+              className="block textbox mt-2 w-full"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck="false"
+              onChange={handleCodeFontChange}
+              defaultValue={codeFont}
+            />
+          </div>
+          <div className="w-1/5">
+            <label className="block">Font Size</label>
+            <input
+              type="number"
+              className="block textbox mt-2 w-full"
+              autoComplete="off"
+              autoCorrect="off"
+              inputMode="numeric"
+              onChange={handleCodeFontSizeChange}
+              defaultValue={codeFontSize}
+            />
+          </div>
         </div>
       </div>
 

--- a/packages/bruno-app/src/components/SingleLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/StyledWrapper.js
@@ -46,7 +46,7 @@ const StyledWrapper = styled.div`
     }
 
     pre {
-      font-family: Inter, sans-serif !important;
+      font-family: ${(props) => props.theme.uiFont || 'Inter'}, sans-serif !important;
       font-weight: 400;
     }
 

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -1,6 +1,12 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
+  html,
+  body {
+    font-family: ${(props) => props.theme.uiFont || 'Inter'}, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important;
+    font-size: ${(props) => props.theme.uiFontSize ? `${props.theme.uiFontSize}px` : '14px'} !important;
+  }
+
   .CodeMirror-gutters {
     background-color: ${(props) => props.theme.codemirror.gutter.bg} !important;
     border-right: solid 1px ${(props) => props.theme.codemirror.border};
@@ -318,7 +324,7 @@ const GlobalStyle = createGlobalStyle`
   .CodeMirror-brunoVarInfo .var-value-display {
     padding: 0.375rem 1.5rem 0.375rem 0.5rem;
     font-size: 0.875rem;
-    font-family: Inter, sans-serif;
+    font-family: ${(props) => props.theme.uiFont || 'Inter'}, sans-serif;
     font-weight: 400;
     word-break: break-word;
     line-height: 1.25rem;
@@ -341,7 +347,7 @@ const GlobalStyle = createGlobalStyle`
     min-height: 1.75rem;
     max-height: 11.125rem;
     font-size: 0.875rem;
-    font-family: Inter, sans-serif;
+    font-family: ${(props) => props.theme.uiFont || 'Inter'}, sans-serif;
     font-weight: 400;
     line-height: 1.25rem;
     border: 0.0625rem solid ${(props) => props.theme.codemirror.variable.info.editorBorder};
@@ -366,7 +372,7 @@ const GlobalStyle = createGlobalStyle`
   .CodeMirror-brunoVarInfo .var-value-editor .CodeMirror-lines {
     padding: 0.375rem 1.5rem 0.375rem 0.5rem;
     max-width: 13.1875rem;
-    font-family: Inter, sans-serif;
+    font-family: ${(props) => props.theme.uiFont || 'Inter'}, sans-serif;
     font-weight: 400;
     line-height: 1.25rem;
     word-break: break-all;
@@ -376,7 +382,7 @@ const GlobalStyle = createGlobalStyle`
 
   .CodeMirror-brunoVarInfo .var-value-editor .CodeMirror pre {
     font-size: 0.875rem;
-    font-family: Inter, sans-serif;
+    font-family: ${(props) => props.theme.uiFont || 'Inter'}, sans-serif;
     font-weight: 400;
     line-height: 1.25rem;
     word-break: break-all;
@@ -391,7 +397,7 @@ const GlobalStyle = createGlobalStyle`
     max-width: 13.1875rem;
     line-height: 1.25rem;
     font-size: 0.875rem;
-    font-family: Inter, sans-serif;
+    font-family: ${(props) => props.theme.uiFont || 'Inter'}, sans-serif;
     font-weight: 400;
     word-break: break-all;
     word-wrap: break-word;
@@ -411,7 +417,7 @@ const GlobalStyle = createGlobalStyle`
     max-width: 13.1875rem;
     padding: 0.375rem 1.5rem 0.375rem 0.5rem;
     font-size: 0.875rem;
-    font-family: Inter, sans-serif;
+    font-family: ${(props) => props.theme.uiFont || 'Inter'}, sans-serif;
     font-weight: 400;
     word-break: break-all;
     word-wrap: break-word;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -24,7 +24,10 @@ const initialState = {
       timeout: 0
     },
     font: {
-      codeFont: 'default'
+      codeFont: 'default',
+      codeFontSize: '14',
+      uiFont: 'Inter',
+      uiFontSize: '14'
     },
     general: {
       defaultCollectionLocation: ''

--- a/packages/bruno-app/src/providers/Theme/index.js
+++ b/packages/bruno-app/src/providers/Theme/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import themes from 'themes/index';
 import useLocalStorage from 'hooks/useLocalStorage/index';
+import { useSelector } from 'react-redux';
+import get from 'lodash/get';
 
 import { createContext, useContext, useEffect, useState } from 'react';
 import { ThemeProvider as SCThemeProvider } from 'styled-components';
@@ -10,6 +12,10 @@ export const ThemeProvider = (props) => {
   const isBrowserThemeLight = window.matchMedia('(prefers-color-scheme: light)').matches;
   const [displayedTheme, setDisplayedTheme] = useState(isBrowserThemeLight ? 'light' : 'dark');
   const [storedTheme, setStoredTheme] = useLocalStorage('bruno.theme', 'system');
+  const preferences = useSelector((state) => state.app.preferences);
+  const uiFont = get(preferences, 'font.uiFont', 'Inter');
+  const uiFontSize = get(preferences, 'font.uiFontSize', '14');
+
   const toggleHtml = () => {
     const html = document.querySelector('html');
     if (html) {
@@ -41,7 +47,12 @@ export const ThemeProvider = (props) => {
   // storedTheme can have 3 values: 'light', 'dark', 'system'
   // displayedTheme can have 2 values: 'light', 'dark'
 
-  const theme = storedTheme === 'system' ? themes[displayedTheme] : themes[storedTheme];
+  const baseTheme = storedTheme === 'system' ? themes[displayedTheme] : themes[storedTheme];
+  const theme = {
+    ...baseTheme,
+    uiFont,
+    uiFontSize
+  };
   const themeOptions = Object.keys(themes);
   const value = {
     theme,


### PR DESCRIPTION
BRU-4457

Recently started using Bruno. I like my productivity tools a bit uniform in terms of visual preferences so decided to add this feature upstream! Lmk if needs any modifications. 

Thanks!

# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

This PR adds UI font family and size customization to Bruno's Display preferences, allowing users to customize the appearance of the entire application interface independently from the code editor font settings.

### Here's a screenshot

<img width="1345" height="942" alt="Screenshot 2025-11-22 at 6 39 51 PM" src="https://github.com/user-attachments/assets/d8fc6e49-a786-4a42-a2ea-1b7c9845b8bd" />

Tested with a few local fonts

Also closes #5634 

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
