### PR TITLE
fix: pass `app-level proxy` config to `bru.sendRequest`

### DIFF
--- a/packages/bruno-electron/src/ipc/network/cert-utils.js
+++ b/packages/bruno-electron/src/ipc/network/cert-utils.js
@@ -207,6 +207,9 @@ const buildCertsAndProxyConfig = async ({
   const collectionProxyConfig = get(brunoConfig, 'proxy', {});
   const collectionLevelProxy = interpolateObject(collectionProxyConfig, interpolationOptions);
 
+  // Get app-level proxy config from global preferences
+  const appLevelProxyConfig = preferencesUtil.getGlobalProxyConfig();
+
   // Get system proxy config
   const systemProxyConfig = getCachedSystemProxy();
 
@@ -215,6 +218,7 @@ const buildCertsAndProxyConfig = async ({
     options,
     clientCertificates,
     collectionLevelProxy,
+    appLevelProxyConfig,
     systemProxyConfig
   };
 };

--- a/packages/bruno-requests/src/utils/http-https-agents.ts
+++ b/packages/bruno-requests/src/utils/http-https-agents.ts
@@ -103,6 +103,7 @@ type GetCertsAndProxyConfigParams = {
     certs?: ClientCertificate[];
   };
   collectionLevelProxy?: ProxyConfig;
+  appLevelProxyConfig?: Record<string, any>;
   systemProxyConfig?: SystemProxyConfig;
 };
 
@@ -129,6 +130,7 @@ type GetHttpHttpsAgentsParams = {
     certs?: ClientCertificate[];
   };
   collectionLevelProxy?: ProxyConfig;
+  appLevelProxyConfig?: Record<string, any>;
   systemProxyConfig?: SystemProxyConfig;
 };
 
@@ -210,6 +212,7 @@ const getCertsAndProxyConfig = ({
   options,
   clientCertificates,
   collectionLevelProxy,
+  appLevelProxyConfig,
   systemProxyConfig
 }: GetCertsAndProxyConfigParams): GetCertsAndProxyConfigResult => {
   const certsConfig: CertsConfig = {};
@@ -302,12 +305,31 @@ const getCertsAndProxyConfig = ({
     proxyConfig = collectionProxyConfigData;
     proxyMode = 'on';
   } else if (!collectionProxyDisabled && collectionProxyInherit) {
-    // Inherit from system proxy
-    const { http_proxy, https_proxy } = systemProxyConfig || {};
-    if (http_proxy?.length || https_proxy?.length) {
-      proxyMode = 'system';
+    // Inherit from app-level proxy settings
+    if (appLevelProxyConfig) {
+      const globalDisabled = get(appLevelProxyConfig, 'disabled', false);
+      const globalInherit = get(appLevelProxyConfig, 'inherit', false);
+      const globalProxyConfigData = get(appLevelProxyConfig, 'config', appLevelProxyConfig);
+
+      if (!globalDisabled && !globalInherit) {
+        // Use app-level custom proxy
+        proxyConfig = globalProxyConfigData;
+        proxyMode = 'on';
+      } else if (!globalDisabled && globalInherit) {
+        // App-level also inherits, fall through to system proxy
+        const { http_proxy, https_proxy } = systemProxyConfig || {};
+        if (http_proxy?.length || https_proxy?.length) {
+          proxyMode = 'system';
+        }
+      }
+      // else: app-level proxy is disabled, proxyMode stays 'off'
+    } else {
+      // No app-level proxy config (e.g. CLI), fall through to system proxy
+      const { http_proxy, https_proxy } = systemProxyConfig || {};
+      if (http_proxy?.length || https_proxy?.length) {
+        proxyMode = 'system';
+      }
     }
-    // else: no system proxy available, proxyMode stays 'off'
   }
   // else: collection proxy is disabled, proxyMode stays 'off'
 
@@ -409,6 +431,7 @@ const getHttpHttpsAgents = async ({
   collectionPath,
   clientCertificates,
   collectionLevelProxy,
+  appLevelProxyConfig,
   systemProxyConfig,
   options
 }: GetHttpHttpsAgentsParams): Promise<AgentResult> => {
@@ -417,6 +440,7 @@ const getHttpHttpsAgents = async ({
     collectionPath,
     clientCertificates,
     collectionLevelProxy,
+    appLevelProxyConfig,
     systemProxyConfig,
     options
   });


### PR DESCRIPTION
### Description

When collection proxy is set to "inherit", bru.sendRequest was skipping the app-level proxy and falling through directly to system proxy. Now it correctly checks app-level proxy settings first, matching the behavior of normal requests. When appLevelProxyConfig is not provided (e.g. CLI), falls through to system proxy preserving existing behavior.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app-level proxy configuration support that works globally across the application.
  * Implemented intelligent proxy prioritization that balances app-level, collection-level, and system proxy settings for seamless proxy management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->