### PR TITLE
Clear input after adding a tag

### DIFF
--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -172,7 +172,7 @@ class SingleLineEditor extends Component {
       // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
       const nextValue = String(this.props.value ?? '');
       const currentValue = this.editor.getValue();
-      if (this.editor.hasFocus?.() && currentValue !== nextValue) {
+      if (this.editor.hasFocus?.() && currentValue !== nextValue && nextValue !== '') {
         this.cachedValue = currentValue;
       } else {
         const cursor = this.editor.getCursor();


### PR DESCRIPTION
### Description
Closes #7179

Currently, when you add a tag to a request, you press Enter and the tag is added, but the value stays in the input.  
It can get annoying if you have many tags to enter.

The cause of this behavior is the code added in #7098 which does not account for empty values. This PR just adds a condition to not restore values if they are empty.

I specifically tested that this does not break the fix made in #7098 on autosave in the URL bar for example.

**Before**
![bruno-before](https://github.com/user-attachments/assets/9db4d0c8-a782-401b-b875-aee18163c95c)

**After**
![bruno-after](https://github.com/user-attachments/assets/d002f029-6698-40c8-9ca7-109895434dee)


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor position restoration during auto-save and new line insertion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->