### PR TITLE
fix: ensure app gains focus when restoring main window

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -93,6 +93,7 @@ let appProtocolUrl;
 // Helper function to focus and restore the main window
 const focusMainWindow = () => {
   if (mainWindow) {
+    app.focus({ steal: true });
     if (mainWindow.isMinimized()) {
       mainWindow.restore();
     }


### PR DESCRIPTION
[jira](https://usebruno.atlassian.net/browse/BRU-2569)

### Description

Add `app.focus({ steal: true })` before restoring the window to ensure the application properly gains focus when activated.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window focus behavior when bringing the application to the front.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->