### PR TITLE
fix: persistence of additional parameters using open-collection format

### DIFF
--- a/packages/bruno-filestore/src/formats/yml/common/auth-oauth2.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/auth-oauth2.ts
@@ -143,13 +143,16 @@ const buildClientCredentialsFlow = (oauth: BrunoOAuth2): OAuth2ClientCredentials
   isNonEmptyString(oauth.scope) && (flow.scope = oauth.scope);
 
   const accessTokenRequest = mapAdditionalParameters(oauth.additionalParameters?.token);
-  if (accessTokenRequest) {
-    flow.additionalParameters = { accessTokenRequest };
-  }
-
   const refreshTokenRequest = mapAdditionalParameters(oauth.additionalParameters?.refresh);
-  if (refreshTokenRequest) {
-    flow.additionalParameters = { refreshTokenRequest };
+
+  if (accessTokenRequest || refreshTokenRequest) {
+    flow.additionalParameters = {};
+    if (accessTokenRequest) {
+      flow.additionalParameters.accessTokenRequest = accessTokenRequest;
+    }
+    if (refreshTokenRequest) {
+      flow.additionalParameters.refreshTokenRequest = refreshTokenRequest;
+    }
   }
 
   const tokenConfig = buildTokenConfig(oauth);
@@ -179,13 +182,16 @@ const buildResourceOwnerPasswordFlow = (oauth: BrunoOAuth2): OAuth2ResourceOwner
   isNonEmptyString(oauth.scope) && (flow.scope = oauth.scope);
 
   const accessTokenRequest = mapAdditionalParameters(oauth.additionalParameters?.token);
-  if (accessTokenRequest) {
-    flow.additionalParameters = { accessTokenRequest };
-  }
-
   const refreshTokenRequest = mapAdditionalParameters(oauth.additionalParameters?.refresh);
-  if (refreshTokenRequest) {
-    flow.additionalParameters = { refreshTokenRequest };
+
+  if (accessTokenRequest || refreshTokenRequest) {
+    flow.additionalParameters = {};
+    if (accessTokenRequest) {
+      flow.additionalParameters.accessTokenRequest = accessTokenRequest;
+    }
+    if (refreshTokenRequest) {
+      flow.additionalParameters.refreshTokenRequest = refreshTokenRequest;
+    }
   }
 
   const tokenConfig = buildTokenConfig(oauth);
@@ -212,18 +218,20 @@ const buildAuthorizationCodeFlow = (oauth: BrunoOAuth2): OAuth2AuthorizationCode
   if (credentials) flow.credentials = credentials;
 
   const authorizationRequest = mapAdditionalParameters(oauth.additionalParameters?.authorization);
-  if (authorizationRequest) {
-    flow.additionalParameters = { authorizationRequest };
-  }
-
   const accessTokenRequest = mapAdditionalParameters(oauth.additionalParameters?.token);
-  if (accessTokenRequest) {
-    flow.additionalParameters = { accessTokenRequest };
-  }
-
   const refreshTokenRequest = mapAdditionalParameters(oauth.additionalParameters?.refresh);
-  if (refreshTokenRequest) {
-    flow.additionalParameters = { refreshTokenRequest };
+
+  if (authorizationRequest || accessTokenRequest || refreshTokenRequest) {
+    flow.additionalParameters = {};
+    if (authorizationRequest) {
+      flow.additionalParameters.authorizationRequest = authorizationRequest;
+    }
+    if (accessTokenRequest) {
+      flow.additionalParameters.accessTokenRequest = accessTokenRequest;
+    }
+    if (refreshTokenRequest) {
+      flow.additionalParameters.refreshTokenRequest = refreshTokenRequest;
+    }
   }
 
   isNonEmptyString(oauth.scope) && (flow.scope = oauth.scope);


### PR DESCRIPTION
### Description

This bug fixes an issue when saving the auth configuration on an collection persisted in the open-collection format.
See issue: #7293 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

For the screenshot of the bug, see issue.

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of OAuth2 parameter configuration for enhanced code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->