### PR TITLE
feat: enhance axios instance to strip sensitive auth headers on cross-origin redirects

### DIFF
--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -27,6 +27,21 @@ const createRedirectConfig = (error, redirectUrl) => {
     headers: { ...error.config.headers }
   };
 
+  // Strip sensitive auth headers when redirecting to a different origin
+  // (matches curl 7.58+ and browser behavior, see CVE-2018-1000007)
+  try {
+    const originalOrigin = new URL(error.config.url).origin;
+    const redirectOrigin = new URL(redirectUrl).origin;
+    if (originalOrigin !== redirectOrigin) {
+      delete requestConfig.headers['authorization'];
+      delete requestConfig.headers['Authorization'];
+      delete requestConfig.headers['proxy-authorization'];
+      delete requestConfig.headers['Proxy-Authorization'];
+    }
+  } catch (_) {
+    // If URL parsing fails, skip origin check — headers pass through unchanged
+  }
+
   const statusCode = error.response.status;
   const originalMethod = (error.config.method || 'get').toLowerCase();
 

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -352,6 +352,28 @@ function makeAxiosInstance({
             }
           };
 
+          // Strip sensitive auth headers when redirecting to a different origin
+          // (matches curl 7.58+ and browser behavior, see CVE-2018-1000007)
+          try {
+            // URL.URL is the WHATWG URL class — line 1's `require('url')` shadows the global `URL`
+            const originalOrigin = new URL.URL(error.config.url).origin;
+            const redirectOrigin = new URL.URL(redirectUrl).origin;
+            if (originalOrigin !== redirectOrigin) {
+              delete requestConfig.headers['authorization'];
+              delete requestConfig.headers['Authorization'];
+              delete requestConfig.headers['proxy-authorization'];
+              delete requestConfig.headers['Proxy-Authorization'];
+
+              timeline.push({
+                timestamp: new Date(),
+                type: 'info',
+                message: `Stripped Authorization headers: redirect crosses origin (${originalOrigin} → ${redirectOrigin})`
+              });
+            }
+          } catch (_) {
+            // If URL parsing fails, skip origin check — headers pass through unchanged
+          }
+
           // Apply proper HTTP redirect behavior based on status code
           const statusCode = error.response.status;
           const originalMethod = (error.config.method || 'get').toLowerCase();

--- a/packages/bruno-tests/collection/redirects/Test Cross Origin Redirect Strips Auth.bru
+++ b/packages/bruno-tests/collection/redirects/Test Cross Origin Redirect Strips Auth.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Test Cross Origin Redirect Strips Auth
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{localhost}}/api/redirect/cross-origin
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer test-secret
+}
+
+assert {
+  res.status: 200
+}
+
+tests {
+  test("should strip authorization header on cross-origin redirect", function() {
+    const headers = res.getBody();
+    expect(headers).to.not.have.property('authorization');
+  });
+}
+
+settings {
+  followRedirects: true
+  maxRedirects: 5
+}

--- a/packages/bruno-tests/collection/redirects/Test Same Origin Redirect Preserves Auth.bru
+++ b/packages/bruno-tests/collection/redirects/Test Same Origin Redirect Preserves Auth.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Test Same Origin Redirect Preserves Auth
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{localhost}}/redirect-to-headers
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer test-secret
+}
+
+assert {
+  res.status: 200
+}
+
+tests {
+  test("should preserve authorization header on same-origin redirect", function() {
+    const headers = res.getBody();
+    expect(headers).to.have.property('authorization');
+    expect(headers.authorization).to.equal('Bearer test-secret');
+  });
+}
+
+settings {
+  followRedirects: true
+  maxRedirects: 5
+}

--- a/packages/bruno-tests/src/index.js
+++ b/packages/bruno-tests/src/index.js
@@ -14,6 +14,7 @@ const sseRouter = require('./sse');
 
 const app = new express();
 const port = process.env.PORT || 8081;
+const crossOriginPort = process.env.CROSS_ORIGIN_PORT || 8082;
 
 app.use(cors());
 
@@ -68,13 +69,22 @@ app.get('/redirect-to-ping', function (req, res) {
   return res.redirect('/ping');
 });
 
+app.get('/redirect-to-headers', function (req, res) {
+  return res.redirect('/headers');
+});
+
 const server = require('http').createServer(app);
 
 server.on('upgrade', wsRouter);
 
+const crossOriginServer = require('http').createServer(app);
+
 setupGraphQL(app).then(() => {
   server.listen(port, function () {
     console.log(`Testbench started on port: ${port}`);
+  });
+  crossOriginServer.listen(crossOriginPort, function () {
+    console.log(`Cross-origin testbench started on port: ${crossOriginPort}`);
   });
 })
   .catch((error) => {

--- a/packages/bruno-tests/src/redirect/index.js
+++ b/packages/bruno-tests/src/redirect/index.js
@@ -103,6 +103,11 @@ router.get('/anything', function (req, res) {
   });
 });
 
+router.get('/cross-origin', function (req, res) {
+  // Redirect to a different port = different origin
+  res.status(302).set('Location', 'http://localhost:8082/headers').send();
+});
+
 router.get('/:count', function (req, res) {
   const count = parseInt(req.params.count, 10);
 


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2941)

- Strip `Authorization` and `Proxy-Authorization` headers when a redirect crosses origins (different host, port, or scheme)
- Matches curl 7.58+ and browser behavior (CVE-2018-1000007)
- Applies to both Electron and CLI axios interceptors

Fixes #7570 and #5704

## Test plan
- [ ] `npx bruno run collection/redirects/Test\ Cross\ Origin\ Redirect\ Strips\ Auth.bru` — auth stripped
- [ ] `npx bruno run collection/redirects/Test\ Same\ Origin\ Redirect\ Preserves\ Auth.bru` — auth preserved
- [ ] Existing redirect tests still pass


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced HTTP redirect security: Authorization headers are removed when a request follows a redirect to a different origin, and preserved for same-origin redirects.

* **Tests**
  * Added end-to-end tests verifying auth header behavior for cross-origin and same-origin redirects.
  * Test environment extended with a cross-origin redirect endpoint to validate stripping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->