### PR TITLE
fix: update sidebar item copy toast message

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -535,7 +535,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   const handleCopyItem = () => {
     dispatch(copyRequest(item));
     const itemType = isFolder ? 'Folder' : 'Request';
-    toast.success(`${itemType} copied to clipboard`);
+    toast.success(`${itemType} copied`);
   };
 
   const handlePasteItem = () => {

--- a/tests/request/copy-request/keyboard-shortcuts.spec.ts
+++ b/tests/request/copy-request/keyboard-shortcuts.spec.ts
@@ -34,7 +34,7 @@ test.describe('Copy and Paste with Keyboard Shortcuts', () => {
     await page.keyboard.press(`${modifier}+KeyC`);
 
     // Verify copy success (toast message)
-    await expect(page.getByText(/copied to clipboard/i).first()).toBeVisible();
+    await expect(page.getByText(/Request copied/i).first()).toBeVisible();
 
     // Focus the collection to paste
     await collection.click();
@@ -75,7 +75,7 @@ test.describe('Copy and Paste with Keyboard Shortcuts', () => {
     await page.keyboard.press(`${modifier}+KeyC`);
 
     // Verify copy success
-    await expect(page.getByText(/copied to clipboard/i).first()).toBeVisible();
+    await expect(page.getByText(/Folder copied/i).first()).toBeVisible();
 
     // Focus the collection to paste
     await collection.click();


### PR DESCRIPTION
### Description

Update the sidebar item copy toast message from 'Request/Folder copied to clipboard' to 'Request/Folder copied'. 

Fixes #6997

### Changes
- "Request copied" (when copying a request)
- "Folder copied" (when copying a folder)

### Screenshot
<img width="1001" height="478" alt="Screenshot 2026-02-02 at 3 56 31 PM" src="https://github.com/user-attachments/assets/f7a187b9-4445-4744-ac5e-0378b66ff220" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated copy action notifications to display clearer, more concise messages when copying requests and folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->