### PR TITLE
fix: update secret var alert icon to use danger text color

### DIFF
--- a/packages/bruno-app/src/components/SensitiveFieldWarning/StyledWrapper.js
+++ b/packages/bruno-app/src/components/SensitiveFieldWarning/StyledWrapper.js
@@ -5,6 +5,10 @@ const Wrapper = styled.div`
     font-size: ${(props) => props.theme.font.size.xs} !important;
     width: 150px !important;
   }
+
+  .tooltip-icon { 
+    color: ${(props) => props.theme.colors.text.danger};
+  }
 `;
 
 export default Wrapper;

--- a/packages/bruno-app/src/components/SensitiveFieldWarning/index.js
+++ b/packages/bruno-app/src/components/SensitiveFieldWarning/index.js
@@ -9,7 +9,7 @@ const SensitiveFieldWarning = ({ fieldName, warningMessage }) => {
   return (
     <StyledWrapper>
       <span className="ml-2 flex items-center">
-        <IconAlertTriangle id={tooltipId} className="text-amber-600 cursor-pointer" size={20} />
+        <IconAlertTriangle id={tooltipId} className="tooltip-icon cursor-pointer" size={20} />
         <Tooltip
           anchorId={tooltipId}
           className="tooltip-mod max-w-lg"


### PR DESCRIPTION
### Description

This PR updates the secret variable alert icon color across the application to use theme.colors.text.danger.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for sensitive field warning icons by implementing a unified tooltip styling system. This refactoring consolidates icon styling approaches, improves visual consistency across the application, simplifies CSS maintenance, and ensures a more cohesive design for all warning indicators without affecting the current appearance or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->