### PR TITLE
fix: search not working on collapsed collections #6891

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -258,6 +258,18 @@ const Collection = ({ collection, searchText }) => {
     }
   }, [isCollectionFocused]);
 
+  useEffect(() => {
+    if (searchText && searchText.trim().length && collection.mountStatus === 'unmounted') {
+      dispatch(
+        mountCollection({
+          collectionUid: collection.uid,
+          collectionPathname: collection.pathname,
+          brunoConfig: collection.brunoConfig
+        })
+      );
+    }
+  }, [searchText, collection, dispatch]);
+
   if (searchText && searchText.length) {
     if (!doesCollectionHaveItemsMatchingSearchText(collection, searchText)) {
       return null;
@@ -318,13 +330,13 @@ const Collection = ({ collection, searchText }) => {
     },
     ...(hasCopiedItems
       ? [
-          {
-            id: 'paste',
-            leftSection: IconClipboard,
-            label: 'Paste',
-            onClick: handlePasteItem
-          }
-        ]
+        {
+          id: 'paste',
+          leftSection: IconClipboard,
+          label: 'Paste',
+          onClick: handlePasteItem
+        }
+      ]
       : []),
     {
       id: 'rename',


### PR DESCRIPTION
## Description

This PR fixes the issue where search does not work when a collection is collapsed (unmounted).

### What was happening
- When searching, collapsed collections were not mounted
- So search results were not showing for those collections

### Fix
- If user types search text and collection is unmounted, we automatically mount the collection
- This makes search work properly even on collapsed collections

Fixes #6891


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collections in the sidebar now automatically expand and display when search text is active, making search results more accessible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->