### PR TITLE
feat: remove .bru reference in error message

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/RequestNotFound/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/RequestNotFound/index.js
@@ -33,7 +33,7 @@ const RequestNotFound = ({ itemUid }) => {
   const errors = [
     {
       title: 'Request no longer exists',
-      message: 'This can happen when the .bru file associated with this request was deleted on your filesystem.'
+      message: 'This can happen when the file associated with this request was deleted on your filesystem.'
     }
   ];
 


### PR DESCRIPTION
### Description

Remove the .bru reference in the error message as it can be confusing when working with .yml files.

Before:

<img width="950" height="131" alt="image" src="https://github.com/user-attachments/assets/a2477e2d-8a07-4f5c-97b6-5d9118eed5a9" />

After:

<img width="920" height="137" alt="image" src="https://github.com/user-attachments/assets/49129bca-ad51-471b-a287-0baa2026abdb" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified error message displayed when a request's associated file cannot be located. The updated message now uses clearer language to provide better user guidance, enabling faster identification and resolution of file association issues. This improvement enhances the overall experience when troubleshooting missing file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->