### PR TITLE
fix: re-apply secret masking after editor value changes

### DIFF
--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -164,6 +164,10 @@ class MultiLineEditor extends Component {
         this.cachedValue = nextValue;
         this.editor.setValue(nextValue);
         this.editor.setCursor(cursor);
+        // Re-apply masking after setValue() since it destroys all CodeMirror marks
+        if (this.maskedEditor && this.maskedEditor.isEnabled()) {
+          this.maskedEditor.update();
+        }
       }
     }
     if (!isEqual(this.props.isSecret, prevProps.isSecret)) {

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -179,6 +179,10 @@ class SingleLineEditor extends Component {
         this.cachedValue = nextValue;
         this.editor.setValue(nextValue);
         this.editor.setCursor(cursor);
+        // Re-apply masking after setValue() since it destroys all CodeMirror marks
+        if (this.maskedEditor && this.maskedEditor.isEnabled()) {
+          this.maskedEditor.update();
+        }
 
         // Update newline markers after value change
         if (this.props.showNewlineArrow) {


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2689)

When switching environments, editor.setValue() destroys CodeMirror marks (the * masking) but masking isn't re-applied because isSecret stays true → true, so the change-detection check is skipped
Fixes this by calling maskedEditor.update() after setValue() when masking is active

Closes https://github.com/usebruno/bruno/issues/7517

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where masked content (such as secrets and sensitive information) could lose its masking after editor values were updated. Masking is now properly re-applied to maintain secure display of sensitive data across both single-line and multi-line editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->