### PR TITLE
Fix oauth2 access token retrieval from collection when mTLS certificate is used

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1502,7 +1502,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             runtimeVariables,
             processEnvVars,
             collectionPath,
-            globalEnvironmentVariables
+            globalEnvironmentVariables,
+            originalRequestUrl: requestCopy.url
           });
         }
 
@@ -1528,7 +1529,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             runtimeVariables,
             processEnvVars,
             collectionPath,
-            globalEnvironmentVariables
+            globalEnvironmentVariables,
+            originalRequestUrl: requestCopy.url
           });
         }
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -185,7 +185,8 @@ const configureRequest = async (
         runtimeVariables,
         processEnvVars,
         collectionPath,
-        globalEnvironmentVariables
+        globalEnvironmentVariables,
+        originalRequestUrl: requestCopy.url
       });
     }
 
@@ -210,7 +211,8 @@ const configureRequest = async (
         runtimeVariables,
         processEnvVars,
         collectionPath,
-        globalEnvironmentVariables
+        globalEnvironmentVariables,
+        originalRequestUrl: requestCopy.url
       });
     }
 

--- a/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
@@ -60,7 +60,8 @@ const configureRequest = async (grpcRequest, request, collection, envVars, runti
         runtimeVariables,
         processEnvVars,
         collectionPath,
-        globalEnvironmentVariables
+        globalEnvironmentVariables,
+        originalRequestUrl: requestCopy.url
       });
     }
 
@@ -85,7 +86,8 @@ const configureRequest = async (grpcRequest, request, collection, envVars, runti
         runtimeVariables,
         processEnvVars,
         collectionPath,
-        globalEnvironmentVariables
+        globalEnvironmentVariables,
+        originalRequestUrl: requestCopy.url
       });
     }
 

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
@@ -121,7 +121,8 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
         runtimeVariables,
         processEnvVars,
         collectionPath: collection.pathname,
-        globalEnvironmentVariables: request.globalEnvironmentVariables
+        globalEnvironmentVariables: request.globalEnvironmentVariables,
+        originalRequestUrl: requestCopy.url
       });
     }
 
@@ -146,7 +147,8 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
         runtimeVariables,
         processEnvVars,
         collectionPath: collection.pathname,
-        globalEnvironmentVariables: request.globalEnvironmentVariables
+        globalEnvironmentVariables: request.globalEnvironmentVariables,
+        originalRequestUrl: requestCopy.url
       });
     }
 


### PR DESCRIPTION
### Description

Attempt to fix old bug https://github.com/usebruno/bruno/issues/3342
ATTENTION: this is vibe-code. Yet I've reviewed the code rigorously, and looks like the issue was identified correctly

#### Contribution Checklist:

- [X] **I've used AI significantly to create this pull request**
- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate and proxy resolution for OAuth2 authentication flows by considering the original request URL alongside the current request URL when selecting appropriate client certificates for token and refresh requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->