### PR TITLE
fix: preserve hashes in dotenv values

### DIFF
--- a/packages/bruno-app/src/components/Environments/DotEnvFileEditor/utils.js
+++ b/packages/bruno-app/src/components/Environments/DotEnvFileEditor/utils.js
@@ -1,11 +1,22 @@
 import { uuid } from 'utils/common';
 
+const needsQuoting = (value) => {
+  return (
+    value.includes('\n')
+    || value.includes('"')
+    || value.includes('\'')
+    || value.includes('\\')
+    || value.includes('#')
+    || /^\s|\s$/.test(value)
+  );
+};
+
 export const variablesToRaw = (variables) => {
   return variables
     .filter((v) => v.name && v.name.trim() !== '')
     .map((v) => {
       const value = v.value || '';
-      if (value.includes('\n') || value.includes('"') || value.includes('\'')) {
+      if (needsQuoting(value)) {
         const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
         return `${v.name}="${escapedValue}"`;
       }
@@ -57,3 +68,7 @@ export const rawToVariables = (rawContent) => {
 };
 
 export const MIN_TABLE_HEIGHT = 35 * 2;
+
+export const __private__ = {
+  needsQuoting
+};

--- a/packages/bruno-app/src/components/Environments/DotEnvFileEditor/utils.spec.js
+++ b/packages/bruno-app/src/components/Environments/DotEnvFileEditor/utils.spec.js
@@ -1,0 +1,31 @@
+/** @jest-environment node */
+
+import { rawToVariables, variablesToRaw, __private__ } from './utils';
+
+jest.mock('utils/common', () => ({
+  uuid: () => 'test-uid'
+}));
+
+describe('DotEnvFileEditor utils', () => {
+  it('quotes values containing hash characters before writing raw dotenv text', () => {
+    const raw = variablesToRaw([{ name: 'TOKEN', value: 'ABC#DEF' }]);
+
+    expect(raw).toBe('TOKEN="ABC#DEF"');
+  });
+
+  it('round trips quoted hash values without truncating them', () => {
+    const variables = rawToVariables('TOKEN="ABC#DEF"');
+
+    expect(variables).toEqual([
+      expect.objectContaining({
+        name: 'TOKEN',
+        value: 'ABC#DEF'
+      })
+    ]);
+  });
+
+  it('marks leading or trailing whitespace as needing quotes', () => {
+    expect(__private__.needsQuoting(' value')).toBe(true);
+    expect(__private__.needsQuoting('value ')).toBe(true);
+  });
+});

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -672,15 +672,26 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
       const dotEnvPath = path.join(collectionPathname, filename);
 
+      const needsQuoting = (value) => {
+        return (
+          value.includes('\n')
+          || value.includes('"')
+          || value.includes('\'')
+          || value.includes('\\')
+          || value.includes('#')
+          || /^\s|\s$/.test(value)
+        );
+      };
+
       // Convert variables array to .env format
       const content = variables
         .filter((v) => v.name && v.name.trim() !== '')
         .map((v) => {
           const value = v.value || '';
-          // If value contains newlines or special characters, wrap in quotes
-          if (value.includes('\n') || value.includes('"') || value.includes('\'') || value.includes('\\')) {
+          // Quote values that dotenv would otherwise trim or treat as comments.
+          if (needsQuoting(value)) {
             // Escape backslashes first, then double quotes
-            const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
             return `${v.name}="${escapedValue}"`;
           }
           return `${v.name}=${value}`;

--- a/packages/bruno-lang/v2/tests/dotenvToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/dotenvToJson.spec.js
@@ -50,4 +50,13 @@ SPACE=  value
     const output = parser(input);
     expect(output).toEqual(expected);
   });
+
+  test('it should preserve hash characters when the value is quoted', () => {
+    const input = `
+TOKEN="ABC#DEF"
+`;
+    const expected = { TOKEN: 'ABC#DEF' };
+    const output = parser(input);
+    expect(output).toEqual(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- quote dotenv values that would otherwise be parsed as comments or trimmed by dotenv
- keep app and Electron dotenv serialization logic aligned
- add regression tests for quoted hash values in dotenv parsing and table editor serialization

Closes #7375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable handling to properly quote and preserve values containing special characters (hash symbols, newlines, leading/trailing whitespace) in .env files.

* **Tests**
  * Added comprehensive test coverage for environment variable quoting and parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->