### PR TITLE
feat: enable comments within grpc body

### DIFF
--- a/packages/bruno-electron/tests/network/prepare-grpc-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-grpc-request.spec.js
@@ -91,4 +91,201 @@ describe('prepare-grpc-request: prepareGrpcRequest', () => {
       expect(result.headers).toEqual({});
     });
   });
+
+  describe('Body comment stripping', () => {
+    beforeEach(() => {
+      mockItem.request.body = {
+        mode: 'grpc',
+        grpc: []
+      };
+    });
+
+    describe('Single-line comments (//) ', () => {
+      it('should strip end-of-line comment', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  "name": "test" // This is a comment\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(result.body.grpc[0].content).not.toContain('//');
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test' });
+      });
+
+      it('should strip comment on its own line', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  // Comment on its own line\n  "name": "test"\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test' });
+      });
+
+      it('should strip multiple single-line comments', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  // First comment\n  "name": "test", // inline comment\n  // Another comment\n  "age": 30\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test', age: 30 });
+      });
+
+      it('should preserve URLs containing // in string values', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  "url": "https://example.com/path" // comment\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ url: 'https://example.com/path' });
+      });
+    });
+
+    describe('Multi-line comments (/* */)', () => {
+      it('should strip inline multi-line comment', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  "name": /* comment */ "test"\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test' });
+      });
+
+      it('should strip multi-line comment spanning multiple lines', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  "name": "test",\n  /* This is a\n     multi-line\n     comment */\n  "age": 30\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test', age: 30 });
+      });
+
+      it('should strip block comment at end of line', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  "name": "test" /* end comment */\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test' });
+      });
+    });
+
+    describe('Mixed comment types', () => {
+      it('should strip both single-line and multi-line comments', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  // Single line comment\n  "name": "test", /* block comment */\n  "age": 30 // another single line\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test', age: 30 });
+      });
+
+      it('should handle nested-looking comments correctly', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  "name": "test" /* comment with // inside */\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test' });
+      });
+    });
+
+    describe('Multiple messages', () => {
+      it('should handle multiple messages with different comment styles', async () => {
+        mockItem.request.body.grpc = [
+          { name: 'msg1', content: '{"key": "value1"} // single-line comment' },
+          { name: 'msg2', content: '{"key": "value2"} /* block comment */' },
+          { name: 'msg3', content: '{\n  // comment\n  "key": "value3"\n}' }
+        ];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ key: 'value1' });
+        expect(JSON.parse(result.body.grpc[1].content)).toEqual({ key: 'value2' });
+        expect(JSON.parse(result.body.grpc[2].content)).toEqual({ key: 'value3' });
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should handle empty or null content gracefully', async () => {
+        mockItem.request.body.grpc = [
+          { name: 'msg1', content: null },
+          { name: 'msg2', content: '' },
+          { name: 'msg3', content: '{"valid": true}' }
+        ];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(result.body.grpc[0].content).toBeNull();
+        expect(result.body.grpc[1].content).toBe('');
+        expect(JSON.parse(result.body.grpc[2].content)).toEqual({ valid: true });
+      });
+
+      it('should pass through standard JSON unchanged', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{"name": "test", "age": 30}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ name: 'test', age: 30 });
+      });
+
+      it('should handle comment-only content gracefully', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '// just a comment'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        // After stripping comment, content should be empty/whitespace
+        expect(result.body.grpc[0].content.trim()).toBe('');
+      });
+
+      it('should handle deeply nested objects with comments', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  "user": {\n    // User details\n    "name": "test",\n    "address": {\n      "city": "NYC" /* primary city */\n    }\n  }\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({
+          user: {
+            name: 'test',
+            address: { city: 'NYC' }
+          }
+        });
+      });
+
+      it('should handle arrays with comments', async () => {
+        mockItem.request.body.grpc = [{
+          name: 'message1',
+          content: '{\n  "items": [\n    "item1", // first item\n    "item2" /* second item */\n  ]\n}'
+        }];
+
+        const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+        expect(JSON.parse(result.body.grpc[0].content)).toEqual({ items: ['item1', 'item2'] });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #5843

- Support comments within gRPC body

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * gRPC request bodies now support comments (single-line `//` and multi-line `/* */`), which are automatically stripped before sending.

* **Tests**
  * Added comprehensive end-to-end and unit tests for comment handling in gRPC requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->