### PR TITLE
feat: add CPU architecture dropdown to Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.yaml
+++ b/.github/ISSUE_TEMPLATE/BugReport.yaml
@@ -46,6 +46,22 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    attributes:
+      label: Architecture (CPU)
+      description: The CPU architecture of the machine where the issue occurs.
+      options:
+        - label: x86_64 / amd64
+          value: x86_64
+        - label: arm64 / aarch64
+          value: arm64
+        - label: armv7l
+          value: armv7l
+        - label: Other
+          value: other
+    validations:
+      required: true
+
   - type: textarea
     attributes:
       label: Describe the bug


### PR DESCRIPTION
I created this simple PR that asks the user to select their machine's architecture when creating an issue, rather than requiring them to specify their architecture once the issue is reported.

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**