### PR TITLE
feat(cli): add curl command to generate curl from .bru requests

### DIFF
--- a/packages/bruno-cli/src/commands/curl.js
+++ b/packages/bruno-cli/src/commands/curl.js
@@ -1,0 +1,142 @@
+const chalk = require('chalk');
+const path = require('path');
+const { cloneDeep, find, filter } = require('lodash');
+const { loadEnvironments } = require('../utils/env-loader');
+const constants = require('../constants');
+const { findItemInCollection, createCollectionJsonFromPathname, FORMAT_CONFIG } = require('../utils/collection');
+const prepareRequest = require('../runner/prepare-request');
+const interpolateVars = require('../runner/interpolate-vars');
+const { buildCurlCommand } = require('../utils/curl-builder');
+
+const command = 'curl <path>';
+const desc = 'Generate a curl command from a request';
+
+const builder = async (yargs) => {
+  yargs
+    .option('env', {
+      describe: 'Environment name',
+      type: 'string'
+    })
+    .option('env-file', {
+      describe: 'Path to environment file (.bru or .json) - absolute or relative',
+      type: 'string'
+    })
+    .option('global-env', {
+      describe: 'Global environment name (requires collection to be in a workspace)',
+      type: 'string'
+    })
+    .option('workspace-path', {
+      describe: 'Path to workspace directory (auto-detected if not provided)',
+      type: 'string'
+    })
+    .option('env-var', {
+      describe: 'Overwrite a single environment variable, multiple usages possible',
+      type: 'string'
+    })
+    .example('$0 curl request.bru', 'Generate a curl command from a request')
+    .example('$0 curl request.bru --env local', 'Generate a curl command with the environment set to local');
+};
+
+const handler = async function (argv) {
+  try {
+    let {
+      path: requestPath,
+      env,
+      envFile,
+      globalEnv,
+      workspacePath,
+      envVar
+    } = argv;
+
+    const collectionPath = process.cwd();
+    let collection = createCollectionJsonFromPathname(collectionPath);
+
+    const { envVars, globalEnvVars, processEnvVars } = await loadEnvironments({
+      collectionPath, collection, env, envFile, globalEnv, workspacePath, envVar
+    });
+
+    // --- Resolve request item ---
+
+    const ext = FORMAT_CONFIG[collection.format].ext;
+    let itemPathname = path.resolve(collectionPath, requestPath);
+    if (!itemPathname.endsWith(ext)) {
+      itemPathname = `${itemPathname}${ext}`;
+    }
+
+    const item = cloneDeep(findItemInCollection(collection, itemPathname));
+    if (!item) {
+      console.error(chalk.red(`Request not found: `) + chalk.dim(requestPath));
+      process.exit(constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
+    }
+
+    if (item.type === 'folder') {
+      console.error(chalk.red(`Path is a folder, not a request: `) + chalk.dim(requestPath));
+      process.exit(constants.EXIT_STATUS.ERROR_GENERIC);
+    }
+
+    // --- Capture file paths before prepareRequest reads them into buffers ---
+
+    const filePaths = {};
+    const bodyMode = item.request?.body?.mode;
+
+    if (bodyMode === 'file') {
+      const bodyFile = find(item.request.body.file, (param) => param.selected);
+      if (bodyFile && bodyFile.filePath) {
+        let fp = bodyFile.filePath;
+        if (!path.isAbsolute(fp)) {
+          fp = path.join(collectionPath, fp);
+        }
+        filePaths.body = fp;
+      }
+    }
+
+    if (bodyMode === 'multipartForm') {
+      const enabledParams = filter(item.request.body.multipartForm, (p) => p.enabled);
+      filePaths.multipart = enabledParams
+        .filter((p) => p.type === 'file')
+        .map((p) => {
+          let fp = p.value || '';
+          if (fp && !path.isAbsolute(fp)) {
+            fp = path.join(collectionPath, fp);
+          }
+          return { name: p.name, path: fp };
+        });
+    }
+
+    // --- Prepare and interpolate ---
+
+    const request = await prepareRequest(item, collection);
+    request.globalEnvironmentVariables = globalEnvVars;
+    interpolateVars(request, envVars, {}, processEnvVars);
+
+    // Parse GraphQL variables after interpolation
+    if (request.mode === 'graphql' && typeof request.data?.variables === 'string') {
+      try {
+        request.data.variables = JSON.parse(request.data.variables);
+      } catch (err) {
+        // Leave as string if it can't be parsed
+      }
+    }
+
+    // Add http:// prefix if missing
+    const protocolRegex = /^([-+\w]{1,25})(:?\/\/|:)/;
+    if (!protocolRegex.test(request.url)) {
+      request.url = `http://${request.url}`;
+    }
+
+    // --- Build and output curl command ---
+
+    const curlCommand = buildCurlCommand(request, { filePaths });
+    console.log(curlCommand);
+  } catch (err) {
+    console.error(chalk.red(err.message));
+    process.exit(constants.EXIT_STATUS.ERROR_GENERIC);
+  }
+};
+
+module.exports = {
+  command,
+  desc,
+  builder,
+  handler
+};

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -2,18 +2,16 @@ const fs = require('fs');
 const chalk = require('chalk');
 const path = require('path');
 const yaml = require('js-yaml');
-const { forOwn, cloneDeep } = require('lodash');
+const { cloneDeep } = require('lodash');
 const { getRunnerSummary } = require('@usebruno/common/runner');
 const { exists, isFile, isDirectory } = require('../utils/filesystem');
 const { runSingleRequest } = require('../runner/run-single-request');
-const { getEnvVars } = require('../utils/bru');
-const { parseEnvironmentJson } = require('../utils/environment');
+const { loadEnvironments } = require('../utils/env-loader');
 const { isRequestTagsIncluded } = require('@usebruno/common');
 const makeJUnitOutput = require('../reporters/junit');
 const makeHtmlOutput = require('../reporters/html');
 const { rpad } = require('../utils/common');
 const { getOptions } = require('../utils/bru');
-const { parseDotEnv, parseEnvironment } = require('@usebruno/filestore');
 const constants = require('../constants');
 const { findItemInCollection, createCollectionJsonFromPathname, getCallStack, FORMAT_CONFIG } = require('../utils/collection');
 const { hasExecutableTestInScript } = require('../utils/request');
@@ -353,148 +351,9 @@ const handler = async function (argv) {
     }
 
     const runtimeVariables = {};
-    let envVars = {};
-
-    // Helper to load environment variables from a file
-    const loadEnvFromFile = (filePath, nameOverride) => {
-      const fileExt = path.extname(filePath).toLowerCase();
-      let result = {};
-
-      if (fileExt === '.json') {
-        const content = fs.readFileSync(filePath, 'utf8');
-        const parsed = JSON.parse(content);
-        const normalizedEnv = parseEnvironmentJson(parsed);
-        result = getEnvVars(normalizedEnv);
-        const rawName = normalizedEnv?.name;
-        const trimmedName = typeof rawName === 'string' ? rawName.trim() : '';
-        result.__name__ = trimmedName || path.basename(filePath, '.json');
-      } else if (fileExt === '.yml' || fileExt === '.yaml') {
-        const content = fs.readFileSync(filePath, 'utf8');
-        const envJson = parseEnvironment(content, { format: 'yml' });
-        result = getEnvVars(envJson);
-        result.__name__ = nameOverride || path.basename(filePath, fileExt);
-      } else {
-        const content = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
-        const envJson = parseEnvironment(content, { format: 'bru' });
-        result = getEnvVars(envJson);
-        result.__name__ = nameOverride || path.basename(filePath, '.bru');
-      }
-
-      return result;
-    };
-
-    // Load --env-file if provided
-    if (envFile) {
-      const envFilePath = path.resolve(collectionPath, envFile);
-      if (!(await exists(envFilePath))) {
-        console.error(chalk.red(`Environment file not found: `) + chalk.dim(envFile));
-        process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
-      }
-      try {
-        envVars = loadEnvFromFile(envFilePath);
-      } catch (err) {
-        console.error(chalk.red(`Failed to parse environment file: ${err.message}`));
-        process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
-      }
-    }
-
-    // Load --env and merge (collection env takes precedence)
-    if (env) {
-      const envExt = FORMAT_CONFIG[collection.format].ext;
-      const collectionEnvFilePath = path.join(collectionPath, 'environments', `${env}${envExt}`);
-      if (!(await exists(collectionEnvFilePath))) {
-        console.error(chalk.red(`Environment file not found: `) + chalk.dim(`environments/${env}${envExt}`));
-        process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
-      }
-      try {
-        const collectionEnvVars = loadEnvFromFile(collectionEnvFilePath, env);
-        envVars = { ...envVars, ...collectionEnvVars };
-      } catch (err) {
-        console.error(chalk.red(`Failed to parse Environment file: ${err.message}`));
-        process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
-      }
-    }
-
-    let globalEnvVars = {};
-    if (globalEnv) {
-      const findWorkspacePath = (startPath) => {
-        let currentPath = startPath;
-        while (currentPath !== path.dirname(currentPath)) {
-          const workspaceYmlPath = path.join(currentPath, 'workspace.yml');
-          if (fs.existsSync(workspaceYmlPath)) {
-            return currentPath;
-          }
-          currentPath = path.dirname(currentPath);
-        }
-        return null;
-      };
-
-      if (!workspacePath) {
-        workspacePath = findWorkspacePath(collectionPath);
-      }
-
-      if (!workspacePath) {
-        console.error(chalk.red(`Workspace not found. Please specify a workspace path using --workspace-path or ensure the collection is inside a workspace directory.`));
-        process.exit(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_REQUIRES_WORKSPACE);
-      }
-
-      const workspaceExists = await exists(workspacePath);
-      if (!workspaceExists) {
-        console.error(chalk.red(`Workspace path not found: `) + chalk.dim(workspacePath));
-        process.exit(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
-      }
-
-      const workspaceYmlPath = path.join(workspacePath, 'workspace.yml');
-      const workspaceYmlExists = await exists(workspaceYmlPath);
-      if (!workspaceYmlExists) {
-        console.error(chalk.red(`Invalid workspace: workspace.yml not found in `) + chalk.dim(workspacePath));
-        process.exit(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
-      }
-
-      const globalEnvFilePath = path.join(workspacePath, 'environments', `${globalEnv}.yml`);
-      const globalEnvFileExists = await exists(globalEnvFilePath);
-      if (!globalEnvFileExists) {
-        console.error(chalk.red(`Global environment not found: `) + chalk.dim(`environments/${globalEnv}.yml`));
-        console.error(chalk.dim(`Workspace: ${workspacePath}`));
-        process.exit(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_NOT_FOUND);
-      }
-
-      try {
-        const globalEnvContent = fs.readFileSync(globalEnvFilePath, 'utf8');
-        const globalEnvJson = parseEnvironment(globalEnvContent, { format: 'yml' });
-        globalEnvVars = getEnvVars(globalEnvJson);
-        globalEnvVars.__name__ = globalEnv;
-      } catch (err) {
-        console.error(chalk.red(`Failed to parse global environment: ${err.message}`));
-        process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
-      }
-    }
-
-    if (envVar) {
-      let processVars;
-      if (typeof envVar === 'string') {
-        processVars = [envVar];
-      } else if (typeof envVar === 'object' && Array.isArray(envVar)) {
-        processVars = envVar;
-      } else {
-        console.error(chalk.red(`overridable environment variables not parsable: use name=value`));
-        process.exit(constants.EXIT_STATUS.ERROR_MALFORMED_ENV_OVERRIDE);
-      }
-      if (processVars && Array.isArray(processVars)) {
-        for (const value of processVars.values()) {
-          // split the string at the first equals sign
-          const match = value.match(/^([^=]+)=(.*)$/);
-          if (!match) {
-            console.error(
-              chalk.red(`Overridable environment variable not correct: use name=value - presented: `)
-              + chalk.dim(`${value}`)
-            );
-            process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE);
-          }
-          envVars[match[1]] = match[2];
-        }
-      }
-    }
+    const { envVars, globalEnvVars, processEnvVars } = await loadEnvironments({
+      collectionPath, collection, env, envFile, globalEnv, workspacePath, envVar
+    });
 
     const options = getOptions();
     if (bail) {
@@ -551,21 +410,6 @@ const handler = async function (argv) {
 
     if (reporterJunit && reporterJunit.length) {
       formats['junit'] = reporterJunit;
-    }
-
-    // load .env file at root of collection if it exists
-    const dotEnvPath = path.join(collectionPath, '.env');
-    const dotEnvExists = await exists(dotEnvPath);
-    const processEnvVars = {
-      ...process.env
-    };
-    if (dotEnvExists) {
-      const content = fs.readFileSync(dotEnvPath, 'utf8');
-      const jsonData = parseDotEnv(content);
-
-      forOwn(jsonData, (value, key) => {
-        processEnvVars[key] = value;
-      });
     }
 
     let requestItems = [];

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -165,8 +165,6 @@ const prepareRequest = async (item = {}, collection = {}) => {
         'X-WSSE'
       ] = `UsernameToken Username="${username}", PasswordDigest="${digest}", Nonce="${nonce}", Created="${ts}"`;
     }
-
-    console.log('axiosRequest', axiosRequest);
   }
 
   if (request.auth && request.auth.mode !== 'inherit') {

--- a/packages/bruno-cli/src/utils/curl-builder.js
+++ b/packages/bruno-cli/src/utils/curl-builder.js
@@ -1,0 +1,121 @@
+/**
+ * Converts a prepared + interpolated axios request config into a curl command string.
+ *
+ * @param {object} request - The axios request config (after prepareRequest + interpolateVars)
+ * @param {object} options
+ * @param {object} [options.filePaths] - Original file paths captured before prepareRequest read them
+ * @param {string} [options.filePaths.body] - File path for body mode 'file'
+ * @param {Array}  [options.filePaths.multipart] - Array of {name, path} for multipart file entries
+ * @returns {string} The curl command string
+ */
+const buildCurlCommand = (request, options = {}) => {
+  const { filePaths = {} } = options;
+  const parts = ['curl'];
+
+  // Method
+  const method = (request.method || 'GET').toUpperCase();
+  if (method !== 'GET') {
+    parts.push(`-X ${method}`);
+  }
+
+  // URL
+  parts.push(shellQuote(request.url));
+
+  // Headers
+  if (request.headers) {
+    for (const [name, value] of Object.entries(request.headers)) {
+      if (value === null || value === undefined) continue;
+      parts.push(`-H ${shellQuote(`${name}: ${value}`)}`);
+    }
+  }
+
+  // Digest auth
+  if (request.digestConfig) {
+    const { username, password } = request.digestConfig;
+    parts.push('--digest');
+    parts.push(`--user ${shellQuote(`${username || ''}:${password || ''}`)}`);
+  }
+
+  // NTLM auth
+  if (request.ntlmConfig) {
+    const { username, password, domain } = request.ntlmConfig;
+    const user = domain ? `${domain}\\${username || ''}` : (username || '');
+    parts.push('--ntlm');
+    parts.push(`--user ${shellQuote(`${user}:${password || ''}`)}`);
+  }
+
+  // OAuth2 note
+  if (request.oauth2) {
+    parts.push('# Note: OAuth2 token must be fetched separately; add \'-H "Authorization: Bearer <token>"\'');
+  }
+
+  // AWS SigV4 note
+  if (request.awsv4config) {
+    parts.push('# Note: AWS SigV4 requires dynamic signing; headers will differ at runtime');
+  }
+
+  // Body
+  const mode = request.mode;
+  const data = request.data;
+
+  if (mode === 'json' || mode === 'text' || mode === 'xml' || mode === 'sparql') {
+    if (data != null && data !== '') {
+      const bodyStr = typeof data === 'object' ? JSON.stringify(data) : String(data);
+      parts.push(`--data-raw ${shellQuote(bodyStr)}`);
+    }
+  } else if (mode === 'formUrlEncoded') {
+    if (Array.isArray(data)) {
+      for (const param of data) {
+        parts.push(`--data-urlencode ${shellQuote(`${param.name}=${param.value}`)}`);
+      }
+    } else if (typeof data === 'string' && data.length > 0) {
+      parts.push(`--data-raw ${shellQuote(data)}`);
+    }
+  } else if (mode === 'multipartForm') {
+    if (Array.isArray(data)) {
+      const multipartFilePaths = filePaths.multipart || [];
+      for (const param of data) {
+        if (param.type === 'file') {
+          const fileEntry = multipartFilePaths.find((f) => f.name === param.name);
+          const filePath = fileEntry ? fileEntry.path : (param.value || 'unknown');
+          parts.push(`-F ${shellQuote(`${param.name}=@${filePath}`)}`);
+        } else {
+          parts.push(`-F ${shellQuote(`${param.name}=${param.value || ''}`)}`);
+        }
+      }
+    }
+  } else if (mode === 'graphql') {
+    if (data != null) {
+      const graphqlBody = {
+        query: data.query || '',
+        variables: data.variables || {}
+      };
+      parts.push(`--data-raw ${shellQuote(JSON.stringify(graphqlBody))}`);
+    }
+  } else if (mode === 'file') {
+    const filePath = filePaths.body || 'unknown';
+    parts.push(`--data-binary ${shellQuote(`@${filePath}`)}`);
+  }
+
+  // Format with line continuations
+  if (parts.length <= 2) {
+    return parts.join(' ');
+  }
+
+  return parts.join(' \\\n  ');
+};
+
+/**
+ * Shell-quote a string using single quotes.
+ * Embedded single quotes are handled via the '\'' technique.
+ */
+const shellQuote = (str) => {
+  if (str == null) return '\'\'';
+  const s = String(str);
+  // If string contains no special characters, we can still quote for safety
+  return '\'' + s.replace(/'/g, '\'\\\'\'') + '\'';
+};
+
+module.exports = {
+  buildCurlCommand
+};

--- a/packages/bruno-cli/src/utils/env-loader.js
+++ b/packages/bruno-cli/src/utils/env-loader.js
@@ -1,0 +1,188 @@
+const fs = require('fs');
+const chalk = require('chalk');
+const path = require('path');
+const { forOwn } = require('lodash');
+const { exists } = require('./filesystem');
+const { getEnvVars } = require('./bru');
+const { parseEnvironmentJson } = require('./environment');
+const { parseDotEnv, parseEnvironment } = require('@usebruno/filestore');
+const constants = require('../constants');
+const { FORMAT_CONFIG } = require('./collection');
+
+const loadEnvFromFile = (filePath, nameOverride) => {
+  const fileExt = path.extname(filePath).toLowerCase();
+  let result = {};
+
+  if (fileExt === '.json') {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(content);
+    const normalizedEnv = parseEnvironmentJson(parsed);
+    result = getEnvVars(normalizedEnv);
+    const rawName = normalizedEnv?.name;
+    const trimmedName = typeof rawName === 'string' ? rawName.trim() : '';
+    result.__name__ = trimmedName || path.basename(filePath, '.json');
+  } else if (fileExt === '.yml' || fileExt === '.yaml') {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const envJson = parseEnvironment(content, { format: 'yml' });
+    result = getEnvVars(envJson);
+    result.__name__ = nameOverride || path.basename(filePath, fileExt);
+  } else {
+    const content = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+    const envJson = parseEnvironment(content, { format: 'bru' });
+    result = getEnvVars(envJson);
+    result.__name__ = nameOverride || path.basename(filePath, '.bru');
+  }
+
+  return result;
+};
+
+/**
+ * Load environment variables from all sources (--env-file, --env, --global-env, --env-var, .env).
+ *
+ * @param {object} options
+ * @param {string} options.collectionPath - Absolute path to the collection root
+ * @param {object} options.collection - The parsed collection object (needs .format)
+ * @param {string} [options.env] - Collection environment name (--env)
+ * @param {string} [options.envFile] - Path to an external environment file (--env-file)
+ * @param {string} [options.globalEnv] - Global environment name (--global-env)
+ * @param {string} [options.workspacePath] - Explicit workspace path (--workspace-path)
+ * @param {string|string[]} [options.envVar] - Override variables (--env-var)
+ * @returns {Promise<{ envVars: object, globalEnvVars: object, processEnvVars: object }>}
+ */
+async function loadEnvironments({ collectionPath, collection, env, envFile, globalEnv, workspacePath, envVar }) {
+  let envVars = {};
+
+  // Load --env-file if provided
+  if (envFile) {
+    const envFilePath = path.resolve(collectionPath, envFile);
+    if (!(await exists(envFilePath))) {
+      console.error(chalk.red(`Environment file not found: `) + chalk.dim(envFile));
+      process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
+    }
+    try {
+      envVars = loadEnvFromFile(envFilePath);
+    } catch (err) {
+      console.error(chalk.red(`Failed to parse environment file: ${err.message}`));
+      process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
+    }
+  }
+
+  // Load --env and merge (collection env takes precedence)
+  if (env) {
+    const envExt = FORMAT_CONFIG[collection.format].ext;
+    const collectionEnvFilePath = path.join(collectionPath, 'environments', `${env}${envExt}`);
+    if (!(await exists(collectionEnvFilePath))) {
+      console.error(chalk.red(`Environment file not found: `) + chalk.dim(`environments/${env}${envExt}`));
+      process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
+    }
+    try {
+      const collectionEnvVars = loadEnvFromFile(collectionEnvFilePath, env);
+      envVars = { ...envVars, ...collectionEnvVars };
+    } catch (err) {
+      console.error(chalk.red(`Failed to parse Environment file: ${err.message}`));
+      process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
+    }
+  }
+
+  // Load --global-env
+  let globalEnvVars = {};
+  if (globalEnv) {
+    const findWorkspacePath = (startPath) => {
+      let currentPath = startPath;
+      while (currentPath !== path.dirname(currentPath)) {
+        const workspaceYmlPath = path.join(currentPath, 'workspace.yml');
+        if (fs.existsSync(workspaceYmlPath)) {
+          return currentPath;
+        }
+        currentPath = path.dirname(currentPath);
+      }
+      return null;
+    };
+
+    if (!workspacePath) {
+      workspacePath = findWorkspacePath(collectionPath);
+    }
+
+    if (!workspacePath) {
+      console.error(chalk.red(`Workspace not found. Please specify a workspace path using --workspace-path or ensure the collection is inside a workspace directory.`));
+      process.exit(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_REQUIRES_WORKSPACE);
+    }
+
+    const workspaceExists = await exists(workspacePath);
+    if (!workspaceExists) {
+      console.error(chalk.red(`Workspace path not found: `) + chalk.dim(workspacePath));
+      process.exit(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
+    }
+
+    const workspaceYmlPath = path.join(workspacePath, 'workspace.yml');
+    const workspaceYmlExists = await exists(workspaceYmlPath);
+    if (!workspaceYmlExists) {
+      console.error(chalk.red(`Invalid workspace: workspace.yml not found in `) + chalk.dim(workspacePath));
+      process.exit(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
+    }
+
+    const globalEnvFilePath = path.join(workspacePath, 'environments', `${globalEnv}.yml`);
+    const globalEnvFileExists = await exists(globalEnvFilePath);
+    if (!globalEnvFileExists) {
+      console.error(chalk.red(`Global environment not found: `) + chalk.dim(`environments/${globalEnv}.yml`));
+      console.error(chalk.dim(`Workspace: ${workspacePath}`));
+      process.exit(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_NOT_FOUND);
+    }
+
+    try {
+      const globalEnvContent = fs.readFileSync(globalEnvFilePath, 'utf8');
+      const globalEnvJson = parseEnvironment(globalEnvContent, { format: 'yml' });
+      globalEnvVars = getEnvVars(globalEnvJson);
+      globalEnvVars.__name__ = globalEnv;
+    } catch (err) {
+      console.error(chalk.red(`Failed to parse global environment: ${err.message}`));
+      process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
+    }
+  }
+
+  // Load --env-var overrides
+  if (envVar) {
+    let processVars;
+    if (typeof envVar === 'string') {
+      processVars = [envVar];
+    } else if (typeof envVar === 'object' && Array.isArray(envVar)) {
+      processVars = envVar;
+    } else {
+      console.error(chalk.red(`overridable environment variables not parsable: use name=value`));
+      process.exit(constants.EXIT_STATUS.ERROR_MALFORMED_ENV_OVERRIDE);
+    }
+    if (processVars && Array.isArray(processVars)) {
+      for (const value of processVars.values()) {
+        // split the string at the first equals sign
+        const match = value.match(/^([^=]+)=(.*)$/);
+        if (!match) {
+          console.error(
+            chalk.red(`Overridable environment variable not correct: use name=value - presented: `)
+            + chalk.dim(`${value}`)
+          );
+          process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE);
+        }
+        envVars[match[1]] = match[2];
+      }
+    }
+  }
+
+  // Load .env file at root of collection
+  const dotEnvPath = path.join(collectionPath, '.env');
+  const dotEnvExists = await exists(dotEnvPath);
+  const processEnvVars = {
+    ...process.env
+  };
+  if (dotEnvExists) {
+    const content = fs.readFileSync(dotEnvPath, 'utf8');
+    const jsonData = parseDotEnv(content);
+
+    forOwn(jsonData, (value, key) => {
+      processEnvVars[key] = value;
+    });
+  }
+
+  return { envVars, globalEnvVars, processEnvVars };
+}
+
+module.exports = { loadEnvironments };

--- a/packages/bruno-cli/tests/utils/curl-builder.spec.js
+++ b/packages/bruno-cli/tests/utils/curl-builder.spec.js
@@ -1,0 +1,356 @@
+const { describe, it, expect } = require('@jest/globals');
+const { buildCurlCommand } = require('../../src/utils/curl-builder');
+
+describe('buildCurlCommand', () => {
+  describe('method and URL', () => {
+    it('should generate a simple GET request', () => {
+      const result = buildCurlCommand({ method: 'GET', url: 'https://example.com/api' });
+      expect(result).toBe('curl \'https://example.com/api\'');
+    });
+
+    it('should omit -X for GET requests', () => {
+      const result = buildCurlCommand({ method: 'GET', url: 'https://example.com' });
+      expect(result).not.toContain('-X');
+    });
+
+    it('should include -X for non-GET methods', () => {
+      const result = buildCurlCommand({ method: 'POST', url: 'https://example.com' });
+      expect(result).toContain('-X POST');
+    });
+
+    it('should uppercase the method', () => {
+      const result = buildCurlCommand({ method: 'post', url: 'https://example.com' });
+      expect(result).toContain('-X POST');
+    });
+
+    it('should default to GET when method is not provided', () => {
+      const result = buildCurlCommand({ url: 'https://example.com' });
+      expect(result).not.toContain('-X');
+    });
+
+    it('should shell-quote the URL', () => {
+      const result = buildCurlCommand({ method: 'GET', url: 'https://example.com/search?q=hello world' });
+      expect(result).toContain('\'https://example.com/search?q=hello world\'');
+    });
+  });
+
+  describe('headers', () => {
+    it('should include headers with -H', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        headers: { 'Content-Type': 'application/json' }
+      });
+      expect(result).toContain('-H \'Content-Type: application/json\'');
+    });
+
+    it('should include multiple headers', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer token123'
+        }
+      });
+      expect(result).toContain('-H \'Content-Type: application/json\'');
+      expect(result).toContain('-H \'Authorization: Bearer token123\'');
+    });
+
+    it('should skip headers with null or undefined values', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        headers: { 'X-Null': null, 'X-Undef': undefined, 'X-Valid': 'yes' }
+      });
+      expect(result).not.toContain('X-Null');
+      expect(result).not.toContain('X-Undef');
+      expect(result).toContain('-H \'X-Valid: yes\'');
+    });
+  });
+
+  describe('JSON body', () => {
+    it('should include JSON object body with --data-raw', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'json',
+        data: { key: 'value' }
+      });
+      expect(result).toContain(`--data-raw '{"key":"value"}'`);
+    });
+
+    it('should include JSON string body with --data-raw', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'json',
+        data: '{"key":"value"}'
+      });
+      expect(result).toContain(`--data-raw '{"key":"value"}'`);
+    });
+
+    it('should not include body when data is null', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'json',
+        data: null
+      });
+      expect(result).not.toContain('--data-raw');
+    });
+
+    it('should not include body when data is empty string', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'json',
+        data: ''
+      });
+      expect(result).not.toContain('--data-raw');
+    });
+  });
+
+  describe('text, xml, sparql body modes', () => {
+    it('should handle text body', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'text',
+        data: 'plain text body'
+      });
+      expect(result).toContain('--data-raw \'plain text body\'');
+    });
+
+    it('should handle xml body', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'xml',
+        data: '<root><item>value</item></root>'
+      });
+      expect(result).toContain('--data-raw \'<root><item>value</item></root>\'');
+    });
+
+    it('should handle sparql body', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'sparql',
+        data: 'SELECT ?s WHERE { ?s ?p ?o }'
+      });
+      expect(result).toContain('--data-raw \'SELECT ?s WHERE { ?s ?p ?o }\'');
+    });
+  });
+
+  describe('form URL encoded body', () => {
+    it('should use --data-urlencode for array params', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'formUrlEncoded',
+        data: [
+          { name: 'username', value: 'john' },
+          { name: 'password', value: 's3cret' }
+        ]
+      });
+      expect(result).toContain('--data-urlencode \'username=john\'');
+      expect(result).toContain('--data-urlencode \'password=s3cret\'');
+    });
+
+    it('should use --data-raw for string form data', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'formUrlEncoded',
+        data: 'username=john&password=s3cret'
+      });
+      expect(result).toContain('--data-raw \'username=john&password=s3cret\'');
+    });
+
+    it('should not include body for empty string form data', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'formUrlEncoded',
+        data: ''
+      });
+      expect(result).not.toContain('--data-raw');
+    });
+  });
+
+  describe('multipart form body', () => {
+    it('should use -F for text fields', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'multipartForm',
+        data: [{ name: 'field1', value: 'value1', type: 'text' }]
+      });
+      expect(result).toContain('-F \'field1=value1\'');
+    });
+
+    it('should use -F with @ for file fields using filePaths', () => {
+      const result = buildCurlCommand(
+        {
+          method: 'POST',
+          url: 'https://example.com',
+          mode: 'multipartForm',
+          data: [{ name: 'upload', value: '', type: 'file' }]
+        },
+        { filePaths: { multipart: [{ name: 'upload', path: '/home/user/photo.jpg' }] } }
+      );
+      expect(result).toContain('-F \'upload=@/home/user/photo.jpg\'');
+    });
+
+    it('should fall back to param.value for file fields without filePaths', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'multipartForm',
+        data: [{ name: 'upload', value: 'photo.jpg', type: 'file' }]
+      });
+      expect(result).toContain('-F \'upload=@photo.jpg\'');
+    });
+  });
+
+  describe('graphql body', () => {
+    it('should serialize graphql query and variables', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com/graphql',
+        mode: 'graphql',
+        data: {
+          query: '{ users { id name } }',
+          variables: { limit: 10 }
+        }
+      });
+      const body = JSON.parse(result.match(/--data-raw '(.+)'/)[1]);
+      expect(body).toEqual({
+        query: '{ users { id name } }',
+        variables: { limit: 10 }
+      });
+    });
+
+    it('should default variables to empty object', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com/graphql',
+        mode: 'graphql',
+        data: { query: '{ users { id } }' }
+      });
+      const body = JSON.parse(result.match(/--data-raw '(.+)'/)[1]);
+      expect(body.variables).toEqual({});
+    });
+  });
+
+  describe('file body', () => {
+    it('should use --data-binary with @ for file body', () => {
+      const result = buildCurlCommand(
+        {
+          method: 'POST',
+          url: 'https://example.com/upload',
+          mode: 'file',
+          data: null
+        },
+        { filePaths: { body: '/home/user/data.bin' } }
+      );
+      expect(result).toContain('--data-binary \'@/home/user/data.bin\'');
+    });
+
+    it('should use "unknown" when no file path is provided', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com/upload',
+        mode: 'file',
+        data: null
+      });
+      expect(result).toContain('--data-binary \'@unknown\'');
+    });
+  });
+
+  describe('authentication', () => {
+    it('should include --digest and --user for digest auth', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        digestConfig: { username: 'admin', password: 'secret' }
+      });
+      expect(result).toContain('--digest');
+      expect(result).toContain('--user \'admin:secret\'');
+    });
+
+    it('should include --ntlm and --user for NTLM auth', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        ntlmConfig: { username: 'admin', password: 'secret', domain: 'CORP' }
+      });
+      expect(result).toContain('--ntlm');
+      expect(result).toContain('--user \'CORP\\admin:secret\'');
+    });
+
+    it('should handle NTLM auth without domain', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        ntlmConfig: { username: 'admin', password: 'secret' }
+      });
+      expect(result).toContain('--user \'admin:secret\'');
+    });
+
+    it('should add a comment for OAuth2', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        oauth2: { grantType: 'client_credentials' }
+      });
+      expect(result).toContain('# Note: OAuth2');
+    });
+
+    it('should add a comment for AWS SigV4', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        awsv4config: { region: 'us-east-1' }
+      });
+      expect(result).toContain('# Note: AWS SigV4');
+    });
+  });
+
+  describe('shell quoting', () => {
+    it('should escape single quotes in values', () => {
+      const result = buildCurlCommand({
+        method: 'POST',
+        url: 'https://example.com',
+        mode: 'json',
+        data: 'it\'s a test'
+      });
+      expect(result).toContain('\'it\'\\\'\'s a test\'');
+    });
+
+    it('should handle special shell characters in URLs', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com/api?a=1&b=2'
+      });
+      expect(result).toContain('\'https://example.com/api?a=1&b=2\'');
+    });
+  });
+
+  describe('formatting', () => {
+    it('should use single line for simple GET requests', () => {
+      const result = buildCurlCommand({ method: 'GET', url: 'https://example.com' });
+      expect(result).not.toContain('\\\n');
+    });
+
+    it('should use line continuations when there are multiple parts', () => {
+      const result = buildCurlCommand({
+        method: 'GET',
+        url: 'https://example.com',
+        headers: { Accept: 'application/json' }
+      });
+      expect(result).toContain(' \\\n  ');
+    });
+  });
+});


### PR DESCRIPTION
closes https://github.com/usebruno/bruno/issues/6670
## Summary
- Add a new `bru curl` CLI command that converts Bruno request files into curl commands with full environment variable interpolation
- Extract shared environment loading logic from `run.js` into a reusable `env-loader.js` module
- Add `curl-builder.js` utility that handles all body modes (JSON, form, multipart, GraphQL, file), auth types (digest, NTLM), and proper shell quoting
- Remove stray `console.log` debug statement from `prepare-request.js`

## Test plan
- [x] 35 unit tests added for `curl-builder.js` covering all body modes, auth types, shell quoting, and formatting
- [x] Manual test: `bru curl request.bru` generates valid curl output
- [x] Manual test: `bru curl request.bru --env local` interpolates environment variables correctly
- [x] Manual test: `bru run` still works as expected after env-loader refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `curl` command to generate portable curl commands from saved requests, with support for environment variables, workspace configurations, and file-based request bodies.

* **Bug Fixes**
  * Removed unintended debug output from request preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->