### PR TITLE
feat(comments): add comment support

### DIFF
--- a/packages/bruno-lang/v2/src/collectionBruToJson.js
+++ b/packages/bruno-lang/v2/src/collectionBruToJson.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const { safeParseJson, outdentString } = require('./utils');
 
 const grammar = ohm.grammar(`Bru {
-  BruFile = (meta | query | headers | auth | auths | vars | script | tests | docs)*
+  BruFile = (comment | meta | query | headers | auth | auths | vars | script | tests | docs)*
   auths = authawsv4 | authbasic | authbearer | authdigest | authNTLM |authOAuth2 | authwsse | authapikey | authOauth2Configs
 
   // Oauth2 additional parameters
@@ -19,6 +19,10 @@ const grammar = ohm.grammar(`Bru {
   optionalnl = ~tagend nl
   keychar = ~(tagend | st | nl | ":") any
   valuechar = ~(nl | tagend) any
+
+  // Comments
+  comment = st* commentstart (~nl any)* nl
+  commentstart = "#" | "//"
 
   // Multiline text block surrounded by '''
   multilinetextblockdelimiter = "'''"
@@ -135,6 +139,9 @@ const sem = grammar.createSemantics().addAttribute('ast', {
       },
       {}
     );
+  },
+  comment(_1, _2, _3, _4) {
+    return null;
   },
   dictionary(_1, _2, pairlist, _3) {
     return pairlist.ast;

--- a/packages/bruno-lang/v2/src/envToJson.js
+++ b/packages/bruno-lang/v2/src/envToJson.js
@@ -12,7 +12,7 @@ const _ = require('lodash');
 // }
 const indentLevel = 4;
 const grammar = ohm.grammar(`Bru {
-  BruEnvFile = (vars | secretvars)*
+  BruEnvFile = (comment | vars | secretvars)*
 
   nl = "\\r"? "\\n"
   st = " " | "\\t"
@@ -21,6 +21,10 @@ const grammar = ohm.grammar(`Bru {
   optionalnl = ~tagend nl
   keychar = ~(tagend | st | nl | ":") any
   valuechar = ~(nl | tagend | multilinetextblockstart) any
+
+  // Comments
+  comment = st* commentstart (~nl any)* nl
+  commentstart = "#" | "//"
 
   multilinetextblockdelimiter = "'''"
   multilinetextblockstart = "'''" nl
@@ -111,6 +115,9 @@ const sem = grammar.createSemantics().addAttribute('ast', {
       },
       {}
     );
+  },
+  comment(_1, _2, _3, _4) {
+    return null;
   },
   array(_1, _2, _3, valuelist, _4, _5) {
     return valuelist.ast;

--- a/packages/bruno-lang/v2/tests/comments.spec.js
+++ b/packages/bruno-lang/v2/tests/comments.spec.js
@@ -1,0 +1,282 @@
+const bruToJson = require('../src/bruToJson');
+
+describe('comments', () => {
+  it('should parse # comments', () => {
+    const input = `# This is a comment
+meta {
+  name: Test Request
+  type: http
+}
+
+# Another comment
+get {
+  url: https://api.example.com
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      meta: {
+        name: 'Test Request',
+        type: 'http',
+        seq: 1
+      },
+      http: {
+        method: 'get',
+        url: 'https://api.example.com'
+      }
+    });
+  });
+
+  it('should parse // comments', () => {
+    const input = `// This is a comment
+meta {
+  name: Test Request
+  type: http
+}
+
+// Another comment
+get {
+  url: https://api.example.com
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      meta: {
+        name: 'Test Request',
+        type: 'http',
+        seq: 1
+      },
+      http: {
+        method: 'get',
+        url: 'https://api.example.com'
+      }
+    });
+  });
+
+  it('should parse mixed # and // comments', () => {
+    const input = `# Hash comment
+// Slash comment
+meta {
+  name: Test Request
+  type: http
+}
+
+get {
+  url: https://api.example.com
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      meta: {
+        name: 'Test Request',
+        type: 'http',
+        seq: 1
+      },
+      http: {
+        method: 'get',
+        url: 'https://api.example.com'
+      }
+    });
+  });
+
+  it('should handle comments at end of file', () => {
+    const input = `meta {
+  name: Test Request
+  type: http
+}
+
+get {
+  url: https://api.example.com
+}
+# Comment at the end
+`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      meta: {
+        name: 'Test Request',
+        type: 'http',
+        seq: 1
+      },
+      http: {
+        method: 'get',
+        url: 'https://api.example.com'
+      }
+    });
+  });
+
+  it('should handle empty comments', () => {
+    const input = `#
+meta {
+  name: Test Request
+  type: http
+}
+//
+get {
+  url: https://api.example.com
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      meta: {
+        name: 'Test Request',
+        type: 'http',
+        seq: 1
+      },
+      http: {
+        method: 'get',
+        url: 'https://api.example.com'
+      }
+    });
+  });
+
+  it('should parse comments inside dictionary blocks', () => {
+    const input = `meta {
+  # This is a comment inside meta
+  name: Test Request
+  // Another comment
+  type: http
+}
+
+headers {
+  # Header comment
+  Content-Type: application/json
+  // Another header comment
+  Authorization: Bearer token
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      meta: {
+        name: 'Test Request',
+        type: 'http',
+        seq: 1
+      },
+      headers: [
+        {
+          name: 'Content-Type',
+          value: 'application/json',
+          enabled: true
+        },
+        {
+          name: 'Authorization',
+          value: 'Bearer token',
+          enabled: true
+        }
+      ]
+    });
+  });
+
+  it('should parse comments inside query params', () => {
+    const input = `params:query {
+  # Page parameter
+  page: 1
+  // Limit parameter
+  limit: 10
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      params: [
+        {
+          name: 'page',
+          value: '1',
+          enabled: true,
+          type: 'query'
+        },
+        {
+          name: 'limit',
+          value: '10',
+          enabled: true,
+          type: 'query'
+        }
+      ]
+    });
+  });
+
+  it('should parse comments inside assert blocks', () => {
+    const input = `assert {
+  # Status assertion
+  res.status: eq 200
+  // Body assertion
+  res.body.success: eq true
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      assertions: [
+        {
+          name: 'res.status',
+          value: 'eq 200',
+          enabled: true
+        },
+        {
+          name: 'res.body.success',
+          value: 'eq true',
+          enabled: true
+        }
+      ]
+    });
+  });
+
+  it('should parse comments inside vars blocks', () => {
+    const input = `vars:pre-request {
+  # User ID variable
+  userId: 123
+  // Timestamp variable
+  timestamp: {{Date.now()}}
+}
+
+vars:post-response {
+  # Extract username
+  userName: res.body.name
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      vars: {
+        req: [
+          {
+            name: 'userId',
+            value: '123',
+            enabled: true,
+            local: false
+          },
+          {
+            name: 'timestamp',
+            value: '{{Date.now()}}',
+            enabled: true,
+            local: false
+          }
+        ],
+        res: [
+          {
+            name: 'userName',
+            value: 'res.body.name',
+            enabled: true,
+            local: false
+          }
+        ]
+      }
+    });
+  });
+
+  it('should parse comments inside auth blocks', () => {
+    const input = `auth:basic {
+  # Username field
+  username: admin
+  // Password field
+  password: secret123
+}`;
+
+    const output = bruToJson(input);
+    expect(output).toEqual({
+      auth: {
+        basic: {
+          username: 'admin',
+          password: 'secret123'
+        }
+      }
+    });
+  });
+});

