### PR TITLE
fix(converters): ensure insomnia variables are strings before matching

### DIFF
--- a/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
+++ b/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
@@ -34,7 +34,7 @@ const addSuffixToDuplicateName = (item, index, allItems) => {
 const regexVariable = new RegExp('{{.*?}}', 'g');
 
 const normalizeVariables = (value) => {
-  value = value || '';
+  value = value != null ? String(value) : '';
   const variables = value.match(regexVariable) || [];
   each(variables, (variable) => {
     value = value.replace(variable, variable.replace('_.', '').replaceAll(' ', ''));


### PR DESCRIPTION
### Description
Fixes #7687

#### The Problem
When importing Insomnia collections in YAML format, unquoted values (such as dates, numbers, or booleans) are parsed as non-string JavaScript types. Because the `normalizeVariables` function immediately calls `.match()` on these values, it triggers a `TypeError: value.match is not a function`, causing the entire import process to crash.

#### The Fix
I have updated the `normalizeVariables` function in `packages/bruno-converters/src/insomnia/insomnia-to-bruno.js` to explicitly cast incoming values to a `String`. 

- Used a nullish check (`value != null`) to ensure that `null` or `undefined` default to an empty string.
- Guaranteed that values like `0` (number) or `false` (boolean) are correctly converted to `"0"` and `"false"` rather than being treated as falsy and erased.

#### Verification
- Created a reproduction Insomnia YAML export containing unquoted integers and dates.
- Verified that the import fails with a `TypeError` in the console before the fix.
- Verified that the import succeeds and correctly populates headers and variables after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable normalization during Insomnia to Bruno conversion to properly preserve falsy values such as `0` and `false`, instead of converting them to empty strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->