### PR TITLE
fix: content-type parsing should handle charset and boundary params

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -514,7 +514,12 @@ const registerNetworkIpc = (mainWindow) => {
     // stringify the request url encoded params
     const contentTypeHeader = Object.keys(request.headers).find((name) => name.toLowerCase() === 'content-type');
 
-    if (contentTypeHeader && request.headers[contentTypeHeader] === 'application/x-www-form-urlencoded') {
+    let mediaType;
+    if (contentTypeHeader && request.headers[contentTypeHeader]) {
+      mediaType = request.headers[contentTypeHeader].split(';')[0].trim();
+    }
+
+    if (mediaType === 'application/x-www-form-urlencoded') {
       if (Array.isArray(request.data)) {
         request.data = buildFormUrlEncodedPayload(request.data);
       } else if (typeof request.data !== 'string') {
@@ -523,7 +528,7 @@ const registerNetworkIpc = (mainWindow) => {
       // if `data` is of string type - return as-is (assumes already encoded)
     }
 
-    if (contentTypeHeader && request.headers[contentTypeHeader] === 'multipart/form-data') {
+    if (mediaType === 'multipart/form-data') {
       if (!isFormData(request.data)) {
         request._originalMultipartData = request.data;
         request.collectionPath = collectionPath;

--- a/tests/request/encoding/form-url-encoding.spec.ts
+++ b/tests/request/encoding/form-url-encoding.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '../../../playwright';
+import {
+  closeAllCollections,
+  createCollection,
+  createRequest,
+  selectRequestPaneTab,
+  saveRequest,
+  expectResponseContains
+} from '../../utils/page';
+
+test.describe('Form URL Encoding with Content-Type Parameters', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('Should encode form params correctly without explicit Content-Type header', async ({ page, createTmpDir }) => {
+    const collectionName = 'form-encoding-test';
+    const requestName = 'form-basic';
+
+    await test.step('Create collection and request', async () => {
+      await createCollection(page, collectionName, await createTmpDir(collectionName));
+      await createRequest(page, requestName, collectionName, { url: 'https://echo.usebruno.com' });
+    });
+
+    await test.step('Navigate to request and populate fields', async () => {
+      await page.locator('.collection-item-name').filter({ hasText: requestName }).first().click();
+
+      // Change method to POST
+      await page.locator('.method-selector').click();
+      await page.locator('.dropdown-item').filter({ hasText: 'POST' }).click();
+
+      // Select Body tab and switch to form-urlencoded
+      await selectRequestPaneTab(page, 'Body');
+      await page.locator('.body-mode-selector').click();
+      await page.locator('[data-item-id="formUrlEncoded"]').click();
+
+      // Add form parameters with special characters
+      const formTable = page.locator('table').first();
+      const firstRow = formTable.locator('tbody tr').first();
+
+      await firstRow.locator('input[placeholder="Key"]').fill('foo');
+      await firstRow.locator('.CodeMirror').click();
+      await firstRow.locator('textarea').fill('bar');
+
+      // Add second parameter
+      const secondRow = formTable.locator('tbody tr').nth(1);
+      await secondRow.locator('input[placeholder="Key"]').fill('baz');
+      await secondRow.locator('.CodeMirror').click();
+      await secondRow.locator('textarea').fill('test');
+
+      await saveRequest(page);
+    });
+
+    await test.step('Send request', async () => {
+      // Send request
+      await page.getByTestId('send-arrow-icon').click();
+      await page.getByTestId('response-status-code').waitFor({ state: 'visible', timeout: 15000 });
+    });
+
+    await test.step('Validate response', async () => {
+      await expect(page.getByTestId('response-status-code')).toContainText('200', { timeout: 15000 });
+
+      // Verify response contains properly encoded data
+      await expectResponseContains(page, ['foo=bar&baz=test']);
+    });
+  });
+
+  test('Should encode form params correctly WITH Content-Type header including charset', async ({ page, createTmpDir }) => {
+    const collectionName = 'form-encoding-charset-test';
+    const requestName = 'form-with-charset';
+
+    await test.step('Create collection and request', async () => {
+      await createCollection(page, collectionName, await createTmpDir(collectionName));
+      await createRequest(page, requestName, collectionName, { url: 'https://echo.usebruno.com' });
+    });
+
+    await test.step('Navigate to request and populate fields', async () => {
+      await page.locator('.collection-item-name').filter({ hasText: requestName }).first().click();
+
+      // Change method to POST
+      await page.locator('.method-selector').click();
+      await page.locator('.dropdown-item').filter({ hasText: 'POST' }).click();
+
+      // Add Content-Type header with charset parameter
+      await selectRequestPaneTab(page, 'Headers');
+      const headerTable = page.locator('table').first();
+      const headerRow = headerTable.locator('tbody tr').first();
+
+      await headerRow.locator('.CodeMirror').first().click();
+      await headerRow.locator('textarea').first().fill('Content-Type');
+
+      await headerRow.locator('.CodeMirror').nth(1).click();
+      await headerRow.locator('textarea').nth(1).fill('application/x-www-form-urlencoded; charset=utf-8');
+
+      // Select Body tab and switch to form-urlencoded
+      await selectRequestPaneTab(page, 'Body');
+      await page.locator('.body-mode-selector').click();
+      await page.locator('[data-item-id="formUrlEncoded"]').click();
+
+      // Add form parameters with special characters
+      const formTable = page.locator('table').first();
+      const firstRow = formTable.locator('tbody tr').first();
+
+      await firstRow.locator('input[placeholder="Key"]').fill('foo');
+      await firstRow.locator('.CodeMirror').click();
+      await firstRow.locator('textarea').fill('bar');
+
+      // Add second parameter
+      const secondRow = formTable.locator('tbody tr').nth(1);
+      await secondRow.locator('input[placeholder="Key"]').fill('baz');
+      await secondRow.locator('.CodeMirror').click();
+      await secondRow.locator('textarea').fill('test');
+
+      await saveRequest(page);
+    });
+
+    await test.step('Send request', async () => {
+      // Send request
+      await page.getByTestId('send-arrow-icon').click();
+      await page.getByTestId('response-status-code').waitFor({ state: 'visible', timeout: 15000 });
+    });
+
+    await test.step('Verify response', async () => {
+      await expect(page.getByTestId('response-status-code')).toContainText('200', { timeout: 15000 });
+
+      // Verify response contains properly encoded data
+      await expectResponseContains(page, ['foo=bar&baz=test']);
+    });
+  });
+
+  test('Should encode form params correctly with multiple Content-Type parameters', async ({ page, createTmpDir }) => {
+    const collectionName = 'form-encoding-multiple-params-test';
+    const requestName = 'form-multiple-params';
+
+    await test.step('Setup request', async () => {
+      await createCollection(page, collectionName, await createTmpDir(collectionName));
+      await createRequest(page, requestName, collectionName, { url: 'https://echo.usebruno.com' });
+    });
+
+    await test.step('Navigate to request and populate fields', async () => {
+      await page.locator('.collection-item-name').filter({ hasText: requestName }).first().click();
+      // Change method to POST
+      await page.locator('.method-selector').click();
+      await page.locator('.dropdown-item').filter({ hasText: 'POST' }).click();
+
+      // Add Content-Type header with multiple parameters
+      await selectRequestPaneTab(page, 'Headers');
+      const headerTable = page.locator('table').first();
+      const headerRow = headerTable.locator('tbody tr').first();
+
+      await headerRow.locator('.CodeMirror').first().click();
+      await headerRow.locator('textarea').first().fill('Content-Type');
+
+      await headerRow.locator('.CodeMirror').nth(1).click();
+      await headerRow
+        .locator('textarea')
+        .nth(1)
+        .fill('application/x-www-form-urlencoded; charset=utf-8; boundary=something');
+
+      // Select Body tab and switch to form-urlencoded
+      await selectRequestPaneTab(page, 'Body');
+      await page.locator('.body-mode-selector').click();
+      await page.locator('[data-item-id="formUrlEncoded"]').click();
+
+      // Add form parameters
+      const formTable = page.locator('table').first();
+      const firstRow = formTable.locator('tbody tr').first();
+
+      await firstRow.locator('input[placeholder="Key"]').fill('test');
+      await firstRow.locator('.CodeMirror').click();
+      await firstRow.locator('textarea').fill('value with spaces');
+
+      await saveRequest(page);
+    });
+
+    await test.step('Send request', async () => {
+      // Send request
+      await page.getByTestId('send-arrow-icon').click();
+      await page.getByTestId('response-status-code').waitFor({ state: 'visible', timeout: 15000 });
+    });
+
+    await test.step('Verify response', async () => {
+      await expect(page.getByTestId('response-status-code')).toContainText('200', { timeout: 15000 });
+      // Verify response contains properly encoded data
+      await expectResponseContains(page, ['test=value+with+spaces']);
+    });
+  });
+});


### PR DESCRIPTION
REF - BRU-3218

### Description

Fixes #6916 by parsing the Content-Type value to extract the `media-type` component and use that for determining whether or not to form-urlencode parameters.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.** (in the original issue)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

**Note**: 
I wasn't quite sure how to answer the first question in the Contribution Checklist (whether I used AI "significantly"). I answered "no", but I'm unsure what the threshold for "significantly" is. 

In full disclosure, while I authored most of this change myself, I used Windsurf/Cascade editor for the following:

- During debugging, I used it to help me identify the part of the code where the request parameter encoding was occurring.
- When writing the tests, I used it to help get the tests working, as it was much quicker for me to ask it what the selectors for specific fields would be, rather than dig through the codebase myself
- I asked it to double-check my work several times to ensure that I hadn't made any silly mistakes.

In my opinion, this isn't "significant" use, as it's using an AI-enhanced editor as a tool rather than a vibe-coding style code generator, but I want to be as transparent as possible due to lack of a definition of what "significant" entails in this case. I'm willing to update my answer to "yes" if my use does meet that threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form-encoded request handling to correctly process Content-Type headers that include additional parameters (e.g., charset specifications), ensuring requests are properly formatted regardless of header formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->