### PR TITLE
fix(security): santize HTML before being rendered in documentation blocks

### DIFF
--- a/packages/bruno-app/src/components/MarkDown/index.jsx
+++ b/packages/bruno-app/src/components/MarkDown/index.jsx
@@ -35,7 +35,7 @@ const Markdown = ({ collectionPath, onDoubleClick, content }) => {
   };
 
   const md = new MarkdownIt(markdownItOptions).use(MarkdownItReplaceLink);
-  const htmlFromMarkdown = useMemo(() => md.render(content || ''), [content]);
+  const htmlFromMarkdown = useMemo(() => md.render(content || ''), [content, collectionPath]);
   const cleanHTML = useMemo(() => DOMPurify.sanitize(htmlFromMarkdown), [htmlFromMarkdown]);
 
   return (


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2972)

Fixes a potential security issue in the Markdown renderer where unsanitized HTML could allow malicious scripts or frames in rendered content to access internal APIs

Credits to @andrejtomci and another anonymous contributor for bringing it up.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML sanitization for Markdown content to reduce risk from unsafe markup.

* **Refactor**
  * Reduced unnecessary re-computation when rendering Markdown, improving component performance and ensuring updates run only when content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->