### PR TITLE
fix: default `normalizeProxyUrl` to `http` protocol for all proxy URLs

### DIFF
--- a/packages/bruno-requests/src/network/system-proxy/index.ts
+++ b/packages/bruno-requests/src/network/system-proxy/index.ts
@@ -48,7 +48,6 @@ export class SystemProxyResolver {
 
       return result;
     } catch (error) {
-      console.warn(`System proxy detection failed after ${Date.now() - startTime}ms:`, error instanceof Error ? error.message : String(error));
       throw error;
     }
   }
@@ -75,7 +74,7 @@ export class SystemProxyResolver {
 
     return {
       http_proxy: httpProxy ? normalizeProxyUrl(httpProxy) : null,
-      https_proxy: httpsProxy ? normalizeProxyUrl(httpsProxy, 'https') : null,
+      https_proxy: httpsProxy ? normalizeProxyUrl(httpsProxy) : null,
       no_proxy: noProxy ? normalizeNoProxy(noProxy) : null,
       source: 'environment'
     };
@@ -99,7 +98,6 @@ export async function getSystemProxy(): Promise<ProxyConfiguration> {
       source: hasEnvironmentProxy ? `${systemProxyEnvironmentVariables?.source} + environment` : systemProxyEnvironmentVariables?.source
     };
   } catch (error) {
-    console.error('Error getting system proxy:', error);
     return proxyEnvironmentVariables;
   }
 }

