### PR TITLE
fix: handle non-array tags from bru parser to prevent crash

### DIFF
--- a/packages/bruno-filestore/src/formats/bru/index.ts
+++ b/packages/bruno-filestore/src/formats/bru/index.ts
@@ -32,6 +32,7 @@ export const parseBruRequest = (data: string | any, parsed: boolean = false): an
     }
 
     const sequence = _.get(json, 'meta.seq');
+    const tags = _.get(json, 'meta.tags', []);
     const urlPath: Record<typeof requestType, string> = {
       'grpc-request': 'grpc.url',
       'ws-request': 'ws.url',
@@ -42,7 +43,7 @@ export const parseBruRequest = (data: string | any, parsed: boolean = false): an
       name: _.get(json, 'meta.name'),
       seq: !_.isNaN(sequence) ? Number(sequence) : 1,
       settings: _.get(json, 'settings', {}),
-      tags: _.get(json, 'meta.tags', []),
+      tags: Array.isArray(tags) ? tags : [],
       request: {
         // Preserving special characters in custom methods. Using _.upperCase strips special characters.
         method:


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2990)

- Fixes crash (`v.map is not a function`) when a `.bru` file contains `tags: []` (inline empty array) in the meta block
- The bru grammar requires newlines inside list brackets, so `tags: []` gets parsed as the string `"[]"` instead of an empty array — this causes `.map()` calls in React components to crash
- Adds `Array.isArray` guard when extracting tags in `parseBruRequest`

Fixes #7357

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tag validation in Bru format file parsing to ensure tags are always properly formatted as arrays, preventing potential issues when processing files with malformed tag data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->