### PR TITLE
feat: update primary colors in schema

### DIFF
--- a/packages/bruno-app/src/themes/dark/catppuccin-frappe.js
+++ b/packages/bruno-app/src/themes/dark/catppuccin-frappe.js
@@ -58,6 +58,13 @@ const catppuccinFrappeTheme = {
   textLink: colors.BLUE,
   bg: colors.BASE,
 
+  primary: {
+    solid: colors.MAUVE,
+    text: colors.MAUVE,
+    strong: colors.MAUVE,
+    subtle: colors.MAUVE
+  },
+
   accents: {
     primary: colors.MAUVE
   },

--- a/packages/bruno-app/src/themes/dark/catppuccin-macchiato.js
+++ b/packages/bruno-app/src/themes/dark/catppuccin-macchiato.js
@@ -58,6 +58,13 @@ const catppuccinMacchiatoTheme = {
   textLink: colors.BLUE,
   bg: colors.BASE,
 
+  primary: {
+    solid: colors.MAUVE,
+    text: colors.MAUVE,
+    strong: colors.MAUVE,
+    subtle: colors.MAUVE
+  },
+
   accents: {
     primary: colors.MAUVE
   },

--- a/packages/bruno-app/src/themes/dark/catppuccin-mocha.js
+++ b/packages/bruno-app/src/themes/dark/catppuccin-mocha.js
@@ -58,6 +58,13 @@ const catppuccinMochaTheme = {
   textLink: colors.BLUE,
   bg: colors.BASE,
 
+  primary: {
+    solid: colors.MAUVE,
+    text: colors.MAUVE,
+    strong: colors.MAUVE,
+    subtle: colors.MAUVE
+  },
+
   accents: {
     primary: colors.MAUVE
   },

--- a/packages/bruno-app/src/themes/dark/dark-monochrome.js
+++ b/packages/bruno-app/src/themes/dark/dark-monochrome.js
@@ -43,6 +43,13 @@ const darkMonochromeTheme = {
   textLink: colors.TEXT_LINK,
   bg: colors.BG,
 
+  primary: {
+    solid: colors.BRAND,
+    text: colors.BRAND,
+    strong: colors.BRAND,
+    subtle: colors.BRAND
+  },
+
   accents: {
     primary: colors.BRAND
   },

--- a/packages/bruno-app/src/themes/dark/dark-pastel.js
+++ b/packages/bruno-app/src/themes/dark/dark-pastel.js
@@ -64,6 +64,13 @@ const darkPastelTheme = {
   textLink: colors.TEXT_LINK,
   bg: colors.BG,
 
+  primary: {
+    solid: colors.BRAND,
+    text: colors.BRAND,
+    strong: colors.BRAND,
+    subtle: colors.BRAND
+  },
+
   accents: {
     primary: colors.BRAND
   },

--- a/packages/bruno-app/src/themes/dark/nord.js
+++ b/packages/bruno-app/src/themes/dark/nord.js
@@ -63,6 +63,13 @@ const nordTheme = {
   textLink: colors.TEXT_LINK,
   bg: colors.BG,
 
+  primary: {
+    solid: colors.BRAND,
+    text: colors.BRAND,
+    strong: colors.BRAND,
+    subtle: colors.BRAND
+  },
+
   accents: {
     primary: colors.BRAND
   },

--- a/packages/bruno-app/src/themes/dark/vscode.js
+++ b/packages/bruno-app/src/themes/dark/vscode.js
@@ -65,6 +65,13 @@ const vscodeDarkTheme = {
   textLink: colors.TEXT_LINK,
   bg: colors.EDITOR_BG,
 
+  primary: {
+    solid: colors.BRAND,
+    text: colors.TEXT_LINK,
+    strong: '#0098ff',
+    subtle: '#005a9e'
+  },
+
   accents: {
     primary: colors.BRAND
   },

--- a/packages/bruno-app/src/themes/light/catppuccin-latte.js
+++ b/packages/bruno-app/src/themes/light/catppuccin-latte.js
@@ -56,6 +56,13 @@ const catppuccinLatteTheme = {
   textLink: colors.BLUE,
   bg: colors.BASE,
 
+  primary: {
+    solid: colors.MAUVE,
+    text: colors.MAUVE,
+    strong: colors.MAUVE,
+    subtle: colors.MAUVE
+  },
+
   accents: {
     primary: colors.MAUVE
   },

--- a/packages/bruno-app/src/themes/light/light-monochrome.js
+++ b/packages/bruno-app/src/themes/light/light-monochrome.js
@@ -44,6 +44,13 @@ const lightMonochromeTheme = {
   textLink: colors.TEXT_LINK,
   bg: colors.BACKGROUND,
 
+  primary: {
+    solid: colors.BRAND,
+    text: colors.BRAND,
+    strong: colors.BRAND,
+    subtle: colors.BRAND
+  },
+
   accents: {
     primary: colors.BRAND
   },

--- a/packages/bruno-app/src/themes/light/light-pastel.js
+++ b/packages/bruno-app/src/themes/light/light-pastel.js
@@ -62,6 +62,13 @@ const lightPastelTheme = {
   textLink: colors.TEXT_LINK,
   bg: colors.BACKGROUND,
 
+  primary: {
+    solid: colors.BRAND,
+    text: colors.BRAND,
+    strong: colors.BRAND,
+    subtle: colors.BRAND
+  },
+
   accents: {
     primary: colors.BRAND
   },

--- a/packages/bruno-app/src/themes/light/vscode.js
+++ b/packages/bruno-app/src/themes/light/vscode.js
@@ -66,6 +66,13 @@ const vscodeLightTheme = {
   textLink: colors.TEXT_LINK,
   bg: colors.EDITOR_BG,
 
+  primary: {
+    solid: colors.BRAND,
+    text: colors.TEXT_LINK,
+    strong: '#0078d4',
+    subtle: '#4da6ff'
+  },
+
   accents: {
     primary: colors.BRAND
   },

--- a/packages/bruno-app/src/themes/schema/oss.js
+++ b/packages/bruno-app/src/themes/schema/oss.js
@@ -7,6 +7,18 @@ export const ossSchema = {
     textLink: { type: 'string', description: 'Link text color' },
     bg: { type: 'string', description: 'Background color' },
 
+    primary: {
+      type: 'object',
+      properties: {
+        solid: { type: 'string', description: 'Buttons, toggles, active pills' },
+        text: { type: 'string', description: 'Links, emphasized text' },
+        strong: { type: 'string', description: 'Thick borders, tab underlines' },
+        subtle: { type: 'string', description: 'Focus rings, subtle outlines' }
+      },
+      required: ['solid', 'text', 'strong', 'subtle'],
+      additionalProperties: false
+    },
+
     accents: {
       type: 'object',
       properties: {
@@ -1114,7 +1126,7 @@ export const ossSchema = {
     }
   },
   required: [
-    'mode', 'brand', 'text', 'textLink', 'bg', 'accents', 'background', 'overlay', 'font', 'shadow', 'border', 'colors', 'input',
+    'mode', 'brand', 'text', 'textLink', 'bg', 'primary', 'accents', 'background', 'overlay', 'font', 'shadow', 'border', 'colors', 'input',
     'sidebar', 'dropdown', 'workspace', 'request',
     'requestTabPanel', 'notifications', 'modal', 'button', 'button2', 'tabs',
     'requestTabs', 'codemirror', 'table', 'plainGrid', 'scrollbar', 'dragAndDrop',


### PR DESCRIPTION
update primary colors in schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added primary color configuration to all available themes, including Catppuccin (Frappé, Macchiato, Mocha, Latte), dark/light monochrome and pastel variants, Nord, and VS Code themes. The new configuration includes solid, text, strong, and subtle color variants for enhanced theme customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->