### PR TITLE
fix: prevent URL marking within variable patterns in CodeMirror

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/linkAware.js
+++ b/packages/bruno-app/src/utils/codemirror/linkAware.js
@@ -59,7 +59,18 @@ function markUrls(editor, linkify, linkClass, linkHint) {
       const matches = linkify.match(lineContent);
       if (!matches) continue;
 
+      const variablePatterns = [];
+      const variablePattern = /\{\{[^}]*\}\}/g;
+      let varMatch;
+      while ((varMatch = variablePattern.exec(lineContent)) !== null) {
+        variablePatterns.push({ start: varMatch.index, end: varMatch.index + varMatch[0].length });
+      }
       matches.forEach(({ index, lastIndex, url }) => {
+        const isInVariable = variablePatterns.some(
+          ({ start, end }) => index < end && lastIndex > start
+        );
+        if (isInVariable) return;
+
         try {
           editor.markText(
             { line: lineNum, ch: index },


### PR DESCRIPTION
### Description

This PR prevents marking URL in Codemirror for texts with the pattern {{...}}

PR for CMD+Click - https://github.com/usebruno/bruno/issues/6671

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where URLs appearing within template variables were incorrectly marked as clickable links. The app now properly skips link marking for URLs that exist inside template variable blocks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->