### PR TITLE
fix: move gql variables prettify icon to a better position

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
@@ -50,7 +50,7 @@ const GraphQLVariables = ({ variables, item, collection }) => {
   return (
     <>
       <button
-        className="btn-add-param text-link px-4 py-4 select-none absolute top-13 right-0 z-10"
+        className="btn-add-param text-link px-4 py-4 select-none absolute right-0 z-10"
         onClick={onPrettify}
         title="Prettify"
       >


### PR DESCRIPTION
### Description

Move the prettify icon for GQL Variables editor to a similar position as the Query Editor. 

[JIRA](https://usebruno.atlassian.net/browse/BRU-2357)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.


#### Visual


https://github.com/user-attachments/assets/3ae686af-ed6d-40d8-815d-4224721eeaf7



#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical positioning of the Prettify button in the GraphQL Variables editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->