### PR TITLE
fix: cache system proxy

### DIFF
--- a/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { IconLoader2 } from '@tabler/icons';
-import { getSystemProxyVariables } from 'providers/ReduxStore/slices/app';
+import { IconLoader2, IconRefresh } from '@tabler/icons';
+import { getSystemProxyVariables, refreshSystemProxy } from 'providers/ReduxStore/slices/app';
 import StyledWrapper from '../StyledWrapper';
 
 const SystemProxy = () => {
@@ -11,12 +11,23 @@ const SystemProxy = () => {
   const [isFetching, setIsFetching] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    dispatch(getSystemProxyVariables())
+  const fetchProxy = (forceRefresh = false) => {
+    setIsFetching(true);
+    setError(null);
+    const action = forceRefresh ? refreshSystemProxy : getSystemProxyVariables;
+    dispatch(action())
       .then(() => setError(null))
       .catch((err) => setError(err.message || String(err)))
       .finally(() => setIsFetching(false));
+  };
+
+  useEffect(() => {
+    fetchProxy(false);
   }, [dispatch]);
+
+  const handleRefresh = () => {
+    fetchProxy(true);
+  };
 
   return (
     <StyledWrapper>
@@ -24,8 +35,8 @@ const SystemProxy = () => {
         <div className="flex items-start justify-start flex-col gap-2 mt-2">
           <div className="flex flex-row items-center gap-2">
             <div>
-              <h2 className="text-xs system-proxy-title">
-                System Proxy {isFetching ? <IconLoader2 className="animate-spin ml-1" size={18} strokeWidth={1.5} /> : null}
+              <h2 className="text-xs system-proxy-title flex flex-row">
+                System Proxy {isFetching ? <IconLoader2 className="animate-spin ml-1" size={16} strokeWidth={1.5} /> : null}
               </h2>
               <small className="system-proxy-description">
                 Below values are sourced from your system proxy settings.
@@ -75,6 +86,13 @@ const SystemProxy = () => {
             <div className="system-proxy-value">{no_proxy || '-'}</div>
           </div>
         </div>
+        <span
+          className="text-link cursor-pointer hover:underline default-collection-location-browse flex flex-row items-center"
+          onClick={handleRefresh}
+        >
+          <IconRefresh size={14} strokeWidth={1.5} className="mr-1" />
+          Refresh
+        </span>
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -248,4 +248,16 @@ export const getSystemProxyVariables = () => (dispatch, getState) => {
   });
 };
 
+export const refreshSystemProxy = () => (dispatch, getState) => {
+  return new Promise((resolve, reject) => {
+    const { ipcRenderer } = window;
+    ipcRenderer.invoke('renderer:refresh-system-proxy')
+      .then((variables) => {
+        dispatch(updateSystemProxyVariables(variables));
+        return variables;
+      })
+      .then(resolve).catch(reject);
+  });
+};
+
 export default appSlice.reducer;

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -18,6 +18,7 @@ const constants = require('../constants');
 const { findItemInCollection, createCollectionJsonFromPathname, getCallStack, FORMAT_CONFIG } = require('../utils/collection');
 const { hasExecutableTestInScript } = require('../utils/request');
 const { createSkippedFileResults } = require('../utils/run');
+const { getSystemProxy } = require('@usebruno/requests');
 const command = 'run [paths...]';
 const desc = 'Run one or more requests/folders';
 
@@ -607,6 +608,15 @@ const handler = async function (argv) {
     });
 
     const runtime = getJsSandboxRuntime(sandbox);
+
+    // Fetch system proxy once for all requests (skip if --noproxy flag is set)
+    if (!noproxy) {
+      try {
+        options['cachedSystemProxy'] = await getSystemProxy();
+      } catch (error) {
+        console.warn(chalk.yellow('Failed to detect system proxy, continuing without system proxy'));
+      }
+    }
 
     const runSingleRequestByPathname = async (relativeItemPathname) => {
       const ext = FORMAT_CONFIG[collection.format].ext;

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -171,6 +171,12 @@ app.on('ready', async () => {
     }
   }
 
+  // Initialize system proxy cache early (non-blocking)
+  const { initializeSystemProxy } = require('./store/system-proxy');
+  initializeSystemProxy().catch((err) => {
+    console.warn('Failed to initialize system proxy cache:', err);
+  });
+
   Menu.setApplicationMenu(menu);
   const { maximized, x, y, width, height } = loadWindowState();
 

--- a/packages/bruno-electron/src/ipc/network/cert-utils.js
+++ b/packages/bruno-electron/src/ipc/network/cert-utils.js
@@ -1,9 +1,10 @@
 const fs = require('node:fs');
 const path = require('path');
 const { get } = require('lodash');
-const { getCACertificates, getSystemProxy } = require('@usebruno/requests');
+const { getCACertificates } = require('@usebruno/requests');
 const { preferencesUtil } = require('../../store/preferences');
 const { getBrunoConfig } = require('../../store/bruno-config');
+const { getCachedSystemProxy } = require('../../store/system-proxy');
 const { interpolateString } = require('./interpolate-string');
 
 /**
@@ -142,10 +143,10 @@ const getCertsAndProxyConfig = async ({
       proxyConfig = globalProxyConfigData;
       proxyMode = 'on';
     } else if (!globalDisabled && globalInherit) {
-      // Use system proxy
+      // Use system proxy (cached at app startup)
       proxyMode = 'system';
-      const systemProxyConfig = await getSystemProxy();
-      proxyConfig = systemProxyConfig;
+      const systemProxyConfig = getCachedSystemProxy();
+      proxyConfig = systemProxyConfig || { http_proxy: null, https_proxy: null, no_proxy: null, source: 'cache-miss' };
     }
     // else: global proxy is disabled, proxyMode stays 'off'
   }

--- a/packages/bruno-electron/src/ipc/preferences.js
+++ b/packages/bruno-electron/src/ipc/preferences.js
@@ -1,7 +1,7 @@
 const { ipcMain, nativeTheme } = require('electron');
 const { getPreferences, savePreferences } = require('../store/preferences');
 const { globalEnvironmentsStore } = require('../store/global-environments');
-const { getSystemProxy } = require('@usebruno/requests');
+const { getCachedSystemProxy, refreshSystemProxy } = require('../store/system-proxy');
 
 const registerPreferencesIpc = (mainWindow) => {
   ipcMain.handle('renderer:ready', async (event) => {
@@ -40,8 +40,17 @@ const registerPreferencesIpc = (mainWindow) => {
   });
 
   ipcMain.handle('renderer:get-system-proxy-variables', async () => {
-    const systemProxyConfig = await getSystemProxy();
-    return systemProxyConfig;
+    // Return cached value (initialized at app startup)
+    const cachedProxy = getCachedSystemProxy();
+    if (cachedProxy) {
+      return cachedProxy;
+    }
+    // Fallback: refresh if cache is empty (shouldn't happen normally)
+    return await refreshSystemProxy();
+  });
+
+  ipcMain.handle('renderer:refresh-system-proxy', async () => {
+    return await refreshSystemProxy();
   });
 };
 

--- a/packages/bruno-electron/src/store/system-proxy.js
+++ b/packages/bruno-electron/src/store/system-proxy.js
@@ -1,0 +1,39 @@
+const { getSystemProxy } = require('@usebruno/requests');
+
+let cachedSystemProxy = null;
+
+const initializeSystemProxy = async () => {
+  try {
+    cachedSystemProxy = await getSystemProxy();
+    return cachedSystemProxy;
+  } catch (error) {
+    console.error('Failed to initialize system proxy:', error);
+    cachedSystemProxy = {
+      http_proxy: null,
+      https_proxy: null,
+      no_proxy: null,
+      source: 'error'
+    };
+    return cachedSystemProxy;
+  }
+};
+
+const refreshSystemProxy = async () => {
+  try {
+    cachedSystemProxy = await getSystemProxy();
+    return cachedSystemProxy;
+  } catch (error) {
+    console.error('Failed to refresh system proxy:', error);
+    throw error;
+  }
+};
+
+const getCachedSystemProxy = () => {
+  return cachedSystemProxy;
+};
+
+module.exports = {
+  initializeSystemProxy,
+  refreshSystemProxy,
+  getCachedSystemProxy
+};


### PR DESCRIPTION
[jira](https://usebruno.atlassian.net/browse/BRU-1315)

### Description

- `bruno-cli`: fetch system proxy once before request loop and store in options
- `bruno-electron`: initialize system proxy cache at app startup
- Add refresh button in preferences to manually update cached system proxy
- Replace per-request `getSystemProxy()` calls with cached values

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual refresh button in System Proxy settings to allow users to update proxy configuration without restarting the application.

* **Performance Improvements**
  * System proxy configuration is now cached at application startup, reducing unnecessary proxy lookups during network requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->