### PR TITLE
fix: file picker component overflow

### DIFF
--- a/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
@@ -4,6 +4,8 @@ const StyledWrapper = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
+  overflow: hidden;
+  min-width: 0;
 
   .file-picker-btn {
     display: flex;
@@ -18,6 +20,9 @@ const StyledWrapper = styled.div`
     transition: color 0.15s ease;
     font-size: 12px;
     white-space: nowrap;
+    overflow: hidden;
+    min-width: 0;
+    max-width: 100%;
 
     &:hover {
       color: ${(props) => props.theme.text} !important;
@@ -30,6 +35,7 @@ const StyledWrapper = styled.div`
 
     &.icon-only {
       padding: 4px;
+      flex-shrink: 0;
     }
 
     &.icon-right {
@@ -39,6 +45,9 @@ const StyledWrapper = styled.div`
 
     span {
       line-height: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
     }
 
     .label {


### PR DESCRIPTION
### Description

#### Before 
<img width="330" height="197" alt="Screenshot 2026-01-02 at 7 14 12 PM" src="https://github.com/user-attachments/assets/d06a49f4-0e1c-4957-93d0-2d6c8cda9c11" />

#### After
https://github.com/user-attachments/assets/3ae3825a-c44e-4063-ab7a-7a4ac10c0a09




#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text truncation and overflow handling in file picker components to display ellipsis for long filenames and prevent layout overflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->