### PR TITLE
The name of requests are now clickable in the test results.

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RunnerResults/StyledWrapper.js
@@ -166,6 +166,27 @@ const Wrapper = styled.div`
       }
     }
   }
+
+  .runner-request-name-link {
+    cursor: pointer;
+    border-radius: 4px;
+    padding: 0 0.15rem;
+    transition: background-color 0.15s ease, text-decoration-color 0.15s ease, opacity 0.15s ease;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
+
+    &:hover {
+      background-color: ${(props) => props.theme.background.surface1};
+      text-decoration-style: solid;
+      opacity: 0.9;
+    }
+
+    &:focus-visible {
+      outline: 2px solid ${(props) => props.theme.tabs.active.border};
+      outline-offset: 2px;
+    }
+  }
 `;
 
 export default Wrapper;

--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -6,6 +6,7 @@ import { runCollectionFolder, cancelRunnerExecution, mountCollection, updateRunn
 import { resetCollectionRunner, updateRunnerTagsDetails } from 'providers/ReduxStore/slices/collections';
 import { findItemInCollection, getTotalRequestCountInCollection, areItemsLoading, getRequestItemsForCollectionRun } from 'utils/collections';
 import { IconRefresh, IconCircleCheck, IconCircleX, IconCircleOff, IconCheck, IconX, IconRun, IconExternalLink } from '@tabler/icons';
+import { addTab } from 'providers/ReduxStore/slices/tabs';
 import ResponsePane from './ResponsePane';
 import StyledWrapper from './StyledWrapper';
 import RunnerTags from './RunnerTags/index';
@@ -237,6 +238,11 @@ export default function RunnerResults({ collection }) {
     dispatch(cancelRunnerExecution(runnerInfo.cancelTokenUid));
   };
 
+  const navigateToRequestEditor = (item) => {
+    if (!item?.uid || !collection?.uid) return;
+    dispatch(addTab({ uid: item.uid, collectionUid: collection.uid, type: 'request' }));
+  };
+
   const toggleConfigureMode = () => {
     dispatch(updateRunnerTagsDetails({ collectionUid: collection.uid, tagsEnabled: false }));
     setConfigureMode(!configureMode);
@@ -439,7 +445,17 @@ export default function RunnerResults({ collection }) {
                           : null}
                       </span>
                       <span
-                        className={`mr-1 ml-2 ${item.status == 'skipped' ? 'skipped-request' : anyTestFailed(item) ? 'danger' : ''}`}
+                        className={`runner-request-name-link mr-1 ml-2 ${item.status == 'skipped' ? 'skipped-request' : anyTestFailed(item) ? 'danger' : ''}`}
+                        role="button"
+                        tabIndex={0}
+                        title="Click to open request in editor"
+                        onClick={() => navigateToRequestEditor(item)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            navigateToRequestEditor(item);
+                          }
+                        }}
                       >
                         {item.displayName}
                       </span>
@@ -556,7 +572,21 @@ export default function RunnerResults({ collection }) {
             <div className="flex flex-col w-full overflow-hidden">
               <div className="flex items-center justify-between mb-4 font-medium">
                 <div className="flex items-center">
-                  <span className="mr-2">{selectedItem.displayName}</span>
+                  <span
+                    className="runner-request-name-link mr-2"
+                    role="button"
+                    tabIndex={0}
+                    title="Click to open request in editor"
+                    onClick={() => navigateToRequestEditor(selectedItem)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        navigateToRequestEditor(selectedItem);
+                      }
+                    }}
+                  >
+                    {selectedItem.displayName}
+                  </span>
                   <span>
                     {allTestsPassed(selectedItem)
                       ? <IconCircleCheck className="test-success" size={20} strokeWidth={1.5} />

--- a/tests/script-errors/script-errors.spec.ts
+++ b/tests/script-errors/script-errors.spec.ts
@@ -432,5 +432,74 @@ for (const mode of ['safe', 'developer'] as const) {
         await expect(testsTab).toHaveClass(/active/);
       });
     });
