### PR TITLE
fix: oauth tokens being incorrectly reused across environments with different credentials

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
@@ -38,7 +38,13 @@ const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, c
     return interpolate(accessTokenUrl, variables);
   }, [collection, item, accessTokenUrl]);
 
-  const credentialsData = find(collection?.oauth2Credentials, (creds) => creds?.url == interpolatedAccessTokenUrl && creds?.collectionUid == collectionUid && creds?.credentialsId == credentialsId);
+  const activeEnvironmentUid = collection?.activeEnvironmentUid ?? null;
+  const credentialsData = find(collection?.oauth2Credentials, (creds) =>
+    creds?.url == interpolatedAccessTokenUrl
+    && creds?.collectionUid == collectionUid
+    && creds?.credentialsId == credentialsId
+    && (creds?.activeEnvironmentUid ?? null) == activeEnvironmentUid
+  );
   const creds = credentialsData?.credentials || {};
 
   const handleFetchOauth2Credentials = async () => {

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2TokenViewer/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2TokenViewer/index.js
@@ -130,7 +130,13 @@ const Oauth2TokenViewer = ({ collection, item, url, credentialsId, handleRun }) 
     return interpolate(url, variables);
   }, [collection, item, url]);
 
-  const credentialsData = find(collection?.oauth2Credentials, (creds) => creds?.url == interpolatedUrl && creds?.collectionUid == collectionUid && creds?.credentialsId == credentialsId);
+  const activeEnvironmentUid = collection?.activeEnvironmentUid ?? null;
+  const credentialsData = find(collection?.oauth2Credentials, (creds) =>
+    creds?.url == interpolatedUrl
+    && creds?.collectionUid == collectionUid
+    && creds?.credentialsId == credentialsId
+    && (creds?.activeEnvironmentUid ?? null) == activeEnvironmentUid
+  );
   const creds = credentialsData?.credentials || {};
 
   return (

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2522,6 +2522,7 @@ export const fetchOauth2Credentials = (payload) => async (dispatch, getState) =>
   const state = getState();
   const { globalEnvironments, activeGlobalEnvironmentUid } = state.globalEnvironments;
   const globalEnvironmentVariables = getGlobalEnvironmentVariables({ globalEnvironments, activeGlobalEnvironmentUid });
+  const activeEnvironmentUid = collection?.activeEnvironmentUid ?? null;
   request.globalEnvironmentVariables = globalEnvironmentVariables;
   return new Promise((resolve, reject) => {
     window.ipcRenderer
@@ -2533,6 +2534,7 @@ export const fetchOauth2Credentials = (payload) => async (dispatch, getState) =>
             url,
             collectionUid,
             credentialsId,
+            activeEnvironmentUid,
             debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)),
             folderUid: folderUid || null,
             itemUid: !folderUid ? itemUid : null
@@ -2549,6 +2551,7 @@ export const refreshOauth2Credentials = (payload) => async (dispatch, getState) 
   const state = getState();
   const { globalEnvironments, activeGlobalEnvironmentUid } = state.globalEnvironments;
   const globalEnvironmentVariables = getGlobalEnvironmentVariables({ globalEnvironments, activeGlobalEnvironmentUid });
+  const activeEnvironmentUid = collection?.activeEnvironmentUid ?? null;
   request.globalEnvironmentVariables = globalEnvironmentVariables;
   return new Promise((resolve, reject) => {
     window.ipcRenderer
@@ -2560,6 +2563,7 @@ export const refreshOauth2Credentials = (payload) => async (dispatch, getState) 
             url,
             collectionUid,
             credentialsId,
+            activeEnvironmentUid,
             debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)),
             folderUid: folderUid || null,
             itemUid: !folderUid ? itemUid : null

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -3047,7 +3047,7 @@ export const collectionsSlice = createSlice({
       }
     },
     collectionAddOauth2CredentialsByUrl: (state, action) => {
-      const { collectionUid, folderUid, itemUid, url, credentials, credentialsId, debugInfo } = action.payload;
+      const { collectionUid, folderUid, itemUid, url, credentials, credentialsId, activeEnvironmentUid, debugInfo } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
       if (!collection) return;
 
@@ -3058,13 +3058,14 @@ export const collectionsSlice = createSlice({
       let collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
 
       // Remove existing credentials for the same combination
+      const envUidToMatch = activeEnvironmentUid ?? null;
       const filteredOauth2Credentials = filter(
         collectionOauth2Credentials,
         (creds) =>
-          !(creds.url === url && creds.collectionUid === collectionUid && creds.credentialsId === credentialsId)
+          !(creds.url === url && creds.collectionUid === collectionUid && creds.credentialsId === credentialsId && envUidToMatch === (creds.activeEnvironmentUid ?? null))
       );
 
-      // Add the new credential with folderUid and itemUid
+      // Add the new credential with folderUid, itemUid, and activeEnvironmentUid
       filteredOauth2Credentials.push({
         collectionUid,
         folderUid,
@@ -3072,6 +3073,7 @@ export const collectionsSlice = createSlice({
         url,
         credentials,
         credentialsId,
+        activeEnvironmentUid: envUidToMatch,
         debugInfo
       });
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1296,7 +1296,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               request: requestCopy,
               collectionUid,
               forceFetch: true,
-              certsAndProxyConfig
+              certsAndProxyConfig,
+              activeEnvironmentUid
             }).then(handleOAuth2Response);
 
           case 'client_credentials':
@@ -1305,7 +1306,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               request: requestCopy,
               collectionUid,
               forceFetch: true,
-              certsAndProxyConfig
+              certsAndProxyConfig,
+              activeEnvironmentUid
             }).then(handleOAuth2Response);
 
           case 'password':
@@ -1314,7 +1316,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               request: requestCopy,
               collectionUid,
               forceFetch: true,
-              certsAndProxyConfig
+              certsAndProxyConfig,
+              activeEnvironmentUid
             }).then(handleOAuth2Response);
 
           case 'implicit':
