### PR TITLE
fix: response pane size when devtool open

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -52,6 +52,7 @@ const RequestTabPanel = () => {
   const _collections = useSelector((state) => state.collections.collections);
   const preferences = useSelector((state) => state.app.preferences);
   const isVerticalLayout = preferences?.layout?.responsePaneOrientation === 'vertical';
+  const isConsoleOpen = useSelector((state) => state.logs.isConsoleOpen);
 
   // merge `globalEnvironmentVariables` into the active collection and rebuild `collections` immer proxy object
   let collections = produce(_collections, (draft) => {
@@ -73,6 +74,7 @@ const RequestTabPanel = () => {
   const [dragging, setDragging] = useState(false);
   const dragOffset = useRef({ x: 0, y: 0 });
   const { left: leftPaneWidth, top: topPaneHeight, reset: resetPaneBoundaries, setTop: setTopPaneHeight, setLeft: setLeftPaneWidth } = useTabPaneBoundaries(activeTabUid);
+  const previousTopPaneHeight = useRef(null); // Store height before devtools opens
 
   // Not a recommended pattern here to have the child component
   // make a callback to set state, but treating this as an exception
@@ -135,6 +137,30 @@ const RequestTabPanel = () => {
       document.removeEventListener('mousemove', handleMouseMove);
     };
   }, [dragging]);
+
+  // When devtools opens in vertical layout, reduce request pane height to ensure response pane is visible
+  // When devtools closes, restore the previous height
+  useEffect(() => {
+    if (!isVerticalLayout) return;
+
+    if (isConsoleOpen) {
+      // Store current height before reducing
+      if (previousTopPaneHeight.current === null) {
+        previousTopPaneHeight.current = topPaneHeight;
+      }
+      // Reduce request pane height to make room for response pane when devtools is open
+      const maxHeight = 200;
+      if (topPaneHeight > maxHeight) {
+        setTopPaneHeight(maxHeight);
+      }
+    } else {
+      // Restore previous height when devtools closes
+      if (previousTopPaneHeight.current !== null) {
+        setTopPaneHeight(previousTopPaneHeight.current);
+        previousTopPaneHeight.current = null;
+      }
+    }
+  }, [isConsoleOpen, isVerticalLayout]);
 
   if (!activeTabUid) {
     return <WorkspaceHome />;

--- a/packages/bruno-app/src/components/ResponsePane/Placeholder/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Placeholder/index.js
@@ -12,12 +12,14 @@ const Placeholder = () => {
   const preferences = useSelector((state) => state.app.preferences);
   const isVerticalLayout = preferences?.layout?.responsePaneOrientation === 'vertical';
 
+  const iconSize = isVerticalLayout ? 80 : 150;
+
   return (
     <StyledWrapper className={`${isVerticalLayout ? 'vertical-layout' : ''}`}>
-      <div className="send-icon flex justify-center" style={{ fontSize: 200 }}>
-        <IconSend size={150} strokeWidth={1} />
+      <div className="send-icon flex justify-center" style={{ fontSize: isVerticalLayout ? 100 : 200 }}>
+        <IconSend size={iconSize} strokeWidth={1} />
       </div>
-      <div className="flex mt-4">
+      <div className={`flex ${isVerticalLayout ? 'mt-2' : 'mt-4'}`}>
         <div className="flex flex-1 flex-col items-end px-1">
           <div className="px-1 py-2">Send Request</div>
           <div className="px-1 py-2">New Request</div>


### PR DESCRIPTION
### Description

[JIRA]( https://usebruno.atlassian.net/browse/BRU-2296)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/dfc0427a-242f-4322-a84f-08dc82353fae


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed console panel height management in vertical layout—heights are now properly stored and restored when opening/closing the console.
  * Improved layout responsiveness—icon sizes and vertical spacing now automatically adjust based on layout orientation for better visual consistency across different screen configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->