### PR TITLE
fix: update codemirror bg for pastel light theme

### DIFF
--- a/packages/bruno-app/src/themes/light/light-pastel.js
+++ b/packages/bruno-app/src/themes/light/light-pastel.js
@@ -398,14 +398,14 @@ const lightPastelTheme = {
   },
 
   codemirror: {
-    bg: 'transparent',
+    bg: colors.BACKGROUND,
     border: colors.WHITE,
     placeholder: {
       color: colors.GRAY_6,
       opacity: 0.75
     },
     gutter: {
-      bg: 'transparent'
+      bg: colors.BACKGROUND
     },
     variable: {
       valid: colors.GREEN,


### PR DESCRIPTION
### Description

Fixes the issue of code mirror warning messages having transparent background making it the text inside unreadable. 
Fixes [JIRA](https://usebruno.atlassian.net/browse/BRU-2650)

### Screenshot 
<img width="708" height="402" alt="image" src="https://github.com/user-attachments/assets/488e7388-43cd-4a9e-919d-60b0604a6961" />



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
