### PR TITLE
fix(theme): convert theme bg to hex for Electron backgroundColor

### DIFF
--- a/packages/bruno-app/src/providers/Theme/index.js
+++ b/packages/bruno-app/src/providers/Theme/index.js
@@ -57,13 +57,8 @@ export const ThemeProvider = (props) => {
       const variantName = isLight ? themeVariantLight : themeVariantDark;
       const rawBg = themes[variantName]?.bg || (isLight ? '#ffffff' : '#1e1e1e');
       // Convert to hex — Electron's backgroundColor only accepts hex colors
-      let themeBg;
-      try {
-        const { red, green, blue } = parseToRgb(rawBg);
-        themeBg = `#${[red, green, blue].map((c) => c.toString(16).padStart(2, '0')).join('')}`;
-      } catch {
-        themeBg = isLight ? '#ffffff' : '#1e1e1e';
-      }
+      const { red, green, blue } = parseToRgb(rawBg);
+      const themeBg = `#${[red, green, blue].map((c) => c.toString(16).padStart(2, '0')).join('')}`;
       window.ipcRenderer.send('renderer:theme-change', storedTheme, themeBg);
     }
   }, [storedTheme, themeVariantLight, themeVariantDark]);


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2851)
Follow up PR of https://github.com/usebruno/bruno/pull/7454
Electron's BrowserWindow backgroundColor doesn't support HSL values, causing it to silently fall back to white on startup.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed theme color handling: background color sent in theme-change events is now converted to a standard #RRGGBB hex string (with fallback to default light/dark colors) so theme variants display correctly across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->