@@ -1322,7 +1325,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             return await getOAuth2TokenUsingImplicitGrant({
               request: requestCopy,
               collectionUid,
-              forceFetch: true
+              forceFetch: true,
+              activeEnvironmentUid
             }).then(handleOAuth2Response);
 
           default:
@@ -1365,7 +1369,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           globalEnvironmentVariables
         });
 
-        let { credentials, url, credentialsId, debugInfo } = await refreshOauth2Token({ requestCopy, collectionUid, certsAndProxyConfig });
+        let { credentials, url, credentialsId, debugInfo } = await refreshOauth2Token({ requestCopy, collectionUid, certsAndProxyConfig, activeEnvironmentUid });
         return { credentials, url, collectionUid, credentialsId, debugInfo };
       }
     } catch (error) {

--- a/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
@@ -133,6 +133,7 @@ const registerGrpcEventHandlers = (window) => {
           url: preparedRequest.oauth2Credentials?.url,
           collectionUid: collection.uid,
           credentialsId: preparedRequest.oauth2Credentials?.credentialsId,
+          activeEnvironmentUid: collection?.activeEnvironmentUid || null,
           ...(preparedRequest.oauth2Credentials?.folderUid ? { folderUid: preparedRequest.oauth2Credentials.folderUid } : { itemUid: preparedRequest.uid }),
           debugInfo: preparedRequest.oauth2Credentials.debugInfo
         });
@@ -258,6 +259,7 @@ const registerGrpcEventHandlers = (window) => {
           url: preparedRequest.oauth2Credentials?.url,
           collectionUid: collection.uid,
           credentialsId: preparedRequest.oauth2Credentials?.credentialsId,
+          activeEnvironmentUid: collection?.activeEnvironmentUid || null,
           ...(preparedRequest.oauth2Credentials?.folderUid ? { folderUid: preparedRequest.oauth2Credentials.folderUid } : { itemUid: preparedRequest.uid }),
           debugInfo: preparedRequest.oauth2Credentials.debugInfo
         });

