### PR TITLE
fix: prevent rerun flicker and fix runner configuration list order

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/RunConfigurationPanel/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/RunConfigurationPanel/index.jsx
@@ -5,7 +5,8 @@ import { IconGripVertical, IconCheck } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { updateRunnerConfiguration } from 'providers/ReduxStore/slices/collections/actions';
 import StyledWrapper from './StyledWrapper';
-import { isItemARequest } from 'utils/collections';
+import { isItemARequest, isItemAFolder } from 'utils/collections';
+import { sortByNameThenSequence } from 'utils/common/index';
 import path from 'utils/common/path';
 import { cloneDeep, get } from 'lodash';
 import Button from 'ui/Button/index';
@@ -187,20 +188,25 @@ const RunConfigurationPanel = ({ collection, selectedItems, setSelectedItems, ta
     const processItems = (items) => {
       if (!items?.length) return;
 
-      items.forEach((item) => {
-        if (isItemARequest(item) && !item.partial && !item.isTransient) {
-          const relativePath = path.relative(collection.pathname, path.dirname(item.pathname));
-          const folderPath = relativePath !== '.' ? relativePath : '';
+      const folderItems = sortByNameThenSequence(items.filter((item) => isItemAFolder(item) && !item.isTransient));
+      const requestItems = items
+        .filter((item) => isItemARequest(item) && !item.partial && !item.isTransient)
+        .sort((a, b) => a.seq - b.seq);
 
-          result.push({
-            ...item,
-            folderPath: folderPath.replace(/\\/g, '/')
-          });
+      folderItems.forEach((folder) => {
+        if (folder.items?.length) {
+          processItems(folder.items);
         }
+      });
 
-        if (item.items?.length) {
-          processItems(item.items);
-        }
+      requestItems.forEach((item) => {
+        const relativePath = path.relative(collection.pathname, path.dirname(item.pathname));
+        const folderPath = relativePath !== '.' ? relativePath : '';
+
+        result.push({
+          ...item,
+          folderPath: folderPath.replace(/\\/g, '/')
+        });
       });
     };
 

--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -81,6 +81,7 @@ export default function RunnerResults({ collection }) {
   const [delay, setDelay] = useState(null);
   const [activeFilter, setActiveFilter] = useState('all');
   const [selectedRequestItems, setSelectedRequestItems] = useState([]);
+  const isReRunningRef = useRef(false);
   // ref for the runner output body
   const runnerBodyRef = useRef();
 
@@ -165,6 +166,13 @@ export default function RunnerResults({ collection }) {
     }
   }, [collection.runnerConfiguration, delay]);
 
+  useEffect(() => {
+    if (isReRunningRef.current
+      && (items?.length > 0 || runnerInfo?.status === 'ended' || runnerInfo?.status === 'cancelled')) {
+      isReRunningRef.current = false;
+    }
+  }, [items, runnerInfo?.status]);
+
   const ensureCollectionIsMounted = () => {
     if (collection.mountStatus === 'mounted') {
       return;
@@ -184,6 +192,7 @@ export default function RunnerResults({ collection }) {
 
   const runAgain = () => {
     ensureCollectionIsMounted();
+    isReRunningRef.current = true;
     // Get the saved configuration to determine what to run
     const savedConfiguration = get(collection, 'runnerConfiguration', null);
     const savedSelectedItems = savedConfiguration?.selectedRequestItems || [];
@@ -201,6 +210,7 @@ export default function RunnerResults({ collection }) {
   };
 
   const resetRunner = () => {
+    isReRunningRef.current = false;
     dispatch(
       resetCollectionRunner({
         collectionUid: collection.uid
@@ -222,7 +232,7 @@ export default function RunnerResults({ collection }) {
   };
 
   let isCollectionLoading = areItemsLoading(collection);
-  if (!items || !items.length) {
+  if ((!items || !items.length) && !isReRunningRef.current) {
     return (
       <StyledWrapper className="pl-4 overflow-hidden h-full">
         <div className="flex overflow-hidden max-h-full h-full">


### PR DESCRIPTION
### Description

Update Run Configuration ordering to mirror sidebar behavior by sorting folders and requests consistently, and avoid transient panel flicker during Run Again by guarding empty-result rerun transitions.

### Screenshots

<img width="1454" height="810" alt="image" src="https://github.com/user-attachments/assets/d59162df-6234-49ec-b6a2-862148ca74a8" />
<br /><br />

- Run Again button issue and fix


https://github.com/user-attachments/assets/d1b5ca68-b8b1-48f2-b602-c985a089db9b

https://github.com/user-attachments/assets/8166245d-3788-48b6-8e9b-ea40b3514729




#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the organization and sorting of test folders and requests during execution to provide clearer and more consistent result presentations
  * Fixed UI behavior during test reruns to prevent the "no items yet" message from appearing while rerun operations are actively in progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->