### PR TITLE
fix: multipart header check

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -559,18 +559,18 @@ const runSingleRequest = async function (
       // if `data` is of string type - return as-is (assumes already encoded)
     }
 
-    if (contentTypeHeader && request.headers[contentTypeHeader].startsWith('multipart/')) {
+    const contentType = contentTypeHeader ? request.headers[contentTypeHeader] : '';
+    if (typeof contentType === 'string' && contentType.startsWith('multipart/')) {
       if (!isFormData(request?.data)) {
         request._originalMultipartData = request.data;
         request.collectionPath = collectionPath;
         let form = createFormData(request.data, collectionPath);
         request.data = form;
 
-        if (request?.headers?.['content-type'] !== 'multipart/form-data') {
+        if (contentType !== 'multipart/form-data') {
           // Patch: Axios leverages getHeaders method to get the headers so FormData should be monkey patched
           const formHeaders = form.getHeaders();
-          const ct = request.headers['content-type'];
-          formHeaders['content-type'] = `${ct}; boundary=${form.getBoundary()}`;
+          formHeaders['content-type'] = `${contentType}; boundary=${form.getBoundary()}`;
           form.getHeaders = function () {
             return formHeaders;
           };

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -594,17 +594,17 @@ const registerNetworkIpc = (mainWindow) => {
       // if `data` is of string type - return as-is (assumes already encoded)
     }
 
-    if (contentTypeHeader && request.headers[contentTypeHeader].startsWith('multipart/')) {
+    const contentType = contentTypeHeader ? request.headers[contentTypeHeader] : '';
+    if (typeof contentType === 'string' && contentType.startsWith('multipart/')) {
       if (!isFormData(request.data)) {
         request._originalMultipartData = request.data;
         request.collectionPath = collectionPath;
         let form = createFormData(request.data, collectionPath);
         request.data = form;
-        if (request.headers[contentTypeHeader] !== 'multipart/form-data') {
+        if (contentType !== 'multipart/form-data') {
           // Patch: Axios leverages getHeaders method to get the headers so FormData should be monkey patched
           const formHeaders = form.getHeaders();
-          const ct = request.headers[contentTypeHeader];
-          formHeaders['content-type'] = `${ct}; boundary=${form.getBoundary()}`;
+          formHeaders['content-type'] = `${contentType}; boundary=${form.getBoundary()}`;
           form.getHeaders = function () {
             return formHeaders;
           };


### PR DESCRIPTION
### Description

                                                                                                                                    
Fixes issue where contentTypeHeader (the header key name, e.g. "content-type") was compared instead of request.headers[contentTypeHeader]

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Before
https://github.com/user-attachments/assets/c959265e-6947-4566-9a90-693c6e3f12ca


After
https://github.com/user-attachments/assets/580c814e-45b3-466e-b74b-1ec9868d470b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multipart/form-data handling in both CLI and Electron builds so multipart requests are detected from the actual Content-Type header, wrapped into form data properly, and sent with the correct content-type and boundary headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->