### PR TITLE
feat: update WSSE password digest calculation to use base64-encoded nonce

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -152,17 +152,24 @@ const prepareRequest = async (item = {}, collection = {}) => {
       const password = get(collectionAuth, 'wsse.password', '');
 
       const ts = new Date().toISOString();
-      const nonce = crypto.randomBytes(16).toString('hex');
+      const nonceBytes = crypto.randomBytes(16);
 
       // Create the password digest using SHA-1 as required for WSSE
-      const hash = crypto.createHash('sha1');
-      hash.update(nonce + ts + password);
-      const digest = Buffer.from(hash.digest('hex').toString('utf8')).toString('base64');
+      // WSSE spec: PasswordDigest = Base64(SHA1(nonce_bytes + created_bytes + password_bytes))
+      const passwordDigest = crypto
+        .createHash('sha1')
+        .update(
+          Buffer.concat([nonceBytes, Buffer.from(ts, 'utf8'), Buffer.from(password, 'utf8')])
+        )
+        .digest('base64');
+
+      // Nonce must be base64-encoded in the header
+      const nonce = nonceBytes.toString('base64');
 
       // Construct the WSSE header
       axiosRequest.headers[
         'X-WSSE'
-      ] = `UsernameToken Username="${username}", PasswordDigest="${digest}", Nonce="${nonce}", Created="${ts}"`;
+      ] = `UsernameToken Username="${username}", PasswordDigest="${passwordDigest}", Nonce="${nonce}", Created="${ts}"`;
     }
 
     console.log('axiosRequest', axiosRequest);

--- a/packages/bruno-electron/tests/prepare-request.test.js
+++ b/packages/bruno-electron/tests/prepare-request.test.js
@@ -181,7 +181,7 @@ describe('setAuthHeaders', () => {
 
       const result = setAuthHeaders(mockAxiosRequest, mockRequest, mockCollectionRoot);
 
-      expect(result.headers['X-WSSE']).toMatch(/UsernameToken Username="testuser", PasswordDigest="[^"]+", Nonce="1234567890abcdef", Created="[^"]+"/);
+      expect(result.headers['X-WSSE']).toMatch(/UsernameToken Username="testuser", PasswordDigest="[^"]+", Nonce="EjRWeJCrze8=", Created="[^"]+"/);
     });
 
     test('should inherit API key authentication from collection (header placement)', () => {
@@ -571,7 +571,7 @@ describe('setAuthHeaders', () => {
 
       const result = setAuthHeaders(mockAxiosRequest, mockRequest, mockCollectionRoot);
 
-      expect(result.headers['X-WSSE']).toMatch(/UsernameToken Username="requestuser", PasswordDigest="[^"]+", Nonce="1234567890abcdef", Created="[^"]+"/);
+      expect(result.headers['X-WSSE']).toMatch(/UsernameToken Username="requestuser", PasswordDigest="[^"]+", Nonce="EjRWeJCrze8=", Created="[^"]+"/);
     });
 
     test('should set API key authentication at request level (header placement)', () => {


### PR DESCRIPTION
fixes: #6482 

### Description

The WSSE implementation had three critical bugs that violated the OASIS WS-Security UsernameToken Profile 1.1 specification, causing authentication to fail with any standards-compliant WSSE server.

### Problems
Bruno's WSSE authentication was generating:
- ❌ **56-character digests** (should be 28 characters)
- ❌ **Hex-encoded nonces** (should be base64-encoded)
- ❌ **Incorrect digest calculation** (triple encoding bug)


**3 bugs fixed:**
1. ✅ Nonce kept as raw bytes for hashing
2. ✅ Byte-level concatenation using `Buffer.concat()`
3. ✅ Direct base64 encoding of raw SHA-1 output

**Result:**
- 56-char digest → 28-char digest ✅
- hex nonce → base64 nonce ✅
- Failed authentication → Successful authentication ✅
- Spec non-compliant → OASIS compliant ✅

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WSSE (Web Services Security) authentication header generation across the application. Corrected nonce handling and digest computation algorithms to ensure proper authentication compliance with standard WSSE specifications and improve compatibility with secure web services.

* **Tests**
  * Updated test cases to validate corrected WSSE authentication header values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->