### PR TITLE
fix(playwright): interpolate request url with odata param

### DIFF
--- a/tests/interpolation/init-user-data/preferences.json
+++ b/tests/interpolation/init-user-data/preferences.json
@@ -1,5 +1,5 @@
 {
-  "maximized": true,
+  "maximized": false,
   "lastOpenedCollections": [
     "{{projectRoot}}/tests/interpolation/collection"
   ]

--- a/tests/interpolation/interpolate-request-url.spec.ts
+++ b/tests/interpolation/interpolate-request-url.spec.ts
@@ -13,7 +13,7 @@ test.describe.serial('URL Interpolation', () => {
     await locators.sidebar.request('echo-request-url').click();
     await sendRequest(page, 200);
 
-    const texts = await page.locator('div:nth-child(2) > .CodeMirror-scroll').allInnerTexts();
+    const texts = await page.getByTestId('response-preview-container').locator('.CodeMirror-scroll').allInnerTexts();
     await expect(texts.some((d) => d.includes(`"url": "/path/some-data"`))).toBe(true);
   });
 
@@ -22,7 +22,7 @@ test.describe.serial('URL Interpolation', () => {
     await locators.sidebar.request('echo-request-odata').click();
     await sendRequest(page, 200);
 
-    const texts = await page.locator('div:nth-child(2) > .CodeMirror-scroll').allInnerTexts();
+    const texts = await page.getByTestId('response-preview-container').locator('.CodeMirror-scroll').allInnerTexts();
     await expect(texts.some((d) => d.includes(`"url": "/path/Category('category123')/Item(item456)/foobar/Tags(%22tag%20test%22)"`))).toBe(true);
   });
 });


### PR DESCRIPTION
### Description

Fixes playwright test - interpolate request url with odata param

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data configuration and improved test element selection methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->