### PR TITLE
fix(`bruno-requests`): mark `node.js built-in` modules as `external` in rollup config

### DIFF
--- a/packages/bruno-requests/rollup.config.js
+++ b/packages/bruno-requests/rollup.config.js
@@ -5,6 +5,7 @@ const dts = require('rollup-plugin-dts');
 const { terser } = require('rollup-plugin-terser');
 const peerDepsExternal = require('rollup-plugin-peer-deps-external');
 const json = require('@rollup/plugin-json');
+const { isBuiltin } = require('module');
 const packageJson = require('./package.json');
 
 module.exports = [
@@ -38,6 +39,6 @@ module.exports = [
       typescript({ tsconfig: './tsconfig.json' }),
       terser()
     ],
-    external: ['axios', 'qs', 'ws', 'debug']
+    external: (id) => isBuiltin(id) || ['axios', 'qs', 'ws', 'debug'].includes(id)
   }
 ];


### PR DESCRIPTION
[jira](https://usebruno.atlassian.net/browse/BRU-2287)

### Description

Use `isBuiltin` from the `module` package to dynamically exclude all Node.js built-in modules from the bundle, preventing rollup from trying to bundle core modules like path, fs, crypto, etc.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to automatically detect and externalize Node.js built-in modules while preserving externalization of key dependencies (axios, qs, ws, debug).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->