### PR TITLE
Fix multipart file picker truncation

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/StyledWrapper.js
@@ -24,9 +24,16 @@ const Wrapper = styled.div`
   }
 
   .file-value-cell {
+    width: 100%;
+    min-width: 0;
     padding: 4px 0;
 
     .file-name {
+      display: block;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       font-size: 12px;
       color: ${(props) => props.theme.text};
     }

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -129,13 +129,13 @@ const MultipartFormParams = ({ item, collection }) => {
 
         if (fileName) {
           return (
-            <div className="flex items-center file-value-cell">
-              <IconFile size={16} className="text-muted mr-1" />
-              <span className="file-name flex-1 truncate" title={Array.isArray(value) ? value.join(', ') : value}>
+            <div className="flex w-full min-w-0 items-center file-value-cell">
+              <IconFile size={16} className="text-muted mr-1 shrink-0" />
+              <span className="file-name flex-1 min-w-0 truncate" title={Array.isArray(value) ? value.join(', ') : value}>
                 {fileName}
               </span>
               <button
-                className="clear-file-btn ml-1"
+                className="clear-file-btn ml-1 shrink-0"
                 onClick={() => handleClearFile(row)}
                 title="Remove file"
               >
@@ -162,7 +162,7 @@ const MultipartFormParams = ({ item, collection }) => {
             </div>
             {!hasTextValue && !isLastEmptyRow && (
               <button
-                className="upload-btn ml-1"
+                className="upload-btn ml-1 shrink-0"
                 onClick={() => handleBrowseFiles(row, onChange)}
                 title="Select file"
               >


### PR DESCRIPTION
## Summary
- keep the selected file row shrinkable so long filenames truncate with an ellipsis again
- prevent the file and action icons from shrinking out of view when the request pane is narrow

## Testing
- npx eslint packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js packages/bruno-app/src/components/RequestPane/MultipartFormParams/StyledWrapper.js

Closes #7381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Long filenames in multipart form parameters now display with proper text truncation and ellipsis to prevent layout overflow.
  * Improved layout consistency for file input fields to ensure better spacing and alignment of file icons, names, and action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->