### PR TITLE
fix: CLI form-urlencoded body mode mismatch

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -356,7 +356,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
     }
   }
 
-  if (request.body.mode === 'formUrlEncoded') {
+  if (request.body.mode === 'formUrlEncoded' || request.body.mode === 'form-urlencoded') {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'application/x-www-form-urlencoded';
     }


### PR DESCRIPTION
### Description

Fixes a bug where Bruno CLI sends `Content-Length: 0` with an empty body for all `body:form-urlencoded` requests while Bruno GUI works correctly.

#### Contribution Checklist:

- [ ] I've used AI significantly to create this pull request
- [x] The pull request only addresses one issue or adds one feature.
- [x] The pull request does not introduce any breaking changes
- [x] I have added screenshots or gifs to help explain the change if applicable.
- [x] I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).

### Root Cause

The `.bru` file parser chain (`@usebruno/lang` → `@usebruno/filestore` `parseRequest()`) outputs `body.mode` as `"form-urlencoded"` (hyphenated string), but `prepare-request.js` only checks for `"formUrlEncoded"` (camelCase):

```javascript
// prepare-request.js line 358
if (request.body.mode === 'formUrlEncoded') {  // never matches "form-urlencoded"
    axiosRequest.data = enabledParams;          // data is never assigned
}
```

This causes `axiosRequest.data` to remain `undefined`, and `qs.stringify(undefined)` produces `""`, resulting in `Content-Length: 0`.

**Note**: Other body modes (`json`, `text`, `xml`, `sparql`) are not affected because their mode strings are consistent between the parser and `prepare-request.js`.

### Evidence

Verified by instrumenting the CLI source with debug logs:

```
[DEBUG] body.mode: "form-urlencoded"   ← parser output
[DEBUG] check: 'formUrlEncoded'        ← prepare-request.js comparison
[DEBUG] request.data: undefined        ← never assigned
```

Diagnostic HTTP server captured:
- **Bruno CLI form-urlencoded (before fix)**: Content-Length: 0, body empty ❌
- **Bruno CLI JSON (control group)**: Content-Length: 132, body present ✅
- **curl form-urlencoded**: Content-Length: 65, body present ✅
- **Bruno CLI form-urlencoded (after fix)**: Content-Length: 276, body present ✅

### Fix

Add `|| request.body.mode === 'form-urlencoded'` to accept both naming conventions:

```diff
- if (request.body.mode === 'formUrlEncoded') {
+ if (request.body.mode === 'formUrlEncoded' || request.body.mode === 'form-urlencoded') {
```

### Related

- #6916 — Similar exact-string-match issue in `packages/bruno-electron/src/ipc/network/index.js` for Content-Type header parsing
- #6917 — Fix for #6916 (Content-Type charset/boundary handling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form URL encoding handling in the CLI to recognize both 'formUrlEncoded' and 'form-urlencoded' naming conventions, ensuring consistent request body processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->