### PR TITLE
remove max height for keybinding table

### DIFF
--- a/packages/bruno-app/src/components/Preferences/Keybindings/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/Keybindings/StyledWrapper.js
@@ -29,8 +29,7 @@ const StyledWrapper = styled.div`
   }
 
   .table-container {
-    max-height: 400px;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   .key-button {


### PR DESCRIPTION
### Description

Removed the max height from the keybinding table so it now occupies the full height of the modal.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="776" height="663" alt="image" src="https://github.com/user-attachments/assets/0f718ac3-2f72-46d6-ad95-b4be80246929" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keybindings preferences layout to automatically expand with content. Scrollbar now displays only when needed instead of always being visible, providing a cleaner user interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->