### PR TITLE
FIX: Sync URL Input when pasting a cURL command

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -112,6 +112,11 @@ const QueryUrl = ({ item, collection, handleRun }) => {
         url: request.url
       }));
 
+      // Update URL in the editor UI
+      if (editorRef.current?.editor) {
+        editorRef.current.editor.setValue(request.url);
+      }
+
       // Update method
       dispatch(updateRequestMethod({
         method: request.method.toUpperCase(), // Convert to uppercase
@@ -193,6 +198,11 @@ const QueryUrl = ({ item, collection, handleRun }) => {
           url: request.url
         })
       );
+
+      // Update URL in the editor UI
+      if (editorRef.current?.editor) {
+        editorRef.current.editor.setValue(request.url);
+      }
 
       // Update method
       if (request.method) {


### PR DESCRIPTION
### Description

After the recent update when I tried pasting in the a cURL command in the URL text input. The cURL was parsed properly and it was updated in the app state as well. But the URL input did not reflect the API URL.

![20260302-1715-17 5834206](https://github.com/user-attachments/assets/906350b7-08d6-4d0d-a978-3346db13345e)

I think it was due to the `event.PreventDefault()` on the paste operation that was causing the issue and causing the single line editor to not reflect changes, since its paste event was interrupted.

So I explicitly set the URL once the cURL command is parsed. I hope this seems like a valid approach. I made the changes for both `handleGraphqlPaste()` and `handleHttpPaste()` functions.

Thanks.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where URL changes from pasting curl or GraphQL code were not immediately reflected in the editor UI, ensuring real-time synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->