### PR TITLE
fix: resolve Load Request button error when loading large collection …

### DIFF
--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -583,7 +583,7 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       const fileStats = fs.statSync(pathname);
 
       if (fileStats.size >= MAX_FILE_SIZE && format === 'bru') {
-        file.data = await parseLargeRequestWithRedaction(content, format);
+        file.data = await parseLargeRequestWithRedaction(content, 'bru');
       } else {
         file.data = await parseRequest(content, { format });
       }

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -106,12 +106,6 @@ const validatePathIsInsideCollection = (filePath) => {
   }
 };
 
-// Helper: Get collection format from file pathname
-const getFormatFromPathname = (pathname) => {
-  const collectionPath = findCollectionPathByItemPath(pathname);
-  return collectionPath ? getCollectionFormat(collectionPath) : 'bru';
-};
-
 const registerRendererEventHandlers = (mainWindow, watcher) => {
   // create collection
   ipcMain.handle(
@@ -1435,8 +1429,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         file.size = sizeInMB(fileStats?.size);
         hydrateRequestWithUuid(file.data, pathname);
         mainWindow.webContents.send('main:collection-tree-updated', 'addFile', file);
-        const format = getFormatFromPathname(pathname);
-        file.data = await parseRequestViaWorker(bruContent, { format });
+        file.data = await parseRequestViaWorker(bruContent, { format: 'bru' });
         file.partial = false;
         file.loading = true;
         file.size = sizeInMB(fileStats?.size);
@@ -1543,8 +1536,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       await mainWindow.webContents.send('main:collection-tree-updated', 'addFile', file);
 
       try {
-        const format = getFormatFromPathname(pathname);
-        const parsedData = await parseLargeRequestWithRedaction(bruContent, format);
+        const parsedData = await parseLargeRequestWithRedaction(bruContent, 'bru');
 
         file.data = parsedData;
         file.loading = false;

--- a/packages/bruno-electron/src/utils/parse.js
+++ b/packages/bruno-electron/src/utils/parse.js
@@ -4,10 +4,10 @@ const { parseRequestAndRedactBody, parseRequestViaWorker } = require('@usebruno/
  * Parses a large BRU request string by redacting body blocks, parsing the remainder,
  * and then reinserting extracted body content into the parsed structure.
  * @param {string} bruContent
- * @param {string} format - Collection format ('bru' or 'yml')
+ * @param {string} format - Collection format, defaults to 'bru'
  * @returns {Promise<any>} parsed request JSON
  */
-async function parseLargeRequestWithRedaction(bruContent, format) {
+async function parseLargeRequestWithRedaction(bruContent, format = 'bru') {
   const { bruFileStringWithRedactedBody, extractedBodyContent } = parseRequestAndRedactBody(bruContent, { format });
   const parsedData = await parseRequestViaWorker(bruFileStringWithRedactedBody, { format });
 


### PR DESCRIPTION
### Description

Fixed an issue where clicking the "Load Request" button threw the following error instead of loading the collection request file:
"Error invoking remote method 'renderer:load-large-request': TypeError: Cannot read properties of undefined (reading 'format')To run code, enable code execution and file creation in Settings > Capabilities."


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved BRU-format parsing flow so format information is consistently propagated across collection operations, including large-request handling and file parsing.
  * Tightened parsing/serialization paths for more reliable detection and processing of BRU files.
  * No public APIs or exported interfaces were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->