### PR TITLE
fix: prevent white flash on startup with dark theme

### DIFF
--- a/packages/bruno-app/src/providers/Theme/index.js
+++ b/packages/bruno-app/src/providers/Theme/index.js
@@ -52,9 +52,12 @@ export const ThemeProvider = (props) => {
     applyThemeToRoot(effectiveTheme);
 
     if (window.ipcRenderer) {
-      window.ipcRenderer.send('renderer:theme-change', storedTheme);
+      const isLight = effectiveTheme === 'light';
+      const variantName = isLight ? themeVariantLight : themeVariantDark;
+      const themeBg = themes[variantName]?.bg || (isLight ? '#ffffff' : '#1e1e1e');
+      window.ipcRenderer.send('renderer:theme-change', storedTheme, themeBg);
     }
-  }, [storedTheme]);
+  }, [storedTheme, themeVariantLight, themeVariantDark]);
 
   // storedTheme can have 3 values: 'light', 'dark', 'system'
   // displayedTheme can have 2 values: 'light', 'dark'

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -203,6 +203,9 @@ app.on('ready', async () => {
 
   Menu.setApplicationMenu(menu);
   const { maximized, x, y, width, height } = loadWindowState();
+  const WindowStateStore = require('./store/window-state');
+  const windowStateStore = new WindowStateStore();
+  const themeBg = windowStateStore.getThemeBg();
 
   mainWindow = new BrowserWindow({
     x,
@@ -212,6 +215,7 @@ app.on('ready', async () => {
     minWidth: 700,
     minHeight: 400,
     show: false,
+    backgroundColor: themeBg,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: true,

--- a/packages/bruno-electron/src/ipc/preferences.js
+++ b/packages/bruno-electron/src/ipc/preferences.js
@@ -7,6 +7,7 @@ const { getCachedSystemProxy, fetchSystemProxy } = require('../store/system-prox
 const { resolveDefaultLocation } = require('../utils/default-location');
 const onboardUser = require('../app/onboarding');
 const LastOpenedCollections = require('../store/last-opened-collections');
+const WindowStateStore = require('../store/window-state');
 const { clearAgentCache } = require('@usebruno/requests');
 
 const registerPreferencesIpc = (mainWindow) => {
@@ -66,8 +67,13 @@ const registerPreferencesIpc = (mainWindow) => {
     }
   });
 
-  ipcMain.on('renderer:theme-change', (event, theme) => {
+  ipcMain.on('renderer:theme-change', (event, theme, themeBg) => {
     nativeTheme.themeSource = theme;
+    const windowStateStore = new WindowStateStore();
+    windowStateStore.setThemeMode(theme);
+    if (themeBg) {
+      windowStateStore.setThemeBg(themeBg);
+    }
   });
 
   ipcMain.handle('renderer:get-system-proxy-variables', async () => {

--- a/packages/bruno-electron/src/store/window-state.js
+++ b/packages/bruno-electron/src/store/window-state.js
@@ -35,6 +35,22 @@ class WindowStateStore {
   setMaximized(isMaximized) {
     this.store.set('maximized', isMaximized);
   }
+
+  getThemeMode() {
+    return this.store.get('themeMode') || 'system';
+  }
+
+  setThemeMode(mode) {
+    this.store.set('themeMode', mode);
+  }
+
+  getThemeBg() {
+    return this.store.get('themeBg') || '#ffffff';
+  }
+
+  setThemeBg(bg) {
+    this.store.set('themeBg', bg);
+  }
 }
 
 module.exports = WindowStateStore;


### PR DESCRIPTION
### Description

- Persist the user's theme background color to electron-store via the existing renderer:theme-change IPC event
- Use the persisted background color as BrowserWindow.backgroundColor so the native window matches the theme before HTML loads
- Fixes the white flash visible when launching the app with a dark theme

Closes #7446 , #5224 

[JIRA](https://usebruno.atlassian.net/browse/BRU-2851)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme mode and background color preferences are now persisted and automatically restored when the application restarts.
  * Window background color is now properly synchronized with the active theme selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->