### PR TITLE
fix: collection scope undefined var

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -233,7 +233,7 @@ export const renderVarInfo = (token, options) => {
 
     // If variable doesn't exist in any scope, determine scope based on context
     if (!scopeInfo) {
-      if (item) {
+      if (item && item.uid) {
         // Determine if item is a folder or request
         const isFolder = item.type === 'folder';
 


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2706)

When hovering over an undefined variable (e.g., {{myVar}}) in collection settings the tooltip shows "Request" scope instead of "Collection" scope

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before:
<img width="600" height="266" alt="image" src="https://github.com/user-attachments/assets/1320f962-3b0d-4b91-825c-05b928d87d99" />

After: 
<img width="600" height="266" alt="image" src="https://github.com/user-attachments/assets/9bd76682-5cf6-4e30-9b38-62314ef54e17" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable resolution accuracy in the code editor when variable data is incomplete, preventing incorrect context inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->