### PR TITLE
Fix response rendered as [object Object] in Network Logs tab

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.js
@@ -1,3 +1,14 @@
+// Safely stringify objects for display
+const formatMessage = (message) => {
+  if (message === null || message === undefined) return '';
+  if (typeof message === 'string') return message;
+  try {
+    return JSON.stringify(message, null, 2);
+  } catch (e) {
+    return '[Unserializable Object]';
+  }
+};
+
 const Network = ({ logs }) => {
   return (
     <div className="bg-black/5 text-white network-logs rounded overflow-auto h-96">
@@ -47,7 +58,7 @@ const NetworkLogsEntry = ({ entry }) => {
 
   return (
     <div className={`${className}`}>
-      <div>{message}</div>
+      <div>{formatMessage(message)}</div>
     </div>
   );
 };


### PR DESCRIPTION
Added `formatMessage` helper to properly stringify object messages in the Network Logs tab.

Before: Objects were rendered as `[object Object]`
After: Objects are properly JSON stringified with formatting

Fixes #6505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network log message display handling to ensure all messages render consistently and clearly in the timeline view, including null, undefined, and complex object values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->