### PR TITLE
feat: add quick access button to open collection folder in file explorer

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
@@ -46,6 +46,8 @@ const Info = ({ collection }) => {
                   onClick={handleOpenInFolder}
                   className="flex-shrink-0 text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 cursor-pointer"
                   title="Open in File Explorer"
+                  aria-label="Open in File Explorer"
+                  type="button"
                 >
                   <IconExternalLink size={14} stroke={1.5} />
                 </button>


### PR DESCRIPTION
### Description

This PR adds a quick access button to open the collection folder directly from the Collection Settings overview page.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<img width="623" height="742" alt="Screenshot 2025-12-16 at 21 43 22" src="https://github.com/user-attachments/assets/6decb59e-0689-4ac8-a43d-3d7c5fd1eb47" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open in Folder" button to Collection Settings (Location row) so users can jump to a collection's file-system location from the app.
  * Button includes an external-link icon, accessible labels, and updated layout to place the control alongside the displayed path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->