### PR TITLE
fix: prompt variable in URL path incorrectly parsed as query parameter

### DIFF
--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -73,7 +73,10 @@ export const splitOnFirst = (str, char) => {
     return [str];
   }
 
-  let index = str.indexOf(char);
+  // Mask {{ }} template variables so their contents don't interfere with the search
+  const masked = str.replace(/\{\{.*?\}\}/g, (match) => '_'.repeat(match.length));
+  const index = masked.indexOf(char);
+
   if (index === -1) {
     return [str];
   }

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -286,6 +286,33 @@ describe('Url Utils - splitOnFirst', () => {
     const params = splitOnFirst('a=1&b=2', '&');
     expect(params).toEqual(['a=1', 'b=2']);
   });
+
+  it('should skip ? inside {{ }} template variables', () => {
+    const url = 'https://example.com/domain/{{?domain_id}}?include_dcv=true&include_validation=true';
+    const params = splitOnFirst(url, '?');
+    expect(params).toEqual([
+      'https://example.com/domain/{{?domain_id}}',
+      'include_dcv=true&include_validation=true'
+    ]);
+  });
+
+  it('should handle multiple prompt variables in URL path', () => {
+    const url = 'http://localhost:{{?port}}/api/{{?resource}}?key=value';
+    const params = splitOnFirst(url, '?');
+    expect(params).toEqual([
+      'http://localhost:{{?port}}/api/{{?resource}}',
+      'key=value'
+    ]);
+  });
+
+  it('should handle prompt variable in query param value', () => {
+    const url = 'https://example.com/api?token={{?token}}&active=true';
+    const params = splitOnFirst(url, '?');
+    expect(params).toEqual([
+      'https://example.com/api',
+      'token={{?token}}&active=true'
+    ]);
+  });
 });
 
 describe('Url Utils - interpolateUrl, interpolateUrlPathParams', () => {


### PR DESCRIPTION
### Description

issue: https://github.com/usebruno/bruno/issues/7204
[JIRA](https://usebruno.atlassian.net/browse/BRU-2707)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Before
https://github.com/user-attachments/assets/260f0ecb-b999-4e1c-b83e-e30d4267187b

After
https://github.com/user-attachments/assets/10ebe866-085d-440a-a2f2-3d0d197fb437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL parsing to correctly handle dynamic template variables throughout the URL. Template content is now properly masked during URL analysis, preventing interference with path and query string detection.

* **Tests**
  * Added comprehensive test coverage for URL parsing with template variables in various positions, including multiple variables and template content within query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->