### PR TITLE
fix: add variable interpolation to documentation preview

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Docs/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Docs/index.js
@@ -27,6 +27,7 @@ const Docs = ({ collection }) => {
       const variables = getAllVariables(collection);
       return interpolate(docs, variables);
     } catch (e) {
+      console.warn('Failed to interpolate documentation variables:', e);
       return docs;
     }
   }, [docs, collection]);

--- a/packages/bruno-app/src/components/Documentation/index.js
+++ b/packages/bruno-app/src/components/Documentation/index.js
@@ -24,6 +24,7 @@ const Documentation = ({ item, collection }) => {
       const variables = getAllVariables(collection, item);
       return interpolate(docs, variables);
     } catch (e) {
+      console.warn('Failed to interpolate documentation variables:', e);
       return docs;
     }
   }, [docs, collection, item]);

--- a/packages/bruno-app/src/components/FolderSettings/Documentation/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Documentation/index.js
@@ -25,6 +25,7 @@ const Documentation = ({ collection, folder }) => {
       const variables = getAllVariables(collection, folder);
       return interpolate(docs, variables);
     } catch (e) {
+      console.warn('Failed to interpolate documentation variables:', e);
       return docs;
     }
   }, [docs, collection, folder]);


### PR DESCRIPTION
## Summary

- **Bug:** `{{variables}}` (e.g. `{{host}}`, `{{baseUrl}}`, environment variables) were not being replaced/interpolated when viewing documentation in preview mode. Users would see the raw `{{variable}}` placeholders instead of their resolved values.
- **Scope:** Affects all three documentation views: **request docs**, **collection docs**, and **folder docs**.
- **Fix:** Uses the existing `getAllVariables()` utility and `interpolate()` function from `@usebruno/common` — the same pattern already used in other frontend components (e.g. OAuth2 auth URL interpolation) — to resolve variables before rendering the markdown preview.

## What changed

| File | Change |
|------|--------|
| `packages/bruno-app/src/components/Documentation/index.js` | Added variable interpolation for request-level docs |
| `packages/bruno-app/src/components/CollectionSettings/Docs/index.js` | Added variable interpolation for collection-level docs |
| `packages/bruno-app/src/components/FolderSettings/Documentation/index.js` | Added variable interpolation for folder-level docs |

### How it works

1. `getAllVariables(collection, item)` gathers all variable scopes (environment, collection, folder, request, runtime, global, process env, OAuth2 credentials)
2. `interpolate(docs, variables)` replaces `{{placeholder}}` patterns with resolved values
3. The interpolated content is passed to the `<Markdown>` renderer for preview
4. The raw markdown source in the editor remains unchanged — `{{variable}}` placeholders are preserved for editing
5. Interpolation is wrapped in `useMemo` for performance and in a `try/catch` to gracefully fall back to raw content on errors

### Variable scopes supported

All variable scopes are resolved in documentation preview, matching the behavior of request execution:
- Environment variables
- Collection variables
- Folder variables
- Request variables (request docs only)
- Runtime variables (set via scripts)
- Global environment variables
- Process environment variables
- OAuth2 credential variables

## Test plan

- [ ] Create a collection with environment variables (e.g. `host = api.example.com`)
- [ ] Add `{{host}}` to request documentation markdown, switch to preview → should show `api.example.com`
- [ ] Add `{{host}}` to collection documentation markdown, switch to preview → should show `api.example.com`
- [ ] Add `{{host}}` to folder documentation markdown, switch to preview → should show `api.example.com`
- [ ] Switch back to edit mode → `{{host}}` should still be visible as raw placeholder
- [ ] Test with undefined variables → should render the raw `{{undefined_var}}` gracefully
- [ ] Test with nested variables (e.g. `{{user.name}}`) → should resolve dot-notation paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation now supports variable interpolation across collection, folder, and general docs, with memoized computation for improved rendering performance.
* **Bug Fixes**
  * Interpolation failures now log a warning and gracefully fall back to the original content.
  * Editing and toggle behavior for docs remain unchanged to preserve existing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->