### PR TITLE
Fix: incorrect translations

### DIFF
--- a/packages/bruno-converters/src/utils/bruno-to-postman-translator.js
+++ b/packages/bruno-converters/src/utils/bruno-to-postman-translator.js
@@ -318,19 +318,19 @@ const complexTransformations = [
       return updateCall;
     }
   },
-  // req.setHeader(key, value) -> pm.request.headers.add({key: key, value: value})
+  // req.setHeader(key, value) -> pm.request.headers.upsert({key: key, value: value})
   {
     pattern: 'req.setHeader',
     transform: (path) => {
       const args = path.value.arguments;
       if (!args || args.length < 2) {
         return j.callExpression(
-          buildMemberExpressionFromString('pm.request.headers.add'),
+          buildMemberExpressionFromString('pm.request.headers.upsert'),
           args || []
         );
       }
       return j.callExpression(
-        buildMemberExpressionFromString('pm.request.headers.add'),
+        buildMemberExpressionFromString('pm.request.headers.upsert'),
         [
           j.objectExpression([
             j.property('init', j.identifier('key'), args[0]),

--- a/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/request.test.js
+++ b/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/request.test.js
@@ -73,10 +73,10 @@ describe('Bruno to Postman Request Translation', () => {
     expect(translatedCode).toBe('const contentType = pm.request.headers.get("Content-Type");');
   });
 
-  it('should translate req.setHeader() to pm.request.headers.add() with object arg', () => {
+  it('should translate req.setHeader() to pm.request.headers.upsert() with object arg', () => {
     const code = 'req.setHeader("Authorization", "Bearer token123");';
     const translatedCode = translateBruToPostman(code);
-    expect(translatedCode).toContain('pm.request.headers.add({\n  key: "Authorization",\n  value: "Bearer token123"\n})');
+    expect(translatedCode).toContain('pm.request.headers.upsert({\n  key: "Authorization",\n  value: "Bearer token123"\n})');
   });
 
   it('should translate req.deleteHeader() to pm.request.headers.remove()', () => {


### PR DESCRIPTION
[Jira](https://usebruno.atlassian.net/browse/BRU-2572)
### Description

`req.setHeader` -> `pm.request.headers.upsert`

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header translation in the Bruno → Postman converter: header calls now produce upsert-style key/value object arguments to ensure correct formatting and compatibility when translating requests.

* **Tests**
  * Updated translation tests to reflect the new header output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->