### PR TITLE
feat: add hideResultTypeSelector prop to QueryResponse component

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResponse/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResponse/StyledWrapper.js
@@ -8,8 +8,8 @@ const StyledWrapper = styled.div`
   border-radius: 4px;
   border: 1px solid ${(props) => props.theme.console.border};
 
-  .query-response-content {
-    border-top: 1px solid ${(props) => props.theme.console.border};
+  .result-type-selector {
+    border-bottom: 1px solid ${(props) => props.theme.console.border};
   }
 `;
 

--- a/packages/bruno-app/src/components/ResponsePane/QueryResponse/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResponse/index.js
@@ -12,7 +12,8 @@ const QueryResponse = ({
   dataBuffer,
   disableRunEventListener,
   headers,
-  error
+  error,
+  hideResultTypeSelector
 }) => {
   const { initialFormat, initialTab } = useInitialResponseFormat(dataBuffer, headers);
   const previewFormatOptions = useResponsePreviewFormatOptions(dataBuffer, headers);
@@ -27,20 +28,23 @@ const QueryResponse = ({
   }, [initialFormat, initialTab]);
   return (
     <StyledWrapper>
-      <div className="flex items-center justify-end p-2">
-        <QueryResultTypeSelector
-          formatOptions={previewFormatOptions}
-          formatValue={selectedFormat}
-          onFormatChange={(newFormat) => {
-            setSelectedFormat(newFormat);
-          }}
-          onPreviewTabSelect={() => {
-            setSelectedTab((prev) => prev === 'editor' ? 'preview' : 'editor');
-          }}
-          selectedTab={selectedTab}
-        />
-      </div>
-      <div className={classnames('flex-1 query-response-content', selectedTab === 'editor' ? 'px-2 py-1' : '')}>
+      {!hideResultTypeSelector && (
+        <div className="flex items-center justify-end p-2 result-type-selector">
+
+          <QueryResultTypeSelector
+            formatOptions={previewFormatOptions}
+            formatValue={selectedFormat}
+            onFormatChange={(newFormat) => {
+              setSelectedFormat(newFormat);
+            }}
+            onPreviewTabSelect={() => {
+              setSelectedTab((prev) => prev === 'editor' ? 'preview' : 'editor');
+            }}
+            selectedTab={selectedTab}
+          />
+        </div>
+      )}
+      <div className={classnames('flex-1 result-content', selectedTab === 'editor' ? 'px-2 py-1' : '')}>
         <QueryResult
           item={item}
           collection={collection}

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Common/Body/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Common/Body/index.js
@@ -1,7 +1,7 @@
 import QueryResponse from 'components/ResponsePane/QueryResponse/index';
 import { useState } from 'react';
 
-const BodyBlock = ({ collection, data, dataBuffer, headers, error, item }) => {
+const BodyBlock = ({ collection, data, dataBuffer, headers, error, item, type }) => {
   const [isBodyCollapsed, toggleBody] = useState(true);
   return (
     <div className="collapsible-section">
@@ -22,6 +22,7 @@ const BodyBlock = ({ collection, data, dataBuffer, headers, error, item }) => {
                 headers={headers}
                 error={error}
                 key={item?.uid}
+                hideResultTypeSelector={type === 'request'}
               />
             </div>
           ) : (

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Request/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Request/index.js
@@ -32,7 +32,7 @@ const Request = ({ collection, request, item }) => {
       <Headers headers={headers} type="request" />
 
       {/* Body */}
-      <BodyBlock collection={collection} data={data} dataBuffer={dataBuffer} error={error} headers={headers} item={item} />
+      <BodyBlock collection={collection} data={data} dataBuffer={dataBuffer} error={error} headers={headers} item={item} type="request" />
     </div>
   );
 };

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Response/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Response/index.js
@@ -35,7 +35,7 @@ const Response = ({ collection, response, item }) => {
       <Headers headers={headers} type="response" />
 
       {/* Body */}
-      <BodyBlock collection={collection} data={data} dataBuffer={dataBuffer} error={error} headers={headers} item={item} />
+      <BodyBlock collection={collection} data={data} dataBuffer={dataBuffer} error={error} headers={headers} item={item} type="response" />
     </div>
   );
 };


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2311)

* Introduced hideResultTypeSelector prop to conditionally render the QueryResultTypeSelector in the QueryResponse component.
* Updated BodyBlock to pass the type prop to control the visibility of the result type selector based on the request or response context.
* Adjusted styling in StyledWrapper for improved layout consistency.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated response pane styling and improved visual layout of the result type selector display across different views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->