### PR TITLE
fix: update default state for advanced options and change default collection format

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -27,7 +27,7 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation }) => 
   const [isEditing, toggleEditing] = useState(false);
   const preferences = useSelector((state) => state.app.preferences);
   const [showExternalLocation, setShowExternalLocation] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(true);
   const dropdownTippyRef = useRef();
   const onDropdownCreate = (ref) => (dropdownTippyRef.current = ref);
 
@@ -47,7 +47,7 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation }) => 
       collectionName: '',
       collectionFolderName: '',
       collectionLocation: defaultLocation || '',
-      format: 'yml'
+      format: 'bru'
     },
     validationSchema: Yup.object({
       collectionName: Yup.string()


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

- Set default state of showAdvanced to true in CreateCollection component.
- Change default format for collections from 'yml' to 'bru'.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced options now display by default when creating collections.
  * Default file format for new collections changed to BRU.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->