### PR TITLE
collapsible request/response split in request tab

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/CollapsedPanelIndicator/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/CollapsedPanelIndicator/StyledWrapper.js
@@ -12,8 +12,9 @@ const StyledWrapper = styled.div`
     background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
   }
 
-  &:focus {
-    outline: none;
+  &:focus-visible {
+    outline: 1px solid ${(props) => props.theme.requestTabPanel.dragbar.activeBorder};
+    outline-offset: -1px;
   }
 
   .panel-label {

--- a/packages/bruno-app/src/components/RequestTabPanel/CollapsedPanelIndicator/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/CollapsedPanelIndicator/StyledWrapper.js
@@ -1,0 +1,126 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${(props) => props.theme.bg};
+  transition: background-color 0.15s ease;
+  user-select: none;
+
+  &:hover {
+    background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  .panel-label {
+    font-size: 10px;
+    font-weight: 500;
+    color: ${(props) => props.theme.colors.text.muted};
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .expand-icon {
+    color: ${(props) => props.theme.colors.text.muted};
+    opacity: 0.6;
+    flex-shrink: 0;
+  }
+
+  &:hover .expand-icon {
+    opacity: 1;
+    color: ${(props) => props.theme.text};
+  }
+
+  &:hover .panel-label {
+    color: ${(props) => props.theme.text};
+  }
+
+  /* Horizontal layout - panels stacked on left or right */
+  &.horizontal {
+    width: 32px;
+    min-width: 32px;
+    height: 100%;
+    cursor: pointer;
+    border-left: 1px solid ${(props) => props.theme.requestTabPanel.dragbar.border};
+    border-right: 1px solid ${(props) => props.theme.requestTabPanel.dragbar.border};
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      width: 8px;
+      height: 100%;
+      cursor: col-resize;
+      z-index: 2;
+    }
+
+    .indicator-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) rotate(-90deg);
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      white-space: nowrap;
+    }
+
+    &.request {
+      border-left: none;
+      &::before { right: -4px; }
+    }
+
+    &.response {
+      border-right: none;
+      &::before { left: -4px; }
+    }
+  }
+
+  /* Vertical layout - panels stacked on top or bottom */
+  &.vertical {
+    width: 100%;
+    height: 28px;
+    min-height: 28px;
+    flex-direction: row;
+    cursor: pointer;
+    border-top: 1px solid ${(props) => props.theme.requestTabPanel.dragbar.border};
+    border-bottom: 1px solid ${(props) => props.theme.requestTabPanel.dragbar.border};
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      width: 100%;
+      height: 8px;
+      cursor: row-resize;
+      z-index: 2;
+    }
+
+    .indicator-content {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 6px;
+    }
+
+    &.request {
+      border-top: none;
+      &::before { bottom: -4px; }
+    }
+
+    &.response {
+      border-bottom: none;
+      &::before { top: -4px; }
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/RequestTabPanel/CollapsedPanelIndicator/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/CollapsedPanelIndicator/index.js
@@ -19,8 +19,9 @@ const CollapsedPanelIndicator = ({
   const handlePointerDown = useCallback((e) => {
     if (e.button !== 0) return;
     e.currentTarget.setPointerCapture(e.pointerId);
+    e.currentTarget.style.cursor = isVertical ? 'row-resize' : 'col-resize';
     pointerDownRef.current = { x: e.clientX, y: e.clientY };
-  }, []);
+  }, [isVertical]);
 
   const handlePointerMove = useCallback((e) => {
     if (!pointerDownRef.current) return;
@@ -36,6 +37,7 @@ const CollapsedPanelIndicator = ({
   const handlePointerUp = useCallback((e) => {
     if (!pointerDownRef.current) return;
     pointerDownRef.current = null;
+    e.currentTarget.style.cursor = '';
     e.currentTarget.releasePointerCapture(e.pointerId);
     onExpand();
   }, [onExpand]);
@@ -43,6 +45,7 @@ const CollapsedPanelIndicator = ({
   const handlePointerCancel = useCallback((e) => {
     if (!pointerDownRef.current) return;
     pointerDownRef.current = null;
+    e.currentTarget.style.cursor = '';
     e.currentTarget.releasePointerCapture(e.pointerId);
   }, []);
 

--- a/packages/bruno-app/src/components/RequestTabPanel/CollapsedPanelIndicator/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/CollapsedPanelIndicator/index.js
@@ -1,0 +1,77 @@
+import React, { useRef, useCallback } from 'react';
+import { IconChevronDown, IconChevronUp } from '@tabler/icons';
+import StyledWrapper from './StyledWrapper';
+
+const CollapsedPanelIndicator = ({
+  panelType, // 'request' or 'response'
+  isVertical,
+  onExpand,
+  onDragStart,
+  dragThresholdPx
+}) => {
+  const dragThresholdSq = dragThresholdPx * dragThresholdPx; // to use in distance check
+  const label = panelType === 'request' ? 'Request' : 'Response';
+
+  const ChevronIcon = panelType === 'request' ? IconChevronDown : IconChevronUp;
+
+  const pointerDownRef = useRef(null);
+
+  const handlePointerDown = useCallback((e) => {
+    if (e.button !== 0) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    pointerDownRef.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const handlePointerMove = useCallback((e) => {
+    if (!pointerDownRef.current) return;
+    const dx = e.clientX - pointerDownRef.current.x;
+    const dy = e.clientY - pointerDownRef.current.y;
+    if (dx * dx + dy * dy > dragThresholdSq) {
+      pointerDownRef.current = null;
+      e.currentTarget.releasePointerCapture(e.pointerId);
+      onDragStart?.(e);
+    }
+  }, [onDragStart, dragThresholdSq]);
+
+  const handlePointerUp = useCallback((e) => {
+    if (!pointerDownRef.current) return;
+    pointerDownRef.current = null;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    onExpand();
+  }, [onExpand]);
+
+  const handlePointerCancel = useCallback((e) => {
+    if (!pointerDownRef.current) return;
+    pointerDownRef.current = null;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+  }, []);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onExpand();
+    }
+  }, [onExpand]);
+
+  return (
+    <StyledWrapper
+      className={`collapsed-panel-indicator ${isVertical ? 'vertical' : 'horizontal'} ${panelType}`}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      role="button"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      aria-label={`Expand ${label} pane`}
+      title={`Click to expand ${label} pane, or drag to resize`}
+    >
+      <div className="indicator-content">
+        <ChevronIcon size={14} strokeWidth={2} className="expand-icon" />
+        <span className="panel-label">{label}</span>
+      </div>
+    </StyledWrapper>
+  );
+};
+
+export default CollapsedPanelIndicator;

--- a/packages/bruno-app/src/components/RequestTabPanel/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/StyledWrapper.js
@@ -17,56 +17,89 @@ const StyledWrapper = styled.div`
     min-width: 0;
   }
 
