### PR TITLE
fix: clear CodeMirror selection highlight on blur in inline editors

### DIFF
--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -92,12 +92,19 @@ class MultiLineEditor extends Component {
 
     this.editor.setValue(String(this.props.value) || '');
     this.editor.on('change', this._onEdit);
+    this.editor.on('blur', this._onBlur);
     this.addOverlay(variables);
 
     // Initialize masking if this is a secret field
     this.setState({ maskInput: this.props.isSecret });
     this._enableMaskedEditor(this.props.isSecret);
   }
+
+  _onBlur = () => {
+    if (this.editor) {
+      this.editor.setCursor(this.editor.getCursor());
+    }
+  };
 
   _onEdit = () => {
     if (!this.ignoreChangeEvent && this.editor) {
@@ -193,7 +200,11 @@ class MultiLineEditor extends Component {
       this.maskedEditor.destroy();
       this.maskedEditor = null;
     }
-    this.editor.getWrapperElement().remove();
+    if (this.editor) {
+      this.editor.off('change', this._onEdit);
+      this.editor.off('blur', this._onBlur);
+      this.editor.getWrapperElement().remove();
+    }
   }
 
   addOverlay = (variables) => {

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -99,6 +99,7 @@ class SingleLineEditor extends Component {
     this.editor.setValue(String(this.props.value ?? ''));
     this.editor.on('change', this._onEdit);
     this.editor.on('paste', this._onPaste);
+    this.editor.on('blur', this._onBlur);
     this.addOverlay(variables);
     this._enableMaskedEditor(this.props.isSecret);
     this.setState({ maskInput: this.props.isSecret });
@@ -123,6 +124,12 @@ class SingleLineEditor extends Component {
         this.maskedEditor.destroy();
         this.maskedEditor = null;
       }
+    }
+  };
+
+  _onBlur = () => {
+    if (this.editor) {
+      this.editor.setCursor(this.editor.getCursor());
     }
   };
 
@@ -212,6 +219,7 @@ class SingleLineEditor extends Component {
       }
       this.editor.off('change', this._onEdit);
       this.editor.off('paste', this._onPaste);
+      this.editor.off('blur', this._onBlur);
       this._clearNewlineMarkers();
       this.editor.getWrapperElement().remove();
       this.editor = null;


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2992)

- Fixes query param value highlight persisting after selecting another value (#7612)
- Adds blur event handler to SingleLineEditor and MultiLineEditor that collapses selection via setCursor(getCursor())
- Adds null-guarded cleanup of event listeners in MultiLineEditor.componentWillUnmount

Root Cause
Each query param row uses an independent CodeMirror instance. CodeMirror keeps text selection visible after blur by default. Double-clicking a value in one row and then another leaves both highlights visible.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed cursor position preservation in editor components. MultiLineEditor and SingleLineEditor now correctly maintain cursor position when the editor loses focus. Improved event handler management during the component lifecycle ensures consistent, reliable cursor state preservation throughout editing sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->