### PR TITLE
fix: consistent button size on save requests modal

### DIFF
--- a/packages/bruno-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
+++ b/packages/bruno-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
@@ -218,7 +218,7 @@ const SaveRequestsModal = ({ onClose }) => {
           </Button>
         </div>
         <div className="flex gap-2">
-          <Button size="sm" color="secondary" variant="ghost" onClick={onClose}>
+          <Button color="secondary" variant="ghost" onClick={onClose}>
             Cancel
           </Button>
           <Button onClick={closeWithSave}>


### PR DESCRIPTION
### Description

Fixes buttons size on "unsaved changes" modal

(button hovered on screenshot for better readability)

#### Before 

<img width="492" height="178" alt="image" src="https://github.com/user-attachments/assets/591fbea1-7c19-40c9-bc4f-0fdfc8815f49" />

#### After

<img width="496" height="177" alt="image" src="https://github.com/user-attachments/assets/78760178-d3f4-4aa0-804c-e162cb6e3f93" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Cancel button size in the save requests modal for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->