### PR TITLE
fix: header and var tooltip overflow

### DIFF
--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -138,6 +138,9 @@ const StyledWrapper = styled.div`
 
   .tooltip-mod {
     max-width: 200px !important;
+    word-wrap: break-word !important;
+    overflow-wrap: break-word !important;
+    white-space: normal !important;
   }
 
   input[type='text'] {


### PR DESCRIPTION
### Description

fix header and var tooltip

[JIRA](https://usebruno.atlassian.net/browse/BRU-2642)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="613" height="390" alt="image" src="https://github.com/user-attachments/assets/0b65545a-c220-4266-91a9-3af732f49e86" />