### PR TITLE
fix(schema): support all Unicode letters in tag validation

### DIFF
--- a/packages/bruno-app/src/components/TagList/index.js
+++ b/packages/bruno-app/src/components/TagList/index.js
@@ -7,7 +7,7 @@ import { useTheme } from 'providers/Theme/index';
 const TagList = ({ tagsHintList = [], handleAddTag, tags, handleRemoveTag, onSave, handleValidation, collectionFormat }) => {
   const { displayedTheme } = useTheme();
   const isBruFormat = collectionFormat === 'bru';
-  const tagNameRegex = isBruFormat ? /^[\w-]+$/ : /^[\w-][\w\s-]*[\w-]$|^[\w-]+$/;
+  const tagNameRegex = isBruFormat ? /^[\p{L}\p{N}_-]+$/u : /^[\p{L}\p{N}_-](?:[\p{L}\p{N}_\s-]*[\p{L}\p{N}_-])?$/u;
   const [text, setText] = useState('');
   const [error, setError] = useState('');
 
@@ -22,8 +22,8 @@ const TagList = ({ tagsHintList = [], handleAddTag, tags, handleRemoveTag, onSav
     }
     if (!tagNameRegex.test(text)) {
       setError(isBruFormat
-        ? 'Tags in BRU format must only contain alpha-numeric characters, "-", "_".'
-        : 'Tags must only contain alpha-numeric characters, spaces, "-", "_"'
+        ? 'Tags in BRU format must only contain letters, numbers, "-", "_".'
+        : 'Tags must only contain letters, numbers, spaces, "-", "_"'
       );
       return;
     }

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -545,7 +545,7 @@ const itemSchema = Yup.object({
   type: Yup.string().oneOf(['http-request', 'graphql-request', 'folder', 'js', 'grpc-request', 'ws-request']).required('type is required'),
   seq: Yup.number().min(1),
   name: Yup.string().min(1, 'name must be at least 1 character').required('name is required'),
-  tags: Yup.array().of(Yup.string().matches(/^[\w-][\w\s-]*[\w-]$|^[\w-]+$/, 'tag must contain only alphanumeric characters, spaces, hyphens, or underscores')),
+  tags: Yup.array().of(Yup.string().matches(/^[\p{L}\p{N}_-](?:[\p{L}\p{N}_\s-]*[\p{L}\p{N}_-])?$/u, 'tag must contain only letters, numbers, spaces, hyphens, or underscores')),
   request: Yup.mixed().when('type', {
     is: (type) => type === 'grpc-request',
     then: grpcRequestSchema.required('request is required when item-type is grpc-request'),

--- a/packages/bruno-schema/src/collections/itemSchema.spec.js
+++ b/packages/bruno-schema/src/collections/itemSchema.spec.js
@@ -15,6 +15,40 @@ describe('Item Schema Validation', () => {
     expect(isValid).toBeTruthy();
   });
 
+  it('item schema must validate tag regex rules', async () => {
+    const validItem = {
+      uid: uuid(),
+      name: 'A Folder',
+      type: 'folder',
+      tags: ['tag_1', 'Äiti-123 test']
+    };
+
+    const isValid = await itemSchema.validate(validItem);
+    expect(isValid).toBeTruthy();
+
+    let invalidItem = {
+      uid: uuid(),
+      name: 'A Folder',
+      type: 'folder',
+      tags: [' invalid-tag']
+    };
+
+    await expect(itemSchema.validate(invalidItem)).rejects.toThrow(
+      'tag must contain only letters, numbers, spaces, hyphens, or underscores'
+    );
+
+    invalidItem = {
+      uid: uuid(),
+      name: 'A Folder',
+      type: 'folder',
+      tags: ['tag🔥name']
+    };
+
+    await expect(itemSchema.validate(invalidItem)).rejects.toThrow(
+      'tag must contain only letters, numbers, spaces, hyphens, or underscores'
+    );
+  });
+
   it('item schema must throw an error if name is missing', async () => {
     const item = {
       uid: uuid(),


### PR DESCRIPTION
Closes #7310 

### Description

The current validation blocks valid tag names in many languages that use an extended alphabet, for example in my case, all scandic letters (ö, ä, å) did not pass the regex.

This change alters the regex so that all Unicode letters pass the UI and schema validations.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tag character validation to support Unicode characters and international letters.
  * Improved validation error messages to clearly specify which characters are allowed: letters, numbers, hyphens, underscores, and spaces.

* **Tests**
  * Added test cases for tag validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->