### PR TITLE
Remove isLikelyText detection from detectContentTypeFromBuffer utility function

### DIFF
--- a/packages/bruno-app/src/utils/response/index.js
+++ b/packages/bruno-app/src/utils/response/index.js
@@ -250,11 +250,6 @@ export const detectContentTypeFromBuffer = (buffer) => {
     return 'application/gzip';
   }
 
-  // Check if it's likely text (UTF-8)
-  if (isLikelyText(buffer.slice(0, Math.min(512, buffer.length)))) {
-    return 'text/plain';
-  }
-
   return null;
 };
 


### PR DESCRIPTION
### Description

isLikelyText function should be called only after isSvgContent function call, which is already been handled in detectContentTypeFromBase64 function. So, removing the redundant function call in the detectContentTypeFromBuffer utility function.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated content type detection to be more strict; plain text buffers may no longer be automatically classified as text/plain unless other detection rules apply.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->