### PR TITLE
fix: refocus search bar in code editor on Ctrl/Cmd +  F 

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -310,7 +310,10 @@ export default class CodeEditor extends React.Component {
         fontSize={this.props.fontSize}
       >
         <CodeMirrorSearch
-          ref={this.searchBarRef}
+          ref={(node) => {
+            if (!node) return;
+            this.searchBarRef.current = node;
+          }}
           visible={this.state.searchBarVisible}
           editor={this.editor}
           onClose={() => this.setState({ searchBarVisible: false })}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -111,7 +111,6 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     focus: () => {
       if (inputRef.current) {
         inputRef.current.focus();
-        inputRef.current.select();
       }
     }
   }));


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Fixes : #6930

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cmd-F/Ctrl-F opens the search bar and automatically focuses the input for immediate typing.
  * Search input now reliably receives focus so keyboard navigation and typing work immediately.

* **Bug Fixes**
  * Closing the search bar returns focus to the editor to prevent lost keyboard input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->