### PR TITLE
fix: folder docs save button visibility issue

### DIFF
--- a/packages/bruno-app/src/components/FolderSettings/Documentation/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Documentation/index.js
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions';
 import Markdown from 'components/MarkDown';
 import CodeEditor from 'components/CodeEditor';
+import Button from 'ui/Button';
 import StyledWrapper from './StyledWrapper';
 
 const Documentation = ({ collection, folder }) => {
@@ -37,27 +38,35 @@ const Documentation = ({ collection, folder }) => {
   }
 
   return (
-    <StyledWrapper className="mt-1 h-full w-full relative flex flex-col">
-      <div className="editing-mode flex justify-between items-center" role="tab" onClick={toggleViewMode}>
+    <StyledWrapper className="mt-1 w-full relative flex flex-col">
+      <div className="editing-mode flex justify-between items-center flex-shrink-0" role="tab" onClick={toggleViewMode}>
         {isEditing ? 'Preview' : 'Edit'}
       </div>
 
       {isEditing ? (
-        <div className="mt-2 flex-1 max-h-[70vh]">
-          <CodeEditor
-            collection={collection}
-            theme={displayedTheme}
-            value={docs || ''}
-            onEdit={onEdit}
-            onSave={onSave}
-            mode="application/text"
-          />
-          <button type="submit" className="submit btn btn-sm btn-secondary my-6" onClick={onSave}>
-            Save
-          </button>
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="mt-2 flex-1 overflow-auto min-h-0">
+            <CodeEditor
+              collection={collection}
+              theme={displayedTheme}
+              value={docs || ''}
+              onEdit={onEdit}
+              onSave={onSave}
+              font={get(preferences, 'font.codeFont', 'default')}
+              fontSize={get(preferences, 'font.codeFontSize')}
+              mode="application/text"
+            />
+          </div>
+          <div className="mt-6 flex-shrink-0">
+            <Button type="submit" size="sm" onClick={onSave}>
+              Save
+            </Button>
+          </div>
         </div>
       ) : (
-        <Markdown collectionPath={collection.pathname} onDoubleClick={toggleViewMode} content={docs} />
+        <div className="h-full">
+          <Markdown collectionPath={collection.pathname} onDoubleClick={toggleViewMode} content={docs} />
+        </div>
       )}
     </StyledWrapper>
   );


### PR DESCRIPTION
### Description

- save button in folder-level documentation was hidden below the visible area, making it inaccessible without scrolling
- normal button with themed Button

### Screenshot
<img width="995" height="781" alt="Screenshot 2026-01-01 at 7 57 09 PM" src="https://github.com/user-attachments/assets/2e18a5e9-5b5f-4b03-9a8b-f8c84e90874a" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced documentation editor layout with improved overflow handling, spacing adjustments, and flex layout refinements for better display
  * Redesigned Save button with enhanced visual styling and improved consistency
  * Improved code editor configuration with support for user-defined font preferences and sizes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->