### PR TITLE
fix: code editor null value crash

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -235,7 +235,7 @@ export default class CodeEditor extends React.Component {
     if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
       const cursor = this.editor.getCursor();
       this.cachedValue = this.props.value;
-      this.editor.setValue(this.props.value);
+      this.editor.setValue(this.props.value ?? '');
       this.editor.setCursor(cursor);
     }
 


### PR DESCRIPTION
### Description

[JIRA](http://usebruno.atlassian.net/browse/BRU-2607)

 Fixed an issue where the app crashed when clearing all content in the documentation editor during autosave specifically in Yaml files. 

This happens in `yml` files since `docs` can be `null` in yaml and that isn't handled in the codeeditor right nwo
 
 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/5d632830-67d9-4ca4-b432-9489bb4ec6a7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code editor stability by properly handling null or undefined values while maintaining cursor position during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->