### PR TITLE
feat(grpc): include null fields in responses + tests

### DIFF
--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -79,7 +79,11 @@ const normalizeGrpcResponseWithNulls = (data, fields) => {
   }
 
   const isObject = data && typeof data === 'object' && !Array.isArray(data);
-  const normalized = isObject ? { ...data } : {};
+  if (!isObject) {
+    return data;
+  }
+
+  const normalized = { ...data };
 
   fields.forEach((field) => {
     const key = field.name;

--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -51,6 +51,75 @@ const ensureBuffer = (data) => {
   return Buffer.from(data, 'utf-8');
 };
 
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+const getMethodResponseFields = (method) => {
+  try {
+    if (method?.responseType?.type?.field) {
+      return method.responseType.type.field;
+    }
+
+    if (method?.responseType?.field) {
+      return method.responseType.field;
+    }
+
+    if (method?.responseType?.type) {
+      return method.responseType.type;
+    }
+  } catch (error) {
+    console.error('Error extracting method response fields:', error);
+  }
+
+  return null;
+};
+
+const normalizeGrpcResponseWithNulls = (data, fields) => {
+  if (!fields || !Array.isArray(fields)) {
+    return data;
+  }
+
+  const isObject = data && typeof data === 'object' && !Array.isArray(data);
+  const normalized = isObject ? { ...data } : {};
+
+  fields.forEach((field) => {
+    const key = field.name;
+    const isRepeated = field.label === 'LABEL_REPEATED';
+    const isMessage = field.type === 'TYPE_MESSAGE';
+    const hasValue = hasOwn(normalized, key) && normalized[key] !== undefined;
+
+    if (isRepeated) {
+      if (!hasValue) {
+        normalized[key] = null;
+        return;
+      }
+
+      if (isMessage && Array.isArray(normalized[key]) && field.messageType?.field) {
+        normalized[key] = normalized[key].map((item) => normalizeGrpcResponseWithNulls(item, field.messageType.field));
+      }
+      return;
+    }
+
+    if (!hasValue) {
+      normalized[key] = null;
+      return;
+    }
+
+    if (isMessage && normalized[key] !== null && field.messageType?.field) {
+      normalized[key] = normalizeGrpcResponseWithNulls(normalized[key], field.messageType.field);
+    }
+  });
+
+  return normalized;
+};
+
+const normalizeGrpcResponseForMethod = (data, method) => {
+  const fields = getMethodResponseFields(method);
+  if (!fields) {
+    return data;
+  }
+  return normalizeGrpcResponseWithNulls(data, fields);
+};
+
 /**
  * Safely parse JSON string with error handling
  * @param {string} jsonString - The JSON string to parse
@@ -150,13 +219,14 @@ const getParsedGrpcUrlObject = (url) => {
  * @param {string} collectionUid - The collection UID
  * @param {Object} rpc - The gRPC object
  */
-const setupGrpcEventHandlers = (callback, requestId, collectionUid, rpc) => {
+const setupGrpcEventHandlers = (callback, requestId, collectionUid, rpc, normalizeResponse) => {
   rpc.on('status', (status, res) => {
     const statusWithMetadata = {
       ...status,
       metadata: processGrpcMetadata(status.metadata.getMap ? status.metadata.getMap() : status.metadata)
     };
-    callback('grpc:status', requestId, collectionUid, { status: statusWithMetadata, res });
+    const normalizedRes = normalizeResponse ? normalizeResponse(res) : res;
+    callback('grpc:status', requestId, collectionUid, { status: statusWithMetadata, res: normalizedRes });
   });
 
   rpc.on('error', (error) => {
@@ -168,17 +238,20 @@ const setupGrpcEventHandlers = (callback, requestId, collectionUid, rpc) => {
   });
 
   rpc.on('end', (res) => {
-    callback('grpc:server-end-stream', requestId, collectionUid, { res });
+    const normalizedRes = normalizeResponse ? normalizeResponse(res) : res;
+    callback('grpc:server-end-stream', requestId, collectionUid, { res: normalizedRes });
     const channel = rpc?.call?.channel;
     if (channel) channel.close();
   });
 
   rpc.on('data', (res) => {
-    callback('grpc:response', requestId, collectionUid, { error: null, res });
+    const normalizedRes = normalizeResponse ? normalizeResponse(res) : res;
+    callback('grpc:response', requestId, collectionUid, { error: null, res: normalizedRes });
   });
 
   rpc.on('cancel', (res) => {
-    callback('grpc:server-cancel-stream', requestId, collectionUid, { res });
+    const normalizedRes = normalizeResponse ? normalizeResponse(res) : res;
+    callback('grpc:server-cancel-stream', requestId, collectionUid, { res: normalizedRes });
 
     const channel = rpc?.call?.channel;
     if (channel) channel.close();
@@ -415,6 +488,7 @@ class GrpcClient {
    * Handle unary responses
    */
   #handleUnaryResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid }) {
+    const normalizeResponse = (res) => normalizeGrpcResponseForMethod(res, method);
     const rpc = client.makeUnaryRequest(
       requestPath,
       method.requestSerialize,
@@ -422,30 +496,34 @@ class GrpcClient {
       messages[0],
       metadata,
       (error, res) => {
-        this.eventCallback('grpc:response', requestId, collectionUid, { error, res });
+        const normalizedRes = normalizeResponse(res);
+        this.eventCallback('grpc:response', requestId, collectionUid, { error, res: normalizedRes });
       }
     );
 
-    setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc);
+    setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc, normalizeResponse);
   }
 
   #handleClientStreamingResponse({ client, requestId, requestPath, method, metadata, collectionUid }) {
+    const normalizeResponse = (res) => normalizeGrpcResponseForMethod(res, method);
     const rpc = client.makeClientStreamRequest(
       requestPath,
       method.requestSerialize,
       method.responseDeserialize,
       metadata,
       (error, res) => {
-        this.eventCallback('grpc:response', requestId, collectionUid, { error, res });
+        const normalizedRes = normalizeResponse(res);
+        this.eventCallback('grpc:response', requestId, collectionUid, { error, res: normalizedRes });
       }
     );
     this.#addConnection(requestId, rpc);
 
-    setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc);
+    setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc, normalizeResponse);
   }
 
   #handleServerStreamingResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid }) {
     const message = messages[0];
+    const normalizeResponse = (res) => normalizeGrpcResponseForMethod(res, method);
     const rpc = client.makeServerStreamRequest(
       requestPath,
       method.requestSerialize,
@@ -453,15 +531,17 @@ class GrpcClient {
       message,
       metadata,
       (error, res) => {
-        this.eventCallback('grpc:response', requestId, collectionUid, { error, res });
+        const normalizedRes = normalizeResponse(res);
+        this.eventCallback('grpc:response', requestId, collectionUid, { error, res: normalizedRes });
       }
     );
     this.#addConnection(requestId, rpc);
 
-    setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc);
+    setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc, normalizeResponse);
   }
 
   #handleBidiStreamingResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid }) {
+    const normalizeResponse = (res) => normalizeGrpcResponseForMethod(res, method);
     const rpc = client.makeBidiStreamRequest(
       requestPath,
       method.requestSerialize,
@@ -470,7 +550,7 @@ class GrpcClient {
     );
     this.#addConnection(requestId, rpc);
 
-    setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc);
+    setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc, normalizeResponse);
   }
 
   /**

--- a/packages/bruno-requests/src/grpc/grpc-client.spec.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.spec.js
@@ -4,6 +4,8 @@
 
 // Store captured channel options for assertions
 let capturedChannelOptions = null;
+let lastRpc = null;
+let lastUnaryCallback = null;
 
 // Mock GrpcReflection to capture options
 const mockListServices = jest.fn().mockResolvedValue(['test.Service']);
@@ -53,6 +55,11 @@ jest.mock('@grpc/grpc-js', () => {
         handlers[event] = handler;
         return mockRpc; // Return the mock object for chaining
       }),
+      __emit: jest.fn((event, payload) => {
+        if (handlers[event]) {
+          handlers[event](payload);
+        }
+      }),
       write: jest.fn(),
       end: jest.fn(),
       cancel: jest.fn(),
@@ -68,9 +75,13 @@ jest.mock('@grpc/grpc-js', () => {
       return jest.fn().mockImplementation((host, credentials, options) => {
         capturedChannelOptions = options;
         const mockRpc = createMockRpc();
+        lastRpc = mockRpc;
         return {
           close: jest.fn(),
-          makeUnaryRequest: jest.fn().mockReturnValue(mockRpc),
+          makeUnaryRequest: jest.fn((requestPath, requestSerialize, responseDeserialize, message, metadata, callback) => {
+            lastUnaryCallback = callback;
+            return mockRpc;
+          }),
           makeClientStreamRequest: jest.fn().mockReturnValue(mockRpc),
           makeServerStreamRequest: jest.fn().mockReturnValue(mockRpc),
           makeBidiStreamRequest: jest.fn().mockReturnValue(mockRpc)
@@ -105,6 +116,8 @@ describe('GrpcClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedChannelOptions = null;
+    lastRpc = null;
+    lastUnaryCallback = null;
     mockEventCallback = jest.fn();
     grpcClient = new GrpcClient(mockEventCallback);
   });
@@ -503,6 +516,127 @@ describe('GrpcClient', () => {
         // Empty string is falsy, so grpc.primary_user_agent should not be set
         expect(capturedChannelOptions['grpc.primary_user_agent']).toBeUndefined();
       });
+    });
+  });
+
+  describe('gRPC response normalization', () => {
+    const baseRequest = {
+      url: 'grpc://localhost:50051',
+      uid: 'test-request-uid',
+      method: '/test.Service/TestMethod',
+      headers: {},
+      body: {
+        grpc: [{ content: '{}' }]
+      }
+    };
+
+    const baseCollection = {
+      uid: 'test-collection-uid',
+      pathname: '/test/path'
+    };
+
+    test('should add nulls for missing response fields', async () => {
+      grpcClient.methods.set('/test.Service/TestMethod', {
+        path: '/test.Service/TestMethod',
+        requestStream: false,
+        responseStream: false,
+        requestSerialize: (val) => Buffer.from(JSON.stringify(val)),
+        responseDeserialize: (val) => JSON.parse(val.toString()),
+        responseType: {
+          field: [
+            { name: 'id', type: 'TYPE_STRING' },
+            { name: 'count', type: 'TYPE_INT32' },
+            { name: 'tags', type: 'TYPE_STRING', label: 'LABEL_REPEATED' },
+            {
+              name: 'meta',
+              type: 'TYPE_MESSAGE',
+              messageType: {
+                field: [
+                  { name: 'createdAt', type: 'TYPE_STRING' },
+                  {
+                    name: 'owner',
+                    type: 'TYPE_MESSAGE',
+                    messageType: {
+                      field: [
+                        { name: 'name', type: 'TYPE_STRING' },
+                        { name: 'age', type: 'TYPE_INT32' }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              name: 'items',
+              type: 'TYPE_MESSAGE',
+              label: 'LABEL_REPEATED',
+              messageType: {
+                field: [{ name: 'value', type: 'TYPE_STRING' }]
+              }
+            }
+          ]
+        }
+      });
+
+      await grpcClient.startConnection({
+        request: baseRequest,
+        collection: baseCollection
+      });
+
+      const response = {
+        id: 'abc',
+        meta: { owner: { name: 'Alice' } },
+        items: [{}]
+      };
+
+      lastUnaryCallback(null, response);
+
+      const expected = {
+        id: 'abc',
+        count: null,
+        tags: null,
+        meta: {
+          createdAt: null,
+          owner: {
+            name: 'Alice',
+            age: null
+          }
+        },
+        items: [{ value: null }]
+      };
+
+      expect(mockEventCallback).toHaveBeenCalledWith(
+        'grpc:response',
+        'test-request-uid',
+        'test-collection-uid',
+        { error: null, res: expected }
+      );
+    });
+
+    test('should leave response unchanged when schema is missing', async () => {
+      grpcClient.methods.set('/test.Service/TestMethod', {
+        path: '/test.Service/TestMethod',
+        requestStream: false,
+        responseStream: false,
+        requestSerialize: (val) => Buffer.from(JSON.stringify(val)),
+        responseDeserialize: (val) => JSON.parse(val.toString())
+      });
+
+      await grpcClient.startConnection({
+        request: baseRequest,
+        collection: baseCollection
+      });
+
+      const response = { id: 'abc', count: 2 };
+
+      lastUnaryCallback(null, response);
+
+      expect(mockEventCallback).toHaveBeenCalledWith(
+        'grpc:response',
+        'test-request-uid',
+        'test-collection-uid',
+        { error: null, res: response }
+      );
     });
   });
 });


### PR DESCRIPTION
•
normalize gRPC response objects based on response schema, filling missing fields with null (including nested messages) •
add grpc-client unit tests for normalization and schema-missing behavior

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

fixes: #7435 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gRPC response handling with safer field extraction and normalization for missing fields.
  * Enhanced JSON parsing with more robust error reporting.

* **Tests**
  * Added comprehensive tests for gRPC response normalization to ensure correct handling of nested and missing response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->