### PR TITLE
fix(import): resolve EEXIST error when importing OpenAPI collections with paths folder arrangement

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1186,7 +1186,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             if (item.type === 'folder') {
               let sanitizedFolderName = sanitizeName(item?.filename || item?.name);
               const folderPath = path.join(currentPath, sanitizedFolderName);
-              fs.mkdirSync(folderPath);
+              fs.mkdirSync(folderPath, { recursive: true });
 
               if (item?.root?.meta?.name) {
                 const folderFilePath = path.join(folderPath, `folder.${format}`);


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2872)

### Problem
Importing an OpenAPI spec using the Paths folder arrangement fails with:

Error EEXIST: file already exists, mkdir '.../{customerID}'
The collection directory is partially created on disk but never opens in Bruno. This affects both macOS and Windows.

### Root cause
The import handler calls fs.mkdirSync(folderPath) without { recursive: true }. When a spec contains paths with the same path parameter name in different casing (e.g. {customerId} and {customerID}), the path-based grouper creates two distinct folder items for them. On case-insensitive filesystems, both map to the same directory — the second mkdirSync call throws EEXIST, aborting the import and preventing main:collection-opened from firing.

### Fix
Pass { recursive: true } to mkdirSync in parseCollectionItems inside the renderer:import-collection handler. This silently succeeds if the directory already exists instead of throwing, allowing the import to complete. Both sets of requests are written into the same folder, which is the correct behavior since they represent the same URL pattern.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where creating nested folder structures would fail if parent directories didn't exist. The system now automatically creates all required parent directories when adding new folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->