### PR TITLE
fix: importing from openapi excludes documentation for requests

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -926,23 +926,18 @@ const getDefaultUrl = (serverObject) => {
 
 const getSecurity = (apiSpec) => {
   let defaultSchemes = apiSpec.security || [];
-
   let securitySchemes = get(apiSpec, 'components.securitySchemes', {});
-  if (Object.keys(securitySchemes).length === 0) {
-    return {
-      supported: []
-    };
-  }
+
+  const hasSchemes = Object.keys(securitySchemes).length > 0;
 
   return {
-    supported: defaultSchemes.map((scheme) => {
-      var schemeName = Object.keys(scheme)[0];
-      return securitySchemes[schemeName];
-    }),
+    supported: hasSchemes
+      ? defaultSchemes
+          .map((scheme) => securitySchemes[Object.keys(scheme)[0]])
+          .filter(Boolean)
+      : [],
     schemes: securitySchemes,
-    getScheme: (schemeName) => {
-      return securitySchemes[schemeName];
-    }
+    getScheme: (schemeName) => securitySchemes[schemeName]
   };
 };
 


### PR DESCRIPTION
fixes issue #5094 for requests

### Description

When importing an OpenApi collection to Bruno, the documentation for requests are excluded by the cli. For instance when importing a file containing:

```
...
"paths": {
    "/pet": {
      "put": {
        "tags": ["pet"],
        "summary": "Create a pet",
        "description": "DESCRIPTION WHICH IS IGNORED ON IMPORT",
        "operationId": "createPet",
        ...
      }
    }
  }
...
```

Bruno generates:

| Capture | Expected |
|-|-|
|<img width="321" height="212" alt="bruno-doc-missing" src="https://github.com/user-attachments/assets/0d197fe9-ff27-4f67-ae90-8b3588b830ee" />|<img width="321" height="212" alt="bruno-doc-expected" src="https://github.com/user-attachments/assets/0c4d3b52-1810-4e5e-aecc-fc2fef4e306d" />|

and the Bruno collection in json is missing a field `docs` like so:

```
...
"request": {
            "docs": "DESCRIPTION WHICH IS IGNORED ON IMPORT",
            "url": "{{baseUrl}}/pet",
            ...
            }
...
```

#### Environnement

I don't think this is specific to my environment but:

- System: MacOS
- OpenApi version: 3.1.0

#### Contribution Checklist:

- [x] **Checked**
- [x] **Create an issue and link to the pull request.**
  > the issue already exists. I will link to this PR via comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP request items now include documentation fields extracted from OpenAPI specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->