### PR TITLE
fix: multipart form-data file param export/import for Postman

### DIFF
--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -267,11 +267,15 @@ export const brunoToPostman = (collection) => {
         return {
           mode: 'formdata',
           formdata: map(body.multipartForm || [], (bodyItem) => {
+            const isFile = bodyItem.type === 'file';
             return {
               key: bodyItem.name || '',
-              value: bodyItem.value || '',
               disabled: !bodyItem.enabled,
-              type: 'default'
+              type: isFile ? 'file' : 'text',
+              ...(isFile
+                ? { src: Array.isArray(bodyItem.value) ? bodyItem.value : bodyItem.value ? [bodyItem.value] : [] }
+                : { value: bodyItem.value || '' }),
+              ...(bodyItem.contentType && { contentType: bodyItem.contentType })
             };
           })
         };

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -465,27 +465,19 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
           brunoRequestItem.request.body.mode = 'multipartForm';
 
           each(i.request.body.formdata, (param) => {
-            const isFile = param.type === 'file';
-            let value;
-            let type;
-
-            if (isFile) {
-              // If param.src is an array, keep it as it is.
-              // If param.src is a string, convert it into an array with a single element.
-              value = Array.isArray(param.src) ? param.src : typeof param.src === 'string' ? [param.src] : null;
-              type = 'file';
-            } else {
-              value = param.value;
-              type = 'text';
-            }
+            const isFile = param.type === 'file' || (param.type === 'default' && param.src);
+            const value = isFile
+              ? (Array.isArray(param.src) ? param.src : param.src ? [param.src] : [])
+              : (Array.isArray(param.value) ? param.value.join('') : param.value);
 
             brunoRequestItem.request.body.multipartForm.push({
               uid: uuid(),
-              type: type,
+              type: isFile ? 'file' : 'text',
               name: param.key,
-              value: value,
+              value,
               description: transformDescription(param.description),
-              enabled: !param.disabled
+              enabled: !param.disabled,
+              ...(param.contentType && { contentType: param.contentType })
             });
           });
         }
