### PR TITLE
fix: resolve request pane tooltip visibility issue

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/StyledWrapper.js
@@ -55,7 +55,7 @@ const Wrapper = styled.div`
     border-radius: 4px;
     padding: 4px 8px;
     position: absolute;
-    z-index: 1;
+    z-index: 3;
     bottom: 34px;
     left: 50%;
     transform: translateX(-50%);

--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/StyledWrapper.js
@@ -26,7 +26,7 @@ const Wrapper = styled.div`
     border-radius: 4px;
     padding: 4px 8px;
     position: absolute;
-    z-index: 2;
+    z-index: 3;
     bottom: 34px;
     left: 50%;
     transform: translateX(-50%);

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/StyledWrapper.js
@@ -68,7 +68,7 @@ const StyledWrapper = styled.div`
     border-radius: 4px;
     padding: 4px 8px;
     position: absolute;
-    z-index: 1;
+    z-index: 3;
     bottom: 34px;
     left: 50%;
     transform: translateX(-50%);


### PR DESCRIPTION
### Description

Fix an issue where tooltips for the Generate Code and Save icons were hidden behind the request tab

### Before
<img width="479" height="346" alt="Screenshot 2026-01-01 at 5 15 15 PM" src="https://github.com/user-attachments/assets/78e93701-9d5b-4b48-9b8a-f74f0b777234" />

### After
<img width="671" height="331" alt="Screenshot 2026-01-01 at 5 27 53 PM" src="https://github.com/user-attachments/assets/5c6ce88c-c621-4d1a-8559-ad527559667a" />



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved tooltip visibility across request panes (HTTP, gRPC, WebSocket) by adjusting display layering so informational tooltips reliably appear above surrounding elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->