### PR TITLE
fix: prevent colons in OData datetime values from being parsed as path parameters

### DIFF
--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -53,7 +53,7 @@ export const parsePathParams = (url) => {
       return;
     }
 
-    const paramRegex = /[:](\w+)/g;
+    const paramRegex = /[:]([a-zA-Z_]\w*)/g;
     let match;
     while ((match = paramRegex.exec(segment))) {
       if (!match[1]) continue;
@@ -119,7 +119,7 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
           return segment;
         }
 
-        const regex = /[:](\w+)/g;
+        const regex = /[:]([a-zA-Z_]\w*)/g;
         let match;
         let result = segment;
         while ((match = regex.exec(segment))) {

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -156,6 +156,20 @@ describe('Url Utils - parsePathParams', () => {
     expect(params).toEqual([]);
   });
 
+  it('should NOT treat colons in datetime values as path parameters', () => {
+    const params = parsePathParams(
+      'https://api10.successfactors.com/odata/v2/EmpJob(seqNumber=1L,startDate=datetime\'2021-08-29T00:00:00\',userId=\'213668\')'
+    );
+    expect(params).toEqual([]);
+  });
+
+  it('should still parse named path params in OData segments with datetime values', () => {
+    const params = parsePathParams(
+      'https://example.com/odata/EmpJob(startDate=datetime\'2021-08-29T00:00:00\',userId=:userId)'
+    );
+    expect(params).toEqual([{ name: 'userId', value: '' }]);
+  });
+
   it('should NOT treat embedded colons as path parameters (regression fix)', () => {
     // This test case reproduces the bug reported in issue #5805
     const params = parsePathParams('/start/1:2:AHLS-HASD/form');

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -147,7 +147,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         // 2. EntitySet(Key1=value1,Key2=value2)
         // 3. Function(param=value)
         if (/^[A-Za-z0-9_.-]+\([^)]*\)$/.test(path)) {
-          const paramRegex = /[:](\w+)/g;
+          const paramRegex = /[:]([a-zA-Z_]\w*)/g;
           let match;
           let result = path;
           while ((match = paramRegex.exec(path))) {

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -184,7 +184,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         // 2. EntitySet(Key1=value1,Key2=value2)
         // 3. Function(param=value)
         if (/^[A-Za-z0-9_.-]+\([^)]*\)$/.test(path)) {
-          const paramRegex = /[:](\w+)/g;
+          const paramRegex = /[:]([a-zA-Z_]\w*)/g;
           let match;
           let result = path;
           while ((match = paramRegex.exec(path))) {


### PR DESCRIPTION
### Description

- Fixes colons in OData datetime values (e.g., T00:00:00) being incorrectly treated as path parameter prefixes, which truncated the URL
- Changed the OData path parameter regex from /[:](\w+)/g to /[:]([a-zA-Z_]\w*)/g to require param names to start with a letter or underscore

Closes #7384 

[JIRA](https://usebruno.atlassian.net/browse/BRU-2837)

### Bug
For the URL: `https://api10.successfactors.com/odata/v2/EmpJob(seqNumber=1L,startDate=datetime'2021-08-29T00:00:00',userId='213668')?$format=json`
The regex /[:](\w+)/g matched :00 from the time string T00:00:00 as a path parameter named 00. During interpolation, these were replaced with empty values, corrupting the URL to: `datetime'2021-08-29T00`

### Fix
Path parameter names are identifiers (:userId, :orderId) — they always start with a letter or underscore, never a digit. The updated regex /[:]([a-zA-Z_]\w*)/g enforces this, so :00 in datetime strings is ignored while :userId is still correctly detected.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path parameter validation to correctly identify valid parameter names in URLs, preventing incorrect interpretation of special characters in values like datetime strings.

* **Tests**
  * Added test coverage for datetime values in path parameters to ensure proper handling of OData-style URL segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->