### PR TITLE
feat: implement uncommitted user edits tracking in editors

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -33,6 +33,7 @@ export default class CodeEditor extends React.Component {
     // unnecessary updates during the update lifecycle.
     this.cachedValue = props.value || '';
     this.variables = {};
+    this._hasUncommittedUserEdits = false;
     this.searchResultsCountElementId = 'search-results-count';
     this.searchBarRef = createRef();
 
@@ -197,6 +198,7 @@ export default class CodeEditor extends React.Component {
     if (editor) {
       editor.setOption('lint', this.props.mode && editor.getValue().trim().length > 0 ? this.lintOptions : false);
       editor.on('change', this._onEdit);
+      editor.on('blur', this._onBlur);
       editor.scrollTo(null, this.props.initialScroll);
       this.addOverlay();
 
@@ -232,18 +234,22 @@ export default class CodeEditor extends React.Component {
       this.editor.options.jump.schema = this.props.schema;
       CodeMirror.signal(this.editor, 'change', this.editor);
     }
-    if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
-      const nextValue = this.props.value ?? '';
-      const currentValue = this.editor.getValue();
-      // Skip updating only when focused and editable; read-only editors (e.g. response viewer) must always show new value
-      if (this.editor.hasFocus?.() && currentValue !== nextValue && !this.props.readOnly) {
-        this.cachedValue = currentValue;
+    if (this.props.value !== prevProps.value && this.editor) {
+      if (this.props.value === this.cachedValue) {
+        this._hasUncommittedUserEdits = false;
       } else {
-        const cursor = this.editor.getCursor();
-        this.cachedValue = nextValue;
-        this.editor.setValue(nextValue);
-        this.editor.setCursor(cursor);
+        const nextValue = this.props.value ?? '';
+        const currentValue = this.editor.getValue();
+        // Skip updating only when user is actively editing and editor is editable; read-only editors must always show new value
+        if (this._hasUncommittedUserEdits && currentValue !== nextValue && !this.props.readOnly) {
+          this.cachedValue = currentValue;
+        } else {
+          this._hasUncommittedUserEdits = false;
+          const cursor = this.editor.getCursor();
+          this.cachedValue = nextValue;
+          this.editor.setValue(nextValue);
+          this.editor.setCursor(cursor);
+        }
       }
     }
 
@@ -295,6 +301,7 @@ export default class CodeEditor extends React.Component {
 
       this.editor?._destroyLinkAware?.();
       this.editor.off('change', this._onEdit);
+      this.editor.off('blur', this._onBlur);
 
       // Clean up lint error tooltip
       this.cleanupLintErrorTooltip?.();
@@ -349,8 +356,13 @@ export default class CodeEditor extends React.Component {
     this.editor.setOption('mode', 'brunovariables');
   };
 
+  _onBlur = () => {
+    this._hasUncommittedUserEdits = false;
+  };
+
   _onEdit = () => {
     if (!this.ignoreChangeEvent && this.editor) {
+      this._hasUncommittedUserEdits = true;
       this.editor.setOption('lint', this.editor.getValue().trim().length > 0 ? this.lintOptions : false);
       this.cachedValue = this.editor.getValue();
       if (this.props.onEdit) {

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -20,6 +20,7 @@ class MultiLineEditor extends Component {
     this.editorRef = React.createRef();
     this.variables = {};
     this.readOnly = props.readOnly || false;
+    this._hasUncommittedUserEdits = false;
 
     this.state = {
       maskInput: props.isSecret || false // Always mask the input by default (if it's a secret)
@@ -92,6 +93,7 @@ class MultiLineEditor extends Component {
 
     this.editor.setValue(String(this.props.value) || '');
     this.editor.on('change', this._onEdit);
+    this.editor.on('blur', this._onBlur);
     this.addOverlay(variables);
 
     // Initialize masking if this is a secret field
@@ -101,11 +103,16 @@ class MultiLineEditor extends Component {
 
   _onEdit = () => {
     if (!this.ignoreChangeEvent && this.editor) {
+      this._hasUncommittedUserEdits = true;
       this.cachedValue = this.editor.getValue();
       if (this.props.onChange) {
         this.props.onChange(this.cachedValue);
       }
     }
+  };
+
+  _onBlur = () => {
+    this._hasUncommittedUserEdits = false;
   };
 
   /** Enable or disable masking the rendered content of the editor */
@@ -153,20 +160,24 @@ class MultiLineEditor extends Component {
     if (this.props.readOnly !== prevProps.readOnly && this.editor) {
       this.editor.setOption('readOnly', this.props.readOnly);
     }
-    if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
-      const nextValue = String(this.props.value ?? '');
-      const currentValue = this.editor.getValue();
-      if (this.editor.hasFocus?.() && currentValue !== nextValue) {
-        this.cachedValue = currentValue;
+    if (this.props.value !== prevProps.value && this.editor) {
+      if (this.props.value === this.cachedValue) {
+        this._hasUncommittedUserEdits = false;
       } else {
-        const cursor = this.editor.getCursor();
-        this.cachedValue = nextValue;
-        this.editor.setValue(nextValue);
-        this.editor.setCursor(cursor);
-        // Re-apply masking after setValue() since it destroys all CodeMirror marks
-        if (this.maskedEditor && this.maskedEditor.isEnabled()) {
-          this.maskedEditor.update();
+        const nextValue = String(this.props.value ?? '');
+        const currentValue = this.editor.getValue();
+        if (this._hasUncommittedUserEdits && currentValue !== nextValue) {
+          this.cachedValue = currentValue;
+        } else {
+          this._hasUncommittedUserEdits = false;
+          const cursor = this.editor.getCursor();
+          this.cachedValue = nextValue;
+          this.editor.setValue(nextValue);
+          this.editor.setCursor(cursor);
+          // Re-apply masking after setValue() since it destroys all CodeMirror marks
+          if (this.maskedEditor && this.maskedEditor.isEnabled()) {
+            this.maskedEditor.update();
+          }
         }
       }
     }
@@ -192,6 +203,9 @@ class MultiLineEditor extends Component {
     if (this.maskedEditor) {
       this.maskedEditor.destroy();
       this.maskedEditor = null;
+    }
+    if (this.editor) {
+      this.editor.off('blur', this._onBlur);
     }
     this.editor.getWrapperElement().remove();
   }

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
@@ -50,6 +50,7 @@ export default class QueryEditor extends React.Component {
     // unnecessary updates during the update lifecycle.
     this.cachedValue = props.value || '';
     this.variables = {};
+    this._hasUncommittedUserEdits = false;
   }
 
   componentDidMount() {
@@ -155,6 +156,7 @@ export default class QueryEditor extends React.Component {
       editor.on('keyup', this._onKeyUp);
       editor.on('hasCompletion', this._onHasCompletion);
       editor.on('beforeChange', this._onBeforeChange);
+      editor.on('blur', this._onBlur);
     }
     this.addOverlay();
 
@@ -173,15 +175,19 @@ export default class QueryEditor extends React.Component {
       this.editor.options.jump.schema = this.props.schema;
       CodeMirror.signal(this.editor, 'change', this.editor);
     }
-    if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
-      const nextValue = this.props.value ?? '';
-      const currentValue = this.editor.getValue();
-      if (this.editor.hasFocus?.() && currentValue !== nextValue) {
-        this.cachedValue = currentValue;
+    if (this.props.value !== prevProps.value && this.editor) {
+      if (this.props.value === this.cachedValue) {
+        this._hasUncommittedUserEdits = false;
       } else {
-        this.cachedValue = nextValue;
-        this.editor.setValue(nextValue);
+        const nextValue = this.props.value ?? '';
+        const currentValue = this.editor.getValue();
+        if (this._hasUncommittedUserEdits && currentValue !== nextValue) {
+          this.cachedValue = currentValue;
+        } else {
+          this._hasUncommittedUserEdits = false;
+          this.cachedValue = nextValue;
+          this.editor.setValue(nextValue);
+        }
       }
     }
 
@@ -205,6 +211,7 @@ export default class QueryEditor extends React.Component {
       this.editor.off('keyup', this._onKeyUp);
       this.editor.off('hasCompletion', this._onHasCompletion);
       this.editor.off('beforeChange', this._onBeforeChange);
+      this.editor.off('blur', this._onBlur);
       // Remove the CodeMirror DOM element so React 18 Strict Mode's
       // unmount-remount cycle doesn't leave an orphaned instance behind.
       const wrapper = this.editor.getWrapperElement();
@@ -271,8 +278,13 @@ export default class QueryEditor extends React.Component {
     }
   };
 
+  _onBlur = () => {
+    this._hasUncommittedUserEdits = false;
+  };
+
   _onEdit = () => {
     if (!this.ignoreChangeEvent && this.editor) {
+      this._hasUncommittedUserEdits = true;
       this.cachedValue = this.editor.getValue();
       if (this.props.onEdit) {
         this.props.onEdit(this.cachedValue);

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -20,6 +20,7 @@ class SingleLineEditor extends Component {
     this.editorRef = React.createRef();
     this.variables = {};
     this.readOnly = props.readOnly || false;
+    this._hasUncommittedUserEdits = false;
 
     this.state = {
       maskInput: props.isSecret || false // Always mask the input by default (if it's a secret)
@@ -99,6 +100,7 @@ class SingleLineEditor extends Component {
     this.editor.setValue(String(this.props.value ?? ''));
     this.editor.on('change', this._onEdit);
     this.editor.on('paste', this._onPaste);
+    this.editor.on('blur', this._onBlur);
     this.addOverlay(variables);
     this._enableMaskedEditor(this.props.isSecret);
     this.setState({ maskInput: this.props.isSecret });
@@ -128,6 +130,7 @@ class SingleLineEditor extends Component {
 
   _onEdit = () => {
     if (!this.ignoreChangeEvent && this.editor) {
+      this._hasUncommittedUserEdits = true;
       this.cachedValue = this.editor.getValue();
       if (this.props.onChange && (this.props.value !== this.cachedValue)) {
         this.props.onChange(this.cachedValue);
@@ -140,7 +143,14 @@ class SingleLineEditor extends Component {
     }
   };
 
-  _onPaste = (_, event) => this.props.onPaste?.(event);
+  _onPaste = (_, event) => {
+    this._hasUncommittedUserEdits = false;
+    this.props.onPaste?.(event);
+  };
+
+  _onBlur = () => {
+    this._hasUncommittedUserEdits = false;
+  };
 
   componentDidUpdate(prevProps) {
     // Ensure the changes caused by this update are not interpreted as
@@ -168,25 +178,29 @@ class SingleLineEditor extends Component {
     if (this.props.theme !== prevProps.theme && this.editor) {
       this.editor.setOption('theme', this.props.theme === 'dark' ? 'monokai' : 'default');
     }
-    if (this.props.value !== prevProps.value && this.props.value !== this.cachedValue && this.editor) {
-      // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
-      const nextValue = String(this.props.value ?? '');
-      const currentValue = this.editor.getValue();
-      if (this.editor.hasFocus?.() && currentValue !== nextValue && nextValue !== '') {
-        this.cachedValue = currentValue;
+    if (this.props.value !== prevProps.value && this.editor) {
+      if (this.props.value === this.cachedValue) {
+        this._hasUncommittedUserEdits = false;
       } else {
-        const cursor = this.editor.getCursor();
-        this.cachedValue = nextValue;
-        this.editor.setValue(nextValue);
-        this.editor.setCursor(cursor);
-        // Re-apply masking after setValue() since it destroys all CodeMirror marks
-        if (this.maskedEditor && this.maskedEditor.isEnabled()) {
-          this.maskedEditor.update();
-        }
+        const nextValue = String(this.props.value ?? '');
+        const currentValue = this.editor.getValue();
+        if (this._hasUncommittedUserEdits && currentValue !== nextValue && nextValue !== '') {
+          this.cachedValue = currentValue;
+        } else {
+          this._hasUncommittedUserEdits = false;
+          const cursor = this.editor.getCursor();
+          this.cachedValue = nextValue;
+          this.editor.setValue(nextValue);
+          this.editor.setCursor(cursor);
+          // Re-apply masking after setValue() since it destroys all CodeMirror marks
+          if (this.maskedEditor && this.maskedEditor.isEnabled()) {
+            this.maskedEditor.update();
+          }
 
-        // Update newline markers after value change
-        if (this.props.showNewlineArrow) {
-          this._updateNewlineMarkers();
+          // Update newline markers after value change
+          if (this.props.showNewlineArrow) {
+            this._updateNewlineMarkers();
+          }
         }
       }
     }
@@ -212,6 +226,7 @@ class SingleLineEditor extends Component {
       }
       this.editor.off('change', this._onEdit);
       this.editor.off('paste', this._onPaste);
+      this.editor.off('blur', this._onBlur);
       this._clearNewlineMarkers();
       this.editor.getWrapperElement().remove();
       this.editor = null;

--- a/packages/bruno-app/src/components/SingleLineEditor/index.spec.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.spec.js
@@ -1,0 +1,385 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+// Mock CodeMirror with event handler tracking
+jest.mock('codemirror', () => {
+  const CodeMirror = jest.fn((node, options) => {
+    const editor = {
+      options,
+      _currentValue: '',
+      getCursor: jest.fn(() => ({ line: 0, ch: 0 })),
+      getValue: jest.fn(() => editor._currentValue),
+      setValue: jest.fn((val) => {
+        editor._currentValue = val;
+      }),
+      setCursor: jest.fn(),
+      getLine: jest.fn(() => ''),
+      setOption: jest.fn(),
+      refresh: jest.fn(),
+      hasFocus: jest.fn(() => true),
+      getWrapperElement: jest.fn(() => ({ remove: jest.fn() })),
+      on: jest.fn(),
+      off: jest.fn(),
+      lineCount: jest.fn(() => 1),
+      posFromIndex: jest.fn((i) => ({ line: 0, ch: i })),
+      markText: jest.fn(() => ({ clear: jest.fn() }))
+    };
+    return editor;
+  });
+  CodeMirror.commands = { autocomplete: jest.fn() };
+  CodeMirror.hint = {};
+  CodeMirror.registerHelper = jest.fn();
+  CodeMirror.defineMode = jest.fn();
+  CodeMirror.signal = jest.fn();
+  return CodeMirror;
+});
+
+jest.mock('utils/collections', () => ({
+  getAllVariables: jest.fn(() => ({}))
+}));
+
+jest.mock('utils/common/codemirror', () => ({
+  defineCodeMirrorBrunoVariablesMode: jest.fn()
+}));
+
+jest.mock('utils/common/masked-editor', () => ({
+  MaskedEditor: jest.fn(() => ({
+    enable: jest.fn(),
+    disable: jest.fn(),
+    destroy: jest.fn(),
+    isEnabled: jest.fn(() => false),
+    update: jest.fn()
+  }))
+}));
+
+jest.mock('utils/codemirror/autocomplete', () => ({
+  setupAutoComplete: jest.fn(() => jest.fn())
+}));
+
+jest.mock('utils/codemirror/linkAware', () => ({
+  setupLinkAware: jest.fn()
+}));
+
+const SingleLineEditor = require('./index').default;
+
+const MOCK_THEME = {
+  text: '#333',
+  font: { size: { base: '14px' } },
+  codemirror: {
+    bg: '#fff',
+    border: '#ccc',
+    placeholder: { color: '#999', opacity: '0.6' }
+  },
+  textLink: '#007acc'
+};
+
+const defaultProps = {
+  value: '',
+  collection: {},
+  item: {},
+  theme: 'light'
+};
+
+const renderEditor = (props = {}) => {
+  const ref = React.createRef();
+  const result = render(
+    <ThemeProvider theme={MOCK_THEME}>
+      <SingleLineEditor ref={ref} {...defaultProps} {...props} />
+    </ThemeProvider>
+  );
+  return { ref, ...result };
+};
+
+describe('SingleLineEditor - _hasUncommittedUserEdits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Flag state transitions ───────────────────────────────────────────
+
+  it('initializes _hasUncommittedUserEdits to false', () => {
+    const { ref } = renderEditor({ value: 'https://example.com' });
+    expect(ref.current._hasUncommittedUserEdits).toBe(false);
+  });
+
+  it('sets flag to true when user edits (typing)', () => {
+    const { ref } = renderEditor({ value: 'initial' });
+    const instance = ref.current;
+
+    // Simulate user typing a character
+    instance.editor._currentValue = 'initial-x';
+    instance._onEdit();
+
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+  });
+
+  it('resets flag to false on blur', () => {
+    const { ref } = renderEditor({ value: 'initial' });
+    const instance = ref.current;
+
+    // User types → flag true
+    instance.editor._currentValue = 'changed';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+
+    // User blurs → flag false
+    instance._onBlur();
+    expect(instance._hasUncommittedUserEdits).toBe(false);
+  });
+
+  it('resets flag to false on paste event', () => {
+    const { ref } = renderEditor({ value: 'initial' });
+    const instance = ref.current;
+
+    // User types → flag true
+    instance.editor._currentValue = 'changed';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+
+    // Paste event fires → flag false
+    const mockEvent = {};
+    instance._onPaste(null, mockEvent);
+    expect(instance._hasUncommittedUserEdits).toBe(false);
+  });
+
+  it('does not set flag when ignoreChangeEvent is true (programmatic changes)', () => {
+    const { ref } = renderEditor({ value: 'initial' });
+    const instance = ref.current;
+
+    // Simulate programmatic change (e.g. during componentDidUpdate)
+    instance.ignoreChangeEvent = true;
+    instance.editor._currentValue = 'programmatic';
+    instance._onEdit();
+    instance.ignoreChangeEvent = false;
+
+    expect(instance._hasUncommittedUserEdits).toBe(false);
+  });
+
+  // ── Autosave protection: user edits are preserved ────────────────────
+
+  it('skips external value update when user has uncommitted edits', () => {
+    const { ref, rerender } = renderEditor({ value: 'original-url' });
+    const instance = ref.current;
+
+    // User types a different URL
+    instance.editor._currentValue = 'user-typed-url';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+
+    // Clear setValue calls from mount
+    instance.editor.setValue.mockClear();
+
+    // Autosave round-trip arrives with a slightly different (normalized) value
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="normalized-url" />
+      </ThemeProvider>
+    );
+
+    // Editor should NOT have been updated with the autosave value
+    expect(instance.editor.setValue).not.toHaveBeenCalledWith('normalized-url');
+    // Editor should retain the user's version
+    expect(instance.cachedValue).toBe('user-typed-url');
+  });
+
+  // ── cURL paste: programmatic updates go through ──────────────────────
+
+  it('applies external value update when no uncommitted user edits', () => {
+    const { ref, rerender } = renderEditor({ value: 'old-url' });
+    const instance = ref.current;
+
+    // No user edits — flag is false
+    expect(instance._hasUncommittedUserEdits).toBe(false);
+
+    instance.editor.setValue.mockClear();
+
+    // cURL paste dispatches a new URL via Redux, arrives as a prop update
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="https://api.example.com/users" />
+      </ThemeProvider>
+    );
+
+    // Editor should be updated with the parsed cURL URL
+    expect(instance.editor.setValue).toHaveBeenCalledWith('https://api.example.com/users');
+    expect(instance.cachedValue).toBe('https://api.example.com/users');
+  });
+
+  it('applies external value update after paste resets the flag (full cURL flow)', () => {
+    const onPasteSpy = jest.fn();
+    const { ref, rerender } = renderEditor({ value: 'old-url', onPaste: onPasteSpy });
+    const instance = ref.current;
+
+    // Step 1: User was typing before the paste
+    instance.editor._currentValue = 'old-url-modified';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+
+    // Step 2: User pastes a cURL command → _onPaste fires and resets the flag
+    const mockEvent = { preventDefault: jest.fn() };
+    instance._onPaste(null, mockEvent);
+    expect(instance._hasUncommittedUserEdits).toBe(false);
+    expect(onPasteSpy).toHaveBeenCalledWith(mockEvent);
+
+    // Step 3: The cURL handler dispatches the parsed URL, arrives as a prop update
+    instance.editor.setValue.mockClear();
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="https://parsed-curl.example.com" onPaste={onPasteSpy} />
+      </ThemeProvider>
+    );
+
+    // Editor should accept the new URL
+    expect(instance.editor.setValue).toHaveBeenCalledWith('https://parsed-curl.example.com');
+    expect(instance.cachedValue).toBe('https://parsed-curl.example.com');
+  });
+
+  // ── Round-trip reset ─────────────────────────────────────────────────
+
+  it('resets flag when prop value matches cachedValue (successful round-trip)', () => {
+    const onChange = jest.fn();
+    const { ref, rerender } = renderEditor({ value: 'initial', onChange });
+    const instance = ref.current;
+
+    // User types → flag true, cachedValue updated
+    instance.editor._currentValue = 'new-value';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+    expect(instance.cachedValue).toBe('new-value');
+
+    // Prop round-trips with the exact same value
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="new-value" onChange={onChange} />
+      </ThemeProvider>
+    );
+
+    // Flag should be reset — the edit was acknowledged
+    expect(instance._hasUncommittedUserEdits).toBe(false);
+  });
+
+  it('after round-trip reset, subsequent external updates are applied', () => {
+    const onChange = jest.fn();
+    const { ref, rerender } = renderEditor({ value: 'step-0', onChange });
+    const instance = ref.current;
+
+    // User types → flag true
+    instance.editor._currentValue = 'step-1';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+
+    // Round-trip: prop matches cachedValue → flag reset
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="step-1" onChange={onChange} />
+      </ThemeProvider>
+    );
+    expect(instance._hasUncommittedUserEdits).toBe(false);
+
+    // Now an external update (e.g., cURL paste) arrives
+    instance.editor.setValue.mockClear();
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="step-2-external" onChange={onChange} />
+      </ThemeProvider>
+    );
+
+    // Should be applied since flag is false
+    expect(instance.editor.setValue).toHaveBeenCalledWith('step-2-external');
+  });
+
+  // ── Normal paste (not cURL) still protects edits ─────────────────────
+
+  it('normal paste re-enables protection via subsequent _onEdit', () => {
+    const { ref, rerender } = renderEditor({ value: 'before-paste' });
+    const instance = ref.current;
+
+    // User types → flag true
+    instance.editor._currentValue = 'before-paste-edited';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+
+    // Paste event fires (not cURL, so no preventDefault) → flag reset momentarily
+    instance._onPaste(null, {});
+    expect(instance._hasUncommittedUserEdits).toBe(false);
+
+    // CodeMirror inserts pasted text → _onEdit fires again → flag back to true
+    instance.editor._currentValue = 'before-paste-edited-pasted-text';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+
+    // Autosave arrives with different value → should be skipped
+    instance.editor.setValue.mockClear();
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="autosave-normalized" />
+      </ThemeProvider>
+    );
+
+    expect(instance.editor.setValue).not.toHaveBeenCalledWith('autosave-normalized');
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────
+
+  it('applies update even with uncommitted edits when incoming value is empty', () => {
+    const { ref, rerender } = renderEditor({ value: 'some-url' });
+    const instance = ref.current;
+
+    // User types → flag true
+    instance.editor._currentValue = 'some-url-edited';
+    instance._onEdit();
+    expect(instance._hasUncommittedUserEdits).toBe(true);
+
+    instance.editor.setValue.mockClear();
+
+    // External update with empty string (e.g., new request reset)
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="" />
+      </ThemeProvider>
+    );
+
+    // Should still apply — the `nextValue !== ''` check lets empty through
+    expect(instance.editor.setValue).toHaveBeenCalledWith('');
+  });
+
+  it('cursor position is preserved when external update is applied', () => {
+    const { ref, rerender } = renderEditor({ value: 'old' });
+    const instance = ref.current;
+
+    // Set up a cursor position
+    const mockCursor = { line: 0, ch: 3 };
+    instance.editor.getCursor.mockReturnValue(mockCursor);
+
+    instance.editor.setValue.mockClear();
+    instance.editor.setCursor.mockClear();
+
+    // External update applied (flag is false)
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="new-value" />
+      </ThemeProvider>
+    );
+
+    expect(instance.editor.setValue).toHaveBeenCalledWith('new-value');
+    expect(instance.editor.setCursor).toHaveBeenCalledWith(mockCursor);
+  });
+
+  it('no update when prop value does not change', () => {
+    const { ref, rerender } = renderEditor({ value: 'same' });
+    const instance = ref.current;
+
+    instance.editor.setValue.mockClear();
+
+    // Rerender with same value
+    rerender(
+      <ThemeProvider theme={MOCK_THEME}>
+        <SingleLineEditor ref={ref} {...defaultProps} value="same" />
+      </ThemeProvider>
+    );
+
+    // setValue should not be called (value didn't change)
+    expect(instance.editor.setValue).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where code editors would overwrite active user edits. Your typing is now protected from external updates until you finish editing and move focus away from the field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->