### PR TITLE
fix(common): handle string tags in isRequestTagsIncluded

### DIFF
--- a/packages/bruno-common/src/tags/index.spec.ts
+++ b/packages/bruno-common/src/tags/index.spec.ts
@@ -40,4 +40,29 @@ describe('isRequestTagsIncluded', () => {
     const result = isRequestTagsIncluded(requestTags, includeTags, excludeTags);
     expect(result).toBe(false);
   });
+
+  it('should handle requestTags as a single string when excluding', () => {
+    const result = isRequestTagsIncluded('ignore', [], ['ignore']);
+    expect(result).toBe(false);
+  });
+
+  it('should handle requestTags as a single string when including', () => {
+    const result = isRequestTagsIncluded('smoke', ['smoke'], []);
+    expect(result).toBe(true);
+  });
+
+  it('should handle requestTags as a single string that does not match exclude', () => {
+    const result = isRequestTagsIncluded('smoke', [], ['ignore']);
+    expect(result).toBe(true);
+  });
+
+  it('should handle requestTags as undefined without crashing', () => {
+    const result = isRequestTagsIncluded(undefined, [], ['ignore']);
+    expect(result).toBe(true);
+  });
+
+  it('should handle requestTags as null without crashing', () => {
+    const result = isRequestTagsIncluded(null, [], ['ignore']);
+    expect(result).toBe(true);
+  });
 });

--- a/packages/bruno-common/src/tags/index.spec.ts
+++ b/packages/bruno-common/src/tags/index.spec.ts
@@ -65,6 +65,7 @@ describe('isRequestTagsIncluded', () => {
     const result = isRequestTagsIncluded(undefined, ['smoke'], []);
     expect(result).toBe(false);
   });
+
   it('should handle requestTags as null without crashing', () => {
     const result = isRequestTagsIncluded(null, [], ['ignore']);
     expect(result).toBe(true);
@@ -73,5 +74,10 @@ describe('isRequestTagsIncluded', () => {
   it('should handle requestTags as a comma-separated string', () => {
     const result = isRequestTagsIncluded('smoke, api', ['smoke'], []);
     expect(result).toBe(true);
+  });
+
+  it('should handle comma-separated string with exclusion', () => {
+    const result = isRequestTagsIncluded('smoke, ignore', [], ['ignore']);
+    expect(result).toBe(false);
   });
 });

--- a/packages/bruno-common/src/tags/index.spec.ts
+++ b/packages/bruno-common/src/tags/index.spec.ts
@@ -61,6 +61,10 @@ describe('isRequestTagsIncluded', () => {
     expect(result).toBe(true);
   });
 
+  it('should not include request when requestTags is undefined and includeTags is non-empty', () => {
+    const result = isRequestTagsIncluded(undefined, ['smoke'], []);
+    expect(result).toBe(false);
+  });
   it('should handle requestTags as null without crashing', () => {
     const result = isRequestTagsIncluded(null, [], ['ignore']);
     expect(result).toBe(true);

--- a/packages/bruno-common/src/tags/index.spec.ts
+++ b/packages/bruno-common/src/tags/index.spec.ts
@@ -69,4 +69,9 @@ describe('isRequestTagsIncluded', () => {
     const result = isRequestTagsIncluded(null, [], ['ignore']);
     expect(result).toBe(true);
   });
+
+  it('should handle requestTags as a comma-separated string', () => {
+    const result = isRequestTagsIncluded('smoke, api', ['smoke'], []);
+    expect(result).toBe(true);
+  });
 });

--- a/packages/bruno-common/src/tags/index.ts
+++ b/packages/bruno-common/src/tags/index.ts
@@ -12,7 +12,7 @@ const toTagsArray = (tags: string | string[] | undefined | null): string[] => {
 };
 
 /**
- * A request should be included if it has at least one tag that is included and no tags that are excluded
+ * Determines whether a request should be included based on its tags: if no includeTags are provided, all requests are included (unless excluded); otherwise, it must have at least one included tag and no excluded tags.
  * @param requestTags Tags of the request (string or array — BRU parser may return either)
  * @param includeTags Tags to include
  * @param excludeTags Tags to exclude

--- a/packages/bruno-common/src/tags/index.ts
+++ b/packages/bruno-common/src/tags/index.ts
@@ -1,6 +1,6 @@
 /**
- * Normalizes a tags value to an array of strings.
- * The BRU parser may return a single string when only one tag is defined.
+ * Normalizes a tags value from the BRU parser to an array of strings.
+ * The BRU parser may return tags as a string (single tag or comma-separated list) or as an array.
  */
 const toTagsArray = (tags: string | string[] | undefined | null): string[] => {
   if (!tags) return [];

--- a/packages/bruno-common/src/tags/index.ts
+++ b/packages/bruno-common/src/tags/index.ts
@@ -1,12 +1,30 @@
 /**
+ * Normalizes a tags value to an array of strings.
+ * The BRU parser may return a single string when only one tag is defined.
+ */
+const toTagsArray = (tags: string | string[] | undefined | null): string[] => {
+  if (!tags) return [];
+  if (Array.isArray(tags)) return tags;
+  return String(tags)
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+};
+
+/**
  * A request should be included if it has at least one tag that is included and no tags that are excluded
- * @param requestTags Tags of the request
+ * @param requestTags Tags of the request (string or array — BRU parser may return either)
  * @param includeTags Tags to include
  * @param excludeTags Tags to exclude
  */
-export const isRequestTagsIncluded = (requestTags: string[], includeTags: string[], excludeTags: string[]) => {
-  const shouldInclude = includeTags.length === 0 || requestTags.some((tag) => includeTags.includes(tag));
-  const shouldExclude = excludeTags.length > 0 && requestTags.some((tag) => excludeTags.includes(tag));
+export const isRequestTagsIncluded = (
+  requestTags: string | string[] | undefined | null,
+  includeTags: string[],
+  excludeTags: string[]
+) => {
+  const tags = toTagsArray(requestTags);
+  const shouldInclude = includeTags.length === 0 || tags.some((tag) => includeTags.includes(tag));
+  const shouldExclude = excludeTags.length > 0 && tags.some((tag) => excludeTags.includes(tag));
   return shouldInclude && !shouldExclude;
 };
 


### PR DESCRIPTION
## Description

Fixes #7431

When a `.bru` file has a single tag defined as a string (e.g. `tags: ignore`), the BRU parser returns a `string` instead of `string[]`. This caused `--exclude-tags` to crash with `TypeError: e.some is not a function` because `String.prototype.some` does not exist.

## Root Cause

`isRequestTagsIncluded` in `@usebruno/common` called `.some()` directly on `requestTags` without normalizing the input, assuming it was always an array.

## Fix

Added a `toTagsArray` helper that normalizes `string | string[] | undefined | null` to `string[]`. Updated the function signature of `isRequestTagsIncluded` accordingly so any caller passing a raw string is also covered.

## Tests

Added 5 new test cases covering: single string tag with exclude/include, non-matching string, `undefined`, and `null`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag filtering to accept single strings, arrays, comma-separated values, and null/undefined inputs, preventing crashes and ensuring correct include/exclude behavior.

* **Tests**
  * Added comprehensive tests covering single-string, array, null/undefined, comma-separated, include, and exclude tag scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->