### PR TITLE
fix: restore system-ca for OS certificate store access (#7597)

### DIFF
--- a/packages/bruno-requests/rollup.config.js
+++ b/packages/bruno-requests/rollup.config.js
@@ -39,6 +39,6 @@ module.exports = [
       typescript({ tsconfig: './tsconfig.json' }),
       terser()
     ],
-    external: (id) => isBuiltin(id) || ['axios', 'qs', 'ws', 'debug', 'shell-env'].includes(id)
+    external: (id) => isBuiltin(id) || ['axios', 'qs', 'ws', 'debug', 'shell-env', 'system-ca'].includes(id)
   }
 ];

--- a/packages/bruno-requests/src/utils/ca-cert.spec.ts
+++ b/packages/bruno-requests/src/utils/ca-cert.spec.ts
@@ -1,0 +1,93 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const mockSystemCertsSync = jest.fn(() => [
+  '-----BEGIN CERTIFICATE-----\nFAKE_SYSTEM_CERT_1\n-----END CERTIFICATE-----',
+  '-----BEGIN CERTIFICATE-----\nFAKE_SYSTEM_CERT_2\n-----END CERTIFICATE-----'
+]);
+
+// Mock system-ca before importing the module under test
+jest.mock('system-ca', () => ({
+  systemCertsSync: () => mockSystemCertsSync()
+}));
+
+// Mock node:tls to control rootCertificates
+jest.mock('node:tls', () => ({
+  rootCertificates: [
+    '-----BEGIN CERTIFICATE-----\nFAKE_ROOT_CERT_1\n-----END CERTIFICATE-----'
+  ]
+}));
+
+import { getCACertificates } from './ca-cert';
+
+describe('getCACertificates', () => {
+  it('returns system and root certificates when no custom CA is provided', () => {
+    const result = getCACertificates({});
+
+    // system-ca's systemCertsSync should be used (not tls.getCACertificates)
+    expect(mockSystemCertsSync).toHaveBeenCalled();
+    expect(result.caCertificatesCount.system).toBe(2);
+    expect(result.caCertificatesCount.root).toBe(1);
+    expect(result.caCertificatesCount.custom).toBe(0);
+    expect(result.caCertificates).toContain('FAKE_SYSTEM_CERT_1');
+    expect(result.caCertificates).toContain('FAKE_SYSTEM_CERT_2');
+    expect(result.caCertificates).toContain('FAKE_ROOT_CERT_1');
+  });
+
+  it('includes custom CA certificate when file path is provided', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ca-cert-test-'));
+    const certPath = path.join(tmpDir, 'custom-ca.pem');
+    const customCert = '-----BEGIN CERTIFICATE-----\nCUSTOM_CA_CERT\n-----END CERTIFICATE-----';
+    fs.writeFileSync(certPath, customCert);
+
+    try {
+      const result = getCACertificates({ caCertFilePath: certPath });
+
+      expect(result.caCertificatesCount.custom).toBe(1);
+      expect(result.caCertificates).toContain('CUSTOM_CA_CERT');
+      // Default certs should also be included (shouldKeepDefaultCerts defaults to true)
+      expect(result.caCertificatesCount.system).toBe(2);
+      expect(result.caCertificatesCount.root).toBe(1);
+    } finally {
+      fs.unlinkSync(certPath);
+      fs.rmdirSync(tmpDir);
+    }
+  });
+
+  it('excludes default certs when shouldKeepDefaultCerts is false with custom CA', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ca-cert-test-'));
+    const certPath = path.join(tmpDir, 'custom-ca.pem');
+    const customCert = '-----BEGIN CERTIFICATE-----\nCUSTOM_ONLY\n-----END CERTIFICATE-----';
+    fs.writeFileSync(certPath, customCert);
+
+    try {
+      const result = getCACertificates({ caCertFilePath: certPath, shouldKeepDefaultCerts: false });
+
+      expect(result.caCertificatesCount.custom).toBe(1);
+      expect(result.caCertificatesCount.system).toBe(0);
+      expect(result.caCertificatesCount.root).toBe(0);
+      expect(result.caCertificates).toContain('CUSTOM_ONLY');
+      expect(result.caCertificates).not.toContain('FAKE_SYSTEM_CERT_1');
+    } finally {
+      fs.unlinkSync(certPath);
+      fs.rmdirSync(tmpDir);
+    }
+  });
+
+  it('throws when custom CA file path does not exist', () => {
+    expect(() => getCACertificates({ caCertFilePath: '/nonexistent/path.pem' }))
+      .toThrow('Invalid custom CA certificate path');
+  });
+
+  it('deduplicates certificates across sources', () => {
+    // The first test already cached system certs with 2 fake certs.
+    // Root certs include FAKE_ROOT_CERT_1. If system also returned it, it should be deduped.
+    // Since caching is in play, we test dedup by checking the merged output
+    // has no duplicate PEM blocks.
+    const result = getCACertificates({});
+    const certs = result.caCertificates.split('-----BEGIN CERTIFICATE-----').filter(Boolean);
+    const uniqueCerts = new Set(certs);
+    expect(certs.length).toBe(uniqueCerts.size);
+  });
+});

--- a/packages/bruno-requests/src/utils/ca-cert.ts
+++ b/packages/bruno-requests/src/utils/ca-cert.ts
@@ -1,4 +1,5 @@
-import * as tls from 'node:tls';
+import { systemCertsSync } from 'system-ca';
+import { rootCertificates } from 'node:tls';
 import * as fs from 'node:fs';
 
 type T_CACertificatesOptions = {
@@ -22,7 +23,7 @@ function getSystemCerts(): string[] {
   if (systemCertsCache) return systemCertsCache;
 
   try {
-    systemCertsCache = tls.getCACertificates('system');
+    systemCertsCache = systemCertsSync();
 
     return systemCertsCache;
   } catch (error) {
@@ -128,7 +129,7 @@ const getCACertificates = ({ caCertFilePath, shouldKeepDefaultCerts = true }: T_
         caCertificatesCount.system = systemCerts.length;
 
         // get root certs
-        rootCerts = [...tls.rootCertificates];
+        rootCerts = [...rootCertificates];
         caCertificatesCount.root = rootCerts.length;
       }
     } else {
@@ -137,7 +138,7 @@ const getCACertificates = ({ caCertFilePath, shouldKeepDefaultCerts = true }: T_
       caCertificatesCount.system = systemCerts.length;
 
       // get root certs
-      rootCerts = [...tls.rootCertificates];
+      rootCerts = [...rootCertificates];
       caCertificatesCount.root = rootCerts.length;
     }
 


### PR DESCRIPTION
### Description

The switch from system-ca to tls.getCACertificates('system') in commit 66bcbf00e broke custom root certificate recognition on macOS. The Node.js API returns 0 system certificates on macOS while system-ca correctly reads all certificates from the macOS Keychain, including user-installed root CAs.

This reverts to using system-ca (which was still a dependency but unused) and adds it back to the rollup externals list.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system certificate retrieval to ensure proper CA certificate handling and resolution.

* **Tests**
  * Added comprehensive test coverage for CA certificate management, including system, root, and custom certificate handling, with deduplication verification.

* **Chores**
  * Optimized bundling configuration to exclude external dependencies from output bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->