### PR TITLE
fix: update GraphQL variable parsing

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -368,7 +368,9 @@ const prepareRequest = async (item = {}, collection = {}) => {
   if (request.body.mode === 'graphql') {
     const graphqlQuery = {
       query: get(request, 'body.graphql.query'),
-      variables: JSON.parse(decomment(get(request, 'body.graphql.variables') || '{}'))
+      // Keep variables as string for now - will be parsed after variable interpolation
+      // https://github.com/usebruno/bruno/issues/6076
+      variables: decomment(get(request, 'body.graphql.variables') || '{}')
     };
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/json';

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -224,6 +224,16 @@ const runSingleRequest = async function (
     // interpolate variables inside request
     interpolateVars(request, envVariables, runtimeVariables, processEnvVars);
 
+    // Parse GraphQL variables after interpolation (they were kept as string to allow variable interpolation)
+    // https://github.com/usebruno/bruno/issues/6076
+    if (request.data && typeof request.data.variables === 'string') {
+      try {
+        request.data.variables = JSON.parse(request.data.variables);
+      } catch (error) {
+        throw new Error(`Failed to parse GraphQL variables: ${error.message}`);
+      }
+    }
+
     if (request.settings?.encodeUrl) {
       request.url = encodeUrl(request.url);
     }

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -28,7 +28,14 @@ class BrunoRequest {
      */
     const isJson = this.hasJSONContentType(this.req.headers);
     if (isJson) {
-      this.body = this.__safeParseJSON(req.data);
+      // For GraphQL requests, data is already an object with {query, variables}
+      // where variables is still a string that hasn't been interpolated yet
+      // We should not try to parse it here
+      if (typeof req.data === 'string') {
+        this.body = this.__safeParseJSON(req.data);
+      } else if (typeof req.data === 'object' && req.data !== null) {
+        this.body = req.data;
+      }
     }
   }
 
@@ -104,6 +111,10 @@ class BrunoRequest {
 
     const isJson = this.hasJSONContentType(this.req.headers);
     if (isJson) {
+      // If data is already an object (e.g., GraphQL), return as-is
+      if (typeof this.req.data === 'object') {
+        return this.req.data;
+      }
       return this.__safeParseJSON(this.req.data);
     }
 


### PR DESCRIPTION
fixes: #6076 

### Description
This PR implements the logic of fixing an issue where GraphQL requests failed when using non-string variable types (like integers or booleans) with template variables (e.g., `{{userId}}`). The problem was caused by GraphQL variables being parsed as JSON before interpolation.

### What's changed:

* The order of operations is updated so that:

  1. GraphQL variables stay as strings during request preparation.
  2. Environment/runtime variables are interpolated.
  3. After that, the data is parsed as JSON.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GraphQL variables handling so variables are preserved as strings through preparation and parsed after interpolation, with clearer error reporting for invalid JSON.
  * Improved JSON request body processing to accept both string and pre-parsed object payloads without unnecessary re-parsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->