### PR TITLE
fix: disable text-overflow ellipsis on checkbox column

### DIFF
--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -129,6 +129,7 @@ const StyledWrapper = styled.div`
     text-align: center;
     vertical-align: middle;
     line-height: 1;
+    text-overflow: clip;
 
     input[type='checkbox'] {
       vertical-align: baseline;


### PR DESCRIPTION
### Description

Disable text-overflow ellipsis on checkbox column so "..." no longer appears next to the checkbox column in table.
[JIRA](https://usebruno.atlassian.net/browse/BRU-2639)

### Screenshots
#### Before
<img width="704" height="444" alt="image" src="https://github.com/user-attachments/assets/9869605a-38d1-4d48-bbbc-574d91fedb10" />

#### After
<img width="704" height="444" alt="image" src="https://github.com/user-attachments/assets/e6d88992-dd3e-4380-8440-05f1aa0c2fa7" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text overflow handling in table header cells to ensure cleaner display of content in the checkbox column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->