### PR TITLE
fix(app): preserve nested parentheses in response links

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/linkAware.js
+++ b/packages/bruno-app/src/utils/codemirror/linkAware.js
@@ -1,6 +1,9 @@
 import LinkifyIt from 'linkify-it';
 import { isMacOS } from 'utils/common/platform';
 import { debounce } from 'lodash';
+
+const URL_CONTINUATION_RE = /^[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]$/;
+const TRAILING_URL_PUNCTUATION_RE = /[.,!?;:]+$/;
 /**
  * Gets the visible line range using scroll info and lineAtHeight
  * @param {Object} editor - The CodeMirror editor instance
@@ -65,7 +68,8 @@ function markUrls(editor, linkify, linkClass, linkHint) {
       while ((varMatch = variablePattern.exec(lineContent)) !== null) {
         variablePatterns.push({ start: varMatch.index, end: varMatch.index + varMatch[0].length });
       }
-      matches.forEach(({ index, lastIndex, url }) => {
+      matches.forEach((rawMatch) => {
+        const { index, lastIndex, url } = extendUrlMatch(lineContent, rawMatch);
         const isInVariable = variablePatterns.some(
           ({ start, end }) => index < end && lastIndex > start
         );
@@ -90,6 +94,52 @@ function markUrls(editor, linkify, linkClass, linkHint) {
       });
     }
   });
+}
+
+function extendUrlMatch(lineContent, match) {
+  if (!needsParenthesisExtension(match)) {
+    return match;
+  }
+
+  let end = match.lastIndex;
+  while (end < lineContent.length && URL_CONTINUATION_RE.test(lineContent[end])) {
+    end += 1;
+  }
+
+  const extendedRaw = trimExtendedUrl(lineContent.slice(match.index, end));
+
+  return {
+    ...match,
+    raw: extendedRaw,
+    text: extendedRaw,
+    url: extendedRaw,
+    lastIndex: match.index + extendedRaw.length
+  };
+}
+
+function needsParenthesisExtension(match) {
+  const candidate = match?.raw || match?.text || match?.url || '';
+  const opens = (candidate.match(/\(/g) || []).length;
+  const closes = (candidate.match(/\)/g) || []).length;
+
+  return opens > closes;
+}
+
+function trimExtendedUrl(value) {
+  let trimmed = value.replace(TRAILING_URL_PUNCTUATION_RE, '');
+
+  while (hasExtraClosingParen(trimmed)) {
+    trimmed = trimmed.slice(0, -1);
+  }
+
+  return trimmed;
+}
+
+function hasExtraClosingParen(value) {
+  const opens = (value.match(/\(/g) || []).length;
+  const closes = (value.match(/\)/g) || []).length;
+
+  return closes > opens && value.endsWith(')');
 }
 
 /**

--- a/packages/bruno-app/src/utils/codemirror/linkAware.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/linkAware.spec.js
@@ -337,6 +337,37 @@ describe('setupLinkAware', () => {
           }
         });
     });
+
+    it('should extend truncated matches with nested parentheses', () => {
+      const fullUrl = 'https://kibana-elasticsearch-sink-connector.loc/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now))&_a=(columns:!(TopicName,key),sort:!(!(KafkaConnectTimestamp,asc)))';
+
+      mockDoc.getLine.mockImplementation((lineNum) => lineNum === 0 ? fullUrl : '');
+      mockLinkify.match.mockReturnValue([
+        {
+          index: 0,
+          lastIndex: 148,
+          raw: 'https://kibana-elasticsearch-sink-connector.loc/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now)',
+          text: 'https://kibana-elasticsearch-sink-connector.loc/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now)',
+          url: 'https://kibana-elasticsearch-sink-connector.loc/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now)'
+        }
+      ]);
+
+      setupLinkAware(mockEditor);
+
+      const changeHandler = mockEditor.on.mock.calls.find((call) => call[0] === 'changes')[1];
+      changeHandler();
+      jest.runAllTimers();
+
+      expect(mockEditor.markText).toHaveBeenCalledWith(
+        { line: 0, ch: 0 },
+        { line: 0, ch: fullUrl.length },
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            'data-url': fullUrl
+          })
+        })
+      );
+    });
   });
 
   // Test animation frame handling


### PR DESCRIPTION
## Summary
- extend truncated CodeMirror response links when linkify-it stops inside nested parentheses
- keep the extension scoped to valid URL continuation characters and trim stray trailing punctuation
- add a regression test for the Kibana/RISON-style nested-parentheses URL from #7402

## Testing
- npm test --workspace=packages/bruno-app -- --runInBand src/utils/codemirror/linkAware.spec.js

Closes #7402.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL detection in the editor to properly recognize URLs containing nested parentheses and trailing punctuation characters that were previously missed.
  * Improved handling of complex URL patterns to ensure accurate linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->