### PR TITLE
style: remove unnecessary padding from pre elements in StyledWrapper component

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/RequestDetailsPanel/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Devtools/Console/RequestDetailsPanel/StyledWrapper.js
@@ -259,10 +259,6 @@ const StyledWrapper = styled.div`
     height: 400px;
     display: flex;
     flex-direction: column;
-    
-    pre {
-      padding: 8px !important;
-    }
 
     .w-full.h-full.relative.flex {
       height: 100% !important;
@@ -321,7 +317,7 @@ const StyledWrapper = styled.div`
       height: 100% !important;
       max-height: 400px !important;
       padding: 0.5rem !important;
-      
+
       .network-logs-pre {
         color: ${(props) => props.theme.console.messageColor} !important;
         font-size: ${(props) => props.theme.font.size.xs} !important;


### PR DESCRIPTION
### Description

 Remove unnecessary padding from pre elements in StyledWrapper component

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined Devtools Console styling by consolidating pre element CSS rules for improved consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->