### PR TITLE
feat: add FeatureTip component for onboarding tooltips

### DIFF
--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -14,6 +14,7 @@ import MenuDropdown from 'ui/MenuDropdown';
 import ActionIcon from 'ui/ActionIcon';
 import IconSidebarToggle from 'components/Icons/IconSidebarToggle';
 import CreateWorkspace from 'components/WorkspaceSidebar/CreateWorkspace';
+import FeatureTip from 'components/FeatureTip';
 
 import IconBottombarToggle from 'components/Icons/IconBottombarToggle/index';
 import StyledWrapper from './StyledWrapper';
@@ -192,14 +193,21 @@ const AppTitleBar = () => {
           </ActionIcon>
 
           {/* Workspace Dropdown */}
-          <MenuDropdown
-            data-testid="workspace-menu"
-            items={workspaceMenuItems}
+          <FeatureTip
+            tipId="workspace-intro"
+            title="Workspaces"
+            description="Workspaces help you organize your collections. Each workspace can contain multiple collections, and you can create separate workspaces for different projects or teams."
             placement="bottom-start"
-            selectedItemId={activeWorkspaceUid}
           >
-            <WorkspaceName />
-          </MenuDropdown>
+            <MenuDropdown
+              data-testid="workspace-menu"
+              items={workspaceMenuItems}
+              placement="bottom-start"
+              selectedItemId={activeWorkspaceUid}
+            >
+              <WorkspaceName />
+            </MenuDropdown>
+          </FeatureTip>
         </div>
 
         {/* Center section: Bruno logo + text */}

--- a/packages/bruno-app/src/components/FeatureTip/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FeatureTip/StyledWrapper.js
@@ -1,0 +1,184 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+
+  .feature-tip-popover {
+    position: absolute;
+    z-index: 1000;
+    width: 280px;
+    background-color: ${(props) => props.theme.sidebar.badge.bg};
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+    animation: fadeIn 0.2s ease-out;
+  }
+
+  &.placement-bottom .feature-tip-popover {
+    top: calc(100% + 10px);
+    right: 0;
+  }
+
+  &.placement-bottom-start .feature-tip-popover {
+    top: calc(100% + 10px);
+    left: 0;
+  }
+
+  &.placement-top .feature-tip-popover {
+    bottom: calc(100% + 10px);
+    right: 0;
+  }
+
+  &.placement-left .feature-tip-popover {
+    right: calc(100% + 10px);
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  &.placement-right .feature-tip-popover {
+    left: calc(100% + 10px);
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .tip-arrow {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    background-color: ${(props) => props.theme.sidebar.badge.bg};
+    transform: rotate(45deg);
+  }
+
+  &.placement-bottom .tip-arrow {
+    top: -6px;
+    right: 16px;
+  }
+
+  &.placement-bottom-start .tip-arrow {
+    top: -6px;
+    left: 16px;
+  }
+
+  &.placement-top .tip-arrow {
+    bottom: -6px;
+    right: 16px;
+  }
+
+  &.placement-left .tip-arrow {
+    right: -6px;
+    top: 50%;
+    margin-top: -6px;
+  }
+
+  &.placement-right .tip-arrow {
+    left: -6px;
+    top: 50%;
+    margin-top: -6px;
+  }
+
+  .tip-content {
+    position: relative;
+    padding: 12px;
+  }
+
+  .tip-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .tip-icon {
+    color: #f59e0b;
+    flex-shrink: 0;
+  }
+
+  .tip-title {
+    font-weight: 600;
+    font-size: 13px;
+    color: ${(props) => props.theme.text};
+    flex: 1;
+  }
+
+  .tip-close {
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+    color: ${(props) => props.theme.text};
+    opacity: 0.6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    
+    &:hover {
+      opacity: 1;
+      background-color: rgba(255, 255, 255, 0.1);
+    }
+  }
+
+  .tip-description {
+    font-size: 12px;
+    color: ${(props) => props.theme.text};
+    opacity: 0.85;
+    line-height: 1.5;
+    margin: 0 0 12px 0;
+  }
+
+  .tip-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    align-items: center;
+  }
+
+  .tip-learn-more {
+    font-size: 12px;
+    color: #3b82f6;
+    text-decoration: none;
+    
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .tip-dismiss-btn {
+    background-color: #3b82f6;
+    color: white;
+    border: none;
+    padding: 6px 14px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    
+    &:hover {
+      background-color: #2563eb;
+    }
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  &.placement-left, &.placement-right {
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/FeatureTip/index.js
+++ b/packages/bruno-app/src/components/FeatureTip/index.js
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from 'react';
+import { IconX, IconBulb } from '@tabler/icons';
+import useLocalStorage from 'hooks/useLocalStorage';
+import StyledWrapper from './StyledWrapper';
+
+/**
+ * FeatureTip - A simple, dismissable tip dialogue for onboarding users
+ *
+ * @param {string} tipId - Unique identifier for the tip (used for localStorage)
+ * @param {string} title - Title of the tip
+ * @param {string} description - Description/content of the tip
+ * @param {string} learnMoreUrl - Optional URL for "Learn more" link
+ * @param {React.ReactNode} children - The element to attach the tip to
+ * @param {string} placement - Placement of the tip: 'top' | 'bottom' | 'left' | 'right'
+ * @param {boolean} disabled - If true, the tip won't be shown even if not dismissed
+ * @param {string} dependsOn - Optional tipId that must be dismissed before this tip shows
+ */
+const FeatureTip = ({
+  tipId,
+  title,
+  description,
+  learnMoreUrl,
+  children,
+  placement = 'bottom',
+  disabled = false,
+  dependsOn = null
+}) => {
+  const [isDismissed, setIsDismissed] = useLocalStorage(`bruno.featureTip.${tipId}`, false);
+  const [isDependencyDismissed, setIsDependencyDismissed] = useState(!dependsOn);
+
+  // Check if dependency tip has been dismissed
+  useEffect(() => {
+    if (!dependsOn) {
+      setIsDependencyDismissed(true);
+      return;
+    }
+
+    const checkDependency = () => {
+      try {
+        const stored = localStorage.getItem(`bruno.featureTip.${dependsOn}`);
+        if (stored !== null) {
+          const parsed = JSON.parse(stored);
+          setIsDependencyDismissed(parsed === true);
+        } else {
+          setIsDependencyDismissed(false);
+        }
+      } catch {
+        setIsDependencyDismissed(false);
+      }
+    };
+
+    // Check immediately
+    checkDependency();
+
+    // Listen for storage changes (when the dependency tip is dismissed)
+    const handleStorageChange = (e) => {
+      if (e.key === `bruno.featureTip.${dependsOn}`) {
+        checkDependency();
+      }
+    };
+
+    // Also poll periodically in case storage event doesn't fire (same tab)
+    const interval = setInterval(checkDependency, 500);
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      clearInterval(interval);
+    };
+  }, [dependsOn]);
+
+  const handleDismiss = (e) => {
+    e.stopPropagation();
+    setIsDismissed(true);
+  };
+
+  // Don't show if: already dismissed, explicitly disabled, or dependency not yet dismissed
+  console.log(`FeatureTip [${tipId}]: isDismissed=${isDismissed}, disabled=${disabled}, isDependencyDismissed=${isDependencyDismissed}`);
+  if (isDismissed || disabled || !isDependencyDismissed) {
+    return children;
+  }
+
+  return (
+    <StyledWrapper className={`feature-tip-container placement-${placement}`}>
+      {children}
+      <div className="feature-tip-popover">
+        <div className="tip-arrow" />
+        <div className="tip-content">
+          <div className="tip-header">
+            <IconBulb size={16} className="tip-icon" />
+            <span className="tip-title">{title}</span>
+            <button className="tip-close" onClick={handleDismiss} aria-label="Dismiss tip">
+              <IconX size={14} />
+            </button>
+          </div>
+          <p className="tip-description">{description}</p>
+          <div className="tip-actions">
+            {learnMoreUrl && (
+              <a
+                href={learnMoreUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="tip-learn-more"
+              >
+                Learn more
+              </a>
+            )}
+            <button className="tip-dismiss-btn" onClick={handleDismiss}>
+              Got it
+            </button>
+          </div>
+        </div>
+      </div>
+    </StyledWrapper>
+  );
+};
+
+export default FeatureTip;

--- a/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionToolBar/index.js
@@ -5,6 +5,7 @@ import EnvironmentSelector from 'components/Environments/EnvironmentSelector';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import { useDispatch } from 'react-redux';
 import ToolHint from 'components/ToolHint';
+import FeatureTip from 'components/FeatureTip';
 import StyledWrapper from './StyledWrapper';
 import JsSandboxMode from 'components/SecuritySettings/JsSandboxMode';
 
@@ -60,9 +61,17 @@ const CollectionToolBar = ({ collection }) => {
             </ToolHint>
           </span>
           <span className="mr-3">
-            <ToolHint text="Collection Settings" toolhintId="CollectionSettingsToolhintId">
-              <IconSettings className="cursor-pointer" size={16} strokeWidth={1.5} onClick={viewCollectionSettings} />
-            </ToolHint>
+            <FeatureTip
+              tipId="collection-settings-intro"
+              title="Collection Settings"
+              description="Configure headers, auth, scripts, and more for your entire collection. Settings here apply to all requests."
+              placement="bottom"
+              dependsOn="workspace-intro"
+            >
+              <ToolHint text="Collection Settings" toolhintId="CollectionSettingsToolhintId">
+                <IconSettings className="cursor-pointer" size={16} strokeWidth={1.5} onClick={viewCollectionSettings} />
+              </ToolHint>
+            </FeatureTip>
           </span>
           <span className="mr-2">
             <ToolHint text="Javascript Sandbox" toolhintId="JavascriptSandboxToolhintId" place="bottom">
@@ -70,7 +79,15 @@ const CollectionToolBar = ({ collection }) => {
             </ToolHint>
           </span>
           <span>
-            <EnvironmentSelector collection={collection} />
+            <FeatureTip
+              tipId="environment-selector-intro"
+              title="Environments"
+              description="Switch between Collection and Global environments. Collection environments are specific to this collection, while Global environments are shared across all collections."
+              placement="bottom"
+              dependsOn="collection-settings-intro"
+            >
+              <EnvironmentSelector collection={collection} />
+            </FeatureTip>
           </span>
         </div>
       </div>


### PR DESCRIPTION
### What?
- Add new FeatureTip component with sequential display support
- Uses Tippy.js for tooltip rendering with custom styling
- Supports dependency chain (tips shown in order)
- Persists dismissed state to localStorage
- Add tips for: workspace selector, collection settings, environment selector

### Description

New Bruno users are not familiar with all the different settings, UI differences from other clients, or the purpose of certain areas of the app.

Vibe coded Proof of Concept Only.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Screenshots / Video
![dialogue-demo-day](https://github.com/user-attachments/assets/e25b42b7-86e0-4774-aa54-d5d147170c56)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive feature tips throughout the app to guide users through key features
  * Tips appear on the workspace menu, collection settings, environment selector, and dev tools button
  * Users can dismiss tips individually, and dismissals are remembered

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->