### PR TITLE
fix: allow default input copy paste

### DIFF
--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -56,6 +56,30 @@ const BOUND_ACTIONS = [
 ];
 
 /**
+ * Check if the event is a native editing shortcut (copy, cut, paste, select all, undo, redo)
+ * These should allow default browser behavior in input fields as they are using mousetrap class everywhere
+ */
+function isNativeEditingShortcut(e) {
+  const key = e.key?.toLowerCase();
+  const ctrl = e.ctrlKey || e.metaKey; // Ctrl on Windows/Linux, Cmd on Mac
+  const shift = e.shiftKey;
+
+  // Copy (C), Cut (X), Paste (V), Select All (A), Undo (Z), Redo (Y or Shift+Z)
+  if (ctrl && !shift && (key === 'c' || key === 'x' || key === 'v' || key === 'a' || key === 'z')) {
+    return true;
+  }
+  // Redo: Ctrl+Shift+Z or Ctrl+Y
+  if (ctrl && shift && key === 'z') {
+    return true;
+  }
+  if (ctrl && key === 'y') {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Bind a single hotkey action using Mousetrap.
  * Reads from merged defaults + user preferences via getKeyBindingsForActionAllOS.
  */
@@ -64,19 +88,15 @@ function bindHotkey(action, handler, userKeyBindings) {
   if (!combos?.length) return;
 
   Mousetrap.bind([...combos], (e) => {
-    // Allow default browser behavior for input, textarea, select, and contenteditable elements
-    // This ensures copy/paste (Ctrl+C/V) works in input fields
+    // Check if we're in an input field with 'mousetrap' class
     const target = e.target || e.srcElement;
-    const tagName = target?.tagName?.toLowerCase();
-    const isInputField
-      = tagName === 'input'
-        || tagName === 'textarea'
-        || tagName === 'select'
-        || target?.isContentEditable
-        || target?.classList?.contains('mousetrap');
+    const hasMousetrapClass = target?.classList?.contains('mousetrap');
 
-    if (isInputField) {
-      return true; // Allow default behavior (copy/paste) in input fields
+    // Only allow default behavior for native editing shortcuts in elements with 'mousetrap' class
+    // This ensures copy/cut/paste/select-all/undo/redo work normally in input fields
+    // Other Bruno shortcuts (save, send, etc.) will still work
+    if (hasMousetrapClass && isNativeEditingShortcut(e)) {
+      return true; // Allow default browser behavior
     }
 
     e?.preventDefault?.();


### PR DESCRIPTION
### Description

In many places we are using <input with classname `mousetrap` due to which it is not capturing default copy/paste behaviour `text/textarea/select` as it is getting captured in `HotkeysProvider` and disabling default behaviour

Returns true for native editing shortcuts `(Ctrl/Cmd + C, X, V, A, Z, Y)` in elements with class="mousetrap"
bindHotkey

Same logic as stopCallback - checks for mousetrap class and native editing shortcuts
Returns true for native shortcuts, calls handler for `BOUND_ACTIONS`

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored native browser editing shortcuts (copy, cut, paste, select all, undo, redo) when typing in inputs, textareas, selects and contentEditable areas so standard keyboard behavior is preserved while other app hotkeys continue to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->