+  .main {
+    padding-bottom: 1rem;
+  }
+
+  &.request-collapsed .query-url-wrapper,
+  &.response-collapsed .query-url-wrapper {
+    padding-bottom: 0;
+  }
+
+  &.request-collapsed .main,
+  &.response-collapsed .main {
+    padding-bottom: 0;
+  }
+
+  &.request-collapsed .response-pane,
+  &.response-collapsed .request-pane {
+    padding-top: 1rem;
+  }
+
   div.dragbar-wrapper {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 10px;
-    min-width: 10px;
+    width: 12px;
+    min-width: 12px;
     padding: 0;
     cursor: col-resize;
     background: transparent;
     position: relative;
+    z-index: 1;
 
     div.dragbar-handle {
       display: flex;
       height: 100%;
       width: 1px;
       border-left: solid 1px ${(props) => props.theme.requestTabPanel.dragbar.border};
+      pointer-events: none;
     }
 
     &:hover div.dragbar-handle {
       border-left: solid 1px ${(props) => props.theme.requestTabPanel.dragbar.activeBorder};
     }
+
   }
 
   &.vertical-layout {
     .request-pane {
       padding-bottom: 0.5rem;
+
     }
 
     .response-pane {
       padding-top: 0.5rem;
     }
+    &.request-collapsed .response-pane {
+      padding-top: 0;
+    }
+
+    &.response-collapsed .request-pane {
+      padding-bottom: 0;
+    }
 
     div.dragbar-wrapper {
       width: 100%;
-      height: 10px;
+      height: 12px;
       cursor: row-resize;
       padding: 0 1rem;
       position: relative;
+      z-index: 1;
 
       div.dragbar-handle {
         width: 100%;
         height: 1px;
         border-left: none;
         border-top: solid 1px ${(props) => props.theme.requestTabPanel.dragbar.border};
+        pointer-events: none;
       }
 
       &:hover div.dragbar-handle {
         border-left: none;
         border-top: solid 1px ${(props) => props.theme.requestTabPanel.dragbar.activeBorder};
       }
+
     }
   }
 

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -426,20 +426,20 @@ const RequestTabPanel = () => {
 
     return isVerticalLayout
       ? {
-        height: `${Math.max(topPaneHeight, MIN_TOP_PANE_HEIGHT)}px`,
-        minHeight: `${MIN_TOP_PANE_HEIGHT}px`,
-        width: '100%'
-      }
+          height: `${Math.max(topPaneHeight, MIN_TOP_PANE_HEIGHT)}px`,
+          minHeight: `${MIN_TOP_PANE_HEIGHT}px`,
+          width: '100%'
+        }
       : {
-        width: `${Math.max(leftPaneWidth, MIN_LEFT_PANE_WIDTH)}px`
-      };
+          width: `${Math.max(leftPaneWidth, MIN_LEFT_PANE_WIDTH)}px`
+        };
   };
 
   return (
     <ScopedPersistenceProvider scope={focusedTab.uid}>
       <StyledWrapper
         className={`flex flex-col flex-grow relative ${dragging ? 'dragging' : ''} ${isVerticalLayout ? 'vertical-layout' : ''
-          } ${requestPaneCollapsed ? 'request-collapsed' : ''} ${responsePaneCollapsed ? 'response-collapsed' : ''}`}
+        } ${requestPaneCollapsed ? 'request-collapsed' : ''} ${responsePaneCollapsed ? 'response-collapsed' : ''}`}
       >
         <div className="query-url-wrapper pt-3 pb-4 px-4">
           {renderQueryUrl()}

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -41,11 +41,13 @@ import EnvironmentSettings from 'components/Environments/EnvironmentSettings';
 import GlobalEnvironmentSettings from 'components/Environments/GlobalEnvironmentSettings';
 import OpenAPISyncTab from 'components/OpenAPISyncTab';
 import OpenAPISpecTab from 'components/OpenAPISpecTab';
+import CollapsedPanelIndicator from './CollapsedPanelIndicator';
 
 const MIN_LEFT_PANE_WIDTH = 300;
 const MIN_RIGHT_PANE_WIDTH = 490;
 const MIN_TOP_PANE_HEIGHT = 150;
 const MIN_BOTTOM_PANE_HEIGHT = 150;
+const COLLAPSE_EDGE_THRESHOLD = 80;
 
 const RequestTabPanel = () => {
   const dispatch = useDispatch();
@@ -91,8 +93,21 @@ const RequestTabPanel = () => {
   const collection = find(collections, (c) => c.uid === focusedTab?.collectionUid);
   const [dragging, setDragging] = useState(false);
   const draggingRef = useRef(false);
+  const dragStartRef = useRef(null);
 
-  const { left: leftPaneWidth, top: topPaneHeight, reset: resetPaneBoundaries, setTop: setTopPaneHeight, setLeft: setLeftPaneWidth } = useTabPaneBoundaries(activeTabUid);
+  const {
+    left: leftPaneWidth,
+    top: topPaneHeight,
+    reset: resetPaneBoundaries,
+    setTop: setTopPaneHeight,
+    setLeft: setLeftPaneWidth,
+    requestPaneCollapsed,
+    responsePaneCollapsed,
+    collapseRequest,
+    expandRequest,
+    collapseResponse,
+    expandResponse
+  } = useTabPaneBoundaries(activeTabUid);
   const previousTopPaneHeight = useRef(null); // Store height before devtools opens
 
   // Not a recommended pattern here to have the child component
@@ -119,40 +134,87 @@ const RequestTabPanel = () => {
     }
   }, [dispatch, activeTabUid, showGqlDocs]);
 
+  // Refs for panel collapse functions
+  const collapseRequestRef = useRef(collapseRequest);
+  const collapseResponseRef = useRef(collapseResponse);
+  useEffect(() => {
+    collapseRequestRef.current = collapseRequest;
+    collapseResponseRef.current = collapseResponse;
+  }, [collapseRequest, collapseResponse]);
+
+  const stopDragging = useCallback(() => {
+    draggingRef.current = false;
+    dragStartRef.current = null;
+    setDragging(false);
+  }, []);
+
   const handleMouseMove = useCallback((e) => {
-    if (!draggingRef.current || !mainSectionRef.current) return;
+    if (!draggingRef.current || !mainSectionRef.current || !dragStartRef.current) return;
 
     e.preventDefault();
     const mainRect = mainSectionRef.current.getBoundingClientRect();
+    const dragStart = dragStartRef.current;
 
     if (isVerticalLayoutRef.current) {
       const newHeight = e.clientY - mainRect.top;
       const maxHeight = mainRect.height - MIN_BOTTOM_PANE_HEIGHT;
-      // Clamp to bounds instead of returning early
+      const distanceFromBottom = mainRect.bottom - e.clientY;
+
+      if (e.clientY < dragStart.y && newHeight < COLLAPSE_EDGE_THRESHOLD) {
+        collapseRequestRef.current();
+        return stopDragging();
+      }
+
+      if (e.clientY > dragStart.y && distanceFromBottom < COLLAPSE_EDGE_THRESHOLD) {
+        collapseResponseRef.current();
+        return stopDragging();
+      }
+
       const clampedHeight = Math.max(MIN_TOP_PANE_HEIGHT, Math.min(newHeight, maxHeight));
       setTopPaneHeight(clampedHeight);
     } else {
       const newWidth = e.clientX - mainRect.left;
       const maxWidth = mainRect.width - MIN_RIGHT_PANE_WIDTH;
-      // Clamp to bounds instead of returning early
+      const distanceFromRight = mainRect.right - e.clientX;
+
+      if (e.clientX < dragStart.x && newWidth < COLLAPSE_EDGE_THRESHOLD) {
+        collapseRequestRef.current();
+        return stopDragging();
+      }
+
+      if (e.clientX > dragStart.x && distanceFromRight < COLLAPSE_EDGE_THRESHOLD) {
+        collapseResponseRef.current();
+        return stopDragging();
+      }
+
       const clampedWidth = Math.max(MIN_LEFT_PANE_WIDTH, Math.min(newWidth, maxWidth));
       setLeftPaneWidth(clampedWidth);
     }
-  }, [setTopPaneHeight, setLeftPaneWidth]);
+  }, [setTopPaneHeight, setLeftPaneWidth, stopDragging]);
 
   const handleMouseUp = useCallback((e) => {
     if (draggingRef.current) {
       e.preventDefault();
-      draggingRef.current = false;
-      setDragging(false);
+      stopDragging();
     }
-  }, []);
+  }, [stopDragging]);
 
-  const handleDragbarMouseDown = useCallback((e) => {
+  const startDragging = useCallback((e) => {
     e.preventDefault();
     draggingRef.current = true;
+    dragStartRef.current = { x: e.clientX, y: e.clientY };
     setDragging(true);
   }, []);
+
+  const handleRequestIndicatorDragStart = useCallback((e) => {
+    expandRequest();
+    startDragging(e);
+  }, [expandRequest, startDragging]);
+
+  const handleResponseIndicatorDragStart = useCallback((e) => {
+    expandResponse();
+    startDragging(e);
+  }, [expandResponse, startDragging]);
 
   useEffect(() => {
     document.addEventListener('mouseup', handleMouseUp);
@@ -355,50 +417,76 @@ const RequestTabPanel = () => {
     }
   };
 
-  const requestPaneStyle = isVerticalLayout
-    ? {
+  const getRequestPaneStyle = () => {
+    if (responsePaneCollapsed) {
+      return isVerticalLayout
+        ? { flex: 1, width: '100%' }
+        : { flex: 1 };
+    }
+
+    return isVerticalLayout
+      ? {
         height: `${Math.max(topPaneHeight, MIN_TOP_PANE_HEIGHT)}px`,
         minHeight: `${MIN_TOP_PANE_HEIGHT}px`,
         width: '100%'
       }
-    : {
+      : {
         width: `${Math.max(leftPaneWidth, MIN_LEFT_PANE_WIDTH)}px`
       };
+  };
 
   return (
     <ScopedPersistenceProvider scope={focusedTab.uid}>
       <StyledWrapper
-        className={`flex flex-col flex-grow relative ${dragging ? 'dragging' : ''} ${
-          isVerticalLayout ? 'vertical-layout' : ''
-        }`}
+        className={`flex flex-col flex-grow relative ${dragging ? 'dragging' : ''} ${isVerticalLayout ? 'vertical-layout' : ''
+          } ${requestPaneCollapsed ? 'request-collapsed' : ''} ${responsePaneCollapsed ? 'response-collapsed' : ''}`}
       >
-        <div className="pt-3 pb-3 px-4">
+        <div className="query-url-wrapper pt-3 pb-4 px-4">
           {renderQueryUrl()}
         </div>
-        <section ref={mainSectionRef} className={`main flex ${isVerticalLayout ? 'flex-col' : ''} flex-grow pb-4 relative overflow-auto`}>
-          <section className="request-pane" data-testid="request-pane">
+        <section ref={mainSectionRef} className={`main flex ${isVerticalLayout ? 'flex-col' : ''} flex-grow relative overflow-auto`}>
+          {requestPaneCollapsed ? (
+            <CollapsedPanelIndicator
+              panelType="request"
+              isVertical={isVerticalLayout}
+              onExpand={expandRequest}
+              onDragStart={handleRequestIndicatorDragStart}
+              dragThresholdPx={isVerticalLayout ? MIN_TOP_PANE_HEIGHT / 2 : MIN_LEFT_PANE_WIDTH / 2}
+            />
+          ) : (
+            <section className="request-pane" data-testid="request-pane" style={getRequestPaneStyle()}>
+              <div className="px-4 h-full">
+                {renderRequestPane()}
+              </div>
+            </section>
+          )}
+
+          {!requestPaneCollapsed && !responsePaneCollapsed && (
             <div
-              className="px-4 h-full"
-              style={requestPaneStyle}
+              className="dragbar-wrapper"
+              onDoubleClick={(e) => {
+                e.preventDefault();
+                resetPaneBoundaries();
+              }}
+              onMouseDown={startDragging}
             >
-              {renderRequestPane()}
+              <div className="dragbar-handle" />
             </div>
-          </section>
+          )}
 
-          <div
-            className="dragbar-wrapper"
-            onDoubleClick={(e) => {
-              e.preventDefault();
-              resetPaneBoundaries();
-            }}
-            onMouseDown={handleDragbarMouseDown}
-          >
-            <div className="dragbar-handle" />
-          </div>
-
-          <section className="response-pane flex-grow overflow-x-auto" data-testid="response-pane">
-            {renderResponsePane()}
-          </section>
+          {responsePaneCollapsed ? (
+            <CollapsedPanelIndicator
+              panelType="response"
+              isVertical={isVerticalLayout}
+              onExpand={expandResponse}
+              onDragStart={handleResponseIndicatorDragStart}
+              dragThresholdPx={isVerticalLayout ? MIN_BOTTOM_PANE_HEIGHT / 2 : MIN_RIGHT_PANE_WIDTH / 2}
+            />
+          ) : (
+            <section className="response-pane flex-grow overflow-x-auto" data-testid="response-pane" style={requestPaneCollapsed ? { flex: 1 } : undefined}>
+              {renderResponsePane()}
+            </section>
+          )}
         </section>
 
         {item.type === 'graphql-request' ? (

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -48,6 +48,7 @@ const MIN_RIGHT_PANE_WIDTH = 490;
 const MIN_TOP_PANE_HEIGHT = 150;
 const MIN_BOTTOM_PANE_HEIGHT = 150;
 const COLLAPSE_EDGE_THRESHOLD = 80;
+const EXPAND_EDGE_THRESHOLD = 100;
 
 const RequestTabPanel = () => {
   const dispatch = useDispatch();
@@ -93,7 +94,6 @@ const RequestTabPanel = () => {
   const collection = find(collections, (c) => c.uid === focusedTab?.collectionUid);
   const [dragging, setDragging] = useState(false);
   const draggingRef = useRef(false);
-  const dragStartRef = useRef(null);
 
   const {
     left: leftPaneWidth,
@@ -134,41 +134,53 @@ const RequestTabPanel = () => {
     }
   }, [dispatch, activeTabUid, showGqlDocs]);
 
-  // Refs for panel collapse functions
+  // Refs for panel collapse/expand functions and current collapsed state
   const collapseRequestRef = useRef(collapseRequest);
   const collapseResponseRef = useRef(collapseResponse);
+  const expandRequestRef = useRef(expandRequest);
+  const expandResponseRef = useRef(expandResponse);
+  const requestPaneCollapsedRef = useRef(requestPaneCollapsed);
+  const responsePaneCollapsedRef = useRef(responsePaneCollapsed);
   useEffect(() => {
     collapseRequestRef.current = collapseRequest;
     collapseResponseRef.current = collapseResponse;
-  }, [collapseRequest, collapseResponse]);
+    expandRequestRef.current = expandRequest;
+    expandResponseRef.current = expandResponse;
+    requestPaneCollapsedRef.current = requestPaneCollapsed;
+    responsePaneCollapsedRef.current = responsePaneCollapsed;
+  }, [collapseRequest, collapseResponse, expandRequest, expandResponse, requestPaneCollapsed, responsePaneCollapsed]);
 
   const stopDragging = useCallback(() => {
     draggingRef.current = false;
-    dragStartRef.current = null;
     setDragging(false);
   }, []);
 
   const handleMouseMove = useCallback((e) => {
-    if (!draggingRef.current || !mainSectionRef.current || !dragStartRef.current) return;
+    if (!draggingRef.current || !mainSectionRef.current) return;
 
     e.preventDefault();
     const mainRect = mainSectionRef.current.getBoundingClientRect();
-    const dragStart = dragStartRef.current;
 
     if (isVerticalLayoutRef.current) {
       const newHeight = e.clientY - mainRect.top;
       const maxHeight = mainRect.height - MIN_BOTTOM_PANE_HEIGHT;
       const distanceFromBottom = mainRect.bottom - e.clientY;
 
-      if (e.clientY < dragStart.y && newHeight < COLLAPSE_EDGE_THRESHOLD) {
-        collapseRequestRef.current();
-        return stopDragging();
+      if (newHeight < COLLAPSE_EDGE_THRESHOLD) {
+        if (!requestPaneCollapsedRef.current) collapseRequestRef.current();
+        return;
       }
 
-      if (e.clientY > dragStart.y && distanceFromBottom < COLLAPSE_EDGE_THRESHOLD) {
-        collapseResponseRef.current();
-        return stopDragging();
+      if (distanceFromBottom < COLLAPSE_EDGE_THRESHOLD) {
+        if (!responsePaneCollapsedRef.current) collapseResponseRef.current();
+        return;
       }
+
+      if (requestPaneCollapsedRef.current && newHeight < EXPAND_EDGE_THRESHOLD) return;
+      if (responsePaneCollapsedRef.current && distanceFromBottom < EXPAND_EDGE_THRESHOLD) return;
+
+      if (requestPaneCollapsedRef.current) expandRequestRef.current();
+      if (responsePaneCollapsedRef.current) expandResponseRef.current();
 
       const clampedHeight = Math.max(MIN_TOP_PANE_HEIGHT, Math.min(newHeight, maxHeight));
       setTopPaneHeight(clampedHeight);
@@ -177,20 +189,26 @@ const RequestTabPanel = () => {
       const maxWidth = mainRect.width - MIN_RIGHT_PANE_WIDTH;
       const distanceFromRight = mainRect.right - e.clientX;
 
-      if (e.clientX < dragStart.x && newWidth < COLLAPSE_EDGE_THRESHOLD) {
-        collapseRequestRef.current();
-        return stopDragging();
+      if (newWidth < COLLAPSE_EDGE_THRESHOLD) {
+        if (!requestPaneCollapsedRef.current) collapseRequestRef.current();
+        return;
       }
 
-      if (e.clientX > dragStart.x && distanceFromRight < COLLAPSE_EDGE_THRESHOLD) {
-        collapseResponseRef.current();
-        return stopDragging();
+      if (distanceFromRight < COLLAPSE_EDGE_THRESHOLD) {
+        if (!responsePaneCollapsedRef.current) collapseResponseRef.current();
+        return;
       }
+
+      if (requestPaneCollapsedRef.current && newWidth < EXPAND_EDGE_THRESHOLD) return;
+      if (responsePaneCollapsedRef.current && distanceFromRight < EXPAND_EDGE_THRESHOLD) return;
+
+      if (requestPaneCollapsedRef.current) expandRequestRef.current();
+      if (responsePaneCollapsedRef.current) expandResponseRef.current();
 
       const clampedWidth = Math.max(MIN_LEFT_PANE_WIDTH, Math.min(newWidth, maxWidth));
       setLeftPaneWidth(clampedWidth);
     }
-  }, [setTopPaneHeight, setLeftPaneWidth, stopDragging]);
+  }, [setTopPaneHeight, setLeftPaneWidth]);
 
   const handleMouseUp = useCallback((e) => {
     if (draggingRef.current) {
@@ -202,7 +220,6 @@ const RequestTabPanel = () => {
   const startDragging = useCallback((e) => {
     e.preventDefault();
     draggingRef.current = true;
-    dragStartRef.current = { x: e.clientX, y: e.clientY };
     setDragging(true);
   }, []);
 
@@ -247,6 +264,7 @@ const RequestTabPanel = () => {
 
   useEffect(() => {
     if (!isVerticalLayout) return;
+    if (responsePaneCollapsed) return;
 
     if (isConsoleOpen) {
       // Store current height before reducing
@@ -265,7 +283,7 @@ const RequestTabPanel = () => {
         previousTopPaneHeight.current = null;
       }
     }
-  }, [isConsoleOpen, isVerticalLayout]);
+  }, [isConsoleOpen, isVerticalLayout, responsePaneCollapsed]);
 
   if (typeof window == 'undefined') {
     return <div></div>;
@@ -516,6 +534,17 @@ const RequestTabPanel = () => {
               </button>
             </DocExplorer>
           </div>
+        ) : null}
+        {dragging ? (
+          <div
+            style={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 9999,
+              cursor: isVerticalLayout ? 'row-resize' : 'col-resize',
+              userSelect: 'none'
+            }}
+          />
         ) : null}
       </StyledWrapper>
     </ScopedPersistenceProvider>

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -206,15 +206,34 @@ const RequestTabPanel = () => {
     setDragging(true);
   }, []);
 
+  const applyPointerResize = useCallback((e) => {
+    if (!mainSectionRef.current) return;
+    const mainRect = mainSectionRef.current.getBoundingClientRect();
+
+    if (isVerticalLayoutRef.current) {
+      const newHeight = e.clientY - mainRect.top;
+      const maxHeight = mainRect.height - MIN_BOTTOM_PANE_HEIGHT;
+      const clampedHeight = Math.max(MIN_TOP_PANE_HEIGHT, Math.min(newHeight, maxHeight));
+      setTopPaneHeight(clampedHeight);
+    } else {
+      const newWidth = e.clientX - mainRect.left;
+      const maxWidth = mainRect.width - MIN_RIGHT_PANE_WIDTH;
+      const clampedWidth = Math.max(MIN_LEFT_PANE_WIDTH, Math.min(newWidth, maxWidth));
+      setLeftPaneWidth(clampedWidth);
+    }
+  }, [setTopPaneHeight, setLeftPaneWidth]);
+
   const handleRequestIndicatorDragStart = useCallback((e) => {
     expandRequest();
+    applyPointerResize(e);
     startDragging(e);
-  }, [expandRequest, startDragging]);
+  }, [expandRequest, applyPointerResize, startDragging]);
 
   const handleResponseIndicatorDragStart = useCallback((e) => {
     expandResponse();
+    applyPointerResize(e);
     startDragging(e);
-  }, [expandResponse, startDragging]);
+  }, [expandResponse, applyPointerResize, startDragging]);
 
   useEffect(() => {
     document.addEventListener('mouseup', handleMouseUp);

--- a/packages/bruno-app/src/hooks/useTabPaneBoundaries/index.js
+++ b/packages/bruno-app/src/hooks/useTabPaneBoundaries/index.js
@@ -1,5 +1,12 @@
 import find from 'lodash/find';
-import { updateRequestPaneTabHeight, updateRequestPaneTabWidth } from 'providers/ReduxStore/slices/tabs';
+import {
+  updateRequestPaneTabHeight,
+  updateRequestPaneTabWidth,
+  collapseRequestPane,
+  collapseResponsePane,
+  expandRequestPane,
+  expandResponsePane
+} from 'providers/ReduxStore/slices/tabs';
 import { useDispatch, useSelector } from 'react-redux';
 
 const MIN_TOP_PANE_HEIGHT = 380;
@@ -13,11 +20,16 @@ export function useTabPaneBoundaries(activeTabUid) {
   let asideWidth = useSelector((state) => state.app.leftSidebarWidth);
   const left = focusedTab && focusedTab.requestPaneWidth ? focusedTab.requestPaneWidth : (screenWidth - asideWidth) / DEFAULT_PANE_WIDTH_DIVISOR;
   const top = focusedTab?.requestPaneHeight || MIN_TOP_PANE_HEIGHT;
+  const requestPaneCollapsed = focusedTab?.requestPaneCollapsed || false;
+  const responsePaneCollapsed = focusedTab?.responsePaneCollapsed || false;
+
   const dispatch = useDispatch();
 
   return {
     left,
     top,
+    requestPaneCollapsed,
+    responsePaneCollapsed,
     setLeft(value) {
       dispatch(updateRequestPaneTabWidth({
         uid: activeTabUid,
@@ -30,6 +42,18 @@ export function useTabPaneBoundaries(activeTabUid) {
         requestPaneHeight: value
       }));
     },
+    collapseRequest() {
+      dispatch(collapseRequestPane({ uid: activeTabUid }));
+    },
+    expandRequest() {
+      dispatch(expandRequestPane({ uid: activeTabUid }));
+    },
+    collapseResponse() {
+      dispatch(collapseResponsePane({ uid: activeTabUid }));
+    },
+    expandResponse() {
+      dispatch(expandResponsePane({ uid: activeTabUid }));
+    },
     reset() {
       dispatch(updateRequestPaneTabHeight({
         uid: activeTabUid,
@@ -39,6 +63,8 @@ export function useTabPaneBoundaries(activeTabUid) {
         uid: activeTabUid,
         requestPaneWidth: (screenWidth - asideWidth) / DEFAULT_PANE_WIDTH_DIVISOR
       }));
+      dispatch(expandRequestPane({ uid: activeTabUid }));
+      dispatch(expandResponsePane({ uid: activeTabUid }));
     }
   };
 }

--- a/packages/bruno-app/src/hooks/useTabPaneBoundaries/index.js
+++ b/packages/bruno-app/src/hooks/useTabPaneBoundaries/index.js
@@ -55,6 +55,8 @@ export function useTabPaneBoundaries(activeTabUid) {
       dispatch(expandResponsePane({ uid: activeTabUid }));
     },
     reset() {
+      dispatch(expandRequestPane({ uid: activeTabUid }));
+      dispatch(expandResponsePane({ uid: activeTabUid }));
       dispatch(updateRequestPaneTabHeight({
         uid: activeTabUid,
         requestPaneHeight: MIN_TOP_PANE_HEIGHT
@@ -63,8 +65,6 @@ export function useTabPaneBoundaries(activeTabUid) {
         uid: activeTabUid,
         requestPaneWidth: (screenWidth - asideWidth) / DEFAULT_PANE_WIDTH_DIVISOR
       }));
-      dispatch(expandRequestPane({ uid: activeTabUid }));
-      dispatch(expandResponsePane({ uid: activeTabUid }));
     }
   };
 }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -64,6 +64,11 @@ export const tabsSlice = createSlice({
           uid,
           collectionUid,
           requestPaneWidth: null,
+          requestPaneHeight: null,
+          requestPaneCollapsed: false,
+          responsePaneCollapsed: false,
+          requestPaneWidthBeforeCollapse: null,
+          requestPaneHeightBeforeCollapse: null,
           requestPaneTab: requestPaneTab || defaultRequestPaneTab,
           responsePaneTab: 'response',
           responseFormat: null,
@@ -86,6 +91,11 @@ export const tabsSlice = createSlice({
         uid,
         collectionUid,
         requestPaneWidth: null,
+        requestPaneHeight: null,
+        requestPaneCollapsed: false,
+        responsePaneCollapsed: false,
+        requestPaneWidthBeforeCollapse: null,
+        requestPaneHeightBeforeCollapse: null,
         requestPaneTab: requestPaneTab || defaultRequestPaneTab,
         responsePaneTab: 'response',
         responsePaneScrollPosition: null,
@@ -328,6 +338,42 @@ export const tabsSlice = createSlice({
         console.error('Tab not found!');
       }
     },
+    collapseRequestPane: (state, action) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+      if (tab) {
+        tab.requestPaneCollapsed = true;
+        tab.responsePaneCollapsed = false;
+        tab.requestPaneWidthBeforeCollapse = tab.requestPaneWidth;
+        tab.requestPaneHeightBeforeCollapse = tab.requestPaneHeight;
+      }
+    },
+    collapseResponsePane: (state, action) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+      if (tab) {
+        tab.responsePaneCollapsed = true;
+        tab.requestPaneCollapsed = false;
+      }
+    },
+    expandRequestPane: (state, action) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+      if (tab) {
+        tab.requestPaneCollapsed = false;
+        if (tab.requestPaneWidthBeforeCollapse != null) {
+          tab.requestPaneWidth = tab.requestPaneWidthBeforeCollapse;
+        }
+        if (tab.requestPaneHeightBeforeCollapse != null) {
+          tab.requestPaneHeight = tab.requestPaneHeightBeforeCollapse;
+        }
+        tab.requestPaneWidthBeforeCollapse = null;
+        tab.requestPaneHeightBeforeCollapse = null;
+      }
+    },
+    expandResponsePane: (state, action) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+      if (tab) {
+        tab.responsePaneCollapsed = false;
+      }
+    },
     reorderTabs: (state, action) => {
       const { direction, sourceUid, targetUid } = action.payload;
       const tabs = state.tabs;
@@ -397,6 +443,10 @@ export const {
   closeTabs,
   closeAllCollectionTabs,
   makeTabPermanent,
+  collapseRequestPane,
+  collapseResponsePane,
+  expandRequestPane,
+  expandResponsePane,
   reorderTabs,
   reopenLastClosedTab,
   updateQueryBuilderOpen,


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3063)

Add collapse and expand behaviour for the request and response panes in the request tab.

- Layout: Works in both horizontal and vertical layouts.
- Collapse: Drag the splitter until it is near the viewport edge.
- Expand: Click the Request or Response collapsed strip, or drag from it to resize the split.

### Screenshots

<img width="1093" height="771" alt="image" src="https://github.com/user-attachments/assets/27e6dd06-4fcd-455e-97cb-58bfade850d5" />
<img width="1123" height="705" alt="image" src="https://github.com/user-attachments/assets/f672688e-0144-4470-84ee-03cfb1e32576" />
<img width="488" height="787" alt="image" src="https://github.com/user-attachments/assets/04759123-c247-4cf1-b2d2-619c81b1cbec" />




#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request and response panes can be collapsed/expanded via a visible, keyboard-accessible indicator (Enter/Space). Indicator shows contextual chevrons/labels, supports pointer drag-to-initiate resizing/collapse, and restores panes to their previous size on expand. Middle dragbar hides when a pane is collapsed; edge-proximity during drag can trigger collapse.

* **Style / UI Improvements**
  * Larger dragbar hit areas, adjusted collapsed-state padding, improved z-order and cursor feedback for clearer visuals and more reliable resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->