### PR TITLE
 import response examples for description only responses in swagger 2.0 convertion

### DIFF
--- a/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
@@ -322,6 +322,18 @@ const transformSwaggerRequestItem = (request, usedNames = new Set(), options = {
           requestBodySchema,
           requestBodyContentType
         }));
+      } else if (response.description) {
+        // description only (e.g., 204 No Content) — create example without body
+        examples.push(createBrunoExample({
+          brunoRequestItem,
+          exampleValue: '',
+          exampleName: `${statusCode} Response`,
+          exampleDescription: response.description,
+          statusCode,
+          contentType: null,
+          requestBodySchema,
+          requestBodyContentType
+        }));
       }
     });
 

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-examples.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-examples.spec.js
@@ -209,7 +209,7 @@ describe('swagger2-to-bruno response examples', () => {
     expect(req.examples[0].response.status).toBe(200);
   });
 
-  it('should not generate examples when responses have no schema or examples', () => {
+  it('should generate examples from description only responses', () => {
     const spec = {
       swagger: '2.0',
       info: { title: 'No Schema API', version: '1.0' },
@@ -229,8 +229,20 @@ describe('swagger2-to-bruno response examples', () => {
     const collection = swagger2ToBruno(spec);
     const req = collection.items.find((i) => i.name === 'Delete data');
 
-    // No schema or examples → no examples array
-    expect(req.examples).toBeUndefined();
+    expect(req.examples).toBeDefined();
+    expect(req.examples.length).toBe(2);
+
+    const noContentExample = req.examples.find((e) => e.response.status === 204);
+    expect(noContentExample).toBeDefined();
+    expect(noContentExample.name).toBe('204 Response');
+    expect(noContentExample.description).toBe('No Content');
+    expect(noContentExample.response.body.content).toBe('');
+    expect(noContentExample.response.headers).toEqual([]);
+
+    const notFoundExample = req.examples.find((e) => e.response.status === 404);
+    expect(notFoundExample).toBeDefined();
+    expect(notFoundExample.name).toBe('404 Response');
+    expect(notFoundExample.description).toBe('Not Found');
   });
 
   it('should set correct statusText in response examples', () => {


### PR DESCRIPTION
### Description

- Swagger 2.0 responses with only a `description` (no `examples` or `schema`) were silently skipped during import, unlike the OpenAPI 3.0 converter which creates examples for them
- Added a conversion path that creates Bruno examples with an empty body and no content type for description only responses (e.g., 204 No Content, 404 Not Found)
- Updated existing test to verify description only responses are now converted with correct status, description, and empty body

Tracker in - [JIRA](https://usebruno.atlassian.net/browse/BRU-3045)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved conversion of Swagger/OpenAPI responses containing only descriptions. These responses (e.g., 204 No Content) now generate Bruno example entries instead of being skipped during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->