### PR TITLE
fix: Only update scroll position when unmounting the editor

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -192,7 +192,6 @@ export default class CodeEditor extends React.Component {
     if (editor) {
       editor.setOption('lint', this.props.mode && editor.getValue().trim().length > 0 ? this.lintOptions : false);
       editor.on('change', this._onEdit);
-      editor.on('scroll', this.onScroll);
       editor.scrollTo(null, this.props.initialScroll);
       this.addOverlay();
 
@@ -275,12 +274,18 @@ export default class CodeEditor extends React.Component {
 
   componentWillUnmount() {
     if (this.editor) {
+      if (this.props.onScroll) {
+        this.props.onScroll(this.editor);
+      }
+
       this.editor?._destroyLinkAware?.();
       this.editor.off('change', this._onEdit);
-      this.editor.off('scroll', this.onScroll);
 
       // Clean up lint error tooltip
       this.cleanupLintErrorTooltip?.();
+
+      const wrapper = this.editor.getWrapperElement();
+      wrapper?.parentNode?.removeChild(wrapper);
 
       this.editor = null;
     }
@@ -324,8 +329,6 @@ export default class CodeEditor extends React.Component {
     defineCodeMirrorBrunoVariablesMode(variables, mode, false, this.props.enableVariableHighlighting);
     this.editor.setOption('mode', 'brunovariables');
   };
-
-  onScroll = (event) => this.props.onScroll?.(event);
 
   _onEdit = () => {
     if (!this.ignoreChangeEvent && this.editor) {


### PR DESCRIPTION
### Description

When scrolling, the `responsePaneScrollPosition` was updated on every frame, causing unnecessary re-renders of everything related to the tab, including the code editor itself. This caused performance issues and made scrolling look "sluggish".

The scroll location is now only saved when needed (on unmount/navigation) rather than on every scroll event. The scroll position is still properly restored after sending a new request.

I also added proper cleanup for the CodeMirror instance. This prevents duplicate editors in development mode due to React StrictMode's double-rendering: https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-double-rendering-in-development (Notice the doubled scrollbar in the before video)
```js
const wrapper = this.editor.getWrapperElement();
wrapper?.parentNode?.removeChild(wrapper);
```

### Before
https://github.com/user-attachments/assets/6c927fb7-0737-4475-8da5-3d65670ccb7b

### After
https://github.com/user-attachments/assets/27686884-c9e4-49b6-a296-2178a0d88c68

Notice in the "after" video, there are no red bars in the performance recording. These red bars indicate dropped frames.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed continuous scroll listener and its handler from the editor to simplify event processing.
  * Now the editor reports final scroll state when it is closed and its DOM wrapper is removed to ensure thorough cleanup.
  * Retained cleanup for link-awareness and lint tooltips to preserve stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->