### PR TITLE
chore: reorder collection item menu option info

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -290,14 +290,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
   // Build menu items for MenuDropdown
   const buildMenuItems = () => {
-    const items = [
-      {
-        id: 'info',
-        leftSection: IconInfoCircle,
-        label: 'Info',
-        onClick: () => setItemInfoModalOpen(true)
-      }
-    ];
+    const items = [];
 
     if (isFolder) {
       items.push(
@@ -390,6 +383,13 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     }
 
     items.push({ id: 'separator-1', type: 'divider' });
+
+    items.push({
+      id: 'info',
+      leftSection: IconInfoCircle,
+      label: 'Info',
+      onClick: () => setItemInfoModalOpen(true)
+    });
 
     if (isFolder) {
       items.push(


### PR DESCRIPTION
### Description

Reorder collection item menu option info

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized menu item structure in the collections sidebar. The Info menu item has been repositioned and now appears as a separate item after a divider, rather than at the beginning of the menu sequence. Visual label, icon, and functionality remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->