### PR TITLE
feat: consistent documentation editing UI across collection, folder, and request levels

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Docs/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Docs/index.js
@@ -8,7 +8,7 @@ import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/
 import Markdown from 'components/MarkDown';
 import CodeEditor from 'components/CodeEditor';
 import StyledWrapper from './StyledWrapper';
-import { IconEdit, IconX, IconFileText } from '@tabler/icons';
+import { IconEdit, IconFileText } from '@tabler/icons';
 
 const Docs = ({ collection }) => {
   const dispatch = useDispatch();
@@ -55,9 +55,9 @@ const Docs = ({ collection }) => {
         <div className="flex flex-row gap-2 items-center justify-center">
           {isEditing ? (
             <>
-              <div className="editing-mode" role="tab" onClick={handleDiscardChanges}>
-                <IconX className="cursor-pointer" size={20} strokeWidth={1.5} />
-              </div>
+              <button type="button" className="btn btn-sm btn-close" onClick={handleDiscardChanges}>
+                Cancel
+              </button>
               <button type="submit" className="submit btn btn-sm btn-secondary" onClick={onSave}>
                 Save
               </button>

--- a/packages/bruno-app/src/components/Documentation/index.js
+++ b/packages/bruno-app/src/components/Documentation/index.js
@@ -8,6 +8,7 @@ import { saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import Markdown from 'components/MarkDown';
 import CodeEditor from 'components/CodeEditor';
 import StyledWrapper from './StyledWrapper';
+import { IconEdit } from '@tabler/icons';
 
 const Documentation = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -30,7 +31,14 @@ const Documentation = ({ item, collection }) => {
     );
   };
 
-  const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
+  const onSave = () => {
+    dispatch(saveRequest(item.uid, collection.uid));
+    toggleViewMode();
+  };
+
+  const handleCancel = () => {
+    toggleViewMode();
+  };
 
   if (!item) {
     return null;
@@ -38,8 +46,21 @@ const Documentation = ({ item, collection }) => {
 
   return (
     <StyledWrapper className="flex flex-col gap-y-1 h-full w-full relative">
-      <div className="editing-mode" role="tab" onClick={toggleViewMode}>
-        {isEditing ? 'Preview' : 'Edit'}
+      <div className="flex flex-row gap-2 items-center">
+        {isEditing ? (
+          <>
+            <button type="button" className="btn btn-sm btn-close" onClick={handleCancel}>
+              Cancel
+            </button>
+            <button type="submit" className="submit btn btn-sm btn-secondary" onClick={onSave}>
+              Save
+            </button>
+          </>
+        ) : (
+          <div className="editing-mode" role="tab" onClick={toggleViewMode}>
+            <IconEdit className="cursor-pointer" size={20} strokeWidth={1.5} />
+          </div>
+        )}
       </div>
 
       {isEditing ? (

--- a/packages/bruno-app/src/components/FolderSettings/Documentation/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Documentation/index.js
@@ -8,6 +8,7 @@ import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions'
 import Markdown from 'components/MarkDown';
 import CodeEditor from 'components/CodeEditor';
 import StyledWrapper from './StyledWrapper';
+import { IconEdit } from '@tabler/icons';
 
 const Documentation = ({ collection, folder }) => {
   const dispatch = useDispatch();
@@ -30,7 +31,14 @@ const Documentation = ({ collection, folder }) => {
     );
   };
 
-  const onSave = () => dispatch(saveFolderRoot(collection.uid, folder.uid));
+  const onSave = () => {
+    dispatch(saveFolderRoot(collection.uid, folder.uid));
+    toggleViewMode();
+  };
+
+  const handleCancel = () => {
+    toggleViewMode();
+  };
 
   if (!folder) {
     return null;
@@ -38,8 +46,21 @@ const Documentation = ({ collection, folder }) => {
 
   return (
     <StyledWrapper className="mt-1 h-full w-full relative flex flex-col">
-      <div className="editing-mode flex justify-between items-center" role="tab" onClick={toggleViewMode}>
-        {isEditing ? 'Preview' : 'Edit'}
+      <div className="flex flex-row gap-2 items-center">
+        {isEditing ? (
+          <>
+            <button type="button" className="btn btn-sm btn-close" onClick={handleCancel}>
+              Cancel
+            </button>
+            <button type="submit" className="submit btn btn-sm btn-secondary" onClick={onSave}>
+              Save
+            </button>
+          </>
+        ) : (
+          <div className="editing-mode" role="tab" onClick={toggleViewMode}>
+            <IconEdit className="cursor-pointer" size={20} strokeWidth={1.5} />
+          </div>
+        )}
       </div>
 
       {isEditing ? (
@@ -51,10 +72,9 @@ const Documentation = ({ collection, folder }) => {
             onEdit={onEdit}
             onSave={onSave}
             mode="application/text"
+            font={get(preferences, 'font.codeFont', 'default')}
+            fontSize={get(preferences, 'font.codeFontSize')}
           />
-          <button type="submit" className="submit btn btn-sm btn-secondary my-6" onClick={onSave}>
-            Save
-          </button>
         </div>
       ) : (
         <Markdown collectionPath={collection.pathname} onDoubleClick={toggleViewMode} content={docs} />


### PR DESCRIPTION
### Goal
- Replace text-based Edit/Preview toggle with edit icon (pencil) for all levels
- Add proper Cancel and Save buttons when editing documentation
- Ensure folder and request docs match collection docs UI pattern
- Add font preferences to folder documentation CodeEditor

### Description

#### Problem
Previously, the documentation editing UI was inconsistent:

1. Collection level: Had an edit icon (pencil) and proper Cancel/Save buttons
2. Folder level: Had a text-based "Edit/Preview" toggle and a Save button placed below the editor
3. Request level: Had a text-based "Edit/Preview" toggle with no Save button visible
4. Solution
5. All three levels now share the same UI pattern:

  - View mode: Shows an edit icon (pencil) to enter editing
  - Edit mode: Shows "Cancel" and "Save" buttons side-by-side
  - Changes
  - Collection Docs - Minor fix: Changed X icon to "Cancel" text button for consistency
  - Folder Docs - Updated to use edit icon + Cancel/Save buttons, added font preferences to CodeEditor
  - Request Docs - Updated to use edit icon + Cancel/Save buttons

This improves UX by giving users a predictable interface regardless of whether they're editing documentation at the collection, folder, or request level.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Screenshots
Consistent edit icons and buttons
<img width="462" height="243" alt="image" src="https://github.com/user-attachments/assets/c1e6e2df-dd63-421a-8ca0-0df5eef029bd" />
<img width="437" height="243" alt="image" src="https://github.com/user-attachments/assets/6aee7f97-9b7e-4e79-b0e0-135a54f1f0b1" />
<img width="490" height="308" alt="image" src="https://github.com/user-attachments/assets/2d539627-55db-41a8-8645-8b0d3bf643ea" />
<img width="465" height="233" alt="image" src="https://github.com/user-attachments/assets/715f8d63-0114-4fbb-a295-d6b4d6eafe41" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced documentation editing interface with improved visual state management: explicit Cancel and Save buttons are now displayed in edit mode, while an Edit button appears in preview mode for easy access.
  * Streamlined editing workflow across documentation editors with clearer action buttons, providing improved user experience when managing and saving documentation changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->