### PR TITLE
feat: allow user to change default workspace location (#6816)

### DIFF
--- a/packages/bruno-app/src/components/ManageWorkspace/index.js
+++ b/packages/bruno-app/src/components/ManageWorkspace/index.js
@@ -8,6 +8,7 @@ import { showHomePage } from 'providers/ReduxStore/slices/app';
 import { createWorkspaceWithUniqueName, switchWorkspace } from 'providers/ReduxStore/slices/workspaces/actions';
 import { showInFolder } from 'providers/ReduxStore/slices/collections/actions';
 import { sortWorkspaces } from 'utils/workspaces';
+import { updateWorkspace } from 'providers/ReduxStore/slices/workspaces';
 
 import CreateWorkspace from 'components/WorkspaceSidebar/CreateWorkspace';
 import RenameWorkspace from './RenameWorkspace';
@@ -59,6 +60,28 @@ const ManageWorkspace = () => {
       return;
     }
     setDeleteWorkspaceModal({ open: true, workspace });
+  };
+
+  const handleSetAsDefault = async (workspace) => {
+    if (workspace.type === 'default' || !workspace.pathname) return;
+    const currentDefault = workspaces.find((w) => w.type === 'default');
+    try {
+      const result = await window.ipcRenderer.invoke('renderer:set-default-workspace-path', workspace.pathname);
+      if (!result?.success) {
+        throw new Error('Failed to set default workspace');
+      }
+      if (currentDefault && !result.previousDefaultUid) {
+        toast.error('Failed to resolve previous default workspace');
+        return;
+      }
+      if (currentDefault) {
+        dispatch(updateWorkspace({ uid: currentDefault.uid, newUid: result.previousDefaultUid, type: 'workspace' }));
+      }
+      dispatch(updateWorkspace({ uid: workspace.uid, newUid: 'default', type: 'default' }));
+      toast.success(`${workspace.name} set as default workspace`);
+    } catch (err) {
+      toast.error('Failed to set default workspace');
+    }
   };
 
   const handleCreateWorkspace = async () => {
@@ -158,8 +181,9 @@ const ManageWorkspace = () => {
                       placement="bottom-end"
                       items={[
                         { id: 'rename', label: 'Rename', onClick: () => handleRenameClick(workspace) },
-                        { id: 'remove', label: 'Remove', onClick: () => handleCloseClick(workspace) }
-                      ]}
+                        { id: 'remove', label: 'Remove', onClick: () => handleCloseClick(workspace) },
+                        workspace.pathname && { id: 'set_as_default', label: 'Set as default', onClick: () => handleSetAsDefault(workspace) }
+                      ].filter(Boolean)}
                     >
                       <button className="more-actions-btn">
                         <IconDots size={14} strokeWidth={1.5} />

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/index.js
@@ -38,10 +38,16 @@ export const workspacesSlice = createSlice({
     },
 
     updateWorkspace: (state, action) => {
-      const { uid, ...updates } = action.payload;
+      const { uid, newUid, ...updates } = action.payload;
       const workspace = state.workspaces.find((w) => w.uid === uid);
       if (workspace) {
         Object.assign(workspace, updates);
+        if (newUid) {
+          if (state.activeWorkspaceUid === uid) {
+            state.activeWorkspaceUid = newUid;
+          }
+          workspace.uid = newUid;
+        }
       }
     },
 

--- a/packages/bruno-electron/src/app/apiSpecs.js
+++ b/packages/bruno-electron/src/app/apiSpecs.js
@@ -25,7 +25,7 @@ const prepareWorkspaceConfigForClient = (workspaceConfig, isDefault) => {
   if (isDefault) {
     return {
       ...workspaceConfig,
-      name: DEFAULT_WORKSPACE_NAME,
+      name: workspaceConfig.name || DEFAULT_WORKSPACE_NAME,
       type: 'default'
     };
   }

--- a/packages/bruno-electron/src/app/workspace-watcher.js
+++ b/packages/bruno-electron/src/app/workspace-watcher.js
@@ -51,7 +51,7 @@ const handleWorkspaceFileChange = (win, workspacePath) => {
 
     win.webContents.send('main:workspace-config-updated', workspacePath, workspaceUid, {
       ...workspaceConfig,
-      name: isDefault ? DEFAULT_WORKSPACE_NAME : workspaceConfig.name,
+      name: isDefault ? (workspaceConfig.name || DEFAULT_WORKSPACE_NAME) : workspaceConfig.name,
       type: isDefault ? 'default' : workspaceConfig.type
     });
   } catch (error) {

--- a/packages/bruno-electron/src/ipc/workspace.js
+++ b/packages/bruno-electron/src/ipc/workspace.js
@@ -51,7 +51,7 @@ const prepareWorkspaceConfigForClient = (workspaceConfig, workspacePath, isDefau
   if (isDefault) {
     return {
       ...config,
-      name: DEFAULT_WORKSPACE_NAME,
+      name: config.name || DEFAULT_WORKSPACE_NAME,
       type: 'default'
     };
   }
@@ -622,6 +622,22 @@ const registerWorkspaceIpc = (mainWindow, workspaceWatcher) => {
     }
   });
 
+  ipcMain.handle('renderer:set-default-workspace-path', async (event, workspacePath) => {
+    try {
+      validateWorkspacePath(workspacePath);
+      const workspaceConfig = readWorkspaceConfig(workspacePath);
+      validateWorkspaceConfig(workspaceConfig);
+      const previousDefaultPath = defaultWorkspaceManager.getDefaultWorkspacePath();
+      await defaultWorkspaceManager.setDefaultWorkspacePath(workspacePath);
+      return {
+        success: true,
+        previousDefaultUid: previousDefaultPath ? getWorkspaceUid(previousDefaultPath) : null
+      };
+    } catch (error) {
+      throw error;
+    }
+  });
+
   ipcMain.handle('renderer:get-default-workspace', async (event) => {
     try {
       const result = await defaultWorkspaceManager.ensureDefaultWorkspaceExists();
@@ -662,6 +678,8 @@ const registerWorkspaceIpc = (mainWindow, workspaceWatcher) => {
         defaultWorkspacePath = workspacePath;
         const workspaceConfig = readWorkspaceConfig(workspacePath);
         const configForClient = prepareWorkspaceConfigForClient(workspaceConfig, workspacePath, true);
+
+        lastOpenedWorkspaces.add(workspacePath);
 
         win.webContents.send('main:workspace-opened', workspacePath, workspaceUid, configForClient);
 


### PR DESCRIPTION
Add "Set as default" option to workspace context menu, persist the default workspace in lastOpenedWorkspaces to prevent losing it on change, and preserve the original workspace name instead of always overriding it with "My Workspace".

### Description

<img width="1730" height="764" alt="image" src="https://github.com/user-attachments/assets/32f573cf-69b9-423c-b33a-a93f68a7629e" />

fixes: #6816


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Set as default" action in the workspace context menu to mark any workspace as your default.

* **Improvements**
  * Preserve custom workspace names when a workspace is designated as default.
  * Ensure the default workspace is recorded among recently opened workspaces so it appears in open/tracking flows.
  * State update now supports changing a workspace identifier and keeps the active workspace reference in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->