### PR TITLE
fix: update @opencollection/types to version 0.6.0 and refactor auth …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@eslint/compat": "^1.3.2",
         "@faker-js/faker": "^7.6.0",
         "@jest/globals": "^29.2.0",
-        "@opencollection/types": "~0.5.0",
+        "@opencollection/types": "~0.6.0",
         "@playwright/test": "^1.51.1",
         "@rollup/plugin-json": "^6.1.0",
         "@storybook/addon-webpack5-compiler-babel": "^4.0.0",
@@ -6100,9 +6100,9 @@
       }
     },
     "node_modules/@opencollection/types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opencollection/types/-/types-0.5.0.tgz",
-      "integrity": "sha512-9rpu5agMrMLcMVU2UgyV+PYV3Zf/sHBJDHMQoq8XiMEUH8lt9f7yGtlerm/9dS3SHMpGX4A8ik0OFtc0dX4r1Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opencollection/types/-/types-0.6.0.tgz",
+      "integrity": "sha512-nasB4/1hIZ61xp2dnnZWhdH83f0t800VrSl3G2q+BtHabBqN/IG+j9BMOJg0hYZjAVx+Yhl1njkzUqkiX5+Q0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -33642,6 +33642,13 @@
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.8.4"
       }
+    },
+    "packages/bruno-converters/node_modules/@opencollection/types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opencollection/types/-/types-0.5.0.tgz",
+      "integrity": "sha512-9rpu5agMrMLcMVU2UgyV+PYV3Zf/sHBJDHMQoq8XiMEUH8lt9f7yGtlerm/9dS3SHMpGX4A8ik0OFtc0dX4r1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/bruno-converters/node_modules/glob": {
       "version": "10.4.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@eslint/compat": "^1.3.2",
     "@faker-js/faker": "^7.6.0",
     "@jest/globals": "^29.2.0",
-    "@opencollection/types": "~0.5.0",
+    "@opencollection/types": "~0.6.0",
     "@playwright/test": "^1.51.1",
     "@rollup/plugin-json": "^6.1.0",
     "@storybook/addon-webpack5-compiler-babel": "^4.0.0",

--- a/packages/bruno-converters/src/opencollection/items/graphql.ts
+++ b/packages/bruno-converters/src/opencollection/items/graphql.ts
@@ -63,7 +63,7 @@ export const fromOpenCollectionGraphqlItem = (item: GraphQLRequest): BrunoItem =
       headers: fromOpenCollectionHeaders(graphql.headers),
       params: fromOpenCollectionParams(graphql.params),
       body: fromOpenCollectionBody(graphqlBody, 'graphql'),
-      auth: fromOpenCollectionAuth(runtime.auth as Auth),
+      auth: fromOpenCollectionAuth(graphql.auth as Auth),
       script: scripts?.script,
       vars: {
         req: variables.req,
@@ -136,12 +136,17 @@ export const toOpenCollectionGraphqlItem = (item: BrunoItem): GraphQLRequest => 
     graphql.body = body;
   }
 
+  // auth
+  const auth = toOpenCollectionAuth(request.auth as Parameters<typeof toOpenCollectionAuth>[0]);
+  if (auth) {
+    graphql.auth = auth;
+  }
+
   const ocRequest: GraphQLRequest = {
     info,
     graphql
   };
 
-  const auth = toOpenCollectionAuth(request.auth as Parameters<typeof toOpenCollectionAuth>[0]);
   const scripts = toOpenCollectionScripts(request as Parameters<typeof toOpenCollectionScripts>[0]);
   const variables = toOpenCollectionVariables(request.vars as Parameters<typeof toOpenCollectionVariables>[0]);
   const assertions = toOpenCollectionAssertions(request.assertions as BrunoKeyValue[]);
@@ -150,12 +155,8 @@ export const toOpenCollectionGraphqlItem = (item: BrunoItem): GraphQLRequest => 
   const vars = request.vars as { req?: unknown[]; res?: unknown[] } | undefined;
   const actions = toOpenCollectionActions(vars?.res as Parameters<typeof toOpenCollectionActions>[0]);
 
-  if (auth || scripts || variables || assertions || actions) {
+  if (scripts || variables || assertions || actions) {
     const runtime: GraphQLRequestRuntime = {};
-
-    if (auth) {
-      runtime.auth = auth;
-    }
 
     if (scripts) {
       runtime.scripts = scripts;

--- a/packages/bruno-converters/src/opencollection/items/grpc.ts
+++ b/packages/bruno-converters/src/opencollection/items/grpc.ts
@@ -78,7 +78,7 @@ export const fromOpenCollectionGrpcItem = (item: GrpcRequest): BrunoItem => {
         mode: 'grpc',
         grpc: grpcMessages
       },
-      auth: fromOpenCollectionAuth(runtime.auth as Auth),
+      auth: fromOpenCollectionAuth(grpc.auth as Auth),
       script: scripts?.script,
       vars: {
         req: variables.req,
@@ -166,12 +166,17 @@ export const toOpenCollectionGrpcItem = (item: BrunoItem): GrpcRequest => {
     }
   }
 
+  // auth
+  const auth = toOpenCollectionAuth(request.auth as Parameters<typeof toOpenCollectionAuth>[0]);
+  if (auth) {
+    grpc.auth = auth;
+  }
+
   const ocRequest: GrpcRequest = {
     info,
     grpc
   };
 
-  const auth = toOpenCollectionAuth(request.auth as Parameters<typeof toOpenCollectionAuth>[0]);
   const scripts = toOpenCollectionScripts(request as Parameters<typeof toOpenCollectionScripts>[0]);
   const variables = toOpenCollectionVariables(request.vars as Parameters<typeof toOpenCollectionVariables>[0]);
   const assertions = toOpenCollectionAssertions(request.assertions as BrunoKeyValue[]);
@@ -180,12 +185,8 @@ export const toOpenCollectionGrpcItem = (item: BrunoItem): GrpcRequest => {
   const vars = request.vars as { req?: unknown[]; res?: unknown[] } | undefined;
   const actions = toOpenCollectionActions(vars?.res as Parameters<typeof toOpenCollectionActions>[0]);
 
-  if (auth || scripts || variables || assertions || actions) {
+  if (scripts || variables || assertions || actions) {
     const runtime: GrpcRequestRuntime = {};
-
-    if (auth) {
-      runtime.auth = auth;
-    }
 
     if (scripts) {
       runtime.scripts = scripts;

--- a/packages/bruno-converters/src/opencollection/items/http.ts
+++ b/packages/bruno-converters/src/opencollection/items/http.ts
@@ -72,7 +72,7 @@ export const fromOpenCollectionHttpItem = (ocRequest: HttpRequest): BrunoItem =>
       graphql: null,
       file: []
     },
-    auth: fromOpenCollectionAuth(runtime?.auth as Auth),
+    auth: fromOpenCollectionAuth(http?.auth as Auth),
     script: {
       req: scripts?.script?.req || null,
       res: scripts?.script?.res || null
@@ -178,6 +178,12 @@ export const toOpenCollectionHttpItem = (item: BrunoItem): HttpRequest => {
     http.body = body;
   }
 
+  // auth
+  const auth = toOpenCollectionAuth(brunoRequest?.auth);
+  if (auth) {
+    http.auth = auth;
+  }
+
   ocRequest.http = http;
 
   const runtime: HttpRequestRuntime = {};
@@ -206,12 +212,6 @@ export const toOpenCollectionHttpItem = (item: BrunoItem): HttpRequest => {
   const actions = toOpenCollectionActions(resVars);
   if (actions) {
     runtime.actions = actions;
-    hasRuntime = true;
-  }
-
-  const auth = toOpenCollectionAuth(brunoRequest?.auth);
-  if (auth) {
-    runtime.auth = auth;
     hasRuntime = true;
   }
 

--- a/packages/bruno-converters/src/opencollection/items/websocket.ts
+++ b/packages/bruno-converters/src/opencollection/items/websocket.ts
@@ -71,7 +71,7 @@ export const fromOpenCollectionWebsocketItem = (item: WebSocketRequest): BrunoIt
       url: websocket.url || '',
       headers: fromOpenCollectionHeaders(websocket.headers),
       body: wsBody,
-      auth: fromOpenCollectionAuth(runtime.auth as Auth),
+      auth: fromOpenCollectionAuth(websocket.auth as Auth),
       script: scripts?.script,
       vars: {
         req: variables.req,
@@ -133,12 +133,17 @@ export const toOpenCollectionWebsocketItem = (item: BrunoItem): WebSocketRequest
     }
   }
 
+  // auth
+  const auth = toOpenCollectionAuth(request.auth as Parameters<typeof toOpenCollectionAuth>[0]);
+  if (auth) {
+    websocket.auth = auth;
+  }
+
   const ocRequest: WebSocketRequest = {
     info,
     websocket
   };
 
-  const auth = toOpenCollectionAuth(request.auth as Parameters<typeof toOpenCollectionAuth>[0]);
   const scripts = toOpenCollectionScripts(request as Parameters<typeof toOpenCollectionScripts>[0]);
   const variables = toOpenCollectionVariables(request.vars as Parameters<typeof toOpenCollectionVariables>[0]);
 
@@ -146,12 +151,8 @@ export const toOpenCollectionWebsocketItem = (item: BrunoItem): WebSocketRequest
   const vars = request.vars as { req?: unknown[]; res?: unknown[] } | undefined;
   const actions = toOpenCollectionActions(vars?.res as Parameters<typeof toOpenCollectionActions>[0]);
 
-  if (auth || scripts || variables || actions) {
+  if (scripts || variables || actions) {
     const runtime: WebSocketRequestRuntime = {};
-
-    if (auth) {
-      runtime.auth = auth;
-    }
 
     if (scripts) {
       runtime.scripts = scripts;

--- a/packages/bruno-filestore/src/formats/yml/items/parseGraphQLRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseGraphQLRequest.ts
@@ -20,7 +20,7 @@ const parseGraphQLRequest = (ocRequest: GraphQLRequest): BrunoItem => {
     method: graphql?.method || 'POST',
     headers: toBrunoHttpHeaders(graphql?.headers) || [],
     params: toBrunoParams(graphql?.params) || [],
-    auth: toBrunoAuth(runtime?.auth),
+    auth: toBrunoAuth(graphql?.auth),
     body: {
       mode: 'graphql',
       json: null,

--- a/packages/bruno-filestore/src/formats/yml/items/parseGrpcRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseGrpcRequest.ts
@@ -38,7 +38,7 @@ const parseGrpcRequest = (ocRequest: GrpcRequest): BrunoItem => {
     methodType: grpc?.methodType || '',
     protoPath: grpc?.protoFilePath || null,
     headers: toBrunoGrpcMetadata(grpc?.metadata) || [],
-    auth: toBrunoAuth(runtime?.auth),
+    auth: toBrunoAuth(grpc?.auth),
     body: {
       mode: 'grpc',
       grpc: []

--- a/packages/bruno-filestore/src/formats/yml/items/parseHttpRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseHttpRequest.ts
@@ -21,7 +21,7 @@ const parseHttpRequest = (ocRequest: HttpRequest): BrunoItem => {
     method: http?.method || 'GET',
     headers: toBrunoHttpHeaders(http?.headers) || [],
     params: toBrunoParams(http?.params) || [],
-    auth: toBrunoAuth(runtime?.auth),
+    auth: toBrunoAuth(http?.auth),
     body: toBrunoBody(http?.body as HttpRequestBody) || {
       mode: 'none',
       json: null,

--- a/packages/bruno-filestore/src/formats/yml/items/parseWebsocketRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseWebsocketRequest.ts
@@ -7,14 +7,7 @@ import { toBrunoVariables } from '../common/variables';
 import { toBrunoScripts } from '../common/scripts';
 import { uuid } from '../../../utils';
 
-interface WebSocketRequestWithSettings extends WebSocketRequest {
-  settings?: {
-    timeout?: number;
-    keepAliveInterval?: number;
-  };
-}
-
-const parseWebsocketRequest = (ocRequest: WebSocketRequestWithSettings): BrunoItem => {
+const parseWebsocketRequest = (ocRequest: WebSocketRequest): BrunoItem => {
   const info = ocRequest.info;
   const websocket = ocRequest.websocket;
   const runtime = ocRequest.runtime;
@@ -22,7 +15,7 @@ const parseWebsocketRequest = (ocRequest: WebSocketRequestWithSettings): BrunoIt
   const brunoRequest: BrunoWebSocketRequest = {
     url: websocket?.url || '',
     headers: toBrunoHttpHeaders(websocket?.headers) || [],
-    auth: toBrunoAuth(runtime?.auth),
+    auth: toBrunoAuth(websocket?.auth),
     body: {
       mode: 'ws',
       ws: []

--- a/packages/bruno-filestore/src/formats/yml/items/stringifyGraphQLRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/stringifyGraphQLRequest.ts
@@ -73,6 +73,12 @@ const stringifyGraphQLRequest = (item: BrunoItem): string => {
       }
     }
 
+    // auth (in graphql block, not runtime)
+    const auth: Auth | undefined = toOpenCollectionAuth(brunoRequest.auth);
+    if (auth) {
+      graphql.auth = auth;
+    }
+
     ocRequest.graphql = graphql;
 
     // runtime block
@@ -105,13 +111,6 @@ const stringifyGraphQLRequest = (item: BrunoItem): string => {
     const actions: Action[] | undefined = toOpenCollectionActions(resVars);
     if (actions) {
       runtime.actions = actions;
-      hasRuntime = true;
-    }
-
-    // auth
-    const auth: Auth | undefined = toOpenCollectionAuth(brunoRequest.auth);
-    if (auth) {
-      runtime.auth = auth;
       hasRuntime = true;
     }
 

--- a/packages/bruno-filestore/src/formats/yml/items/stringifyGrpcRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/stringifyGrpcRequest.ts
@@ -85,6 +85,12 @@ const stringifyGrpcRequest = (item: BrunoItem): string => {
       }
     }
 
+    // auth
+    const auth: Auth | undefined = toOpenCollectionAuth(brunoRequest.auth);
+    if (auth) {
+      grpc.auth = auth;
+    }
+
     ocRequest.grpc = grpc;
 
     // runtime block
@@ -109,13 +115,6 @@ const stringifyGrpcRequest = (item: BrunoItem): string => {
     const assertions: Assertion[] | undefined = toOpenCollectionAssertions(brunoRequest.assertions);
     if (assertions) {
       runtime.assertions = assertions;
-      hasRuntime = true;
-    }
-
-    // auth
-    const auth: Auth | undefined = toOpenCollectionAuth(brunoRequest.auth);
-    if (auth) {
-      runtime.auth = auth;
       hasRuntime = true;
     }
 

--- a/packages/bruno-filestore/src/formats/yml/items/stringifyHttpRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/stringifyHttpRequest.ts
@@ -60,6 +60,12 @@ const stringifyHttpRequest = (item: BrunoItem): string => {
       http.body = body;
     }
 
+    // auth
+    const auth: Auth | undefined = toOpenCollectionAuth(brunoRequest.auth);
+    if (auth) {
+      http.auth = auth;
+    }
+
     ocRequest.http = http;
 
     // runtime block
@@ -92,13 +98,6 @@ const stringifyHttpRequest = (item: BrunoItem): string => {
     const actions: Action[] | undefined = toOpenCollectionActions(resVars);
     if (actions) {
       runtime.actions = actions;
-      hasRuntime = true;
-    }
-
-    // auth
-    const auth: Auth | undefined = toOpenCollectionAuth(brunoRequest.auth);
-    if (auth) {
-      runtime.auth = auth;
       hasRuntime = true;
     }
 

--- a/packages/bruno-filestore/src/formats/yml/items/stringifyWebsocketRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/stringifyWebsocketRequest.ts
@@ -12,16 +12,9 @@ import { toOpenCollectionHttpHeaders } from '../common/headers';
 import { toOpenCollectionVariables } from '../common/variables';
 import { toOpenCollectionScripts } from '../common/scripts';
 
-interface WebSocketRequestWithSettings extends WebSocketRequest {
-  settings?: {
-    timeout?: number;
-    keepAliveInterval?: number;
-  };
-}
-
 const stringifyWebsocketRequest = (item: BrunoItem): string => {
   try {
-    const ocRequest: WebSocketRequestWithSettings = {};
+    const ocRequest: WebSocketRequest = {};
     const brunoRequest = item.request as BrunoWebSocketRequest;
 
     // info block
@@ -66,6 +59,12 @@ const stringifyWebsocketRequest = (item: BrunoItem): string => {
       }
     }
 
+    // auth
+    const auth: Auth | undefined = toOpenCollectionAuth(brunoRequest.auth);
+    if (auth) {
+      websocket.auth = auth;
+    }
+
     ocRequest.websocket = websocket;
 
     // runtime block
@@ -83,13 +82,6 @@ const stringifyWebsocketRequest = (item: BrunoItem): string => {
     const scripts: Scripts | undefined = toOpenCollectionScripts(brunoRequest);
     if (scripts) {
       runtime.scripts = scripts;
-      hasRuntime = true;
-    }
-
-    // auth
-    const auth: Auth | undefined = toOpenCollectionAuth(brunoRequest.auth);
-    if (auth) {
-      runtime.auth = auth;
       hasRuntime = true;
     }
 

--- a/packages/bruno-filestore/src/formats/yml/parseItem.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseItem.ts
@@ -23,9 +23,48 @@ const getItemType = (item: Item): string | undefined => {
   return undefined;
 };
 
+/**
+ * In v3.0.0-rc1 release auth was present under runtime property for all requests
+ * This has now been moved to the respective request properties
+ * This backward compatibility has been put in place for folks who tried out our early preview
+ * Should be safe to remove this in 3 months. Delete after 5 Apr 2026
+ */
+const ensureAuthV3Rc1BackwardsCompatibility = (parsedItemYml: any): any => {
+  const itemType = parsedItemYml?.info?.type;
+
+  switch (itemType) {
+    case 'http':
+      if (parsedItemYml.runtime?.auth && !parsedItemYml.http?.auth) {
+        parsedItemYml.http.auth = parsedItemYml.runtime.auth;
+      }
+      break;
+    case 'graphql':
+      if (parsedItemYml.runtime?.auth && !parsedItemYml.graphql?.auth) {
+        parsedItemYml.graphql.auth = parsedItemYml.runtime.auth;
+      }
+      break;
+    case 'grpc':
+      if (parsedItemYml.runtime?.auth && !parsedItemYml.grpc?.auth) {
+        parsedItemYml.grpc.auth = parsedItemYml.runtime.auth;
+      }
+      break;
+    case 'websocket':
+      if (parsedItemYml.runtime?.auth && !parsedItemYml.websocket?.auth) {
+        parsedItemYml.websocket.auth = parsedItemYml.runtime.auth;
+      }
+      break;
+    default:
+      break;
+  }
+
+  return parsedItemYml;
+};
+
 const parseItem = (ymlString: string): BrunoItem => {
   try {
-    const ocItem: Item = parseYml(ymlString);
+    const parsedYml = parseYml(ymlString);
+
+    const ocItem: Item = ensureAuthV3Rc1BackwardsCompatibility(parsedYml);
     const itemType = getItemType(ocItem);
 
     if (!ocItem || !itemType) {


### PR DESCRIPTION
* Updated to OpenCollection schema v0.6.0
* Moved auth from runtime to request properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@opencollection/types` dependency from ~0.5.0 to ~0.6.0

* **Refactor**
  * Reorganized authentication data structure to be stored at the request level (HTTP, GraphQL, gRPC, WebSocket) instead of runtime level
  * Added backward compatibility support for existing configurations using the previous authentication structure

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->