### PR TITLE
fixed a bug where on curl paste, the input field remains empty

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -179,7 +179,6 @@ const QueryUrl = ({ item, collection, handleRun }) => {
     event.preventDefault();
 
     editorRef.current?.editor?.getInputField()?.blur();
-
     try {
       // Parse the curl command
       const request = getRequestFromCurlCommand(pastedData);


### PR DESCRIPTION
i### Description

I use Bruno daily and encountered an issue where pasting a cURL command didn’t update the input field. This PR addresses the problem by blurring the input before setting its value, as the update is currently prevented while the field is focused.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input field focus behavior when pasting URLs or cURL commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->