### PR TITLE
fix: fetching reflection adds draft state in gRPC

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -129,11 +129,15 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
     setProtoFilePath('');
     setIsReflectionMode(true);
 
-    dispatch(updateRequestProtoPath({
-      protoPath: '',
-      itemUid: item.uid,
-      collectionUid: collection.uid
-    }));
+    // Only update protoPath if it was previously set (to avoid creating unnecessary draft state)
+    const currentProtoPath = getPropertyFromDraftOrRequest(item, 'request.protoPath', '');
+    if (currentProtoPath) {
+      dispatch(updateRequestProtoPath({
+        protoPath: '',
+        itemUid: item.uid,
+        collectionUid: collection.uid
+      }));
+    }
 
     if (methods && methods.length > 0) {
       toast.success(`Loaded ${methods.length} gRPC methods from reflection`);


### PR DESCRIPTION
# Description
When opening a gRPC request, it always opens up in draft state, although there are no changes made to the request

Jira ticket https://usebruno.atlassian.net/browse/BRU-2227

### Contribution Checklist:

- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
