### PR TITLE
fix: get os arch info to help prioritise arch related bugs

### DIFF
--- a/packages/bruno-app/src/providers/App/useTelemetry.js
+++ b/packages/bruno-app/src/providers/App/useTelemetry.js
@@ -2,6 +2,7 @@
  * Telemetry in bruno is just an anonymous visit counter (triggered once per day).
  * The only details shared are:
  *      - OS (ex: mac, windows, linux)
+ *      - OS Architecture (ex: arm64, x64)
  *      - Bruno Version (ex: 1.3.0)
  * We don't track usage analytics / micro-interactions / crash logs / anything else.
  */
@@ -9,6 +10,7 @@
 import { useEffect } from 'react';
 import { PostHog } from 'posthog-node';
 import platformLib from 'platform';
+import os from 'os';
 import { uuid } from 'utils/common';
 
 const posthogApiKey = process.env.NEXT_PUBLIC_POSTHOG_API_KEY;
@@ -58,6 +60,7 @@ const trackStart = (version) => {
     event: 'start',
     properties: {
       os: platformLib.os.family,
+      os_arch: os.arch(),
       version: version
     }
   });


### PR DESCRIPTION
### Description

Add platform `arch` info if available for figuring out Mac OS Intel vs Arm split.

Necessary to help decide if need a dedicated Intel device to better help with Mac Intel issues as compared to the emulation based solution debug and solving that we have right now

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced telemetry to include operating system architecture information.
  * No user-facing behavior changes introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->