--- a/packages/bruno-requests/src/network/system-proxy/utils/linux.spec.ts
+++ b/packages/bruno-requests/src/network/system-proxy/utils/linux.spec.ts
@@ -58,7 +58,7 @@ describe('LinuxProxyResolver', () => {
 
       expect(result).toEqual({
         http_proxy: 'http://proxy.usebruno.com:8080',
-        https_proxy: 'https://secure-proxy.usebruno.com:8443',
+        https_proxy: 'http://secure-proxy.usebruno.com:8443',
         no_proxy: 'localhost,127.0.0.1',
         source: 'linux-system'
       });
@@ -84,7 +84,7 @@ describe('LinuxProxyResolver', () => {
 
       expect(result).toEqual({
         http_proxy: 'http://proxy.usebruno.com:8080',
-        https_proxy: 'https://proxy.usebruno.com:8080',
+        https_proxy: 'http://proxy.usebruno.com:8080',
         no_proxy: null,
         source: 'linux-system'
       });

--- a/packages/bruno-requests/src/network/system-proxy/utils/linux.ts
+++ b/packages/bruno-requests/src/network/system-proxy/utils/linux.ts
@@ -66,7 +66,7 @@ export class LinuxProxyResolver implements ProxyResolver {
       const cleanIgnoreHosts = ignoreHosts || '';
 
       const http_proxy = cleanHttpHost && cleanHttpPort ? normalizeProxyUrl(`${cleanHttpHost}:${cleanHttpPort}`) : null;
-      const https_proxy = cleanHttpsHost && cleanHttpsPort ? normalizeProxyUrl(`${cleanHttpsHost}:${cleanHttpsPort}`, 'https') : null;
+      const https_proxy = cleanHttpsHost && cleanHttpsPort ? normalizeProxyUrl(`${cleanHttpsHost}:${cleanHttpsPort}`) : null;
 
       const rawNoProxy = cleanIgnoreHosts !== '[]' ? cleanIgnoreHosts.replace(/[\[\]']/g, '').replace(/,\s*/g, ',') : null;
 
@@ -107,7 +107,7 @@ export class LinuxProxyResolver implements ProxyResolver {
       const cleanNoProxy = noProxy || '';
 
       const http_proxy = cleanHttpProxy ? normalizeProxyUrl(cleanHttpProxy) : null;
-      const https_proxy = cleanHttpsProxy ? normalizeProxyUrl(cleanHttpsProxy, 'https') : null;
+      const https_proxy = cleanHttpsProxy ? normalizeProxyUrl(cleanHttpsProxy) : null;
 
       return {
         http_proxy,
@@ -210,7 +210,7 @@ export class LinuxProxyResolver implements ProxyResolver {
     const httpProxy = proxies.http_proxy || proxies.all_proxy || null;
     const httpsProxy = proxies.https_proxy || proxies.all_proxy || null;
     const http_proxy = httpProxy ? normalizeProxyUrl(httpProxy) : null;
-    const https_proxy = httpsProxy ? normalizeProxyUrl(httpsProxy, 'https') : null;
+    const https_proxy = httpsProxy ? normalizeProxyUrl(httpsProxy) : null;
     const no_proxy = proxies.no_proxy || null;
 
     if (http_proxy || https_proxy) {

--- a/packages/bruno-requests/src/network/system-proxy/utils/macos.spec.ts
+++ b/packages/bruno-requests/src/network/system-proxy/utils/macos.spec.ts
@@ -43,7 +43,7 @@ describe('MacOSProxyResolver', () => {
 
       expect(result).toEqual({
         http_proxy: 'http://proxy.usebruno.com:8080',
-        https_proxy: 'https://secure-proxy.usebruno.com:8443',
+        https_proxy: 'http://secure-proxy.usebruno.com:8443',
         no_proxy: 'localhost,127.0.0.1,<local>',
         source: 'macos-system'
       });
@@ -82,7 +82,7 @@ describe('MacOSProxyResolver', () => {
       const result = await detector.detect();
 
       expect(result.http_proxy).toBe('http://proxy.usebruno.com:80');
-      expect(result.https_proxy).toBe('https://secure-proxy.usebruno.com:443');
+      expect(result.https_proxy).toBe('http://secure-proxy.usebruno.com:443');
     });
 
     it('should handle only HTTP proxy enabled', async () => {
@@ -121,7 +121,7 @@ describe('MacOSProxyResolver', () => {
 
       expect(result).toEqual({
         http_proxy: null,
-        https_proxy: 'https://secure-proxy.usebruno.com:8443',
+        https_proxy: 'http://secure-proxy.usebruno.com:8443',
         no_proxy: null,
         source: 'macos-system'
       });
@@ -146,7 +146,7 @@ describe('MacOSProxyResolver', () => {
 
       expect(result).toEqual({
         http_proxy: 'http://proxy.usebruno.com:8080',
-        https_proxy: 'https://proxy.usebruno.com:8080',
+        https_proxy: 'http://proxy.usebruno.com:8080',
         no_proxy: null,
         source: 'macos-system'
       });
@@ -169,7 +169,7 @@ describe('MacOSProxyResolver', () => {
 
       expect(result).toEqual({
         http_proxy: 'http://proxy.usebruno.com:8080',
-        https_proxy: 'https://proxy.usebruno.com:8080',
+        https_proxy: 'http://proxy.usebruno.com:8080',
         no_proxy: '<local>',
         source: 'macos-system'
       });
@@ -198,7 +198,7 @@ describe('MacOSProxyResolver', () => {
 
       expect(result).toEqual({
         http_proxy: 'http://proxy.usebruno.com:8080',
-        https_proxy: 'https://proxy.usebruno.com:8080',
+        https_proxy: 'http://proxy.usebruno.com:8080',
         no_proxy: 'localhost,127.0.0.1,*.local,192.168.1.0/24,<local>',
         source: 'macos-system'
       });

--- a/packages/bruno-requests/src/network/system-proxy/utils/macos.ts
+++ b/packages/bruno-requests/src/network/system-proxy/utils/macos.ts
@@ -92,7 +92,7 @@ export class MacOSProxyResolver implements ProxyResolver {
     // Check HTTPS proxy
     if (config.HTTPSEnable === 1 && config.HTTPSProxy) {
       const port = config.HTTPSPort || 443;
-      https_proxy = normalizeProxyUrl(`${config.HTTPSProxy}:${port}`, 'https');
+      https_proxy = normalizeProxyUrl(`${config.HTTPSProxy}:${port}`);
     }
 
     // Check bypass list

--- a/packages/bruno-requests/src/network/system-proxy/utils/windows.spec.ts
+++ b/packages/bruno-requests/src/network/system-proxy/utils/windows.spec.ts
@@ -55,7 +55,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
 
       expect(result).toEqual({
         http_proxy: 'http://proxy.usebruno.com:8080',
-        https_proxy: 'https://proxy.usebruno.com:8443',
+        https_proxy: 'http://proxy.usebruno.com:8443',
         no_proxy: null,
         source: 'windows-system'
       });
@@ -128,7 +128,7 @@ Current WinHTTP proxy settings:
 
       expect(result).toEqual({
         http_proxy: 'http://proxy.usebruno.com:8080',
-        https_proxy: 'https://proxy.usebruno.com:8443',
+        https_proxy: 'http://proxy.usebruno.com:8443',
         no_proxy: 'localhost',
         source: 'windows-system'
       });

--- a/packages/bruno-requests/src/network/system-proxy/utils/windows.ts
+++ b/packages/bruno-requests/src/network/system-proxy/utils/windows.ts
@@ -130,7 +130,7 @@ export class WindowsProxyResolver implements ProxyResolver {
     if (http_proxy || https_proxy) {
       return {
         http_proxy: http_proxy ? normalizeProxyUrl(http_proxy) : null,
-        https_proxy: https_proxy ? normalizeProxyUrl(https_proxy, 'https') : null,
+        https_proxy: https_proxy ? normalizeProxyUrl(https_proxy) : null,
         no_proxy: no_proxy ? normalizeNoProxy(no_proxy) : null,
         source: 'windows-system'
       };
@@ -171,7 +171,7 @@ export class WindowsProxyResolver implements ProxyResolver {
     if (http_proxy || https_proxy) {
       return {
         http_proxy: http_proxy ? normalizeProxyUrl(http_proxy) : null,
-        https_proxy: https_proxy ? normalizeProxyUrl(https_proxy, 'https') : null,
+        https_proxy: https_proxy ? normalizeProxyUrl(https_proxy) : null,
         no_proxy: no_proxy ? normalizeNoProxy(no_proxy) : null,
         source: 'windows-system'
       };
@@ -193,7 +193,7 @@ export class WindowsProxyResolver implements ProxyResolver {
         if (proto === 'http') {
           http_proxy = normalizeProxyUrl(server);
         } else if (proto === 'https') {
-          https_proxy = normalizeProxyUrl(server, 'https');
+          https_proxy = normalizeProxyUrl(server);
         }
       }
     } else {


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system proxy detection and normalization across all platforms (Linux, macOS, and Windows) to ensure more accurate HTTPS proxy handling in various network configurations.

* **Refactor**
  * Simplified proxy URL normalization logic by removing redundant parameters.
  * Reduced error logging verbosity in proxy detection processes for improved operational clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->