### PR TITLE
Fix for 'Enter' key double submission issue

### DIFF
--- a/packages/bruno-app/src/components/Modal/index.js
+++ b/packages/bruno-app/src/components/Modal/index.js
@@ -85,7 +85,9 @@ const Modal = ({
         return closeModal({ type: 'esc' });
       }
       case ENTER_KEY_CODE: {
-        if (!shiftKey && !ctrlKey && !altKey && !metaKey && handleConfirm) {
+        // Skip if a submit button is focused - let native button click handle it to avoid double-fire
+        const isSubmitButton = event.target?.type === 'submit';
+        if (!shiftKey && !ctrlKey && !altKey && !metaKey && handleConfirm && !isSubmitButton) {
           return handleConfirm();
         }
       }


### PR DESCRIPTION
fixes: #6355

### Description

Fix: 
- https://github.com/usebruno/bruno/issues/6355

When users navigate to a modal's Save/Create button using Tab and press Enter, the form action was being triggered twice. 

**This caused:**

- Duplicate toast notifications (e.g., "Collection renamed!" appearing twice)
- Race conditions in operations like Git branch creation (fatal: Unable to create '.git/index.lock': File exists)
- Duplicate environment/collection entries being created

**Root Cause:**
The Modal component has a document-level keydown listener that calls handleConfirm() on Enter. When a type="submit" button is focused, pressing Enter also triggers the button's native click event, resulting in handleConfirm() being called twice.

**Fix:**
Skip the document-level Enter handler when a type="submit" button is focused, allowing the native button click to handle submission (single execution).

Very small code change:

```javascript
case ENTER_KEY_CODE: {
  // Skip if a submit button is focused - let native button click handle it to avoid double-fire
  const isSubmitButton = event.target?.type === 'submit';
  if (!shiftKey && !ctrlKey && !altKey && !metaKey && handleConfirm && !isSubmitButton) {
    return handleConfirm();
  }
}
```

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

#### Recording

No longer causing duplicate environment creation:

https://github.com/user-attachments/assets/6cf7e0c5-a825-46e3-95b5-9d982b3820b3


