### PR TITLE
Fix: Terminal Resize

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/TerminalTab/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/TerminalTab/index.js
@@ -398,6 +398,18 @@ const TerminalTab = () => {
     };
   }, [activeSessionId]);
 
+  const onSessionMount = useCallback(
+    (node) => {
+      if (!node) return;
+      terminalRef.current = node;
+      fitTerminal(activeSessionId, node);
+      const ro = new ResizeObserver(() => fitTerminal(activeSessionId, node));
+      ro.observe(node.parentNode);
+      return () => ro.disconnect();
+    },
+    [activeSessionId]
+  );
+
   return (
     <StyledWrapper>
       <div className="terminal-content">
@@ -440,14 +452,7 @@ const TerminalTab = () => {
             </div>
           )}
           <div
-            ref={(node) => {
-              if (!node) return;
-              terminalRef.current = node;
-              fitTerminal(activeSessionId, node);
-              const ro = new ResizeObserver(() => fitTerminal(activeSessionId, node));
-              ro.observe(node.parentNode);
-              return () => ro.disconnect();
-            }}
+            ref={onSessionMount}
             className="terminal-container"
             style={{
               height: '100%',


### PR DESCRIPTION
### Description

This PR fixes the issue where the terminal would not resize on change in dev tools's size.
It fixes: https://usebruno.atlassian.net/browse/BRU-2324

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Terminal now uses fit-driven resizing for reliable reaction to container and layout changes, skipping fits for zero-sized containers.
  * Replaced global window resize handling with a parent ResizeObserver to reduce redundant work.
  * Preserves terminal DOM on session switch to avoid disruptive reflows and retain resize behavior.
  * Improved initial sizing and reduced noisy lifecycle events.

* **Refactor**
  * Session creation now handles failures gracefully and logs errors without changing public interfaces.

* **UI**
  * Minor text and loading-message formatting tweaks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->