### PR TITLE
fix: text size inconsistency in collection settings 

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
@@ -69,7 +69,7 @@ const Info = ({ collection }) => {
                 </button>
                 <button
                   type="button"
-                  className="text-sm text-link cursor-pointer hover:underline text-left bg-transparent"
+                  className="text-link cursor-pointer hover:underline text-left bg-transparent"
                   onClick={() => {
                     dispatch(
                       addTab({


### PR DESCRIPTION
Before:
<img width="452" height="714" alt="image" src="https://github.com/user-attachments/assets/091bff2b-59f8-4666-8baf-ea47fa08d7b3" />

After:
<img width="452" height="714" alt="image" src="https://github.com/user-attachments/assets/16ed6c73-a806-4076-95e1-e1393e7dfa87" />
