### PR TITLE
fix: prevent null scope error in OpenAPI export

### DIFF
--- a/packages/bruno-app/src/utils/exporters/openapi-spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.js
@@ -369,7 +369,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
                     authorizationCode: {
                       authorizationUrl,
                       tokenUrl: accessTokenUrl,
-                      ...(scope.length > 0
+                      ...(scope?.length > 0
                         ? {
                             scopes: {
                               [scope]: ''
@@ -389,7 +389,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
                   flows: {
                     password: {
                       tokenUrl: accessTokenUrl,
-                      ...(scope.length > 0
+                      ...(scope?.length > 0
                         ? {
                             scopes: {
                               [scope]: ''
@@ -409,7 +409,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
                   flows: {
                     password: {
                       tokenUrl: accessTokenUrl,
-                      ...(scope.length > 0
+                      ...(scope?.length > 0
                         ? {
                             scopes: {
                               [scope]: ''


### PR DESCRIPTION
Fixes #7365

OpenAPI Specification Export was failing with error "Cannot read properties of null (reading length)" when exporting collections that use OAuth2 authentication without a scope defined. The issue was in the openapi-spec exporter where `scope.length` was called without checking if scope exists first.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability of OAuth2 authentication flows (authorization code, password, and client credentials) by preventing potential runtime errors during the authentication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->