### PR TITLE
fix: tabs z-index issue

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/StyledWrapper.js
@@ -15,7 +15,6 @@ const StyledWrapper = styled.div.attrs((props) => ({
   right: 0;
   top: 0;
   padding-right: 4px;
-  z-index: 3;
   
   background-image: linear-gradient(
     90deg,

--- a/packages/bruno-app/src/components/RequestTabs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/StyledWrapper.js
@@ -38,7 +38,6 @@ const Wrapper = styled.div`
     display: flex;
     align-items: flex-end;
     position: relative;
-    z-index: 1;
 
     &::-webkit-scrollbar {
       display: none;


### PR DESCRIPTION
### Description

issue:
<img width="855" height="335" alt="Screenshot 2025-12-15 at 5 51 26 PM" src="https://github.com/user-attachments/assets/8f172cc4-d029-496b-a38a-3784d861252c" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual stacking order of tab interface elements and associated controls for improved layering presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->