### PR TITLE
fix: html report collapse for repeated requests

### DIFF
--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -294,7 +294,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
           </n-switch>
 
           <n-collapse>
-            <x-result v-for="(result, index) in results" :result="result" :key="results.length"></x-result>
+            <x-result v-for="(result, index) in results" :result="result" :index="index" :key="index"></x-result>
           </n-collapse>
         </n-flex>
       </n-card>
@@ -673,7 +673,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
 
       app.component('x-result', {
         template: '#result-component',
-        props: ['result'],
+        props: ['result', 'index'],
         setup(props) {
           const headerColumns = [
             {
@@ -760,7 +760,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
           const hasError = computed(() => !!props?.result?.error || props?.result?.status === 'error' || (props?.result?.response?.status === 'skipped' && props?.result?.error));
           const hasFailure = computed(() => total.value !== totalPassed.value);
           const testDuration = computed(() => Math.round(props?.result?.runDuration * 1000) + ' ms');
-          const resultTitle = computed(() => props?.result?.path + ' ' + props?.result?.response?.status + ' ' + props?.result?.response?.statusText);
+          const resultTitle = computed(() => props?.result?.path + ' ' + props?.result?.response?.status + ' ' + props?.result?.response?.statusText + ' ' + props?.index);
           const getAlertType = computed(() => {
             if (props.result.response.status === 'skipped') {
               return 'warning';


### PR DESCRIPTION
### Description

Fixes repeated requests in the HTML report all expanding/collapsing together. The collapse item name and v-for key were identical for retries of the same request, causing Naive UI to treat them as one item. Added a unique index to each entry

[JIRA](https://usebruno.atlassian.net/browse/BRU-2671)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before

https://github.com/user-attachments/assets/aab615bd-f235-45a6-a1b6-3826fd9755ae

After


https://github.com/user-attachments/assets/80a57108-a618-4b86-8716-4ae7ca9458cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced HTML test report generation with improved result identification and indexing, making individual test results more distinguishable and easier to reference in generated reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->