### PR TITLE
chore: update responsive tab's more icon

### DIFF
--- a/packages/bruno-app/src/ui/ResponsiveTabs/index.js
+++ b/packages/bruno-app/src/ui/ResponsiveTabs/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import classnames from 'classnames';
 import MenuDropdown from 'ui/MenuDropdown';
-import { IconChevronDown } from '@tabler/icons';
+import { IconChevronsRight } from '@tabler/icons';
 import StyledWrapper from './StyledWrapper';
 
 const DROPDOWN_WIDTH = 60;
@@ -251,8 +251,7 @@ const ResponsiveTabs = ({
             selectedItemId={activeTab}
           >
             <div className="more-tabs select-none flex items-center cursor-pointer gap-1">
-              <span>More</span>
-              <IconChevronDown size={14} strokeWidth={2} />
+              <IconChevronsRight size={18} strokeWidth={2} />
             </div>
           </MenuDropdown>
         )}


### PR DESCRIPTION
### Description

Update responsive tab's more icon

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual indicator for the responsive tabs overflow menu. The control now displays a single, larger chevron icon instead of a text label combined with a chevron, providing a cleaner interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->