### PR TITLE
fix(ws): prevent duplicate WebSocket connect attempts

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
@@ -62,18 +62,19 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
 
   useEffect(() => {
     if (
-      connectionStatus === CONNECTION_STATUS.CONNECTED ||
-      connectionStatus === CONNECTION_STATUS.DISCONNECTED
+      connectionStatus === CONNECTION_STATUS.CONNECTED
+      || connectionStatus === CONNECTION_STATUS.DISCONNECTED
     ) {
       connectAttemptRef.current = false;
     }
   }, [connectionStatus]);
 
-  const handleConnect = async () => {
+  const handleConnect = async (e, skipGuard = false) => {
     if (
-      connectionStatus === CONNECTION_STATUS.CONNECTED ||
-      connectionStatus === CONNECTION_STATUS.CONNECTING ||
-      connectAttemptRef.current
+      !skipGuard
+      && (connectionStatus === CONNECTION_STATUS.CONNECTED
+        || connectionStatus === CONNECTION_STATUS.CONNECTING
+        || connectAttemptRef.current)
     ) {
       toast.error('WebSocket is already connected or connecting');
       return;
@@ -100,9 +101,10 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
   const handleReconnect = async (e) => {
     e && e.stopPropagation();
     try {
+      connectAttemptRef.current = false;
       handleDisconnect(e, false);
       setTimeout(() => {
-        handleConnect(e, false);
+        handleConnect(e, true);
       }, 2000);
     } catch (err) {
       console.error('Failed to re-connect WebSocket connection', err);


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate WebSocket connection attempts by blocking new connects when a connection is active or already starting; blocked attempts show a clear error toast.
  * Improved reconnection flow: automatic reconnects reliably reset attempt state, include a short delay, bypass the usual guard, and update status to CONNECTING so reconnects proceed consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->