### PR TITLE
Fix CLI Buffer handling in variable interpolation

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -67,7 +67,8 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
   const contentType = getContentType(request.headers);
 
   if (contentType.includes('json')) {
-    if (typeof request.data === 'object') {
+    // Skip interpolation if data is a Buffer (e.g., gzip-compressed data)
+    if (typeof request.data === 'object' && !Buffer.isBuffer(request.data)) {
       try {
         let parsed = JSON.stringify(request.data);
         parsed = _interpolate(parsed, { escapeJSONStrings: true });


### PR DESCRIPTION
### Description

This PR fixes a bug where gzip-compressed request bodies fail in Bruno CLI while working correctly in Bruno GUI (Developer Mode).

### Problem

In `packages/bruno-cli/src/runner/interpolate-vars.js`, when `Content-Type` includes `json`, Buffer data is incorrectly processed by `JSON.stringify()` because `typeof Buffer === 'object'`. This destroys the binary data (e.g., gzip-compressed bodies).

### Solution

Add `!Buffer.isBuffer(request.data)` check to skip interpolation for Buffer data.
```diff
- if (typeof request.data === 'object') {
+ // Skip interpolation if data is a Buffer (e.g., gzip-compressed data)
+ if (typeof request.data === 'object' && !Buffer.isBuffer(request.data)) {
```

### Why this fix works

The GUI (Developer Mode) version (`packages/bruno-electron/src/ipc/network/interpolate-vars.js`, line 111) already has this fix. This PR aligns CLI behavior with GUI.

Github Issue: [6921](https://github.com/usebruno/bruno/issues/6921)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of compressed and binary request data that was being incorrectly processed during variable interpolation. Request data in certain formats is now preserved without modification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->