### PR TITLE
fix: skip null query parameters in Postman to Bruno conversion

### DIFF
--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -465,15 +465,16 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
           brunoRequestItem.request.body.mode = 'multipartForm';
 
           each(i.request.body.formdata, (param) => {
+            if (param.key == null && param.value == null) return;
             const isFile = param.type === 'file' || (param.type === 'default' && param.src);
             const value = isFile
               ? (Array.isArray(param.src) ? param.src : param.src ? [param.src] : [])
-              : (Array.isArray(param.value) ? param.value.join('') : param.value);
+              : (Array.isArray(param.value) ? param.value.join('') : param.value ?? '');
 
             brunoRequestItem.request.body.multipartForm.push({
               uid: uuid(),
               type: isFile ? 'file' : 'text',
-              name: param.key,
+              name: param.key ?? '',
               value,
               description: transformDescription(param.description),
               enabled: !param.disabled,
@@ -485,10 +486,11 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
         if (bodyMode === 'urlencoded') {
           brunoRequestItem.request.body.mode = 'formUrlEncoded';
           each(i.request.body.urlencoded, (param) => {
+            if (param.key == null && param.value == null) return;
             brunoRequestItem.request.body.formUrlEncoded.push({
               uid: uuid(),
-              name: param.key,
-              value: param.value,
+              name: param.key ?? '',
+              value: param.value ?? '',
               description: transformDescription(param.description),
               enabled: !param.disabled
             });
@@ -520,10 +522,11 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
       }
 
       each(i.request.header, (header) => {
+        if (header.key == null && header.value == null) return;
         brunoRequestItem.request.headers.push({
           uid: uuid(),
-          name: header.key,
-          value: header.value,
+          name: header.key ?? '',
+          value: header.value ?? '',
           description: transformDescription(header.description),
           enabled: !header.disabled
         });
@@ -609,10 +612,11 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
           // Convert original request headers
           if (originalRequest.header && Array.isArray(originalRequest.header)) {
             originalRequest.header.forEach((header) => {
+              if (header.key == null && header.value == null) return;
               example.request.headers.push({
                 uid: uuid(),
-                name: header.key,
-                value: header.value,
+                name: header.key ?? '',
+                value: header.value ?? '',
                 description: transformDescription(header.description),
                 enabled: !header.disabled
               });
@@ -638,6 +642,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
 
           if (originalRequest.url && originalRequest.url.variable && Array.isArray(originalRequest.url.variable)) {
             originalRequest.url.variable.forEach((param) => {
+              if (!param.key) return;
               example.request.params.push({
                 uid: uuid(),
                 name: param.key,
@@ -656,15 +661,16 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
               example.request.body.mode = 'multipartForm';
               if (originalRequest.body.formdata && Array.isArray(originalRequest.body.formdata)) {
                 originalRequest.body.formdata.forEach((param) => {
+                  if (param.key == null && param.value == null) return;
                   const isFile = param.type === 'file' || (param.type === 'default' && param.src);
                   const value = isFile
                     ? (Array.isArray(param.src) ? param.src : param.src ? [param.src] : [])
-                    : (Array.isArray(param.value) ? param.value.join('') : param.value);
+                    : (Array.isArray(param.value) ? param.value.join('') : param.value ?? '');
 
                   example.request.body.multipartForm.push({
                     uid: uuid(),
                     type: isFile ? 'file' : 'text',
-                    name: param.key,
+                    name: param.key ?? '',
                     value,
                     description: transformDescription(param.description),
                     enabled: !param.disabled,
@@ -676,10 +682,11 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
               example.request.body.mode = 'formUrlEncoded';
               if (originalRequest.body.urlencoded && Array.isArray(originalRequest.body.urlencoded)) {
                 originalRequest.body.urlencoded.forEach((param) => {
+                  if (param.key == null && param.value == null) return;
                   example.request.body.formUrlEncoded.push({
                     uid: uuid(),
-                    name: param.key,
-                    value: param.value,
+                    name: param.key ?? '',
+                    value: param.value ?? '',
                     description: transformDescription(param.description),
                     enabled: !param.disabled
                   });
@@ -706,10 +713,11 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
           // Convert response headers
           if (response.header && Array.isArray(response.header)) {
             response.header.forEach((header) => {
+              if (header.key == null && header.value == null) return;
               example.response.headers.push({
                 uid: uuid(),
-                name: header.key,
-                value: header.value,
+                name: header.key ?? '',
+                value: header.value ?? '',
                 description: transformDescription(header.description),
                 enabled: true
               });


### PR DESCRIPTION
[Jira](https://usebruno.atlassian.net/browse/BRU-2496)

## Summary
- Postman collections can contain query parameters with `null` keys/values (e.g., `{"key": null, "value": null}`), which causes a crash during import: `TypeError: Cannot read properties of null (reading 'includes')`
- Skip query params where both key and value are `null`, and normalize individual `null` keys/values to empty strings — matching the existing guard used for path variables
- Applied the fix in both regular request params and response example params

## Test plan
- [x] Added test case covering: fully-null params (skipped), null key with value (normalized), key with null value (normalized)
- [ ] Verify existing `bruno-converters` tests still pass (`npm run test --workspace=packages/bruno-converters`)
- [ ] Manually import a Postman collection containing null query params and confirm no crash

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of null query parameters in Postman collection imports to properly filter invalid entries and normalize empty values.

* **Tests**
  * Added test cases validating query parameter filtering and normalization when converting Postman collections to Bruno format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->