### PR TITLE
fix: example response statusCode not persisted in yml file

### DIFF
--- a/packages/bruno-filestore/src/formats/yml/items/stringifyHttpRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/stringifyHttpRequest.ts
@@ -174,8 +174,9 @@ const stringifyHttpRequest = (item: BrunoItem): string => {
         if (example.response) {
           ocExample.response = {};
 
-          if (example.response.status !== undefined && example.response.status !== null && isNumber(example.response.status)) {
-            ocExample.response.status = Number(example.response.status);
+          const statusNum = Number(example.response.status);
+          if (Number.isInteger(statusNum) && statusNum > 0) {
+            ocExample.response.status = statusNum;
           }
 
           if (isNonEmptyString(example.response.statusText)) {


### PR DESCRIPTION
### Description

- The example response status code was not being stored in the YML file because `isNumber()` 
  only accepts `typeof === 'number'`, but the Redux store always stores status as a string 
  (e.g., `"200"`)
- Replaced the check with `Number.isInteger(statusNum) && statusNum > 0` which correctly handles 
  string numeric values and rejects edge cases (empty strings, whitespace, floats, NaN, Infinity)

[JIRA](https://usebruno.atlassian.net/browse/BRU-2662)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of HTTP status codes in example responses. Only positive integer codes are now accepted; non-integer, negative, or otherwise invalid values are ignored. This prevents malformed examples and aligns outputs with HTTP standards. Users may notice that previously accepted decimal or loosely formatted status values no longer appear, resulting in cleaner exports and fewer parsing or rendering issues in tools that consume these examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->