### PR TITLE
Revert "Save cookies on redirect response"

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -546,10 +546,6 @@ const runSingleRequest = async function (
         err.response.dataBuffer = dataBuffer;
         response = err.response;
 
-        if (!options.disableCookies) {
-          saveCookies(request.url, err.response.headers);
-        }
-
         // Prevents the duration on leaking to the actual result
         responseTime = response.headers.get('request-duration');
         response.headers.delete('request-duration');

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1417,10 +1417,6 @@ const registerNetworkIpc = (mainWindow) => {
                 error.response.data = data;
                 error.response.dataBuffer = dataBuffer;
 
-                if (preferencesUtil.shouldStoreCookies()) {
-                  saveCookies(request.url, error.response.headers);
-                }
-
                 timeEnd = Date.now();
                 response = {
                   status: error.response.status,


### PR DESCRIPTION
Reverts usebruno/bruno#6094 in favour of https://github.com/usebruno/bruno/pull/5387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cookie persistence handling to prevent automatic cookie saving when HTTP error responses occur. Cookies are now only stored for successful requests, ensuring cleaner session management and more predictable behavior when working with APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->