### PR TITLE
feat: add F2 keyboard shortcut for renaming collection items on all platforms

### DIFF
--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -36,7 +36,7 @@ const KeyMapping = {
   zoomIn: { mac: 'command+=', windows: 'ctrl+=', name: 'Zoom In' },
   zoomOut: { mac: 'command+-', windows: 'ctrl+-', name: 'Zoom Out' },
   resetZoom: { mac: 'command+0', windows: 'ctrl+0', name: 'Reset Zoom' },
-  renameItem: { mac: 'enter', windows: 'f2', name: 'Rename Collection Item' }
+  renameItem: { mac: 'f2', windows: 'f2', name: 'Rename Collection Item' }
 };
 
 /**


### PR DESCRIPTION
## Description

This PR adds F2 as the keyboard shortcut for renaming collection items across all platforms (Mac and Windows) for consistency.

### Changes
- Changed `renameItem` keyboard shortcut from platform-specific keys (Enter on Mac, F2 on Windows) to F2 on all platforms

### Why
- Many users expect F2 to work for renaming files across all platforms
- Provides a consistent experience between Mac and Windows
- Addresses feature request #7536

### Testing
- Verified the key mapping change in `keyMappings.js`
- The existing keyboard handling in `CollectionItem/index.js` already uses the key mapping, so no additional changes were needed

Fixes #7536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the rename item keyboard shortcut on macOS from Enter to F2, creating consistent hotkey behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->