### PR TITLE
fix: convert non-string variable values to strings during postman import

### DIFF
--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -159,7 +159,7 @@ const importCollectionLevelVariables = (variables, requestObject) => {
   const vars = variables.filter((v) => !(v.key == null && v.value == null)).map((v) => ({
     uid: uuid(),
     name: (v.key ?? '').replace(invalidVariableCharacterRegex, '_'),
-    value: v.value ?? '',
+    value: v.value == null ? '' : typeof v.value === 'string' ? v.value : JSON.stringify(v.value),
     enabled: true
   }));
 

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
@@ -238,6 +238,43 @@ describe('postman-collection', () => {
     ]);
   });
 
+  it('should convert non-string variable values to strings', async () => {
+    const collectionWithNonStringVars = {
+      info: {
+        name: 'Non-String Variable Demo',
+        _postman_id: 'abcd1234-5678-90ef-ghij-1234567890ab',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      variable: [
+        { key: 'timeout', value: 5000 },
+        { key: 'enabled', value: true },
+        { key: 'user', value: { id: 1, name: 'Alice' } }
+      ],
+      item: [
+        {
+          name: 'Sample Request',
+          request: {
+            method: 'GET',
+            url: {
+              raw: 'https://postman-echo.com/get',
+              protocol: 'https',
+              host: ['postman-echo', 'com'],
+              path: ['get']
+            }
+          }
+        }
+      ]
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithNonStringVars);
+    const vars = brunoCollection.root.request.vars.req;
+
+    expect(vars).toHaveLength(3);
+    expect(vars[0]).toMatchObject({ name: 'timeout', value: '5000' });
+    expect(vars[1]).toMatchObject({ name: 'enabled', value: 'true' });
+    expect(vars[2]).toMatchObject({ name: 'user', value: '{"id":1,"name":"Alice"}' });
+  });
+
   it('should handle empty variables', async () => {
     const collectionWithEmptyVars = {
       info: {


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2575)

Postman collections can have variable values that are numbers, booleans, or objects. Previously, importing such collections into Bruno would fail because the converter expected all variable values to be strings.   

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of variable values during Postman to Bruno collection conversion to properly serialize non-string values.

* **Tests**
  * Added test coverage for variable value conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->