### PR TITLE
fix: measure total response time instead of TTFB (#7594)

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -105,6 +105,14 @@ const promisifyStream = async (stream, abortController, closeOnFirst) => {
   });
 };
 
+const measureResponseTime = (config, headers, isStream) => {
+  const startTime = config?.headers?.['request-start-time'];
+  if (!isStream && startTime != null) {
+    return Date.now() - startTime;
+  }
+  return Number(headers.get('request-duration')) || 0;
+};
+
 const configureRequest = async (
   collectionUid,
   collection,
@@ -1028,13 +1036,8 @@ const registerNetworkIpc = (mainWindow) => {
 
         if (!isResponseStream) {
           response.data = await promisifyStream(response.data);
-          // Measure after full body download. The interceptor only captures TTFB
-          // (because responseType='stream'), so re-measure here for non-stream responses.
-          responseTime = Date.now() - response.config.headers['request-start-time'];
-        } else {
-          // For SSE/event-stream responses, TTFB from the interceptor is appropriate.
-          responseTime = response.headers.get('request-duration');
         }
+        responseTime = measureResponseTime(response.config, response.headers, isResponseStream);
         // Prevents the duration on leaking to the actual result
         response.headers.delete('request-duration');
       } catch (error) {
@@ -1053,16 +1056,13 @@ const registerNetworkIpc = (mainWindow) => {
         }
         if (error?.response) {
           response = error.response;
-          // Prevents the duration on leaking to the actual result
-          response.headers.delete('request-duration');
           isResponseStream = hasStreamHeaders(response.headers);
           if (!isResponseStream) {
             response.data = await promisifyStream(response.data);
-            // Same fix as the happy path: measure after full body download.
-            responseTime = Date.now() - response.config.headers['request-start-time'];
-          } else {
-            responseTime = response.headers.get('request-duration');
           }
+          responseTime = measureResponseTime(response.config, response.headers, isResponseStream);
+          // Prevents the duration on leaking to the actual result
+          response.headers.delete('request-duration');
         } else {
           await executeRequestOnFailHandler(request, error);
 
@@ -2282,3 +2282,4 @@ module.exports.executeRequestOnFailHandler = executeRequestOnFailHandler;
 module.exports.buildResponseBodyFromStreamChunks = buildResponseBodyFromStreamChunks;
 module.exports.promisifyStream = promisifyStream;
 module.exports.hasStreamHeaders = hasStreamHeaders;
+module.exports.measureResponseTime = measureResponseTime;

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1885,7 +1885,7 @@ const registerNetworkIpc = (mainWindow) => {
               const { data, dataBuffer } = parseDataFromResponse(response, request.__brunoDisableParsingResponseJson);
               response.data = data;
               response.dataBuffer = dataBuffer;
-              response.responseTime = response.headers.get('request-duration');
+              response.responseTime = measureResponseTime(response.config, response.headers, false);
               response.headers.delete('request-duration');
 
               // save cookies
@@ -1923,7 +1923,7 @@ const registerNetworkIpc = (mainWindow) => {
               if (error?.response) {
                 error.response.data = await promisifyStream(error.response.data, currentAbortController, false);
                 const { data, dataBuffer } = parseDataFromResponse(error.response);
-                error.response.responseTime = error.response.headers.get('request-duration');
+                error.response.responseTime = measureResponseTime(error.response.config, error.response.headers, false);
                 error.response.headers.delete('request-duration');
                 error.response.data = data;
                 error.response.dataBuffer = dataBuffer;

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1028,10 +1028,14 @@ const registerNetworkIpc = (mainWindow) => {
 
         if (!isResponseStream) {
           response.data = await promisifyStream(response.data);
+          // Measure after full body download. The interceptor only captures TTFB
+          // (because responseType='stream'), so re-measure here for non-stream responses.
+          responseTime = Date.now() - response.config.headers['request-start-time'];
+        } else {
+          // For SSE/event-stream responses, TTFB from the interceptor is appropriate.
+          responseTime = response.headers.get('request-duration');
         }
-
         // Prevents the duration on leaking to the actual result
-        responseTime = response.headers.get('request-duration');
         response.headers.delete('request-duration');
       } catch (error) {
         deleteCancelToken(cancelTokenUid);
@@ -1049,13 +1053,15 @@ const registerNetworkIpc = (mainWindow) => {
         }
         if (error?.response) {
           response = error.response;
-
           // Prevents the duration on leaking to the actual result
-          responseTime = response.headers.get('request-duration');
           response.headers.delete('request-duration');
           isResponseStream = hasStreamHeaders(response.headers);
           if (!isResponseStream) {
             response.data = await promisifyStream(response.data);
+            // Same fix as the happy path: measure after full body download.
+            responseTime = Date.now() - response.config.headers['request-start-time'];
+          } else {
+            responseTime = response.headers.get('request-duration');
           }
         } else {
           await executeRequestOnFailHandler(request, error);
@@ -2274,3 +2280,5 @@ module.exports.getCertsAndProxyConfig = getCertsAndProxyConfig;
 module.exports.fetchGqlSchemaHandler = fetchGqlSchemaHandler;
 module.exports.executeRequestOnFailHandler = executeRequestOnFailHandler;
 module.exports.buildResponseBodyFromStreamChunks = buildResponseBodyFromStreamChunks;
+module.exports.promisifyStream = promisifyStream;
+module.exports.hasStreamHeaders = hasStreamHeaders;

--- a/packages/bruno-electron/tests/network/index.spec.js
+++ b/packages/bruno-electron/tests/network/index.spec.js
@@ -1,4 +1,4 @@
-const { configureRequest, promisifyStream, hasStreamHeaders } = require('../../src/ipc/network/index');
+const { configureRequest, promisifyStream, hasStreamHeaders, measureResponseTime } = require('../../src/ipc/network/index');
 const { Readable } = require('stream');
 
 describe('index: hasStreamHeaders', () => {
@@ -56,6 +56,33 @@ describe('index: promisifyStream', () => {
     const resultPromise = promisifyStream(stream, null, false);
     stream.emit('error', new Error('stream error'));
     await expect(resultPromise).rejects.toThrow('stream error');
+  });
+});
+
+describe('index: measureResponseTime', () => {
+  it('returns elapsed ms from request-start-time for non-stream response', () => {
+    const start = Date.now() - 150;
+    const config = { headers: { 'request-start-time': start } };
+    const headers = { get: () => null };
+    expect(measureResponseTime(config, headers, false)).toBeGreaterThanOrEqual(150);
+  });
+
+  it('falls back to Number(request-duration) when request-start-time is absent', () => {
+    const config = {};
+    const headers = { get: (k) => (k === 'request-duration' ? '300' : null) };
+    expect(measureResponseTime(config, headers, false)).toBe(300);
+  });
+
+  it('returns Number(request-duration) for stream (SSE) response', () => {
+    const config = {};
+    const headers = { get: (k) => (k === 'request-duration' ? '50' : null) };
+    expect(measureResponseTime(config, headers, true)).toBe(50);
+  });
+
+  it('returns 0 when both request-start-time and request-duration are absent', () => {
+    const config = {};
+    const headers = { get: () => null };
+    expect(measureResponseTime(config, headers, true)).toBe(0);
   });
 });
 

--- a/packages/bruno-electron/tests/network/index.spec.js
+++ b/packages/bruno-electron/tests/network/index.spec.js
@@ -61,10 +61,12 @@ describe('index: promisifyStream', () => {
 
 describe('index: measureResponseTime', () => {
   it('returns elapsed ms from request-start-time for non-stream response', () => {
-    const start = Date.now() - 150;
-    const config = { headers: { 'request-start-time': start } };
+    jest.useFakeTimers();
+    jest.setSystemTime(1000000);
+    const config = { headers: { 'request-start-time': 1000000 - 150 } };
     const headers = { get: () => null };
-    expect(measureResponseTime(config, headers, false)).toBeGreaterThanOrEqual(150);
+    expect(measureResponseTime(config, headers, false)).toBe(150);
+    jest.useRealTimers();
   });
 
   it('falls back to Number(request-duration) when request-start-time is absent', () => {

--- a/packages/bruno-electron/tests/network/index.spec.js
+++ b/packages/bruno-electron/tests/network/index.spec.js
@@ -62,11 +62,14 @@ describe('index: promisifyStream', () => {
 describe('index: measureResponseTime', () => {
   it('returns elapsed ms from request-start-time for non-stream response', () => {
     jest.useFakeTimers();
-    jest.setSystemTime(1000000);
-    const config = { headers: { 'request-start-time': 1000000 - 150 } };
-    const headers = { get: () => null };
-    expect(measureResponseTime(config, headers, false)).toBe(150);
-    jest.useRealTimers();
+    try {
+      jest.setSystemTime(1000000);
+      const config = { headers: { 'request-start-time': 1000000 - 150 } };
+      const headers = { get: () => null };
+      expect(measureResponseTime(config, headers, false)).toBe(150);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('falls back to Number(request-duration) when request-start-time is absent', () => {

--- a/packages/bruno-electron/tests/network/index.spec.js
+++ b/packages/bruno-electron/tests/network/index.spec.js
@@ -1,4 +1,63 @@
-const { configureRequest } = require('../../src/ipc/network/index');
+const { configureRequest, promisifyStream, hasStreamHeaders } = require('../../src/ipc/network/index');
+const { Readable } = require('stream');
+
+describe('index: hasStreamHeaders', () => {
+  it('returns true when content-type is text/event-stream', () => {
+    const h = { get: (k) => (k === 'content-type' ? 'text/event-stream' : null) };
+    expect(hasStreamHeaders(h)).toBe(true);
+  });
+
+  it('returns true when content-type includes charset alongside text/event-stream', () => {
+    const h = { get: (k) => (k === 'content-type' ? 'text/event-stream; charset=utf-8' : null) };
+    expect(hasStreamHeaders(h)).toBe(true);
+  });
+
+  it('returns false for application/json', () => {
+    const h = { get: (k) => (k === 'content-type' ? 'application/json' : null) };
+    expect(hasStreamHeaders(h)).toBe(false);
+  });
+
+  it('returns false when content-type header is missing', () => {
+    const h = { get: () => null };
+    expect(hasStreamHeaders(h)).toBe(false);
+  });
+});
+
+describe('index: promisifyStream', () => {
+  it('resolves with concatenated chunks on close', async () => {
+    const stream = new Readable({ read() {} });
+    const resultPromise = promisifyStream(stream, null, false);
+    stream.emit('data', Buffer.from('hello '));
+    stream.emit('data', Buffer.from('world'));
+    stream.emit('close');
+    const result = await resultPromise;
+    expect(Buffer.from(result).toString()).toBe('hello world');
+  });
+
+  it('resolves immediately on first data chunk when closeOnFirst is true', async () => {
+    const stream = new Readable({ read() {} });
+    const resultPromise = promisifyStream(stream, null, true);
+    stream.push(Buffer.from('first'));
+    const result = await resultPromise;
+    expect(Buffer.from(result).toString()).toBe('first');
+  });
+
+  it('calls abortController.abort() when closeOnFirst is true', async () => {
+    const stream = new Readable({ read() {} });
+    const abortController = { abort: jest.fn() };
+    const resultPromise = promisifyStream(stream, abortController, true);
+    stream.push(Buffer.from('data'));
+    await resultPromise;
+    expect(abortController.abort).toHaveBeenCalled();
+  });
+
+  it('rejects when stream emits error', async () => {
+    const stream = new Readable({ read() {} });
+    const resultPromise = promisifyStream(stream, null, false);
+    stream.emit('error', new Error('stream error'));
+    await expect(resultPromise).rejects.toThrow('stream error');
+  });
+});
 
 // Integration tests: full configureRequest (URL must survive cookie-jar parse)
 describe('index: configureRequest — URL normalization', () => {


### PR DESCRIPTION
### Description

Fixes #7594.

Since #4472, `request.responseType = 'stream'` is set for all requests so SSE responses don't hang. A side-effect: Axios fires its response interceptor at **TTFB** (when headers arrive), not after the body is fully received. The interceptor sets `request-duration` at that point, so Bruno reports TTFB as "Response Time" — even when the body takes 30+ seconds to download.

For non-`text/event-stream` responses, `responseTime` is now re-measured after `promisifyStream()` resolves, capturing total end-to-end duration. SSE responses keep the interceptor's TTFB timing, which is appropriate for streams. Both the happy path and the error-response path are fixed.

I created a small server to reproduce the issue:

```javascript
const http = require('http');
http.createServer((req, res) => {
  res.writeHead(200, { 'Content-Type': 'application/json' });
  setTimeout(() => { res.end(JSON.stringify({ done: true })); }, 5000);
}).listen(9999, () => console.log('Listening on :9999'));
```

And confirmed that we now show 5000ms instead of 0s.

<img width="1274" height="759" alt="image" src="https://github.com/user-attachments/assets/0099790c-7e1c-44b7-81f6-e3816daf6806" />

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate and consistent response-time measurement for both standard and streaming responses; duration metadata is now handled and cleaned up reliably.

* **Tests**
  * Added comprehensive tests covering response-time computation and stream-handling utilities, including event-stream detection, chunk concatenation, early-close behavior, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->