### PR TITLE
fix: improve value handling in editor components

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -233,7 +233,7 @@ export default class CodeEditor extends React.Component {
       CodeMirror.signal(this.editor, 'change', this.editor);
     }
     if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      //TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
+      // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
       const nextValue = this.props.value ?? '';
       const currentValue = this.editor.getValue();
       if (this.editor.hasFocus?.() && currentValue !== nextValue) {

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -154,7 +154,7 @@ class MultiLineEditor extends Component {
       this.editor.setOption('readOnly', this.props.readOnly);
     }
     if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      //TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
+      // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
       const nextValue = String(this.props.value ?? '');
       const currentValue = this.editor.getValue();
       if (this.editor.hasFocus?.() && currentValue !== nextValue) {

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
@@ -156,7 +156,7 @@ export default class QueryEditor extends React.Component {
       CodeMirror.signal(this.editor, 'change', this.editor);
     }
     if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      //TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
+      // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
       const nextValue = this.props.value ?? '';
       const currentValue = this.editor.getValue();
       if (this.editor.hasFocus?.() && currentValue !== nextValue) {

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -169,7 +169,7 @@ class SingleLineEditor extends Component {
       this.editor.setOption('theme', this.props.theme === 'dark' ? 'monokai' : 'default');
     }
     if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      //TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
+      // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
       const nextValue = String(this.props.value ?? '');
       const currentValue = this.editor.getValue();
       if (this.editor.hasFocus?.() && currentValue !== nextValue) {


### PR DESCRIPTION
### Description

Temporary fix for preserving cursor positions lost during editor re-renders. This is not an ideal long-term solution, but it avoids the overhead of storing the entire CodeMirror operation log. It specifically addresses cursor displacement that occurs when auto-save and new-line shortcuts are pressed simultaneously, causing a re-render that resets the cursor position.

A proper solution is to add stable ids to items and collections so a combination can be used for editors and other things to avoid the re-render from happening in the first place. 

[JIRA](https://usebruno.atlassian.net/browse/BRU-2646)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor syncing across single-line, multi-line and query editors: when an editor is focused, incoming external value changes are cached instead of overwriting in-progress edits. Editors now preserve cursor/selection, defer replacements until editing ends, and avoid accidental loss during typing.
  * Added safeguards to reduce collisions with auto-save/newline insertions (temporary mitigation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->