### PR TITLE
fix: make the folder runner spinner consistent with the single-request spinner

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RunnerResults/StyledWrapper.js
@@ -114,6 +114,11 @@ const Wrapper = styled.div`
     }
   }
 
+  .loading-icon {
+    transform: scaleY(-1);
+    animation: rotateCounterClockwise 1s linear infinite;
+  }
+
   .filter-button {
     display: inline-flex;
     align-items: center;

--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -444,7 +444,7 @@ export default function RunnerResults({ collection }) {
                         {item.displayName}
                       </span>
                       {item.status !== 'error' && item.status !== 'skipped' && item.status !== 'completed' ? (
-                        <IconRefresh className="animate-spin ml-1" size={18} strokeWidth={1.5} />
+                        <IconRefresh className="loading-icon ml-1" size={18} strokeWidth={1.5} />
                       ) : item.responseReceived?.status ? (
                         <span className="text-xs link cursor-pointer" onClick={() => setSelectedItem(item)}>
                           <span className="mr-1">{item.responseReceived?.status}</span>


### PR DESCRIPTION
### Description

This makes the folder runner spinner consistent with the single-request spinner. 
The arrows were pointing the wrong way.

Before

https://github.com/user-attachments/assets/8db05a28-3f72-4705-9ad0-a727ca9a5f43

After

https://github.com/user-attachments/assets/df1babdc-f021-4470-a4ee-393c26a07bf1

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the runner results loading indicator with a vertically flipped visual treatment and continuous one-second counterclockwise rotation.
* **Accessibility**
  * Added status semantics and a descriptive label to indicate when a request is running.
* **Layout**
  * Improved the runner toolbar layout across different screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->