### PR TITLE
fix:prevent JS hint leak on Ctrl+Space and show allowed root hints

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { isEqual, escapeRegExp } from 'lodash';
 import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
-import { setupAutoComplete } from 'utils/codemirror/autocomplete';
+import { setupAutoComplete, showRootHints } from 'utils/codemirror/autocomplete';
 import StyledWrapper from './StyledWrapper';
 import * as jsonlint from '@prantlf/jsonlint';
 import { JSHINT } from 'jshint';
@@ -111,8 +111,12 @@ export default class CodeEditor extends React.Component {
             : cm.replaceSelection('  ', 'end');
         },
         'Shift-Tab': 'indentLess',
-        'Ctrl-Space': 'autocomplete',
-        'Cmd-Space': 'autocomplete',
+        'Ctrl-Space': (cm) => {
+          showRootHints(cm, this.props.showHintsFor);
+        },
+        'Cmd-Space': (cm) => {
+          showRootHints(cm, this.props.showHintsFor);
+        },
         'Ctrl-Y': 'foldAll',
         'Cmd-Y': 'foldAll',
         'Ctrl-I': 'unfoldAll',

--- a/packages/bruno-app/src/utils/codemirror/autocomplete.js
+++ b/packages/bruno-app/src/utils/codemirror/autocomplete.js
@@ -294,9 +294,14 @@ const calculateWordReplacementPositions = (cursor, start, end, word) => {
  * @returns {string} The determined context
  */
 const determineWordContext = (word) => {
-  if (word.startsWith('req') || word.startsWith('res') || word.startsWith('bru')) {
+  const isApiHint = Object.keys(STATIC_API_HINTS).some(
+    (apiRoot) => apiRoot.toLowerCase().startsWith(word.toLowerCase()) || word.toLowerCase().startsWith(apiRoot.toLowerCase())
+  );
+
+  if (isApiHint) {
     return 'api';
   }
+
   return 'anyword';
 };
 
@@ -514,6 +519,34 @@ const createStandardHintList = (filteredHints, from, to) => {
 };
 
 /**
+ * Show root-level API hints when the editor is empty
+ * @param {Object} cm - CodeMirror instance
+ * @param {string[]} showHintsFor - Array of hint types to show (e.g., ['req', 'res', 'bru'])
+ * @returns {boolean} True if hints were shown, false otherwise
+ */
+export const showRootHints = (cm, showHintsFor = []) => {
+  const wordInfo = getCurrentWordWithContext(cm);
+  // If user is currently typing a word, let handleKeyupForAutocomplete
+  // handle it instead of showing root hints.
+  if (wordInfo) {
+    return false;
+  }
+
+  const hints = Object.keys(STATIC_API_HINTS).filter((rootHint) => showHintsFor.includes(rootHint));
+
+  if (hints.length === 0) return false;
+
+  const cursor = cm.getCursor();
+  const hintList = createStandardHintList(hints, cursor, cursor);
+
+  cm.showHint({
+    hint: () => hintList,
+    completeSingle: false
+  });
+  return true;
+};
+
+/**
  * Bruno AutoComplete Helper - Main function with context awareness
  * @param {Object} cm - CodeMirror instance
  * @param {Object} allVariables - All available variables
@@ -624,7 +657,8 @@ const handleKeyupForAutocomplete = (cm, event, options) => {
   const hints = getAutoCompleteHints(cm, allVariables, anywordAutocompleteHints, options);
 
   if (!hints) {
-    if (cm.state.completionActive) {
+    const wordInfo = getCurrentWordWithContext(cm);
+    if (cm.state.completionActive && wordInfo) {
       cm.state.completionActive.close();
     }
     return;

--- a/packages/bruno-app/src/utils/codemirror/autocomplete.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/autocomplete.spec.js
@@ -482,7 +482,7 @@ describe('Bruno Autocomplete', () => {
         mockedCodemirror.state.completionActive = mockCompletion;
 
         mockedCodemirror.getCursor.mockReturnValue({ line: 0, ch: 0 });
-        mockedCodemirror.getLine.mockReturnValue('   ');
+        mockedCodemirror.getLine.mockReturnValue('req.bodyy');
         mockedCodemirror.getRange.mockReturnValue('');
 
         const mockEvent = { key: 'a' };


### PR DESCRIPTION
### Description

#### Root cause
In the Script editor, pressing Ctrl + Space when the cursor is at an empty position triggers autocomplete without a valid word context. Since the hint provider returns null in this case, CodeMirror immediately closes the completion popup, causing it to briefly flash and disappear.

#### Fix
This change explicitly handles Ctrl + Space when the editor is empty by showing root-level hints (API objects), while preserving the existing keyup-based autocomplete behavior for all other cases.
Additionally, context detection was improved to allow progressive discovery of API hints (r → re → req).

- Fixes #5871 
#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

#### Ctrl+Space now shows root hints without flashing 
![fix](https://github.com/user-attachments/assets/2e6b1547-246f-4f65-9bce-13be45b28a4c)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Broader autocomplete context detection for more relevant API suggestions
  - Added an action to surface top-level completions on demand via keyboard shortcuts

* **Bug Fixes**
  - Refined autocomplete closing behavior so the completion panel only closes when appropriate based on cursor context

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->