### PR TITLE
feat: show inherited headers at request level

### DIFF
--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -1,5 +1,5 @@
+import { IconAlertCircle, IconGripVertical, IconMinusVertical, IconTrash } from '@tabler/icons';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { IconTrash, IconAlertCircle, IconGripVertical, IconMinusVertical } from '@tabler/icons';
 import { Tooltip } from 'react-tooltip';
 import { uuid } from 'utils/common';
 import StyledWrapper from './StyledWrapper';
@@ -249,11 +249,12 @@ const EditableTable = ({
           <tbody>
             {rowsWithEmpty.map((row, rowIndex) => {
               const isEmpty = isLastEmptyRow(row, rowIndex);
-              const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount;
+              const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount && row.editable !== false;
 
               return (
                 <tr
                   key={row.uid}
+                  className={row.editable === false ? 'read-only' : ''}
                   draggable={canDrag}
                   onDragStart={canDrag ? (e) => handleDragStart(e, rowIndex) : undefined}
                   onDragOver={canDrag ? (e) => handleDragOver(e, rowIndex) : undefined}
@@ -289,7 +290,7 @@ const EditableTable = ({
                           className="mousetrap"
                           data-testid="column-checkbox"
                           checked={row[checkboxKey] ?? true}
-                          disabled={disableCheckbox}
+                          disabled={disableCheckbox || row.editable === false}
                           onChange={(e) => handleCheckboxChange(row.uid, e.target.checked)}
                         />
                       )}
@@ -302,7 +303,7 @@ const EditableTable = ({
                   ))}
                   {showDelete && (
                     <td>
-                      {!isEmpty && (
+                      {!isEmpty && row.editable !== false && (
                         <button
                           data-testid="column-delete"
                           onClick={() => handleRemoveRow(row.uid)}

--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -249,12 +249,12 @@ const EditableTable = ({
           <tbody>
             {rowsWithEmpty.map((row, rowIndex) => {
               const isEmpty = isLastEmptyRow(row, rowIndex);
-              const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount && row.editable !== false;
+              const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount && row?.editable !== false;
 
               return (
                 <tr
-                  key={row.uid}
-                  className={row.editable === false ? 'read-only' : ''}
+                  key={row?.rowKey ?? row.uid}
+                  className={row?.editable === false ? 'read-only' : ''}
                   draggable={canDrag}
                   onDragStart={canDrag ? (e) => handleDragStart(e, rowIndex) : undefined}
                   onDragOver={canDrag ? (e) => handleDragOver(e, rowIndex) : undefined}
@@ -290,7 +290,7 @@ const EditableTable = ({
                           className="mousetrap"
                           data-testid="column-checkbox"
                           checked={row[checkboxKey] ?? true}
-                          disabled={disableCheckbox || row.editable === false}
+                          disabled={disableCheckbox || row?.editable === false}
                           onChange={(e) => handleCheckboxChange(row.uid, e.target.checked)}
                         />
                       )}
@@ -303,7 +303,7 @@ const EditableTable = ({
                   ))}
                   {showDelete && (
                     <td>
-                      {!isEmpty && row.editable !== false && (
+                      {!isEmpty && row?.editable !== false && (
                         <button
                           data-testid="column-delete"
                           onClick={() => handleRemoveRow(row.uid)}

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
@@ -19,7 +19,15 @@ const Wrapper = styled.div`
     }
     td {
       padding: 6px 10px;
+    }
+    tr.read-only {
+      color: ${(props) => props.theme.colors?.text?.muted || 'inherit'};
+      opacity: 0.7;
+      background-color: ${(props) => props.theme.table?.row?.readonly?.bg || 'transparent'};
+      .single-line-editor {
+        font-style: italic;
       }
+    }
   }
 
   .btn-action {

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
@@ -24,6 +24,7 @@ const Wrapper = styled.div`
       color: ${(props) => props.theme.colors?.text?.muted || 'inherit'};
       opacity: 0.7;
       background-color: ${(props) => props.theme.table?.row?.readonly?.bg || 'transparent'};
+      
       .single-line-editor {
         font-style: italic;
       }

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -1,42 +1,91 @@
-import React, { useState, useCallback } from 'react';
-import get from 'lodash/get';
-import { useDispatch } from 'react-redux';
-import { useTheme } from 'providers/Theme';
-import { moveRequestHeader, setRequestHeaders } from 'providers/ReduxStore/slices/collections';
-import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
-import SingleLineEditor from 'components/SingleLineEditor';
+import { IconInfoCircle } from '@tabler/icons';
 import EditableTable from 'components/EditableTable';
-import StyledWrapper from './StyledWrapper';
+import SingleLineEditor from 'components/SingleLineEditor';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
+import get from 'lodash/get';
+import { moveRequestHeader, setRequestHeaders } from 'providers/ReduxStore/slices/collections';
+import { saveRequest, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { useTheme } from 'providers/Theme';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { Tooltip } from 'react-tooltip';
 import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
+import { getTreePathFromCollectionToItem } from 'utils/collections/index';
 import BulkEditor from '../../BulkEditor';
+import StyledWrapper from './StyledWrapper';
 
 const headerAutoCompleteList = StandardHTTPHeaders.map((e) => e.header);
 
 const RequestHeaders = ({ item, collection, addHeaderText }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
+
   const headers = item.draft ? get(item, 'draft.request.headers') : get(item, 'request.headers');
+
+  const allHeaders = useMemo(() => {
+    const requestTreePath = getTreePathFromCollectionToItem(collection, item);
+    const folderHeaders = [];
+    requestTreePath.forEach((pathItem) => {
+      if (pathItem.type === 'folder' && pathItem.uid !== item.uid) {
+        const fHeaders = pathItem.draft ? get(pathItem, 'draft.request.headers', []) : get(pathItem, 'root.request.headers', []);
+        folderHeaders.push(...fHeaders);
+      }
+    });
+
+    const collectionHeaders = collection.draft?.root
+      ? get(collection, 'draft.root.request.headers', [])
+      : get(collection, 'root.request.headers', []);
+
+    const categorizedHeaders = {
+      request: (headers || []).map((h) => ({ ...h, source: 'request', editable: true, description: 'Request' })),
+      folder: (folderHeaders || []).map((h) => ({ ...h, source: 'folder', editable: false, description: 'Folder' })),
+      collection: (collectionHeaders || []).map((h) => ({ ...h, source: 'collection', editable: false, description: 'Collection' }))
+    };
+
+    return [
+      ...categorizedHeaders.request,
+      ...categorizedHeaders.folder,
+      ...categorizedHeaders.collection
+    ];
+  }, [headers, collection, item]);
+
   const [isBulkEditMode, setIsBulkEditMode] = useState(false);
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
   const handleRun = () => dispatch(sendRequest(item, collection.uid));
 
-  const handleHeadersChange = useCallback((updatedHeaders) => {
-    dispatch(setRequestHeaders({
-      collectionUid: collection.uid,
-      itemUid: item.uid,
-      headers: updatedHeaders
-    }));
-  }, [dispatch, collection.uid, item.uid]);
+  const handleHeadersChange = useCallback(
+    (updatedHeaders) => {
+      const requestHeaders = updatedHeaders
+        .filter((h) => h.source === 'request' || !h.source)
+        .map((h) => {
+          const { source, editable, description, ...rest } = h;
+          return rest;
+        });
 
-  const handleHeaderDrag = useCallback(({ updateReorderedItem }) => {
-    dispatch(moveRequestHeader({
-      collectionUid: collection.uid,
-      itemUid: item.uid,
-      updateReorderedItem
-    }));
-  }, [dispatch, collection.uid, item.uid]);
+      dispatch(
+        setRequestHeaders({
+          collectionUid: collection.uid,
+          itemUid: item.uid,
+          headers: requestHeaders
+        })
+      );
+    },
+    [dispatch, collection.uid, item.uid]
+  );
+
+  const handleHeaderDrag = useCallback(
+    ({ updateReorderedItem }) => {
+      dispatch(
+        moveRequestHeader({
+          collectionUid: collection.uid,
+          itemUid: item.uid,
+          updateReorderedItem
+        })
+      );
+    },
+    [dispatch, collection.uid, item.uid]
+  );
 
   const toggleBulkEditMode = () => {
     setIsBulkEditMode(!isBulkEditMode);
@@ -48,29 +97,40 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
       name: 'Name',
       isKeyField: true,
       placeholder: 'Name',
-      width: '30%',
+      width: '40%',
       render: ({ row, value, onChange, isLastEmptyRow }) => (
-        <SingleLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={onSave}
-          onChange={(newValue) => onChange(newValue.replace(/[\r\n]/g, ''))}
-          autocomplete={headerAutoCompleteList}
-          onRun={handleRun}
-          collection={collection}
-          item={item}
-          placeholder={isLastEmptyRow ? 'Name' : ''}
-        />
+        <div className="flex items-center w-full">
+          <SingleLineEditor
+            value={value || ''}
+            theme={storedTheme}
+            readOnly={row.editable === false}
+            onSave={onSave}
+            onChange={(newValue) => onChange(newValue.replace(/[\r\n]/g, ''))}
+            autocomplete={headerAutoCompleteList}
+            onRun={handleRun}
+            collection={collection}
+            item={item}
+            placeholder={isLastEmptyRow ? 'Name' : ''}
+          />
+          {row.editable === false && (
+            <div className="ml-1 flex items-center text-muted" aria-label={`Inherited from ${row.description}`}>
+              <IconInfoCircle size={16} strokeWidth={1.5} data-tooltip-id={`info-${row.uid}`} />
+              <Tooltip className="tooltip-mod" id={`info-${row.uid}`} html={`Inherited from ${row.description}`} />
+            </div>
+          )}
+        </div>
       )
     },
     {
       key: 'value',
       name: 'Value',
       placeholder: 'Value',
+      width: '50%',
       render: ({ row, value, onChange, isLastEmptyRow }) => (
         <SingleLineEditor
           value={value || ''}
           theme={storedTheme}
+          readOnly={row.editable === false}
           onSave={onSave}
           onChange={onChange}
           onRun={handleRun}
@@ -92,13 +152,7 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
   if (isBulkEditMode) {
     return (
       <StyledWrapper className="w-full mt-3">
-        <BulkEditor
-          params={headers}
-          onChange={handleHeadersChange}
-          onToggle={toggleBulkEditMode}
-          onSave={onSave}
-          onRun={handleRun}
-        />
+        <BulkEditor params={headers} onChange={handleHeadersChange} onToggle={toggleBulkEditMode} onSave={onSave} onRun={handleRun} />
       </StyledWrapper>
     );
   }
@@ -107,7 +161,7 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
     <StyledWrapper className="w-full">
       <EditableTable
         columns={columns}
-        rows={headers || []}
+        rows={allHeaders || []}
         onChange={handleHeadersChange}
         defaultRow={defaultRow}
         reorderable={true}

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -104,7 +104,7 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
         })
       );
     },
-    [dispatch, collection.uid, item.uid]
+    [dispatch, collection.uid, item.uid, allHeaders]
   );
 
   const toggleBulkEditMode = () => {

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -59,7 +59,7 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
         rowKey: `collection-${h.uid}`
       }))
     };
-    console.log('categorizedHeaders', categorizedHeaders);
+
     return Object.values(categorizedHeaders).flat();
   }, [headers, collection, item]);
 


### PR DESCRIPTION
Attempted to resolve #5364 

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

### Screenshots
<img width="1603" height="570" alt="image" src="https://github.com/user-attachments/assets/5be98dc0-fbf5-40ec-bb8e-f4b366ada3ea" />
<img width="1601" height="577" alt="image" src="https://github.com/user-attachments/assets/75b76646-2af4-47b9-9bcc-e59692cde2c1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headers now aggregate from request, folder, and collection levels for unified viewing and editing.
  * Bulk edit UI clarifies scope when mixing inherited and request-level headers.

* **Improvements**
  * Inherited (non-editable) headers display an informational badge and tooltip; editors reflect read-only state.
  * Read-only rows styled as muted/italic with subtle background.
  * Drag reordering, checkboxes and delete controls now respect row editability.
  * Name/value column sizes adjusted for better editing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->