### PR TITLE
fix: default to Pre Request tab when both scripts are empty

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -22,10 +22,11 @@ const Script = ({ item, collection }) => {
   const focusedTab = find(tabs, (t) => t.uid === activeTabUid);
   const scriptPaneTab = focusedTab?.scriptPaneTab;
 
+  const hasPreRequestScript = requestScript && requestScript.trim().length > 0;
+  const hasPostResponseScript = responseScript && responseScript.trim().length > 0;
+
   // Default to pre-request if both scripts are empty, otherwise default to whichever has content
   const getDefaultTab = () => {
-    const hasPreRequestScript = requestScript && requestScript.trim().length > 0;
-    const hasPostResponseScript = responseScript && responseScript.trim().length > 0;
     if (hasPreRequestScript) return 'pre-request';
     if (hasPostResponseScript) return 'post-response';
     return 'pre-request';
@@ -72,9 +73,6 @@ const Script = ({ item, collection }) => {
 
   const onRun = () => dispatch(sendRequest(item, collection.uid));
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
-
-  const hasPreRequestScript = requestScript && requestScript.trim().length > 0;
-  const hasPostResponseScript = responseScript && responseScript.trim().length > 0;
 
   const onScriptTabChange = (tab) => {
     dispatch(updateScriptPaneTab({ uid: item.uid, scriptPaneTab: tab }));


### PR DESCRIPTION
### Description

Updates the Script pane so that when both pre-request and post-response scripts are empty, the default selected tab is **Pre Request** instead of Post Response.

### Changes
Adjusted `getDefaultTab()` logic:
    - Both scripts empty → default to Pre Request
    - Only pre-request has content → default to Pre Request
    - Only post-response has content → default to Post Response

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined default script tab behavior: the UI now selects the most relevant script tab based on available content (preferring pre-request when present, otherwise post-response; defaults to pre-request if both are empty), ensuring users see the most appropriate script view on open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->