### PR TITLE
update redux state to keep currently active script tab in state

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -63,6 +63,7 @@ export const tabsSlice = createSlice({
           responsePaneTab: 'response',
           responseFormat: null,
           responseViewTab: null,
+          scriptPaneTab: null,
           type: type || 'request',
           preview: preview !== undefined
             ? preview
@@ -85,6 +86,7 @@ export const tabsSlice = createSlice({
         responsePaneScrollPosition: null,
         responseFormat: null,
         responseViewTab: null,
+        scriptPaneTab: null,
         type: type || 'request',
         ...(uid ? { folderUid: uid } : {}),
         preview: preview !== undefined
@@ -169,6 +171,13 @@ export const tabsSlice = createSlice({
 
       if (tab) {
         tab.responseViewTab = action.payload.responseViewTab;
+      }
+    },
+    updateScriptPaneTab: (state, action) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+
+      if (tab) {
+        tab.scriptPaneTab = action.payload.scriptPaneTab;
       }
     },
     closeTabs: (state, action) => {
@@ -264,6 +273,7 @@ export const {
   updateResponsePaneScrollPosition,
   updateResponseFormat,
   updateResponseViewTab,
+  updateScriptPaneTab,
   closeTabs,
   closeAllCollectionTabs,
   makeTabPermanent,


### PR DESCRIPTION
### Description

#### Problem
When switching between requests with Pre Request and Post Response scripts, the active tab would always reset to Pre Request (or Post Response if Pre Request was empty) instead of remembering which tab you were viewing.

#### Root Cause
The Script component was unmounting and remounting when switching between requests (since it's part of HttpRequestPane's dynamic tab panels).

#### Solution
Store the script tab state in Redux, similar to how the main requestPaneTab is stored. This persists the tab selection across component mount/unmount cycles.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
#6945 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Script pane tab now persists reliably when switching between requests—your selected pre-request or post-response tab is retained.
* **New Behavior**
  * When no tab is explicitly set, the editor defaults to the pre-request tab if a pre-request script exists, otherwise it shows the post-response tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->