### PR TITLE
fix: wrap script in async IIFE to create isolated scope

### DIFF
--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -286,46 +286,46 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
   // This allows each script to run separately with its own scope,
   // preventing variable re-declaration errors and allowing early returns
   // to only affect that specific script segment
-  const preReqScripts = compact([
+  const preReqScripts = [
     collectionPreReqScript,
     ...combinedPreReqScript,
     request?.script?.req || ''
-  ]);
+  ];
   request.script.req = compact(preReqScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
 
   // Handle post-response scripts based on scriptFlow
   if (scriptFlow === 'sequential') {
-    const postResScripts = compact([
+    const postResScripts = [
       collectionPostResScript,
       ...combinedPostResScript,
       request?.script?.res || ''
-    ]);
+    ];
     request.script.res = compact(postResScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
   } else {
     // Reverse order for non-sequential flow
-    const postResScripts = compact([
+    const postResScripts = [
       request?.script?.res || '',
-      ...combinedPostResScript.reverse(),
+      ...[...combinedPostResScript].reverse(),
       collectionPostResScript
-    ]);
+    ];
     request.script.res = compact(postResScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
   }
 
   // Handle tests based on scriptFlow
   if (scriptFlow === 'sequential') {
-    const testScripts = compact([
+    const testScripts = [
       collectionTests,
       ...combinedTests,
       request?.tests || ''
-    ]);
+    ];
     request.tests = compact(testScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
   } else {
     // Reverse order for non-sequential flow
-    const testScripts = compact([
+    const testScripts = [
       request?.tests || '',
-      ...combinedTests.reverse(),
+      ...[...combinedTests].reverse(),
       collectionTests
-    ]);
+    ];
     request.tests = compact(testScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
   }
 };

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -183,46 +183,46 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
   // This allows each script to run separately with its own scope,
   // preventing variable re-declaration errors and allowing early returns
   // to only affect that specific script segment
-  const preReqScripts = compact([
+  const preReqScripts = [
     collectionPreReqScript,
     ...combinedPreReqScript,
     request?.script?.req || ''
-  ]);
+  ];
   request.script.req = compact(preReqScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
 
   // Handle post-response scripts based on scriptFlow
   if (scriptFlow === 'sequential') {
-    const postResScripts = compact([
+    const postResScripts = [
       collectionPostResScript,
       ...combinedPostResScript,
       request?.script?.res || ''
-    ]);
+    ];
     request.script.res = compact(postResScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
   } else {
     // Reverse order for non-sequential flow
-    const postResScripts = compact([
+    const postResScripts = [
       request?.script?.res || '',
-      ...combinedPostResScript.reverse(),
+      ...[...combinedPostResScript].reverse(),
       collectionPostResScript
-    ]);
+    ];
     request.script.res = compact(postResScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
   }
 
   // Handle tests based on scriptFlow
   if (scriptFlow === 'sequential') {
-    const testScripts = compact([
+    const testScripts = [
       collectionTests,
       ...combinedTests,
       request?.tests || ''
-    ]);
+    ];
     request.tests = compact(testScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
   } else {
     // Reverse order for non-sequential flow
-    const testScripts = compact([
+    const testScripts = [
       request?.tests || '',
-      ...combinedTests.reverse(),
+      ...[...combinedTests].reverse(),
       collectionTests
-    ]);
+    ];
     request.tests = compact(testScripts.map(wrapScriptInClosure)).join(os.EOL + os.EOL);
   }
 };


### PR DESCRIPTION
# Description
Currently bruno concatenates all the scripts across the request tree path, so if we declare a variable within collection level script, we cannot redeclare the same variable, within any of the scripts that comes after it.

The problem exists even for guard clauses within the scripts, the script can return early within the collection level itself, and folder, request level scripts are never ran!

Fixes #6130

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation between pre-request, post-response, and test script segments to prevent variable leakage and cross-script conflicts.
  * Corrected execution ordering for non-sequential script flows so post-response and test scripts run in the intended order.
  * Prevented early-return behavior in one segment from affecting other script segments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->