### PR TITLE
Fix Close All not closing all tabs

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -477,19 +477,39 @@ function RequestTabMenu({ menuDropdownRef, tabLabelRef, collectionRequestTabs, t
     } catch (err) { }
   }
 
+  // Helper to save and close multiple tabs
+  async function saveAndCloseTabs(tabs) {
+    // Save unsaved changes for request tabs that have items in the collection
+    const savePromises = tabs.map(async (tab) => {
+      try {
+        const item = findItemInCollection(collection, tab.uid);
+        if (item && hasRequestChanges(item)) {
+          await dispatch(saveRequest(item.uid, collection.uid, true));
+        }
+      } catch (err) {
+        // Ignore save errors - still close the tab
+      }
+    });
+    await Promise.all(savePromises);
+
+    // Close all specified tabs
+    const tabUids = tabs.map((tab) => tab.uid);
+    dispatch(closeTabs({ tabUids }));
+  }
+
   async function handleCloseOtherTabs() {
     const otherTabs = collectionRequestTabs.filter((_, index) => index !== tabIndex);
-    await Promise.all(otherTabs.map((tab) => handleCloseTab(tab.uid)));
+    await saveAndCloseTabs(otherTabs);
   }
 
   async function handleCloseTabsToTheLeft() {
     const leftTabs = collectionRequestTabs.filter((_, index) => index < tabIndex);
-    await Promise.all(leftTabs.map((tab) => handleCloseTab(tab.uid)));
+    await saveAndCloseTabs(leftTabs);
   }
 
   async function handleCloseTabsToTheRight() {
     const rightTabs = collectionRequestTabs.filter((_, index) => index > tabIndex);
-    await Promise.all(rightTabs.map((tab) => handleCloseTab(tab.uid)));
+    await saveAndCloseTabs(rightTabs);
   }
 
   function handleCloseSavedTabs() {
@@ -500,7 +520,7 @@ function RequestTabMenu({ menuDropdownRef, tabLabelRef, collectionRequestTabs, t
   }
 
   async function handleCloseAllTabs() {
-    await Promise.all(collectionRequestTabs.map((tab) => handleCloseTab(tab.uid)));
+    await saveAndCloseTabs(collectionRequestTabs);
   }
 
   const menuItems = useMemo(() => [


### PR DESCRIPTION
Fixes the issue where "Close All" would not close special tabs like variables or "Not Found" tabs.

The previous implementation called `handleCloseTab` for each tab individually, which could silently fail due to the try-catch block when the tab doesn't have a corresponding item in the collection.

Now we:
1. Save unsaved changes for tabs that have items
2. Close all tabs in one dispatch call

This ensures all tabs are closed regardless of their type.

Fixes #2965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unsaved changes in request tabs are now automatically saved before tabs are closed when using close tab operations (closing single, multiple, or all tabs).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->