### PR TITLE
fix: JSON response examples being saved as [object Object] in YAML format

### DIFF
--- a/packages/bruno-filestore/src/formats/yml/items/stringifyHttpRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/stringifyHttpRequest.ts
@@ -189,9 +189,12 @@ const stringifyHttpRequest = (item: BrunoItem): string => {
           }
 
           if (example.response.body && example.response.body.type && example.response.body.content !== undefined) {
+            const content = example.response.body.content;
+            const contentString = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
+
             ocExample.response.body = {
               type: example.response.body.type as 'json' | 'text' | 'xml' | 'html' | 'binary',
-              data: String(example.response.body.content || '')
+              data: contentString
             };
           }
         }


### PR DESCRIPTION
[BRU-2389](https://usebruno.atlassian.net/browse/BRU-2389)

Issue:
When saving JSON response examples in YAML format, the response body content was being saved as `[object Object]` instead of the actual JSON data. This occurred because `String()` was used to convert the content, which doesn't properly serialize objects.

Fix:
Updated `stringifyHttpRequest.ts` to check the content type before serialization:
- If content is a string, use it as-is
- Otherwise, use `JSON.stringify()` to properly serialize objects, arrays, and primitives

The fix is similar to how we are handling JSON in bru, https://github.com/usebruno/bruno/blob/b61d2212f68eadada0631a41ddf26e3b9c125378/packages/bruno-lang/v2/src/example/jsonToBru.js#L212-L229