### PR TITLE
fix: improve Content-Type handling when request body is none (#6486)

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -10,7 +10,8 @@ const getContentType = (headers = {}) => {
     }
   });
 
-  return contentType;
+  // Return empty string if contentType is not a string (e.g., null/false for no body requests)
+  return typeof contentType === 'string' ? contentType : '';
 };
 
 const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, processEnvVars = {}) => {

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -376,6 +376,17 @@ const prepareRequest = async (item = {}, collection = {}) => {
     axiosRequest.data = graphqlQuery;
   }
 
+  // if the mode is 'none' then set the content-type header to null to prevent axios from adding default. #1693
+  // AWS SigV4 requires Content-Type header in canonical request for signature calculation,
+  // even with no body. Omitting it would cause authentication failures.
+  if (request.body.mode === 'none' && (!request.auth || request.auth.mode !== 'awsv4')) {
+    if (!contentTypeDefined) {
+      // Setting to null tells axios not to add a default Content-Type header
+      // Use lowercase to match what scripts use, avoiding duplicate headers
+      axiosRequest.headers['content-type'] = null;
+    }
+  }
+
   if (request.script) {
     axiosRequest.script = request.script;
   }


### PR DESCRIPTION
Fixes: #6486
Related to: #1693 


### Description

The Bruno CLI was sending an unwanted `Content-Type: application/x-www-form-urlencoded` header for requests with no body. This fix ensures that requests with no body do not send a Content-Type header, matching the behavior of the Electron version.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made Content-Type handling more robust to avoid runtime errors when the header is missing or not a string; improves handling for JSON, form-encoded, and multipart requests.
  * Added support for a request body mode of "none" to prevent automatic injection of a Content-Type header when no body is intended, improving request signing compatibility.
  * No public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->