### PR TITLE
fix: call `initializeShellEnv` directly in app ready handler

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -5,9 +5,6 @@ const isDev = require('electron-is-dev');
 const os = require('os');
 const { initializeShellEnv } = require('@usebruno/requests');
 
-// Fetch shell environment early (before app ready)
-const shellEnvPromise = initializeShellEnv();
-
 if (isDev) {
   if (!fs.existsSync(path.join(__dirname, '../../bruno-js/src/sandbox/bundle-browser-rollup.js'))) {
     console.log('JS Sandbox libraries have not been bundled yet');
@@ -160,7 +157,7 @@ if (useSingleInstance && !gotTheLock) {
 // Prepare the renderer once the app is ready
 app.on('ready', async () => {
   // Ensure shell environment is loaded before any operations that need it
-  await shellEnvPromise;
+  await initializeShellEnv();
 
   if (isDev) {
     const { installExtension, REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer');


### PR DESCRIPTION
### Description

Move the shell environment initialization from module-level into the app ready callback, avoiding a dangling promise at import time.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized app initialization by deferring shell environment setup to occur during app startup rather than at module load time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->