### PR TITLE
fix: change transient request directory from os temp to app data

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -86,7 +86,7 @@ const MAX_COLLECTION_FILES_COUNT = 2000;
 
 // Get the base directory for transient request files (stored in app data directory)
 const getTransientDirectoryBase = () => {
-  return path.join(app.getPath('userData'), 'transient');
+  return path.join(app.getPath('userData'), 'tmp', 'transient');
 };
 
 // Get the prefix used for transient collection directories


### PR DESCRIPTION


### Description

Move transient request files from os.tmpdir() to app.getPath('userData')/transient to prevent data loss when the OS clears temporary files.

Changes:
- Add helper functions for transient directory paths
- Update findCollectionPathByItemPath to use new transient path check
- Update renderer:mount-collection to create temp dirs in app data
- Update renderer:mount-workspace-scratch to create temp dirs in app data
- Update renderer:delete-transient-requests prefix validation

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of temporary file storage for enhanced stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->