### PR TITLE
fix: variables set via setVar should be interpolated only during runtime

### DIFF
--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -230,7 +230,7 @@ class Bru {
       );
     }
 
-    this.runtimeVariables[key] = this.interpolate(value);
+    this.runtimeVariables[key] = value;
   }
 
   getVar(key) {

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -248,14 +248,14 @@ describe('runtime', () => {
   });
 
   describe('bru.setVar random variable', () => {
-    it('should not be equal to {{$randomFirstName}}', async () => {
+    it('should be able to set random variables as values', async () => {
       const script = `bru.setVar('title', '{{$randomFirstName}}')`;
 
       const runtime = new ScriptRuntime({ runtime: 'nodevm' });
 
       const result = await runtime.runRequestScript(script, {}, {}, {}, '.', null, process.env);
 
-      expect(result.runtimeVariables.title).not.toBe('{{$randomFirstName}}');
+      expect(result.runtimeVariables.title).toBe('{{$randomFirstName}}');
     });
   });
 });


### PR DESCRIPTION
### Description

Variables set via setVar should be interpolated only during runtime using the latest value of highest precedence

Fixes: https://github.com/usebruno/bruno/issues/6419 (on top of PR https://github.com/usebruno/bruno/pull/6393)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed how variables are stored in runtime to prevent premature interpolation. Variables now retain their raw values at assignment time, ensuring proper behavior in subsequent operations and retrievals throughout execution.

* **Tests**
  * Updated runtime tests to validate the corrected variable storage behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->