### PR TITLE
feat: Add `randomZipCode` support.

### DIFF
--- a/packages/bruno-common/src/utils/faker-functions.spec.ts
+++ b/packages/bruno-common/src/utils/faker-functions.spec.ts
@@ -54,6 +54,7 @@ describe('mockDataFunctions Regex Validation', () => {
       randomStreetAddress: /^[\s\S]+$/,
       randomCountry: /^[\s\S]+$/,
       randomCountryCode: /^[\s\S]+$/,
+      randomZipCode: /^[0-9]{5}$/,
       randomLatitude: /^[\s\S]+$/,
       randomLongitude: /^[\s\S]+$/,
       randomAvatarImage: /^[\s\S]+$/,

--- a/packages/bruno-common/src/utils/faker-functions.spec.ts
+++ b/packages/bruno-common/src/utils/faker-functions.spec.ts
@@ -54,6 +54,7 @@ describe('mockDataFunctions Regex Validation', () => {
       randomStreetAddress: /^[\s\S]+$/,
       randomCountry: /^[\s\S]+$/,
       randomCountryCode: /^[\s\S]+$/,
+      randomZipCode: /^[0-9]{5}(-[0-9]{4})?$/,
       randomLatitude: /^[\s\S]+$/,
       randomLongitude: /^[\s\S]+$/,
       randomAvatarImage: /^[\s\S]+$/,

--- a/packages/bruno-common/src/utils/faker-functions.ts
+++ b/packages/bruno-common/src/utils/faker-functions.ts
@@ -39,6 +39,7 @@ export const mockDataFunctions = {
   randomStreetAddress: () => faker.location.streetAddress(),
   randomCountry: () => faker.location.country(),
   randomCountryCode: () => faker.location.countryCode(),
+  randomZipCode: () => faker.location.zipCode(),
   randomLatitude: () => faker.location.latitude(),
   randomLongitude: () => faker.location.longitude(),
   randomAvatarImage: () => faker.image.avatar(),


### PR DESCRIPTION
Resolves #7693

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Adds a `randomZipCode` function that uses `faker.location.zipCode()`

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability to generate random ZIP codes, including five-digit and ZIP+4 formats.

* **Tests**
  * Added validation for supported ZIP code formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->