--- a/packages/bruno-lang/v2/tests/envComments.spec.js
+++ b/packages/bruno-lang/v2/tests/envComments.spec.js
@@ -1,0 +1,54 @@
+const envToJson = require('../src/envToJson');
+
+describe('env comments', () => {
+  it('should parse # comments in env file', () => {
+    const input = `# Environment configuration
+vars {
+  API_KEY: secret123
+  BASE_URL: https://api.example.com
+}`;
+
+    const output = envToJson(input);
+    expect(output).toEqual({
+      variables: [
+        { name: 'API_KEY', value: 'secret123', secret: false, enabled: true },
+        { name: 'BASE_URL', value: 'https://api.example.com', secret: false, enabled: true }
+      ]
+    });
+  });
+
+  it('should parse // comments in env file', () => {
+    const input = `// Environment configuration
+vars {
+  API_KEY: secret123
+  BASE_URL: https://api.example.com
+}`;
+
+    const output = envToJson(input);
+    expect(output).toEqual({
+      variables: [
+        { name: 'API_KEY', value: 'secret123', secret: false, enabled: true },
+        { name: 'BASE_URL', value: 'https://api.example.com', secret: false, enabled: true }
+      ]
+    });
+  });
+
+  it('should parse comments between vars and secretvars', () => {
+    const input = `vars {
+  API_KEY: secret123
+}
+
+# Secret variables below
+vars:secret [
+  PASSWORD
+]`;
+
+    const output = envToJson(input);
+    expect(output).toEqual({
+      variables: [
+        { name: 'API_KEY', value: 'secret123', secret: false, enabled: true },
+        { name: 'PASSWORD', value: '', secret: true, enabled: true }
+      ]
+    });
+  });
+});

