### PR TITLE
fix: stale collectionUid when working with transient requests across multiple collections

### DIFF
--- a/packages/bruno-app/src/components/CreateTransientRequest/index.js
+++ b/packages/bruno-app/src/components/CreateTransientRequest/index.js
@@ -57,7 +57,7 @@ const CreateTransientRequest = ({ collectionUid }) => {
 
   const collection = useMemo(() => {
     return collections?.find((c) => c.uid === collectionUid);
-  }, [collections]);
+  }, [collections, collectionUid]);
 
   const collectionPresets = useMemo(() => {
     return get(collection, collection?.draft?.brunoConfig ? 'draft.brunoConfig.presets' : 'brunoConfig.presets', {


### PR DESCRIPTION
### Description
This PR addresses the bug where when a new transient request is created, and multiple collections were mounted, the request gets created in the previous collection.

[JIRA](https://usebruno.atlassian.net/browse/BRU-2633)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collection reference handling for transient requests to ensure proper updates when switching collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->