### PR TITLE
fix: parsing dates from insomnia

### DIFF
--- a/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
+++ b/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
@@ -301,7 +301,7 @@ const parseInsomniaCollection = (data) => {
 export const insomniaToBruno = (insomniaCollection) => {
   try {
     if (typeof insomniaCollection !== 'object') {
-      insomniaCollection = jsyaml.load(insomniaCollection);
+      insomniaCollection = jsyaml.load(insomniaCollection, { schema: jsyaml.JSON_SCHEMA });
     }
     let collection;
     if (isInsomniaV5Export(insomniaCollection)) {

--- a/packages/bruno-converters/tests/insomnia/insomnia-collection-v5.spec.js
+++ b/packages/bruno-converters/tests/insomnia/insomnia-collection-v5.spec.js
@@ -33,6 +33,9 @@ collection:
           isPrivate: false
           sortKey: -1744194421965
         method: GET
+        parameters:
+          - name: date
+            value: 2022-10-28
         settings:
           renderRequestBody: true
           encodeUrl: true
@@ -127,7 +130,14 @@ const expectedOutput = {
             },
             headers: [],
             method: 'GET',
-            params: [],
+            params: [
+              {
+                enabled: true,
+                name: 'date',
+                type: 'query',
+                value: '2022-10-28'
+              }
+            ],
             url: 'https://testbench-sanity.usebruno.com/ping'
           },
           seq: 1,


### PR DESCRIPTION
js-yaml uses DEFAULT_SCHEMA by default and implicitly casts date-like strings to Date (timestamp). This caused unexpected config values where dates were supposed to remain plain strings.

Switched YAML parsing to JSON_SCHEMA to disable timestamp resolution and keep date-like values as strings.

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for Insomnia collection imports with stricter YAML/schema enforcement to reduce parsing errors and better handle malformed inputs.

* **New Features**
  * Query parameters from Insomnia collections are now correctly extracted and converted to Bruno format during import, preserving request parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->