### PR TITLE
fix:  multipart form upload icon visibility

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -122,11 +122,9 @@ const MultipartFormParams = ({ item, collection }) => {
       name: 'Value',
       placeholder: 'Value',
       width: '35%',
-      render: ({ row, value, onChange, isLastEmptyRow }) => {
+      render: ({ row, value, onChange }) => {
         const isFile = row.type === 'file';
         const fileName = isFile ? getFileName(value) : null;
-        const hasTextValue = !isFile && value && value.length > 0;
-
         if (fileName) {
           return (
             <div className="flex items-center file-value-cell">
@@ -160,15 +158,13 @@ const MultipartFormParams = ({ item, collection }) => {
                 placeholder={!value ? 'Value' : ''}
               />
             </div>
-            {!hasTextValue && !isLastEmptyRow && (
-              <button
-                className="upload-btn ml-1"
-                onClick={() => handleBrowseFiles(row, onChange)}
-                title="Select file"
-              >
-                <IconUpload size={16} />
-              </button>
-            )}
+            <button
+              className="upload-btn ml-1"
+              onClick={() => handleBrowseFiles(row, onChange)}
+              title="Select file"
+            >
+              <IconUpload size={16} />
+            </button>
           </div>
         );
       }

--- a/packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleMultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleMultipartFormParams/index.js
@@ -170,11 +170,9 @@ const ResponseExampleMultipartFormParams = ({ item, collection, exampleUid, edit
       placeholder: 'Value',
       width: '40%',
       readOnly: !editMode,
-      render: ({ row, value, onChange, isLastEmptyRow }) => {
+      render: ({ row, value, onChange }) => {
         const isFile = row.type === 'file';
         const fileName = isFile ? getFileName(value) : null;
-        const hasTextValue = !isFile && value && value.length > 0;
-
         if (fileName) {
           return (
             <div className="flex items-center file-value-cell">
@@ -209,15 +207,13 @@ const ResponseExampleMultipartFormParams = ({ item, collection, exampleUid, edit
                 placeholder={!value ? 'Value' : ''}
               />
             </div>
-            {!hasTextValue && !isLastEmptyRow && (
-              <button
-                className="upload-btn ml-1"
-                onClick={() => handleBrowseFiles(row, onChange)}
-                title="Select file"
-              >
-                <IconUpload size={16} />
-              </button>
-            )}
+            <button
+              className="upload-btn ml-1"
+              onClick={() => handleBrowseFiles(row, onChange)}
+              title="Select file"
+            >
+              <IconUpload size={16} />
+            </button>
           </div>
         );
       }

--- a/tests/request/multipart-form/multipart-form-upload-icon.spec.ts
+++ b/tests/request/multipart-form/multipart-form-upload-icon.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, createCollection, createRequest, openCollection, openRequest, selectRequestPaneTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe.serial('Multipart Form - Upload Icon Visibility', () => {
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test.beforeAll(async ({ page, createTmpDir }) => {
+    await test.step('Create collection and request', async () => {
+      await createCollection(page, 'multipart-upload-icon', await createTmpDir('multipart-upload-icon'));
+      await createRequest(page, 'test-multipart', '', {
+        url: 'https://httpbin.org/post',
+        method: 'POST',
+        inFolder: false
+      });
+    });
+
+    await test.step('Open the request', async () => {
+      await openCollection(page, 'multipart-upload-icon');
+      await openRequest(page, 'multipart-upload-icon', 'test-multipart', { persist: true });
+    });
+
+    await test.step('Switch body mode to Multipart Form', async () => {
+      await selectRequestPaneTab(page, 'Body');
+      const locators = buildCommonLocators(page);
+      await locators.request.bodyModeSelector().click();
+      await page.locator('.dropdown-item').filter({ hasText: 'Multipart Form' }).click();
+    });
+  });
+
+  test('upload icon should be visible on the empty last row', async ({ page }) => {
+    await test.step('Verify upload icon is visible on the empty row', async () => {
+      const rows = page.locator('table tbody tr');
+      await expect(rows).toHaveCount(1);
+      const uploadBtn = rows.first().locator('.upload-btn');
+      await expect(uploadBtn).toBeVisible();
+    });
+  });
+
+  test('upload icon should be visible after entering a key', async ({ page }) => {
+    await test.step('Enter a key in the empty row', async () => {
+      const row = page.locator('table tbody tr').first();
+      const nameCell = row.locator('td').nth(1);
+      await nameCell.locator('input').fill('myfield');
+      // Press Tab to commit the value
+      await page.keyboard.press('Tab');
+    });
+
+    await test.step('Verify upload icon is visible on the row with the key', async () => {
+      // Wait for the new empty row to appear (should now have 2 rows)
+      await expect(page.locator('table tbody tr')).toHaveCount(2);
+      // The first row has our key, check its upload button
+      const uploadBtn = page.locator('table tbody tr').first().locator('.upload-btn');
+      await expect(uploadBtn).toBeVisible();
+    });
+  });
+
+  test('upload icon should remain visible after entering a value', async ({ page }) => {
+    await test.step('Enter a value in the first row', async () => {
+      const firstRow = page.locator('table tbody tr').first();
+      const editor = firstRow.locator('.value-cell .CodeMirror');
+      await editor.click({ position: { x: 10, y: 10 } });
+      await page.keyboard.type('some text value');
+    });
+
+    await test.step('Verify upload icon is still visible with text value', async () => {
+      const uploadBtn = page.locator('table tbody tr').first().locator('.upload-btn');
+      await expect(uploadBtn).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2869)

The file upload icon in the multipart form body editor was hidden by default and only appeared after specific conditions were met (key entered,  no text value). This made the file upload feature hard to discover. 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="541" height="248" alt="image" src="https://github.com/user-attachments/assets/2b35751e-8a07-4020-8412-603973f7f7aa" />

<img width="541" height="248" alt="image" src="https://github.com/user-attachments/assets/bdfacec8-5081-4e05-a26b-93f099de451f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Select file" button visibility in multipart form fields—it now displays consistently whenever no file is selected, regardless of text input status.

* **Tests**
  * Added test coverage for upload button visibility in multipart form fields across different interaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->