### PR TITLE
Update copyright year to 2026

### DIFF
--- a/packages/bruno-electron/src/app/about-bruno.js
+++ b/packages/bruno-electron/src/app/about-bruno.js
@@ -1,4 +1,5 @@
 module.exports = function aboutBruno({ version }) {
+  const currentYear = new Date().getFullYear();
   return `
     <!DOCTYPE html>
     <html lang="en">
@@ -168,7 +169,7 @@ module.exports = function aboutBruno({ version }) {
         </svg>
       <h2 class="title">Bruno ${version}</h2>
       <footer class="footer">
-          ©2026 Bruno Software Inc
+          ©${currentYear} Bruno Software Inc
       </footer>
     </body>
     </html>


### PR DESCRIPTION
### Description

Most important change of the year ;)

~ Your Golden Edition member ~

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).** (sorry about the branch name)
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the About Bruno dialog footer to display the copyright year dynamically instead of a fixed year, ensuring the displayed year stays current without manual updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->