### PR TITLE
fix: Code generation fails for URLs containing encoded spaces (%20)

### DIFF
--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -107,7 +107,7 @@ export const interpolateUrlPathParams = (url, params) => {
         if (segment.startsWith(':')) {
           const name = segment.slice(1);
           const pathParam = params.find((p) => p?.name === name && p?.type === 'path');
-          return pathParam ? pathParam.value : segment;
+          return pathParam ? encodeURIComponent(pathParam.value) : segment;
         }
 
         // for OData-style parameters (parameters inside parentheses)
@@ -131,7 +131,7 @@ export const interpolateUrlPathParams = (url, params) => {
 
           const pathParam = params.find((p) => p?.name === name && p?.type === 'path');
           if (pathParam) {
-            result = result.replace(':' + match[1], pathParam.value);
+            result = result.replace(':' + match[1], encodeURIComponent(pathParam.value));
           }
         }
         return result;

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -348,4 +348,37 @@ describe('Url Utils - interpolateUrl, interpolateUrlPathParams', () => {
 
     expect(result).toEqual(expectedUrl);
   });
+
+  it('should URL-encode path params with spaces', () => {
+    const url = 'https://example.com/api/v1/roles/:role_name';
+    const params = [{ name: 'role_name', type: 'path', enabled: true, value: 'test - test' }];
+    const expectedUrl = 'https://example.com/api/v1/roles/test%20-%20test';
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual(expectedUrl);
+  });
+
+  it('should URL-encode path params with special characters', () => {
+    const url = 'https://example.com/api/:id/details';
+    const params = [{ name: 'id', type: 'path', enabled: true, value: 'hello world & stuff' }];
+    const expectedUrl = 'https://example.com/api/hello%20world%20%26%20stuff/details';
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual(expectedUrl);
+  });
+
+  it('should URL-encode multiple path params with spaces', () => {
+    const url = 'https://example.com/api/:category/:name';
+    const params = [
+      { name: 'category', type: 'path', enabled: true, value: 'my category' },
+      { name: 'name', type: 'path', enabled: true, value: 'item name' }
+    ];
+    const expectedUrl = 'https://example.com/api/my%20category/item%20name';
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual(expectedUrl);
+  });
 });

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -127,7 +127,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
           if (!existingPathParam) {
             return '/' + path;
           }
-          return '/' + existingPathParam.value;
+          return '/' + encodeURIComponent(existingPathParam.value);
         }
 
         // for OData-style parameters (parameters inside parentheses)
@@ -146,7 +146,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
               if (name) {
                 const existingPathParam = request.pathParams.find((param) => param.name === name);
                 if (existingPathParam) {
-                  result = result.replace(':' + match[1], existingPathParam.value);
+                  result = result.replace(':' + match[1], encodeURIComponent(existingPathParam.value));
                 }
               }
             }

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -173,7 +173,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
           if (!existingPathParam) {
             return '/' + path;
           }
-          return '/' + existingPathParam.value;
+          return '/' + encodeURIComponent(existingPathParam.value);
         }
 
         // for OData-style parameters (parameters inside parentheses)
@@ -192,7 +192,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
               if (name) {
                 const existingPathParam = request.pathParams.find((param) => param.name === name);
                 if (existingPathParam) {
-                  result = result.replace(':' + match[1], existingPathParam.value);
+                  result = result.replace(':' + match[1], encodeURIComponent(existingPathParam.value));
                 }
               }
             }


### PR DESCRIPTION
[Jira](https://usebruno.atlassian.net/browse/BRU-2310)
fixes: #6268 

### Description

* Updated `interpolateUrlPathParams` to URL-encode path parameters, ensuring proper handling of spaces and special characters.
* Added tests to verify encoding functionality for various path parameters in `url` utility functions.
* Enhanced `generateSnippet` to support URL-encoded path parameters in generated code snippets.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


BRU file to reproduce this issue:
```
meta {
  name: Get Role Information
  type: http
  seq: 1
}

get {
  url: https://example.com/api/v1/roles/:role_name
  body: none
  auth: none
}

params:path {
  role_name: test - test
}
```

Before:
<img width="1600" height="862" alt="image" src="https://github.com/user-attachments/assets/0ce64568-aace-41f8-9604-07e1021c61c2" />

After:
<img width="1596" height="872" alt="image" src="https://github.com/user-attachments/assets/37369663-5983-4a03-a695-4be97f318b4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL path parameter handling to properly encode special characters and spaces, ensuring correct API request formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->