### PR TITLE
fix: improve {{var}} detection using cursor-based brace matching

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -683,8 +683,15 @@ if (!SERVER_RENDERED) {
     const line = cm.getLine(pos.line);
     if (!line) return;
 
-    // Use cursor position (pos.ch) instead of token boundaries.
-    // This fixes cases like "{{123}}" and "{{val1}}" inside strings.
+    // If the line doesn't even contain both braces, no need to run loops
+    if (!line.includes('{{') || !line.includes('}}')) {
+      return;
+    }
+
+    // lastIndexOf searches backward from the cursor indexOf searches forward
+    if (line.lastIndexOf('{{', pos.ch) === -1 || line.indexOf('}}', pos.ch) === -1) {
+      return;
+    }
     let start = pos.ch;
     let end = pos.ch;
 
@@ -706,7 +713,7 @@ if (!SERVER_RENDERED) {
       start--;
     }
 
-    // If we reached the start of the line and didn't match '{{', bail
+    // If we reached the start of the line and didn't match '{{', return
     if (start < 0 || line.substring(start, start + 2) !== '{{') {
       return;
     }
@@ -728,7 +735,7 @@ if (!SERVER_RENDERED) {
 
       end++;
     }
-    // If we reached end-of-line without finding '}}', bail
+    // If we reached end-of-line without finding '}}', return
     if (end > line.length || line.substring(end - 2, end) !== '}}') {
       return;
     }


### PR DESCRIPTION
### Description

This PR is for fixing hover tooltip {{...}} detection in JSON by matching around cursor and ignoring empty/escaped vars.

PR for fixing {{...}} detection in JSON - https://github.com/usebruno/bruno/issues/6671
[Jira](https://usebruno.atlassian.net/browse/BRU-2479)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved variable-hover detection so tooltips appear only for well-formed, non-empty variable references by switching to a more robust line-based extraction and validation flow; reduces false/malformed tooltip triggers while preserving existing tooltip rendering behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->