### PR TITLE
fix(runtime): tolerate folded / invalid response headers to prevent h…

### DIFF
--- a/packages/bruno-cli/src/utils/invalid-header-tolerance.js
+++ b/packages/bruno-cli/src/utils/invalid-header-tolerance.js
@@ -1,0 +1,111 @@
+const TRUTHY = new Set(['1', 'true', 'yes', 'y', 'on']);
+const FALSY = new Set(['0', 'false', 'no', 'n', 'off']);
+
+const parseEnvBoolean = (value) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized.length) {
+    return undefined;
+  }
+  if (TRUTHY.has(normalized)) {
+    return true;
+  }
+  if (FALSY.has(normalized)) {
+    return false;
+  }
+  return undefined;
+};
+
+const resolveAllowInvalidHeaders = (requestSettings = {}, env = process.env) => {
+  if (typeof requestSettings.allowInvalidHeaders === 'boolean') {
+    return requestSettings.allowInvalidHeaders;
+  }
+
+  const fromEnv = parseEnvBoolean(env.BRUNO_ALLOW_INVALID_HEADERS);
+  if (typeof fromEnv === 'boolean') {
+    return fromEnv;
+  }
+
+  return true;
+};
+
+const isAxiosHeaders = (headers) => {
+  return !!headers && typeof headers.get === 'function' && typeof headers.set === 'function';
+};
+
+const getHeaderValue = (headers, name) => {
+  if (!headers) {
+    return undefined;
+  }
+  if (isAxiosHeaders(headers)) {
+    return headers.get(name);
+  }
+  return headers[name] ?? headers[name.toLowerCase()];
+};
+
+const setHeaderValue = (headers, name, value) => {
+  if (!headers) {
+    return;
+  }
+  if (isAxiosHeaders(headers)) {
+    headers.set(name, value);
+    return;
+  }
+  headers[name.toLowerCase()] = value;
+};
+
+const normalizeAccessControlAllowHeadersValue = (value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  let normalized = value.replace(/[\r\n]+[ \t]+/g, ' ').replace(/[\r\n]+/g, ' ');
+
+  const parts = normalized
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map((p) => (p.endsWith(':') && /^[A-Za-z0-9-]+:$/.test(p) ? p.slice(0, -1) : p));
+
+  normalized = parts.join(', ');
+  return normalized;
+};
+
+const normalizeObsFoldedResponseHeaders = (headers, request, env = process.env) => {
+  const allowInvalidHeaders = resolveAllowInvalidHeaders(request?.settings || {}, env);
+  if (!allowInvalidHeaders) {
+    return;
+  }
+
+  if (headers) {
+    const entries = isAxiosHeaders(headers) ? Object.entries(headers.toJSON()) : Object.entries(headers);
+    for (const [key, value] of entries) {
+      if (typeof value !== 'string' || (!value.includes('\n') && !value.includes('\r'))) {
+        continue;
+      }
+      const collapsed = value.replace(/[\r\n]+[ \t]+/g, ' ').replace(/[\r\n]+/g, ' ');
+      setHeaderValue(headers, key, collapsed);
+    }
+  }
+
+  const acah = getHeaderValue(headers, 'access-control-allow-headers');
+  if (typeof acah === 'string' && acah.length) {
+    setHeaderValue(headers, 'access-control-allow-headers', normalizeAccessControlAllowHeadersValue(acah));
+  }
+};
+
+const applyInvalidHeaderToleranceToRequest = (request, env = process.env) => {
+  const allowInvalidHeaders = resolveAllowInvalidHeaders(request?.settings || {}, env);
+  if (allowInvalidHeaders) {
+    request.insecureHTTPParser = true;
+  }
+  return allowInvalidHeaders;
+};
+
+module.exports = {
+  applyInvalidHeaderToleranceToRequest,
+  normalizeObsFoldedResponseHeaders,
+  resolveAllowInvalidHeaders
+};

