### PR TITLE
fix: updated the selected state colors of tabs in dev tools

### DIFF
--- a/packages/bruno-app/src/themes/dark.js
+++ b/packages/bruno-app/src/themes/dark.js
@@ -488,7 +488,7 @@ const darkTheme = {
     optionHoverBg: 'rgba(255, 255, 255, 0.05)',
     optionLabelColor: '#cccccc',
     optionCountColor: '#858585',
-    checkboxColor: '#0078d4',
+    checkboxColor: colors.BRAND,
     scrollbarTrack: '#2d2d30',
     scrollbarThumb: '#5a5a5a',
     scrollbarThumbHover: '#6a6a6a'

--- a/packages/bruno-app/src/themes/light.js
+++ b/packages/bruno-app/src/themes/light.js
@@ -493,7 +493,7 @@ const lightTheme = {
     optionHoverBg: '#f8f9fa',
     optionLabelColor: '#212529',
     optionCountColor: '#6c757d',
-    checkboxColor: '#0d6efd',
+    checkboxColor: colors.BRAND,
     scrollbarTrack: '#f8f9fa',
     scrollbarThumb: '#ced4da',
     scrollbarThumbHover: '#adb5bd'


### PR DESCRIPTION
### Description

Updated the color of the devtools tab buttons to match the bruno brand color

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
<img width="1392" height="880" alt="image" src="https://github.com/user-attachments/assets/5a2bdb88-2abc-44cc-a994-1ba77f388204" />
<img width="1392" height="880" alt="image" src="https://github.com/user-attachments/assets/9dde55c2-958a-4ca7-848c-719b2897703e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified checkbox color definitions across UI themes to use a centralized brand color constant, ensuring consistent theming across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->