### PR TITLE
fix: prevent middle-click autoscroll on tabs

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
@@ -37,6 +37,11 @@ const DraggableTab = ({ id, onMoveTab, index, children, className, onClick }) =>
       role="tab"
       style={{ opacity: isDragging || isOver ? 0 : 1 }}
       onClick={onClick}
+      onMouseDown={(event) => {
+        if (event.button === 1) {
+          event.preventDefault();
+        }
+      }}
       data-handler-id={handlerId}
     >
       {children}


### PR DESCRIPTION
## Summary
- prevent the browser default middle-click action on draggable tabs
- keep existing middle-click tab-close behavior intact
- fix the Windows autoscroll cursor appearing while closing tabs

Closes #7398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab interaction to prevent unintended default actions when middle-clicking on draggable tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->