### PR TITLE
fix: show '+ Add request' when only transient items exist

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -69,7 +69,8 @@ const Collection = ({ collection, searchText }) => {
   const dispatch = useDispatch();
   const isLoading = areItemsLoading(collection);
   const collectionRef = useRef(null);
-  const itemCount = collection.items?.length || 0;
+  // Only count persisted items; transients don't affect empty state
+  const itemCount = collection.items?.filter((i) => !i.isTransient).length || 0;
 
   const isCollectionFocused = useSelector(isTabForItemActive({ itemUid: collection.uid }));
   const { hasCopiedItems } = useSelector((state) => state.app.clipboard);


### PR DESCRIPTION
### Description

The “+ Add request” button is displayed when a collection has only transient request (in the sidebar).

Address issues reported in : [JIRA Comment](https://usebruno.atlassian.net/browse/BRU-2675?focusedCommentId=25902)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collection item counts now exclude temporary/transient entries, so displayed counts reflect only persisted items.
  * Empty-state visuals and related behavior now trigger only when a collection truly has no saved items, preventing misleading UI indications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->