--- a/packages/bruno-electron/src/ipc/network/invalid-header-tolerance.js
+++ b/packages/bruno-electron/src/ipc/network/invalid-header-tolerance.js
@@ -1,0 +1,130 @@
+const TRUTHY = new Set(['1', 'true', 'yes', 'y', 'on']);
+const FALSY = new Set(['0', 'false', 'no', 'n', 'off']);
+
+const parseEnvBoolean = (value) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized.length) {
+    return undefined;
+  }
+  if (TRUTHY.has(normalized)) {
+    return true;
+  }
+  if (FALSY.has(normalized)) {
+    return false;
+  }
+  return undefined;
+};
+
+/**
+ * Bruno needs to be tolerant of "obsolete line folding" (obs-fold) and other
+ * real-world broken HTTP responses that curl/Postman accept.
+ *
+ * Node's default HTTP parser (llhttp) rejects obs-fold with:
+ *   HPE_INVALID_HEADER_TOKEN / "Unexpected whitespace after header value"
+ *
+ * Enabling `insecureHTTPParser` makes parsing tolerant for these cases.
+ * This is a DX trade-off: it can hide server header bugs and is less strict
+ * than RFC-compliant parsing, so we provide an opt-out switch.
+ */
+const resolveAllowInvalidHeaders = (requestSettings = {}, env = process.env) => {
+  if (typeof requestSettings.allowInvalidHeaders === 'boolean') {
+    return requestSettings.allowInvalidHeaders;
+  }
+
+  const fromEnv = parseEnvBoolean(env.BRUNO_ALLOW_INVALID_HEADERS);
+  if (typeof fromEnv === 'boolean') {
+    return fromEnv;
+  }
+
+  // Default ON: Bruno is a debugging client; tolerating common broken servers
+  // matches the behavior users expect from curl/Postman/Apifox.
+  return true;
+};
+
+const isAxiosHeaders = (headers) => {
+  return !!headers && typeof headers.get === 'function' && typeof headers.set === 'function';
+};
+
+const getHeaderValue = (headers, name) => {
+  if (!headers) {
+    return undefined;
+  }
+  if (isAxiosHeaders(headers)) {
+    return headers.get(name);
+  }
+  return headers[name] ?? headers[name.toLowerCase()];
+};
+
+const setHeaderValue = (headers, name, value) => {
+  if (!headers) {
+    return;
+  }
+  if (isAxiosHeaders(headers)) {
+    headers.set(name, value);
+    return;
+  }
+  // Axios normalizes node response header keys to lowercase.
+  headers[name.toLowerCase()] = value;
+};
+
+const normalizeAccessControlAllowHeadersValue = (value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  // Collapse obs-fold into spaces (in case a tolerant parser preserves CRLFs).
+  let normalized = value.replace(/[\r\n]+[ \t]+/g, ' ').replace(/[\r\n]+/g, ' ');
+
+  // This header is defined as a comma-separated list of header field-names.
+  // In broken responses we sometimes see "Accept:" as a folded continuation.
+  const parts = normalized
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map((p) => (p.endsWith(':') && /^[A-Za-z0-9-]+:$/.test(p) ? p.slice(0, -1) : p));
+
+  normalized = parts.join(', ');
+  return normalized;
+};
+
+const normalizeObsFoldedResponseHeaders = (headers, request, env = process.env) => {
+  const allowInvalidHeaders = resolveAllowInvalidHeaders(request?.settings || {}, env);
+  if (!allowInvalidHeaders) {
+    return;
+  }
+
+  // If a tolerant parser preserves CR/LF in header values, collapse them to spaces
+  // so the rest of Bruno can treat headers as single-line strings.
+  if (headers) {
+    const entries = isAxiosHeaders(headers) ? Object.entries(headers.toJSON()) : Object.entries(headers);
+    for (const [key, value] of entries) {
+      if (typeof value !== 'string' || (!value.includes('\n') && !value.includes('\r'))) {
+        continue;
+      }
+      const collapsed = value.replace(/[\r\n]+[ \t]+/g, ' ').replace(/[\r\n]+/g, ' ');
+      setHeaderValue(headers, key, collapsed);
+    }
+  }
+
+  const acah = getHeaderValue(headers, 'access-control-allow-headers');
+  if (typeof acah === 'string' && acah.length) {
+    setHeaderValue(headers, 'access-control-allow-headers', normalizeAccessControlAllowHeadersValue(acah));
+  }
+};
+
+const applyInvalidHeaderToleranceToRequest = (request, env = process.env) => {
+  const allowInvalidHeaders = resolveAllowInvalidHeaders(request?.settings || {}, env);
+  if (allowInvalidHeaders) {
+    request.insecureHTTPParser = true;
+  }
+  return allowInvalidHeaders;
+};
+
+module.exports = {
+  applyInvalidHeaderToleranceToRequest,
+  normalizeObsFoldedResponseHeaders,
+  resolveAllowInvalidHeaders
+};

