### PR TITLE
feat: make URLs clickable in console

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Devtools/Console/StyledWrapper.js
@@ -430,7 +430,22 @@ const StyledWrapper = styled.div`
     white-space: pre-wrap;
     word-break: break-word;
     flex: 1;
-    
+
+    .log-link {
+      color: ${(props) => props.theme.colors?.text?.link || '#3b8eea'};
+      text-decoration: underline;
+      cursor: pointer;
+
+      &:hover {
+        color: ${(props) => props.theme.colors?.text?.linkHover || '#5ca0f0'};
+        text-decoration: underline;
+      }
+
+      &:visited {
+        color: ${(props) => props.theme.colors?.text?.linkVisited || '#9b59b6'};
+      }
+    }
+
     .log-object {
       margin: 4px 0;
       padding: 8px;

--- a/packages/bruno-app/src/components/Devtools/Console/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.js
@@ -147,6 +147,38 @@ const getBrunoTypeMetadata = (obj) => {
   return {};
 };
 
+// Helper function to detect URLs and make them clickable
+const linkifyText = (text) => {
+  if (typeof text !== 'string') {
+    return text;
+  }
+
+  const urlPattern = /(https?:\/\/[^\s<>"{}|\\^`[\]]+)/g;
+
+  const parts = text.split(urlPattern);
+  if (parts.length === 1) {
+    return text;
+  }
+
+  return parts.map((part, index) => {
+    if (part.match(/^https?:\/\//)) {
+      return (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="log-link"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
+};
+
 const LogMessage = ({ message, args }) => {
   const { displayedTheme } = useTheme();
 
@@ -187,10 +219,11 @@ const LogMessage = ({ message, args }) => {
             </div>
           );
         }
-        return String(arg);
+        // Convert to string and linkify any URLs
+        return linkifyText(String(arg));
       });
     }
-    return msg;
+    return linkifyText(msg);
   };
 
   const formattedMessage = formatMessage(message, args);


### PR DESCRIPTION
## Summary

This PR makes URLs in the console output clickable, improving the developer experience when working with API responses that include URLs.

**Changes:**
- Added `linkifyText()` helper function that detects http/https URLs in text
- URLs are rendered as `<a>` tags that open in a new browser tab
- Added CSS styles for `.log-link` with hover and visited states
- Links use `target="_blank"` with `rel="noopener noreferrer"` for security

## Before
![before](https://github.com/user-attachments/assets/c9cb728c-bdf2-453c-9ccc-ddd8fb230b37)

URLs appear as plain text and cannot be clicked.

## After

URLs are now clickable links that open in a new tab, similar to browser dev tools:

![firefox-example](https://github.com/user-attachments/assets/c0b95e4f-ef22-4888-a855-3e771c1045b3)

## Test plan

- [x] Console log messages with URLs render as clickable links
- [x] Links open in new tab when clicked
- [x] Hover state shows visual feedback
- [x] Non-URL text renders normally
- [x] URLs in the middle of text are properly detected

Fixes #6275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console logs now detect and convert URLs into clickable links that open in a new tab.
* **Style**
  * Added link styling for console entries, including underline, hover and visited colors driven by theme for clearer visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->