### PR TITLE
fix: YML parsing and stringification to support post-response variables

### DIFF
--- a/packages/bruno-filestore/src/formats/yml/parseCollection.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseCollection.ts
@@ -4,6 +4,7 @@ import { parseYml } from './utils';
 import { toBrunoAuth } from './common/auth';
 import { toBrunoHttpHeaders } from './common/headers';
 import { toBrunoVariables } from './common/variables';
+import { toBrunoPostResponseVariables } from './common/actions';
 import { toBrunoScripts } from './common/scripts';
 import { ensureString } from '../../utils';
 
@@ -160,7 +161,11 @@ const parseCollection = (ymlString: string): ParsedCollection => {
 
       // variables
       const variables = toBrunoVariables(oc.request.variables);
-      collectionRoot.request.vars = variables;
+      const postResponseVars = toBrunoPostResponseVariables((oc.request as any).actions);
+      collectionRoot.request.vars = {
+        req: variables.req,
+        res: postResponseVars
+      };
 
       // scripts
       const scripts = toBrunoScripts(oc.request.scripts);

--- a/packages/bruno-filestore/src/formats/yml/parseFolder.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseFolder.ts
@@ -4,6 +4,7 @@ import { parseYml } from './utils';
 import { toBrunoAuth } from './common/auth';
 import { toBrunoHttpHeaders } from './common/headers';
 import { toBrunoVariables } from './common/variables';
+import { toBrunoPostResponseVariables } from './common/actions';
 import { toBrunoScripts } from './common/scripts';
 import { ensureString } from '../../utils';
 
@@ -52,7 +53,11 @@ const parseFolder = (ymlString: string): FolderRoot => {
 
       // variables
       const variables = toBrunoVariables(ocFolder.request.variables);
-      folderRoot.request.vars = variables;
+      const postResponseVars = toBrunoPostResponseVariables((ocFolder.request as any).actions);
+      folderRoot.request.vars = {
+        req: variables.req,
+        res: postResponseVars
+      };
 
       // scripts
       const scripts = toBrunoScripts(ocFolder.request.scripts);

--- a/packages/bruno-filestore/src/formats/yml/stringifyCollection.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyCollection.ts
@@ -3,11 +3,13 @@ import type { ProtoFileItem, ProtoFileImportPath } from '@opencollection/types/c
 import type { HttpRequestHeader } from '@opencollection/types/requests/http';
 import type { ClientCertificate, PemCertificate, Pkcs12Certificate } from '@opencollection/types/config/certificates';
 import type { Variable } from '@opencollection/types/common/variables';
+import type { Action } from '@opencollection/types/common/actions';
 import type { Scripts } from '@opencollection/types/common/scripts';
 import { stringifyYml } from './utils';
 import { toOpenCollectionAuth } from './common/auth';
 import { toOpenCollectionHttpHeaders } from './common/headers';
 import { toOpenCollectionVariables } from './common/variables';
+import { toOpenCollectionActions } from './common/actions';
 import { toOpenCollectionScripts } from './common/scripts';
 import type { Auth } from '@opencollection/types/common/auth';
 
@@ -39,6 +41,7 @@ const hasRequestDefaults = (collectionRoot: any): boolean => {
 
   return Boolean((requestRoot?.headers?.length)
     || (requestRoot?.vars?.req?.length)
+    || (requestRoot?.vars?.res?.length)
     || hasRequestScripts(collectionRoot)
     || hasRequestAuth(collectionRoot));
 };
@@ -175,6 +178,14 @@ const stringifyCollection = (collectionRoot: any, brunoConfig: any): string => {
         const ocVariables: Variable[] | undefined = toOpenCollectionVariables(collectionRoot.request?.vars);
         if (ocVariables) {
           oc.request.variables = ocVariables;
+        }
+      }
+
+      // actions (post-response variables)
+      if (collectionRoot.request?.vars?.res?.length) {
+        const ocActions: Action[] | undefined = toOpenCollectionActions(collectionRoot.request?.vars?.res);
+        if (ocActions) {
+          (oc.request as any).actions = ocActions;
         }
       }
 

--- a/packages/bruno-filestore/src/formats/yml/stringifyFolder.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyFolder.ts
@@ -1,6 +1,7 @@
 import type { FolderRoot } from '@usebruno/schema-types/collection/folder';
 import type { Folder, FolderInfo } from '@opencollection/types/collection/item';
 import type { Variable } from '@opencollection/types/common/variables';
+import type { Action } from '@opencollection/types/common/actions';
 import type { Scripts } from '@opencollection/types/common/scripts';
 import type { Auth } from '@opencollection/types/common/auth';
 import type { HttpRequestHeader } from '@opencollection/types/requests/http';
@@ -8,6 +9,7 @@ import type { RequestDefaults } from '@opencollection/types/common/request-defau
 import { toOpenCollectionAuth } from './common/auth';
 import { toOpenCollectionHttpHeaders } from './common/headers';
 import { toOpenCollectionVariables } from './common/variables';
+import { toOpenCollectionActions } from './common/actions';
 import { toOpenCollectionScripts } from './common/scripts';
 import { stringifyYml } from './utils';
 
@@ -16,6 +18,7 @@ const hasRequestDefaults = (folderRoot: FolderRoot): boolean => {
 
   return Boolean((requestDefaults?.headers?.length)
     || (requestDefaults?.vars?.req?.length)
+    || (requestDefaults?.vars?.res?.length)
     || hasRequestScripts(folderRoot)
     || hasRequestAuth(folderRoot));
 };
@@ -67,6 +70,14 @@ const stringifyFolder = (folderRoot: FolderRoot): string => {
         const ocVariables: Variable[] | undefined = toOpenCollectionVariables(folderRoot.request?.vars);
         if (ocVariables) {
           ocFolder.request.variables = ocVariables;
+        }
+      }
+
+      // actions (post-response variables)
+      if (folderRoot.request?.vars?.res?.length) {
+        const ocActions: Action[] | undefined = toOpenCollectionActions(folderRoot.request?.vars?.res);
+        if (ocActions) {
+          (ocFolder.request as any).actions = ocActions;
         }
       }
 


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post-response variables are now properly integrated into the request variables structure with separate request and response scopes for improved organization and accessibility across collections and folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->