### PR TITLE
fix: lag when moving Electron window (issue #5203)

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -220,9 +220,15 @@ app.on('ready', async () => {
     }
   });
 
+  let boundsTimeout;
   const handleBoundsChange = () => {
     if (!mainWindow.isMaximized()) {
-      saveBounds(mainWindow);
+      if (boundsTimeout) {
+        clearTimeout(boundsTimeout);
+      }
+      boundsTimeout = setTimeout(() => {
+        saveBounds(mainWindow);
+      }, 100);
     }
   };
 


### PR DESCRIPTION
### Description
This PR fixes the lag when moving the Electron window reported in issue #5203.
The problem was caused by continuously saving the window position on every move event, which led to performance issues.

To solve this, I added a debounced timeout so the window position is saved only after movement stops, instead of on every frame.
This significantly improves window movement smoothness and removes the lag.
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window state management performance by reducing save operation frequency during window resizing and moving, resulting in a more responsive user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->