+
+    test('18. Runner: clicking request name in result list opens request editor tab', async ({ pageWithUserData: page }) => {
+      test.setTimeout(2 * 60 * 1000);
+
+      await test.step('Close all existing request tabs and run collection', async () => {
+        await closeAllTabs(page);
+        await runCollection(page, 'script-errors-test');
+      });
+
+      await test.step('Click request name from runner results list', async () => {
+        const requestName = 'test-script-error';
+        const requestNameLink = commonLocators.runnerResults.requestNameInItem(requestName);
+        await expect(requestNameLink).toBeVisible();
+        await requestNameLink.click();
+      });
+
+      await test.step('Verify request editor tab is opened', async () => {
+        const activeTab = commonLocators.tabs.activeRequestTab();
+        await expect(activeTab).toContainText('test-script-error');
+      });
+    });
+
+    test('19. Runner: clicking request name in detail pane header opens request editor tab', async ({ pageWithUserData: page }) => {
+      test.setTimeout(2 * 60 * 1000);
+
+      await test.step('Close all existing request tabs and run collection', async () => {
+        await closeAllTabs(page);
+        await runCollection(page, 'script-errors-test');
+      });
+
+      await test.step('Open runner detail pane and click request name in header', async () => {
+        const requestName = 'test-script-error';
+        const resultItem = commonLocators.runnerResults.itemPath(requestName);
+        await resultItem.locator('.link').first().click();
+
+        const selectedPaneRequestName = commonLocators.runnerResults.selectedPaneRequestName();
+        await expect(selectedPaneRequestName).toContainText(requestName);
+        await selectedPaneRequestName.click();
+      });
+
+      await test.step('Verify request editor tab is opened', async () => {
+        const activeTab = commonLocators.tabs.activeRequestTab();
+        await expect(activeTab).toContainText('test-script-error');
+      });
+    });
+
+    test('20. Runner: request names expose interactive hover affordance', async ({ pageWithUserData: page }) => {
+      test.setTimeout(2 * 60 * 1000);
+
+      await test.step('Close all existing request tabs and run collection', async () => {
+        await closeAllTabs(page);
+        await runCollection(page, 'script-errors-test');
+      });
+
+      await test.step('Verify request name is keyboard and mouse interactive', async () => {
+        const requestNameLink = commonLocators.runnerResults.requestNameInItem('test-script-error');
+        await expect(requestNameLink).toBeVisible();
+        await expect(requestNameLink).toHaveAttribute('title', 'Click to open request in editor');
+        await expect(requestNameLink).toHaveAttribute('role', 'button');
+        await expect(requestNameLink).toHaveAttribute('tabindex', '0');
+      });
+
+      await test.step('Verify hover style changes from dotted to solid underline', async () => {
+        const requestNameLink = commonLocators.runnerResults.requestNameInItem('test-script-error');
+        await expect(requestNameLink).toHaveCSS('text-decoration-style', 'dotted');
+        await requestNameLink.hover();
+        await expect(requestNameLink).toHaveCSS('text-decoration-style', 'solid');
+      });
+    });
   });
 }

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -92,7 +92,11 @@ export const buildCommonLocators = (page: Page) => ({
     item: (tagName: string) => page.locator('.tag-item', { hasText: tagName })
   },
   runnerResults: {
-    itemPath: (name: string) => page.getByTestId('runner-result-item').filter({ hasText: name })
+    itemPath: (name: string) => page.getByTestId('runner-result-item').filter({ hasText: name }),
+    requestNameInItem: (name: string) =>
+      page.getByTestId('runner-result-item').filter({ hasText: name }).locator('.runner-request-name-link').first(),
+    selectedPaneRequestName: () =>
+      page.locator('.runner-request-name-link[role="button"]').last()
   },
   response: {
     statusCode: () => page.getByTestId('response-status-code'),


### PR DESCRIPTION
### Description

The name of requests are now clickable in the test results.  Clicking them opens a tab where the request can be edited.  The same goes for the request name on the response summary.  I have also written playwright tests.  

<img width="1280" height="768" alt="image" src="https://github.com/user-attachments/assets/2c9b06e1-f9c1-4b69-8b09-70d505bbd94a" />

<img width="1280" height="768" alt="image" src="https://github.com/user-attachments/assets/f5099277-1dcf-42ef-aaf5-fef9619e57e5" />


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Request names in runner results are now interactive and clickable to open requests in the editor
  - Added keyboard navigation support (Enter/Space keys) for accessing the editor

* **Accessibility Improvements**
  - Enhanced keyboard focus indicators with clear visual outlines
  - Improved visual feedback for interactive elements with hover states and underline styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->