### PR TITLE
fix: enhance error handling and status reporting in runSingleRequest

### DIFF
--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -622,7 +622,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             () => props.res.summary.failedTests + props.res.summary.failedAssertions
           );
           const summarySkippedRequests = computed(() => props?.res?.summary?.skippedRequests || 0);
-          const summaryErrors = computed(() => props?.res?.results?.filter((r) => r.error || r.status === 'error').length) || 0;
+          const summaryErrors = computed(() => props?.res?.results?.filter((r) => r.status === 'error').length) || 0;
           const totalRunDuration = computed(() => props.res?.results?.reduce((total, result) => result.runDuration + total, 0));
           const iterationIndex = Number(props.res.iterationIndex) + 1;
           return {
@@ -649,6 +649,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
               return props?.res?.results?.filter(
                 (r) =>
                   r.status === 'error' ||
+                  r.status === 'fail' ||
                   !!r?.testResults?.find((t) => t.status !== 'pass') ||
                   !!r?.assertionResults?.find((t) => t.status !== 'pass')
               );
@@ -757,7 +758,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             return (props?.result?.testResults?.length || 0) + (props?.result?.assertionResults?.length || 0);
           });
 
-          const hasError = computed(() => !!props?.result?.error || props?.result?.status === 'error' || (props?.result?.response?.status === 'skipped' && props?.result?.error));
+          const hasError = computed(() => !!props?.result?.error || props?.result?.status === 'error' || props?.result?.status === 'fail' || (props?.result?.response?.status === 'skipped' && props?.result?.error));
           const hasFailure = computed(() => total.value !== totalPassed.value);
           const testDuration = computed(() => Math.round(props?.result?.runDuration * 1000) + ' ms');
           const resultTitle = computed(() => props?.result?.path + ' ' + props?.result?.response?.status + ' ' + props?.result?.response?.statusText);

--- a/packages/bruno-common/src/runner/runner-summary.ts
+++ b/packages/bruno-common/src/runner/runner-summary.ts
@@ -67,9 +67,9 @@ export const getRunnerSummary = (results: T_RunnerRequestExecutionResult[]): T_R
       }
     }
 
-    if (!anyFailed && status !== 'error') {
+    if (!anyFailed && status !== 'error' && status !== 'fail') {
       passedRequests += 1;
-    } else if (anyFailed) {
+    } else if (anyFailed || status === 'fail') {
       failedRequests += 1;
     } else {
       errorRequests += 1;


### PR DESCRIPTION
Improvements on top of:  https://github.com/usebruno/bruno/pull/6261

**What's fixed:**
1. **Script errors no longer inflate test counts** – Pre/post/test script errors no longer show up as extra “failed tests”; they mark the request as failed/errored without being counted as tests.
2. **Pre-request errors = hard error** – Pre-request script failure stops execution and is reported as an “error,” not a “failure.”
3. **Real error messages in the report** – The report shows the actual script error text (e.g. syntax errors).
4. **Correct summary cards** – “Total errors” and “Total Failed Controls” now match the real state and stay consistent with “Total Controls.”