### PR TITLE
fix: Add New Request CTA alignment in tabs

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -168,17 +168,14 @@ const RequestTabs = () => {
               </ul>
             </div>
 
-            <div className="flex items-center cursor-pointer short-tab px-2">
-              {
-                activeCollection && (
-                  <IconPlus
-                    size={18}
-                    strokeWidth={1.5}
-                    onClick={() => setNewRequestModalOpen(true)}
-                  />
-                )
-              }
-            </div>
+            {activeCollection && (
+              <div className="flex items-center cursor-pointer short-tab px-2" onClick={() => setNewRequestModalOpen(true)}>
+                <IconPlus
+                  size={18}
+                  strokeWidth={1.5}
+                />
+              </div>
+            )}
             <ul role="tablist">
               {showChevrons ? (
                 <li className="select-none short-tab" onClick={rightSlide}>


### PR DESCRIPTION
### Description
- Moved the '+' icon before the chevron to maintain alignment once chevrons appear
- Added padding to the '+' icon for better spacing.

This PR addresses: https://usebruno.atlassian.net/browse/BRU-2417

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Before Fix: 
<img width="1392" height="880" alt="image" src="https://github.com/user-attachments/assets/12a6e4d5-d9b5-44ac-811c-d426af1ae78a" />

After Fix: 
<img width="1392" height="880" alt="image" src="https://github.com/user-attachments/assets/72c7b661-46b4-4467-9dad-9fb637abb7e2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Repositioned the "Create New Request" action in the request tabs for improved layout and accessibility; the clickable area was adjusted to the surrounding block to make activation easier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->