### PR TITLE
fix: stringify `rawValue` in `brunoVarInfo`

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -308,7 +308,7 @@ export const renderVarInfo = (token, options) => {
 
     // Create CodeMirror instance
     const cmEditor = CodeMirror(editorContainer, {
-      value: rawValue, // Use raw value (e.g., {{echo-host}} not resolved value)
+      value: typeof rawValue === 'string' ? rawValue : String(rawValue), // Use raw value (e.g., {{echo-host}} not resolved value) (ensure it's always a string for CodeMirror) #usebruno/bruno/#6265
       mode: 'brunovariables',
       theme: cmTheme,
       lineWrapping: true,


### PR DESCRIPTION
fixes: #6265

## Description (CodeRabbit)

* **Bug Fixes**
  * Improved variable value handling in the editor. Numeric and non-string values are now properly converted to strings for consistent and reliable display, preventing potential rendering errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where non-string values in the code editor could cause display problems, ensuring proper compatibility with the editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->