### PR TITLE
fix: grpc messages vanishes after save if the body contains variables

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcBody/index.js
@@ -41,8 +41,8 @@ const SingleGrpcMessage = ({ message, item, collection, index, methodType, isCol
 
     dispatch(updateRequestBody({
       content: currentMessages,
-            itemUid: item.uid,
-            collectionUid: collection.uid
+      itemUid: item.uid,
+      collectionUid: collection.uid
     }));
   };
 

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -1043,22 +1043,6 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     const messageName = namePair ? namePair.value : '';
     const messageContent = contentPair ? contentPair.value : '';
     
-    try {
-      // Validate JSON by parsing (but don't modify the original string)
-      JSON.parse(messageContent);
-    } catch (error) {
-      console.error("Error validating gRPC message JSON:", error);
-      return {
-        body: {
-          mode: 'grpc',
-          grpc: [{
-            name: messageName,
-            content: '{}'
-          }]
-        }
-      };
-    }
-    
     return {
       body: {
         mode: 'grpc',

--- a/packages/bruno-lang/v2/tests/bruToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/bruToJson.spec.js
@@ -39,6 +39,60 @@ settings {
     });
   });
 
+  describe('body:grpc', () => {
+    it('parses message content with name and content', () => {
+      const input = `
+body:grpc {
+    name: message 1
+    content: '''
+      {"foo":"bar"}
+    ''' 
+}
+`;
+
+      const expected = {
+        body: {
+          mode: 'grpc',
+          grpc: [
+            {
+              content: '{"foo":"bar"}',
+              name: 'message 1'
+            }
+          ]
+        }
+      };
+
+      const output = parser(input);
+      expect(output).toEqual(expected);
+    });
+
+    it('parses message with variables in content', () => {
+      const input = `
+body:grpc {
+    name: message 1
+    content: '''
+      {"id":{{userId}},"name":"{{userName}}"}
+    ''' 
+}
+`;
+
+      const expected = {
+        body: {
+          mode: 'grpc',
+          grpc: [
+            {
+              content: '{"id":{{userId}},"name":"{{userName}}"}',
+              name: 'message 1'
+            }
+          ]
+        }
+      };
+
+      const output = parser(input);
+      expect(output).toEqual(expected);
+    });
+  });
+
   describe('multi-line values', () => {
     it('parses multi-line values in URL, headers, params, and vars', () => {
       const input = `


### PR DESCRIPTION
# Description
Grpc requests vanishes when the body contains any variable.
https://github.com/usebruno/bruno/discussions/5447#discussioncomment-14509184
[Jira ticket](https://usebruno.atlassian.net/browse/BRU-2226)

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
