### PR TITLE
fix: delete persistent environment variables from UI and filesystem

### DIFF
--- a/packages/bruno-app/src/utils/environments.js
+++ b/packages/bruno-app/src/utils/environments.js
@@ -1,7 +1,15 @@
 import { uuid } from './common/index';
 
 const isPersistableEnvVarForMerge = (persistedNames) => (v) => {
-  return !v?.ephemeral || v?.persistedValue !== undefined || (v?.name && persistedNames.has(v.name));
+  // Keep variable if:
+  // 1. It's ephemeral with persistedValue (was modified by script, restore original)
+  // 2. It's in persistedNames (explicitly persisted this run or non-ephemeral that wasn't deleted)
+  // 3. It's non-ephemeral AND in persistedNames (exclude deleted non-ephemeral variables)
+  if (v?.ephemeral) {
+    return v?.persistedValue !== undefined || (v?.name && persistedNames.has(v.name));
+  }
+  // Non-ephemeral variables: only keep if in persistedNames (not deleted)
+  return v?.name && persistedNames.has(v.name);
 };
 
 const toPersistedEnvVarForMerge = (persistedNames) => (v) => {

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -196,6 +196,7 @@ class Bru {
 
   deleteEnvVar(key) {
     delete this.envVariables[key];
+    delete this.persistentEnvVariables[key];
   }
 
   getGlobalEnvVar(key) {


### PR DESCRIPTION
Issues:
1. `bru.deleteEnvVar()` only removed variables from `envVariables`, not `persistentEnvVariables`, so they remained in the UI.
2. `mergeAndPersistEnvironment` preserved all non-ephemeral variables, even when deleted, so they stayed on disk.

Fixes:
1. Updated `deleteEnvVar` in `bru.js` to remove from both `envVariables` and `persistentEnvVariables`.
2. Updated `mergeAndPersistEnvironment` to exclude deleted variables from `persistedNames`.
3. Updated `isPersistableEnvVarForMerge` to filter out deleted non-ephemeral variables.

https://github.com/user-attachments/assets/0999aeb9-0a17-4287-b936-58ad0ee3c069


https://github.com/user-attachments/assets/a06c3159-3e5f-4749-85bc-52d269323cc2
