### PR TITLE
fix: prevent triggering rename action with modifier keys

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -565,7 +565,9 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     const [macRenameKey, winRenameKey] = getKeyBindingsForActionAllOS('renameItem');
     const renameKey = isMac ? macRenameKey : winRenameKey;
 
-    if (e.key.toLowerCase() === renameKey) {
+    // Only trigger rename if no modifier keys are pressed (allow Cmd+Enter for run request)
+    const hasModifier = e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
+    if (e.key.toLowerCase() === renameKey && !hasModifier) {
       e.preventDefault();
       e.stopPropagation();
       setRenameItemModalOpen(true);


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard shortcut handling for the rename action to prevent unintended triggering when modifier keys are held alongside the rename command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->