--- a/packages/bruno-electron/tests/network/invalid-response-headers-obs-fold.spec.js
+++ b/packages/bruno-electron/tests/network/invalid-response-headers-obs-fold.spec.js
@@ -1,0 +1,165 @@
+const net = require('net');
+const axios = require('axios');
+const {
+  applyInvalidHeaderToleranceToRequest,
+  normalizeObsFoldedResponseHeaders
+} = require('../../src/ipc/network/invalid-header-tolerance');
+
+const startRawHttpServer = async (rawResponse) => {
+  const server = net.createServer((socket) => {
+    socket.once('data', () => {
+      socket.end(rawResponse);
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve))
+  };
+};
+
+const buildRawResponse = ({ headers = {}, body = '' }) => {
+  const bodyBuf = Buffer.from(body, 'utf8');
+  const headerLines = Object.entries({
+    Connection: 'close',
+    'Content-Length': String(bodyBuf.length),
+    ...headers
+  }).map(([k, v]) => `${k}: ${v}`);
+
+  return [
+    'HTTP/1.1 200 OK',
+    ...headerLines,
+    '',
+    bodyBuf.toString('utf8')
+  ].join('\r\n');
+};
+
+describe('HTTP response header tolerance (obs-fold)', () => {
+  const originalEnv = process.env.BRUNO_ALLOW_INVALID_HEADERS;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.BRUNO_ALLOW_INVALID_HEADERS;
+    } else {
+      process.env.BRUNO_ALLOW_INVALID_HEADERS = originalEnv;
+    }
+  });
+
+  it('does not modify normal headers', async () => {
+    process.env.BRUNO_ALLOW_INVALID_HEADERS = '1';
+
+    const body = JSON.stringify({ ok: true });
+    const { url, close } = await startRawHttpServer(buildRawResponse({
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Headers': 'a, b, c'
+      },
+      body
+    }));
+
+    try {
+      const request = { method: 'GET', url, settings: {} };
+      applyInvalidHeaderToleranceToRequest(request);
+      const response = await axios({ ...request, responseType: 'text' });
+      normalizeObsFoldedResponseHeaders(response.headers, request);
+
+      expect(response.data).toBe(body);
+      expect(response.headers['access-control-allow-headers']).toBe('a, b, c');
+    } finally {
+      await close();
+    }
+  });
+
+  it('parses and merges obs-fold continuation lines', async () => {
+    process.env.BRUNO_ALLOW_INVALID_HEADERS = '1';
+
+    const body = JSON.stringify({ ok: true });
+    const raw = [
+      'HTTP/1.1 200 OK',
+      'Connection: close',
+      'Content-Type: application/json',
+      `Content-Length: ${Buffer.byteLength(body, 'utf8')}`,
+      'Access-Control-Allow-Headers: a, b,',
+      '  c',
+      '',
+      body
+    ].join('\r\n');
+
+    const { url, close } = await startRawHttpServer(raw);
+
+    try {
+      const request = { method: 'GET', url, settings: {} };
+      applyInvalidHeaderToleranceToRequest(request);
+      const response = await axios({ ...request, responseType: 'text' });
+      normalizeObsFoldedResponseHeaders(response.headers, request);
+
+      expect(response.data).toBe(body);
+      expect(response.headers['access-control-allow-headers']).toBe('a, b, c');
+    } finally {
+      await close();
+    }
+  });
+
+  it('treats folded \"Accept:\" as continuation (does not fail)', async () => {
+    process.env.BRUNO_ALLOW_INVALID_HEADERS = '1';
+
+    const body = JSON.stringify({ ok: true });
+    const raw = [
+      'HTTP/1.1 200 OK',
+      'Connection: close',
+      'Content-Type: application/json',
+      `Content-Length: ${Buffer.byteLength(body, 'utf8')}`,
+      'Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type,',
+      '       Accept:',
+      '',
+      body
+    ].join('\r\n');
+
+    const { url, close } = await startRawHttpServer(raw);
+
+    try {
+      const request = { method: 'GET', url, settings: {} };
+      applyInvalidHeaderToleranceToRequest(request);
+      const response = await axios({ ...request, responseType: 'text' });
+      normalizeObsFoldedResponseHeaders(response.headers, request);
+
+      expect(response.data).toBe(body);
+      expect(response.headers['access-control-allow-headers']).toBe('Origin, X-Requested-With, Content-Type, Accept');
+    } finally {
+      await close();
+    }
+  });
+
+  it('can be disabled via BRUNO_ALLOW_INVALID_HEADERS=0', async () => {
+    process.env.BRUNO_ALLOW_INVALID_HEADERS = '0';
+
+    const body = JSON.stringify({ ok: true });
+    const raw = [
+      'HTTP/1.1 200 OK',
+      'Connection: close',
+      'Content-Type: application/json',
+      `Content-Length: ${Buffer.byteLength(body, 'utf8')}`,
+      'Access-Control-Allow-Headers: a, b,',
+      '  c',
+      '',
+      body
+    ].join('\r\n');
+
+    const { url, close } = await startRawHttpServer(raw);
+
+    try {
+      const request = { method: 'GET', url, settings: {} };
+      applyInvalidHeaderToleranceToRequest(request);
+
+      await expect(axios({ ...request, responseType: 'text' })).rejects.toMatchObject({
+        code: 'HPE_INVALID_HEADER_TOKEN'
+      });
+    } finally {
+      await close();
+    }
+  });
+});
+

