### PR TITLE
fix: set focus tab

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/index.js
@@ -18,7 +18,7 @@ import Overview from './Overview/index';
 
 const CollectionSettings = ({ collection }) => {
   const dispatch = useDispatch();
-  const tab = collection.settingsSelectedTab;
+  const tab = collection.settingsSelectedTab || 'overview';
   const setTab = (tab) => {
     dispatch(
       updateSettingsSelectedTab({

--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -111,10 +111,12 @@ const HttpRequestPane = ({ item, collection }) => {
     responseVars.filter((response) => response.enabled).length;
 
   useEffect(() => {
-    if (activeParamsLength === 0 && body.mode !== 'none') {
-      selectTab('body');
+    if (!focusedTab || !focusedTab.requestPaneTab) {
+      if (activeParamsLength === 0 && body.mode !== 'none') {
+        selectTab('body');
+      }
     }
-  }, []);
+  }, [activeTabUid]);
 
   return (
     <StyledWrapper className="flex flex-col h-full relative">


### PR DESCRIPTION
fixes: #6148
# Description

This PR implements the logic for setting the focused tab

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection Settings tab selection now reliably defaults to the overview tab when the previously selected tab becomes unavailable or invalid.
  * Request pane automatic tab switching has been improved to prevent unnecessary transitions to the Body tab when a focused request tab is already active.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->