### PR TITLE
Fix: Folder-level configuration not applied when using "Configure requests to run"

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -672,26 +672,6 @@ export const runCollectionFolder
         })
       );
 
-      // to only include those requests in the specified order while preserving folder data
-      if (selectedRequestUids && selectedRequestUids.length > 0) {
-        const newItems = [];
-
-        selectedRequestUids.forEach((uid, index) => {
-          const requestItem = findItemInCollection(collectionCopy, uid);
-          if (requestItem) {
-            const clonedRequest = cloneDeep(requestItem);
-            clonedRequest.seq = index + 1;
-            newItems.push(clonedRequest);
-          }
-        });
-
-        if (folder) {
-          folder.items = newItems;
-        } else {
-          collectionCopy.items = newItems;
-        }
-      }
-
       const { ipcRenderer } = window;
       ipcRenderer
         .invoke(
@@ -702,7 +682,8 @@ export const runCollectionFolder
           collectionCopy.runtimeVariables,
           recursive,
           delay,
-          tags
+          tags,
+          selectedRequestUids
         )
         .then(resolve)
         .catch((err) => {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1057,8 +1057,7 @@ const registerNetworkIpc = (mainWindow) => {
   ipcMain.handle('fetch-gql-schema', fetchGqlSchemaHandler);
 
   ipcMain.handle(
-    'renderer:run-collection-folder',
-    async (event, folder, collection, environment, runtimeVariables, recursive, delay, tags) => {
+    'renderer:run-collection-folder', async (event, folder, collection, environment, runtimeVariables, recursive, delay, tags, selectedRequestUids) => {
       const collectionUid = collection.uid;
       const collectionPath = collection.pathname;
       const folderUid = folder ? folder.uid : null;
@@ -1133,6 +1132,22 @@ const registerNetworkIpc = (mainWindow) => {
             requestTags = draft?.tags || requestTags || [];
             return isRequestTagsIncluded(requestTags, includeTags, excludeTags);
           });
+        }
+
+        // Filter requests based on selectedRequestUids (for "Configure requests to run")
+        if (selectedRequestUids && selectedRequestUids.length > 0) {
+          const uidIndexMap = new Map();
+          selectedRequestUids.forEach((uid, index) => {
+            uidIndexMap.set(uid, index);
+          });
+
+          folderRequests = folderRequests
+            .filter((request) => uidIndexMap.has(request.uid))
+            .sort((a, b) => {
+              const indexA = uidIndexMap.get(a.uid);
+              const indexB = uidIndexMap.get(b.uid);
+              return indexA - indexB;
+            });
         }
 
         let currentRequestIndex = 0;


### PR DESCRIPTION
[Jira](https://usebruno.atlassian.net/browse/BRU-2269)
fixes: #5645 

### Description

* Refactor `runCollectionFolder` action to accept `selectedRequestUids` for filtering and ordering requests.
* Update IPC handler to process `selectedRequestUids`, ensuring requests are executed in the specified order while preserving folder data.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running selected requests from a collection folder while preserving execution order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->