--- a/packages/bruno-requests/src/network/invalid-header-tolerance.ts
+++ b/packages/bruno-requests/src/network/invalid-header-tolerance.ts
@@ -1,0 +1,53 @@
+const TRUTHY = new Set(['1', 'true', 'yes', 'y', 'on']);
+const FALSY = new Set(['0', 'false', 'no', 'n', 'off']);
+
+const parseEnvBoolean = (value: unknown): boolean | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized.length) {
+    return undefined;
+  }
+  if (TRUTHY.has(normalized)) {
+    return true;
+  }
+  if (FALSY.has(normalized)) {
+    return false;
+  }
+  return undefined;
+};
+
+export const resolveAllowInvalidHeaders = (
+  requestSettings: { allowInvalidHeaders?: boolean } = {},
+  env: NodeJS.ProcessEnv = process.env
+): boolean => {
+  if (typeof requestSettings.allowInvalidHeaders === 'boolean') {
+    return requestSettings.allowInvalidHeaders;
+  }
+
+  const fromEnv = parseEnvBoolean(env.BRUNO_ALLOW_INVALID_HEADERS);
+  if (typeof fromEnv === 'boolean') {
+    return fromEnv;
+  }
+
+  return true;
+};
+
+export const normalizeAccessControlAllowHeadersValue = (value: unknown): unknown => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  let normalized = value.replace(/[\r\n]+[ \t]+/g, ' ').replace(/[\r\n]+/g, ' ');
+
+  const parts = normalized
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map((p) => (p.endsWith(':') && /^[A-Za-z0-9-]+:$/.test(p) ? p.slice(0, -1) : p));
+
+  normalized = parts.join(', ');
+  return normalized;
+};
+

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,14 @@ echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/bruno.gpg] http://debian.usebr
 sudo apt update && sudo apt install bruno
 ```
 
+## Runtime configuration
+
+Bruno tolerates some common-but-nonstandard HTTP response headers (e.g. obsolete line folding / obs-fold) by default.
+This uses Node.js `insecureHTTPParser` (more tolerant, less strict than RFC parsing).
+
+- `BRUNO_ALLOW_INVALID_HEADERS=0` disables tolerant header parsing (strict mode).
+- Request-level override: set `settings.allowInvalidHeaders` to `true`/`false`.
+
 ## Features
 
 ### Run across multiple platforms 🖥️


### PR DESCRIPTION
### Description

This PR focuses on **improving Bruno’s tolerance for non‑standard (but common) HTTP response headers** so requests do not fail when servers return obsolete header folding (obs-fold) or unusual whitespace.

#### Context / Problem

Some real-world servers (commonly seen with openresty/nginx configurations) still emit **obsolete header folding** (line continuation) in responses. Node.js’ strict HTTP parser rejects such responses and Bruno previously failed the request with:

- `code: HPE_INVALID_HEADER_TOKEN`
- `reason: Unexpected whitespace after header value`

While tools like curl/Postman/Apifox typically tolerate these responses and still return the body, Bruno could not be used to debug these services.

#### What changed

- Enable tolerant parsing by using Node.js’ built-in `insecureHTTPParser` option on the request when tolerance is enabled.
- Add a configuration toggle to control this behavior:
  - Environment variable: `BRUNO_ALLOW_INVALID_HEADERS=0` disables tolerance (strict mode).
  - Request-level override: `settings.allowInvalidHeaders = true|false`.
- Normalize response headers to avoid propagating folded/invalid formatting:
  - Collapse obs-fold into a single-line value.
  - For `access-control-allow-headers` (comma-separated list), folded tokens like `Accept:` are treated as continuation content and normalized to `Accept` (no trailing colon), or at minimum will not cause the request to fail.

 
#### Tests

Adds coverage for:

- Normal response headers (unchanged).
- obs-fold folded headers (merged and successfully parsed).
- The `Access-Control-Allow-Headers` folded example containing a folded `Accept:` token (request succeeds and body is returned).
- Strict mode (`BRUNO_ALLOW_INVALID_HEADERS=0`) reproduces the expected parser failure.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tolerant HTTP header parsing mode to handle non-compliant servers.
  * Introduced `BRUNO_ALLOW_INVALID_HEADERS` environment variable to control header strictness (default: enabled).
  * Added request-level `allowInvalidHeaders` setting to override global configuration.
  * Automatic normalization of folded HTTP header values in responses.

* **Tests**
  * Added test coverage for invalid header handling and obs-fold header scenarios.

* **Documentation**
  * Updated documentation with runtime configuration details for HTTP header tolerance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->