### PR TITLE
fix: focus and text selection in workspace creation flow

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/CollectionHeader/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionHeader/index.js
@@ -186,10 +186,6 @@ const CollectionHeader = ({ collection, isScratchCollection }) => {
     setIsRenamingWorkspace(true);
     setWorkspaceNameInput(currentWorkspace?.name || '');
     setWorkspaceNameError('');
-    setTimeout(() => {
-      workspaceNameInputRef.current?.focus();
-      workspaceNameInputRef.current?.select();
-    }, 50);
   };
 
   const handleCloseWorkspaceClick = () => {


### PR DESCRIPTION
### Description

Fixes the workspace creation flow so the rename input is focused and its text is selected as intended.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection rename behavior: input no longer auto-focuses on initial load; focus now occurs when the user starts renaming.
  * Added and managed a short delay to ensure reliable focus/selection during click-to-rename.
  * Improved cleanup so timing resources are reliably cleared, reducing unexpected focus issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->