### PR TITLE
fix: make documentation edit button sticky on scroll

### DIFF
--- a/packages/bruno-app/src/components/Documentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Documentation/StyledWrapper.js
@@ -1,8 +1,20 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  height: 100%;
+  overflow-y: auto;
+  position: relative;
   .editing-mode {
     cursor: pointer;
+    position: sticky;
+    z-index: 10;
+    top: 0;
+    background: ${(props) => props.theme.bg};
+    padding-bottom: 0.5em;
+  }
+  .markdown-body {
+    height: auto !important;
+    overflow-y: visible !important;
   }
 `;
 


### PR DESCRIPTION
### Description

This PR fixes an issue where the "Edit" button in the Documentation tab would scroll out of view when reading long documents. Users previously had to scroll all the way back to the top to switch to Edit mode.

**Changes:**
- Added `position: sticky` to the `.editing-mode` class.
- Added background color (themed) to the button container to prevent text from scrolling behind it.
- Adjusted the parent container's overflow properties to ensure the sticky behavior works correctly.

Issue: #7142 

Before:

https://github.com/user-attachments/assets/cf3a23d5-d7bf-4537-ade2-a6372fb70974

After:

https://github.com/user-attachments/assets/724d6616-66cd-4922-90bc-95dc950f4fbc



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Documentation component layout and scrolling behavior for better user experience
  * Enhanced editing mode with sticky positioning for improved navigation within documentation
  * Optimized markdown content display and rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->