### PR TITLE
fix: update dropdown item text color to use theme text color 

### DIFF
--- a/packages/bruno-app/src/components/ApiSpecPanel/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/StyledWrapper.js
@@ -7,7 +7,7 @@ const StyledWrapper = styled.div`
   }
 
   div.dropdown-item.menu-item {
-    color: ${(props) => props.theme.colors.danger};
+    color: ${(props) => props.theme.colors.text.danger};
     &:hover {
       background-color: ${(props) => props.theme.colors.bg.danger};
       color: white;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/index.js
@@ -19,8 +19,10 @@ import DeleteResponseExampleModal from './DeleteResponseExampleModal';
 import GenerateCodeItem from '../GenerateCodeItem';
 import toast from 'react-hot-toast';
 import StyledWrapper from './StyledWrapper';
+import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
 
 const ExampleItem = ({ example, item, collection }) => {
+  const { dropdownContainerRef } = useSidebarAccordion();
   const dispatch = useDispatch();
   // Check if this example is the active tab
   const activeTabUid = useSelector((state) => state.tabs?.activeTabUid);
@@ -206,6 +208,8 @@ const ExampleItem = ({ example, item, collection }) => {
           ref={menuDropdownRef}
           items={buildMenuItems()}
           placement="bottom-start"
+          appendTo={dropdownContainerRef?.current || document.body}
+          popperOptions={{ strategy: 'fixed' }}
           data-testid="response-example-menu"
         >
           <IconDots size={22} data-testid="response-example-menu-icon" />

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
@@ -149,7 +149,7 @@ const Wrapper = styled.div`
     }
 
     div.dropdown-item.delete-item {
-      color: ${(props) => props.theme.colors.danger};
+      color: ${(props) => props.theme.colors.text.danger};
       &:hover {
         background-color: ${(props) => props.theme.colors.bg.danger} !important;
         color: white;


### PR DESCRIPTION
### Description

Update dropdown item text color to use theme text color for consistency; enhance ExampleItem dropdown behavior with fixed positioning

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown menu positioning in sidebar collection items to prevent rendering outside content boundaries and ensure menus display correctly within the designated container area.

* **Style**
  * Updated color theming for delete and danger action items throughout the interface, including sidebar controls and menu options, to maintain visual consistency and improve overall theme coherence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->