### PR TITLE
fix: prevent response truncation in recursive collection runner

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1423,7 +1423,7 @@ const registerNetworkIpc = (mainWindow) => {
               }
 
               if (error?.response) {
-                error.response.data = await promisifyStream(error.response.data, currentAbortController, true);
+                error.response.data = await promisifyStream(error.response.data, currentAbortController, false);
                 const { data, dataBuffer } = parseDataFromResponse(error.response);
                 error.response.responseTime = error.response.headers.get('request-duration');
                 error.response.headers.delete('request-duration');


### PR DESCRIPTION
### Description

Resolves response body truncation when executing collections recursively via the UI.

Fixes: #6828

### Problem

When executing a collection recursively via the UI, requests returning 4xx/5xx status codes had their response body prematurely truncated. This resulted in assertion failures due to malformed JSON in the response.

The issue was not reproducible when:
- Executing individual requests in the UI
- Running collections via the CLI

### Fix

Updated the collection runner to consume the complete response stream for error cases, consistent with the existing behavior for successful responses.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error response handling to ensure complete error data is properly captured and processed for more accurate error reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->