### PR TITLE
make post default gql method

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -261,6 +261,11 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
 
   const onSubmit = () => formik.handleSubmit();
 
+  const handleRequestTypeChange = (e) => {
+    formik.handleChange(e);
+    formik.setFieldValue('requestMethod', e.target.value === 'graphql-request' ? 'POST' : 'GET');
+  };
+
   const handlePaste = useCallback(
     (event) => {
       const clipboardData = event.clipboardData || window.clipboardData;
@@ -343,7 +348,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="http-request"
                       checked={formik.values.requestType === 'http-request'}
-                      onChange={formik.handleChange}
+                      onChange={handleRequestTypeChange}
                       data-testid="http-request"
                     />
                     <label htmlFor="http-request" className="ml-1 cursor-pointer select-none">
@@ -357,10 +362,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="graphql-request"
                       checked={formik.values.requestType === 'graphql-request'}
-                      onChange={(e) => {
-                        formik.handleChange(e);
-                        formik.setFieldValue('requestMethod', 'POST');
-                      }}
+                      onChange={handleRequestTypeChange}
                       data-testid="graphql-request"
                     />
                     <label htmlFor="graphql-request" className="ml-1 cursor-pointer select-none">

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -395,7 +395,10 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="ws-request"
                       checked={formik.values.requestType === 'ws-request'}
-                      onChange={formik.handleChange}
+                      onChange={(e) => {
+                        formik.handleChange(e);
+                        formik.setFieldValue('requestMethod', 'ws');
+                      }}
                       data-testid="ws-request"
                     />
                     <label htmlFor="ws-request" className="ml-1 cursor-pointer select-none">

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -261,11 +261,6 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
 
   const onSubmit = () => formik.handleSubmit();
 
-  const handleRequestTypeChange = (e) => {
-    formik.handleChange(e);
-    formik.setFieldValue('requestMethod', e.target.value === 'graphql-request' ? 'POST' : 'GET');
-  };
-
   const handlePaste = useCallback(
     (event) => {
       const clipboardData = event.clipboardData || window.clipboardData;
@@ -348,7 +343,10 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="http-request"
                       checked={formik.values.requestType === 'http-request'}
-                      onChange={handleRequestTypeChange}
+                      onChange={(e) => {
+                        formik.handleChange(e);
+                        formik.setFieldValue('requestMethod', 'GET');
+                      }}
                       data-testid="http-request"
                     />
                     <label htmlFor="http-request" className="ml-1 cursor-pointer select-none">
@@ -362,7 +360,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="graphql-request"
                       checked={formik.values.requestType === 'graphql-request'}
-                      onChange={handleRequestTypeChange}
+                      onChange={formik.handleChange}
                       data-testid="graphql-request"
                     />
                     <label htmlFor="graphql-request" className="ml-1 cursor-pointer select-none">
@@ -379,7 +377,10 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="grpc-request"
                       checked={formik.values.requestType === 'grpc-request'}
-                      onChange={formik.handleChange}
+                      onChange={(e) => {
+                        formik.handleChange(e);
+                        formik.setFieldValue('requestMethod', 'GET');
+                      }}
                       data-testid="grpc-request"
                     />
                     <label htmlFor="grpc-request" className="ml-1 cursor-pointer select-none">

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -111,7 +111,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
       filename: '',
       requestType: getRequestType(collectionPresets),
       requestUrl: collectionPresets.requestUrl || '',
-      requestMethod: 'GET',
+      requestMethod: getRequestType(collectionPresets) === 'graphql-request' ? 'POST' : 'GET',
       curlCommand: ''
     },
     validationSchema: Yup.object({
@@ -357,7 +357,10 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="graphql-request"
                       checked={formik.values.requestType === 'graphql-request'}
-                      onChange={formik.handleChange}
+                      onChange={(e) => {
+                        formik.handleChange(e);
+                        formik.setFieldValue('requestMethod', 'POST');
+                      }}
                       data-testid="graphql-request"
                     />
                     <label htmlFor="graphql-request" className="ml-1 cursor-pointer select-none">


### PR DESCRIPTION
- Make POST as a default method for gql req which user can change but while creating the default will be POST


https://github.com/user-attachments/assets/9af0b9af-a30f-4107-9749-1be4cbbd06da



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL requests now default to POST instead of GET for new requests.
  * Switching a request to GraphQL applies the POST method by default to avoid method/type mismatch.
  * Changing the request type to HTTP or gRPC now forces the HTTP method back to GET to ensure compatibility.
  * Selecting a WebSocket request type sets the request method to WS automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->