### PR TITLE
fixed noproxy flag from `----no-proxy` to `--no-proxy`

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -220,7 +220,7 @@ const builder = async (yargs) => {
       type: 'string',
       description: 'Path to the Client certificate config file used for securing the connection in the request'
     })
-    .option('--noproxy', {
+    .option('noproxy', {
       type: 'boolean',
       description: 'Disable all proxy settings (both collection-defined and system proxies)',
       default: false


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3125)

The `--noproxy` flag in the Bruno CLI was incorrectly defined with a -- prefix in the yargs .option() call. Since yargs automatically prepends -- to option names, this resulted in the flag being registered as `----noproxy` instead of `--noproxy`.

<img width="646" height="240" alt="Screenshot 2026-03-26 at 9 55 17 PM" src="https://github.com/user-attachments/assets/6628c268-9339-4944-bc9d-f81f2e92012c" />

