### PR TITLE
fix: unify hover and keyboard focus styles for collection component

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
@@ -15,9 +15,11 @@ const Wrapper = styled.div`
       visibility: hidden;
     }
 
+    /* Single source of truth for hover/focus states: background and menu icon visibility */
     &:hover,
     &:focus-within,
     &.collection-keyboard-focused {
+      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
       .collection-actions {
         visibility: visible;
         background-color: transparent !important;
@@ -78,10 +80,11 @@ const Wrapper = styled.div`
     }
 
     &.collection-keyboard-focused {
-      background: ${(props) => props.theme.sidebar.collection.item.keyboardFocusBg};
+      border-top: 1px solid ${(props) => props.theme.sidebar.collection.item.focusBorder};
+      border-bottom: 1px solid ${(props) => props.theme.sidebar.collection.item.focusBorder};
       outline: none;
 
-      &:hover {
+       &:hover {
         background: ${(props) => props.theme.sidebar.collection.item.keyboardFocusBg} !important;
       }
     }


### PR DESCRIPTION
### Description

Unify hover and keyboard focus styles for collection component

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced focus indicators on collection items with improved border styling and visual consistency.
  * Refined hover state styling to ensure consistent visual feedback across interactions in the sidebar.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->