### PR TITLE
fix: cap unbounded collection timeline and stream data growth

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -66,6 +66,24 @@ const wsStatusCodes = {
   1015: 'TLS_HANDSHAKE'
 };
 
+const MAX_TIMELINE_ENTRIES = 100;
+const MAX_STREAM_MESSAGES = 500;
+const MAX_DATA_BUFFER_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/**
+ * Appends an entry to collection.timeline while enforcing a maximum size.
+ * When the limit is exceeded, the oldest entries are dropped.
+ */
+const pushToTimeline = (collection, entry) => {
+  if (!collection.timeline) {
+    collection.timeline = [];
+  }
+  collection.timeline.push(entry);
+  if (collection.timeline.length > MAX_TIMELINE_ENTRIES) {
+    collection.timeline = collection.timeline.slice(-MAX_TIMELINE_ENTRIES);
+  }
+};
+
 /**
  * Preserves UIDs from existing array items when merging with new data.
  * UIDs are matched by position to keep React keys stable after file reloads.
@@ -534,17 +552,13 @@ export const collectionsSlice = createSlice({
           item.cancelTokenUid = item.response.stream?.running ? item.cancelTokenUid : null;
           item.requestStartTime = null;
 
-          if (!collection.timeline) {
-            collection.timeline = [];
-          }
-
           // Ensure timestamp is a number (milliseconds since epoch)
           const timestamp = item?.requestSent?.timestamp instanceof Date
             ? item.requestSent.timestamp.getTime()
             : item?.requestSent?.timestamp || Date.now();
 
           // Append the new timeline entry with numeric timestamp
-          collection.timeline.push({
+          pushToTimeline(collection, {
             type: 'request',
             collectionUid: collection.uid,
             folderUid: null,
@@ -579,11 +593,7 @@ export const collectionsSlice = createSlice({
         };
       }
 
-      if (!collection.timeline) {
-        collection.timeline = [];
-      }
-
-      collection.timeline.push({
+      pushToTimeline(collection, {
         type: 'request',
         eventType: eventType, // Add the specific gRPC event type
         collectionUid: collection.uid,
@@ -698,13 +708,8 @@ export const collectionsSlice = createSlice({
       item.requestState = 'received';
       item.response = updatedResponse;
 
-      // Update the timeline
-      if (!collection?.timeline) {
-        collection.timeline = [];
-      }
-
       // Append the new timeline entry with specific gRPC event type
-      collection.timeline.push({
+      pushToTimeline(collection, {
         type: 'request',
         eventType: eventType, // Add the specific gRPC event type
         collectionUid: collection.uid,
@@ -3231,12 +3236,8 @@ export const collectionsSlice = createSlice({
 
       collection.oauth2Credentials = filteredOauth2Credentials;
 
-      if (!collection.timeline) {
-        collection.timeline = [];
-      }
-
       if (debugInfo) {
-        collection.timeline.push({
+        pushToTimeline(collection, {
           type: 'oauth2',
           collectionUid,
           folderUid,
@@ -3303,6 +3304,8 @@ export const collectionsSlice = createSlice({
 
       if (collection) {
         const item = findItemInCollection(collection, itemUid);
+        if (!item?.response) return;
+
         if (data.data) {
           item.response.data ||= [];
           item.response.data.push({
@@ -3312,11 +3315,19 @@ export const collectionsSlice = createSlice({
             messageHexdump: hexdump(data.data),
             timestamp: timestamp || Date.now()
           });
+          if (item.response.data.length > MAX_STREAM_MESSAGES) {
+            item.response.data = item.response.data.slice(-MAX_STREAM_MESSAGES);
+          }
         }
         if (data.dataBuffer) {
-          item.response.dataBuffer = Buffer.concat([Buffer.from(item.response.dataBuffer), Buffer.from(data.dataBuffer)]);
+          const existing = item.response.dataBuffer || '';
+          const combined = Buffer.concat([Buffer.from(existing, 'base64'), Buffer.from(data.dataBuffer, 'base64')]);
+          const capped = combined.length > MAX_DATA_BUFFER_BYTES
+            ? combined.slice(-MAX_DATA_BUFFER_BYTES)
+            : combined;
+          item.response.dataBuffer = capped.toString('base64');
         }
-        item.response.size = data.data?.length + (item.response.size || 0);
+        item.response.size = (data.data?.length || 0) + (item.response.size || 0);
       }
     },
     addRequestTag: (state, action) => {
@@ -3387,11 +3398,7 @@ export const collectionsSlice = createSlice({
         };
       }
 
-      if (!collection.timeline) {
-        collection.timeline = [];
-      }
-
-      collection.timeline.push({
+      pushToTimeline(collection, {
         type: 'request',
         eventType: eventType,
         collectionUid: collection.uid,


### PR DESCRIPTION
## Problem

When Bruno is left open for extended periods, it eventually crashes with the **"Oops! Something went wrong"** error screen (React ErrorBoundary). This is reproducible by actively using Bruno over time — sending requests, testing APIs, etc.

Related issues: #7342 (Insane Memory Consumption), #7090 (High CPU with no activity), #6880 / #6669 (VS Code extension crashes)

## Root Cause

Four issues in the Redux collections reducer combine to cause crashes:

### 1. `collection.timeline` grows unbounded (critical)
Every HTTP request, gRPC call, WebSocket message, and OAuth2 flow appends an entry to `collection.timeline`. Each entry contains **full request and response bodies**. With active API testing, this array grows continuously with no eviction — eventually the Redux state balloons until React chokes trying to render or diff it.

**5 push sites** across the collections reducer, none with any cap:
- `responseReceived` (HTTP)
- `runGrpcRequestEvent` (gRPC)
- `grpcResponseReceived` (gRPC)
- `collectionOauth2CredentialsReceived` (OAuth2)
- `runWsRequestEvent` (WebSocket)

### 2. `item.response.data` for streams grows unbounded (moderate)
`streamDataReceived` pushes incoming messages (including hex dumps) into `item.response.data` with no cap. A long-running WebSocket or SSE connection can accumulate thousands of messages.

### 3. `streamDataReceived` has no null guard (crash trigger)
`streamDataReceived` accesses `item.response.data` without checking if `item` or `item.response` exists. If a stream message arrives after the response is cleared or the item is deleted (race condition), this causes `Cannot read properties of undefined` — which in the minified bundle appears as an undefined single-letter variable (e.g., `t`).

### 4. `dataBuffer` grows unbounded and violates Redux serialization
`streamDataReceived` concatenates incoming data buffers using `Buffer.concat`, which produces a Node.js `Buffer` object stored directly in Redux state. This violates Redux's serialization expectations (all downstream consumers expect a base64 string — see `ResponsePane/index.js:110`). Additionally, `dataBuffer` had no size cap, so long-lived streams could accumulate unbounded binary data.

## Fix

### Timeline cap
- Added `pushToTimeline()` helper function that enforces `MAX_TIMELINE_ENTRIES = 100`
- When the cap is exceeded, oldest entries are evicted via `.slice()`
- Replaced all 5 direct `collection.timeline.push()` call sites
- Removed now-redundant manual `if (!collection.timeline)` initialization guards (the helper handles this)

### Stream data cap
- Added `MAX_STREAM_MESSAGES = 500` cap on `item.response.data` in `streamDataReceived`

### Null guard in streamDataReceived
- Added early return `if (!item?.response) return` to prevent crash when stream data arrives for a cleared/deleted item

### dataBuffer serialization and cap
- Fixed `Buffer.concat` result to be stored as a **base64 string** (`.toString('base64')`) instead of a raw Buffer object, matching what all consumers expect
- Added `MAX_DATA_BUFFER_BYTES = 10 MB` cap — when exceeded, oldest bytes are dropped via `.slice()`

### Constants chosen
- **100 timeline entries**: Sufficient for recent history while preventing accumulation. Each entry contains full request/response payloads, so even 100 can be significant.
- **500 stream messages**: Generous enough for debugging while preventing runaway growth from long-lived connections.
- **10 MB data buffer**: Matches the existing `isLargeResponse` threshold in `QueryResult/index.js`.

## Files Changed

- `packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js`

## Testing

- Verified build passes (`npm run build:web`)
- Verified lint passes (eslint + pre-commit hooks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limits added to timeline history (100 entries) and live stream retention (500 messages) to reduce memory use and improve stability.
  * Stream handling made more robust: ignores incomplete stream items, preserves message order, maintains accurate response sizes, and caps accumulated response bytes to a fixed buffer limit with base64-aware concatenation/truncation.
* **Refactor**
  * Timeline update logic consolidated for consistent behavior across request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->