### PR TITLE
fix: handle nested parentheses in URL link detection

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/linkAware.js
+++ b/packages/bruno-app/src/utils/codemirror/linkAware.js
@@ -1,6 +1,32 @@
 import LinkifyIt from 'linkify-it';
 import { isMacOS } from 'utils/common/platform';
 import { debounce } from 'lodash';
+
+const URL_TERMINATORS = /[\s"<>\\`]/;
+const VALID_URL_CHARS = /^[a-zA-Z0-9\-._~:/?#\[\]@!$&'()*+,;=%]/;
+
+function extendUrlWithBalancedParentheses(url, line, endIndex) {
+  let openParens = 0;
+  for (const char of url) {
+    if (char === '(') openParens++;
+    else if (char === ')') openParens--;
+  }
+  if (openParens <= 0) return { url, lastIndex: endIndex };
+
+  let extendedUrl = url;
+  let i = endIndex;
+  while (i < line.length) {
+    const char = line[i];
+    if (URL_TERMINATORS.test(char) || !VALID_URL_CHARS.test(char)) break;
+    if (char === '(') openParens++;
+    else if (char === ')') openParens--;
+    if (openParens < 0) break;
+    extendedUrl += char;
+    i++;
+  }
+  return { url: extendedUrl, lastIndex: i };
+}
+
 /**
  * Gets the visible line range using scroll info and lineAtHeight
  * @param {Object} editor - The CodeMirror editor instance
@@ -71,14 +97,15 @@ function markUrls(editor, linkify, linkClass, linkHint) {
         );
         if (isInVariable) return;
 
+        const extended = extendUrlWithBalancedParentheses(url, lineContent, lastIndex);
         try {
           editor.markText(
             { line: lineNum, ch: index },
-            { line: lineNum, ch: lastIndex },
+            { line: lineNum, ch: extended.lastIndex },
             {
               className: linkClass,
               attributes: {
-                'data-url': url,
+                'data-url': extended.url,
                 'title': linkHint
               }
             }
@@ -250,4 +277,4 @@ function setupLinkAware(editor, options = {}) {
   };
 }
 
-export { setupLinkAware };
+export { setupLinkAware, extendUrlWithBalancedParentheses };

--- a/packages/bruno-app/src/utils/codemirror/linkAware.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/linkAware.spec.js
@@ -1,4 +1,4 @@
-import { setupLinkAware } from './linkAware';
+import { setupLinkAware, extendUrlWithBalancedParentheses } from './linkAware';
 import LinkifyIt from 'linkify-it';
 import { isMacOS } from 'utils/common/platform';
 
@@ -609,5 +609,36 @@ describe('setupLinkAware', () => {
       expect(mockPrev.classList.add).not.toHaveBeenCalled();
       expect(mockNext.classList.add).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('extendUrlWithBalancedParentheses', () => {
+  it('should not modify URLs with balanced parentheses', () => {
+    const result = extendUrlWithBalancedParentheses('https://example.com/path?q=(a)', 'https://example.com/path?q=(a) end', 31);
+    expect(result.url).toBe('https://example.com/path?q=(a)');
+  });
+
+  it('should extend URL to balance nested parentheses', () => {
+    const url = 'https://example.com?_g=(a:!(),b:(c:d';
+    const line = 'https://example.com?_g=(a:!(),b:(c:d))&_a=(e) end';
+    const result = extendUrlWithBalancedParentheses(url, line, 36);
+    expect(result.url).toBe('https://example.com?_g=(a:!(),b:(c:d))&_a=(e)');
+  });
+
+  it('should stop at whitespace', () => {
+    const result = extendUrlWithBalancedParentheses('https://example.com?q=(a', 'https://example.com?q=(a ) end', 24);
+    expect(result.url).toBe('https://example.com?q=(a');
+  });
+
+  it('should stop when parentheses would become over-balanced', () => {
+    const result = extendUrlWithBalancedParentheses('https://example.com', '(see https://example.com) end', 24);
+    expect(result.url).toBe('https://example.com');
+  });
+
+  it('should handle Kibana/RISON URLs with deeply nested parentheses', () => {
+    const fullUrl = 'https://example.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now))&_a=(columns:!(TopicName,key),dataSource:(dataViewId:f45f79b9,type:dataView),filters:!(),query:(language:kuery,query:\'%22test%22\'),sort:!(!(Timestamp,asc)))';
+    const truncatedUrl = 'https://example.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now)';
+    const result = extendUrlWithBalancedParentheses(truncatedUrl, fullUrl, 120);
+    expect(result.url).toBe(fullUrl);
   });
 });


### PR DESCRIPTION
### Description

The LinkifyIt library was truncating URLs containing nested parentheses, such as Kibana/RISON formatted links. For example, a URL like: https://example.com/?_g=(filters:!(),time:(from:now))&_a=(data) would be cut off at the first balanced parenthesis, losing the &_a=... portion.

Added extendUrlWithBalancedParentheses helper function that:
- Counts unbalanced opening parentheses in the detected URL
- Extends the URL to include closing parens and following content
- Stops at URL terminators (whitespace, quotes, angle brackets)
- Stops if parentheses would become over-balanced (more closing than opening)

Fixes #7402

[JIRA](https://usebruno.atlassian.net/browse/BRU-2822)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced URL detection in the editor to properly identify and mark links containing balanced parentheses, supporting complex URL structures.

* **Tests**
  * Added comprehensive test coverage for URL parentheses handling, including nested parentheses, whitespace boundaries, and complex URL format scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->