### PR TITLE
fix: support response query filters in safe mode

### DIFF
--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.js
@@ -1,8 +1,38 @@
 const { marshallToVm } = require('../utils');
 
+const toHostQueryArg = (vm, arg) => {
+  if (vm.typeof(arg) === 'function') {
+    return (item) => {
+      const itemVm = marshallToVm(item, vm);
+      const result = vm.callFunction(arg, vm.global, itemVm);
+
+      itemVm.dispose();
+
+      if (result.error) {
+        const error = vm.dump(result.error);
+        result.error.dispose();
+        throw error;
+      }
+
+      const value = vm.dump(result.value);
+      result.value.dispose();
+
+      return value;
+    };
+  }
+
+  return vm.dump(arg);
+};
+
 const addBrunoResponseShimToContext = (vm, res) => {
-  let resFn = vm.newFunction('res', function (exprStr) {
-    return marshallToVm(res(vm.dump(exprStr)), vm);
+  let resFn = vm.newFunction('res', function (exprStr, ...queryArgs) {
+    try {
+      const nativeArgs = queryArgs.map((arg) => toHostQueryArg(vm, arg));
+      return marshallToVm(res(vm.dump(exprStr), ...nativeArgs), vm);
+    } finally {
+      exprStr?.dispose?.();
+      queryArgs.forEach((arg) => arg?.dispose?.());
+    }
   });
 
   const status = marshallToVm(res?.status, vm);

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.spec.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.spec.js
@@ -1,0 +1,77 @@
+const { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } = require('@jest/globals');
+const { newQuickJSWASMModule } = require('quickjs-emscripten');
+const addBrunoResponseShimToContext = require('./bruno-response');
+
+describe('bruno response shim', () => {
+  let vm, module;
+
+  beforeAll(async () => {
+    module = await newQuickJSWASMModule();
+  });
+
+  beforeEach(() => {
+    vm = module.newContext();
+  });
+
+  afterEach(() => {
+    vm = null;
+  });
+
+  afterAll(() => {
+    module = null;
+  });
+
+  it('forwards response query filter callbacks in safe mode', () => {
+    const resources = [
+      { id: 'test', value: 1 },
+      { id: 'other', value: 2 }
+    ];
+    const response = Object.assign(
+      (expr, filter) => {
+        expect(expr).toBe('resources[?].id');
+        return resources.filter(filter).map((item) => item.id);
+      },
+      { status: 200, statusText: 'OK', headers: {}, body: { resources } }
+    );
+
+    addBrunoResponseShimToContext(vm, response);
+
+    const result = vm.evalCode(`
+      res('resources[?].id', r => r.id === 'test')
+    `);
+
+    const valueHandle = vm.unwrapResult(result);
+    const filtered = vm.dump(valueHandle);
+    valueHandle.dispose();
+
+    expect(filtered).toEqual(['test']);
+  });
+
+  it('still supports object predicates in safe mode', () => {
+    const resources = [
+      { id: 'test', value: 1 },
+      { id: 'other', value: 2 }
+    ];
+    const response = Object.assign(
+      (expr, predicate) => {
+        expect(expr).toBe('resources[?].id');
+        return resources.filter((item) =>
+          Object.entries(predicate).every(([key, value]) => item[key] === value)
+        ).map((item) => item.id);
+      },
+      { status: 200, statusText: 'OK', headers: {}, body: { resources } }
+    );
+
+    addBrunoResponseShimToContext(vm, response);
+
+    const result = vm.evalCode(`
+      res('resources[?].id', { id: 'other' })
+    `);
+
+    const valueHandle = vm.unwrapResult(result);
+    const filtered = vm.dump(valueHandle);
+    valueHandle.dispose();
+
+    expect(filtered).toEqual(['other']);
+  });
+});


### PR DESCRIPTION
## Summary
- forward QuickJS response query callbacks to the host query engine in safe mode
- keep object predicate filters working alongside function filters
- add focused QuickJS shim coverage for response query filters

Closes #7387


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved resource management and error handling in the sandbox environment for better stability.
  * Added comprehensive test coverage to ensure reliable response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->