### PR TITLE
fix: prevent crash when reordering query params with empty name

### DIFF
--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -75,13 +75,6 @@ const EditableTable = ({
     return !value || (typeof value === 'string' && value.trim() === '');
   }, [columns]);
 
-  const rowHasValue = useCallback((row) => {
-    return columns.some((column) => {
-      const value = column.getValue ? column.getValue(row) : row[column.key];
-      return value && (typeof value !== 'string' || value.trim() !== '');
-    });
-  }, [columns]);
-
   const isLastEmptyRow = useCallback((row, index) => {
     if (!showAddRow) return false;
     return index === rowsWithEmpty.length - 1 && isEmptyRow(row);
@@ -167,8 +160,6 @@ const EditableTable = ({
     const fromIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
     if (fromIndex !== toIndex && onReorder) {
       const reorderableRows = showAddRow ? rowsWithEmpty.slice(0, -1) : rowsWithEmpty;
-      const lastRow = showAddRow ? rowsWithEmpty[rowsWithEmpty.length - 1] : null;
-
       const updatedOrder = [...reorderableRows];
       const [movedRow] = updatedOrder.splice(fromIndex, 1);
       if (!movedRow) {
@@ -177,14 +168,11 @@ const EditableTable = ({
         return;
       }
       updatedOrder.splice(toIndex, 0, movedRow);
-
-      // Preserve last row if it has any content
-      const finalOrder = lastRow && rowHasValue(lastRow) ? [...updatedOrder, lastRow] : updatedOrder;
-      onReorder({ updateReorderedItem: finalOrder.map((row) => row.uid) });
+      onReorder({ updateReorderedItem: updatedOrder.map((row) => row.uid) });
     }
     setDragStart(null);
     setHoveredRow(null);
-  }, [onReorder, rowsWithEmpty, showAddRow, rowHasValue]);
+  }, [onReorder, rowsWithEmpty, showAddRow]);
 
   const handleDragEnd = useCallback(() => {
     setDragStart(null);


### PR DESCRIPTION
### Description

 - Fixes crash when dragging query parameter rows with value but no name. 
 - Fixes #6909

### Problem

When a user has a query param row with only a value (no name) and tries to reorder rows, the app crashes with:
`TypeError: Cannot read properties of undefined (reading 'uid')`

### Changes

- Added validation to check if `movedRow` exists before accessing its properties


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors during drag-and-drop reordering by safely handling cases where the dragged row is missing, ensuring the table's drag state resets cleanly.
  * Improved stability of row reordering operations to avoid unintended behavior on edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->