### PR TITLE
fix: prevent assertions from returning wrong values during large iteration runs

### DIFF
--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -56,9 +56,8 @@ const executeQuickJsVm = ({ script: externalScript, context: externalContext, sc
     externalScript = removeQuotes(externalScript);
   }
 
-  const vm = QuickJSModule.newContext();
-
   try {
+    const vm = QuickJSModule.newContext();
     const { bru, req, res, ...variables } = externalContext;
 
     bru && addBruShimToContext(vm, bru);

--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -14,10 +14,9 @@ const { marshallToVm } = require('./utils');
 const addCryptoUtilsShimToContext = require('./shims/lib/crypto-utils');
 const { wrapScriptInClosure, SANDBOX } = require('../../utils/sandbox');
 
-let QuickJSSyncContext;
+let QuickJSModule;
 const loader = memoizePromiseFactory(() => newQuickJSWASMModule());
-const getContext = (opts) => loader().then((mod) => (QuickJSSyncContext = mod.newContext(opts)));
-getContext();
+loader().then((mod) => (QuickJSModule = mod));
 
 const toNumber = (value) => {
   const num = Number(value);
@@ -57,7 +56,7 @@ const executeQuickJsVm = ({ script: externalScript, context: externalContext, sc
     externalScript = removeQuotes(externalScript);
   }
 
-  const vm = QuickJSSyncContext;
+  const vm = QuickJSModule.newContext();
 
   try {
     const { bru, req, res, ...variables } = externalContext;
@@ -97,7 +96,7 @@ const executeQuickJsVmAsync = async ({ script: externalScript, context: external
   externalScript = externalScript?.trim();
 
   try {
-    const module = await newQuickJSWASMModule();
+    const module = await loader();
     const vm = module.newContext();
 
     // add crypto utilities required by the crypto-js library in bundledCode

--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -174,5 +174,6 @@ const executeQuickJsVmAsync = async ({ script: externalScript, context: external
 
 module.exports = {
   executeQuickJsVm,
-  executeQuickJsVmAsync
+  executeQuickJsVmAsync,
+  loader
 };

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -1,4 +1,5 @@
-const { describe, it, expect } = require('@jest/globals');
+const { describe, it, expect, beforeAll } = require('@jest/globals');
+const { newQuickJSWASMModule } = require('quickjs-emscripten');
 const TestRuntime = require('../src/runtime/test-runtime');
 const ScriptRuntime = require('../src/runtime/script-runtime');
 const AssertRuntime = require('../src/runtime/assert-runtime');
@@ -261,6 +262,10 @@ describe('runtime', () => {
   });
 
   describe('assert-runtime', () => {
+    beforeAll(async () => {
+      await newQuickJSWASMModule();
+    });
+
     const baseRequest = {
       method: 'GET',
       url: 'http://localhost:3000/',
@@ -275,10 +280,80 @@ describe('runtime', () => {
       headers: {}
     });
 
-    const runAssertions = (assertions, response, runtime = 'nodevm') => {
+    const runAssertions = (assertions, response, runtime = 'nodevm', runtimeVariables = {}) => {
       const assertRuntime = new AssertRuntime({ runtime });
-      return assertRuntime.runAssertions(assertions, { ...baseRequest }, response, {}, {}, process.env);
+      return assertRuntime.runAssertions(assertions, { ...baseRequest }, response, {}, runtimeVariables, process.env);
     };
+
+    // Ensures each QuickJS evaluation gets a fresh context
+    describe('quickjs context isolation across iterations', () => {
+      const ITERATION_COUNT = 30;
+
+      it('should return correct res.status on every iteration', () => {
+        for (let i = 0; i < ITERATION_COUNT; i++) {
+          const status = 200 + i;
+          const results = runAssertions(
+            [{ name: 'res.status', value: `eq ${status}`, enabled: true }],
+            { status, statusText: 'OK', data: {}, headers: {} },
+            'quickjs'
+          );
+          expect(results[0].status).toBe('pass');
+        }
+      });
+
+      it('should return correct res.body values on every iteration', () => {
+        for (let i = 0; i < ITERATION_COUNT; i++) {
+          const results = runAssertions(
+            [{ name: 'res.body.id', value: `eq ${i}`, enabled: true }],
+            { status: 200, statusText: 'OK', data: { id: i }, headers: {} },
+            'quickjs'
+          );
+          expect(results[0].status).toBe('pass');
+        }
+      });
+
+      it('should not return stale data from a previous iteration', () => {
+        // First call with status 200
+        runAssertions(
+          [{ name: 'res.status', value: 'eq 200', enabled: true }],
+          { status: 200, statusText: 'OK', data: { token: 'bearer_abc' }, headers: { authorization: 'bearer xyz' } },
+          'quickjs'
+        );
+
+        // Second call with status 404 — must not return 200 or any data from previous call
+        const results = runAssertions(
+          [
+            { name: 'res.status', value: 'eq 404', enabled: true },
+            { name: 'res.body.error', value: 'eq not_found', enabled: true }
+          ],
+          { status: 404, statusText: 'Not Found', data: { error: 'not_found' }, headers: {} },
+          'quickjs'
+        );
+
+        expect(results[0].status).toBe('pass');
+        expect(results[1].status).toBe('pass');
+      });
+
+      it('should not persist runtime variables from a previous call', () => {
+        // First call with runtime variable token = "one"
+        const results1 = runAssertions(
+          [{ name: 'token', value: 'eq one', enabled: true }],
+          { status: 200, statusText: 'OK', data: {}, headers: {} },
+          'quickjs',
+          { token: 'one' }
+        );
+        expect(results1[0].status).toBe('pass');
+
+        // Second call without token
+        const results2 = runAssertions(
+          [{ name: 'token', value: 'eq one', enabled: true }],
+          { status: 200, statusText: 'OK', data: {}, headers: {} },
+          'quickjs'
+        );
+        // Must fail — token should not exist in a fresh context
+        expect(results2[0].status).toBe('fail');
+      });
+    });
 
     describe('isJson', () => {
       it('should pass for a plain object', () => {

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -1,10 +1,10 @@
 const { describe, it, expect, beforeAll } = require('@jest/globals');
-const { newQuickJSWASMModule } = require('quickjs-emscripten');
 const TestRuntime = require('../src/runtime/test-runtime');
 const ScriptRuntime = require('../src/runtime/script-runtime');
 const AssertRuntime = require('../src/runtime/assert-runtime');
 const Bru = require('../src/bru');
 const VarsRuntime = require('../src/runtime/vars-runtime');
+const { loader: quickJsLoader } = require('../src/sandbox/quickjs');
 
 describe('runtime', () => {
   describe('test-runtime', () => {
@@ -263,7 +263,7 @@ describe('runtime', () => {
 
   describe('assert-runtime', () => {
     beforeAll(async () => {
-      await newQuickJSWASMModule();
+      await quickJsLoader();
     });
 
     const baseRequest = {

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -287,7 +287,7 @@ describe('runtime', () => {
 
     // Ensures each QuickJS evaluation gets a fresh context
     describe('quickjs context isolation across iterations', () => {
-      const ITERATION_COUNT = 30;
+      const ITERATION_COUNT = 350;
 
       it('should return correct res.status on every iteration', () => {
         for (let i = 0; i < ITERATION_COUNT; i++) {


### PR DESCRIPTION
### Description

When running collections with `--iteration-count=350`, assertions using `res("...")` queries would start returning wrong values (e.g., "bearer", "POST", "none") around iteration ~310. Once corrupted, all subsequent `res()` evaluations returned the same incorrect value.

### Root cause
`executeQuickJsVm` reused a single `QuickJSSyncContext` for every evaluation. Shims (`addBruShimToContext`, `addBrunoResponseShimToContext`, etc.) set properties on `vm.global` each call, and handles accumulated on the shared context over hundreds of iterations, eventually causing QuickJS to return stale/corrupted data.

### Changes

- Create a fresh QuickJS context per `executeQuickJsVm` call instead of reusing a single shared context across all evaluations
- Reuse the cached WASM module in `executeQuickJsVmAsync` via `loader()` instead of loading a new module every call

Fixes: https://github.com/usebruno/bruno/issues/7167
Tracked: [JIRA](https://usebruno.atlassian.net/browse/BRU-2908)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sandbox now lazy-loads and caches the runtime module and creates a fresh execution context per run for stronger isolation and improved startup performance.
* **Chores**
  * Public module exports updated to expose the shared loader for the runtime.
* **Tests**
  * Added extensive runtime tests validating per-run isolation and that no stale data or variables leak across many sequential executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->