### PR TITLE
fix: make documentation edit button sticky

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Docs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Docs/StyledWrapper.js
@@ -4,6 +4,7 @@ const StyledWrapper = styled.div`
 
   .editing-mode {
     cursor: pointer;
+    
   }
 `;
 

--- a/packages/bruno-app/src/components/Documentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Documentation/StyledWrapper.js
@@ -1,8 +1,20 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  height: 100%;
+  overflow-y: auto;
+  position: relative;
   .editing-mode {
     cursor: pointer;
+    position: sticky;
+    z-index: 10;
+    top: 0;
+    background: ${(props) => props.theme.bg};
+    padding-bottom: 0.5em;
+  }
+  .markdown-body {
+    height: auto !important;
+    overflow-y: visible !important;
   }
 `;
 

--- a/packages/bruno-app/src/components/FolderSettings/Documentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FolderSettings/Documentation/StyledWrapper.js
@@ -4,6 +4,7 @@ const StyledWrapper = styled.div`
   .editing-mode {
     cursor: pointer;
     color: ${(props) => props.theme.colors.text.yellow};
+    
   }
 `;
 

--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
@@ -155,7 +155,7 @@ const GraphQLRequestPane = ({ item, collection, onSchemaLoad, toggleDocs, handle
         rightContentRef={rightContent ? schemaActionsRef : null}
       />
 
-      <section className={classnames('flex w-full flex-1 mt-4')}>
+      <section className={classnames('flex w-full flex-1 mt-4 ')}>
         <HeightBoundContainer>{tabPanel}</HeightBoundContainer>
       </section>
     </div>

--- a/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/HttpRequestPane/index.js
@@ -139,7 +139,7 @@ const HttpRequestPane = ({ item, collection }) => {
         delayedTabs={['body']}
       />
 
-      <section className={classnames('flex w-full flex-1 mt-4')}>
+      <section className={classnames('flex w-full flex-1 mt-4  ')}>
         <HeightBoundContainer>{tabPanel}</HeightBoundContainer>
       </section>
     </div>

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -293,7 +293,7 @@ const ResponsePane = ({ item, collection }) => {
         />
       </div>
       <section
-        className="flex flex-col min-h-0 relative px-4 auto overflow-auto mt-4"
+        className="flex flex-col min-h-0 relative px-4 auto overflow-auto mt-4 "
         style={{
           flex: '1 1 0',
           height: hasScriptError && showScriptErrorCard ? 'auto' : '100%'


### PR DESCRIPTION
### Description

This PR fixes an issue where the "Edit" button in the Documentation tab would scroll out of view when reading long documents. Users previously had to scroll all the way back to the top to switch to Edit mode.

**Changes:**
- Added `position: sticky` to the `.editing-mode` class.
- Added background color (themed) to the button container to prevent text from scrolling behind it.
- Adjusted the parent container's overflow properties to ensure the sticky behavior works correctly.

**Fixes:** #7142 

### Videos
**Before:**

https://github.com/user-attachments/assets/ed038e4c-e54d-4003-ad7e-1391d56a76ae


**After:**

https://github.com/user-attachments/assets/a8af759f-2df3-4f63-a4e2-2c10d5eac043



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustments across multiple components.

* **User Interface**
  * Enhanced documentation editor with sticky header positioning and improved scrolling behavior for better content navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->