### PR TITLE
fix: auth inheritance through folders on the backend

### DIFF
--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -774,14 +774,15 @@ const mergeAuth = (collection, request, requestTreePath) => {
   let lastFolderWithAuth = null;
 
   // Traverse through the path to find the closest auth configuration
-  for (let i of requestTreePath) {
+  for (let i of [...requestTreePath].reverse()) {
     if (i.type === 'folder') {
       const folderRoot = i?.draft || i?.root;
       const folderAuth = get(folderRoot, 'request.auth');
       // Only consider folders that have a valid auth mode
-      if (folderAuth && folderAuth.mode && folderAuth.mode !== 'none' && folderAuth.mode !== 'inherit') {
+      if (folderAuth && folderAuth.mode && folderAuth.mode !== 'inherit') {
         effectiveAuth = folderAuth;
         lastFolderWithAuth = i;
+        break;
       }
     }
   }

--- a/packages/bruno-electron/tests/utils/collection.spec.js
+++ b/packages/bruno-electron/tests/utils/collection.spec.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { parseBruFileMeta, wrapAndJoinScripts, mergeScripts } = require('../../src/utils/collection');
+const { parseBruFileMeta, wrapAndJoinScripts, mergeScripts, mergeAuth } = require('../../src/utils/collection');
 
 describe('parseBruFileMeta', () => {
   test('parses valid meta block correctly', () => {
@@ -543,4 +543,134 @@ describe('mergeScripts metadata', () => {
 
     expect(request.script.resMetadata.requestScriptContent).toBe('let req = 2;');
   });
+});
+
+describe('mergeAuth', () => {
+  const basicAuth = () => ({
+    mode: 'basic',
+    basic: { username: 'USER', password: 'PASS' }
+  });
+  const oauth2 = () => ({
+    mode: 'oauth2',
+    oauth2: {
+      grantType: 'client_credentials',
+      clientId: 'CLIENT_ID',
+      clientSecret: 'CLIENT_SECRET'
+    }
+  });
+
+  it.each([
+    {
+      description: 'no auth inherited from collection',
+      collectionAuth: { mode: 'none' },
+      rootFolderAuth: { mode: 'inherit' },
+      subfolderAuth: { mode: 'inherit' },
+      requestAuth: { mode: 'inherit' },
+      expectedRequestAuth: { mode: 'none' },
+      expectedOauth2Credentials: undefined
+    },
+    {
+      description: 'basic auth inherited from collection',
+      collectionAuth: basicAuth(),
+      rootFolderAuth: { mode: 'inherit' },
+      subfolderAuth: { mode: 'inherit' },
+      requestAuth: { mode: 'inherit' },
+      expectedRequestAuth: basicAuth(),
+      expectedOauth2Credentials: undefined
+    },
+    {
+      description: 'no auth directly on request',
+      collectionAuth: basicAuth(),
+      rootFolderAuth: { mode: 'inherit' },
+      subfolderAuth: { mode: 'inherit' },
+      requestAuth: { mode: 'none' },
+      expectedRequestAuth: { mode: 'none' },
+      expectedOauth2Credentials: undefined
+    },
+    {
+      description: 'no auth inherited from subfolder',
+      collectionAuth: basicAuth(),
+      rootFolderAuth: { mode: 'inherit' },
+      subfolderAuth: { mode: 'none' },
+      requestAuth: { mode: 'inherit' },
+      expectedRequestAuth: { mode: 'none' },
+      expectedOauth2Credentials: undefined
+    },
+    {
+      description: 'no auth inherited from root folder',
+      collectionAuth: basicAuth(),
+      rootFolderAuth: { mode: 'none' },
+      subfolderAuth: { mode: 'inherit' },
+      requestAuth: { mode: 'inherit' },
+      expectedRequestAuth: { mode: 'none' },
+      expectedOauth2Credentials: undefined
+    },
+    {
+      description: 'oauth2 inherited from collection',
+      collectionAuth: oauth2(),
+      rootFolderAuth: { mode: 'inherit' },
+      subfolderAuth: { mode: 'inherit' },
+      requestAuth: { mode: 'inherit' },
+      expectedRequestAuth: oauth2(),
+      expectedOauth2Credentials: { folderUid: null, itemUid: null, mode: 'oauth2' }
+    },
+    {
+      description: 'oauth2 inherited from subfolder',
+      collectionAuth: basicAuth(),
+      rootFolderAuth: { mode: 'inherit' },
+      subfolderAuth: oauth2(),
+      requestAuth: { mode: 'inherit' },
+      expectedRequestAuth: oauth2(),
+      expectedOauth2Credentials: { folderUid: 'subfolder', itemUid: null, mode: 'oauth2' }
+    },
+    {
+      description: 'oauth2 directly on request',
+      collectionAuth: basicAuth(),
+      rootFolderAuth: { mode: 'inherit' },
+      subfolderAuth: { mode: 'inherit' },
+      requestAuth: oauth2(),
+      expectedRequestAuth: oauth2(),
+      expectedOauth2Credentials: undefined
+    }
+  ])(
+    'auth inheritance through folders : $description',
+    ({
+      collectionAuth,
+      rootFolderAuth,
+      subfolderAuth,
+      requestAuth,
+      expectedRequestAuth,
+      expectedOauth2Credentials
+    }) => {
+      const httpRequest = {
+        uid: 'request-one',
+        type: 'http-request',
+        request: { auth: requestAuth }
+      };
+      const subfolder = {
+        uid: 'subfolder',
+        type: 'folder',
+        root: { request: { auth: subfolderAuth } },
+        items: [httpRequest]
+      };
+      const rootFolder = {
+        uid: 'root-folder',
+        type: 'folder',
+        root: { request: { auth: rootFolderAuth } },
+        items: [subfolder]
+      };
+      const collection = {
+        uid: 'my-collection',
+        items: [rootFolder],
+        root: { request: { auth: collectionAuth } }
+      };
+      const request = httpRequest.request;
+      const requestTreePath = [rootFolder, subfolder, httpRequest];
+
+      mergeAuth(collection, request, requestTreePath);
+
+      expect(request.auth).toEqual(expectedRequestAuth);
+      expect(request.oauth2Credentials).toEqual(expectedOauth2Credentials);
+    }
+  );
 });


### PR DESCRIPTION
### Description

Hi, I worked on a patch to fix #5839 because I encountered the same exact problem.

The auth inheritance seems to be correctly displayed on the frontend, but is not correctly computed on the backend.

So I tweaked the `mergeAuth` function from `packages/bruno-electron/src/utils/collection.js`, using a similar algorithm to what is used on the frontend (`getEffectiveAuthSource` in `/home/loic/Documents/code/bruno/packages/bruno-app/src/components/**`, this function exists in multiple files).

I added tests for this function in `packages/bruno-electron/tests/utils/collection.spec.js`.

Also, I noticed that a similar `mergeAuth` function exists in `packages/bruno-cli/src/utils/collection.js`. **Should I also fix this one?** 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes** (technically, there's a change of behaviour, but it's a bug fix)
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (created by @doxic012)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication inheritance now correctly picks the nearest folder-level auth with a defined non-inherit mode, shortening and correcting resolution so requests receive the intended credentials.

* **Tests**
  * New tests validate hierarchical auth resolution across collection → folder → subfolder → request scenarios, covering basic and OAuth2 auth cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->