### PR TITLE
fix: cookie wrapper callback mode returns never-resolving Promise

### DIFF
--- a/packages/bruno-requests/src/cookies/index.spec.ts
+++ b/packages/bruno-requests/src/cookies/index.spec.ts
@@ -190,6 +190,19 @@ describe('Bruno Cookie Jar Wrapper - API Examples', () => {
       expect(ret).toBeUndefined();
     });
 
+    test('validation-error paths with callback return void, not the callback return value', () => {
+      // If the wrapper did `return callback(error)`, the caller would receive
+      // whatever the callback returns — which could be a truthy value or a Promise.
+      // All validation-error callback paths must return void (undefined).
+      const spy = () => 'leaked!' as any;
+
+      expect(jar.getCookie('', '', spy)).toBeUndefined();
+      expect(jar.getCookies('', spy)).toBeUndefined();
+      expect(jar.hasCookie('', '', spy)).toBeUndefined();
+      expect(jar.deleteCookies('', spy)).toBeUndefined();
+      expect(jar.deleteCookie('', '', spy)).toBeUndefined();
+    });
+
     test('getCookie with callback can be safely awaited without hanging', async () => {
       await jar.setCookie(testUrl, 'token', 'abc');
 

--- a/packages/bruno-requests/src/cookies/index.ts
+++ b/packages/bruno-requests/src/cookies/index.ts
@@ -189,7 +189,9 @@ const cookieJarWrapper = () => {
     ) {
       if (!url || !cookieName) {
         const error = new Error('URL and cookie name are required');
-        if (callback) return callback(error);
+        if (callback) {
+          callback(error); return;
+        }
         return Promise.reject(error);
       }
 
@@ -225,7 +227,9 @@ const cookieJarWrapper = () => {
     ) {
       if (!url || !cookieName) {
         const error = new Error('URL and cookie name are required');
-        if (callback) return callback(error);
+        if (callback) {
+          callback(error); return;
+        }
         return Promise.reject(error);
       }
 
@@ -251,7 +255,9 @@ const cookieJarWrapper = () => {
     getCookies: function (url: string, callback?: (err: Error | null | undefined, cookies?: Cookie[]) => void) {
       if (!url) {
         const error = new Error('URL is required');
-        if (callback) return callback(error);
+        if (callback) {
+          callback(error); return;
+        }
         return Promise.reject(error);
       }
 
@@ -417,7 +423,9 @@ const cookieJarWrapper = () => {
     deleteCookies: function (url: string, callback?: (err?: Error | undefined) => void) {
       if (!url) {
         const error = new Error('URL is required');
-        if (callback) return callback(error);
+        if (callback) {
+          callback(error); return;
+        }
         return Promise.reject(error);
       }
 
@@ -468,7 +476,9 @@ const cookieJarWrapper = () => {
     deleteCookie: function (url: string, cookieName: string, callback?: (err?: Error | undefined) => void) {
       if (!url || !cookieName) {
         const error = new Error('URL and cookie name are required');
-        if (callback) return callback(error);
+        if (callback) {
+          callback(error); return;
+        }
         return Promise.reject(error);
       }
 
@@ -503,7 +513,8 @@ const cookieJarWrapper = () => {
 
       if (callback) {
         // Callback mode
-        return executeDelete(callback);
+        executeDelete(callback);
+        return;
       }
 
       // Promise mode


### PR DESCRIPTION
[jira](https://usebruno.atlassian.net/browse/BRU-2842)

### Description

tough-cookie's createPromiseCallback() intentionally never resolves the returned Promise when a callback is provided — only the callback fires. The cookie jar wrapper was propagating this never-resolving Promise via `return cookieJar.getCookies(url, cb)` in callback-mode paths. When user scripts did `await jar.getCookie(url, name, callback)` in the Node VM (developer sandbox), the await hung forever, blocking the CLI runner.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed callback-based cookie operations so they no longer return unresolved Promises that could cause hangs.

* **Tests**
  * Added comprehensive tests covering callback-mode cookie operations (get, list, existence, delete, clear) and awaited-callback scenarios to prevent hanging behavior.

* **Refactor**
  * Internal callback handling and control flow adjusted to ensure callback paths return void; public API signatures unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->