@@ -658,25 +650,19 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
               example.request.body.mode = 'multipartForm';
               if (originalRequest.body.formdata && Array.isArray(originalRequest.body.formdata)) {
                 originalRequest.body.formdata.forEach((param) => {
-                  const isFile = param.type === 'file';
-                  let value;
-                  let type;
-
-                  if (isFile) {
-                    value = Array.isArray(param.src) ? param.src : typeof param.src === 'string' ? [param.src] : null;
-                    type = 'file';
-                  } else {
-                    value = param.value;
-                    type = 'text';
-                  }
+                  const isFile = param.type === 'file' || (param.type === 'default' && param.src);
+                  const value = isFile
+                    ? (Array.isArray(param.src) ? param.src : param.src ? [param.src] : [])
+                    : (Array.isArray(param.value) ? param.value.join('') : param.value);
 
                   example.request.body.multipartForm.push({
                     uid: uuid(),
-                    type: type,
+                    type: isFile ? 'file' : 'text',
                     name: param.key,
-                    value: value,
+                    value,
                     description: transformDescription(param.description),
-                    enabled: !param.disabled
+                    enabled: !param.disabled,
+                    ...(param.contentType && { contentType: param.contentType })
                   });
                 });
               }

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
@@ -665,6 +665,215 @@ const postmanCollection = {
 // │   └── request (GET)
 // └── request (GET)
 
+describe('postman-collection formdata import', () => {
+  it('should import formdata with type: file correctly', async () => {
+    const collectionWithFileFormdata = {
+      info: {
+        _postman_id: 'test-id',
+        name: 'collection with file formdata',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'request with file',
+          request: {
+            method: 'POST',
+            header: [],
+            url: { raw: 'https://example.com/upload' },
+            body: {
+              mode: 'formdata',
+              formdata: [
+                {
+                  key: 'myFile',
+                  type: 'file',
+                  src: ['/path/to/file1.txt', '/path/to/file2.txt'],
+                  disabled: false
+                }
+              ]
+            }
+          }
+        }
+      ]
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithFileFormdata);
+    const multipartForm = brunoCollection.items[0].request.body.multipartForm;
+
+    expect(multipartForm).toHaveLength(1);
+    expect(multipartForm[0].type).toBe('file');
+    expect(multipartForm[0].name).toBe('myFile');
+    expect(multipartForm[0].value).toEqual(['/path/to/file1.txt', '/path/to/file2.txt']);
+    expect(multipartForm[0].enabled).toBe(true);
+  });
+
+  it('should import formdata with type: default and src field as file', async () => {
+    const collectionWithDefaultTypeAndSrc = {
+      info: {
+        _postman_id: 'test-id',
+        name: 'collection with default type formdata',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'request with default type',
+          request: {
+            method: 'POST',
+            header: [],
+            url: { raw: 'https://example.com/upload' },
+            body: {
+              mode: 'formdata',
+              formdata: [
+                {
+                  key: 'myFile',
+                  type: 'default',
+                  src: '/path/to/file.txt',
+                  disabled: false
+                }
+              ]
+            }
+          }
+        }
+      ]
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithDefaultTypeAndSrc);
+    const multipartForm = brunoCollection.items[0].request.body.multipartForm;
+
+    expect(multipartForm).toHaveLength(1);
+    expect(multipartForm[0].type).toBe('file');
+    expect(multipartForm[0].name).toBe('myFile');
+    expect(multipartForm[0].value).toEqual(['/path/to/file.txt']);
+    expect(multipartForm[0].enabled).toBe(true);
+  });
+
+  it('should import formdata with type: default and value array as text', async () => {
+    const collectionWithDefaultTypeAndValueArray = {
+      info: {
+        _postman_id: 'test-id',
+        name: 'collection with default type and value array',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'request with default type',
+          request: {
+            method: 'POST',
+            header: [],
+            url: { raw: 'https://example.com/upload' },
+            body: {
+              mode: 'formdata',
+              formdata: [
+                {
+                  key: 'myField',
+                  type: 'default',
+                  value: ['some', 'text'],
+                  disabled: false
+                }
+              ]
+            }
+          }
+        }
+      ]
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithDefaultTypeAndValueArray);
+    const multipartForm = brunoCollection.items[0].request.body.multipartForm;
+
+    expect(multipartForm).toHaveLength(1);
+    expect(multipartForm[0].type).toBe('text');
+    expect(multipartForm[0].name).toBe('myField');
+    expect(multipartForm[0].value).toBe('sometext');
+    expect(multipartForm[0].enabled).toBe(true);
+  });
+
+  it('should preserve contentType when importing formdata', async () => {
+    const collectionWithContentType = {
+      info: {
+        _postman_id: 'test-id',
+        name: 'collection with contentType',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'request with contentType',
+          request: {
+            method: 'POST',
+            header: [],
+            url: { raw: 'https://example.com/upload' },
+            body: {
+              mode: 'formdata',
+              formdata: [
+                {
+                  key: 'myFile',
+                  type: 'file',
+                  src: '/path/to/file.json',
+                  contentType: 'application/json',
+                  disabled: false
+                }
+              ]
+            }
+          }
+        }
+      ]
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithContentType);
+    const multipartForm = brunoCollection.items[0].request.body.multipartForm;
+
+    expect(multipartForm).toHaveLength(1);
+    expect(multipartForm[0].type).toBe('file');
+    expect(multipartForm[0].contentType).toBe('application/json');
+  });
+
+  it('should handle mixed file and text fields in formdata', async () => {
+    const collectionWithMixedFormdata = {
+      info: {
+        _postman_id: 'test-id',
+        name: 'collection with mixed formdata',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'request with mixed fields',
+          request: {
+            method: 'POST',
+            header: [],
+            url: { raw: 'https://example.com/upload' },
+            body: {
+              mode: 'formdata',
+              formdata: [
+                {
+                  key: 'textField',
+                  type: 'text',
+                  value: 'hello world',
+                  disabled: false
+                },
+                {
+                  key: 'fileField',
+                  type: 'file',
+                  src: '/path/to/file.txt',
+                  disabled: true
+                }
+              ]
+            }
+          }
+        }
+      ]
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithMixedFormdata);
+    const multipartForm = brunoCollection.items[0].request.body.multipartForm;
+
+    expect(multipartForm).toHaveLength(2);
+    expect(multipartForm[0].type).toBe('text');
+    expect(multipartForm[0].value).toBe('hello world');
+    expect(multipartForm[0].enabled).toBe(true);
+    expect(multipartForm[1].type).toBe('file');
+    expect(multipartForm[1].value).toEqual(['/path/to/file.txt']);
+    expect(multipartForm[1].enabled).toBe(false);
+  });
+});
+
 const expectedOutput = {
   name: 'simple collection',
   uid: 'mockeduuidvalue123456',


### PR DESCRIPTION
### Description

Fixed import and export issue in Bruno <-> Postman where an auto type marked file in multipart request was being set as default and no source would be added.

[JIRA](https://usebruno.atlassian.net/browse/BRU-2206)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved multipart form data conversion between Postman and Bruno formats.
  * Enhanced handling of file uploads and text fields during format conversions.
  * Fixed content type preservation for form data entries.

* **Tests**
  * Expanded test coverage for multipart form data conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->