### PR TITLE
feat: add sidebar width persistence and restoration

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/index.js
@@ -47,7 +47,9 @@ const Sidebar = () => {
         })
       );
       // Save sidebar width to preferences
-      dispatch(saveSidebarWidth(asideWidth));
+      if (asideWidth !== leftSidebarWidth) {
+        dispatch(saveSidebarWidth(asideWidth));
+      }
     }
   };
   const handleDragbarMouseDown = (e) => {

--- a/packages/bruno-app/src/components/Sidebar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/index.js
@@ -4,7 +4,7 @@ import StyledWrapper from './StyledWrapper';
 
 import { useState, useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { updateLeftSidebarWidth, updateIsDragging } from 'providers/ReduxStore/slices/app';
+import { updateLeftSidebarWidth, updateIsDragging, saveSidebarWidth } from 'providers/ReduxStore/slices/app';
 
 const MIN_LEFT_SIDEBAR_WIDTH = 221;
 const MAX_LEFT_SIDEBAR_WIDTH = 600;
@@ -46,6 +46,8 @@ const Sidebar = () => {
           isDragging: false
         })
       );
+      // Save sidebar width to preferences
+      dispatch(saveSidebarWidth(asideWidth));
     }
   };
   const handleDragbarMouseDown = (e) => {

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -4,7 +4,6 @@ import {
   updateCookies,
   updatePreferences,
   updateSystemProxyEnvVariables,
-  updateLeftSidebarWidth
 } from 'providers/ReduxStore/slices/app';
 import {
   brunoConfigUpdateEvent,
@@ -163,12 +162,6 @@ const useIpcEvents = () => {
 
     const removePreferencesUpdatesListener = ipcRenderer.on('main:load-preferences', (val) => {
       dispatch(updatePreferences(val));
-      // Restore sidebar width from preferences if available
-      if (val?.layout && val.layout.leftSidebarWidth != null) {
-        dispatch(updateLeftSidebarWidth({
-          leftSidebarWidth: val.layout.leftSidebarWidth
-        }));
-      }
     });
 
     const removeSystemProxyEnvUpdatesListener = ipcRenderer.on('main:load-system-proxy-env', (val) => {

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -164,7 +164,7 @@ const useIpcEvents = () => {
     const removePreferencesUpdatesListener = ipcRenderer.on('main:load-preferences', (val) => {
       dispatch(updatePreferences(val));
       // Restore sidebar width from preferences if available
-      if (val?.layout?.leftSidebarWidth) {
+      if (val?.layout && val.layout.leftSidebarWidth != null) {
         dispatch(updateLeftSidebarWidth({
           leftSidebarWidth: val.layout.leftSidebarWidth
         }));

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -3,7 +3,8 @@ import {
   showPreferences,
   updateCookies,
   updatePreferences,
-  updateSystemProxyEnvVariables
+  updateSystemProxyEnvVariables,
+  updateLeftSidebarWidth
 } from 'providers/ReduxStore/slices/app';
 import {
   brunoConfigUpdateEvent,
@@ -162,6 +163,12 @@ const useIpcEvents = () => {
 
     const removePreferencesUpdatesListener = ipcRenderer.on('main:load-preferences', (val) => {
       dispatch(updatePreferences(val));
+      // Restore sidebar width from preferences if available
+      if (val?.layout?.leftSidebarWidth) {
+        dispatch(updateLeftSidebarWidth({
+          leftSidebarWidth: val.layout.leftSidebarWidth
+        }));
+      }
     });
 
     const removeSystemProxyEnvUpdatesListener = ipcRenderer.on('main:load-system-proxy-env', (val) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -142,16 +142,11 @@ export const savePreferences = (preferences) => (dispatch, getState) => {
 };
 
 export const saveSidebarWidth = (leftSidebarWidth) => (dispatch, getState) => {
-  const currentPreferences = getState().app.preferences;
-  const updatedPreferences = {
-    ...currentPreferences,
-    layout: {
-      ...currentPreferences.layout,
-      leftSidebarWidth
-    }
-  };
-
-  return dispatch(savePreferences(updatedPreferences));
+  const { ipcRenderer } = window;
+  return ipcRenderer.invoke('renderer:update-ui-state-snapshot', {
+    type: 'SIDEBAR',
+    data: { width: leftSidebarWidth }
+  });
 };
 
 export const deleteCookiesForDomain = (domain) => (dispatch, getState) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -141,6 +141,27 @@ export const savePreferences = (preferences) => (dispatch, getState) => {
   });
 };
 
+export const saveSidebarWidth = (leftSidebarWidth) => (dispatch, getState) => {
+  return new Promise((resolve, reject) => {
+    const { ipcRenderer } = window;
+    const currentPreferences = getState().app.preferences;
+
+    const updatedPreferences = {
+      ...currentPreferences,
+      layout: {
+        ...currentPreferences.layout,
+        leftSidebarWidth
+      }
+    };
+
+    ipcRenderer
+      .invoke('renderer:save-preferences', updatedPreferences)
+      .then(() => dispatch(updatePreferences(updatedPreferences)))
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
 export const deleteCookiesForDomain = (domain) => (dispatch, getState) => {
   return new Promise((resolve, reject) => {
     const { ipcRenderer } = window;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -142,24 +142,16 @@ export const savePreferences = (preferences) => (dispatch, getState) => {
 };
 
 export const saveSidebarWidth = (leftSidebarWidth) => (dispatch, getState) => {
-  return new Promise((resolve, reject) => {
-    const { ipcRenderer } = window;
-    const currentPreferences = getState().app.preferences;
+  const currentPreferences = getState().app.preferences;
+  const updatedPreferences = {
+    ...currentPreferences,
+    layout: {
+      ...currentPreferences.layout,
+      leftSidebarWidth
+    }
+  };
 
-    const updatedPreferences = {
-      ...currentPreferences,
-      layout: {
-        ...currentPreferences.layout,
-        leftSidebarWidth
-      }
-    };
-
-    ipcRenderer
-      .invoke('renderer:save-preferences', updatedPreferences)
-      .then(() => dispatch(updatePreferences(updatedPreferences)))
-      .then(resolve)
-      .catch(reject);
-  });
+  return dispatch(savePreferences(updatedPreferences));
 };
 
 export const deleteCookiesForDomain = (domain) => (dispatch, getState) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2357,9 +2357,11 @@ export const hydrateCollectionWithUiStateSnapshot = (payload) => (dispatch, getS
   return new Promise((resolve, reject) => {
     const state = getState();
     try {
-      if (!uiStateSnapshotData) resolve();
+      if (!uiStateSnapshotData) {
+        return resolve();
+      }
 
-      if (uiStateSnapshotData.collections) {
+      if (uiStateSnapshotData.collections && uiStateSnapshotData.collections.pathname) {
         const { pathname, selectedEnvironment } = uiStateSnapshotData.collections;
         const collection = findCollectionByPathname(state.collections.collections, pathname);
         const collectionCopy = cloneDeep(collection);

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -7,7 +7,7 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import trim from 'lodash/trim';
 import path from 'utils/common/path';
-import { insertTaskIntoQueue, toggleSidebarCollapse } from 'providers/ReduxStore/slices/app';
+import { insertTaskIntoQueue, toggleSidebarCollapse, updateLeftSidebarWidth } from 'providers/ReduxStore/slices/app';
 import toast from 'react-hot-toast';
 import {
   findCollectionByUid,
@@ -2353,22 +2353,29 @@ export const saveCollectionSecurityConfig = (collectionUid, securityConfig) => (
 };
 
 export const hydrateCollectionWithUiStateSnapshot = (payload) => (dispatch, getState) => {
-  const collectionSnapshotData = payload;
+  const uiStateSnapshotData = payload;
   return new Promise((resolve, reject) => {
     const state = getState();
     try {
-      if (!collectionSnapshotData) resolve();
-      const { pathname, selectedEnvironment } = collectionSnapshotData;
-      const collection = findCollectionByPathname(state.collections.collections, pathname);
-      const collectionCopy = cloneDeep(collection);
-      const collectionUid = collectionCopy?.uid;
+      if (!uiStateSnapshotData) resolve();
 
-      // update selected environment
-      if (selectedEnvironment) {
-        const environment = findEnvironmentInCollectionByName(collectionCopy, selectedEnvironment);
-        if (environment) {
-          dispatch(_selectEnvironment({ environmentUid: environment?.uid, collectionUid }));
+      if (uiStateSnapshotData.collections) {
+        const { pathname, selectedEnvironment } = uiStateSnapshotData.collections;
+        const collection = findCollectionByPathname(state.collections.collections, pathname);
+        const collectionCopy = cloneDeep(collection);
+        const collectionUid = collectionCopy?.uid;
+
+        // update selected environment
+        if (selectedEnvironment) {
+          const environment = findEnvironmentInCollectionByName(collectionCopy, selectedEnvironment);
+          if (environment) {
+            dispatch(_selectEnvironment({ environmentUid: environment?.uid, collectionUid }));
+          }
         }
+      }
+
+      if (uiStateSnapshotData.sidebar && uiStateSnapshotData.sidebar.width != null) {
+        dispatch(updateLeftSidebarWidth({ leftSidebarWidth: uiStateSnapshotData.sidebar.width }));
       }
 
       // todo: add any other redux state that you want to save

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -660,7 +660,8 @@ const onWatcherSetupComplete = (win, watchPath, collectionUid, watcher) => {
   const UiStateSnapshotStore = new UiStateSnapshot();
   const collectionsSnapshotState = UiStateSnapshotStore.getCollections();
   const collectionSnapshotState = collectionsSnapshotState?.find(c => c?.pathname == watchPath);
-  win.webContents.send('main:hydrate-app-with-ui-state-snapshot', collectionSnapshotState);
+  const uiSnapshotState = { collections: collectionSnapshotState || {} };
+  win.webContents.send('main:hydrate-app-with-ui-state-snapshot', uiSnapshotState);
 };
 
 class CollectionWatcher {

--- a/packages/bruno-electron/src/ipc/preferences.js
+++ b/packages/bruno-electron/src/ipc/preferences.js
@@ -4,7 +4,7 @@ const { isDirectory } = require('../utils/filesystem');
 const { openCollection } = require('../app/collections');
 const { globalEnvironmentsStore } = require('../store/global-environments');
 const UiStateSnapshot = require('../store/ui-state-snapshot');
-``;
+
 const registerPreferencesIpc = (mainWindow, watcher, lastOpenedCollections) => {
   ipcMain.handle('renderer:ready', async (event) => {
     // load preferences

--- a/packages/bruno-electron/src/ipc/preferences.js
+++ b/packages/bruno-electron/src/ipc/preferences.js
@@ -3,6 +3,7 @@ const { getPreferences, savePreferences, preferencesUtil } = require('../store/p
 const { isDirectory } = require('../utils/filesystem');
 const { openCollection } = require('../app/collections');
 const { globalEnvironmentsStore } = require('../store/global-environments');
+const UiStateSnapshot = require('../store/ui-state-snapshot');
 ``;
 const registerPreferencesIpc = (mainWindow, watcher, lastOpenedCollections) => {
   ipcMain.handle('renderer:ready', async (event) => {
@@ -24,6 +25,17 @@ const registerPreferencesIpc = (mainWindow, watcher, lastOpenedCollections) => {
     }
     catch(error) {
       console.error("Error occured while fetching global environements!");
+      console.error(error);
+    }
+
+    // hydrate UI state snapshot sidebar width
+    try {
+      const UiStateSnapshotStore = new UiStateSnapshot();
+      const sidebarSnapshotState = UiStateSnapshotStore.getSidebar();
+      const uiSnapshotState = { sidebar: sidebarSnapshotState || {} };
+      mainWindow.webContents.send('main:hydrate-app-with-ui-state-snapshot', uiSnapshotState);
+    } catch (error) {
+      console.error('Error loading UI state snapshot');
       console.error(error);
     }
 

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -39,7 +39,8 @@ const defaultPreferences = {
     bypassProxy: ''
   },
   layout: {
-    responsePaneOrientation: 'horizontal'
+    responsePaneOrientation: 'horizontal',
+    leftSidebarWidth: 222
   },
   beta: {},
   onboarding: {
@@ -85,7 +86,8 @@ const preferencesSchema = Yup.object().shape({
     bypassProxy: Yup.string().optional().max(1024)
   }),
   layout: Yup.object({
-    responsePaneOrientation: Yup.string().oneOf(['horizontal', 'vertical'])
+    responsePaneOrientation: Yup.string().oneOf(['horizontal', 'vertical']),
+    leftSidebarWidth: Yup.number().min(221).max(600).nullable()
   }),
   beta: Yup.object({
   }),

--- a/packages/bruno-electron/src/store/ui-state-snapshot.js
+++ b/packages/bruno-electron/src/store/ui-state-snapshot.js
@@ -64,14 +64,16 @@ class UiStateSnapshotStore {
 
   update({ type, data }) {
     switch(type) {
-      case 'COLLECTION_ENVIRONMENT':
+      case 'COLLECTION_ENVIRONMENT': {
         const { collectionPath, environmentName } = data;
         this.updateCollectionEnvironment({ collectionPath, environmentName });
         break;
-      case 'SIDEBAR':
+      }
+      case 'SIDEBAR': {
         const { width } = data;
         this.updateSidebarWidth(width);
         break;
+      }
       default:
         break;
     }

--- a/packages/bruno-electron/src/store/ui-state-snapshot.js
+++ b/packages/bruno-electron/src/store/ui-state-snapshot.js
@@ -45,11 +45,32 @@ class UiStateSnapshotStore {
     this.setCollectionByPathname({ collection });
   }
 
+  getSidebar() {
+    return this.store.get('sidebar') || { width: 222 };
+  }
+
+  saveSidebar(sidebar) {
+    this.store.set('sidebar', sidebar);
+  }
+
+  getSidebarWidth() {
+    const sidebar = this.getSidebar();
+    return sidebar && sidebar.width != null ? sidebar.width : 222;
+  }
+
+  updateSidebarWidth(width) {
+    this.saveSidebar({ width });
+  }
+
   update({ type, data }) {
     switch(type) {
       case 'COLLECTION_ENVIRONMENT':
         const { collectionPath, environmentName } = data;
         this.updateCollectionEnvironment({ collectionPath, environmentName });
+        break;
+      case 'SIDEBAR':
+        const { width } = data;
+        this.updateSidebarWidth(width);
         break;
       default:
         break;


### PR DESCRIPTION
# Description

- Implemented saving of left sidebar width to user preferences in the Redux store.
- Added functionality to restore sidebar width from preferences on application load.
- Updated preferences schema to include leftSidebarWidth with validation.
- Set default leftSidebarWidth in the preferences to 222.
- FWIW, Copilot came up with this implementation. I've tested it on my machine and it works.

Fixes #635

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar width is now persisted when you finish resizing it and automatically restored on app launch.
  * App initializes renderer with a stored UI snapshot so sidebar settings are applied reliably at startup.
  * Added a sensible default width and enforced acceptable width range to prevent extreme layouts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->