### PR TITLE
feat: import from git select all

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/CloneGitRespository/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CloneGitRespository/index.js
@@ -36,6 +36,7 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
     ? get(preferences, 'general.defaultLocation', '')
     : (activeWorkspace?.pathname ? path.join(activeWorkspace.pathname, 'collections') : '');
   const inputRef = useRef();
+  const selectAllRef = useRef();
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -55,6 +56,15 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
       inputRef.current.focus();
     }
   }, []);
+
+  const areAllCollectionsSelected = collectionPaths.length > 0 && selectedCollectionPaths.length === collectionPaths.length;
+  const areSomeCollectionsSelected = selectedCollectionPaths.length > 0 && selectedCollectionPaths.length < collectionPaths.length;
+
+  useEffect(() => {
+    if (selectAllRef?.current) {
+      selectAllRef.current.indeterminate = areSomeCollectionsSelected;
+    }
+  }, [areSomeCollectionsSelected]);
 
   const cloneInProgress = () => {
     setSteps((prev) => [
@@ -161,6 +171,12 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
       prevSelected.includes(collection)
         ? prevSelected.filter((c) => c !== collection)
         : [...prevSelected, collection]
+    );
+  };
+
+  const handleToggleSelectAllCollections = () => {
+    setSelectedCollectionPaths((prevSelected) =>
+      prevSelected.length === collectionPaths.length ? [] : [...collectionPaths]
     );
   };
 
@@ -342,6 +358,16 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
                       <h3 className="text-sm mb-2">
                         {collectionPaths.length} bruno collections found. Please select the collections to open:
                       </h3>
+                      <label className="flex items-center space-x-2 mb-2">
+                        <input
+                          type="checkbox"
+                          ref={selectAllRef}
+                          checked={areAllCollectionsSelected}
+                          onChange={handleToggleSelectAllCollections}
+                          className="form-checkbox"
+                        />
+                        <span>Select all</span>
+                      </label>
                       <ul>
                         {collectionPaths.map((collection) => (
                           <li key={collection} className="mb-2">

--- a/tests/import/url-import/github-repository-import.spec.ts
+++ b/tests/import/url-import/github-repository-import.spec.ts
@@ -35,4 +35,73 @@ test.describe('GitHub Repository URL Import', () => {
     // Cleanup: close any open modals using Cancel button (avoids form validation)
     await page.getByRole('button', { name: 'Cancel' }).click();
   });
+
+  test('Clone Git Repository collection selection supports Select all', async ({ page, createTmpDir, electronApp }) => {
+    const githubUrl = 'https://github.com/usebruno/github-rest-api-collection';
+
+    await page.getByTestId('collections-header-add-menu').click();
+    await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Import collection' }).click();
+
+    const importModal = page.getByRole('dialog');
+    await importModal.waitFor({ state: 'visible' });
+    await expect(importModal.locator('.bruno-modal-header-title')).toContainText('Import Collection');
+
+    await page.getByTestId('github-tab').click();
+    await page.getByTestId('git-url-input').fill(githubUrl);
+    await page.locator('#clone-git-button').click();
+    await page.locator('#import-collection-loader').waitFor({ state: 'hidden' });
+
+    const cloneModal = page.getByRole('dialog');
+    await expect(cloneModal.locator('.bruno-modal-header-title')).toContainText('Clone Git Repository');
+
+    const cloneTargetPath = await createTmpDir('clone-git-select-all');
+    const mockedCollectionPaths = [
+      `${cloneTargetPath}/mock-repo/collection-one`,
+      `${cloneTargetPath}/mock-repo/folder/collection-two`,
+      `${cloneTargetPath}/mock-repo/collection-three`
+    ];
+
+    await electronApp.evaluate(({ ipcMain }, paths) => {
+      ipcMain.removeHandler('renderer:clone-git-repository');
+      ipcMain.handle('renderer:clone-git-repository', async () => 'Repository cloned successfully');
+
+      ipcMain.removeHandler('renderer:scan-for-bruno-files');
+      ipcMain.handle('renderer:scan-for-bruno-files', async () => paths);
+    }, mockedCollectionPaths);
+
+    const locationInput = cloneModal.locator('#collection-location');
+    await locationInput.evaluate((el) => {
+      const input = el as HTMLInputElement;
+      input.removeAttribute('readonly');
+      input.readOnly = false;
+    });
+    await locationInput.fill(cloneTargetPath);
+
+    await cloneModal.getByRole('button', { name: 'Clone', exact: true }).click();
+
+    await expect(cloneModal.getByText(/bruno collections found/i)).toBeVisible({ timeout: 120000 });
+
+    const selectAll = cloneModal.getByLabel('Select all');
+    const collectionCheckboxes = cloneModal.locator('ul > li label input[type="checkbox"]');
+
+    await expect(selectAll).toBeVisible();
+    const checkboxCount = await collectionCheckboxes.count();
+    expect(checkboxCount).toBe(3);
+
+    await selectAll.check();
+    for (let i = 0; i < checkboxCount; i++) {
+      await expect(collectionCheckboxes.nth(i)).toBeChecked();
+    }
+
+    await selectAll.uncheck();
+    for (let i = 0; i < checkboxCount; i++) {
+      await expect(collectionCheckboxes.nth(i)).not.toBeChecked();
+    }
+
+    await collectionCheckboxes.first().check();
+    const isIndeterminate = await selectAll.evaluate((el) => (el as HTMLInputElement).indeterminate);
+    expect(isIndeterminate).toBe(true);
+
+    await page.getByRole('button', { name: 'Cancel' }).click();
+  });
 });


### PR DESCRIPTION
### Description

Add the select all collection checkbox on the git clone import feature.
Instead of selecting the collection one by one.

<img width="430" height="273" alt="Screenshot 2026-03-09 at 16 55 26" src="https://github.com/user-attachments/assets/01444df8-ac5d-4972-8c46-859b8bd8ee9f" />

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Select all" checkbox in the Clone Git Repository modal, enabling users to quickly select or deselect all collections at once. The checkbox reflects partial selection states for improved usability during repository import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->