### PR TITLE
fix: coerce numeric header values to string during Postman collection import

### DIFF
--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -617,7 +617,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
               example.request.headers.push({
                 uid: uuid(),
                 name: header.key ?? '',
-                value: header.value ?? '',
+                value: String(header.value ?? ''),
                 description: transformDescription(header.description),
                 enabled: !header.disabled
               });
@@ -718,7 +718,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
               example.response.headers.push({
                 uid: uuid(),
                 name: header.key ?? '',
-                value: header.value ?? '',
+                value: String(header.value ?? ''),
                 description: transformDescription(header.description),
                 enabled: true
               });


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2927)

## Summary
- Postman collections can have numeric values in response/request headers (e.g., `200` instead of `"200"`)
- Bruno's schema validation expects header values to be strings, causing import to fail with `items[N].examples[N].response.headers[N].value must be a 'string' type`
- Wrapped `header.value` in `String()` for example request and response headers, matching the existing pattern already used for regular request headers (line 530)

## Changes
- `packages/bruno-converters/src/postman/postman-to-bruno.js`
  - Example request headers (line 620): `header.value ?? ''` → `String(header.value ?? '')`
  - Example response headers (line 721): `header.value ?? ''` → `String(header.value ?? '')`

## Test plan
- [ ] Import a Postman collection containing responses with numeric header values (e.g., status code `200` as a number)
- [ ] Verify the collection imports successfully without schema validation errors
- [ ] Verify imported header values are preserved correctly as strings


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of header values when importing Postman collections to ensure consistent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->