### PR TITLE
fix: incorrect response formatting when saving examples

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseBookmark/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseBookmark/index.js
@@ -4,7 +4,7 @@ import { IconBookmark } from '@tabler/icons';
 import { addResponseExample } from 'providers/ReduxStore/slices/collections';
 import { saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { insertTaskIntoQueue } from 'providers/ReduxStore/slices/app';
-import { uuid } from 'utils/common';
+import { uuid, formatResponse } from 'utils/common';
 import toast from 'react-hot-toast';
 import CreateExampleModal from 'components/ResponseExample/CreateExampleModal';
 import { getBodyType } from 'utils/responseBodyProcessor';
@@ -83,7 +83,7 @@ const ResponseBookmark = forwardRef(({ item, collection, responseSize, children 
     const contentType = contentTypeHeader?.value?.toLowerCase() || '';
 
     const bodyType = getBodyType(contentType);
-    const content = response.data;
+    const content = formatResponse(response.data, response.dataBuffer, bodyType);
 
     const exampleData = {
       name: name,


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
- fix #6500 

This PR updates example response saving to use the existing `formatResponse` util function instead of storing the raw response. 
https://github.com/usebruno/bruno/blob/f5ed96ad165448e4a637d5d0af3a3f4b15d9cf49/packages/bruno-app/src/utils/common/index.js#L277
Responses are now formatted according to body type (e.g., string, JSON), ensuring quotes are preserved and preventing parse errors in saved examples.

### screenshots
#### as-is 
<img width="1175" height="203" alt="image" src="https://github.com/user-attachments/assets/0ca6d90c-a846-4eb2-9d49-7f19ecddb0a9" />

#### to-be
<img width="1183" height="299" alt="image" src="https://github.com/user-attachments/assets/5b3aea7d-12c8-4633-9c6a-aec12a677586" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response formatting when saving bookmarked responses to ensure accurate handling of response body data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->