### PR TITLE
fix: add the meta block to the object returned by transformFolderRoot…

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -804,6 +804,10 @@ export const transformCollectionRootToSave = (collection) => {
 export const transformFolderRootToSave = (folder) => {
   const _folder = folder.draft ? folder.draft : folder.root;
   const folderRootToSave = {
+    meta: {
+      name: folder.name,
+      seq: folder.seq
+    },
     docs: _folder.docs,
     request: {
       auth: _folder?.request?.auth,


### PR DESCRIPTION
### Description

When adding pre-request variables (or any other folder-level setting like headers, auth, scripts) at the folder level, the `seq` key is removed from the `folder.bru` file after saving. This causes unintended metadata changes and may affect request ordering within the folder.                                                   
                                                            
### Root Cause                                                                                                   
  
`transformFolderRootToSave()` in `packages/bruno-app/src/utils/collections/index.js` was building the folder root object without the meta field. When this object reached the IPC handler (renderer:save-folder-root), it detected the missing meta and created a fallback containing only name — dropping `seq`. The stringifier then either defaulted seq to 1 or omitted it entirely.         

### Fix

Include the meta block (with both name and seq) in the object returned by `transformFolderRootToSave`, pulling the values from the folder item where Redux stores them.


https://github.com/user-attachments/assets/9e74347e-f931-41f9-8afa-ecf5fb655779



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Fixes #7576 
[JIRA](https://usebruno.atlassian.net/browse/BRU-2945)