### PR TITLE
fix: seq becoming NaN when moving requests to collection root

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1129,7 +1129,7 @@ export const handleCollectionItemDrop
 
         // Update sequences in the target directory (if dropping adjacent)
         if (dropType === 'adjacent') {
-          const targetItemSequence = targetItemDirectoryItems.findIndex((i) => i.uid === targetItemUid)?.seq;
+          const targetItemSequence = targetItemDirectoryItems.find((i) => i.uid === targetItemUid)?.seq;
 
           const draggedItemWithNewPathAndSequence = {
             ...draggedItem,
@@ -1176,6 +1176,14 @@ export const handleCollectionItemDrop
           });
           if (!newPathname) return;
           if (targetItemPathname?.startsWith(draggedItemPathname)) return;
+
+          // Discard operation if dragging a root item to the collection name (same location)
+          const isTargetTheCollection = targetItemPathname === collection.pathname;
+          const isDraggedItemAtRoot = draggedItemDirectory === sourceCollection;
+          if (isTargetTheCollection && isDraggedItemAtRoot && !isCrossCollectionMove) {
+            return;
+          }
+
           if (newPathname !== draggedItemPathname) {
             await handleMoveToNewLocation({
               targetItem,


### PR DESCRIPTION
[BRU-2443](https://usebruno.atlassian.net/browse/BRU-2443)
Fixes: https://github.com/usebruno/bruno/issues/6232

Cause:
Logic inside [handleCollectionItemDrop](https://github.com/usebruno/bruno/blob/2b77d663ad578565e6c1d78d9c558cd15d280060/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js#L1084) function used `findIndex` (returns a number) instead of `find` (returns the item), so accessing `.seq` on the index returned `undefined`, which became `NaN`.

Fix:
1. Changed `findIndex` to `find` to get the item's `seq`.
2. Added an early return to discard the operation when dragging a root item to the collection name (same location).