### PR TITLE
fix: add missing scrollbar-color property

### DIFF
--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -187,11 +187,10 @@ const GlobalStyle = createGlobalStyle`
 
 
   // scrollbar styling
-  // the below media query target non-macos devices
-  // (macos scrollbar styling is the ideal style reference)
+  // the below media query targets non-touch devices
   @media not all and (pointer: coarse) {
     * {
-      scrollbar-color: ${(props) => props.theme.scrollbar.color};
+      scrollbar-color: ${(props) => props.theme.scrollbar.color} transparent;
     }
 
     *::-webkit-scrollbar {


### PR DESCRIPTION
### Description

Fixes scrollbar appearing with white background on MacOS devices.

The `scrollbar-color` property only had a single color value but the CSS spec requires two values (background and scroller).
Adding `transparent` as the scroller color makes the property valid, therefore fixes the problem.

Also, corrected misleading comment above about the media query.

---

**Before:**
<img width="528" height="298" alt="image" src="https://github.com/user-attachments/assets/7ef74bf6-bd3a-4b55-b356-1f5239cc92b0" />

**After:**
<img width="532" height="301" alt="image" src="https://github.com/user-attachments/assets/773b77ec-6db0-47de-b50e-89affe8c85e5" />

### Closes:
Found https://github.com/usebruno/bruno/issues/7472 describing the same problem I encountered.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scrollbar styling on non-touch devices for improved visual appearance with a transparent track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->