### PR TITLE
feat: add user-agent support in gRPC client channel options

### DIFF
--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -624,7 +624,7 @@ class GrpcClient {
     pfx,
     verifyOptions,
     sendEvent,
-    channelOptions
+    channelOptions = {}
   }) {
     const { host, path } = getParsedGrpcUrlObject(request.url);
 


### PR DESCRIPTION
[Jira](https://usebruno.atlassian.net/browse/BRU-2504)

## Fix: Allow custom User-Agent for gRPC requests

### Fixes #6800

### Description

This PR enables users to set a custom `User-Agent` header for gRPC requests via the metadata configuration in Bruno.

### Problem

When users set a `User-Agent` in their gRPC metadata headers, it was being ignored. The server would always receive the default `grpc-node-js/X.X.X` user-agent from the `@grpc/grpc-js` library.

### Solution

The custom `User-Agent` header is now extracted from the request headers and passed as the `grpc.primary_user_agent` channel option to `@grpc/grpc-js`. This prepends the custom user-agent to the default one.

**Example:**
- User sets: `User-Agent: my-custom-agent`
- Server receives: `my-custom-agent grpc-node-js/1.13.3`

### Why can't we completely replace the user-agent?

The `@grpc/grpc-js` library does not support completely replacing the user-agent. The library always appends its own identifier (`grpc-node-js/VERSION`) to the user-agent string. This is by design and is a known limitation:

- https://github.com/grpc/grpc-node/issues/2325
- https://github.com/grpc/grpc-node/pull/1668

The only options provided by `@grpc/grpc-js` are:
- `grpc.primary_user_agent` - prepends to the default user-agent
- `grpc.secondary_user_agent` - appends to the default user-agent

### Changes

- **`startConnection`**: Extracts `User-Agent` from request headers and adds it as `grpc.primary_user_agent` channel option
- **`loadMethodsFromReflection`**: Same handling for reflection calls


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently capture user-agent headers (case-insensitive) and apply them to gRPC connections and service reflection, improving compatibility and observability.
  * Public connection APIs now accept channel options so client and reflection calls receive merged runtime options.

* **Tests**
  * Added comprehensive tests validating header extraction, option merging behavior, and scenarios when a user-agent is absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->