--- a/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
@@ -31,24 +31,25 @@ const configureRequest = async (grpcRequest, request, collection, envVars, runti
   if (grpcRequest.oauth2) {
     let requestCopy = cloneDeep(grpcRequest);
     const { oauth2: { grantType, tokenPlacement, tokenHeaderPrefix, tokenQueryKey } = {} } = requestCopy || {};
+    const activeEnvironmentUid = collection?.activeEnvironmentUid || null;
     let credentials, credentialsId, oauth2Url, debugInfo;
     try {
       switch (grantType) {
         case 'authorization_code':
           interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
-          ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingAuthorizationCode({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfig }));
+          ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingAuthorizationCode({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfig, activeEnvironmentUid }));
           grpcRequest.oauth2Credentials = { credentials, url: oauth2Url, collectionUid: collection.uid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
           placeOAuth2Token(grpcRequest, credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey);
           break;
         case 'client_credentials':
           interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
-          ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingClientCredentials({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfig }));
+          ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingClientCredentials({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfig, activeEnvironmentUid }));
           grpcRequest.oauth2Credentials = { credentials, url: oauth2Url, collectionUid: collection.uid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
           placeOAuth2Token(grpcRequest, credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey);
           break;
         case 'password':
           interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
-          ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingPasswordCredentials({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfig }));
+          ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingPasswordCredentials({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfig, activeEnvironmentUid }));
           grpcRequest.oauth2Credentials = { credentials, url: oauth2Url, collectionUid: collection.uid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
           placeOAuth2Token(grpcRequest, credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey);
           break;

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
@@ -95,6 +95,7 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
   if (wsRequest.oauth2) {
     let requestCopy = cloneDeep(wsRequest);
     const { oauth2: { grantType, tokenPlacement, tokenHeaderPrefix, tokenQueryKey } = {} } = requestCopy || {};
+    const activeEnvironmentUid = collection?.activeEnvironmentUid || null;
     let credentials, credentialsId, oauth2Url, debugInfo;
 
     switch (grantType) {
@@ -108,7 +109,8 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
         } = await getOAuth2TokenUsingAuthorizationCode({
           request: requestCopy,
           collectionUid: collection.uid,
-          certsAndProxyConfig
+          certsAndProxyConfig,
+          activeEnvironmentUid
         }));
         wsRequest.oauth2Credentials = {
           credentials,
@@ -138,7 +140,8 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
         } = await getOAuth2TokenUsingClientCredentials({
           request: requestCopy,
           collectionUid: collection.uid,
-          certsAndProxyConfig
+          certsAndProxyConfig,
+          activeEnvironmentUid
         }));
         wsRequest.oauth2Credentials = {
           credentials,
@@ -168,7 +171,8 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
         } = await getOAuth2TokenUsingPasswordCredentials({
           request: requestCopy,
           collectionUid: collection.uid,
-          certsAndProxyConfig
+          certsAndProxyConfig,
+          activeEnvironmentUid
         }));
         wsRequest.oauth2Credentials = {
           credentials,
@@ -282,6 +286,7 @@ const registerWsEventHandlers = (window) => {
             url: preparedRequest.oauth2Credentials?.url,
             collectionUid: collection.uid,
             credentialsId: preparedRequest.oauth2Credentials?.credentialsId,
+            activeEnvironmentUid: collection?.activeEnvironmentUid || null,
             ...(preparedRequest.oauth2Credentials?.folderUid
               ? { folderUid: preparedRequest.oauth2Credentials.folderUid }
               : { itemUid: preparedRequest.uid }),


### PR DESCRIPTION
### Description

Fixes OAuth2 tokens being incorrectly reused across environments with different credentials. Tokens are now stored and retrieved using collection Uid, url, credentialsId, environmentUid as the key.

Changes:
 - Added environmentUId to OAuth2 store operations and all token fetch/refresh functions across HTTP, WebSocket, and gRPC handlers
 
Fixes #6737

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- OAuth2 credentials are now environment-scoped. You can configure different OAuth2 credentials for the same URL across different environments. Token fetching and refresh operations now respect the active environment context, ensuring credentials and tokens are properly managed per-environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->