### PR TITLE
fix: prevent Enter key from submitting form during autocomplete selection

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -317,9 +317,15 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
             className="bruno-form"
             onSubmit={formik.handleSubmit}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                formik.handleSubmit();
+              if (e.key === 'Enter' && !e.defaultPrevented) {
+                const isTextInput
+                  = ['input', 'textarea'].includes(e.target.tagName.toLowerCase())
+                    || e.target.isContentEditable;
+
+                if (!isTextInput) {
+                  e.preventDefault();
+                  formik.handleSubmit();
+                }
               }
             }}
           >


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Fixes unintended form submission when pressing Enter during variable autocomplete in the New Request model.

Previously, pressing Enter would both:
- select the autocomplete option
- and trigger form submission

This change ensures Enter only selects the autocomplete suggestion by respecting event handling and avoiding global submission.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

Fixes #7215 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended form submission when creating new requests. Pressing Enter while typing in input fields no longer triggers form submission. You can now type freely in text inputs, textareas, and other editable areas without accidentally submitting. The form will continue to submit on Enter when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->