### PR TITLE
Feature/ignore folder menu

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -312,6 +312,12 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
           leftSection: IconPlayerPlay,
           label: 'Run',
           onClick: () => setRunCollectionModalOpen(true)
+        },
+        {
+          id: 'ignore-folder',
+          leftSection: IconEyeOff,
+          label: 'Ignore',
+          onClick: handleIgnoreFolder
         }
       );
     }
@@ -322,12 +328,6 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
         leftSection: IconCopy,
         label: 'Clone',
         onClick: () => setCloneItemModalOpen(true)
-      },
-      {
-        id: 'ignore-folder',
-        leftSection: IconEyeOff,
-        label: 'Ignore',
-        onClick: handleIgnoreFolder
       },
       {
         id: 'copy',
@@ -565,7 +565,6 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     if (confirmIgnore) {
       // 1. Get current list and filter out any existing nulls or garbage
       const currentIgnore = (collection?.brunoConfig?.ignore || []).filter(Boolean);
-
       // 2. Only add the name if it's NOT already in the list (prevents duplicates)
       if (!currentIgnore.includes(folderName)) {
         const updatedIgnore = [...currentIgnore, folderName];

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -166,19 +166,29 @@ const Collection = ({ collection, searchText }) => {
     });
   };
 
-  const handleIgnoreFolder = (folderName) => {
-    const confirmIgnore = window.confirm(`Are you sure you want to ignore the folder "${folderName}"?`);
+  const handleIgnoreFolder = () => {
+    const folderName = collection.name; // Automatically get the name from the collection object
+    if (!folderName) return;
+
+    const confirmIgnore = window.confirm(`Are you sure you want to ignore the collection "${folderName}"?`);
     if (confirmIgnore) {
-      const currentIgnore = collection.brunoConfig?.ignore || [];
-      dispatch(
-        brunoConfigUpdateEvent({
-          collectionUid: collection.uid,
-          brunoConfig: {
-            ...collection.brunoConfig,
-            ignore: [...currentIgnore, folderName]
-          }
-        })
-      );
+      // 1. Get current list and filter out any existing nulls
+      const currentIgnore = (collection.brunoConfig?.ignore || []).filter(Boolean);
+
+      // 2. Only add the name if it's NOT already in the list (prevents duplicates)
+      if (!currentIgnore.includes(folderName)) {
+        const updatedIgnore = [...currentIgnore, folderName];
+
+        dispatch(
+          brunoConfigUpdateEvent({
+            collectionUid: collection.uid,
+            brunoConfig: {
+              ...collection.brunoConfig,
+              ignore: updatedIgnore
+            }
+          })
+        );
+      }
     }
   };
 
@@ -331,11 +341,9 @@ const Collection = ({ collection, searchText }) => {
     },
     {
       id: 'ignore-folder',
-      leftSection: IconEyeOff, // You need to import this icon at the top of the file
+      leftSection: IconEyeOff,
       label: 'Ignore',
-      onClick: () => {
-        handleIgnoreFolder();
-      }
+      onClick: handleIgnoreFolder
     },
     ...(hasCopiedItems
       ? [
@@ -489,4 +497,3 @@ const Collection = ({ collection, searchText }) => {
 };
 
 export default Collection;
-// ignore feature


### PR DESCRIPTION
This Pull Request implements a new feature that allows users to ignore specific folders directly from the sidebar context menu. This helps users declutter their workspace by hiding irrelevant directories (like large asset folders or build artifacts) without deleting them from the disk.

#### Key Changes
1) UI Components: Added an "Ignore" option to the context menu in both Collection and CollectionItem components.

2) Icons: Integrated the IconEyeOff from @tabler/icons to provide a clear visual indicator for the action.

3) State Management: Implemented handleIgnoreFolder logic to update the brunoConfig.ignore array via the brunoConfigUpdateEvent.

4) Data Sanitization: Added logic to filter out duplicates and null values to ensure the bruno.json configuration remains clean and valid.

#### Verification Results
1) Redux Logic: Successfully verified using Redux DevTools that the collections/brunoConfigUpdateEvent dispatches the correct payload containing the folder name to be ignored.

2) Configuration: Confirmed that the ignore array in the collection state updates as expected.

Note: Local environment sync issues (specifically related to Windows/OneDrive) were observed during testing, which may affect immediate file persistence in some development environments, but the core Redux logic is verified and functional.

#### Screenshots
<img width="403" height="729" alt="1" src="https://github.com/user-attachments/assets/28904ff0-b142-457a-b2dc-92eff88a158c" />
<img width="428" height="545" alt="3" src="https://github.com/user-attachments/assets/1d1c8a6b-2629-4c43-9ff2-c541faec5255" />

#### Verification:

1) Source of Truth (1.png): Verified via Redux DevTools that the ignore array updates correctly with the folder name while preserving existing ignores.

2) Implementation Scope (3.png): Changes have been applied to both the Collection and CollectionItem UI components, as well as the CLI.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Ignore" option to collection and folder context menus in the sidebar.
  * Right-click any folder or collection and select "Ignore" to exclude it from view.
  * A confirmation dialog appears; ignored entries are saved persistently and duplicate entries are avoided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->