### PR TITLE
fix: initialize selected environment correctly to prevent flicker 

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/index.js
@@ -24,11 +24,14 @@ const DefaultTab = ({ setTab }) => (
 
 const EnvironmentSettings = ({ collection }) => {
   const [isModified, setIsModified] = useState(false);
-  const [selectedEnvironment, setSelectedEnvironment] = useState(null);
+  const environments = collection?.environments || [];
+
+  const [selectedEnvironment, setSelectedEnvironment] = useState(() => {
+    if (!environments.length) return null;
+    return environments.find((env) => env.uid === collection?.activeEnvironmentUid) || environments[0];
+  });
   const [tab, setTab] = useState('default');
   const [showExportModal, setShowExportModal] = useState(false);
-
-  const environments = collection?.environments || [];
 
   if (!environments || !environments.length) {
     return (

--- a/packages/bruno-app/src/components/RequestTabs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/StyledWrapper.js
@@ -59,7 +59,6 @@ const Wrapper = styled.div`
       border: 1px solid transparent;
       padding: 6px 0;
       flex-shrink: 0;
-      transition: background-color 0.15s ease;
       margin-bottom: 3px;
 
       .tab-container {

--- a/packages/bruno-app/src/components/WorkspaceTabs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/WorkspaceTabs/StyledWrapper.js
@@ -59,7 +59,6 @@ const Wrapper = styled.div`
       border: 1px solid transparent;
       padding: 6px 0;
       flex-shrink: 0;
-      transition: background-color 0.15s ease;
       margin-bottom: 3px;
 
       .tab-container {


### PR DESCRIPTION
### Description

Initialize selected environment correctly to prevent flicker in EnvironmentSettings component; remove transition from StyledWrapper in RequestTabs and WorkspaceTabs

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment selection initialization to properly account for the active environment setting and collection configuration.

* **Style**
  * Removed transition animations from tab components, making background-color changes on request and workspace tabs instantaneous rather than animated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->