### PR TITLE
fix: update digest authentication header formatting to comply with RFC 7616

### DIFF
--- a/packages/bruno-requests/src/auth/digestauth-helper.js
+++ b/packages/bruno-requests/src/auth/digestauth-helper.js
@@ -117,7 +117,7 @@ export function addDigestInterceptor(axiosInstance, request) {
         ];
 
         if (authDetails.qop && authDetails.qop.split(',').map((q) => q.trim().toLowerCase()).includes('auth')) {
-          headerFields.push(`qop="auth"`, `algorithm="${authDetails.algorithm}"`, `nc="${nonceCount}"`, `cnonce="${cnonce}"`);
+          headerFields.push(`qop=auth`, `algorithm="${authDetails.algorithm}"`, `nc=${nonceCount}`, `cnonce="${cnonce}"`);
         }
 
         if (authDetails.opaque) {

--- a/packages/bruno-requests/src/auth/digestauth-helper.spec.js
+++ b/packages/bruno-requests/src/auth/digestauth-helper.spec.js
@@ -1,38 +1,33 @@
 const axios = require('axios');
 const { addDigestInterceptor } = require('./digestauth-helper');
 
+function buildAxiosInstance(wwwAuthenticate) {
+  const axiosInstance = axios.create();
+  let callCount = 0;
+  let capturedAuthorization;
+
+  axiosInstance.defaults.adapter = async (config) => {
+    callCount += 1;
+    if (callCount === 1) {
+      const error = new Error('Unauthorized');
+      error.config = config;
+      error.response = {
+        status: 401,
+        headers: { 'www-authenticate': wwwAuthenticate }
+      };
+      throw error;
+    }
+
+    capturedAuthorization = config.headers && (config.headers.Authorization || config.headers.authorization);
+    return { status: 200, statusText: 'OK', headers: {}, config, data: { ok: true } };
+  };
+
+  return { axiosInstance, getAuth: () => capturedAuthorization };
+}
+
 describe('Digest Auth with query params', () => {
   test('uri should include path and query string', async () => {
-    const axiosInstance = axios.create();
-
-    let callCount = 0;
-    let capturedAuthorization;
-
-    // Custom adapter to simulate a 401 challenge then a 200 success
-    axiosInstance.defaults.adapter = async (config) => {
-      callCount += 1;
-      if (callCount === 1) {
-        const error = new Error('Unauthorized');
-        error.config = config;
-        error.response = {
-          status: 401,
-          headers: {
-            'www-authenticate': 'Digest realm="test", nonce="abc", qop="auth"'
-          }
-        };
-        throw error;
-      }
-
-      // Second call should have Authorization header set by interceptor
-      capturedAuthorization = config.headers && (config.headers.Authorization || config.headers.authorization);
-      return {
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config,
-        data: { ok: true }
-      };
-    };
+    const { axiosInstance, getAuth } = buildAxiosInstance('Digest realm="test", nonce="abc", qop="auth"');
 
     const request = {
       method: 'GET',
@@ -46,13 +41,108 @@ describe('Digest Auth with query params', () => {
     const res = await axiosInstance(request);
     expect(res.status).toEqual(200);
 
-    expect(capturedAuthorization).toBeTruthy();
-    // Extract uri="..." from the header
-    const uriMatch = /uri="([^"]+)"/.exec(capturedAuthorization);
-    expect(uriMatch).toBeTruthy();
-    const uri = uriMatch[1];
+    const auth = getAuth();
+    expect(auth).toBeTruthy();
 
-    // Expected to include both pathname and query
-    expect(uri).toBe('/resource?foo=bar&baz=qux');
+    const uriMatch = /uri="([^"]+)"/.exec(auth);
+    expect(uriMatch).toBeTruthy();
+    expect(uriMatch[1]).toBe('/resource?foo=bar&baz=qux');
+  });
+});
+
+describe('Digest Auth RFC 7616 compliance', () => {
+  test('nc parameter must not be quoted (RFC 7616 §3.4)', async () => {
+    const { axiosInstance, getAuth } = buildAxiosInstance('Digest realm="testrealm", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", qop="auth"');
+
+    const request = {
+      method: 'GET',
+      url: 'http://example.com/protected',
+      headers: {},
+      digestConfig: { username: 'Mufasa', password: 'Circle Of Life' }
+    };
+
+    addDigestInterceptor(axiosInstance, request);
+
+    const res = await axiosInstance(request);
+    expect(res.status).toEqual(200);
+
+    const auth = getAuth();
+    expect(auth).toBeTruthy();
+
+    // nc must appear unquoted: nc=00000001
+    expect(auth).toMatch(/nc=00000001(?!["])/);
+    // Must NOT be quoted
+    expect(auth).not.toMatch(/nc="00000001"/);
+  });
+
+  test('qop parameter must not be quoted (RFC 7616 §3.4)', async () => {
+    const { axiosInstance, getAuth } = buildAxiosInstance('Digest realm="testrealm", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", qop="auth"');
+
+    const request = {
+      method: 'GET',
+      url: 'http://example.com/protected',
+      headers: {},
+      digestConfig: { username: 'user', password: 'pass' }
+    };
+
+    addDigestInterceptor(axiosInstance, request);
+
+    const res = await axiosInstance(request);
+    expect(res.status).toEqual(200);
+
+    const auth = getAuth();
+    expect(auth).toBeTruthy();
+
+    // qop must appear unquoted: qop=auth
+    expect(auth).toMatch(/qop=auth(?!["])/);
+    // Must NOT be quoted
+    expect(auth).not.toMatch(/qop="auth"/);
+  });
+
+  test('nc and qop are absent when no qop challenge is sent', async () => {
+    const { axiosInstance, getAuth } = buildAxiosInstance('Digest realm="testrealm", nonce="simplnonce"');
+
+    const request = {
+      method: 'GET',
+      url: 'http://example.com/protected',
+      headers: {},
+      digestConfig: { username: 'user', password: 'pass' }
+    };
+
+    addDigestInterceptor(axiosInstance, request);
+
+    const res = await axiosInstance(request);
+    expect(res.status).toEqual(200);
+
+    const auth = getAuth();
+    expect(auth).toBeTruthy();
+    expect(auth).not.toMatch(/\bnc=/);
+    expect(auth).not.toMatch(/\bqop=/);
+  });
+
+  test('Authorization header contains required quoted fields', async () => {
+    const { axiosInstance, getAuth } = buildAxiosInstance('Digest realm="testrealm", nonce="abc123", qop="auth", opaque="5ccc069c403ebaf9f0171e9517f40e41"');
+
+    const request = {
+      method: 'GET',
+      url: 'http://example.com/resource',
+      headers: {},
+      digestConfig: { username: 'user', password: 'pass' }
+    };
+
+    addDigestInterceptor(axiosInstance, request);
+
+    await axiosInstance(request);
+    const auth = getAuth();
+
+    expect(auth).toMatch(/^Digest /);
+    expect(auth).toMatch(/username="user"/);
+    expect(auth).toMatch(/realm="testrealm"/);
+    expect(auth).toMatch(/nonce="abc123"/);
+    expect(auth).toMatch(/uri="\/resource"/);
+    expect(auth).toMatch(/response="[a-f0-9]{32}"/);
+    expect(auth).toMatch(/cnonce="[a-f0-9]+"/);
+    expect(auth).toMatch(/opaque="5ccc069c403ebaf9f0171e9517f40e41"/);
+    expect(auth).toMatch(/algorithm="MD5"/);
   });
 });


### PR DESCRIPTION
fixes: #5743

### Description

- Changed the formatting of the `qop` and `nc` parameters in the digest authentication header to remove quotes, ensuring compliance with RFC 7616.
- Refactored tests to validate the correct formatting of these parameters and added new tests for various scenarios, including the absence of `qop` and `nc` when not challenged.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Digest Authentication header formatting to comply with RFC 7616: `qop` and `nc` use unquoted token form, and `uri` preserves full path and query string.

* **Tests**
  * Expanded Digest Authentication tests with RFC 7616 compliance cases and a reusable test helper to validate outgoing Authorization headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->