### PR TITLE
fix: styling for traffic light when window is out of focus

### DIFF
--- a/packages/bruno-app/src/components/AppTitleBar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AppTitleBar/StyledWrapper.js
@@ -8,6 +8,39 @@ const Wrapper = styled.div`
   border-bottom: 1px solid ${(props) => props.theme.sidebar.collection.item.hoverBg};
   -webkit-app-region: drag;
   user-select: none;
+  position: relative;
+
+  .traffic-light-placeholders {
+    position: absolute;
+    left: 13px;
+    top: 12px;
+    width: 52px;
+    height: 12px;
+    z-index: 1;
+    pointer-events: none;
+    -webkit-app-region: no-drag;
+  }
+
+  .traffic-light {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.25);
+    top: 0;
+  }
+
+  .traffic-light:nth-child(1) {
+    left: 0;
+  }
+
+  .traffic-light:nth-child(2) {
+    left: 20px;
+  }
+
+  .traffic-light:nth-child(3) {
+    left: 40px;
+  }
 
   .titlebar-content {
     display: flex;

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -181,6 +181,15 @@ app.on('ready', async () => {
     mainWindow.webContents.send('main:leave-full-screen');
   });
 
+  if (isMac) {
+    mainWindow.on('focus', () => {
+      mainWindow.webContents.send('main:window-focus');
+    });
+    mainWindow.on('blur', () => {
+      mainWindow.webContents.send('main:window-blur');
+    });
+  }
+
   mainWindow.on('close', (e) => {
     e.preventDefault();
     terminalManager.cleanup(mainWindow.webContents);


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added traffic light window controls to the macOS app title bar for improved visual consistency with native applications
* Window controls intelligently show and hide based on window focus state, providing clearer visual feedback when the app is active or inactive
* Enhanced platform-specific window management with native focus and blur event tracking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->