### PR TITLE
feat: add zoom controls to key mappings and update key display in preferences

### DIFF
--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -32,7 +32,10 @@ const KeyMapping = {
     name: 'Move Tab Right'
   },
   closeAllTabs: { mac: 'command+shift+w', windows: 'ctrl+shift+w', name: 'Close All Tabs' },
-  collapseSidebar: { mac: 'command+\\', windows: 'ctrl+\\', name: 'Collapse Sidebar' }
+  collapseSidebar: { mac: 'command+\\', windows: 'ctrl+\\', name: 'Collapse Sidebar' },
+  zoomIn: { mac: 'command+=', windows: 'ctrl+=', name: 'Zoom In' },
+  zoomOut: { mac: 'command+-', windows: 'ctrl+-', name: 'Zoom Out' },
+  resetZoom: { mac: 'command+0', windows: 'ctrl+0', name: 'Reset Zoom' }
 };
 
 /**


### PR DESCRIPTION
Addressing this [comment](https://github.com/usebruno/bruno/issues/6708#issuecomment-3718190003)
### Description
- Added new key mappings for zoom in, zoom out, and reset zoom functionalities.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="1556" height="1234" alt="image" src="https://github.com/user-attachments/assets/d70de3af-971a-47fa-bf63-ba0bd2f30e46" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added keyboard shortcuts for zoom controls:
  * **Zoom In**: Cmd+= (Mac) / Ctrl+= (Windows)
  * **Zoom Out**: Cmd+− (Mac) / Ctrl+− (Windows)
  * **Reset Zoom**: Cmd+0 (Mac) / Ctrl+0 (Windows)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->