### PR TITLE
fix(oauth2): Fixing issue with oauth2 manual and auto refresh

### DIFF
--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -209,6 +209,9 @@ const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, fo
           // Try to refresh token
           try {
             const refreshedCredentialsData = await refreshOauth2Token({ requestCopy, collectionUid, certsAndProxyConfig: certsAndProxyConfigForRefreshUrl });
+            if (!refreshedCredentialsData?.credentials?.access_token) {
+              throw new Error('OAuth2 token refresh failed');
+            }
             return { collectionUid, url, credentials: refreshedCredentialsData.credentials, credentialsId };
           } catch (error) {
             // Refresh failed
@@ -419,6 +422,9 @@ const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, fo
           // Try to refresh token
           try {
             const refreshedCredentialsData = await refreshOauth2Token({ requestCopy, collectionUid, certsAndProxyConfig: certsAndProxyConfigForRefreshUrl });
+            if (!refreshedCredentialsData?.credentials?.access_token) {
+              throw new Error('OAuth2 token refresh failed');
+            }
             return { collectionUid, url, credentials: refreshedCredentialsData.credentials, credentialsId };
           } catch (error) {
             clearOauth2Credentials({ collectionUid, url, credentialsId });
@@ -566,6 +572,9 @@ const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, 
           // Try to refresh token
           try {
             const refreshedCredentialsData = await refreshOauth2Token({ requestCopy, collectionUid, certsAndProxyConfig: certsAndProxyConfigForRefreshUrl });
+            if (!refreshedCredentialsData?.credentials?.access_token) {
+              throw new Error('OAuth2 token refresh failed');
+            }
             return { collectionUid, url, credentials: refreshedCredentialsData.credentials, credentialsId };
           } catch (error) {
             clearOauth2Credentials({ collectionUid, url, credentialsId });
@@ -649,17 +658,18 @@ const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, 
 const refreshOauth2Token = async ({ requestCopy, collectionUid, certsAndProxyConfig }) => {
   const oAuth = get(requestCopy, 'oauth2', {});
   const { clientId, clientSecret, credentialsId, credentialsPlacement, additionalParameters } = oAuth;
-  const url = oAuth.refreshTokenUrl ? oAuth.refreshTokenUrl : oAuth.accessTokenUrl;
+  const cacheUrl = oAuth.accessTokenUrl || oAuth.refreshTokenUrl;
+  const refreshUrl = oAuth.refreshTokenUrl || oAuth.accessTokenUrl;
 
-  const credentials = getStoredOauth2Credentials({ collectionUid, url, credentialsId });
-  if (!credentials?.refresh_token) {
-    clearOauth2Credentials({ collectionUid, url, credentialsId });
+  const storedCredentials = getStoredOauth2Credentials({ collectionUid, url: cacheUrl, credentialsId });
+  if (!storedCredentials?.refresh_token) {
+    clearOauth2Credentials({ collectionUid, url: cacheUrl, credentialsId });
     // Proceed without token
-    return { collectionUid, url, credentials: null, credentialsId };
+    return { collectionUid, url: cacheUrl, credentials: null, credentialsId };
   } else {
     const data = {
       grant_type: 'refresh_token',
-      refresh_token: credentials.refresh_token
+      refresh_token: storedCredentials.refresh_token
     };
     if (credentialsPlacement !== 'basic_auth_header') {
       data.client_id = clientId;
@@ -677,7 +687,7 @@ const refreshOauth2Token = async ({ requestCopy, collectionUid, certsAndProxyCon
       const secret = clientSecret ?? '';
       axiosRequestConfig.headers['Authorization'] = `Basic ${Buffer.from(`${clientId}:${secret}`).toString('base64')}`;
     }
-    axiosRequestConfig.url = url;
+    axiosRequestConfig.url = refreshUrl;
     axiosRequestConfig.responseType = 'arraybuffer';
     if (additionalParameters?.refresh?.length) {
       applyAdditionalParameters(axiosRequestConfig, data, additionalParameters.refresh);
@@ -688,15 +698,15 @@ const refreshOauth2Token = async ({ requestCopy, collectionUid, certsAndProxyCon
       const { credentials, requestDetails } = await getCredentialsFromTokenUrl({ requestConfig: axiosRequestConfig, certsAndProxyConfig });
       debugInfo.data.push(requestDetails);
       if (!credentials || credentials?.error) {
-        clearOauth2Credentials({ collectionUid, url, credentialsId });
-        return { collectionUid, url, credentials: null, credentialsId, debugInfo };
+        clearOauth2Credentials({ collectionUid, url: cacheUrl, credentialsId });
+        return { collectionUid, url: cacheUrl, credentials: null, credentialsId, debugInfo };
       }
-      credentials && persistOauth2Credentials({ collectionUid, url, credentials, credentialsId });
-      return { collectionUid, url, credentials, credentialsId, debugInfo };
+      credentials && persistOauth2Credentials({ collectionUid, url: cacheUrl, credentials, credentialsId });
+      return { collectionUid, url: cacheUrl, credentials, credentialsId, debugInfo };
     } catch (error) {
-      clearOauth2Credentials({ collectionUid, url, credentialsId });
+      clearOauth2Credentials({ collectionUid, url: cacheUrl, credentialsId });
       // Proceed without token
-      return { collectionUid, url, credentials: null, credentialsId, debugInfo };
+      return { collectionUid, url: cacheUrl, credentials: null, credentialsId, debugInfo };
     }
   }
 };


### PR DESCRIPTION
### Description

This change fixes Bruno's OAuth2 refresh flow.

## What changed

- `refreshOauth2Token()` now separates:
  - the URL used to read/write cached credentials
  - the URL used to send the refresh request
- the refresh callers now treat a refresh result without an `access_token` as a failed refresh

## Why

- cached OAuth2 credentials are stored under the access token URL
- when `refreshTokenUrl` differs from `accessTokenUrl`, looking up cached credentials with the refresh URL can prevent Bruno from finding the stored `refresh_token`, so no refresh request is made
- `refreshOauth2Token()` can fail by returning `credentials: null`, not only by throwing, so callers need to handle that case explicitly

## Result

- refresh works correctly when access and refresh endpoints are different
- failed refresh results are handled correctly by the existing OAuth2 flow

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 token refresh validation with proper error handling for failed refresh attempts.

* **Refactor**
  * Enhanced internal OAuth2 token refresh flow for improved reliability and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->