### PR TITLE
feat: add caching to `getCACertificates`

### DIFF
--- a/packages/bruno-requests/src/utils/ca-cert.ts
+++ b/packages/bruno-requests/src/utils/ca-cert.ts
@@ -17,7 +17,7 @@ type T_CACertificatesResult = {
 };
 
 let systemCertsCache: string[] | undefined;
-let cachedResult: { key: string; result: T_CACertificatesResult } | undefined;
+let cachedResult = new Map<string, T_CACertificatesResult>();
 
 function getFileMtimeMs(filePath: string | undefined): number | null {
   if (!filePath) return null;
@@ -108,8 +108,8 @@ const getCACertificates = ({ caCertFilePath, shouldKeepDefaultCerts = true }: T_
     shouldKeepDefaultCerts
   });
 
-  if (cachedResult && cachedResult.key === cacheKey) {
-    return cachedResult.result;
+  if (cachedResult.has(cacheKey)) {
+    return cachedResult.get(cacheKey)!;
   }
 
   try {
@@ -172,7 +172,7 @@ const getCACertificates = ({ caCertFilePath, shouldKeepDefaultCerts = true }: T_
     caCertificates = mergedCerts;
 
     const result = { caCertificates, caCertificatesCount };
-    cachedResult = { key: cacheKey, result };
+    cachedResult.set(cacheKey, result);
 
     return result;
   } catch (err) {


### PR DESCRIPTION
### Description

Cache CA certificate results using file modification times for invalidation, avoiding redundant file reads and cert merging on repeated calls with unchanged cert files.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized CA certificate computation through intelligent caching that automatically responds to certificate file changes via timestamp monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->