### PR TITLE
fix(cli): preserve request item type during import and fail on unsupported types

### DIFF
--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -11,6 +11,7 @@ const FORMAT_CONFIG = {
   yml: { ext: '.yml', collectionFile: 'opencollection.yml', folderFile: 'folder.yml' },
   bru: { ext: '.bru', collectionFile: 'collection.bru', folderFile: 'folder.bru' }
 };
+const REQUEST_ITEM_TYPES = ['http-request', 'graphql-request'];
 
 const getCollectionFormat = (collectionPath) => {
   if (fs.existsSync(path.join(collectionPath, 'opencollection.yml'))) return 'yml';
@@ -499,7 +500,7 @@ const processCollectionItems = async (items = [], currentPath) => {
         if (item.seq) {
           item.root.meta.seq = item.seq;
         }
-        const folderContent = await stringifyFolder(item.root, { format: 'bru' });
+        const folderContent = stringifyFolder(item.root, { format: 'bru' });
         safeWriteFileSync(folderBruFilePath, folderContent);
       }
 
@@ -507,7 +508,7 @@ const processCollectionItems = async (items = [], currentPath) => {
       if (item.items && item.items.length) {
         await processCollectionItems(item.items, folderPath);
       }
-    } else if (['http-request', 'graphql-request'].includes(item.type)) {
+    } else if (REQUEST_ITEM_TYPES.includes(item.type)) {
       // Create request file
       let sanitizedFilename = sanitizeName(item?.filename || `${item.name}.bru`);
       if (!sanitizedFilename.endsWith('.bru')) {
@@ -537,8 +538,10 @@ const processCollectionItems = async (items = [], currentPath) => {
       };
 
       // Convert to BRU format and write to file
-      const content = await stringifyRequest(bruJson, { format: 'bru' });
+      const content = stringifyRequest(bruJson, { format: 'bru' });
       safeWriteFileSync(path.join(currentPath, sanitizedFilename), content);
+    } else {
+      throw new Error(`Unsupported item type: ${item.type}`);
     }
   }
 };


### PR DESCRIPTION
## Summary
Fix CLI import serialization in `createCollectionFromBrunoObject` so generated `.bru` files are valid and compatible with filestore expectations.

Fixes #7172.

## Problem
`bru import openapi` could fail with:

`Unsupported item type: http`

Root cause:
- CLI converted request item types from schema values (`http-request`, `graphql-request`) to legacy values (`http`, `graphql`) before calling `stringifyRequest`.
- Request/folder serialization relied on filestore defaults instead of explicitly writing BRU format.

## Changes
- Preserve schema request types when building request objects for stringify:
  - `http-request` stays `http-request`
  - `graphql-request` stays `graphql-request`
- Explicitly serialize imported request and folder files using BRU format:
  - `stringifyRequest(..., { format: 'bru' })`
  - `stringifyFolder(..., { format: 'bru' })`
- Add fail-fast handling for unsupported item types in import writer path.
- Add focused regression tests:
  - writes/reads HTTP and GraphQL `.bru` requests correctly
  - writes/reads `folder.bru` correctly
  - throws on unsupported item type

## Files
- `packages/bruno-cli/src/utils/collection.js`
- `packages/bruno-cli/tests/utils/collection/create-collection-from-bruno-object.spec.js`

## Validation
Target test added:
`packages/bruno-cli/tests/utils/collection/create-collection-from-bruno-object.spec.js`

Recommended command:
`npm run test --workspace=packages/bruno-cli -- tests/utils/collection/create-collection-from-bruno-object.spec.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Apply BRU formatting explicitly during collection export and preserve original request types in exported BRU files.

* **Tests**
  * Added tests that verify exported BRU files are written for HTTP and GraphQL requests and for folders, and that parsed files retain correct types, methods, and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->