### PR TITLE
fix: Add Error constructors to NodeVM context to fix jsonwebtoken test failures

### DIFF
--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -58,7 +58,12 @@ async function runScriptInNodeVm({
       clearTimeout: global.clearTimeout,
       clearInterval: global.clearInterval,
       setImmediate: global.setImmediate,
-      clearImmediate: global.clearImmediate
+      clearImmediate: global.clearImmediate,
+      Error: global.Error,
+      TypeError: global.TypeError,
+      ReferenceError: global.ReferenceError,
+      SyntaxError: global.SyntaxError,
+      RangeError: global.RangeError
     };
 
     mixinTypedArrays(scriptContext);


### PR DESCRIPTION
# Description

When running jsonwebtoken tests with the NodeVM runtime, tests were failing because `instanceOf(Error)` checks were returning false. This occurred because:

- Errors thrown by `jsonwebtoken` inside the NodeVM context were instances of the VM's isolated Error class
- Tests checking `expect(err).to.be.instanceOf(Error)` were comparing against the outer context's Error class
- These are different Error classes, causing the instanceOf checks to fail

Added Error constructors from the global scope to the NodeVM `scriptContext`:
- `Error`
- `TypeError`
- `ReferenceError`
- `SyntaxError`
- `RangeError`

This ensures that errors thrown by `jsonwebtoken` and other modules inside the NodeVM context use the same Error class that tests check against, making `instanceOf(Error)` checks pass correctly.

This PR fixes: https://usebruno.atlassian.net/browse/BRU-2083

## Screenshot
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/2fc664b1-8ab1-45d8-b1b3-643855fd0685" />


### Contribution Checklist:

- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**
