### PR TITLE
fix: req.getPath() when URL uses {{BASEURL}} or other vars

### DIFF
--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -62,14 +62,13 @@ class BrunoRequest {
       if (typeof this.req.url !== 'string') {
         return '';
       }
-      const urlWithoutQuery = this.req.url.split('?')[0];
-      let urlWithoutProtocol = urlWithoutQuery;
-      const protoEnd = urlWithoutProtocol.indexOf('://');
+      let urlWithoutQuery = this.req.url.split('?')[0];
+      const protoEnd = urlWithoutQuery.indexOf('://');
       if (protoEnd >= 0) {
-        urlWithoutProtocol = urlWithoutProtocol.substring(protoEnd + 3);
+        urlWithoutQuery = urlWithoutQuery.substring(protoEnd + 3);
       }
-      const firstSlash = urlWithoutProtocol.indexOf('/');
-      pathname = firstSlash >= 0 ? urlWithoutProtocol.substring(firstSlash) : '';
+      const firstSlash = urlWithoutQuery.indexOf('/');
+      pathname = firstSlash >= 0 ? urlWithoutQuery.substring(firstSlash) : '';
     }
     return interpolatePathParams(pathname, this.req.pathParams) || '';
   }

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -1,3 +1,5 @@
+const { interpolatePathParams } = require('./utils/url');
+
 class BrunoRequest {
   /**
    * The following properties are available as shorthand:
@@ -69,26 +71,7 @@ class BrunoRequest {
       const firstSlash = urlWithoutProtocol.indexOf('/');
       pathname = firstSlash >= 0 ? urlWithoutProtocol.substring(firstSlash) : '';
     }
-    return this._interpolatePathParams(pathname) || '';
-  }
-
-  _interpolatePathParams(pathname) {
-    if (!pathname || !this.req.pathParams || !Array.isArray(this.req.pathParams)) {
-      return pathname;
-    }
-    return pathname
-      .split('/')
-      .map((segment) => {
-        if (segment.startsWith(':')) {
-          const paramName = segment.slice(1);
-          const pathParam = this.req.pathParams.find((param) => param.name === paramName);
-          if (pathParam != null && pathParam.value != null) {
-            return pathParam.value;
-          }
-        }
-        return segment;
-      })
-      .join('/');
+    return interpolatePathParams(pathname, this.req.pathParams) || '';
   }
 
   getQueryString() {

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -60,18 +60,14 @@ class BrunoRequest {
       if (typeof this.req.url !== 'string') {
         return '';
       }
-      const withoutQuery = this.req.url.split('?')[0];
-      if (withoutQuery.startsWith('/')) {
-        pathname = withoutQuery;
-      } else {
-        let searchIn = withoutQuery;
-        const protoEnd = searchIn.indexOf('://');
-        if (protoEnd >= 0) {
-          searchIn = searchIn.substring(protoEnd + 3);
-        }
-        const firstSlash = searchIn.indexOf('/');
-        pathname = firstSlash >= 0 ? searchIn.substring(firstSlash) : '';
+      const urlWithoutQuery = this.req.url.split('?')[0];
+      let urlWithoutProtocol = urlWithoutQuery;
+      const protoEnd = urlWithoutProtocol.indexOf('://');
+      if (protoEnd >= 0) {
+        urlWithoutProtocol = urlWithoutProtocol.substring(protoEnd + 3);
       }
+      const firstSlash = urlWithoutProtocol.indexOf('/');
+      pathname = firstSlash >= 0 ? urlWithoutProtocol.substring(firstSlash) : '';
     }
     return this._interpolatePathParams(pathname) || '';
   }

--- a/packages/bruno-js/src/utils/url.js
+++ b/packages/bruno-js/src/utils/url.js
@@ -1,0 +1,28 @@
+/**
+ * Interpolate path params (:param) in pathname with values from pathParams.
+ * @param {string} pathname - Path string (e.g. '/api/users/:userId')
+ * @param {Array<{ name: string, value: string }>} pathParams - Path param definitions
+ * @returns {string} Path with :param replaced by param.value
+ */
+const interpolatePathParams = (pathname, pathParams) => {
+  if (!pathname || !pathParams || !Array.isArray(pathParams)) {
+    return pathname;
+  }
+  return pathname
+    .split('/')
+    .map((segment) => {
+      if (segment.startsWith(':')) {
+        const paramName = segment.slice(1);
+        const pathParam = pathParams.find((param) => param.name === paramName);
+        if (pathParam != null && pathParam.value != null) {
+          return pathParam.value;
+        }
+      }
+      return segment;
+    })
+    .join('/');
+};
+
+module.exports = {
+  interpolatePathParams
+};

--- a/packages/bruno-js/tests/bruno-request.spec.js
+++ b/packages/bruno-js/tests/bruno-request.spec.js
@@ -1,0 +1,69 @@
+const { describe, it, expect } = require('@jest/globals');
+const BrunoRequest = require('../src/bruno-request');
+
+describe('BrunoRequest', () => {
+  describe('getPath()', () => {
+    it('returns pathname for full URL', () => {
+      const req = new BrunoRequest({
+        url: 'https://example.com/api/users',
+        method: 'GET',
+        headers: {},
+        pathParams: []
+      });
+      expect(req.getPath()).toBe('/api/users');
+    });
+
+    it('returns path with path params interpolated', () => {
+      const req = new BrunoRequest({
+        url: 'https://example.com/api/users/:userId',
+        method: 'GET',
+        headers: {},
+        pathParams: [{ name: 'userId', value: '123', type: 'path' }]
+      });
+      expect(req.getPath()).toBe('/api/users/123');
+    });
+
+    it('returns path when URL has unresolved vars (e.g. {{BASEURL}}/path)', () => {
+      const req = new BrunoRequest({
+        url: '{{BASEURL}}/path/:p1/:p2',
+        method: 'GET',
+        headers: {},
+        pathParams: [
+          { name: 'p1', value: 'value1', type: 'path' },
+          { name: 'p2', value: 'value2', type: 'path' }
+        ]
+      });
+      expect(req.getPath()).toBe('/path/value1/value2');
+    });
+
+    it('strips query string when parsing unparseable URL', () => {
+      const req = new BrunoRequest({
+        url: '{{BASEURL}}/path?foo=bar',
+        method: 'GET',
+        headers: {},
+        pathParams: []
+      });
+      expect(req.getPath()).toBe('/path');
+    });
+
+    it('returns empty string when req.url is missing', () => {
+      const req = new BrunoRequest({
+        url: undefined,
+        method: 'GET',
+        headers: {},
+        pathParams: []
+      });
+      expect(req.getPath()).toBe('');
+    });
+
+    it('returns path when URL has protocol with template host (e.g. https://{{HOST}}/path)', () => {
+      const req = new BrunoRequest({
+        url: 'https://{{HOST}}/api/users',
+        method: 'GET',
+        headers: {},
+        pathParams: []
+      });
+      expect(req.getPath()).toBe('/api/users');
+    });
+  });
+});


### PR DESCRIPTION
[BRU-2778](https://usebruno.atlassian.net/browse/BRU-2778)
Fixes: https://github.com/usebruno/bruno/issues/7248

Pre-request scripts run before URL interpolation, so for URLs like `{{BASEURL}}/path/:p1/:p2`, `req.url` is still a template and `new URL(req.url)` throws, causing `req.getPath()` to return `''`