### PR TITLE
feat: add export command to bruno-cli

### DIFF
--- a/packages/bruno-cli/readme.md
+++ b/packages/bruno-cli/readme.md
@@ -96,6 +96,29 @@ Import Options:
 | --collection-name, -n     | Name for the imported collection                   |
 | --insecure                | Skip SSL certificate validation when fetching from URLs |
 
+## Exporting Collections
+
+You can export Bruno collections to other formats, such as Postman, using the export command:
+
+```bash
+bru export postman --collection ./my-collection --output ./collection.postman.json
+```
+
+You can also use the shorter form with aliases:
+
+```bash
+bru export postman -c ./my-collection -o ./collection.postman.json
+```
+
+This exports your Bruno collection (both `.bru` and OpenCollection `.yml` formats) to Postman v2.1.0 format.
+
+Export Options:
+
+| Option                    | Details                                            |
+| ------------------------- | -------------------------------------------------- |
+| --collection, -c          | Path to the Bruno collection directory (required)  |
+| --output, -o              | Path to the output file (required)                 |
+
 ## Command Line Options
 
 | Option                       | Details                                                                       |

--- a/packages/bruno-cli/src/commands/export.js
+++ b/packages/bruno-cli/src/commands/export.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+const { brunoToPostman } = require('@usebruno/converters');
+const { createCollectionJsonFromPathname } = require('../utils/collection');
+const constants = require('../constants');
+
+const command = 'export <format>';
+const desc = 'Export a Bruno collection to other formats';
+
+const builder = (yargs) => {
+  yargs
+    .positional('format', {
+      describe: 'Format to export to',
+      type: 'string',
+      choices: ['postman']
+    })
+    .option('collection', {
+      alias: 'c',
+      describe: 'Path to the Bruno collection directory',
+      type: 'string',
+      demandOption: true
+    })
+    .option('output', {
+      alias: 'o',
+      describe: 'Path to the output file',
+      type: 'string',
+      demandOption: true
+    })
+    .example('$0 export postman --collection ./my-collection --output ./collection.postman.json')
+    .example('$0 export postman -c ./my-collection -o ./collection.postman.json');
+};
+
+const cleanItems = (items) => {
+  return items.map((item) => {
+    if (item.type === 'folder') {
+      return { ...item, items: cleanItems(item.items) };
+    } else if (['http-request', 'graphql-request'].includes(item.type)) {
+      const cleaned = { ...item };
+      delete cleaned.items;
+      return cleaned;
+    }
+    return item;
+  });
+};
+
+const handler = async (argv) => {
+  try {
+    const { format, collection, output } = argv;
+
+    if (!format || format !== 'postman') {
+      console.error(chalk.red('Only Postman export is supported currently'));
+      process.exit(constants.EXIT_STATUS.ERROR_GENERIC);
+    }
+
+    const collectionPath = path.resolve(collection);
+
+    if (!fs.existsSync(collectionPath)) {
+      console.error(chalk.red(`Collection path does not exist: ${collectionPath}`));
+      process.exit(constants.EXIT_STATUS.ERROR_NOT_IN_COLLECTION);
+    }
+
+    console.log(chalk.yellow('Loading Bruno collection...'));
+    const brunoCollection = createCollectionJsonFromPathname(collectionPath);
+
+    // Clean up items - remove empty items array from requests
+    brunoCollection.items = cleanItems(brunoCollection.items);
+
+    console.log(chalk.yellow('Converting to Postman format...'));
+    const postmanCollection = brunoToPostman(brunoCollection);
+
+    const outputPath = path.resolve(output);
+    const outputDir = path.dirname(outputPath);
+
+    if (!fs.existsSync(outputDir)) {
+      console.error(chalk.red(`Output directory does not exist: ${outputDir}`));
+      process.exit(constants.EXIT_STATUS.ERROR_MISSING_OUTPUT_DIR);
+    }
+
+    console.log(chalk.yellow('Writing Postman collection...'));
+    fs.writeFileSync(outputPath, JSON.stringify(postmanCollection, null, 2));
+
+    console.log(chalk.green(`✓ Successfully exported to: ${outputPath}`));
+  } catch (error) {
+    console.error(chalk.red(`Error: ${error.message}`));
+    if (error.stack) {
+      console.error(chalk.gray(error.stack));
+    }
+    process.exit(constants.EXIT_STATUS.ERROR_GENERIC);
+  }
+};
+
+module.exports = {
+  command,
+  desc,
+  builder,
+  handler,
+  cleanItems
+};

--- a/packages/bruno-cli/tests/commands/export.spec.js
+++ b/packages/bruno-cli/tests/commands/export.spec.js
@@ -1,0 +1,79 @@
+const path = require('node:path');
+const fs = require('node:fs');
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const { handler, cleanItems } = require('../../src/commands/export');
+
+describe('export command', () => {
+  describe('cleanItems', () => {
+    it('should remove items array from http-request objects', () => {
+      const items = [
+        {
+          type: 'http-request',
+          name: 'Test Request',
+          items: [],
+          request: { method: 'GET' }
+        }
+      ];
+
+      const cleaned = cleanItems(items);
+
+      expect(cleaned[0]).not.toHaveProperty('items');
+      expect(cleaned[0]).toHaveProperty('name', 'Test Request');
+      expect(cleaned[0]).toHaveProperty('type', 'http-request');
+    });
+
+    it('should remove items array from graphql-request objects', () => {
+      const items = [
+        {
+          type: 'graphql-request',
+          name: 'Test GraphQL',
+          items: [],
+          request: { method: 'POST' }
+        }
+      ];
+
+      const cleaned = cleanItems(items);
+
+      expect(cleaned[0]).not.toHaveProperty('items');
+      expect(cleaned[0]).toHaveProperty('type', 'graphql-request');
+    });
+
+    it('should recursively clean items in folders', () => {
+      const items = [
+        {
+          type: 'folder',
+          name: 'Test Folder',
+          items: [
+            {
+              type: 'http-request',
+              name: 'Nested Request',
+              items: [],
+              request: { method: 'POST' }
+            }
+          ]
+        }
+      ];
+
+      const cleaned = cleanItems(items);
+
+      expect(cleaned[0]).toHaveProperty('items');
+      expect(cleaned[0].items[0]).not.toHaveProperty('items');
+      expect(cleaned[0].items[0]).toHaveProperty('name', 'Nested Request');
+    });
+
+    it('should preserve folder items array', () => {
+      const items = [
+        {
+          type: 'folder',
+          name: 'Test Folder',
+          items: []
+        }
+      ];
+
+      const cleaned = cleanItems(items);
+
+      expect(cleaned[0]).toHaveProperty('items');
+      expect(cleaned[0].items).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
### Description

As suggested here https://github.com/usebruno/bruno/issues/2679, it might be useful to export a Postman collection using the CLI. This PR can be a starting point

The command follows the existing CLI patterns as per `import` command:
- Leverages existing utilities (`createCollectionJsonFromPathname`)
- Uses `@usebruno/converters` package for format conversion
- Includes error handling with appropriate exit codes

## Usage

```bash
bru export postman --collection ./my-collection --output ./collection.json

# Short hand
bru export postman -c ./my-collection -o ./collection.json
```

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI command to export Bruno collections to Postman v2.1.0 format, supporting .bru and OpenCollection .yml formats.

* **Documentation**
  * New guide for exporting collections with command examples and available export options.

* **Tests**
  * Added test coverage for export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->