### PR TITLE
feat(bruno-js): add hasCookie function to cookie jar shim

### DIFF
--- a/packages/bruno-js/src/sandbox/quickjs/shims/bru.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bru.js
@@ -471,6 +471,20 @@ const addBruShimToContext = (vm, bru) => {
     });
     _deleteCookieFn.consume((handle) => vm.setProp(jarObj, '_deleteCookie', handle));
 
+    const _hasCookieFn = vm.newFunction('_hasCookie', (url, cookieName) => {
+      const promise = vm.newPromise();
+      nativeJar.hasCookie(vm.dump(url), vm.dump(cookieName), (err, exists) => {
+        if (err) {
+          promise.reject(marshallToVm(cleanJson(err), vm));
+        } else {
+          promise.resolve(marshallToVm(exists, vm));
+        }
+      });
+      promise.settled.then(vm.runtime.executePendingJobs);
+      return promise.handle;
+    });
+    _hasCookieFn.consume((handle) => vm.setProp(jarObj, '_hasCookie', handle));
+
     return jarObj;
   });
   _jarFn.consume((handle) => vm.setProp(bruCookiesObject, '_jar', handle));
@@ -540,7 +554,8 @@ const addBruShimToContext = (vm, bru) => {
         setCookies: (url, cookiesArray, cb) => callWithCallback(() => _jar._setCookies(url, cookiesArray), cb),
         clear: (cb) => callWithCallback(() => _jar._clear(), cb),
         deleteCookies: (url, cb) => callWithCallback(() => _jar._deleteCookies(url), cb),
-        deleteCookie: (url, name, cb) => callWithCallback(() => _jar._deleteCookie(url, name), cb)
+        deleteCookie: (url, name, cb) => callWithCallback(() => _jar._deleteCookie(url, name), cb),
+        hasCookie: (url, name, cb) => callWithCallback(() => _jar._hasCookie(url, name), cb)
       };
     };
   `);


### PR DESCRIPTION


### Description

add missing quick js shim for hasCookie

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hasCookie()` method to the bru.cookies.jar API for checking cookie existence by URL and name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->