### PR TITLE
feat: add description column in Headers, VarsTable, and other components to allow multi-line descriptions

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Headers/index.js
@@ -5,6 +5,7 @@ import { useTheme } from 'providers/Theme';
 import { setCollectionHeaders } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
 import SingleLineEditor from 'components/SingleLineEditor';
+import MultiLineEditor from 'components/MultiLineEditor';
 import EditableTable from 'components/EditableTable';
 import StyledWrapper from './StyledWrapper';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
@@ -49,6 +50,23 @@ const Headers = ({ collection }) => {
     return null;
   }, []);
 
+  const descriptionColumn = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={handleSave}
+        onChange={onChange}
+        allowNewlines={true}
+        collection={collection}
+      />
+    )
+  };
+
   const columns = [
     {
       key: 'name',
@@ -83,7 +101,8 @@ const Headers = ({ collection }) => {
           placeholder={!value ? 'Value' : ''}
         />
       )
-    }
+    },
+    descriptionColumn
   ];
 
   const defaultRow = {
@@ -120,7 +139,7 @@ const Headers = ({ collection }) => {
         defaultRow={defaultRow}
         getRowError={getRowError}
       />
-      <div className="flex justify-end mt-2">
+      <div className="flex justify-end mt-2 gap-2">
         <button className="text-link select-none" onClick={toggleBulkEditMode}>
           Bulk Edit
         </button>

--- a/packages/bruno-app/src/components/CollectionSettings/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Vars/VarsTable/index.js
@@ -33,9 +33,10 @@ const VarsTable = ({ collection, vars, varType }) => {
     name: 'Description',
     placeholder: 'Description',
     width: '25%',
-    render: ({ value, onChange }) => (
+    render: ({ value, onChange, rowIndex }) => (
       <MultiLineEditor
         value={value || ''}
+        name={`${rowIndex}.description`}
         theme={storedTheme}
         onSave={onSave}
         onChange={onChange}
@@ -62,9 +63,10 @@ const VarsTable = ({ collection, vars, varType }) => {
         </div>
       ),
       placeholder: varType === 'request' ? 'Value' : 'Expr',
-      render: ({ value, onChange }) => (
+      render: ({ value, onChange, rowIndex }) => (
         <MultiLineEditor
           value={value || ''}
+          name={`${rowIndex}.value`}
           theme={storedTheme}
           onSave={onSave}
           onChange={onChange}

--- a/packages/bruno-app/src/components/CollectionSettings/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Vars/VarsTable/index.js
@@ -13,7 +13,6 @@ import { setCollectionVars } from 'providers/ReduxStore/slices/collections/index
 const VarsTable = ({ collection, vars, varType }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
-
   const onSave = () => dispatch(saveCollectionSettings(collection.uid));
 
   const handleVarsChange = useCallback((updatedVars) => {
@@ -28,6 +27,23 @@ const VarsTable = ({ collection, vars, varType }) => {
     }
     return null;
   }, []);
+
+  const descriptionColumn = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={onSave}
+        onChange={onChange}
+        allowNewlines={true}
+        collection={collection}
+      />
+    )
+  };
 
   const columns = [
     {
@@ -56,12 +72,14 @@ const VarsTable = ({ collection, vars, varType }) => {
           placeholder={!value ? (varType === 'request' ? 'Value' : 'Expr') : ''}
         />
       )
-    }
+    },
+    descriptionColumn
   ];
 
   const defaultRow = {
     name: '',
     value: '',
+    description: '',
     ...(varType === 'response' ? { local: false } : {})
   };
 

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/StyledWrapper.js
@@ -11,6 +11,28 @@ const Wrapper = styled.div`
     user-select: none;
   }
 
+  &.has-description-column table td {
+    vertical-align: top;
+
+    &:nth-child(1) {
+      padding-top: 10px;
+    }
+
+    &:nth-child(4) {
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      word-break: break-word;
+    }
+    &:nth-child(5) {
+      width: 80px;
+      padding-top: 10px;
+    }
+    &:nth-child(6) {
+      width: 60px;
+      padding-top: 6px;
+    }
+  }
+
   .table-container {
     overflow-y: auto;
     border-radius: 8px;
@@ -31,13 +53,21 @@ const Wrapper = styled.div`
         width: 25px;
         border-right: none;
       }
+      &:nth-child(2) {
+        padding-top: 8px;
+        border-left: none;
+      }
+      &:nth-child(3) {
+        vertical-align: top;
+      }
       &:nth-child(4) {
         width: 80px;
       }
       &:nth-child(5) {
-        width: 60px;
+        width: 10%;
       }
     }
+
 
     thead {
       color: ${(props) => props.theme.table.thead.color} !important;
@@ -145,6 +175,12 @@ const Wrapper = styled.div`
     transition: color 0.15s ease, background 0.15s ease;
   }
 
+  .btn-action {
+    position: relative;
+    right: 6px;
+    width: max-content !important;
+  }
+
   .button-container {
     padding: 12px 2px;
     background: ${(props) => props.theme.bg};
@@ -166,6 +202,23 @@ const Wrapper = styled.div`
     &:hover {
       opacity: 0.9;
     }
+  }
+
+  .description-toggle {
+    background: transparent;
+    padding: 6px;
+    color: ${(props) => props.theme.brand};
+    &:hover {
+      opacity: 0.9;
+    }
+  }
+
+  .secret-column {
+    width: 8% !important;
+  }
+
+  .actions-column {
+    width: 5%;
   }
 
   .reset {

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/StyledWrapper.js
@@ -11,28 +11,6 @@ const Wrapper = styled.div`
     user-select: none;
   }
 
-  &.has-description-column table td {
-    vertical-align: top;
-
-    &:nth-child(1) {
-      padding-top: 10px;
-    }
-
-    &:nth-child(4) {
-      white-space: pre-wrap;
-      word-wrap: break-word;
-      word-break: break-word;
-    }
-    &:nth-child(5) {
-      width: 80px;
-      padding-top: 10px;
-    }
-    &:nth-child(6) {
-      width: 60px;
-      padding-top: 6px;
-    }
-  }
-
   .table-container {
     overflow-y: auto;
     border-radius: 8px;
@@ -53,13 +31,7 @@ const Wrapper = styled.div`
         width: 25px;
         border-right: none;
       }
-      &:nth-child(2) {
-        padding-top: 8px;
-        border-left: none;
-      }
-      &:nth-child(3) {
-        vertical-align: top;
-      }
+
       &:nth-child(4) {
         width: 80px;
       }
@@ -67,7 +39,6 @@ const Wrapper = styled.div`
         width: 10%;
       }
     }
-
 
     thead {
       color: ${(props) => props.theme.table.thead.color} !important;
@@ -175,12 +146,6 @@ const Wrapper = styled.div`
     transition: color 0.15s ease, background 0.15s ease;
   }
 
-  .btn-action {
-    position: relative;
-    right: 6px;
-    width: max-content !important;
-  }
-
   .button-container {
     padding: 12px 2px;
     background: ${(props) => props.theme.bg};
@@ -199,15 +164,6 @@ const Wrapper = styled.div`
     cursor: pointer;
     transition: opacity 0.15s ease;
 
-    &:hover {
-      opacity: 0.9;
-    }
-  }
-
-  .description-toggle {
-    background: transparent;
-    padding: 6px;
-    color: ${(props) => props.theme.brand};
     &:hover {
       opacity: 0.9;
     }

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -31,6 +31,8 @@ const TableRow = React.memo(
   }
 );
 
+const columns = ['name', 'value', 'description', 'secret'];
+
 const EnvironmentVariablesTable = ({
   environment,
   collection,
@@ -62,7 +64,8 @@ const EnvironmentVariablesTable = ({
 
     const startX = e.clientX;
     const startWidth = currentCell.offsetWidth;
-    const nextColumnKey = ['name', 'value', 'description', 'secret'][['name', 'value', 'description', 'secret'].indexOf(columnKey) + 1];
+    const matchedNextCol = columns[columns.indexOf(columnKey) + 1];
+    const nextColumnKey = matchedNextCol > -1 ? matchedNextCol : columns.at(-1);
     const nextColumnStartWidth = nextCell.offsetWidth;
 
     setResizing(columnKey);
@@ -477,7 +480,13 @@ const EnvironmentVariablesTable = ({
                   onMouseDown={(e) => handleResizeStart(e, 'value')}
                 />
               </td>
-              <td style={{ width: columnWidths.description }}>Description</td>
+              <td style={{ width: columnWidths.description }}>Description
+                <div
+                  className={`resize-handle ${resizing === 'description' ? 'resizing' : ''}`}
+                  style={{ height: tableHeight > 0 ? `${tableHeight}px` : undefined }}
+                  onMouseDown={(e) => handleResizeStart(e, 'description')}
+                />
+              </td>
               <td className="text-center secret-column">Secret</td>
               <td className="actions-column"></td>
             </tr>

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -48,7 +48,7 @@ const EnvironmentVariablesTable = ({
   const hasDraftForThisEnv = draft?.environmentUid === environment.uid;
 
   const [tableHeight, setTableHeight] = useState(MIN_H);
-  const [columnWidths, setColumnWidths] = useState({ name: '30%', value: 'auto' });
+  const [columnWidths, setColumnWidths] = useState({ name: '30%', value: 'auto', description: '25%' });
   const [resizing, setResizing] = useState(null);
   const [pinnedData, setPinnedData] = useState({ query: '', uids: new Set() });
 
@@ -62,7 +62,7 @@ const EnvironmentVariablesTable = ({
 
     const startX = e.clientX;
     const startWidth = currentCell.offsetWidth;
-    const nextColumnKey = 'value';
+    const nextColumnKey = ['name', 'value', 'description', 'secret'][['name', 'value', 'description', 'secret'].indexOf(columnKey) + 1];
     const nextColumnStartWidth = nextCell.offsetWidth;
 
     setResizing(columnKey);
@@ -73,10 +73,11 @@ const EnvironmentVariablesTable = ({
       const maxShrink = startWidth - MIN_COLUMN_WIDTH;
       const clampedDiff = Math.max(-maxShrink, Math.min(maxGrow, diff));
 
-      setColumnWidths({
+      setColumnWidths((prev) => ({
+        ...prev,
         [columnKey]: `${startWidth + clampedDiff}px`,
         [nextColumnKey]: `${nextColumnStartWidth - clampedDiff}px`
-      });
+      }));
     };
 
     const handleMouseUp = () => {
@@ -101,7 +102,6 @@ const EnvironmentVariablesTable = ({
   }, [searchQuery]);
 
   const prevEnvUidRef = useRef(null);
-  const prevEnvVariablesRef = useRef(environment.variables);
   const mountedRef = useRef(false);
 
   let _collection = collection ? cloneDeep(collection) : {};
@@ -113,14 +113,15 @@ const EnvironmentVariablesTable = ({
   const initialValues = useMemo(() => {
     const vars = environment.variables || [];
     return [
-      ...vars,
+      ...vars.map((v) => ({ ...v, description: v.description ?? '' })),
       {
         uid: uuid(),
         name: '',
         value: '',
         type: 'text',
         secret: false,
-        enabled: true
+        enabled: true,
+        description: ''
       }
     ];
   }, [environment.uid, environment.variables]);
@@ -146,7 +147,8 @@ const EnvironmentVariablesTable = ({
         secret: Yup.boolean(),
         type: Yup.string(),
         uid: Yup.string(),
-        value: Yup.mixed().nullable()
+        value: Yup.mixed().nullable(),
+        description: Yup.string().nullable()
       })
     ),
     validate: (values) => {
@@ -173,30 +175,29 @@ const EnvironmentVariablesTable = ({
     onSubmit: () => {}
   });
 
-  // Restore draft values on mount or environment switch
+  // Restore draft values on mount or environment switch (not on external filesystem reloads)
   useEffect(() => {
     const isMount = !mountedRef.current;
     const envChanged = prevEnvUidRef.current !== null && prevEnvUidRef.current !== environment.uid;
-    const variablesReloaded = !isMount && !envChanged && prevEnvVariablesRef.current !== environment.variables;
 
     prevEnvUidRef.current = environment.uid;
-    prevEnvVariablesRef.current = environment.variables;
     mountedRef.current = true;
 
-    if ((isMount || envChanged || variablesReloaded) && hasDraftForThisEnv && draft?.variables) {
+    if ((isMount || envChanged) && hasDraftForThisEnv && draft?.variables) {
       formik.setValues([
-        ...draft.variables,
+        ...draft.variables.map((v) => ({ ...v, description: v.description ?? '' })),
         {
           uid: uuid(),
           name: '',
           value: '',
           type: 'text',
           secret: false,
-          enabled: true
+          enabled: true,
+          description: ''
         }
       ]);
     }
-  }, [environment.uid, environment.variables, hasDraftForThisEnv, draft?.variables]);
+  }, [environment.uid, hasDraftForThisEnv, draft?.variables]);
 
   const savedValuesJson = useMemo(() => {
     return JSON.stringify((environment.variables || []).map(stripEnvVarUid));
@@ -291,7 +292,8 @@ const EnvironmentVariablesTable = ({
               value: '',
               type: 'text',
               secret: false,
-              enabled: true
+              enabled: true,
+              description: ''
             }
           ];
 
@@ -311,7 +313,8 @@ const EnvironmentVariablesTable = ({
         value: '',
         type: 'text',
         secret: false,
-        enabled: true
+        enabled: true,
+        description: ''
       };
       setTimeout(() => {
         formik.setFieldValue(formik.values.length, newVariable, false);
@@ -368,7 +371,8 @@ const EnvironmentVariablesTable = ({
             value: '',
             type: 'text',
             secret: false,
-            enabled: true
+            enabled: true,
+            description: ''
           }
         ];
         formik.resetForm({ values: newValues });
@@ -383,14 +387,15 @@ const EnvironmentVariablesTable = ({
   const handleReset = useCallback(() => {
     const originalVars = environment.variables || [];
     const resetValues = [
-      ...originalVars,
+      ...originalVars.map((v) => ({ ...v, description: v.description ?? '' })),
       {
         uid: uuid(),
         name: '',
         value: '',
         type: 'text',
         secret: false,
-        enabled: true
+        enabled: true,
+        description: ''
       }
     ];
     formik.resetForm({ values: resetValues });
@@ -431,14 +436,19 @@ const EnvironmentVariablesTable = ({
             ? String(variable.value)
             : '';
       const valueMatch = valueText.toLowerCase().includes(query);
-      return !!(nameMatch || valueMatch);
+      const descriptionMatch
+        = variable.description && typeof variable.description === 'string'
+          ? variable.description.toLowerCase().includes(query)
+          : false;
+
+      return !!(nameMatch || valueMatch || descriptionMatch);
     });
   }, [formik.values, searchQuery, pinnedData]);
 
   const isSearchActive = !!searchQuery?.trim();
 
   return (
-    <StyledWrapper className={resizing ? 'is-resizing' : ''}>
+    <StyledWrapper className={`${resizing ? 'is-resizing' : ''} has-description-column`.trim()}>
       {isSearchActive && filteredVariables.length === 0 ? (
         <div className="no-results">No results found for &ldquo;{searchQuery.trim()}&rdquo;</div>
       ) : (
@@ -459,12 +469,20 @@ const EnvironmentVariablesTable = ({
                   onMouseDown={(e) => handleResizeStart(e, 'name')}
                 />
               </td>
-              <td style={{ width: columnWidths.value }}>Value</td>
-              <td className="text-center">Secret</td>
-              <td></td>
+              <td style={{ width: columnWidths.value }}>
+                Value
+                <div
+                  className={`resize-handle ${resizing === 'value' ? 'resizing' : ''}`}
+                  style={{ height: tableHeight > 0 ? `${tableHeight}px` : undefined }}
+                  onMouseDown={(e) => handleResizeStart(e, 'value')}
+                />
+              </td>
+              <td style={{ width: columnWidths.description }}>Description</td>
+              <td className="text-center secret-column">Secret</td>
+              <td className="actions-column"></td>
             </tr>
           )}
-          fixedItemHeight={35}
+          defaultItemHeight={35}
           computeItemKey={(virtualIndex, item) => `${environment.uid}-${item.index}`}
           itemContent={(virtualIndex, { variable, index: actualIndex }) => {
             const isLastRow = actualIndex === formik.values.length - 1;
@@ -510,43 +528,53 @@ const EnvironmentVariablesTable = ({
                   </div>
                 </td>
                 <td
-                  className="flex flex-row flex-nowrap items-center"
                   style={{ width: columnWidths.value }}
                 >
-                  <div
-                    className="overflow-hidden grow w-full relative"
-                    onFocus={() => handleRowFocus(variable.uid)}
-                  >
-                    <MultiLineEditor
-                      theme={storedTheme}
-                      collection={_collection}
-                      name={`${actualIndex}.value`}
-                      value={variable.value}
-                      placeholder={isLastEmptyRow ? 'Value' : ''}
-                      isSecret={variable.secret}
-                      readOnly={typeof variable.value !== 'string'}
-                      onChange={(newValue) => {
-                        formik.setFieldValue(`${actualIndex}.value`, newValue, true);
-                        // Clear ephemeral metadata when user manually edits the value
-                        if (variable.ephemeral) {
-                          formik.setFieldValue(`${actualIndex}.ephemeral`, undefined, false);
-                          formik.setFieldValue(`${actualIndex}.persistedValue`, undefined, false);
-                        }
-                      }}
-                      onSave={handleSave}
-                    />
-                  </div>
-                  {typeof variable.value !== 'string' && (
-                    <span className="ml-2 flex items-center">
-                      <IconInfoCircle id={`${variable.uid}-disabled-info-icon`} className="text-muted" size={16} />
-                      <Tooltip
-                        anchorId={`${variable.uid}-disabled-info-icon`}
-                        content="Non-string values set via scripts are read-only and can only be updated through scripts."
-                        place="top"
+                  <div className="flex flex-row flex-nowrap items-start w-full" onFocus={() => handleRowFocus(variable.uid)}>
+                    <div className="overflow-hidden grow w-full relative">
+                      <MultiLineEditor
+                        theme={storedTheme}
+                        collection={_collection}
+                        name={`${actualIndex}.value`}
+                        value={variable.value}
+                        placeholder={isLastEmptyRow ? 'Value' : ''}
+                        isSecret={variable.secret}
+                        readOnly={typeof variable.value !== 'string'}
+                        onChange={(newValue) => {
+                          formik.setFieldValue(`${actualIndex}.value`, newValue, true);
+                          // Clear ephemeral metadata when user manually edits the value
+                          if (variable.ephemeral) {
+                            formik.setFieldValue(`${actualIndex}.ephemeral`, undefined, false);
+                            formik.setFieldValue(`${actualIndex}.persistedValue`, undefined, false);
+                          }
+                        }}
+                        onSave={handleSave}
                       />
-                    </span>
-                  )}
-                  {renderExtraValueContent && renderExtraValueContent(variable)}
+                    </div>
+                    {typeof variable.value !== 'string' && (
+                      <span className="ml-2 flex items-center flex-shrink-0">
+                        <IconInfoCircle id={`${variable.uid}-disabled-info-icon`} className="text-muted" size={16} />
+                        <Tooltip
+                          anchorId={`${variable.uid}-disabled-info-icon`}
+                          content="Non-string values set via scripts are read-only and can only be updated through scripts."
+                          place="top"
+                        />
+                      </span>
+                    )}
+                    {renderExtraValueContent && renderExtraValueContent(variable)}
+                  </div>
+                </td>
+                <td style={{ width: columnWidths.description }}>
+                  <MultiLineEditor
+                    theme={storedTheme}
+                    collection={_collection}
+                    name={`${actualIndex}.description`}
+                    value={variable.description ?? ''}
+                    readOnly={false}
+                    onChange={(newValue) => formik.setFieldValue(`${actualIndex}.description`, newValue, true)}
+                    onSave={handleSave}
+                    allowNewlines={true}
+                  />
                 </td>
                 <td className="text-center">
                   {!isLastEmptyRow && (

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -64,8 +64,12 @@ const EnvironmentVariablesTable = ({
 
     const startX = e.clientX;
     const startWidth = currentCell.offsetWidth;
-    const matchedNextCol = columns[columns.indexOf(columnKey) + 1];
-    const nextColumnKey = matchedNextCol > -1 ? matchedNextCol : columns.at(-1);
+
+    const colIndex = columns.indexOf(columnKey) + 1;
+    if (colIndex >= columns.length - 1) return;
+
+    const matchedNextCol = columns[colIndex];
+    const nextColumnKey = matchedNextCol ?? columns.at(-1);
     const nextColumnStartWidth = nextCell.offsetWidth;
 
     setResizing(columnKey);
@@ -76,11 +80,15 @@ const EnvironmentVariablesTable = ({
       const maxShrink = startWidth - MIN_COLUMN_WIDTH;
       const clampedDiff = Math.max(-maxShrink, Math.min(maxGrow, diff));
 
-      setColumnWidths((prev) => ({
-        ...prev,
-        [columnKey]: `${startWidth + clampedDiff}px`,
-        [nextColumnKey]: `${nextColumnStartWidth - clampedDiff}px`
-      }));
+      setColumnWidths((prev) => {
+        const next = {
+          ...prev,
+          [columnKey]: `${startWidth + clampedDiff}px`,
+          [nextColumnKey]: `${nextColumnStartWidth - clampedDiff}px`
+        };
+        console.log({ next });
+        return next;
+      });
     };
 
     const handleMouseUp = () => {
@@ -480,13 +488,7 @@ const EnvironmentVariablesTable = ({
                   onMouseDown={(e) => handleResizeStart(e, 'value')}
                 />
               </td>
-              <td style={{ width: columnWidths.description }}>Description
-                <div
-                  className={`resize-handle ${resizing === 'description' ? 'resizing' : ''}`}
-                  style={{ height: tableHeight > 0 ? `${tableHeight}px` : undefined }}
-                  onMouseDown={(e) => handleResizeStart(e, 'description')}
-                />
-              </td>
+              <td style={{ width: columnWidths.description }}>Description</td>
               <td className="text-center secret-column">Secret</td>
               <td className="actions-column"></td>
             </tr>

--- a/packages/bruno-app/src/components/FolderSettings/Headers/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Headers/index.js
@@ -5,6 +5,7 @@ import { useTheme } from 'providers/Theme';
 import { setFolderHeaders } from 'providers/ReduxStore/slices/collections';
 import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions';
 import SingleLineEditor from 'components/SingleLineEditor';
+import MultiLineEditor from 'components/MultiLineEditor';
 import EditableTable from 'components/EditableTable';
 import StyledWrapper from './StyledWrapper';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
@@ -53,6 +54,24 @@ const Headers = ({ collection, folder }) => {
     return null;
   }, []);
 
+  const descriptionColumn = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={handleSave}
+        onChange={onChange}
+        allowNewlines={true}
+        collection={collection}
+        item={folder}
+      />
+    )
+  };
+
   const columns = [
     {
       key: 'name',
@@ -88,7 +107,8 @@ const Headers = ({ collection, folder }) => {
           placeholder={!value ? 'Value' : ''}
         />
       )
-    }
+    },
+    descriptionColumn
   ];
 
   const defaultRow = {
@@ -125,7 +145,7 @@ const Headers = ({ collection, folder }) => {
         defaultRow={defaultRow}
         getRowError={getRowError}
       />
-      <div className="flex justify-end mt-2">
+      <div className="flex justify-end mt-2 gap-2">
         <button className="text-link select-none" onClick={toggleBulkEditMode}>
           Bulk Edit
         </button>

--- a/packages/bruno-app/src/components/FolderSettings/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Vars/VarsTable/index.js
@@ -38,9 +38,10 @@ const VarsTable = ({ folder, collection, vars, varType }) => {
     name: 'Description',
     placeholder: 'Description',
     width: '25%',
-    render: ({ value, onChange }) => (
+    render: ({ value, onChange, rowIndex }) => (
       <MultiLineEditor
         value={value || ''}
+        name={`${rowIndex}.description`}
         theme={storedTheme}
         onSave={onSave}
         onChange={onChange}
@@ -68,9 +69,10 @@ const VarsTable = ({ folder, collection, vars, varType }) => {
         </div>
       ),
       placeholder: varType === 'request' ? 'Value' : 'Expr',
-      render: ({ value, onChange }) => (
+      render: ({ value, onChange, rowIndex }) => (
         <MultiLineEditor
           value={value || ''}
+          name={`${rowIndex}.value`}
           theme={storedTheme}
           onSave={onSave}
           onChange={onChange}

--- a/packages/bruno-app/src/components/FolderSettings/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Vars/VarsTable/index.js
@@ -13,7 +13,6 @@ import { setFolderVars } from 'providers/ReduxStore/slices/collections/index';
 const VarsTable = ({ folder, collection, vars, varType }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
-
   const onSave = () => dispatch(saveFolderRoot(collection.uid, folder.uid));
 
   const handleVarsChange = useCallback((updatedVars) => {
@@ -33,6 +32,24 @@ const VarsTable = ({ folder, collection, vars, varType }) => {
     }
     return null;
   }, []);
+
+  const descriptionColumn = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={onSave}
+        onChange={onChange}
+        allowNewlines={true}
+        collection={collection}
+        item={folder}
+      />
+    )
+  };
 
   const columns = [
     {
@@ -62,12 +79,14 @@ const VarsTable = ({ folder, collection, vars, varType }) => {
           placeholder={!value ? (varType === 'request' ? 'Value' : 'Expr') : ''}
         />
       )
-    }
+    },
+    descriptionColumn
   ];
 
   const defaultRow = {
     name: '',
     value: '',
+    description: '',
     ...(varType === 'response' ? { local: false } : {})
   };
 

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -105,6 +105,7 @@ class MultiLineEditor extends Component {
       if (this.props.onChange) {
         this.props.onChange(this.cachedValue);
       }
+      requestAnimationFrame(() => this.editor?.refresh());
     }
   };
 
@@ -165,6 +166,7 @@ class MultiLineEditor extends Component {
         this.editor.setValue(nextValue);
         this.editor.setCursor(cursor);
       }
+      requestAnimationFrame(() => this.editor?.refresh());
     }
     if (!isEqual(this.props.isSecret, prevProps.isSecret)) {
       // If the secret flag has changed, update the editor to reflect the change

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -228,7 +228,7 @@ class MultiLineEditor extends Component {
   render() {
     const wrapperClass = `multi-line-editor grow ${this.props.readOnly ? 'read-only' : ''}`;
     return (
-      <div className={`flex flex-row justify-between w-full overflow-x-auto ${this.props.className}`}>
+      <div data-testid={`test-multiline-editor-${this.props.name}`} className={`flex flex-row justify-between w-full overflow-x-auto ${this.props.className}`}>
         <StyledWrapper ref={this.editorRef} className={wrapperClass} />
         {this.secretEye(this.props.isSecret)}
       </div>

--- a/packages/bruno-app/src/components/RequestPane/Assertions/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Assertions/index.js
@@ -5,6 +5,7 @@ import { useTheme } from 'providers/Theme';
 import { moveAssertion, setRequestAssertions } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import SingleLineEditor from 'components/SingleLineEditor';
+import MultiLineEditor from 'components/MultiLineEditor';
 import AssertionOperator from './AssertionOperator';
 import EditableTable from 'components/EditableTable';
 import StyledWrapper from './StyledWrapper';
@@ -74,6 +75,25 @@ const Assertions = ({ item, collection }) => {
       updateReorderedItem
     }));
   }, [dispatch, collection.uid, item.uid]);
+
+  const descriptionColumn = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={onSave}
+        onChange={onChange}
+        allowNewlines={true}
+        onRun={handleRun}
+        collection={collection}
+        item={item}
+      />
+    )
+  };
 
   const columns = [
     {
@@ -145,13 +165,15 @@ const Assertions = ({ item, collection }) => {
           />
         );
       }
-    }
+    },
+    descriptionColumn
   ];
 
   const defaultRow = {
     name: '',
     value: 'eq ',
-    operator: 'eq'
+    operator: 'eq',
+    description: ''
   };
 
   return (

--- a/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FormUrlEncodedParams/index.js
@@ -15,7 +15,6 @@ const FormUrlEncodedParams = ({ item, collection }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
   const params = item.draft ? get(item, 'draft.request.body.formUrlEncoded') : get(item, 'request.body.formUrlEncoded');
-
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
   const handleRun = () => dispatch(sendRequest(item, collection.uid));
 
@@ -34,6 +33,25 @@ const FormUrlEncodedParams = ({ item, collection }) => {
       updateReorderedItem
     }));
   }, [dispatch, collection.uid, item.uid]);
+
+  const descriptionColumn = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={onSave}
+        onChange={onChange}
+        allowNewlines={true}
+        onRun={handleRun}
+        collection={collection}
+        item={item}
+      />
+    )
+  };
 
   const columns = [
     {
@@ -60,7 +78,8 @@ const FormUrlEncodedParams = ({ item, collection }) => {
           placeholder={!value ? 'Value' : ''}
         />
       )
-    }
+    },
+    descriptionColumn
   ];
 
   const defaultRow = {

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -20,7 +20,6 @@ const MultipartFormParams = ({ item, collection }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
   const params = item.draft ? get(item, 'draft.request.body.multipartForm') : get(item, 'request.body.multipartForm');
-
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
   const handleRun = () => dispatch(sendRequest(item, collection.uid));
 
@@ -189,6 +188,24 @@ const MultipartFormParams = ({ item, collection }) => {
           collection={collection}
         />
       )
+    },
+    {
+      key: 'description',
+      name: 'Description',
+      placeholder: 'Description',
+      width: '25%',
+      render: ({ value, onChange }) => (
+        <MultiLineEditor
+          value={value || ''}
+          theme={storedTheme}
+          onSave={onSave}
+          onChange={onChange}
+          allowNewlines={true}
+          onRun={handleRun}
+          collection={collection}
+          item={item}
+        />
+      )
     }
   ];
 
@@ -196,7 +213,8 @@ const MultipartFormParams = ({ item, collection }) => {
     name: '',
     value: '',
     contentType: '',
-    type: 'text'
+    type: 'text',
+    description: ''
   };
 
   return (

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -35,16 +35,21 @@ const QueryParams = ({ item, collection }) => {
     }));
   }, [dispatch, collection.uid, item.uid]);
 
-  const handlePathParamChange = useCallback((rowUid, key, value) => {
-    const pathParam = pathParams.find((p) => p.uid === rowUid);
-    if (pathParam) {
-      dispatch(updatePathParam({
-        pathParam: { ...pathParam, [key]: value },
-        itemUid: item.uid,
-        collectionUid: collection.uid
-      }));
-    }
-  }, [dispatch, pathParams, item.uid, collection.uid]);
+  const handlePathParamChange = useCallback(
+    (rowUid, key, value) => {
+      const pathParam = pathParams.find((p) => p.uid === rowUid);
+      if (pathParam) {
+        dispatch(
+          updatePathParam({
+            pathParam: { ...pathParam, [key]: value },
+            itemUid: item.uid,
+            collectionUid: collection.uid
+          })
+        );
+      }
+    },
+    [dispatch, pathParams, item.uid, collection.uid]
+  );
 
   const handleQueryParamDrag = useCallback(({ updateReorderedItem }) => {
     dispatch(moveQueryParam({
@@ -56,6 +61,44 @@ const QueryParams = ({ item, collection }) => {
 
   const toggleBulkEditMode = () => {
     setIsBulkEditMode(!isBulkEditMode);
+  };
+
+  const descriptionColumnQuery = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={onSave}
+        onChange={onChange}
+        allowNewlines={true}
+        onRun={handleRun}
+        collection={collection}
+        item={item}
+      />
+    )
+  };
+
+  const descriptionColumnPath = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ row, value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={onSave}
+        onChange={(newValue) => handlePathParamChange(row.uid, 'description', newValue)}
+        allowNewlines={true}
+        onRun={handleRun}
+        collection={collection}
+        item={item}
+      />
+    )
   };
 
   const queryColumns = [
@@ -83,7 +126,8 @@ const QueryParams = ({ item, collection }) => {
           placeholder={!value ? 'Value' : ''}
         />
       )
-    }
+    },
+    descriptionColumnQuery
   ];
 
   const pathColumns = [
@@ -109,7 +153,8 @@ const QueryParams = ({ item, collection }) => {
           item={item}
         />
       )
-    }
+    },
+    descriptionColumnPath
   ];
 
   const defaultQueryRow = {
@@ -136,7 +181,9 @@ const QueryParams = ({ item, collection }) => {
   return (
     <StyledWrapper className="w-full flex flex-col">
       <div className="flex-1">
-        <div className="mb-3 title text-xs">Query</div>
+        <div className="mb-3 title text-xs">
+          <span>Query</span>
+        </div>
         <EditableTable
           columns={queryColumns}
           rows={queryParams || []}

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -5,6 +5,7 @@ import { useTheme } from 'providers/Theme';
 import { moveRequestHeader, setRequestHeaders } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import SingleLineEditor from 'components/SingleLineEditor';
+import MultiLineEditor from 'components/MultiLineEditor';
 import EditableTable from 'components/EditableTable';
 import StyledWrapper from './StyledWrapper';
 import { headers as StandardHTTPHeaders } from 'know-your-http-well';
@@ -59,6 +60,25 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
     setIsBulkEditMode(!isBulkEditMode);
   };
 
+  const descriptionColumn = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={onSave}
+        onChange={onChange}
+        allowNewlines={true}
+        onRun={handleRun}
+        collection={collection}
+        item={item}
+      />
+    )
+  };
+
   const columns = [
     {
       key: 'name',
@@ -97,7 +117,8 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
           placeholder={!value ? 'Value' : ''}
         />
       )
-    }
+    },
+    descriptionColumn
   ];
 
   const defaultRow = {
@@ -131,7 +152,7 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
         reorderable={true}
         onReorder={handleHeaderDrag}
       />
-      <div className="flex justify-end mt-2">
+      <div className="flex justify-end mt-2 gap-2">
         <button className="btn-action text-link select-none" onClick={toggleBulkEditMode}>
           Bulk Edit
         </button>

--- a/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
@@ -13,7 +13,6 @@ import { variableNameRegex } from 'utils/common/regex';
 const VarsTable = ({ item, collection, vars, varType }) => {
   const dispatch = useDispatch();
   const { storedTheme } = useTheme();
-
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
   const handleRun = () => dispatch(sendRequest(item, collection.uid));
 
@@ -44,6 +43,25 @@ const VarsTable = ({ item, collection, vars, varType }) => {
     return null;
   }, []);
 
+  const descriptionColumn = {
+    key: 'description',
+    name: 'Description',
+    placeholder: 'Description',
+    width: '25%',
+    render: ({ value, onChange }) => (
+      <MultiLineEditor
+        value={value || ''}
+        theme={storedTheme}
+        onSave={onSave}
+        onChange={onChange}
+        allowNewlines={true}
+        onRun={handleRun}
+        collection={collection}
+        item={item}
+      />
+    )
+  };
+
   const columns = [
     {
       key: 'name',
@@ -73,12 +91,14 @@ const VarsTable = ({ item, collection, vars, varType }) => {
           placeholder={!value ? (varType === 'request' ? 'Value' : 'Expr') : ''}
         />
       )
-    }
+    },
+    descriptionColumn
   ];
 
   const defaultRow = {
     name: '',
     value: '',
+    description: '',
     ...(varType === 'response' ? { local: false } : {})
   };
 

--- a/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Vars/VarsTable/index.js
@@ -48,9 +48,10 @@ const VarsTable = ({ item, collection, vars, varType }) => {
     name: 'Description',
     placeholder: 'Description',
     width: '25%',
-    render: ({ value, onChange }) => (
+    render: ({ value, onChange, rowIndex }) => (
       <MultiLineEditor
         value={value || ''}
+        name={`${rowIndex}.description`}
         theme={storedTheme}
         onSave={onSave}
         onChange={onChange}
@@ -79,9 +80,10 @@ const VarsTable = ({ item, collection, vars, varType }) => {
         </div>
       ),
       placeholder: varType === 'request' ? 'Value' : 'Expr',
-      render: ({ value, onChange }) => (
+      render: ({ value, onChange, rowIndex }) => (
         <MultiLineEditor
           value={value || ''}
+          name={`${rowIndex}.value`}
           theme={storedTheme}
           onSave={onSave}
           onChange={onChange}

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1221,6 +1221,12 @@ export const collectionsSlice = createSlice({
           if (param) {
             param.name = action.payload.pathParam.name;
             param.value = action.payload.pathParam.value;
+            if ('description' in action.payload.pathParam) {
+              param.description = action.payload.pathParam.description;
+            }
+            if ('enabled' in action.payload.pathParam) {
+              param.enabled = action.payload.pathParam.enabled;
+            }
           }
         }
       }
@@ -1551,13 +1557,14 @@ export const collectionsSlice = createSlice({
       if (!item.draft) {
         item.draft = cloneDeep(item);
       }
-      item.draft.request.body.multipartForm = map(params, ({ uid, name = '', value = '', contentType = '', type = 'text', enabled = true }) => ({
+      item.draft.request.body.multipartForm = map(params, ({ uid, name = '', value = '', contentType = '', type = 'text', enabled = true, description = '' }) => ({
         uid: uid || uuid(),
         name,
         value,
         contentType,
         type,
-        enabled
+        enabled,
+        description
       }));
     },
     moveMultipartFormParam: (state, action) => {
@@ -1902,12 +1909,13 @@ export const collectionsSlice = createSlice({
       if (!item.draft) {
         item.draft = cloneDeep(item);
       }
-      item.draft.request.assertions = map(assertions, ({ uid, name = '', value = '', operator = 'eq', enabled = true }) => ({
+      item.draft.request.assertions = map(assertions, ({ uid, name = '', value = '', operator = 'eq', enabled = true, description = '' }) => ({
         uid: uid || uuid(),
         name,
         value,
         operator,
-        enabled
+        enabled,
+        description
       }));
     },
     moveAssertion: (state, action) => {
@@ -2037,12 +2045,13 @@ export const collectionsSlice = createSlice({
         item.draft = cloneDeep(item);
       }
       item.draft.request.vars = item.draft.request.vars || {};
-      const mappedVars = map(vars, ({ uid, name = '', value = '', enabled = true, local = false }) => ({
+      const mappedVars = map(vars, ({ uid, name = '', value = '', enabled = true, local = false, description }) => ({
         uid: uid || uuid(),
         name,
         value,
         enabled,
-        ...(type === 'response' ? { local } : {})
+        ...(type === 'response' ? { local } : {}),
+        ...(description !== undefined ? { description } : {})
       }));
       if (type === 'request') {
         item.draft.request.vars.req = mappedVars;
@@ -2382,12 +2391,13 @@ export const collectionsSlice = createSlice({
       if (!folder.draft) {
         folder.draft = cloneDeep(folder.root);
       }
-      const mappedVars = map(vars, ({ uid, name = '', value = '', enabled = true, local = false }) => ({
+      const mappedVars = map(vars, ({ uid, name = '', value = '', enabled = true, local = false, description }) => ({
         uid: uid || uuid(),
         name,
         value,
         enabled,
-        ...(type === 'response' ? { local } : {})
+        ...(type === 'response' ? { local } : {}),
+        ...(description !== undefined ? { description } : {})
       }));
       if (type === 'request') {
         set(folder, 'draft.request.vars.req', mappedVars);
@@ -2617,12 +2627,13 @@ export const collectionsSlice = createSlice({
           root: cloneDeep(collection.root)
         };
       }
-      const mappedVars = map(vars, ({ uid, name = '', value = '', enabled = true, local = false }) => ({
+      const mappedVars = map(vars, ({ uid, name = '', value = '', enabled = true, local = false, description }) => ({
         uid: uid || uuid(),
         name,
         value,
         enabled,
-        ...(type === 'response' ? { local } : {})
+        ...(type === 'response' ? { local } : {}),
+        ...(description !== undefined ? { description } : {})
       }));
       if (type === 'request') {
         set(collection, 'draft.root.request.vars.req', mappedVars);

--- a/packages/bruno-app/src/utils/environments.js
+++ b/packages/bruno-app/src/utils/environments.js
@@ -41,6 +41,10 @@ export const buildEnvVariable = ({ envVariable: obj, withUuid = false }) => {
     secret: !!obj.secret
   };
 
+  if (obj.description) {
+    envVariable.description = obj.description;
+  }
+
   if (!withUuid) {
     return envVariable;
   }
@@ -56,6 +60,8 @@ export const buildEnvVariable = ({ envVariable: obj, withUuid = false }) => {
  * This is useful when comparing variables where UIDs may differ but the actual data is the same.
  */
 export const stripEnvVarUid = (variable) => {
-  const { name, value, type, enabled, secret } = variable;
-  return { name, value, type, enabled, secret };
+  const { name, value, type, enabled, secret, description } = variable;
+  const result = { name, value, type, enabled, secret };
+  if (description !== undefined && description !== '') result.description = description;
+  return result;
 };

--- a/packages/bruno-converters/src/opencollection/common/body.ts
+++ b/packages/bruno-converters/src/opencollection/common/body.ts
@@ -90,13 +90,17 @@ export const fromOpenCollectionBody = (body: HttpRequestBody | GraphQLBody | und
         return {
           ...defaultBody,
           mode: 'formUrlEncoded',
-          formUrlEncoded: (formBody.data || []).map((field): BrunoKeyValue => ({
-            uid: uuid(),
-            name: field.name || '',
-            value: field.value || '',
-            description: typeof field.description === 'string' ? field.description : field.description?.content || null,
-            enabled: field.disabled !== true
-          }))
+          formUrlEncoded: (formBody.data || []).map((field): BrunoKeyValue => {
+            const entry: BrunoKeyValue = {
+              uid: uuid(),
+              name: field.name || '',
+              value: field.value || '',
+              enabled: field.disabled !== true
+            };
+            const desc = typeof field.description === 'string' ? field.description : field.description?.content;
+            if (desc && desc.trim().length) entry.description = desc;
+            return entry;
+          })
         };
       }
 
@@ -105,15 +109,19 @@ export const fromOpenCollectionBody = (body: HttpRequestBody | GraphQLBody | und
         return {
           ...defaultBody,
           mode: 'multipartForm',
-          multipartForm: (multipartBody.data || []).map((field): BrunoMultipartFormEntry => ({
-            uid: uuid(),
-            type: field.type || 'text',
-            name: field.name || '',
-            value: Array.isArray(field.value) ? field.value : (field.value || ''),
-            description: typeof field.description === 'string' ? field.description : field.description?.content || null,
-            contentType: null,
-            enabled: field.disabled !== true
-          }))
+          multipartForm: (multipartBody.data || []).map((field): BrunoMultipartFormEntry => {
+            const entry: BrunoMultipartFormEntry = {
+              uid: uuid(),
+              type: field.type || 'text',
+              name: field.name || '',
+              value: Array.isArray(field.value) ? field.value : (field.value || ''),
+              contentType: null,
+              enabled: field.disabled !== true
+            };
+            const desc = typeof field.description === 'string' ? field.description : field.description?.content;
+            if (desc && desc.trim().length) entry.description = desc;
+            return entry;
+          })
         };
       }
 

--- a/packages/bruno-converters/src/opencollection/common/headers.ts
+++ b/packages/bruno-converters/src/opencollection/common/headers.ts
@@ -9,13 +9,17 @@ export const fromOpenCollectionHeaders = (headers: HttpRequestHeader[] | undefin
     return [];
   }
 
-  return headers.map((header): BrunoKeyValue => ({
-    uid: uuid(),
-    name: header.name || '',
-    value: header.value || '',
-    description: typeof header.description === 'string' ? header.description : header.description?.content || null,
-    enabled: header.disabled !== true
-  }));
+  return headers.map((header): BrunoKeyValue => {
+    const entry: BrunoKeyValue = {
+      uid: uuid(),
+      name: header.name || '',
+      value: header.value || '',
+      enabled: header.disabled !== true
+    };
+    const desc = typeof header.description === 'string' ? header.description : header.description?.content;
+    if (desc && desc.trim().length) entry.description = desc;
+    return entry;
+  });
 };
 
 export const toOpenCollectionHeaders = (headers: BrunoKeyValue[] | null | undefined): HttpRequestHeader[] | undefined => {

--- a/packages/bruno-converters/src/opencollection/common/params.ts
+++ b/packages/bruno-converters/src/opencollection/common/params.ts
@@ -10,14 +10,18 @@ export const fromOpenCollectionParams = (params: HttpRequestParam[] | undefined)
     return [];
   }
 
-  return params.map((param): BrunoHttpRequestParam => ({
-    uid: uuid(),
-    name: param.name || '',
-    value: param.value || '',
-    description: typeof param.description === 'string' ? param.description : param.description?.content || null,
-    type: (param.type || 'query') as BrunoHttpRequestParamType,
-    enabled: param.disabled !== true
-  }));
+  return params.map((param): BrunoHttpRequestParam => {
+    const entry: BrunoHttpRequestParam = {
+      uid: uuid(),
+      name: param.name || '',
+      value: param.value || '',
+      type: (param.type || 'query') as BrunoHttpRequestParamType,
+      enabled: param.disabled !== true
+    };
+    const desc = typeof param.description === 'string' ? param.description : param.description?.content;
+    if (desc && desc.trim().length) entry.description = desc;
+    return entry;
+  });
 };
 
 export const toOpenCollectionParams = (params: BrunoHttpRequestParam[] | null | undefined): HttpRequestParam[] | undefined => {

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -259,7 +259,8 @@ export const brunoToPostman = (collection) => {
               key: bodyItem.name || '',
               value: bodyItem.value || '',
               disabled: !bodyItem.enabled,
-              type: 'default'
+              type: 'default',
+              description: bodyItem.description || ''
             };
           })
         };
@@ -282,6 +283,7 @@ export const brunoToPostman = (collection) => {
               key: bodyItem.name || '',
               disabled: !bodyItem.enabled,
               type: isFile ? 'file' : 'text',
+              description: bodyItem.description || '',
               ...(isFile ? { src: getSrc() } : { value: bodyItem.value || '' }),
               ...(bodyItem.contentType && { contentType: bodyItem.contentType })
             };

--- a/packages/bruno-converters/tests/opencollection/description.spec.js
+++ b/packages/bruno-converters/tests/opencollection/description.spec.js
@@ -1,0 +1,347 @@
+import { describe, it, expect } from '@jest/globals';
+import { brunoToOpenCollection, openCollectionToBruno } from '../../dist/esm/index.js';
+
+describe('opencollection description round-trip', () => {
+  it('preserves description on headers and vars when converting Bruno -> OpenCollection -> Bruno', () => {
+    const brunoCollection = {
+      uid: 'c1',
+      name: 'Test',
+      version: '1',
+      items: [],
+      root: {
+        request: {
+          headers: [
+            { uid: 'h1', name: 'X-API-Key', value: 'secret', enabled: true, description: 'API key for auth' }
+          ],
+          vars: {
+            req: [
+              { uid: 'v1', name: 'baseUrl', value: 'https://api.example.com', enabled: true, description: 'Base API URL' }
+            ],
+            res: []
+          }
+        }
+      }
+    };
+
+    const openCollection = brunoToOpenCollection(brunoCollection);
+
+    expect(openCollection.request).toBeDefined();
+    expect(openCollection.request.headers).toHaveLength(1);
+    expect(openCollection.request.headers[0]).toMatchObject({
+      name: 'X-API-Key',
+      value: 'secret',
+      description: 'API key for auth'
+    });
+    expect(openCollection.request.variables).toHaveLength(1);
+    expect(openCollection.request.variables[0]).toMatchObject({
+      name: 'baseUrl',
+      value: 'https://api.example.com',
+      description: 'Base API URL'
+    });
+
+    const backToBruno = openCollectionToBruno(openCollection);
+
+    expect(backToBruno.root.request.headers).toHaveLength(1);
+    expect(backToBruno.root.request.headers[0].description).toBe('API key for auth');
+    expect(backToBruno.root.request.vars.req).toHaveLength(1);
+    expect(backToBruno.root.request.vars.req[0].description).toBe('Base API URL');
+  });
+
+  it('does not set description when input has no description', () => {
+    const brunoCollection = {
+      uid: 'c2',
+      name: 'No Desc',
+      version: '1',
+      items: [],
+      root: {
+        request: {
+          headers: [
+            { uid: 'h2', name: 'Content-Type', value: 'application/json', enabled: true }
+          ],
+          vars: {
+            req: [{ uid: 'v2', name: 'port', value: '3000', enabled: true }],
+            res: []
+          }
+        }
+      }
+    };
+
+    const openCollection = brunoToOpenCollection(brunoCollection);
+    expect(openCollection.request.headers[0]).not.toHaveProperty('description');
+    expect(openCollection.request.variables[0]).not.toHaveProperty('description');
+
+    const backToBruno = openCollectionToBruno(openCollection);
+    expect(backToBruno.root.request.headers[0]).not.toHaveProperty('description');
+    expect(backToBruno.root.request.vars.req[0]).not.toHaveProperty('description');
+  });
+
+  it('preserves description when converting OpenCollection -> Bruno -> OpenCollection', () => {
+    const openCollection = {
+      opencollection: '1.0.0',
+      info: { name: 'OC Test' },
+      request: {
+        headers: [
+          { name: 'Authorization', value: 'Bearer x', description: 'Auth header' }
+        ],
+        variables: [
+
+          { name: 'token', value: 'abc', description: 'Request token' }
+        ]
+      }
+    };
+
+    const brunoCollection = openCollectionToBruno(openCollection);
+
+    expect(brunoCollection.root.request.headers).toHaveLength(1);
+    expect(brunoCollection.root.request.headers[0].description).toBe('Auth header');
+    expect(brunoCollection.root.request.vars.req).toHaveLength(1);
+    expect(brunoCollection.root.request.vars.req[0].description).toBe('Request token');
+
+    const backToOC = brunoToOpenCollection(brunoCollection);
+
+    expect(backToOC.request.headers[0].description).toBe('Auth header');
+    expect(backToOC.request.variables[0].description).toBe('Request token');
+  });
+
+  describe('request params description', () => {
+    it('Bruno→OC→Bruno: preserves description, omits when absent or whitespace-only', () => {
+      const brunoCollection = {
+        uid: 'c-p1',
+        name: 'Test',
+        version: '1',
+        items: [
+          {
+            uid: 'i-p1',
+            type: 'http-request',
+            name: 'R',
+            request: {
+              method: 'GET',
+              url: 'https://example.com',
+              params: [
+                { uid: 'p1', name: 'q', value: 'search', type: 'query', enabled: true, description: 'Search term' },
+                { uid: 'p2', name: 'id', value: '42', type: 'path', enabled: true, description: 'Resource ID' },
+                { uid: 'p3', name: 'nod', value: 'v', type: 'query', enabled: true },
+                { uid: 'p4', name: 'ws', value: 'v', type: 'query', enabled: true, description: '   ' }
+              ],
+              headers: []
+            }
+          }
+        ],
+        root: {}
+      };
+
+      const oc = brunoToOpenCollection(brunoCollection);
+      const ocParams = oc.items[0].http.params;
+      expect(ocParams).toHaveLength(4);
+      expect(ocParams[0]).toMatchObject({ name: 'q', description: 'Search term' });
+      expect(ocParams[1]).toMatchObject({ name: 'id', description: 'Resource ID' });
+      expect(ocParams[2]).not.toHaveProperty('description');
+      expect(ocParams[3]).not.toHaveProperty('description');
+
+      const back = openCollectionToBruno(oc);
+      const backParams = back.items[0].request.params;
+      expect(backParams[0]).toMatchObject({ name: 'q', description: 'Search term' });
+      expect(backParams[1]).toMatchObject({ name: 'id', description: 'Resource ID' });
+      expect(backParams[2]).not.toHaveProperty('description');
+      expect(backParams[3]).not.toHaveProperty('description');
+    });
+
+    it('OC→Bruno→OC: preserves description, omits when absent or whitespace-only', () => {
+      const openCollection = {
+        opencollection: '1.0.0',
+        info: { name: 'Test' },
+        items: [
+          {
+            info: { name: 'R', type: 'http' },
+            http: {
+              method: 'GET',
+              url: 'https://example.com',
+              params: [
+                { name: 'q', value: 'search', type: 'query', description: 'Search term' },
+                { name: 'id', value: '42', type: 'path', description: 'Resource ID' },
+                { name: 'nod', value: 'v', type: 'query' },
+                { name: 'ws', value: 'v', type: 'query', description: '   ' }
+              ]
+            }
+          }
+        ]
+      };
+
+      const bruno = openCollectionToBruno(openCollection);
+      const brunoParams = bruno.items[0].request.params;
+      expect(brunoParams[0]).toMatchObject({ name: 'q', description: 'Search term' });
+      expect(brunoParams[1]).toMatchObject({ name: 'id', description: 'Resource ID' });
+      expect(brunoParams[2]).not.toHaveProperty('description');
+      expect(brunoParams[3]).not.toHaveProperty('description');
+
+      const backOC = brunoToOpenCollection(bruno);
+      const backParams = backOC.items[0].http.params;
+      expect(backParams[0]).toMatchObject({ name: 'q', description: 'Search term' });
+      expect(backParams[1]).toMatchObject({ name: 'id', description: 'Resource ID' });
+      expect(backParams[2]).not.toHaveProperty('description');
+      expect(backParams[3]).not.toHaveProperty('description');
+    });
+  });
+
+  describe('form-urlencoded body description', () => {
+    it('Bruno→OC→Bruno: preserves description, omits when absent or whitespace-only', () => {
+      const brunoCollection = {
+        uid: 'c-f1',
+        name: 'Test',
+        version: '1',
+        items: [
+          {
+            uid: 'i-f1',
+            type: 'http-request',
+            name: 'R',
+            request: {
+              method: 'POST',
+              url: 'https://example.com',
+              headers: [],
+              body: {
+                mode: 'formUrlEncoded',
+                formUrlEncoded: [
+                  { uid: 'f1', name: 'field', value: 'val', enabled: true, description: 'A form field' },
+                  { uid: 'f2', name: 'nod', value: 'v', enabled: true },
+                  { uid: 'f3', name: 'ws', value: 'v', enabled: true, description: '   ' }
+                ]
+              }
+            }
+          }
+        ],
+        root: {}
+      };
+
+      const oc = brunoToOpenCollection(brunoCollection);
+      const ocBody = oc.items[0].http.body;
+      expect(ocBody.type).toBe('form-urlencoded');
+      expect(ocBody.data).toHaveLength(3);
+      expect(ocBody.data[0]).toMatchObject({ name: 'field', description: 'A form field' });
+      expect(ocBody.data[1]).not.toHaveProperty('description');
+      expect(ocBody.data[2]).not.toHaveProperty('description');
+
+      const back = openCollectionToBruno(oc);
+      const backForm = back.items[0].request.body.formUrlEncoded;
+      expect(backForm[0]).toMatchObject({ name: 'field', description: 'A form field' });
+      expect(backForm[1]).not.toHaveProperty('description');
+      expect(backForm[2]).not.toHaveProperty('description');
+    });
+
+    it('OC→Bruno→OC: preserves description, omits when absent or whitespace-only', () => {
+      const openCollection = {
+        opencollection: '1.0.0',
+        info: { name: 'Test' },
+        items: [
+          {
+            info: { name: 'R', type: 'http' },
+            http: {
+              method: 'POST',
+              url: 'https://example.com',
+              body: {
+                type: 'form-urlencoded',
+                data: [
+                  { name: 'field', value: 'val', description: 'A form field' },
+                  { name: 'nod', value: 'v' },
+                  { name: 'ws', value: 'v', description: '   ' }
+                ]
+              }
+            }
+          }
+        ]
+      };
+
+      const bruno = openCollectionToBruno(openCollection);
+      const brunoForm = bruno.items[0].request.body.formUrlEncoded;
+      expect(brunoForm[0]).toMatchObject({ name: 'field', description: 'A form field' });
+      expect(brunoForm[1]).not.toHaveProperty('description');
+      expect(brunoForm[2]).not.toHaveProperty('description');
+
+      const backOC = brunoToOpenCollection(bruno);
+      const backData = backOC.items[0].http.body.data;
+      expect(backData[0]).toMatchObject({ name: 'field', description: 'A form field' });
+      expect(backData[1]).not.toHaveProperty('description');
+      expect(backData[2]).not.toHaveProperty('description');
+    });
+  });
+
+  describe('multipart-form body description', () => {
+    it('Bruno→OC→Bruno: preserves description, omits when absent or whitespace-only', () => {
+      const brunoCollection = {
+        uid: 'c-m1',
+        name: 'Test',
+        version: '1',
+        items: [
+          {
+            uid: 'i-m1',
+            type: 'http-request',
+            name: 'R',
+            request: {
+              method: 'POST',
+              url: 'https://example.com',
+              headers: [],
+              body: {
+                mode: 'multipartForm',
+                multipartForm: [
+                  { uid: 'm1', name: 'file', value: '', type: 'text', enabled: true, description: 'Upload field' },
+                  { uid: 'm2', name: 'nod', value: '', type: 'text', enabled: true },
+                  { uid: 'm3', name: 'ws', value: '', type: 'text', enabled: true, description: '   ' }
+                ]
+              }
+            }
+          }
+        ],
+        root: {}
+      };
+
+      const oc = brunoToOpenCollection(brunoCollection);
+      const ocBody = oc.items[0].http.body;
+      expect(ocBody.type).toBe('multipart-form');
+      expect(ocBody.data).toHaveLength(3);
+      expect(ocBody.data[0]).toMatchObject({ name: 'file', description: 'Upload field' });
+      expect(ocBody.data[1]).not.toHaveProperty('description');
+      expect(ocBody.data[2]).not.toHaveProperty('description');
+
+      const back = openCollectionToBruno(oc);
+      const backMultipart = back.items[0].request.body.multipartForm;
+      expect(backMultipart[0]).toMatchObject({ name: 'file', description: 'Upload field' });
+      expect(backMultipart[1]).not.toHaveProperty('description');
+      expect(backMultipart[2]).not.toHaveProperty('description');
+    });
+
+    it('OC→Bruno→OC: preserves description, omits when absent or whitespace-only', () => {
+      const openCollection = {
+        opencollection: '1.0.0',
+        info: { name: 'Test' },
+        items: [
+          {
+            info: { name: 'R', type: 'http' },
+            http: {
+              method: 'POST',
+              url: 'https://example.com',
+              body: {
+                type: 'multipart-form',
+                data: [
+                  { name: 'file', type: 'text', value: '', description: 'Upload field' },
+                  { name: 'nod', type: 'text', value: '' },
+                  { name: 'ws', type: 'text', value: '', description: '   ' }
+                ]
+              }
+            }
+          }
+        ]
+      };
+
+      const bruno = openCollectionToBruno(openCollection);
+      const brunoMultipart = bruno.items[0].request.body.multipartForm;
+      expect(brunoMultipart[0]).toMatchObject({ name: 'file', description: 'Upload field' });
+      expect(brunoMultipart[1]).not.toHaveProperty('description');
+      expect(brunoMultipart[2]).not.toHaveProperty('description');
+
+      const backOC = brunoToOpenCollection(bruno);
+      const backData = backOC.items[0].http.body.data;
+      expect(backData[0]).toMatchObject({ name: 'file', description: 'Upload field' });
+      expect(backData[1]).not.toHaveProperty('description');
+      expect(backData[2]).not.toHaveProperty('description');
+    });
+  });
+});

--- a/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
+++ b/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
@@ -241,8 +241,8 @@ describe('brunoToPostman null checks and fallbacks', () => {
 
     const result = brunoToPostman(simpleCollection);
     expect(result.item[0].request.body.urlencoded).toEqual([
-      { key: '', value: 'test-value', disabled: false, type: 'default' },
-      { key: 'field', value: '', disabled: false, type: 'default' }
+      { key: '', value: 'test-value', disabled: false, type: 'default', description: '' },
+      { key: 'field', value: '', disabled: false, type: 'default', description: '' }
     ]);
   });
 
@@ -524,6 +524,7 @@ describe('brunoToPostman multipartForm handling', () => {
       mode: 'formdata',
       formdata: [
         {
+          description: '',
           key: 'myFile',
           src: ['/path/to/file1.txt', '/path/to/file2.txt'],
           disabled: false,
@@ -563,6 +564,7 @@ describe('brunoToPostman multipartForm handling', () => {
       mode: 'formdata',
       formdata: [
         {
+          description: '',
           key: 'myField',
           value: 'some text value',
           disabled: false,
@@ -603,6 +605,7 @@ describe('brunoToPostman multipartForm handling', () => {
       mode: 'formdata',
       formdata: [
         {
+          description: '',
           key: 'myFile',
           src: '/path/to/file.json',
           disabled: false,
@@ -649,12 +652,14 @@ describe('brunoToPostman multipartForm handling', () => {
       mode: 'formdata',
       formdata: [
         {
+          description: '',
           key: 'textField',
           value: 'hello',
           disabled: false,
           type: 'text'
         },
         {
+          description: '',
           key: 'fileField',
           src: '/path/to/file.txt',
           disabled: true,
@@ -691,6 +696,7 @@ describe('brunoToPostman multipartForm handling', () => {
 
     const result = brunoToPostman(simpleCollection);
     expect(result.item[0].request.body.formdata[0]).toEqual({
+      description: '',
       key: 'myFile',
       src: '/single/file/path.txt',
       disabled: false,
@@ -725,6 +731,7 @@ describe('brunoToPostman multipartForm handling', () => {
 
     const result = brunoToPostman(simpleCollection);
     expect(result.item[0].request.body.formdata[0]).toEqual({
+      description: '',
       key: 'myFile',
       src: null,
       disabled: false,

--- a/packages/bruno-filestore/src/formats/yml/parseEnvironment.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseEnvironment.ts
@@ -15,7 +15,7 @@ const toBrunoEnvironmentVariables = (variables: (Variable | SecretVariable)[] | 
 
   return variables.map((v): BrunoEnvironmentVariable => {
     if (isSecretVariable(v)) {
-      return {
+      const secretVar: BrunoEnvironmentVariable = {
         uid: uuid(),
         name: ensureString(v.name),
         value: '',
@@ -23,6 +23,10 @@ const toBrunoEnvironmentVariables = (variables: (Variable | SecretVariable)[] | 
         enabled: v.disabled !== true,
         secret: true
       };
+      if (v.description != null) {
+        secretVar.description = ensureString(v.description);
+      }
+      return secretVar;
     }
     const variable: BrunoEnvironmentVariable = {
       uid: uuid(),
@@ -32,6 +36,9 @@ const toBrunoEnvironmentVariables = (variables: (Variable | SecretVariable)[] | 
       enabled: v.disabled !== true,
       secret: false
     };
+    if (v.description != null) {
+      variable.description = ensureString(v.description);
+    }
     return variable;
   });
 };

--- a/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.ts
@@ -23,6 +23,9 @@ const toOpenCollectionEnvironmentVariables = (variables: BrunoEnvironmentVariabl
         if (v.enabled === false) {
           secretVar.disabled = true;
         }
+        if (v.description !== undefined) {
+          secretVar.description = v.description;
+        }
         return secretVar;
       }
 
@@ -33,6 +36,10 @@ const toOpenCollectionEnvironmentVariables = (variables: BrunoEnvironmentVariabl
 
       if (v.enabled === false) {
         variable.disabled = true;
+      }
+
+      if (v.description !== undefined) {
+        variable.description = v.description;
       }
 
       return variable;

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -35,13 +35,13 @@ const grammar = ohm.grammar(`Bru {
   bodies = bodyjson | bodytext | bodyxml | bodysparql | bodygraphql | bodygraphqlvars | bodyforms | body | bodygrpc | bodyws
   bodyforms = bodyformurlencoded | bodymultipart | bodyfile
   params = paramspath | paramsquery
-  
+
   // Oauth2 additional parameters
   authOauth2Configs = oauth2AuthReqConfig | oauth2AccessTokenReqConfig | oauth2RefreshTokenReqConfig
-  oauth2AuthReqConfig = oauth2AuthReqHeaders | oauth2AuthReqQueryParams 
+  oauth2AuthReqConfig = oauth2AuthReqHeaders | oauth2AuthReqQueryParams
   oauth2AccessTokenReqConfig = oauth2AccessTokenReqHeaders | oauth2AccessTokenReqQueryParams | oauth2AccessTokenReqBody
   oauth2RefreshTokenReqConfig = oauth2RefreshTokenReqHeaders | oauth2RefreshTokenReqQueryParams | oauth2RefreshTokenReqBody
- 
+
   nl = "\\r"? "\\n"
   st = " " | "\\t"
   stnl = st | nl
@@ -58,7 +58,8 @@ const grammar = ohm.grammar(`Bru {
   // Dictionary Blocks
   dictionary = st* "{" pairlist? tagend
   pairlist = optionalnl* pair (~tagend stnl* pair)* (~tagend space)*
-  pair = st* (quoted_key | key) st* ":" st* value st*
+  pair = descriptionprefix? st* (quoted_key | key) st* ":" st* value st*  -- kv
+       | descriptionprefix  -- orphandesc
   disable_char = "~"
   quote_char = "\\""
   esc_char = "\\\\"
@@ -68,11 +69,23 @@ const grammar = ohm.grammar(`Bru {
   key = keychar*
   value = list | multilinetextblock | singlelinevalue
   singlelinevalue = valuechar*
+  descriptionTripleContent = (~"'''" any)*
+
+  // Prefix description annotation: @description('''...''') on its own line before a key:value pair.
+  // Supports multiline values (unlike the suffix form).
+  // Double-quoted form is used when the description itself contains ''' (cannot embed inside triple-quoted).
+  descriptionprefix = descriptionprefix_triple | descriptionprefix_double
+  descriptionprefix_triple = st* "@" "description" "(" "'''" descriptionTripleContent "'''" ")" st* nl
+  descriptionprefix_double = st* "@" "description" "(" "\\"" descriptionDoubleChar* "\\"" ")" st* nl
+  descriptionDoubleChar = descriptionDoubleEsc | descriptionDoubleNorm
+  descriptionDoubleEsc = "\\\\" any
+  descriptionDoubleNorm = ~"\\"" ~nl any
 
   // Dictionary for Assert Block
   assertdictionary = st* "{" assertpairlist? tagend
   assertpairlist = optionalnl* assertpair (~tagend stnl* assertpair)* (~tagend space)*
-  assertpair = st* assertkey st* ":" st* value st*
+  assertpair = descriptionprefix? st* assertkey st* ":" st* value st*  -- kv
+            | descriptionprefix                                          -- orphandesc
   assertkey = ~tagend assertkeychar*
   assertkeychar = ~(tagend | nl | ":") any
 
@@ -152,7 +165,7 @@ const grammar = ohm.grammar(`Bru {
   // Examples - multiple example blocks
   example = "example" st* "{" nl* examplecontent tagend
   examplecontent = (~tagend any)*
-  
+
   script = scriptreq | scriptres
   scriptreq = "script:pre-request" st* "{" nl* textblock tagend
   scriptres = "script:post-response" st* "{" nl* textblock tagend
@@ -165,7 +178,8 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
     return [];
   }
   return _.map(pairList[0], (pair) => {
-    let name = _.keys(pair)[0];
+    // Skip the internal __desc marker when resolving the real key name
+    let name = _.keys(pair).find((k) => k !== '__desc');
     let value = pair[name];
 
     if (!parseEnabled) {
@@ -181,11 +195,17 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
       enabled = false;
     }
 
-    return {
+    const result = {
       name,
       value,
       enabled
     };
+
+    if (pair.__desc !== undefined) {
+      result.description = pair.__desc;
+    }
+
+    return result;
   });
 };
 
@@ -194,7 +214,8 @@ const mapRequestParams = (pairList = [], type) => {
     return [];
   }
   return _.map(pairList[0], (pair) => {
-    let name = _.keys(pair)[0];
+    // Skip the internal __desc marker when resolving the real key name
+    let name = _.keys(pair).find((k) => k !== '__desc');
     let value = pair[name];
     let enabled = true;
     if (name && name.length && name.charAt(0) === '~') {
@@ -202,12 +223,18 @@ const mapRequestParams = (pairList = [], type) => {
       enabled = false;
     }
 
-    return {
+    const result = {
       name,
       value,
       enabled,
       type
     };
+
+    if (pair.__desc !== undefined) {
+      result.description = pair.__desc;
+    }
+
+    return result;
   });
 };
 
@@ -240,9 +267,10 @@ const mapPairListToKeyValPairsMultipart = (pairList = [], parseEnabled = true) =
 
   return pairs.map((pair) => {
     pair.type = 'text';
+    // Description is already handled inside mapPairListToKeyValPairs
     multipartExtractContentType(pair);
 
-    if (pair.value.startsWith('@file(') && pair.value.endsWith(')')) {
+    if (_.isString(pair.value) && pair.value.startsWith('@file(') && pair.value.endsWith(')')) {
       let filestr = pair.value.replace(/^@file\(/, '').replace(/\)$/, '');
       pair.type = 'file';
       pair.value = filestr.split('|');
@@ -351,14 +379,50 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   pairlist(_1, pair, _2, rest, _3) {
     return [pair.ast, ...rest.ast];
   },
-  pair(_1, key, _2, _3, _4, value, _5) {
+  descriptionprefix(alt) {
+    return alt.ast;
+  },
+  descriptionprefix_triple(_st, _at, _desc, _lp, _open, descContent, _close, _rp, _st2, _nl) {
+    const raw = descContent.sourceString;
+    if (raw.includes('\n')) {
+      return raw.split('\n').map((line) => (line.startsWith('    ') ? line.slice(4) : line)).join('\n').trim();
+    }
+    return raw.trim();
+  },
+  descriptionprefix_double(_st, _at, _desc, _lp, _dqOpen, descChars, _dqClose, _rp, _st2, _nl) {
+    return descChars.sourceString.replace(/\\(\\|"|n|r|t)/g, (_, c) => {
+      if (c === '\\') return '\\';
+      if (c === '"') return '"';
+      if (c === 'n') return '\n';
+      if (c === 'r') return '\r';
+      if (c === 't') return '\t';
+      return c;
+    });
+  },
+  pair_kv(descPrefix, _1, key, _2, _3, _4, value, _5) {
     let res = {};
-    if (Array.isArray(value.ast)) {
-      res[key.ast] = value.ast;
+    const valueAst = value.ast;
+    const prefixDesc = descPrefix.children.length > 0 ? descPrefix.children[0].ast : undefined;
+
+    if (Array.isArray(valueAst)) {
+      res[key.ast] = valueAst;
+      if (prefixDesc !== undefined) res.__desc = prefixDesc;
       return res;
     }
-    res[key.ast] = value.ast ? value.ast.trim() : '';
+
+    if (valueAst && typeof valueAst === 'object' && '__value' in valueAst) {
+      res[key.ast] = valueAst.__value;
+      // Prefix description takes precedence over suffix description
+      res.__desc = prefixDesc !== undefined ? prefixDesc : valueAst.__desc;
+      return res;
+    }
+
+    res[key.ast] = valueAst ? valueAst.trim() : '';
+    if (prefixDesc !== undefined) res.__desc = prefixDesc;
     return res;
+  },
+  pair_orphandesc(descPrefix) {
+    return { '': '', '__desc': descPrefix.ast };
   },
   esc_quote_char(_1, quote) {
     // unescape
@@ -377,10 +441,16 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   assertpairlist(_1, pair, _2, rest, _3) {
     return [pair.ast, ...rest.ast];
   },
-  assertpair(_1, key, _2, _3, _4, value, _5) {
+  assertpair_kv(descPrefix, _1, key, _2, _3, _4, value, _5) {
     let res = {};
-    res[key.ast] = value.ast ? value.ast.trim() : '';
+    const valueAst = value.ast;
+    const prefixDesc = descPrefix.children.length > 0 ? descPrefix.children[0].ast : undefined;
+    res[key.ast] = valueAst ? valueAst.trim() : '';
+    if (prefixDesc !== undefined) res.__desc = prefixDesc;
     return res;
+  },
+  assertpair_orphandesc(descPrefix) {
+    return { '': '', '__desc': descPrefix.ast };
   },
   assertkey(chars) {
     return chars.sourceString ? chars.sourceString.trim() : '';

--- a/packages/bruno-lang/v2/src/collectionBruToJson.js
+++ b/packages/bruno-lang/v2/src/collectionBruToJson.js
@@ -8,7 +8,7 @@ const grammar = ohm.grammar(`Bru {
 
   // Oauth2 additional parameters
   authOauth2Configs = oauth2AuthReqConfig | oauth2AccessTokenReqConfig | oauth2RefreshTokenReqConfig
-  oauth2AuthReqConfig = oauth2AuthReqHeaders | oauth2AuthReqQueryParams 
+  oauth2AuthReqConfig = oauth2AuthReqHeaders | oauth2AuthReqQueryParams
   oauth2AccessTokenReqConfig = oauth2AccessTokenReqHeaders | oauth2AccessTokenReqQueryParams | oauth2AccessTokenReqBody
   oauth2RefreshTokenReqConfig = oauth2RefreshTokenReqHeaders | oauth2RefreshTokenReqQueryParams | oauth2RefreshTokenReqBody
 
@@ -27,7 +27,8 @@ const grammar = ohm.grammar(`Bru {
   // Dictionary Blocks
   dictionary = st* "{" pairlist? tagend
   pairlist = optionalnl* pair (~tagend stnl* pair)* (~tagend space)*
-  pair = st* (quoted_key | key) st* ":" st* value st*
+  pair = descriptionprefix? st* (quoted_key | key) st* ":" st* value st*  -- kv
+       | descriptionprefix                                                  -- orphandesc
   disable_char = "~"
   quote_char = "\\""
   esc_char = "\\\\"
@@ -35,13 +36,25 @@ const grammar = ohm.grammar(`Bru {
   quoted_key_char = ~(quote_char | esc_quote_char | nl) any
   quoted_key = disable_char? quote_char (esc_quote_char | quoted_key_char)* quote_char
   key = keychar*
-  value = multilinetextblock | valuechar*
+  value = multilinetextblock | singlelinevalue
+  singlelinevalue = valuechar*
+  descriptionTripleContent = (~"'''" any)*
+
+  // Prefix description annotation: @description('''...''') on its own line before a key:value pair.
+  // Supports multiline values (unlike the suffix form).
+  // Double-quoted form is used when the description itself contains ''' (cannot embed inside triple-quoted).
+  descriptionprefix = descriptionprefix_triple | descriptionprefix_double
+  descriptionprefix_triple = st* "@" "description" "(" "'''" descriptionTripleContent "'''" ")" st* nl
+  descriptionprefix_double = st* "@" "description" "(" "\\"" descriptionDoubleChar* "\\"" ")" st* nl
+  descriptionDoubleChar = descriptionDoubleEsc | descriptionDoubleNorm
+  descriptionDoubleEsc = "\\\\" any
+  descriptionDoubleNorm = ~"\\"" ~nl any
 
   // Text Blocks
   textblock = textline (~tagend nl textline)*
   textline = textchar*
   textchar = ~nl any
-  
+
   meta = "meta" dictionary
 
   auth = "auth" dictionary
@@ -84,7 +97,8 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
     return [];
   }
   return _.map(pairList[0], (pair) => {
-    let name = _.keys(pair)[0];
+    // Skip the internal __desc marker when resolving the real key name
+    let name = _.keys(pair).find((k) => k !== '__desc');
     let value = pair[name];
 
     if (!parseEnabled) {
@@ -100,11 +114,17 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
       enabled = false;
     }
 
-    return {
+    const result = {
       name,
       value,
       enabled
     };
+
+    if (pair.__desc !== undefined) {
+      result.description = pair.__desc;
+    }
+
+    return result;
   });
 };
 
@@ -142,10 +162,36 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   pairlist(_1, pair, _2, rest, _3) {
     return [pair.ast, ...rest.ast];
   },
-  pair(_1, key, _2, _3, _4, value, _5) {
+  descriptionprefix(alt) {
+    return alt.ast;
+  },
+  descriptionprefix_triple(_st, _at, _desc, _lp, _open, descContent, _close, _rp, _st2, _nl) {
+    const raw = descContent.sourceString;
+    if (raw.includes('\n')) {
+      return raw.split('\n').map((line) => (line.startsWith('    ') ? line.slice(4) : line)).join('\n').trim();
+    }
+    return raw.trim();
+  },
+  descriptionprefix_double(_st, _at, _desc, _lp, _dqOpen, descChars, _dqClose, _rp, _st2, _nl) {
+    return descChars.sourceString.replace(/\\(\\|"|n|r|t)/g, (_, c) => {
+      if (c === '\\') return '\\';
+      if (c === '"') return '"';
+      if (c === 'n') return '\n';
+      if (c === 'r') return '\r';
+      if (c === 't') return '\t';
+      return c;
+    });
+  },
+  pair_kv(descPrefix, _1, key, _2, _3, _4, value, _5) {
     let res = {};
-    res[key.ast] = value.ast ? value.ast.trim() : '';
+    const valueAst = value.ast;
+    const prefixDesc = descPrefix.children.length > 0 ? descPrefix.children[0].ast : undefined;
+    res[key.ast] = valueAst ? valueAst.trim() : '';
+    if (prefixDesc !== undefined) res.__desc = prefixDesc;
     return res;
+  },
+  pair_orphandesc(descPrefix) {
+    return { '': '', '__desc': descPrefix.ast };
   },
   quoted_key(disabled, _1, chars, _2) {
     // unquote and handle disabled prefix
@@ -163,23 +209,10 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     return chars.sourceString ? chars.sourceString.trim() : '';
   },
   value(chars) {
-    if (chars.ctorName === 'list') {
-      return chars.ast;
-    }
-    try {
-      let isMultiline = chars.sourceString?.startsWith(`'''`) && chars.sourceString?.endsWith(`'''`);
-      if (isMultiline) {
-        const multilineString = chars.sourceString?.replace(/^'''|'''$/g, '');
-        return multilineString
-          .split('\n')
-          .map((line) => line.slice(4))
-          .join('\n');
-      }
-      return chars.sourceString ? chars.sourceString.trim() : '';
-    } catch (err) {
-      console.error(err);
-    }
-    return chars.sourceString ? chars.sourceString.trim() : '';
+    return chars.ast;
+  },
+  singlelinevalue(chars) {
+    return chars.sourceString?.trim() || '';
   },
   textblock(line, _1, rest) {
     return [line.ast, ...rest.ast].join('\n');
@@ -191,8 +224,11 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     return char.sourceString;
   },
   multilinetextblock(_1, content, _2) {
-    // Join all the content between the triple quotes and trim it
-    return content.sourceString.trim();
+    return content.sourceString
+      .split('\n')
+      .map((line) => line.slice(4))
+      .join('\n')
+      .trim();
   },
   nl(_1, _2) {
     return '';

--- a/packages/bruno-lang/v2/src/common/semantic-utils.js
+++ b/packages/bruno-lang/v2/src/common/semantic-utils.js
@@ -11,7 +11,8 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
     return [];
   }
   return _.map(pairList[0], (pair) => {
-    let name = _.keys(pair)[0];
+    // Skip the internal __desc marker when resolving the real key name
+    let name = _.keys(pair).find((k) => k !== '__desc');
     let value = pair[name];
 
     if (!parseEnabled) {
@@ -27,11 +28,17 @@ const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
       enabled = false;
     }
 
-    return {
+    const result = {
       name,
       value,
       enabled
     };
+
+    if (pair.__desc !== undefined) {
+      result.description = pair.__desc;
+    }
+
+    return result;
   });
 };
 
@@ -46,7 +53,8 @@ const mapRequestParams = (pairList = [], type) => {
     return [];
   }
   return _.map(pairList[0], (pair) => {
-    let name = _.keys(pair)[0];
+    // Skip the internal __desc marker when resolving the real key name
+    let name = _.keys(pair).find((k) => k !== '__desc');
     let value = pair[name];
     let enabled = true;
     if (name && name.length && name.charAt(0) === '~') {
@@ -54,12 +62,18 @@ const mapRequestParams = (pairList = [], type) => {
       enabled = false;
     }
 
-    return {
+    const result = {
       name,
       value,
       enabled,
       type
     };
+
+    if (pair.__desc !== undefined) {
+      result.description = pair.__desc;
+    }
+
+    return result;
   });
 };
 
@@ -106,9 +120,10 @@ const mapPairListToKeyValPairsMultipart = (pairList = [], parseEnabled = true) =
 
   return pairs.map((pair) => {
     pair.type = 'text';
+    // Description is already handled inside mapPairListToKeyValPairs
     multipartExtractContentType(pair);
 
-    if (pair.value.startsWith('@file(') && pair.value.endsWith(')')) {
+    if (_.isString(pair.value) && pair.value.startsWith('@file(') && pair.value.endsWith(')')) {
       let filestr = pair.value.replace(/^@file\(/, '').replace(/\)$/, '');
       pair.type = 'file';
       pair.value = filestr.split('|');

--- a/packages/bruno-lang/v2/src/envToJson.js
+++ b/packages/bruno-lang/v2/src/envToJson.js
@@ -31,9 +31,22 @@ const grammar = ohm.grammar(`Bru {
   // Dictionary Blocks
   dictionary = st* "{" pairlist? tagend
   pairlist = optionalnl* pair (~tagend stnl* pair)* (~tagend space)*
-  pair = st* key st* ":" st* value st*
+  pair = descriptionprefix? st* key st* ":" st* value st*  -- kv
+       | descriptionprefix                                  -- orphandesc
   key = keychar*
-  value = multilinetextblock | valuechar*
+  value = multilinetextblock | singlelinevalue
+  singlelinevalue = valuechar*
+  descriptionTripleContent = (~"'''" any)*
+
+  // Prefix description annotation: @description('''...''') on its own line before a key:value pair.
+  // Supports multiline values (unlike the suffix form).
+  // Double-quoted form is used when the description itself contains ''' (cannot embed inside triple-quoted).
+  descriptionprefix = descriptionprefix_triple | descriptionprefix_double
+  descriptionprefix_triple = st* "@" "description" "(" "'''" descriptionTripleContent "'''" ")" st* nl
+  descriptionprefix_double = st* "@" "description" "(" "\\"" descriptionDoubleChar* "\\"" ")" st* nl
+  descriptionDoubleChar = descriptionDoubleEsc | descriptionDoubleNorm
+  descriptionDoubleEsc = "\\\\" any
+  descriptionDoubleNorm = ~"\\"" ~nl any
 
   // Array Blocks
   array = st* "[" stnl* valuelist stnl* "]"
@@ -52,7 +65,8 @@ const mapPairListToKeyValPairs = (pairList = []) => {
   }
 
   return _.map(pairList[0], (pair) => {
-    let name = _.keys(pair)[0];
+    // Skip the internal __desc marker when resolving the real key name
+    let name = _.keys(pair).find((k) => k !== '__desc');
     let value = pair[name];
     let enabled = true;
     if (name && name.length && name.charAt(0) === '~') {
@@ -60,11 +74,17 @@ const mapPairListToKeyValPairs = (pairList = []) => {
       enabled = false;
     }
 
-    return {
+    const result = {
       name,
       value,
       enabled
     };
+
+    if (pair.__desc !== undefined) {
+      result.description = pair.__desc;
+    }
+
+    return result;
   });
 };
 
@@ -128,20 +148,45 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   pairlist(_1, pair, _2, rest, _3) {
     return [pair.ast, ...rest.ast];
   },
-  pair(_1, key, _2, _3, _4, value, _5) {
+  descriptionprefix(alt) {
+    return alt.ast;
+  },
+  descriptionprefix_triple(_st, _at, _desc, _lp, _open, descContent, _close, _rp, _st2, _nl) {
+    const raw = descContent.sourceString;
+    if (raw.includes('\n')) {
+      return raw.split('\n').map((line) => (line.startsWith('    ') ? line.slice(4) : line)).join('\n').trim();
+    }
+    return raw.trim();
+  },
+  descriptionprefix_double(_st, _at, _desc, _lp, _dqOpen, descChars, _dqClose, _rp, _st2, _nl) {
+    return descChars.sourceString.replace(/\\(\\|"|n|r|t)/g, (_, c) => {
+      if (c === '\\') return '\\';
+      if (c === '"') return '"';
+      if (c === 'n') return '\n';
+      if (c === 'r') return '\r';
+      if (c === 't') return '\t';
+      return c;
+    });
+  },
+  pair_kv(descPrefix, _1, key, _2, _3, _4, value, _5) {
     let res = {};
-    res[key.ast] = value.ast ? value.ast.trim() : '';
+    const valueAst = value.ast;
+    const prefixDesc = descPrefix.children.length > 0 ? descPrefix.children[0].ast : undefined;
+    res[key.ast] = valueAst ? valueAst.trim() : '';
+    if (prefixDesc !== undefined) res.__desc = prefixDesc;
     return res;
+  },
+  pair_orphandesc(descPrefix) {
+    return { '': '', '__desc': descPrefix.ast };
   },
   key(chars) {
     return chars.sourceString ? chars.sourceString.trim() : '';
   },
   value(chars) {
-    // .ctorName provides the name of the rule that matched the input
-    if (chars.ctorName === 'multilinetextblock') {
-      return chars.ast;
-    }
-    return chars.sourceString ? chars.sourceString.trim() : '';
+    return chars.ast;
+  },
+  singlelinevalue(chars) {
+    return chars.sourceString?.trim() || '';
   },
   multilinetextblockstart(_1, _2) {
     return '';

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -6,6 +6,56 @@ const jsonToExampleBru = require('./example/jsonToBru');
 const enabled = (items = [], key = 'enabled') => items.filter((item) => item[key]);
 const disabled = (items = [], key = 'enabled') => items.filter((item) => !item[key]);
 
+/** JSON-style escape for use inside double-quoted @description("..."). */
+const escapeDescriptionDouble = (s) =>
+  String(s)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+
+/**
+ * Emit @description as a prefix line before a key:value pair.
+ *
+ * Normal forms:
+ *   Single-line:  @description('''desc''')
+ *   Multiline:    @description('''
+ *                   line1
+ *                   line2
+ *                 ''')
+ *
+ * Fallback form (when description itself contains '''):
+ *   @description("line1\nline2\nline3")
+ *
+ *   The triple-quoted grammar rule is  descriptionTripleContent = (~"'''" any)*
+ *   so the parser treats the first ''' it encounters as the closing delimiter —
+ *   there is no escape mechanism inside '''...'''. The double-quoted form is the
+ *   only safe representation, with newlines encoded as \n escape sequences.
+ *
+ *   This is a known readability trade-off: a long multiline description that
+ *   contains ''' (e.g. Python docstrings, SQL literals, bru format examples)
+ *   will appear as a single opaque escaped line in the file. Fixing it cleanly
+ *   would require a grammar change to introduce an escape for ''' inside the
+ *   triple-quoted block (e.g. \'\'\').
+ *
+ * Note: leading/trailing newlines in the description are stripped by .trim()
+ * before serialization, so they will not survive a save/reload cycle.
+ */
+const getDescriptionPrefix = (item) => {
+  const desc = item && item.description && String(item.description).trim();
+  if (!desc) return '';
+  if (desc.includes('\'\'\'')) {
+    return '@description("' + escapeDescriptionDouble(desc) + '")\n';
+  }
+  const descHasNewline = desc.includes('\n') || desc.includes('\r');
+  if (descHasNewline) {
+    const indented = desc.split('\n').map((line) => '  ' + line).join('\n');
+    return '@description(\'\'\'\n' + indented + '\n\'\'\')\n';
+  }
+  return '@description(\'\'\'' + desc.replace(/\\/g, '\\\\') + '\'\'\')\n';
+};
+
 // remove the last line if two new lines are found
 const stripLastLine = (text) => {
   if (!text || !text.length) return text;
@@ -128,7 +178,7 @@ const jsonToBru = (json) => {
       if (enabled(queryParams).length) {
         bru += `\n${indentString(
           enabled(queryParams)
-            .map((item) => `${getKeyString(item.name)}: ${getValueString(item.value)}`)
+            .map((item) => `${getDescriptionPrefix(item)}${getKeyString(item.name)}: ${getValueString(item.value)}`)
             .join('\n')
         )}`;
       }
@@ -136,7 +186,7 @@ const jsonToBru = (json) => {
       if (disabled(queryParams).length) {
         bru += `\n${indentString(
           disabled(queryParams)
-            .map((item) => `~${getKeyString(item.name)}: ${getValueString(item.value)}`)
+            .map((item) => `${getDescriptionPrefix(item)}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
             .join('\n')
         )}`;
       }
@@ -147,7 +197,7 @@ const jsonToBru = (json) => {
     if (pathParams.length) {
       bru += 'params:path {';
 
-      bru += `\n${indentString(pathParams.map((item) => `${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(pathParams.map((item) => `${getDescriptionPrefix(item)}${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
 
       bru += '\n}\n\n';
     }
@@ -158,7 +208,7 @@ const jsonToBru = (json) => {
     if (enabled(headers).length) {
       bru += `\n${indentString(
         enabled(headers)
-          .map((item) => `${getKeyString(item.name)}: ${getValueString(item.value)}`)
+          .map((item) => `${getDescriptionPrefix(item)}${getKeyString(item.name)}: ${getValueString(item.value)}`)
           .join('\n')
       )}`;
     }
@@ -166,7 +216,7 @@ const jsonToBru = (json) => {
     if (disabled(headers).length) {
       bru += `\n${indentString(
         disabled(headers)
-          .map((item) => `~${getKeyString(item.name)}: ${getValueString(item.value)}`)
+          .map((item) => `${getDescriptionPrefix(item)}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
           .join('\n')
       )}`;
     }
@@ -506,14 +556,14 @@ ${indentString(body.sparql)}
 
     if (enabled(body.formUrlEncoded).length) {
       const enabledValues = enabled(body.formUrlEncoded)
-        .map((item) => `${getKeyString(item.name)}: ${getValueString(item.value)}`)
+        .map((item) => `${getDescriptionPrefix(item)}${getKeyString(item.name)}: ${getValueString(item.value)}`)
         .join('\n');
       bru += `${indentString(enabledValues)}\n`;
     }
 
     if (disabled(body.formUrlEncoded).length) {
       const disabledValues = disabled(body.formUrlEncoded)
-        .map((item) => `~${getKeyString(item.name)}: ${getValueString(item.value)}`)
+        .map((item) => `${getDescriptionPrefix(item)}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
         .join('\n');
       bru += `${indentString(disabledValues)}\n`;
     }
@@ -529,12 +579,13 @@ ${indentString(body.sparql)}
       bru += `\n${indentString(
         multipartForms
           .map((item) => {
-            const enabled = item.enabled ? '' : '~';
+            const enabledPrefix = item.enabled ? '' : '~';
             const contentType
               = item.contentType && item.contentType !== '' ? ' @contentType(' + item.contentType + ')' : '';
+            const descPrefix = getDescriptionPrefix(item);
 
             if (item.type === 'text') {
-              return `${enabled}${getKeyString(item.name)}: ${getValueString(item.value)}${contentType}`;
+              return `${descPrefix}${enabledPrefix}${getKeyString(item.name)}: ${getValueString(item.value)}${contentType}`;
             }
 
             if (item.type === 'file') {
@@ -542,7 +593,7 @@ ${indentString(body.sparql)}
               const filestr = filepaths.join('|');
 
               const value = `@file(${filestr})`;
-              return `${enabled}${getKeyString(item.name)}: ${value}${contentType}`;
+              return `${descPrefix}${enabledPrefix}${getKeyString(item.name)}: ${value}${contentType}`;
             }
           })
           .join('\n')
@@ -641,19 +692,19 @@ ${indentString(body.sparql)}
     bru += `vars:pre-request {`;
 
     if (varsEnabled.length) {
-      bru += `\n${indentString(varsEnabled.map((item) => `${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsEnabled.map((item) => `${getDescriptionPrefix(item)}${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsLocalEnabled.length) {
-      bru += `\n${indentString(varsLocalEnabled.map((item) => `@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsLocalEnabled.map((item) => `${getDescriptionPrefix(item)}@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsDisabled.length) {
-      bru += `\n${indentString(varsDisabled.map((item) => `~${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsDisabled.map((item) => `${getDescriptionPrefix(item)}~${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsLocalDisabled.length) {
-      bru += `\n${indentString(varsLocalDisabled.map((item) => `~@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsLocalDisabled.map((item) => `${getDescriptionPrefix(item)}~@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     bru += '\n}\n\n';
@@ -667,19 +718,19 @@ ${indentString(body.sparql)}
     bru += `vars:post-response {`;
 
     if (varsEnabled.length) {
-      bru += `\n${indentString(varsEnabled.map((item) => `${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsEnabled.map((item) => `${getDescriptionPrefix(item)}${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsLocalEnabled.length) {
-      bru += `\n${indentString(varsLocalEnabled.map((item) => `@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsLocalEnabled.map((item) => `${getDescriptionPrefix(item)}@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsDisabled.length) {
-      bru += `\n${indentString(varsDisabled.map((item) => `~${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsDisabled.map((item) => `${getDescriptionPrefix(item)}~${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsLocalDisabled.length) {
-      bru += `\n${indentString(varsLocalDisabled.map((item) => `~@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsLocalDisabled.map((item) => `${getDescriptionPrefix(item)}~@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     bru += '\n}\n\n';
@@ -691,7 +742,7 @@ ${indentString(body.sparql)}
     if (enabled(assertions).length) {
       bru += `\n${indentString(
         enabled(assertions)
-          .map((item) => `${item.name}: ${getValueString(item.value)}`)
+          .map((item) => `${getDescriptionPrefix(item)}${item.name}: ${getValueString(item.value)}`)
           .join('\n')
       )}`;
     }
@@ -699,7 +750,7 @@ ${indentString(body.sparql)}
     if (disabled(assertions).length) {
       bru += `\n${indentString(
         disabled(assertions)
-          .map((item) => `~${getKeyString(item.name)}: ${getValueString(item.value)}`)
+          .map((item) => `${getDescriptionPrefix(item)}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
           .join('\n')
       )}`;
     }

--- a/packages/bruno-lang/v2/src/jsonToCollectionBru.js
+++ b/packages/bruno-lang/v2/src/jsonToCollectionBru.js
@@ -5,6 +5,33 @@ const { indentString, getValueString, getKeyString } = require('./utils');
 const enabled = (items = []) => items.filter((item) => item.enabled);
 const disabled = (items = []) => items.filter((item) => !item.enabled);
 
+/** JSON-style escape for use inside double-quoted @description("..."). */
+const escapeDescriptionDouble = (s) =>
+  String(s)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+
+/**
+ * Emit @description as a prefix line before a key:value pair.
+ * Using a prefix (instead of suffix) correctly handles multiline values and multiline descriptions.
+ */
+const getDescriptionPrefix = (item) => {
+  const desc = item && item.description && String(item.description).trim();
+  if (!desc) return '';
+  if (desc.includes('\'\'\'')) {
+    return '@description("' + escapeDescriptionDouble(desc) + '")\n';
+  }
+  const descHasNewline = desc.includes('\n') || desc.includes('\r');
+  if (descHasNewline) {
+    const indented = desc.split('\n').map((line) => '  ' + line).join('\n');
+    return '@description(\'\'\'\n' + indented + '\n\'\'\')\n';
+  }
+  return '@description(\'\'\'' + desc.replace(/\\/g, '\\\\') + '\'\'\')\n';
+};
+
 // remove the last line if two new lines are found
 const stripLastLine = (text) => {
   if (!text || !text.length) return text;
@@ -30,7 +57,7 @@ const jsonToCollectionBru = (json) => {
     if (enabled(query).length) {
       bru += `\n${indentString(
         enabled(query)
-          .map((item) => `${getKeyString(item.name)}: ${getValueString(item.value)}`)
+          .map((item) => `${getDescriptionPrefix(item)}${getKeyString(item.name)}: ${getValueString(item.value)}`)
           .join('\n')
       )}`;
     }
@@ -38,7 +65,7 @@ const jsonToCollectionBru = (json) => {
     if (disabled(query).length) {
       bru += `\n${indentString(
         disabled(query)
-          .map((item) => `~${getKeyString(item.name)}: ${getValueString(item.value)}`)
+          .map((item) => `${getDescriptionPrefix(item)}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
           .join('\n')
       )}`;
     }
@@ -51,7 +78,7 @@ const jsonToCollectionBru = (json) => {
     if (enabled(headers).length) {
       bru += `\n${indentString(
         enabled(headers)
-          .map((item) => `${getKeyString(item.name)}: ${getValueString(item.value)}`)
+          .map((item) => `${getDescriptionPrefix(item)}${getKeyString(item.name)}: ${getValueString(item.value)}`)
           .join('\n')
       )}`;
     }
@@ -59,7 +86,7 @@ const jsonToCollectionBru = (json) => {
     if (disabled(headers).length) {
       bru += `\n${indentString(
         disabled(headers)
-          .map((item) => `~${getKeyString(item.name)}: ${getValueString(item.value)}`)
+          .map((item) => `${getDescriptionPrefix(item)}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
           .join('\n')
       )}`;
     }
@@ -358,19 +385,19 @@ ${indentString(
     bru += `vars:pre-request {`;
 
     if (varsEnabled.length) {
-      bru += `\n${indentString(varsEnabled.map((item) => `${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsEnabled.map((item) => `${getDescriptionPrefix(item)}${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsLocalEnabled.length) {
-      bru += `\n${indentString(varsLocalEnabled.map((item) => `@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsLocalEnabled.map((item) => `${getDescriptionPrefix(item)}@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsDisabled.length) {
-      bru += `\n${indentString(varsDisabled.map((item) => `~${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsDisabled.map((item) => `${getDescriptionPrefix(item)}~${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsLocalDisabled.length) {
-      bru += `\n${indentString(varsLocalDisabled.map((item) => `~@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsLocalDisabled.map((item) => `${getDescriptionPrefix(item)}~@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     bru += '\n}\n\n';
@@ -384,19 +411,19 @@ ${indentString(
     bru += `vars:post-response {`;
 
     if (varsEnabled.length) {
-      bru += `\n${indentString(varsEnabled.map((item) => `${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsEnabled.map((item) => `${getDescriptionPrefix(item)}${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsLocalEnabled.length) {
-      bru += `\n${indentString(varsLocalEnabled.map((item) => `@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsLocalEnabled.map((item) => `${getDescriptionPrefix(item)}@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsDisabled.length) {
-      bru += `\n${indentString(varsDisabled.map((item) => `~${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsDisabled.map((item) => `${getDescriptionPrefix(item)}~${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     if (varsLocalDisabled.length) {
-      bru += `\n${indentString(varsLocalDisabled.map((item) => `~@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(varsLocalDisabled.map((item) => `${getDescriptionPrefix(item)}~@${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
     }
 
     bru += '\n}\n\n';

--- a/packages/bruno-lang/v2/src/jsonToEnv.js
+++ b/packages/bruno-lang/v2/src/jsonToEnv.js
@@ -1,6 +1,32 @@
 const _ = require('lodash');
 const { getValueString, indentString } = require('./utils');
 
+const escapeDescriptionDouble = (s) =>
+  String(s)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+
+/**
+ * Emit @description as a prefix line before a key:value pair.
+ * Using a prefix (instead of suffix) lets the value be multiline without conflict.
+ */
+const getDescriptionPrefix = (variable) => {
+  const desc = variable && variable.description && String(variable.description).trim();
+  if (!desc) return '';
+  if (desc.includes('\'\'\'')) {
+    return '@description("' + escapeDescriptionDouble(desc) + '")\n';
+  }
+  const descHasNewline = desc.includes('\n') || desc.includes('\r');
+  if (descHasNewline) {
+    const indented = desc.split('\n').map((line) => '  ' + line).join('\n');
+    return '@description(\'\'\'\n' + indented + '\n\'\'\')\n';
+  }
+  return '@description(\'\'\'' + desc.replace(/\\/g, '\\\\') + '\'\'\')\n';
+};
+
 const envToJson = (json) => {
   const variables = _.get(json, 'variables', []);
   const color = _.get(json, 'color', null);
@@ -11,7 +37,7 @@ const envToJson = (json) => {
       const { name, value, enabled } = variable;
       const prefix = enabled ? '' : '~';
 
-      return indentString(`${prefix}${name}: ${getValueString(value)}`);
+      return indentString(`${getDescriptionPrefix(variable)}${prefix}${name}: ${getValueString(value)}`);
     });
 
   const secretVars = variables

--- a/packages/bruno-lang/v2/src/jsonToEnv.js
+++ b/packages/bruno-lang/v2/src/jsonToEnv.js
@@ -19,9 +19,10 @@ const getDescriptionPrefix = (variable) => {
   if (desc.includes('\'\'\'')) {
     return '@description("' + escapeDescriptionDouble(desc) + '")\n';
   }
-  const descHasNewline = desc.includes('\n') || desc.includes('\r');
+
+  const descHasNewline = desc.includes('\r\n') || desc.includes('\r') || desc.includes('\n');
   if (descHasNewline) {
-    const indented = desc.split('\n').map((line) => '  ' + line).join('\n');
+    const indented = desc.split(/\r\n|\r|\n/g).map((line) => '  ' + line).join('\n');
     return '@description(\'\'\'\n' + indented + '\n\'\'\')\n';
   }
   return '@description(\'\'\'' + desc.replace(/\\/g, '\\\\') + '\'\'\')\n';

--- a/packages/bruno-lang/v2/src/utils.js
+++ b/packages/bruno-lang/v2/src/utils.js
@@ -19,6 +19,48 @@ const indentString = (str, levels = 1) => {
     .join('\n');
 };
 
+/**
+ * Like indentString but adds one extra indent level to lines inside @description('''...''') content
+ * so multiline description content is indented relative to its key line, matching env multiline value behaviour.
+ * When reading back, parsers strip those 4 spaces (2 block + 2 extra) to recover the original description.
+ */
+const indentWithDescription = (str, levels = 1) => {
+  if (!str || !str.length) {
+    return str || '';
+  }
+
+  const indent = '  '.repeat(levels);
+  // split the string into lines
+  const lines = str.split(/\r\n|\r|\n/);
+
+  // tracks whether we're inside a multiline @description('''...''') block
+  let inDescContent = false;
+  const result = [];
+
+  for (const line of lines) {
+    const trimmed = line.trimEnd();
+    if (inDescContent) {
+      if (/^\s*'''\s*\)?\s*$/.test(trimmed)) {
+        // closing ''' or ''') — exit description content and apply normal indent
+        inDescContent = false;
+        result.push(indent + line);
+      } else {
+        // description content line — add one extra indent level so it's visually nested
+        result.push(indent + '  ' + line);
+      }
+    } else {
+      // detect start of a multiline @description(''' — it ends with ''' but NOT with ''')
+      // (single-line @description('''text''') ends with ''' ) so we skip those)
+      if (trimmed.includes('@description(\'\'\'') && trimmed.endsWith('\'\'\'') && !trimmed.endsWith('\'\'\')')) {
+        inDescContent = true;
+      }
+      result.push(indent + line);
+    }
+  }
+
+  return result.join('\n');
+};
+
 const outdentString = (str, spaces = 2) => {
   if (!str || !str.length) {
     return str || '';
@@ -71,6 +113,7 @@ const getValueUrl = (url) => {
 module.exports = {
   safeParseJson,
   indentString,
+  indentWithDescription,
   outdentString,
   getValueString,
   getKeyString,

--- a/packages/bruno-lang/v2/tests/bruToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/bruToJson.spec.js
@@ -9,7 +9,7 @@ body:ws {
     name: message 1
     content: '''
       {"foo":"bar"}
-    ''' 
+    '''
 }
 
 settings {
@@ -46,7 +46,7 @@ body:grpc {
     name: message 1
     content: '''
       {"foo":"bar"}
-    ''' 
+    '''
 }
 `;
 
@@ -72,7 +72,7 @@ body:grpc {
     name: message 1
     content: '''
       {"id":{{userId}},"name":"{{userName}}"}
-    ''' 
+    '''
 }
 `;
 
@@ -202,6 +202,359 @@ body:multipart-form {
 
       const output = parser(input);
       expect(output).toEqual(expected);
+    });
+  });
+
+  describe('description annotation', () => {
+    it('parses @description in headers', () => {
+      const input = `
+headers {
+  @description('''API key for auth.''')
+  Authorization: Bearer xxx
+  @description("Single-line desc")
+  X-Custom: val
+}`;
+
+      const output = parser(input);
+      expect(output.headers).toHaveLength(2);
+      expect(output.headers[0]).toMatchObject({
+        name: 'Authorization',
+        value: 'Bearer xxx',
+        enabled: true,
+        description: 'API key for auth.'
+      });
+      expect(output.headers[1]).toMatchObject({
+        name: 'X-Custom',
+        value: 'val',
+        enabled: true,
+        description: 'Single-line desc'
+      });
+    });
+
+    it('parses @description in params and body form-urlencoded', () => {
+      const input = `
+params:query {
+  @description('''Search term.''')
+  q: search
+}
+body:form-urlencoded {
+  @description("Field description")
+  field: value
+}`;
+
+      const output = parser(input);
+      expect(output.params).toHaveLength(1);
+      expect(output.params[0]).toMatchObject({
+        name: 'q',
+        value: 'search',
+        type: 'query',
+        description: 'Search term.'
+      });
+      expect(output.body.formUrlEncoded).toHaveLength(1);
+      expect(output.body.formUrlEncoded[0]).toMatchObject({
+        name: 'field',
+        value: 'value',
+        enabled: true,
+        description: 'Field description'
+      });
+    });
+
+    it('parses @description in vars:pre-request and vars:post-response', () => {
+      const input = `
+vars:pre-request {
+  @description("Pre-request auth token")
+  token: secret
+}
+vars:post-response {
+  @description("Saved ID from response")
+  saved: res.body.id
+}`;
+
+      const output = parser(input);
+      expect(output.vars).toBeDefined();
+      expect(output.vars.req).toHaveLength(1);
+      expect(output.vars.req[0]).toMatchObject({
+        name: 'token',
+        value: 'secret',
+        enabled: true,
+        local: false,
+        description: 'Pre-request auth token'
+      });
+      expect(output.vars.res).toHaveLength(1);
+      expect(output.vars.res[0]).toMatchObject({
+        name: 'saved',
+        value: 'res.body.id',
+        enabled: true,
+        local: false,
+        description: 'Saved ID from response'
+      });
+    });
+
+    it('parses @description in assert', () => {
+      const input = `
+assert {
+  @description("Expect success status")
+  res.body.status: eq 200
+  @description("Response must have data")
+  res.body.data: isDefined
+}`;
+
+      const output = parser(input);
+      expect(output.assertions).toHaveLength(2);
+      expect(output.assertions[0]).toMatchObject({
+        name: 'res.body.status',
+        value: 'eq 200',
+        enabled: true,
+        description: 'Expect success status'
+      });
+      expect(output.assertions[1]).toMatchObject({
+        name: 'res.body.data',
+        value: 'isDefined',
+        enabled: true,
+        description: 'Response must have data'
+      });
+    });
+
+    it('parses double-quoted @description with escaped newline', () => {
+      const input = `
+headers {
+  @description("Line one\\nLine two")
+  X-Note: v
+}`;
+
+      const output = parser(input);
+      expect(output.headers).toHaveLength(1);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Note',
+        value: 'v',
+        enabled: true,
+        description: 'Line one\nLine two'
+      });
+    });
+
+    it('parses triple-quoted @description with literal newlines', () => {
+      const input = `
+headers {
+  @description('''
+    Line one
+    Line two
+  ''')
+  X-Note: v
+}`;
+
+      const output = parser(input);
+      expect(output.headers).toHaveLength(1);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Note',
+        value: 'v',
+        enabled: true,
+        description: 'Line one\nLine two'
+      });
+    });
+
+    it('parses escaped characters in descriptions', () => {
+      const input = `
+headers {
+  @description("Say \\"hello\\"")
+  X-Quote: val
+  @description("Path: \\\\usr\\\\bin")
+  X-Backslash: val
+  @description("Line1\\nLine2")
+  X-Newline: val
+}
+params:query {
+  @description("Escaped \\" quote")
+  q: x
+}
+body:form-urlencoded {
+  @description("\\\\ and \\" and \\\\n")
+  f: v
+}`;
+
+      const output = parser(input);
+      expect(output.headers).toHaveLength(3);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Quote',
+        value: 'val',
+        enabled: true,
+        description: 'Say "hello"'
+      });
+      expect(output.headers[1]).toMatchObject({
+        name: 'X-Backslash',
+        value: 'val',
+        enabled: true,
+        description: 'Path: \\usr\\bin'
+      });
+      expect(output.headers[2]).toMatchObject({
+        name: 'X-Newline',
+        value: 'val',
+        enabled: true,
+        description: 'Line1\nLine2'
+      });
+      expect(output.params[0]).toMatchObject({
+        name: 'q',
+        value: 'x',
+        type: 'query',
+        description: 'Escaped " quote'
+      });
+      expect(output.body.formUrlEncoded[0]).toMatchObject({
+        name: 'f',
+        value: 'v',
+        enabled: true,
+        description: '\\ and " and \\n'
+      });
+    });
+
+    it('parses emoji in triple-quoted prefix description', () => {
+      const input = `
+headers {
+  @description('''Auth token 🔑''')
+  Authorization: Bearer xxx
+  @description('''Region 🌍 selector''')
+  X-Region: us-east
+}`;
+
+      const output = parser(input);
+      expect(output.headers[0]).toMatchObject({
+        name: 'Authorization',
+        value: 'Bearer xxx',
+        description: 'Auth token 🔑'
+      });
+      expect(output.headers[1]).toMatchObject({
+        name: 'X-Region',
+        value: 'us-east',
+        description: 'Region 🌍 selector'
+      });
+    });
+
+    it('parses emoji in double-quoted description', () => {
+      const input = `
+vars:pre-request {
+  @description("API key 🔐 required")
+  token: secret
+}
+assert {
+  @description("Status check ✅")
+  res.status: eq 200
+}`;
+
+      const output = parser(input);
+      expect(output.vars.req[0]).toMatchObject({
+        name: 'token',
+        value: 'secret',
+        description: 'API key 🔐 required'
+      });
+      expect(output.assertions[0]).toMatchObject({
+        name: 'res.status',
+        value: 'eq 200',
+        description: 'Status check ✅'
+      });
+    });
+
+    it('parses emoji in multiline triple-quoted prefix description', () => {
+      const input = `
+headers {
+  @description('''
+    Launch 🚀
+    Second line
+  ''')
+  X-Launch: val
+}`;
+
+      const output = parser(input);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Launch',
+        value: 'val',
+        description: 'Launch 🚀\nSecond line'
+      });
+    });
+
+    it('parses \\r\\n escape sequence in double-quoted description as CRLF', () => {
+      const input = `
+headers {
+  @description("Line one\\r\\nLine two")
+  X-Note: v
+}`;
+
+      const output = parser(input);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Note',
+        value: 'v',
+        description: 'Line one\r\nLine two'
+      });
+    });
+
+    it('parses \\n escape sequence in double-quoted description as LF', () => {
+      const input = `
+headers {
+  @description("First\\nSecond\\nThird")
+  X-Note: v
+}`;
+
+      const output = parser(input);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Note',
+        value: 'v',
+        description: 'First\nSecond\nThird'
+      });
+    });
+
+    it('parses triple-quoted prefix with CRLF file line endings', () => {
+      // Simulate a .bru file saved with Windows CRLF line endings
+      const input = 'headers {\r\n  @description(\'\'\'Line one\'\'\')\r\n  X-Note: val\r\n}';
+
+      const output = parser(input);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Note',
+        value: 'val',
+        description: 'Line one'
+      });
+    });
+
+    it('parses multiline triple-quoted prefix with CRLF file line endings', () => {
+      const input = 'headers {\r\n  @description(\'\'\'\r\n    Line one\r\n    Line two\r\n  \'\'\')\r\n  X-Note: val\r\n}';
+
+      const output = parser(input);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Note',
+        value: 'val',
+        description: 'Line one\r\nLine two'
+      });
+    });
+
+    it('parses multiline triple-quoted prefix with CRLF across three lines', () => {
+      const input = 'headers {\r\n  @description(\'\'\'\r\n    Line one\r\n    Line two\r\n    Line three\r\n  \'\'\')\r\n  X-Note: val\r\n}';
+
+      const output = parser(input);
+      expect(output.headers[0]).toMatchObject({
+        name: 'X-Note',
+        value: 'val',
+        description: 'Line one\r\nLine two\r\nLine three'
+      });
+    });
+
+    it('multiple consecutive @description prefixes: orphaned annotation becomes empty row, last one applies to the key', () => {
+      const input = `
+headers {
+  @description('''hello''')
+  @description('''hi''')
+  a: b
+}`;
+
+      const output = parser(input);
+      expect(output.headers).toHaveLength(2);
+      expect(output.headers[0]).toMatchObject({
+        name: '',
+        value: '',
+        enabled: true,
+        description: 'hello'
+      });
+      expect(output.headers[1]).toMatchObject({
+        name: 'a',
+        value: 'b',
+        enabled: true,
+        description: 'hi'
+      });
     });
   });
 });

--- a/packages/bruno-lang/v2/tests/collection.spec.js
+++ b/packages/bruno-lang/v2/tests/collection.spec.js
@@ -22,3 +22,36 @@ describe('jsonToCollectionBru', () => {
     expect(output).toEqual(expected);
   });
 });
+
+describe('description round-trip in collection.bru', () => {
+  it('should round-trip a multiline description on a header', () => {
+    const json = {
+      headers: [{ name: 'Authorization', value: 'Bearer token', enabled: true, description: 'Line 1\nLine 2' }]
+    };
+    const bru = jsonToCollectionBru(json);
+    const parsed = collectionBruToJson(bru);
+    expect(parsed.headers[0].description).toBe('Line 1\nLine 2');
+    expect(parsed.headers[0].value).toBe('Bearer token');
+  });
+
+  it('should round-trip a description on a var with a multiline value', () => {
+    const json = {
+      vars: {
+        req: [{ name: 'myVar', value: 'line1\nline2', enabled: true, description: 'my desc' }]
+      }
+    };
+    const bru = jsonToCollectionBru(json);
+    const parsed = collectionBruToJson(bru);
+    expect(parsed.vars.req[0].description).toBe('my desc');
+    expect(parsed.vars.req[0].value).toBe('line1\nline2');
+  });
+
+  it('should round-trip a description containing triple-quotes', () => {
+    const json = {
+      headers: [{ name: 'X-Token', value: 'abc', enabled: true, description: 'has \'\'\' quotes' }]
+    };
+    const bru = jsonToCollectionBru(json);
+    const parsed = collectionBruToJson(bru);
+    expect(parsed.headers[0].description).toBe('has \'\'\' quotes');
+  });
+});

--- a/packages/bruno-lang/v2/tests/envToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/envToJson.spec.js
@@ -35,6 +35,61 @@ vars {
     expect(output).toEqual(expected);
   });
 
+  it('should parse @description in vars', () => {
+    const input = `
+vars {
+  @description('''Base API URL.''')
+  url: http://localhost:3000
+  @description("Server port")
+  port: 3000
+}`;
+
+    const output = parser(input);
+    const expected = {
+      variables: [
+        {
+          name: 'url',
+          value: 'http://localhost:3000',
+          enabled: true,
+          secret: false,
+          description: 'Base API URL.'
+        },
+        {
+          name: 'port',
+          value: '3000',
+          enabled: true,
+          secret: false,
+          description: 'Server port'
+        }
+      ]
+    };
+
+    expect(output).toEqual(expected);
+  });
+
+  it('should parse disabled variable with @description', () => {
+    const input = `
+vars {
+  @description("Disabled base URL")
+  ~url: http://localhost:3000
+}`;
+
+    const output = parser(input);
+    const expected = {
+      variables: [
+        {
+          name: 'url',
+          value: 'http://localhost:3000',
+          enabled: false,
+          secret: false,
+          description: 'Disabled base URL'
+        }
+      ]
+    };
+
+    expect(output).toEqual(expected);
+  });
+
   it('should parse multiple var lines', () => {
     const input = `
 vars {
@@ -391,6 +446,86 @@ vars {
     expect(output).toEqual(expected);
   });
 
+  it('should parse @description with emoji', () => {
+    const input = `
+vars {
+  @description('''API key 🔐 required''')
+  token: secret
+  @description('''Region 🌍 selector''')
+  region: us-east
+}`;
+
+    const output = parser(input);
+    const expected = {
+      variables: [
+        {
+          name: 'token',
+          value: 'secret',
+          enabled: true,
+          secret: false,
+          description: 'API key 🔐 required'
+        },
+        {
+          name: 'region',
+          value: 'us-east',
+          enabled: true,
+          secret: false,
+          description: 'Region 🌍 selector'
+        }
+      ]
+    };
+
+    expect(output).toEqual(expected);
+  });
+
+  it('should parse @description with double-quoted \\n escape sequence as LF', () => {
+    const input = `
+vars {
+  @description("First\\nSecond\\nThird")
+  note: val
+}`;
+
+    const output = parser(input);
+    expect(output.variables[0]).toMatchObject({
+      name: 'note',
+      value: 'val',
+      description: 'First\nSecond\nThird'
+    });
+  });
+
+  it('should parse @description with double-quoted \\r\\n escape sequence as CRLF', () => {
+    const input = `
+vars {
+  @description("Line one\\r\\nLine two")
+  note: val
+}`;
+
+    const output = parser(input);
+    expect(output.variables[0]).toMatchObject({
+      name: 'note',
+      value: 'val',
+      description: 'Line one\r\nLine two'
+    });
+  });
+
+  it('should parse triple-quoted @description with literal newlines', () => {
+    const input = `
+vars {
+  @description('''
+    Line one
+    Line two
+  ''')
+  note: val
+}`;
+
+    const output = parser(input);
+    expect(output.variables[0]).toMatchObject({
+      name: 'note',
+      value: 'val',
+      description: 'Line one\nLine two'
+    });
+  });
+
   it('should parse multiple multiline variables', () => {
     const input = `
 vars {
@@ -424,5 +559,70 @@ vars {
     };
 
     expect(output).toEqual(expected);
+  });
+
+  it('consecutive @description prefixes: first orphaned becomes empty row, last applies to key', () => {
+    const input = `
+vars {
+  @description('''Single-line desc''')
+  host: http://localhost:3000
+  @description('''empty description''')
+  @description('''
+    Line one
+    Line two
+  ''')
+  token: abc123
+  plain: no-description
+  @description("has ''' triple quotes inside")
+  tricky: value
+}`;
+
+    const output = parser(input);
+    expect(output.variables).toHaveLength(5);
+
+    // host — single-line description
+    expect(output.variables[0]).toMatchObject({
+      name: 'host',
+      value: 'http://localhost:3000',
+      enabled: true,
+      secret: false,
+      description: 'Single-line desc'
+    });
+
+    // orphaned @description('''empty description''') — becomes an empty-key row with that description
+    expect(output.variables[1]).toMatchObject({
+      name: '',
+      value: '',
+      enabled: true,
+      secret: false,
+      description: 'empty description'
+    });
+
+    // token — gets the LAST (multiline) description; the first was consumed by the orphaned row above
+    expect(output.variables[2]).toMatchObject({
+      name: 'token',
+      value: 'abc123',
+      enabled: true,
+      secret: false,
+      description: 'Line one\nLine two'
+    });
+
+    // plain — no description
+    expect(output.variables[3]).toMatchObject({
+      name: 'plain',
+      value: 'no-description',
+      enabled: true,
+      secret: false
+    });
+    expect(output.variables[3].description).toBeUndefined();
+
+    // tricky — description containing ''' stored as double-quoted form
+    expect(output.variables[4]).toMatchObject({
+      name: 'tricky',
+      value: 'value',
+      enabled: true,
+      secret: false,
+      description: 'has \'\'\' triple quotes inside'
+    });
   });
 });

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -136,4 +136,144 @@ describe('jsonToBru stringify', () => {
       `);
     });
   });
+
+  describe('description annotation', () => {
+    it('emits @description with triple-quotes (literal newlines) for headers, params, vars, and assertions when present in JSON', () => {
+      const input = {
+        meta: { name: 'desc-test', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'X-Custom', value: 'val', enabled: true, description: 'Custom header note' }
+        ],
+        params: [
+          { name: 'q', value: 'search', enabled: true, type: 'query', description: 'Query param hint' }
+        ],
+        vars: {
+          req: [
+            { name: 'apiKey', value: 'key123', enabled: true, description: 'Pre-request API key' }
+          ]
+        },
+        assertions: [
+          { name: 'res.status', value: 'eq 200', enabled: true, description: 'Expect OK' }
+        ]
+      };
+
+      const output = stringify(input);
+
+      expect(output).toMatch(/@description\('''Custom header note'''\)\n  X-Custom: val/);
+      expect(output).toMatch(/@description\('''Query param hint'''\)\n  q: search/);
+      expect(output).toMatch(/@description\('''Pre-request API key'''\)\n  apiKey: key123/);
+      expect(output).toMatch(/@description\('''Expect OK'''\)\n  res\.status: eq 200/);
+    });
+
+    it('emits triple-quoted description with literal newlines when description is multiline', () => {
+      const input = {
+        meta: { name: 'ml', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'X-Note', value: 'v', enabled: true, description: 'Line one\nLine two' }
+        ]
+      };
+
+      const output = stringify(input);
+
+      expect(output).toContain('@description(\'\'\'\n    Line one\n    Line two\n  \'\'\')\n  X-Note: v');
+    });
+
+    it('emits double-quoted description when description contains triple quote', () => {
+      const input = {
+        meta: { name: 'tq', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'X-Desc', value: 'v', enabled: true, description: 'Say \'\'\'triple\'\'\'' }
+        ]
+      };
+
+      const output = stringify(input);
+
+      expect(output).toMatch(/@description\("Say '''triple'''"\)/);
+    });
+
+    it('escapes backslash in triple-quoted description; double-quoted when description contains triple quote or newline', () => {
+      const input = {
+        meta: { name: 'esc', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'X-Desc', value: 'v', enabled: true, description: 'Say "hello"' }
+        ]
+      };
+
+      const output = stringify(input);
+      // No ''' or newline so triple-quoted (double-quote is fine inside triple quotes)
+      expect(output).toMatch(/@description\('''Say "hello"'''\)/);
+    });
+
+    it('emits triple-quoted description with emoji', () => {
+      const input = {
+        meta: { name: 'emoji', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'Authorization', value: 'Bearer xxx', enabled: true, description: 'Auth token 🔑' },
+          { name: 'X-Region', value: 'us-east', enabled: true, description: 'Region 🌍 selector' }
+        ]
+      };
+
+      const output = stringify(input);
+      expect(output).toMatch(/@description\('''Auth token 🔑'''\)/);
+      expect(output).toMatch(/@description\('''Region 🌍 selector'''\)/);
+    });
+
+    it('emits multiline triple-quoted description with emoji', () => {
+      const input = {
+        meta: { name: 'emoji-ml', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'X-Launch', value: 'val', enabled: true, description: 'Launch 🚀\nSecond line' }
+        ]
+      };
+
+      const output = stringify(input);
+      expect(output).toContain('@description(\'\'\'\n    Launch 🚀\n    Second line\n  \'\'\')\n  X-Launch: val');
+    });
+
+    it('emits multiline triple-quoted description with \\n (LF)', () => {
+      const input = {
+        meta: { name: 'lf', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'X-Note', value: 'v', enabled: true, description: 'First\nSecond\nThird' }
+        ]
+      };
+
+      const output = stringify(input);
+      expect(output).toContain('@description(\'\'\'\n    First\n    Second\n    Third\n  \'\'\')\n  X-Note: v');
+    });
+
+    it('emits multiline triple-quoted description with \\r\\n (CRLF) normalized to LF', () => {
+      const input = {
+        meta: { name: 'crlf', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'X-Note', value: 'v', enabled: true, description: 'Line one\r\nLine two' }
+        ]
+      };
+
+      const output = stringify(input);
+      // indentString splits on \r\n|\r|\n and rejoins with \n, normalizing Windows CRLF to LF
+      expect(output).toContain('@description(\'\'\'\n    Line one\n    Line two\n  \'\'\')\n  X-Note: v');
+    });
+
+    it('emits multiline triple-quoted description with multiple \\r\\n lines normalized to LF', () => {
+      const input = {
+        meta: { name: 'crlf-multi', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        headers: [
+          { name: 'X-Note', value: 'v', enabled: true, description: 'Line one\r\nLine two\r\nLine three' }
+        ]
+      };
+
+      const output = stringify(input);
+      expect(output).toContain('@description(\'\'\'\n    Line one\n    Line two\n    Line three\n  \'\'\')\n  X-Note: v');
+    });
+  });
 });

--- a/packages/bruno-lang/v2/tests/jsonToEnv.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToEnv.spec.js
@@ -58,6 +58,108 @@ describe('jsonToEnv', () => {
     expect(output).toEqual(expected);
   });
 
+  it('should stringify description in vars (triple-quoted when single-line)', () => {
+    const input = {
+      variables: [
+        {
+          name: 'url',
+          value: 'http://localhost:3000',
+          enabled: true,
+          description: 'Base API URL.'
+        }
+      ]
+    };
+
+    const output = parser(input);
+    expect(output).toEqual(`vars {
+  @description('''Base API URL.''')
+  url: http://localhost:3000
+}
+`);
+  });
+
+  it('should stringify multiline description with triple-quoted literal newlines', () => {
+    const input = {
+      variables: [
+        {
+          name: 'url',
+          value: 'http://localhost:3000',
+          enabled: true,
+          description: 'Line one\nLine two'
+        }
+      ]
+    };
+
+    const output = parser(input);
+    expect(output).toContain('@description(\'\'\'\n    Line one\n    Line two\n  \'\'\')');
+  });
+
+  it('should stringify description with emoji (single-line triple-quoted)', () => {
+    const input = {
+      variables: [
+        {
+          name: 'token',
+          value: 'secret',
+          enabled: true,
+          description: 'API key 🔐 required'
+        }
+      ]
+    };
+
+    const output = parser(input);
+    expect(output).toContain('@description(\'\'\'API key 🔐 required\'\'\')');
+    expect(output).toContain('token: secret');
+  });
+
+  it('should stringify multiline description with emoji using triple-quoted literal newlines', () => {
+    const input = {
+      variables: [
+        {
+          name: 'note',
+          value: 'val',
+          enabled: true,
+          description: 'Launch 🚀\nSecond line'
+        }
+      ]
+    };
+
+    const output = parser(input);
+    expect(output).toContain('@description(\'\'\'\n    Launch 🚀\n    Second line\n  \'\'\')');
+  });
+
+  it('should stringify description with LF (\\n) as multiline triple-quoted', () => {
+    const input = {
+      variables: [
+        {
+          name: 'note',
+          value: 'val',
+          enabled: true,
+          description: 'First\nSecond\nThird'
+        }
+      ]
+    };
+
+    const output = parser(input);
+    expect(output).toContain('@description(\'\'\'\n    First\n    Second\n    Third\n  \'\'\')');
+  });
+
+  it('should stringify description with CRLF (\\r\\n) as multiline triple-quoted with LF normalization', () => {
+    const input = {
+      variables: [
+        {
+          name: 'note',
+          value: 'val',
+          enabled: true,
+          description: 'Line one\r\nLine two'
+        }
+      ]
+    };
+
+    const output = parser(input);
+    // indentString normalizes \r\n to \n when serializing
+    expect(output).toContain('@description(\'\'\'\n    Line one\n    Line two\n  \'\'\')');
+  });
+
   it('should stringify secret vars', () => {
     const input = {
       variables: [
@@ -139,6 +241,30 @@ vars:secret [
 ]
 `;
     expect(output).toEqual(expected);
+  });
+
+  it('should emit @description prefix even for multiline variables', () => {
+    const input = {
+      variables: [
+        {
+          name: 'json_data',
+          value: '{\n  "name": "test"\n}',
+          enabled: true,
+          description: 'A multiline JSON blob'
+        }
+      ]
+    };
+
+    const output = parser(input);
+    expect(output).toEqual(`vars {
+  @description('''A multiline JSON blob''')
+  json_data: '''
+    {
+      "name": "test"
+    }
+  '''
+}
+`);
   });
 
   it('should stringify multiline variables', () => {

--- a/packages/bruno-schema-types/src/collection/environment.ts
+++ b/packages/bruno-schema-types/src/collection/environment.ts
@@ -7,6 +7,7 @@ export interface EnvironmentVariable {
   type: 'text';
   enabled?: boolean;
   secret?: boolean;
+  description?: string | null;
 }
 
 export interface Environment {

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -8,7 +8,8 @@ const environmentVariablesSchema = Yup.object({
   value: Yup.mixed().nullable(),
   type: Yup.string().oneOf(['text']).required('type is required'),
   enabled: Yup.boolean().defined(),
-  secret: Yup.boolean()
+  secret: Yup.boolean(),
+  description: Yup.string().nullable()
 })
   .noUnknown(true)
   .strict();

--- a/packages/bruno-tests/collection/collection.bru
+++ b/packages/bruno-tests/collection/collection.bru
@@ -1,6 +1,13 @@
 headers {
+  @description('''asd''')
   check: again
+  @description('''
+    asd
+    asd
+    asd
+  ''')
   token: {{collection_pre_var_token}}
+  @description('''asd''')
   collection-header: collection-header-value
 }
 

--- a/tests/collection/description/fixtures/collection/bruno.json
+++ b/tests/collection/description/fixtures/collection/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "col-description",
+  "type": "collection"
+}

--- a/tests/collection/description/fixtures/collection/collection.bru
+++ b/tests/collection/description/fixtures/collection/collection.bru
@@ -1,0 +1,27 @@
+meta {
+  name: col-description
+  type: collection
+  version: 1.0.0
+}
+
+headers {
+  @description('''Single-line header desc''')
+  X-Version: 2.0
+  @description('''
+    Header line one
+    Header line two
+  ''')
+  X-Multi: value
+  X-Plain: plain-value
+}
+
+vars:pre-request {
+  @description('''Single-line var desc''')
+  baseUrl: https://example.com
+  @description('''
+    Var line one
+    Var line two
+  ''')
+  apiKey: abc123
+  plain: no-desc
+}

--- a/tests/collection/description/init-user-data/collection-security.json
+++ b/tests/collection/description/init-user-data/collection-security.json
@@ -1,0 +1,9 @@
+{
+  "collections": {
+    "{{collectionPath}}": {
+      "brunoConfig": {
+        "jsSandboxMode": "safe"
+      }
+    }
+  }
+}

--- a/tests/collection/description/init-user-data/preferences.json
+++ b/tests/collection/description/init-user-data/preferences.json
@@ -1,0 +1,28 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": [
+    "{{collectionPath}}"
+  ],
+  "request": {
+    "sslVerification": false,
+    "customCaCertificate": {
+      "enabled": false,
+      "filePath": null
+    }
+  },
+  "font": {
+    "codeFont": "default"
+  },
+  "proxy": {
+    "enabled": false,
+    "protocol": "http",
+    "hostname": "",
+    "port": "",
+    "auth": {
+      "enabled": false,
+      "username": "",
+      "password": ""
+    },
+    "bypassProxy": ""
+  }
+}

--- a/tests/collection/description/read-collection-description.spec.ts
+++ b/tests/collection/description/read-collection-description.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../../../playwright';
+
+const openCollectionSettings = async (page, collectionName: string) => {
+  await page
+    .locator('#sidebar-collection-name')
+    .filter({ hasText: collectionName })
+    .click();
+  // The tab label always reads "Collection" regardless of the collection name
+  await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'Collection' })).toBeVisible();
+};
+
+test.describe('Collection Settings Descriptions - Read', () => {
+  test('reads descriptions from headers and vars in a pre-existing collection.bru', async ({
+    pageWithUserData: page
+  }) => {
+    test.setTimeout(30_000);
+
+    await openCollectionSettings(page, 'col-description');
+
+    // ── Headers tab ──────────────────────────────────────────────────────────
+    await page.locator('.tab.headers').click();
+
+    // Each header row has three CodeMirrors: name (0), value (1), description (2)
+    const headerRows = page.locator('table').first().locator('tbody tr');
+
+    // row 0: X-Version — single-line description
+    const versionDescEditor = headerRows.nth(0).locator('.CodeMirror').nth(2);
+    await expect(versionDescEditor.locator('.CodeMirror-line').first()).toHaveText('Single-line header desc');
+
+    // row 1: X-Multi — multiline description
+    const multiDescEditor = headerRows.nth(1).locator('.CodeMirror').nth(2);
+    await expect(multiDescEditor.locator('.CodeMirror-line').nth(0)).toHaveText('Header line one');
+    await expect(multiDescEditor.locator('.CodeMirror-line').nth(1)).toHaveText('Header line two');
+
+    // row 2: X-Plain — no description (editor is empty)
+    const plainDescEditor = headerRows.nth(2).locator('.CodeMirror').nth(2);
+    await expect(plainDescEditor.locator('.CodeMirror-line').first()).toHaveText('');
+
+    // ── Vars tab ─────────────────────────────────────────────────────────────
+    await page.locator('.tab.vars').click();
+
+    // In the vars tab the pre-request VarsTable is the first <table>.
+    // Var rows have two CodeMirrors: value (nth 0) and description (nth 1).
+    // The name column uses a plain <input> (no CodeMirror).
+    const varRows = page.locator('table').first().locator('tbody tr');
+
+    // row 0: baseUrl — single-line description
+    const baseUrlDescEditor = varRows.nth(0).locator('.CodeMirror').nth(1);
+    await expect(baseUrlDescEditor.locator('.CodeMirror-line').first()).toHaveText('Single-line var desc');
+
+    // row 1: apiKey — multiline description
+    const apiKeyDescEditor = varRows.nth(1).locator('.CodeMirror').nth(1);
+    await expect(apiKeyDescEditor.locator('.CodeMirror-line').nth(0)).toHaveText('Var line one');
+    await expect(apiKeyDescEditor.locator('.CodeMirror-line').nth(1)).toHaveText('Var line two');
+
+    // row 2: plain — no description
+    const plainVarDescEditor = varRows.nth(2).locator('.CodeMirror').nth(1);
+    await expect(plainVarDescEditor.locator('.CodeMirror-line').first()).toHaveText('');
+  });
+});

--- a/tests/collection/description/write-collection-headers-description.spec.ts
+++ b/tests/collection/description/write-collection-headers-description.spec.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from '../../../playwright';
+
+test.describe('Collection Settings Descriptions - Write (Headers)', () => {
+  test('writes a multiline description to a header and persists it to collection.bru', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    test.setTimeout(30_000);
+
+    // Open collection settings by clicking the collection name in the sidebar
+    await page
+      .locator('#sidebar-collection-name')
+      .filter({ hasText: 'col-description' })
+      .click();
+    // The tab label always reads "Collection" regardless of the collection name
+    await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'Collection' })).toBeVisible();
+
+    await page.locator('.tab.headers').click();
+
+    // Target the X-Plain row (row index 2) and its description editor (CodeMirror index 2)
+    const headerRows = page.locator('table').first().locator('tbody tr');
+    const targetRow = headerRows.nth(2);
+
+    // Use CodeMirror's JS API directly so the `change` event fires synchronously and
+    // the EditableTable onChange chain updates Redux state before we click Save.
+    await page.evaluate(() => {
+      const rows = document.querySelectorAll('table:first-of-type tbody tr');
+      const row = rows[2];
+      if (!row) throw new Error('Row 2 not found');
+      const cms = row.querySelectorAll('.CodeMirror');
+      const cm = (cms[2] as any)?.CodeMirror; // description is the 3rd CodeMirror (index 2)
+      if (!cm) throw new Error('CodeMirror instance not found');
+      cm.setValue('First line\nSecond line');
+    });
+
+    // Wait for CodeMirror DOM to reflect the value
+    await expect(targetRow.locator('.CodeMirror').nth(2).locator('.CodeMirror-line').nth(0)).toHaveText('First line');
+    await page.waitForTimeout(200);
+
+    // Save and confirm
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Collection Settings saved successfully')).toBeVisible({ timeout: 5000 });
+
+    // Verify the description was written to collection.bru
+    const collectionBruPath = path.join(collectionFixturePath!, 'collection.bru');
+    const fileContent = fs.readFileSync(collectionBruPath, 'utf8');
+
+    expect(fileContent).toContain('@description');
+    expect(fileContent).toContain('First line');
+    expect(fileContent).toContain('Second line');
+  });
+});

--- a/tests/collection/description/write-collection-vars-description.spec.ts
+++ b/tests/collection/description/write-collection-vars-description.spec.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from '../../../playwright';
+
+test.describe('Collection Settings Descriptions - Write (Vars)', () => {
+  test('writes a multiline description to a pre-request var and persists it to collection.bru', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    test.setTimeout(30_000);
+
+    // Open collection settings
+    await page
+      .locator('#sidebar-collection-name')
+      .filter({ hasText: 'col-description' })
+      .click();
+    // The tab label always reads "Collection" regardless of the collection name
+    await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'Collection' })).toBeVisible();
+
+    await page.locator('.tab.vars').click();
+
+    // Target the 'plain' row (row index 2) in the Pre Request VarsTable (first <table>).
+    // Var rows have two CodeMirrors: value (nth 0) and description (nth 1).
+    const varRows = page.locator('table').first().locator('tbody tr');
+    const targetRow = varRows.nth(2);
+
+    await page.evaluate(() => {
+      // The vars tab renders two tables (pre-request, post-response).
+      // The first table's row 2 is the 'plain' pre-request var.
+      const tables = document.querySelectorAll('table');
+      const rows = tables[0].querySelectorAll('tbody tr');
+      const row = rows[2];
+      if (!row) throw new Error('Row 2 not found in first table');
+      const cms = row.querySelectorAll('.CodeMirror');
+      const cm = (cms[1] as any)?.CodeMirror; // description is the 2nd CodeMirror (index 1)
+      if (!cm) throw new Error('CodeMirror instance not found');
+      cm.setValue('First line\nSecond line');
+    });
+
+    await expect(targetRow.locator('.CodeMirror').nth(1).locator('.CodeMirror-line').nth(0)).toHaveText('First line', { timeout: 2000 });
+
+    // The vars section has a single "Save" button shared by pre and post tables
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Collection Settings saved successfully')).toBeVisible({ timeout: 5000 });
+
+    // Verify the description was written to collection.bru
+    const collectionBruPath = path.join(collectionFixturePath!, 'collection.bru');
+    const fileContent = fs.readFileSync(collectionBruPath, 'utf8');
+
+    expect(fileContent).toContain('First line');
+    expect(fileContent).toContain('Second line');
+  });
+});

--- a/tests/collection/draft/draft-indicator.spec.ts
+++ b/tests/collection/draft/draft-indicator.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../../../playwright';
 import { closeAllCollections, createCollection } from '../../utils/page';
 
-test.describe('Draft indicator in collection and folder settings', () => {
+test.describe.serial('Draft indicator in collection and folder settings', () => {
   test.afterAll(async ({ page }) => {
     // cleanup: close all collections
     await closeAllCollections(page);
@@ -193,8 +193,7 @@ test.describe('Draft indicator in collection and folder settings', () => {
     const varNameInput = varRow.locator('input[type="text"]');
     await varNameInput.click();
     await varNameInput.fill('testVar');
-
-    const varValueEditor = varRow.locator('.CodeMirror');
+    const varValueEditor = varRow.getByTestId(/^test-multiline-editor-\d+\.value$/);
     await varValueEditor.click();
     await page.keyboard.type('testValue');
 
@@ -308,7 +307,7 @@ test.describe('Draft indicator in collection and folder settings', () => {
     await varNameInput.click();
     await varNameInput.fill('folderVar');
 
-    const folderVarValueEditor = varRow.locator('.CodeMirror');
+    const folderVarValueEditor = varRow.getByTestId(/^test-multiline-editor-\d+\.value$/);
     await folderVarValueEditor.click();
     await page.keyboard.type('folderValue');
 

--- a/tests/environments/description/fixtures/collection/bruno.json
+++ b/tests/environments/description/fixtures/collection/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "env-description",
+  "type": "collection"
+}

--- a/tests/environments/description/fixtures/collection/environments/WithDescriptions.bru
+++ b/tests/environments/description/fixtures/collection/environments/WithDescriptions.bru
@@ -1,0 +1,13 @@
+vars {
+  @description('''Single-line desc''')
+  host: http://localhost:3000
+  @description('''empty description''')
+  @description('''
+    Line one
+    Line two
+  ''')
+  token: abc123
+  plain: no-description
+  @description("has ''' triple quotes inside")
+  tricky: value
+}

--- a/tests/environments/description/init-user-data/collection-security.json
+++ b/tests/environments/description/init-user-data/collection-security.json
@@ -1,0 +1,10 @@
+{
+  "collections": [
+    {
+      "path": "{{collectionPath}}",
+      "securityConfig": {
+        "jsSandboxMode": "developer"
+      }
+    }
+  ]
+}

--- a/tests/environments/description/init-user-data/preferences.json
+++ b/tests/environments/description/init-user-data/preferences.json
@@ -1,0 +1,28 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": [
+    "{{collectionPath}}"
+  ],
+  "request": {
+    "sslVerification": false,
+    "customCaCertificate": {
+      "enabled": false,
+      "filePath": null
+    }
+  },
+  "font": {
+    "codeFont": "default"
+  },
+  "proxy": {
+    "enabled": false,
+    "protocol": "http",
+    "hostname": "",
+    "port": "",
+    "auth": {
+      "enabled": false,
+      "username": "",
+      "password": ""
+    },
+    "bypassProxy": ""
+  }
+}

--- a/tests/environments/description/read-environment-description.spec.ts
+++ b/tests/environments/description/read-environment-description.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '../../../playwright';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const openEnvironmentConfigure = async (page, envName: string) => {
+  const locators = buildCommonLocators(page);
+  await locators.environment.currentEnvironment().click();
+  await expect(locators.environment.envOption(envName)).toBeVisible();
+  await locators.environment.envOption(envName).click();
+  await expect(locators.environment.currentEnvironment().filter({ hasText: envName })).toBeVisible();
+  await locators.environment.currentEnvironment().click();
+  await expect(locators.dropdown.item('Configure')).toBeVisible();
+  await locators.dropdown.item('Configure').click();
+  await expect(locators.tabs.requestTab('Environments')).toBeVisible();
+};
+
+test.describe('Environment Variable Descriptions - Read', () => {
+  test('reads single-line and multiline descriptions from a pre-existing environment file', async ({
+    pageWithUserData: page
+  }) => {
+    test.setTimeout(30_000);
+
+    const collection = page
+      .getByTestId('collections')
+      .locator('#sidebar-collection-name')
+      .filter({ hasText: 'env-description' });
+    await expect(collection).toBeVisible();
+    await collection.click();
+
+    await openEnvironmentConfigure(page, 'WithDescriptions');
+
+    const locators = buildCommonLocators(page);
+
+    // row 0: host — single-line description
+    await expect(page.locator('input[name="0.name"]')).toHaveValue('host');
+    const hostDesc = locators.environment.variableDescriptionEditor(0);
+    await expect(hostDesc).toBeVisible();
+    await expect(hostDesc.locator('.CodeMirror-line').first()).toHaveText('Single-line desc');
+
+    // row 1: orphaned @description('''empty description''') — empty name/value, description is 'empty description'
+    await expect(page.locator('input[name="1.name"]')).toHaveValue('');
+    const orphanDesc = locators.environment.variableDescriptionEditor(1);
+    await expect(orphanDesc).toBeVisible();
+    await expect(orphanDesc.locator('.CodeMirror-line').first()).toHaveText('empty description');
+
+    // row 2: token — gets the last (multiline) description; the first was consumed by the orphaned row
+    await expect(page.locator('input[name="2.name"]')).toHaveValue('token');
+    const tokenDesc = locators.environment.variableDescriptionEditor(2);
+    await expect(tokenDesc).toBeVisible();
+    await expect(tokenDesc.locator('.CodeMirror-line').nth(0)).toHaveText('Line one');
+    await expect(tokenDesc.locator('.CodeMirror-line').nth(1)).toHaveText('Line two');
+
+    // row 3: plain — no description (editor is empty)
+    await expect(page.locator('input[name="3.name"]')).toHaveValue('plain');
+    const plainDesc = locators.environment.variableDescriptionEditor(3);
+    await expect(plainDesc).toBeVisible();
+    await expect(plainDesc.locator('.CodeMirror-line').first()).toHaveText('');
+
+    // row 4: tricky — description containing ''' (stored as triple-quoted @description('''...'''))
+    await expect(page.locator('input[name="4.name"]')).toHaveValue('tricky');
+    const trickyDesc = locators.environment.variableDescriptionEditor(4);
+    await expect(trickyDesc).toBeVisible();
+    await expect(trickyDesc.locator('.CodeMirror-line').first()).toHaveText('has \'\'\' triple quotes inside');
+  });
+});

--- a/tests/environments/description/read-environment-description.spec.ts
+++ b/tests/environments/description/read-environment-description.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from '../../../playwright';
+import { test, expect, Page } from '../../../playwright';
 import { buildCommonLocators } from '../../utils/page/locators';
 
-const openEnvironmentConfigure = async (page, envName: string) => {
+const openEnvironmentConfigure = async (page: Page, envName: string) => {
   const locators = buildCommonLocators(page);
   await locators.environment.currentEnvironment().click();
   await expect(locators.environment.envOption(envName)).toBeVisible();

--- a/tests/environments/description/write-environment-description.spec.ts
+++ b/tests/environments/description/write-environment-description.spec.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { test, expect } from '../../../playwright';
+import { test, expect, Page } from '../../../playwright';
 import { buildCommonLocators } from '../../utils/page/locators';
 
-const openEnvironmentConfigure = async (page, envName: string) => {
+const openEnvironmentConfigure = async (page: Page, envName: string) => {
   const locators = buildCommonLocators(page);
   await locators.environment.currentEnvironment().click();
   await expect(locators.environment.envOption(envName)).toBeVisible();

--- a/tests/environments/description/write-environment-description.spec.ts
+++ b/tests/environments/description/write-environment-description.spec.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from '../../../playwright';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const openEnvironmentConfigure = async (page, envName: string) => {
+  const locators = buildCommonLocators(page);
+  await locators.environment.currentEnvironment().click();
+  await expect(locators.environment.envOption(envName)).toBeVisible();
+  await locators.environment.envOption(envName).click();
+  await expect(locators.environment.currentEnvironment().filter({ hasText: envName })).toBeVisible();
+  await locators.environment.currentEnvironment().click();
+  await expect(locators.dropdown.item('Configure')).toBeVisible();
+  await locators.dropdown.item('Configure').click();
+  await expect(locators.tabs.requestTab('Environments')).toBeVisible();
+};
+
+test.describe('Environment Variable Descriptions - Write', () => {
+  test('writes a multiline description and persists it to the .bru file', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    test.setTimeout(30_000);
+
+    const collection = page
+      .getByTestId('collections')
+      .locator('#sidebar-collection-name')
+      .filter({ hasText: 'env-description' });
+    await expect(collection).toBeVisible();
+    await collection.click();
+
+    await openEnvironmentConfigure(page, 'WithDescriptions');
+
+    // Set the description value directly via CodeMirror's JS API so that the `change`
+    // event fires synchronously and formik receives the update before we save.
+    // keyboard.type / insertText are unreliable in Electron because synthetic key events
+    // don't always go through CodeMirror's textarea input handler.
+    await page.evaluate((rowIndex) => {
+      const rows = document.querySelectorAll('tr');
+      for (const row of rows) {
+        if (row.querySelector(`input[name="${rowIndex}.name"]`)) {
+          const cms = row.querySelectorAll('.CodeMirror');
+          const cm = (cms[1] as any)?.CodeMirror; // description editor is the 2nd CodeMirror
+          if (cm) cm.setValue('First line\nSecond line');
+          break;
+        }
+      }
+    }, 2);
+
+    // Wait for the CodeMirror DOM to reflect the value, then give React a tick to flush formik
+    const plainDescEditor = buildCommonLocators(page).environment.variableDescriptionEditor(2);
+    await expect(plainDescEditor.locator('.CodeMirror-line').nth(0)).toHaveText('First line');
+    await page.waitForTimeout(200);
+
+    await page.getByTestId('save-env').click();
+    await expect(page.getByText('Changes saved successfully')).toBeVisible({ timeout: 5000 });
+
+    // The IPC write completes before the toast resolves, so the file is ready to read.
+    const envFilePath = path.join(collectionFixturePath!, 'environments', 'WithDescriptions.bru');
+    const fileContent = fs.readFileSync(envFilePath, 'utf8');
+
+    expect(fileContent).toContain('First line');
+    expect(fileContent).toContain('Second line');
+  });
+});

--- a/tests/environments/multiline-variables/write-multiline-variable.spec.ts
+++ b/tests/environments/multiline-variables/write-multiline-variable.spec.ts
@@ -37,7 +37,7 @@ test.describe('Multiline Variables - Write Test', () => {
     // Use force:true to bypass Playwright's stability check on the CodeMirror click.
     const variableRow = page.locator('tbody tr').filter({ has: page.locator('input[value="multiline_data_json"]') });
     await expect(variableRow).toBeVisible();
-    const codeMirror = variableRow.locator('.CodeMirror');
+    const codeMirror = variableRow.getByTestId(/^test-multiline-editor-\d+\.value$/);
 
     const jsonValue = `{
   "user": {

--- a/tests/global-environments/non-string-values.spec.ts
+++ b/tests/global-environments/non-string-values.spec.ts
@@ -68,7 +68,7 @@ test.describe('Global Environment Variables - Non-string Values', () => {
       await expect(numericRow.locator('.CodeMirror-line').first()).toContainText(/170001/);
 
       // Verify that typing into the input does not mutate the value.
-      await numericRow.locator('.CodeMirror').click();
+      await numericRow.getByTestId(/^test-multiline-editor-\d+\.value$/).click();
       await page.keyboard.type('999');
       await expect(numericRow.locator('.CodeMirror-line').first()).toContainText(/170001/);
 
@@ -95,7 +95,7 @@ test.describe('Global Environment Variables - Non-string Values', () => {
       await expect(booleanRow.locator('.CodeMirror-line').first()).toContainText(/true/);
 
       // Verify that typing into the input does not mutate the value.
-      await booleanRow.locator('.CodeMirror').click();
+      await booleanRow.getByTestId(/^test-multiline-editor-\d+\.value$/).click();
       await page.keyboard.type('false');
       await expect(booleanRow.locator('.CodeMirror-line').first()).toContainText(/true/);
 
@@ -114,7 +114,7 @@ test.describe('Global Environment Variables - Non-string Values', () => {
       const stringRow = stringInput.locator('xpath=ancestor::tr');
 
       await expect(stringRow.locator('.CodeMirror-line').first()).toContainText('hello world');
-      await stringRow.locator('.CodeMirror').click();
+      await stringRow.getByTestId(/^test-multiline-editor-\d+\.value$/).click();
       await page.keyboard.type(' updated');
 
       // Verify the user edit persists in the UI.

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -578,7 +578,7 @@ const addEnvironmentVariable = async (
 
     // Wait for the CodeMirror editor in the row to be ready
     const variableRow = page.locator('tr').filter({ has: page.locator(`input[name="${index}.name"]`) });
-    const codeMirror = variableRow.locator('.CodeMirror');
+    const codeMirror = variableRow.getByTestId(`test-multiline-editor-${index}.value`);
     await codeMirror.waitFor({ state: 'visible' });
     await codeMirror.click();
     await page.keyboard.type(variable.value);

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -68,6 +68,10 @@ export const buildCommonLocators = (page: Page) => ({
     variableNameInput: (index: number) => page.locator(`input[name="${index}.name"]`),
     variableSecretCheckbox: (index: number) => page.locator(`input[name="${index}.secret"]`),
     variableRow: (index: number) => page.locator('tr').filter({ has: page.locator(`input[name="${index}.name"]`) }),
+    /** Returns the description CodeMirror for the variable row at the given index.
+     *  Each var row has two CodeMirrors: value (nth 0) and description (nth 1). */
+    variableDescriptionEditor: (index: number) =>
+      page.locator('tr').filter({ has: page.locator(`input[name="${index}.name"]`) }).locator('.CodeMirror').nth(1),
     createEnvButton: () => page.locator('button[id="create-env"]'),
     envNameInput: () => page.locator('input[name="name"]')
   },


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2308)

- Introduced a description column in Headers, VarsTable, and other components to allow multi-line descriptions.
- Added toggle buttons to show/hide the description column in relevant tables.
- Updated EditableTable component to support dynamic row addition with customizable labels.
- Enhanced UI for better user experience with consistent button styles and spacing adjustments.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added description fields for headers, variables, parameters, and assertions across collections, folders, and requests
  * Descriptions support multi-line editing and persist in collection files and environment configurations
  * Full round-trip support for description data in import/export workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->