### PR TITLE
fix(cli): handle non-array tags from bru parser to prevent crash

### DIFF
--- a/packages/bruno-cli/src/utils/bru.js
+++ b/packages/bruno-cli/src/utils/bru.js
@@ -71,12 +71,13 @@ const bruToJson = (bru) => {
     }
 
     const sequence = _.get(json, 'meta.seq');
+    const tags = _.get(json, 'meta.tags', []);
     const transformedJson = {
       type: requestType,
       name: _.get(json, 'meta.name'),
       seq: !_.isNaN(sequence) ? Number(sequence) : 1,
       settings: _.get(json, 'settings', {}),
-      tags: _.get(json, 'meta.tags', []),
+      tags: Array.isArray(tags) ? tags : [],
       examples: _.get(json, 'examples', []),
       request: {
         url: _.get(json, requestType === 'grpc-request' ? 'grpc.url' : 'http.url'),


### PR DESCRIPTION
### Description

- Fixes crash (`e.some is not a function`) when a `.bru` file has tags defined as a 
  single value (e.g. `tags: ignore`) or inline empty array (`tags: []`)
- The bru parser returns a string instead of an array in these cases, which crashes 
  `isRequestTagsIncluded` when calling `.some()` on a string
- Adds `Array.isArray` guard in the CLI's bru parser transform layer (`bru.js`), 
  consistent with the same fix applied in `bruno-filestore` for the GUI

Fixes #7431

## Test plan
- [ ] Create a `.bru` file with `tags: ignore` in meta block, run `bru run ./ --exclude-tags ignore` — verify no crash
- [ ] Create a `.bru` file with `tags: []` in meta block, run `bru run ./` — verify no crash
- [ ] Verify normal multi-line tags still work correctly with `--tags` and `--exclude-tags`


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tags handling to gracefully process edge cases and prevent errors from invalid tag data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->