### PR TITLE
feat: add warning styling for response statuses in StyledWrapper and theme updates

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/StatusCode/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/StatusCode/StyledWrapper.js
@@ -12,6 +12,10 @@ const Wrapper = styled.div`
   &.text-error {
     color: ${(props) => props.theme.requestTabPanel.responseError};
   }
+
+  &.text-warning {
+    color: ${(props) => props.theme.requestTabPanel.responseWarning || props.theme.colors.text.warning || 'orange'};
+  }
 `;
 
 export default Wrapper;

--- a/packages/bruno-app/src/components/ResponsePane/StatusCode/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/StatusCode/index.js
@@ -3,15 +3,12 @@ import classnames from 'classnames';
 import statusCodePhraseMap from './get-status-code-phrase';
 import StyledWrapper from './StyledWrapper';
 
-// Todo: text-error class is not getting pulled in for 500 errors
 const StatusCode = ({ status, statusText, isStreaming }) => {
   const getTabClassname = (status) => {
     return classnames({
-      'text-ok': status >= 100 && status < 200,
-      'text-ok': status >= 200 && status < 300,
-      'text-error': status >= 300 && status < 400,
-      'text-error': status >= 400 && status < 500,
-      'text-error': status >= 500 && status < 600
+      'text-ok': status >= 100 && status < 300,
+      'text-warning': status >= 300 && status < 400,
+      'text-error': status >= 400 && status < 600
     });
   };
 

--- a/packages/bruno-app/src/themes/dark/catppuccin-mocha.js
+++ b/packages/bruno-app/src/themes/dark/catppuccin-mocha.js
@@ -254,6 +254,7 @@ const catppuccinMochaTheme = {
     },
     responseStatus: colors.TEXT,
     responseOk: colors.GREEN,
+    responseWarning: colors.PEACH,
     responseError: colors.RED,
     responsePending: colors.BLUE,
     responseOverlayBg: 'rgba(30, 30, 46, 0.6)',

--- a/packages/bruno-app/src/themes/dark/dark.js
+++ b/packages/bruno-app/src/themes/dark/dark.js
@@ -286,6 +286,7 @@ const darkTheme = {
     },
     responseStatus: '#ccc',
     responseOk: palette.hues.GREEN,
+    responseWarning: palette.hues.ORANGE,
     responseError: palette.hues.RED,
     responsePending: palette.hues.BLUE,
     responseOverlayBg: rgba(palette.background.BASE, 0.8),

--- a/packages/bruno-app/src/themes/dark/nord.js
+++ b/packages/bruno-app/src/themes/dark/nord.js
@@ -258,6 +258,7 @@ const nordTheme = {
     },
     responseStatus: colors.NORD4,
     responseOk: colors.NORD14,
+    responseWarning: colors.NORD13,
     responseError: colors.NORD11,
     responsePending: colors.NORD8,
     responseOverlayBg: 'rgba(46, 52, 64, 0.6)',

--- a/packages/bruno-app/src/themes/light/light.js
+++ b/packages/bruno-app/src/themes/light/light.js
@@ -278,6 +278,7 @@ const lightTheme = {
     },
     responseStatus: palette.text.SUBTEXT1,
     responseOk: palette.hues.GREEN,
+    responseWarning: palette.hues.ORANGE,
     responseError: palette.hues.RED,
     responsePending: palette.hues.BLUE,
     responseOverlayBg: 'rgba(255, 255, 255, 0.6)',


### PR DESCRIPTION
### Description

This PR fixes a long-standing styling bug in the HTTP Status Code component and introduces more granular visual categorization for response statuses.

Ref: BRU-3676
Related: #8320 #8305

### The Problem
In `StatusCode/index.js`, the `getTabClassname`  function used an object with duplicate keys for `classnames()`. In JavaScript, duplicate keys in an object literal result in the last key "winning," effectively overwriting previous ones. This caused several issues:
- **1xx (Informational)** status codes appeared unstyled (white/gray) because 2xx overwrote the `text-ok` key.
- **3xx (Redirection)** and **4xx (Client Error)** status codes appeared unstyled because 5xx overwrote the `text-error` key.
- Additionally, 3xx status codes were logically grouped as "errors," which isn't semantically accurate for redirects.

### The Solution
- **Fixed Logical Bug**: Refactored the `classnames` logic to use single keys with combined logical ranges, ensuring every status code from 100 to 599 receives its intended style.
- **Improved UX**: Introduced a `text-warning` style for **3xx status codes**. This visually distinguishes Redirections (Orange) from Success (Green) and Errors (Red).
- **Theme Integration**: Added `responseWarning` to the core Design System. I've updated the **Dark, Light, Nord, and Catppuccin** themes, and added a robust fallback in the styled wrapper to ensure compatibility across all Bruno themes.
- **Cleanup**: Removed a resolved `TODO` regarding status code styling.

---

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX Improvement
- [ ] New feature
- [ ] Documentation update

---

### Impact & Visuals

| Status Category | Previous Behavior | New Behavior | Color |
|-----------------|-------------------|--------------|-------|
| **1xx (Info)**  | Unstyled (Gray)   | Styled (Green) | Green |
| **2xx (Success)**| Styled (Green)   | Styled (Green) | Green |
| **3xx (Redirect)**| Unstyled (Gray) | Styled (Orange) | **New: Orange** |
| **4xx (Client Error)**| Unstyled (Gray) | Styled (Red) | Red |
| **5xx (Server Error)**| Styled (Red)   | Styled (Red) | Red |

---

### Testing Done
- [x] Verified **200 OK** displays Green.
- [x] Verified **404 Not Found** now correctly displays Red (was previously unstyled).
- [x] Verified **302 Found** now correctly displays Orange (was previously unstyled).
- [x] Verified **101 Switching Protocols** now correctly displays Green (was previously unstyled).
- [x] Verified theme consistency in both Dark and Light modes.

---

### Contribution Checklist
- [x] **I've used AI to assist in creating this pull request** (Transparent disclosure per Bruno guidelines)
- [x] The pull request only addresses one issue or adds one feature.
- [x] The pull request does not introduce any breaking changes.
- [x] I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).
- [x] Create an issue and link to the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Styling**
  * Enhanced HTTP response status code visualization: 3xx redirect responses now display in a new warning color in the response pane, replacing the previous error styling. This improvement provides clearer visual distinction between different types of HTTP responses, making it easier to quickly identify whether a response represents a redirect, success, or error. The updated color coding improves the user experience when interpreting API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->