### PR TITLE
fix: no environment alignment

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
@@ -22,7 +22,7 @@ const EnvironmentListContent = ({
               onClick={() => onEnvironmentSelect(null)}
             >
               <span className="w-2 shrink-0" />
-              <span className="italic opacity-50">No Environment</span>
+              <span>No Environment</span>
             </div>
             <ToolHint
               anchorSelect="[data-tooltip-content]"

--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/StyledWrapper.js
@@ -117,6 +117,10 @@ const Wrapper = styled.div`
     overflow: hidden;
   }
 
+  .no-environment {
+    color: ${(props) => props.theme.colors.text.subtext0};
+  }
+
   .environment-list {
     flex: 1;
     overflow-y: auto;


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2902)

Fix no environment alignment in environment selector

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="232" height="354" alt="image" src="https://github.com/user-attachments/assets/9a2345f1-2750-437f-8ef6-b4cfbeec8245" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "No Environment" option to properly display active state in the environment selector.

* **Style**
  * Updated visual styling of "No Environment" label for improved clarity and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->