### PR TITLE
fix: render object messages as JSON in Network Logs (#6505)

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.js
@@ -1,3 +1,24 @@
+import React from 'react';
+
+/**
+ * Safely formats a message for display.
+ * Handles the case where message might be an object (when safeStringifyJSON fails in backend).
+ * Fixes issue #6505: HTTP response rendered as [object Object] in Timeline | Network Logs tab
+ */
+const formatMessage = (message) => {
+  if (message === null || message === undefined) {
+    return '';
+  }
+  if (typeof message === 'object') {
+    try {
+      return JSON.stringify(message, null, 2);
+    } catch (e) {
+      return '[Unable to display message]';
+    }
+  }
+  return message;
+};
+
 const Network = ({ logs }) => {
   return (
     <div className="bg-black/5 text-white network-logs rounded overflow-auto h-96">
@@ -9,10 +30,10 @@ const Network = ({ logs }) => {
           const nextLog = logs[index + 1];
           const isSameLogType = nextLog?.type === currentLog?.type;
           return (
-            <>
-              <NetworkLogsEntry key={index} entry={currentLog} />
+            <React.Fragment key={index}>
+              <NetworkLogsEntry entry={currentLog} />
               {!isSameLogType && <div className="mt-4" />}
-            </>
+            </React.Fragment>
           );
         })}
       </pre>
@@ -22,6 +43,7 @@ const Network = ({ logs }) => {
 
 const NetworkLogsEntry = ({ entry }) => {
   const { type, message } = entry;
+  const displayMessage = formatMessage(message);
   let className = '';
 
   switch (type) {
@@ -47,7 +69,7 @@ const NetworkLogsEntry = ({ entry }) => {
 
   return (
     <div className={`${className}`}>
-      <div>{message}</div>
+      <div>{displayMessage}</div>
     </div>
   );
 };

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.spec.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Network from './index';
+
+describe('Network component', () => {
+  describe('NetworkLogsEntry message rendering', () => {
+    it('should render string messages correctly', () => {
+      const logs = [
+        { type: 'info', message: 'Test message' },
+        { type: 'request', message: 'GET https://example.com' }
+      ];
+
+      render(<Network logs={logs} />);
+
+      expect(screen.getByText('Test message')).toBeInTheDocument();
+      expect(screen.getByText('GET https://example.com')).toBeInTheDocument();
+    });
+
+    it('should render object messages as JSON string, not [object Object]', () => {
+      // This test simulates the bug reported in issue #6505
+      // When safeStringifyJSON fails in the backend, it returns an object
+      // instead of a string, which then gets stored in the message field
+      const objectMessage = { error: 'Something went wrong', details: { code: 500 } };
+      const logs = [{ type: 'error', message: objectMessage }];
+
+      render(<Network logs={logs} />);
+
+      // The component should NOT render [object Object]
+      const objectObjectText = screen.queryByText('[object Object]');
+      expect(objectObjectText).not.toBeInTheDocument();
+
+      // Instead, it should render the stringified JSON
+      expect(screen.getByText(/error.*Something went wrong/)).toBeInTheDocument();
+    });
+
+    it('should handle null message gracefully', () => {
+      const logs = [{ type: 'info', message: null }];
+
+      render(<Network logs={logs} />);
+
+      // Should not crash or show [object Object]
+      expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+    });
+
+    it('should handle undefined message gracefully', () => {
+      const logs = [{ type: 'info', message: undefined }];
+
+      render(<Network logs={logs} />);
+
+      // Should not crash or show [object Object]
+      expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+    });
+
+    it('should apply correct CSS class based on log type', () => {
+      const logs = [
+        { type: 'request', message: 'Request log' },
+        { type: 'response', message: 'Response log' },
+        { type: 'error', message: 'Error log' }
+      ];
+
+      const { container } = render(<Network logs={logs} />);
+
+      expect(container.querySelector('.text-blue-500')).toBeInTheDocument();
+      expect(container.querySelector('.text-green-500')).toBeInTheDocument();
+      expect(container.querySelector('.text-red-500')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #6505

---

## The Problem

In **Timeline → Network Logs**, some messages were rendered as `[object Object]` instead of readable text, making the logs hard to understand and debug.

---

## The Fix

A small check was added before rendering messages.  
If the message is an object, it is converted into a readable JSON string before display.

---

## What Changed

| File | Change |
|-----|-------|
| `Network/index.js` | Added a `formatMessage()` helper to stringify object messages |
| `Network/index.spec.js` | Added 5 unit tests to cover the new behavior |

---

## Screenshot (After Fix)

<img width="1916" height="809" alt="Screenshot from 2025-12-26 01-07-03" src="https://github.com/user-attachments/assets/779bbdc1-d89b-48f9-b2ab-b1b1789e4309" />


---

## Contribution Checklist

- [x] I've used AI significantly to create this pull request  
- [x] The pull request only addresses one issue or adds one feature  
- [x] The pull request does not introduce any breaking changes  
- [x] I have added screenshots or gifs to help explain the change (if applicable)  
- [x] I have read the contribution guidelines  
- [x] Created an issue and linked it to this pull request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced network log message rendering in the Timeline view to safely handle null, undefined, and complex object messages without display errors.
  * Complex objects are now properly formatted as JSON strings.
  * Improved visual stability for consecutive log entries.

* **Tests**
  * Added comprehensive test coverage validating message rendering behavior and CSS styling for different log types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->