### PR TITLE
fix: preserve global environment color during script execution

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.js
@@ -226,6 +226,7 @@ export const saveGlobalEnvironment = ({ variables, environmentUid }) => (dispatc
       .then(() => ipcRenderer.invoke('renderer:save-global-environment', {
         environmentUid,
         variables,
+        color: environment.color,
         workspaceUid,
         workspacePath
       }))
@@ -310,6 +311,7 @@ export const globalEnvironmentsUpdateEvent = ({ globalEnvironmentVariables }) =>
       .then(() => ipcRenderer.invoke('renderer:save-global-environment', {
         environmentUid,
         variables,
+        color: environment.color,
         workspaceUid,
         workspacePath
       }))

--- a/packages/bruno-electron/src/ipc/global-environments.js
+++ b/packages/bruno-electron/src/ipc/global-environments.js
@@ -34,13 +34,13 @@ const registerGlobalEnvironmentsIpc = (mainWindow, workspaceEnvironmentsManager)
     }
   });
 
-  ipcMain.handle('renderer:save-global-environment', async (event, { environmentUid, variables, workspaceUid, workspacePath }) => {
+  ipcMain.handle('renderer:save-global-environment', async (event, { environmentUid, variables, color, workspaceUid, workspacePath }) => {
     try {
       if (workspacePath && workspaceEnvironmentsManager) {
-        return await workspaceEnvironmentsManager.saveGlobalEnvironmentByPath(workspacePath, { environmentUid, variables });
+        return await workspaceEnvironmentsManager.saveGlobalEnvironmentByPath(workspacePath, { environmentUid, variables, color });
       }
 
-      globalEnvironmentsStore.saveGlobalEnvironment({ environmentUid, variables });
+      globalEnvironmentsStore.saveGlobalEnvironment({ environmentUid, variables, color });
     } catch (error) {
       console.error('Error in renderer:save-global-environment:', error);
       return Promise.reject(error);

--- a/packages/bruno-electron/src/store/global-environments.js
+++ b/packages/bruno-electron/src/store/global-environments.js
@@ -112,12 +112,15 @@ class GlobalEnvironmentsStore {
     this.setGlobalEnvironments(globalEnvironments);
   }
 
-  saveGlobalEnvironment({ environmentUid: globalEnvironmentUid, variables }) {
+  saveGlobalEnvironment({ environmentUid: globalEnvironmentUid, variables, color }) {
     let globalEnvironments = this.getGlobalEnvironments();
     const environment = globalEnvironments.find((env) => env?.uid == globalEnvironmentUid);
     globalEnvironments = globalEnvironments.filter((env) => env?.uid !== globalEnvironmentUid);
     if (environment) {
       environment.variables = variables;
+      if (color !== undefined) {
+        environment.color = color;
+      }
     }
     globalEnvironments.push(environment);
     this.setGlobalEnvironments(globalEnvironments);

--- a/packages/bruno-electron/src/store/workspace-environments.js
+++ b/packages/bruno-electron/src/store/workspace-environments.js
@@ -213,7 +213,7 @@ class GlobalEnvironmentsManager {
     }
   }
 
-  async saveGlobalEnvironment(workspacePath, { environmentUid, variables }) {
+  async saveGlobalEnvironment(workspacePath, { environmentUid, variables, color }) {
     try {
       if (!workspacePath) {
         throw new Error('Workspace path is required');
@@ -229,6 +229,10 @@ class GlobalEnvironmentsManager {
         name: envFile.name,
         variables: variables
       };
+
+      if (color) {
+        environment.color = color;
+      }
 
       if (this.envHasSecrets(environment)) {
         environmentSecretsStore.storeEnvSecrets(workspacePath, environment);


### PR DESCRIPTION


### Description

When executing requests with pre-request or post-response scripts, the global environment color property was being stripped from YAML files. This happened because the save operation only passed `variables` through the IPC chain, and the workspace-environments store created a new environment object without preserving the existing `color` property.

The fix passes the `color` property through the entire IPC chain:
- Redux actions now include `color` in the save-global-environment IPC call
- IPC handler accepts and forwards `color` to both stores
- workspace-environments store includes `color` when creating the environment object
- global-environments store preserves `color` when updating

Fixes #7348
#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global environments now support custom colors for improved visual organization and distinction between environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->