### PR TITLE
fix: ensure system proxy is initialized before use in network calls

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -199,8 +199,8 @@ app.on('ready', async () => {
   }
 
   // Initialize system proxy cache early (non-blocking)
-  const { initializeSystemProxy } = require('./store/system-proxy');
-  initializeSystemProxy().catch((err) => {
+  const { fetchSystemProxy } = require('./store/system-proxy');
+  fetchSystemProxy().catch((err) => {
     console.warn('Failed to initialize system proxy cache:', err);
   });
 

--- a/packages/bruno-electron/src/ipc/network/cert-utils.js
+++ b/packages/bruno-electron/src/ipc/network/cert-utils.js
@@ -145,7 +145,7 @@ const getCertsAndProxyConfig = async ({
     } else if (!globalDisabled && globalInherit) {
       // Use system proxy (cached at app startup)
       proxyMode = 'system';
-      const systemProxyConfig = getCachedSystemProxy();
+      const systemProxyConfig = await getCachedSystemProxy();
       proxyConfig = systemProxyConfig || { http_proxy: null, https_proxy: null, no_proxy: null, source: 'cache-miss' };
     }
     // else: global proxy is disabled, proxyMode stays 'off'
@@ -211,7 +211,7 @@ const buildCertsAndProxyConfig = async ({
   const appLevelProxyConfig = preferencesUtil.getGlobalProxyConfig();
 
   // Get system proxy config
-  const systemProxyConfig = getCachedSystemProxy();
+  const systemProxyConfig = await getCachedSystemProxy();
 
   return {
     collectionPath,

--- a/packages/bruno-electron/src/ipc/preferences.js
+++ b/packages/bruno-electron/src/ipc/preferences.js
@@ -3,7 +3,7 @@ const { getPreferences, savePreferences } = require('../store/preferences');
 const { getGitVersion } = require('../utils/git');
 const { globalEnvironmentsStore } = require('../store/global-environments');
 const { parsedFileCacheStore } = require('../store/parsed-file-cache-idb');
-const { getCachedSystemProxy, refreshSystemProxy } = require('../store/system-proxy');
+const { getCachedSystemProxy, fetchSystemProxy } = require('../store/system-proxy');
 const { resolveDefaultLocation } = require('../utils/default-location');
 
 const registerPreferencesIpc = (mainWindow) => {
@@ -78,17 +78,11 @@ const registerPreferencesIpc = (mainWindow) => {
   });
 
   ipcMain.handle('renderer:get-system-proxy-variables', async () => {
-    // Return cached value (initialized at app startup)
-    const cachedProxy = getCachedSystemProxy();
-    if (cachedProxy) {
-      return cachedProxy;
-    }
-    // Fallback: refresh if cache is empty (shouldn't happen normally)
-    return await refreshSystemProxy();
+    return await getCachedSystemProxy();
   });
 
   ipcMain.handle('renderer:refresh-system-proxy', async () => {
-    return await refreshSystemProxy();
+    return await fetchSystemProxy({ refresh: true });
   });
 };
 

--- a/packages/bruno-electron/src/store/system-proxy.js
+++ b/packages/bruno-electron/src/store/system-proxy.js
@@ -1,11 +1,11 @@
 const { getSystemProxy } = require('@usebruno/requests');
 
-let cachedSystemProxy = null;
+let cachedSystemProxy;
+let systemProxyPromise;
 
-const initializeSystemProxy = async () => {
+const loadSystemProxy = async () => {
   try {
     cachedSystemProxy = await getSystemProxy();
-    return cachedSystemProxy;
   } catch (error) {
     console.error('Failed to initialize system proxy:', error);
     cachedSystemProxy = {
@@ -14,26 +14,27 @@ const initializeSystemProxy = async () => {
       no_proxy: null,
       source: 'error'
     };
-    return cachedSystemProxy;
   }
+  return cachedSystemProxy;
 };
 
-const refreshSystemProxy = async () => {
-  try {
-    cachedSystemProxy = await getSystemProxy();
-    return cachedSystemProxy;
-  } catch (error) {
-    console.error('Failed to refresh system proxy:', error);
-    throw error;
+const fetchSystemProxy = ({ refresh = false } = {}) => {
+  if (refresh || !systemProxyPromise) {
+    systemProxyPromise = loadSystemProxy();
   }
+  return systemProxyPromise;
 };
 
-const getCachedSystemProxy = () => {
+const getCachedSystemProxy = async () => {
+  if (!systemProxyPromise) {
+    await fetchSystemProxy();
+  } else {
+    await systemProxyPromise;
+  }
   return cachedSystemProxy;
 };
 
 module.exports = {
-  initializeSystemProxy,
-  refreshSystemProxy,
+  fetchSystemProxy,
   getCachedSystemProxy
 };


### PR DESCRIPTION
### Description

`getCachedSystemProxy` now awaits the initialization promise, preventing a race condition where API calls made early in startup would bypass the system proxy.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved system proxy handling: added on-demand cached loading, async retrieval, and coordinated requests to avoid duplicates and reduce latency.

* **Bug Fixes**
  * Renderer now reliably returns cached proxy variables and supports explicit refresh requests, improving proxy resolution and startup stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->