### PR TITLE
fix: use secure file permissions (0o600) for environment files

### DIFF
--- a/packages/bruno-electron/src/store/workspace-environments.js
+++ b/packages/bruno-electron/src/store/workspace-environments.js
@@ -3,7 +3,7 @@ const path = require('path');
 const _ = require('lodash');
 const yaml = require('js-yaml');
 const { parseEnvironment, stringifyEnvironment } = require('@usebruno/filestore');
-const { writeFile, createDirectory } = require('../utils/filesystem');
+const { writeFile, createDirectory, SECURE_FILE_MODE, SECURE_DIR_MODE } = require('../utils/filesystem');
 const { generateUidBasedOnHash, uuid } = require('../utils/common');
 const { decryptStringSafe } = require('../utils/encryption');
 const EnvironmentSecretsStore = require('./env-secrets');
@@ -180,7 +180,7 @@ class GlobalEnvironmentsManager {
       const environmentsDir = this.getEnvironmentsDir(workspacePath);
 
       if (!fs.existsSync(environmentsDir)) {
-        await createDirectory(environmentsDir);
+        await createDirectory(environmentsDir, SECURE_DIR_MODE);
       }
 
       const environmentFilePath = this.getEnvironmentFilePath(workspacePath, name);
@@ -199,7 +199,7 @@ class GlobalEnvironmentsManager {
       }
 
       const content = await stringifyEnvironment(environment, { format: 'yml' });
-      await writeFile(environmentFilePath, content);
+      await writeFile(environmentFilePath, content, false, SECURE_FILE_MODE);
 
       return {
         uid: generateUidBasedOnHash(environmentFilePath),
@@ -233,7 +233,7 @@ class GlobalEnvironmentsManager {
       }
 
       const content = await stringifyEnvironment(environment, { format: 'yml' });
-      await writeFile(envFile.filePath, content);
+      await writeFile(envFile.filePath, content, false, SECURE_FILE_MODE);
 
       return true;
     } catch (error) {
@@ -264,7 +264,7 @@ class GlobalEnvironmentsManager {
       environment.name = newName;
 
       const content = await stringifyEnvironment(environment, { format: 'yml' });
-      await writeFile(newFilePath, content);
+      await writeFile(newFilePath, content, false, SECURE_FILE_MODE);
 
       if (this.envHasSecrets(environment)) {
         const oldEnv = { name: oldName };

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -17,6 +17,12 @@ const DEFAULT_GITIGNORE = [
   'Thumbs.db'
 ].join('\n');
 
+// Secure file permissions for environment files (owner read/write only)
+// These protect sensitive credentials from being world-readable
+// Note: mode is ignored on Windows, which uses ACLs instead
+const SECURE_FILE_MODE = 0o600;
+const SECURE_DIR_MODE = 0o700;
+
 const exists = async (p) => {
   try {
     await fsPromises.access(p);
@@ -93,11 +99,15 @@ function normalizeWSLPath(pathname) {
   return pathname.replace(/^\/wsl.localhost/, '\\\\wsl.localhost').replace(/\//g, '\\');
 }
 
-const writeFile = async (pathname, content, isBinary = false) => {
+const writeFile = async (pathname, content, isBinary = false, mode = null) => {
   try {
-    await safeWriteFile(pathname, content, {
+    const options = {
       encoding: !isBinary ? 'utf-8' : null
-    });
+    };
+    if (mode !== null) {
+      options.mode = mode;
+    }
+    await safeWriteFile(pathname, content, options);
   } catch (err) {
     console.error(`Error writing file at ${pathname}:`, err);
     return Promise.reject(err);
@@ -125,7 +135,7 @@ const hasRequestExtension = (filename, format = null) => {
   return ['bru', 'yml'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
 };
 
-const createDirectory = async (dir) => {
+const createDirectory = async (dir, mode = null) => {
   if (!dir) {
     throw new Error(`directory: path is null`);
   }
@@ -134,7 +144,8 @@ const createDirectory = async (dir) => {
     throw new Error(`directory: ${dir} already exists`);
   }
 
-  return fs.mkdirSync(dir);
+  const options = mode !== null ? { mode } : undefined;
+  return fs.mkdirSync(dir, options);
 };
 
 const browseDirectory = async (win) => {
@@ -357,9 +368,9 @@ async function safeWriteFile(filePath, data, options) {
   }
 }
 
-function safeWriteFileSync(filePath, data) {
+function safeWriteFileSync(filePath, data, options = {}) {
   const safePath = getSafePathToWrite(filePath);
-  fs.writeFileSync(safePath, data);
+  fs.writeFileSync(safePath, data, options);
 }
 
 // Recursively copies a source <file/directory> to a destination <directory>.
@@ -469,6 +480,8 @@ const isCollectionRootBruFile = (pathname, collectionPath) => {
 
 module.exports = {
   DEFAULT_GITIGNORE,
+  SECURE_FILE_MODE,
+  SECURE_DIR_MODE,
   isValidPathname,
   exists,
   isSymbolicLink,


### PR DESCRIPTION
## Summary

- Environment files created with 0o600 permissions (owner read/write only)
- Environment directories created with 0o700 permissions
- Protects sensitive credentials from being world-readable on shared systems

## Changes

- Added `SECURE_FILE_MODE` and `SECURE_DIR_MODE` constants to filesystem.js
- Updated `writeFile()`, `createDirectory()`, `safeWriteFileSync()` to accept optional mode param
- Applied secure permissions to all environment file operations:
  - Global environment create/save/rename
  - Collection environment create/save
  - Environment export (folder, single-file, single-object formats)
  - Collection import with environments

## Platform Notes

The mode parameter is ignored on Windows, which uses ACLs instead of Unix permissions. This is standard Node.js behavior and requires no conditional logic.

## Test Plan

- [ ] Create a new environment on Linux/macOS and verify file permissions are 600
- [ ] Create environments directory and verify permissions are 700
- [ ] Export environments and verify exported files have 600 permissions
- [ ] Import a collection with environments and verify permissions
- [ ] Verify existing functionality works on Windows (mode param is safely ignored)

Closes #2016

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented secure file system permissions for all file and directory creation operations, improving data protection across collections, environments, and workspace management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->