### PR TITLE
fix: clear environment drafts after save

### DIFF
--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -358,6 +358,7 @@ const EnvironmentVariablesTable = ({
     onSave(cloneDeep(variablesToSave))
       .then(() => {
         toast.success('Changes saved successfully');
+        onDraftClear?.();
         const newValues = [
           ...variablesToSave,
           {
@@ -376,7 +377,7 @@ const EnvironmentVariablesTable = ({
         console.error(error);
         toast.error('An error occurred while saving the changes');
       });
-  }, [formik.values, environment.variables, onSave, setIsModified]);
+  }, [formik.values, environment.variables, onSave, onDraftClear, setIsModified]);
 
   const handleReset = useCallback(() => {
     const originalVars = environment.variables || [];


### PR DESCRIPTION
## Summary
- clear environment drafts after a successful table save
- keep the dirty indicator and close confirmation in sync with saved state
- apply the fix to both collection and global environment editors that share the same table component

Closes #7385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable save behavior to properly clear draft state when changes are successfully saved, ensuring consistency with the saved data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->