### PR TITLE
fix: sample collection creation race condition

### DIFF
--- a/packages/bruno-electron/src/app/onboarding.js
+++ b/packages/bruno-electron/src/app/onboarding.js
@@ -7,9 +7,9 @@ const { resolveDefaultLocation } = require('../utils/default-location');
 
 let pendingSampleCollection = null;
 
-// When renderer is ready, send any pending collection-opened event
-// This ensures the sample collection appears in the sidebar after onboarding
-ipcMain.on('main:renderer-ready', (mainWindow) => {
+// When workspaces are ready, send any pending collection-opened event
+// This ensures the sample collection appears in the sidebar after the workspace exists
+ipcMain.on('main:workspaces-ready', (mainWindow) => {
   if (pendingSampleCollection) {
     const { mainWindow: win, collectionPath, uid, brunoConfig } = pendingSampleCollection;
     win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig);

--- a/packages/bruno-electron/src/ipc/workspace.js
+++ b/packages/bruno-electron/src/ipc/workspace.js
@@ -702,6 +702,8 @@ const registerWorkspaceIpc = (mainWindow, workspaceWatcher) => {
     } catch (error) {
       console.error('Error initializing workspaces:', error);
     }
+
+    ipcMain.emit('main:workspaces-ready', win);
   });
 };
 


### PR DESCRIPTION
### Description

Fixes a race condition. 
The sidebar filters collections to only show those belonging to the active workspace.
This PR guarantees the sample collection's main:collection-opened event is sent to the renderer only after the default workspace exists, so openCollectionEvent can properly associate the collection with the workspace and the sidebar filter will include it.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a startup initialization timing issue where collections could load before the workspace sidebar structure was fully prepared. Collections now load after workspace initialization is complete for improved startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->