--- a/packages/bruno-lang/v2/tests/examples/examples.spec.js
+++ b/packages/bruno-lang/v2/tests/examples/examples.spec.js
@@ -13,6 +13,22 @@ describe('Examples functionality', () => {
       expect(output).toEqual(expected);
     });
 
+    it('should parse example-with-comments.bru correctly', () => {
+      const input = fs.readFileSync(path.join(__dirname, 'fixtures', 'bru', 'example-with-comments.bru'), 'utf8');
+      const expected = require('./fixtures/json/example-with-comments.json');
+      const output = bruToJson(input);
+
+      expect(output).toEqual(expected);
+    });
+
+    it('should parse test-comments-in-blocks.bru correctly', () => {
+      const input = fs.readFileSync(path.join(__dirname, 'fixtures', 'bru', 'test-comments-in-blocks.bru'), 'utf8');
+      const expected = require('./fixtures/json/test-comments-in-blocks.json');
+      const output = bruToJson(input);
+
+      expect(output).toEqual(expected);
+    });
+
     it('should parse examples-complex.bru correctly', () => {
       const input = fs.readFileSync(path.join(__dirname, 'fixtures', 'bru', 'examples-complex.bru'), 'utf8');
       const output = bruToJson(input);

--- a/packages/bruno-lang/v2/tests/examples/fixtures/bru/example-with-comments.bru
+++ b/packages/bruno-lang/v2/tests/examples/fixtures/bru/example-with-comments.bru
@@ -1,0 +1,66 @@
+# This is a Bruno request file example with comments
+# Comments can start with # or //
+
+meta {
+  name: Get User Profile
+  type: http
+  seq: 1
+}
+
+// HTTP method and URL
+get {
+  url: https://api.example.com/users/{{userId}}
+}
+
+# Request headers
+headers {
+  Authorization: Bearer {{token}}
+  Content-Type: application/json
+}
+
+// Query parameters
+params:query {
+  include: profile,settings
+  format: json
+}
+
+# Variables to set before the request
+vars:pre-request {
+  userId: 123
+  timestamp: {{new Date().getTime()}}
+}
+
+// Variables to extract from the response
+vars:post-response {
+  userName: res.body.name
+  userEmail: res.body.email
+}
+
+# Assertions to validate the response
+assert {
+  res.status: eq 200
+  res.body.id: eq {{userId}}
+  res.body.email: isString
+}
+
+// Tests script (JavaScript)
+tests {
+  test("Status should be 200", function() {
+    expect(res.status).to.equal(200);
+  });
+  
+  test("Response should have user data", function() {
+    expect(res.body).to.have.property('name');
+    expect(res.body).to.have.property('email');
+  });
+}
+
+# Documentation for this request
+docs {
+  This endpoint retrieves a user's profile information.
+  
+  Required permissions:
+  - read:users
+  
+  Rate limit: 100 requests per minute
+}

--- a/packages/bruno-lang/v2/tests/examples/fixtures/bru/test-comments-in-blocks.bru
+++ b/packages/bruno-lang/v2/tests/examples/fixtures/bru/test-comments-in-blocks.bru
@@ -1,0 +1,56 @@
+# Top-level comment before meta block
+
+meta {
+  # Comment inside meta block
+  name: Test Request with Comments
+  type: http
+  // Another comment style
+  seq: 1
+}
+
+get {
+  # Comment before URL
+  url: https://api.example.com/users
+}
+
+headers {
+  # This is a header comment
+  Authorization: Bearer token123
+  // Another header comment
+  Content-Type: application/json
+  # Comment before next header
+  Accept: application/json
+}
+
+params:query {
+  # Query parameter comment
+  page: 1
+  // Limit comment
+  limit: 10
+}
+
+vars:pre-request {
+  # Variable comment
+  userId: 123
+  // Another variable
+  timestamp: {{Date.now()}}
+}
+
+vars:post-response {
+  # Response variable comment
+  userName: res.body.name
+}
+
+assert {
+  # Assertion comment
+  res.status: eq 200
+  // Body assertion
+  res.body.success: eq true
+}
+
+# Comment before tests block
+tests {
+  test("Status code", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/packages/bruno-lang/v2/tests/examples/fixtures/json/example-with-comments.json
+++ b/packages/bruno-lang/v2/tests/examples/fixtures/json/example-with-comments.json
@@ -1,0 +1,86 @@
+{
+  "meta": {
+    "name": "Get User Profile",
+    "type": "http",
+    "seq": "1"
+  },
+  "http": {
+    "method": "get",
+    "url": "https://api.example.com/users/{{userId}}"
+  },
+  "headers": [
+    {
+      "name": "Authorization",
+      "value": "Bearer {{token}}",
+      "enabled": true
+    },
+    {
+      "name": "Content-Type",
+      "value": "application/json",
+      "enabled": true
+    }
+  ],
+  "params": [
+    {
+      "name": "include",
+      "value": "profile,settings",
+      "enabled": true,
+      "type": "query"
+    },
+    {
+      "name": "format",
+      "value": "json",
+      "enabled": true,
+      "type": "query"
+    }
+  ],
+  "vars": {
+    "req": [
+      {
+        "name": "userId",
+        "value": "123",
+        "enabled": true,
+        "local": false
+      },
+      {
+        "name": "timestamp",
+        "value": "{{new Date().getTime()}}",
+        "enabled": true,
+        "local": false
+      }
+    ],
+    "res": [
+      {
+        "name": "userName",
+        "value": "res.body.name",
+        "enabled": true,
+        "local": false
+      },
+      {
+        "name": "userEmail",
+        "value": "res.body.email",
+        "enabled": true,
+        "local": false
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "name": "res.status",
+      "value": "eq 200",
+      "enabled": true
+    },
+    {
+      "name": "res.body.id",
+      "value": "eq {{userId}}",
+      "enabled": true
+    },
+    {
+      "name": "res.body.email",
+      "value": "isString",
+      "enabled": true
+    }
+  ],
+  "tests": "test(\"Status should be 200\", function() {\n  expect(res.status).to.equal(200);\n});\n\ntest(\"Response should have user data\", function() {\n  expect(res.body).to.have.property('name');\n  expect(res.body).to.have.property('email');\n});",
+  "docs": "This endpoint retrieves a user's profile information.\n\nRequired permissions:\n- read:users\n\nRate limit: 100 requests per minute"
+}

--- a/packages/bruno-lang/v2/tests/examples/fixtures/json/test-comments-in-blocks.json
+++ b/packages/bruno-lang/v2/tests/examples/fixtures/json/test-comments-in-blocks.json
@@ -1,0 +1,79 @@
+{
+  "meta": {
+    "name": "Test Request with Comments",
+    "type": "http",
+    "seq": "1"
+  },
+  "http": {
+    "method": "get",
+    "url": "https://api.example.com/users"
+  },
+  "headers": [
+    {
+      "name": "Authorization",
+      "value": "Bearer token123",
+      "enabled": true
+    },
+    {
+      "name": "Content-Type",
+      "value": "application/json",
+      "enabled": true
+    },
+    {
+      "name": "Accept",
+      "value": "application/json",
+      "enabled": true
+    }
+  ],
+  "params": [
+    {
+      "name": "page",
+      "value": "1",
+      "enabled": true,
+      "type": "query"
+    },
+    {
+      "name": "limit",
+      "value": "10",
+      "enabled": true,
+      "type": "query"
+    }
+  ],
+  "vars": {
+    "req": [
+      {
+        "name": "userId",
+        "value": "123",
+        "enabled": true,
+        "local": false
+      },
+      {
+        "name": "timestamp",
+        "value": "{{Date.now()}}",
+        "enabled": true,
+        "local": false
+      }
+    ],
+    "res": [
+      {
+        "name": "userName",
+        "value": "res.body.name",
+        "enabled": true,
+        "local": false
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "name": "res.status",
+      "value": "eq 200",
+      "enabled": true
+    },
+    {
+      "name": "res.body.success",
+      "value": "eq true",
+      "enabled": true
+    }
+  ],
+  "tests": "test(\"Status code\", function() {\n  expect(res.status).to.equal(200);\n});"
+}


### PR DESCRIPTION
This PR only adds comment support functionality (#1371)
The changes are additive and don't modify existing behavior.

Example:
```
# Top-level comment before meta block

meta {
  # Comment inside meta block
  name: Test Request with Comments
  type: http
  // Another comment style
  seq: 1
}
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for comments in request and environment files
  * Both # and // comment styles are now recognized throughout the language, including in meta, headers, parameters, variables, assertions, and other blocks

* **Tests**
  * Added comprehensive test coverage for comment parsing in various contexts and configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->