### PR TITLE
fix: update header validation test to use triple-click for selecting all text

### DIFF
--- a/tests/request/headers/header-validation.spec.ts
+++ b/tests/request/headers/header-validation.spec.ts
@@ -51,9 +51,8 @@ test.describe.serial('Header Validation', () => {
       const headerRow = page.locator('table tbody tr').first();
       const nameCell = getTableCell(headerRow, 0);
 
-      // Clear and enter a valid header name
-      await nameCell.locator('.CodeMirror').click();
-      await page.keyboard.press('Meta+a');
+      // Clear and enter a valid header name - use triple-click to select all (works cross-platform)
+      await nameCell.locator('.CodeMirror').click({ clickCount: 3 });
       await nameCell.locator('textarea').fill('Valid-Header');
 
       // Verify the error icon is not visible


### PR DESCRIPTION
### Description

fix: update header validation test to use triple-click for selecting all text instead of mac specific Meta+a

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test implementation for header validation testing.

**Note:** This release contains no user-facing changes. The modifications are internal test infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->