### PR TITLE
refactor: update GitHub repository button position and style in StatusBar component

### DIFF
--- a/packages/bruno-app/src/components/StatusBar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/StatusBar/StyledWrapper.js
@@ -61,7 +61,7 @@ const StyledWrapper = styled.div`
   .status-bar-divider {
     width: 1px;
     height: 16px;
-    background: ${(props) => props.theme.sidebar.dragbar};
+    background: ${(props) => props.theme.border.border2};
     opacity: 0.4;
   }
 

--- a/packages/bruno-app/src/components/StatusBar/index.js
+++ b/packages/bruno-app/src/components/StatusBar/index.js
@@ -97,19 +97,6 @@ const StatusBar = () => {
                 <Notifications />
               </div>
             </ToolHint>
-
-            <ToolHint text="GitHub Repository" toolhintId="GitHub" place="top" offset={10}>
-              <button
-                className="status-bar-button"
-                onClick={() => {
-                  window?.ipcRenderer?.openExternal('https://github.com/usebruno/bruno');
-                }}
-                tabIndex={0}
-                aria-label="Open GitHub Repository"
-              >
-                <IconBrandGithub size={16} strokeWidth={1.5} aria-hidden="true" />
-              </button>
-            </ToolHint>
           </div>
         </div>
 
@@ -162,6 +149,19 @@ const StatusBar = () => {
             <div className="status-bar-version">
               v{version}
             </div>
+
+            <ToolHint text="GitHub Repository" toolhintId="GitHub" place="top-end" offset={10}>
+              <button
+                className="status-bar-button"
+                onClick={() => {
+                  window?.ipcRenderer?.openExternal('https://github.com/usebruno/bruno');
+                }}
+                tabIndex={0}
+                aria-label="Open GitHub Repository"
+              >
+                <IconBrandGithub size={16} strokeWidth={1.5} aria-hidden="true" />
+              </button>
+            </ToolHint>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Description

Adjust divider background color in StyledWrapper
Update GitHub repository button position and style in StatusBar component

Before:
<img width="1440" height="73" alt="image" src="https://github.com/user-attachments/assets/7a80ad3e-e2f5-4996-ac93-47f740f3df4f" />

After:
<img width="721" height="49" alt="image" src="https://github.com/user-attachments/assets/301d85c6-0e50-4468-a131-8a56366b3f36" />

Why move GitHub icon to the right side of the status bar:

1. Consistent external link placement — External links (like GitHub) are conventionally placed on the right, separating them from app-internal actions (Preferences, Theme, Notifications)
2. Reduced accidental clicks — Keeps frequently-used settings controls (left) away from outbound navigation (right)
3. Visual grouping by function — Left side = app settings, Right sid = info/external resources (Search, Cookies, Dev Tools, Version, GitHub)
4. Better discoverability — Positioned near version info, making it intuitive for users looking for project/update information

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated status bar divider to use a different theme color for improved visual consistency.
  * Moved the GitHub repository shortcut to appear after the version display and align right for easier access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->