### PR TITLE
fix: prevent double serialization of websocket text messages (#6173)

### DIFF
--- a/packages/bruno-requests/src/ws/ws-client.js
+++ b/packages/bruno-requests/src/ws/ws-client.js
@@ -144,8 +144,11 @@ class WsClient {
         messageToSend = message;
       }
 
+      // If messageToSend is a string, send it raw. If it is an object, stringify it.
+      const payload = typeof messageToSend === 'string' ? messageToSend : JSON.stringify(messageToSend);
+
       // Send the message
-      connectionMeta.connection.send(JSON.stringify(messageToSend), (error) => {
+      connectionMeta.connection.send(payload, (error) => {
         if (error) {
           this.eventCallback('main:ws:error', requestId, collectionUid, { error });
         } else {


### PR DESCRIPTION
# Description

Fixes #6173

This PR fixes a bug where WebSocket messages sent using the "TEXT" message type were being incorrectly serialized as JSON strings (e.g., sending `"message"` instead of `message`). This resulted in the server receiving payloads wrapped in unwanted double quotes.

**Changes:**
- Modified `packages/bruno-requests/src/ws/ws-client.js`.
- Updated the `sendMessage` function to conditionally stringify the payload.
- Added a check: if `messageToSend` is already a string (TEXT mode), it is passed to the socket raw. If it is an object (JSON mode), it is stringified via `JSON.stringify`.

**Verification:**
- Verified locally using a WebSocket server.
- Confirmed that messages sent in TEXT mode are received by the server as raw text without extra quotes.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="1288" height="374" alt="image" src="https://github.com/user-attachments/assets/3ac7eebb-9ab3-40e2-be10-8e9e902767c5" />
<img width="806" height="217" alt="image" src="https://github.com/user-attachments/assets/89b23506-1970-4b16-896d-024290129d74" />
