### PR TITLE
 fix: refresh scopeInfo after variable save in tooltip editor

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -519,7 +519,7 @@ export const renderVarInfo = (token, options) => {
             const freshCollection = findCollectionByUid(state.collections.collections, collection.uid);
             if (collection) {
               const freshItem = item ? findItemInCollectionByItemUid(freshCollection, item.uid) : null;
-              const updatedScopeInfo = getVariableScope(variableName, collection, freshItem);
+              const updatedScopeInfo = getVariableScope(variableName, freshCollection, freshItem);
               if (updatedScopeInfo) {
                 scopeInfo = updatedScopeInfo;
               }


### PR DESCRIPTION
### Description

Fixes a bug in the variable tooltip editor where editing a newly created variable multiple times (while the tooltip stays open) would create duplicate variables instead of updating the existing one.  

[JIRA](https://usebruno.atlassian.net/browse/BRU-2550)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

before:
https://github.com/user-attachments/assets/8d61caa7-dc78-4506-beab-f10d8d75e8f2


after:
https://github.com/user-attachments/assets/c6491012-b56b-48e6-83dc-8bd2b61e4c54



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable update persistence to ensure changes are immediately reflected and available after saving, enhancing variable interpolation reliability in workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->