### PR TITLE
fix: include request URL in prompt variable extraction

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -478,6 +478,7 @@ const extractPromptVariablesForRequest = async (item, collection) => {
     prompts.push(...extractPromptVariables(headers));
     prompts.push(...extractPromptVariables(request.params));
     prompts.push(...extractPromptVariables(resolvedAuthRequest.auth));
+    prompts.push(...extractPromptVariables(request.url));
 
     // Remove duplicates
     const uniquePrompts = Array.from(new Set(prompts));

--- a/tests/interpolation/prompt-variables/fixtures/collection/http-folder/http-request-without-ca.bru
+++ b/tests/interpolation/prompt-variables/fixtures/collection/http-folder/http-request-without-ca.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://localhost:8081/api/echo/json?query={{?Enter Query Variable}}
+  url: http://localhost:{{?Enter Port Variable}}/api/echo/json?query={{?Enter Query Variable}}
   body: json
   auth: inherit
 }

--- a/tests/interpolation/prompt-variables/http-request-prompt-variables.spec.ts
+++ b/tests/interpolation/prompt-variables/http-request-prompt-variables.spec.ts
@@ -32,7 +32,7 @@ test.describe('Prompt Variables Interpolation', () => {
     await test.step('Verify duplicate prompt variables are not allowed', async () => {
       // Enter the prompt variables
       promptInputs = promptVariablesModal.getByTestId('prompt-variable-input-container');
-      await expect(promptInputs).toHaveCount(11);
+      await expect(promptInputs).toHaveCount(12);
     });
 
     await test.step('Verify disabled / non selected modes prompt variables are not prompted', async () => {
@@ -46,6 +46,7 @@ test.describe('Prompt Variables Interpolation', () => {
     });
 
     await test.step('Fill the prompt variables and send the request', async () => {
+      await promptInputs.filter({ hasText: 'Enter Port Variable' }).locator('input').fill('8081');
       await promptInputs.filter({ hasText: 'Enter Query Variable' }).locator('input').fill('queryPromptValue');
       await promptInputs.filter({ hasText: 'Enter Body Variable' }).locator('input').fill('bodyPromptValue');
       await promptInputs.filter({ hasText: 'Enter Number Variable' }).locator('input').fill('123');


### PR DESCRIPTION
fixes: #6405

## Summary by CodeRabbit

* **New Features**
  * Variables from request URLs are now recognized and available for use in prompts across the application, extending the sources of variables considered when prompting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request URLs now support prompt variables, enabling dynamic configuration of ports and other URL components. Users will be prompted to enter these values when executing requests.

* **Tests**
  * Expanded test coverage for prompt variable extraction and interpolation in request URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->