### PR TITLE
fix: ensure terminal gains focus upon opening in the console tab

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/TerminalTab/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/TerminalTab/index.js
@@ -174,6 +174,7 @@ const openTerminalIntoContainer = async (container, sessionId) => {
   await new Promise((resolve) => setTimeout(resolve, 50));
   try {
     fitAddon.fit();
+    terminal.focus();
     const { cols, rows } = terminal;
     if (cols && rows && window.ipcRenderer) {
       window.ipcRenderer.send('terminal:resize', sessionId, { cols, rows });


### PR DESCRIPTION
### Description

- Fix terminal not receiving keyboard focus when opening the Console tab
- Add terminal.focus() call after fitting the terminal to ensure immediate input readiness

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal focus behavior: the terminal now automatically receives input focus when opened in a container, improving user experience and accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->