### PR TITLE
fix: rename `signatureEncoding` to `signatureMethod` for OAuth1 in opencollection types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@eslint/compat": "^1.3.2",
         "@faker-js/faker": "^7.6.0",
         "@jest/globals": "^29.2.0",
-        "@opencollection/types": "0.9.0",
+        "@opencollection/types": "0.9.1",
         "@playwright/test": "^1.51.1",
         "@rollup/plugin-json": "^6.1.0",
         "@storybook/addon-webpack5-compiler-babel": "^4.0.0",
@@ -9642,9 +9642,9 @@
       }
     },
     "node_modules/@opencollection/types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@opencollection/types/-/types-0.9.0.tgz",
-      "integrity": "sha512-2p9Pb1cSpUBvtsnvsHtqxbzmJtUvkfE7r2R/BVWiVG0CRohvuhyClcgb061aa/95TEo0cXdXKLXmtZSGWvf1NA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@opencollection/types/-/types-0.9.1.tgz",
+      "integrity": "sha512-kYJvPSvR9XohCo7qACiCQEbWlvj4KgxM8igrTEhudIxTO1QAy8BBOEUeHLqYeSFz1MSSW1CuWkMJOyw/egr7Gg==",
       "dev": true,
       "license": "MIT"
     },
@@ -34995,7 +34995,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@babel/preset-env": "^7.25.4",
-        "@opencollection/types": "0.9.0",
+        "@opencollection/types": "0.9.1",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-node-resolve": "^15.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@eslint/compat": "^1.3.2",
     "@faker-js/faker": "^7.6.0",
     "@jest/globals": "^29.2.0",
-    "@opencollection/types": "0.9.0",
+    "@opencollection/types": "0.9.1",
     "@playwright/test": "^1.51.1",
     "@rollup/plugin-json": "^6.1.0",
     "@storybook/addon-webpack5-compiler-babel": "^4.0.0",

--- a/packages/bruno-converters/package.json
+++ b/packages/bruno-converters/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.4",
-    "@opencollection/types": "0.9.0",
+    "@opencollection/types": "0.9.1",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/bruno-converters/src/opencollection/common/auth.ts
+++ b/packages/bruno-converters/src/opencollection/common/auth.ts
@@ -292,7 +292,7 @@ export const fromOpenCollectionAuth = (auth: Auth | undefined): BrunoAuth => {
           accessTokenSecret: oauth1Auth.accessTokenSecret || null,
           callbackUrl: oauth1Auth.callbackUrl || null,
           verifier: oauth1Auth.verifier || null,
-          signatureMethod: (oauth1Auth.signatureEncoding as BrunoAuthOauth1['signatureMethod']) || 'HMAC-SHA1',
+          signatureMethod: (oauth1Auth.signatureMethod as BrunoAuthOauth1['signatureMethod']) || 'HMAC-SHA1',
           privateKey: (typeof oauth1Auth.privateKey === 'object' && oauth1Auth.privateKey ? oauth1Auth.privateKey.value : oauth1Auth.privateKey) || null,
           privateKeyType: (typeof oauth1Auth.privateKey === 'object' && oauth1Auth.privateKey ? oauth1Auth.privateKey.type : 'text') as BrunoAuthOauth1['privateKeyType'],
           timestamp: oauth1Auth.timestamp || null,
@@ -500,7 +500,7 @@ export const toOpenCollectionAuth = (auth: BrunoAuth | null | undefined): Auth |
         accessTokenSecret: auth.oauth1?.accessTokenSecret || '',
         callbackUrl: auth.oauth1?.callbackUrl || '',
         verifier: auth.oauth1?.verifier || '',
-        signatureEncoding: auth.oauth1?.signatureMethod || 'HMAC-SHA1',
+        signatureMethod: auth.oauth1?.signatureMethod || 'HMAC-SHA1',
         privateKey: auth.oauth1?.privateKeyType === 'file'
           ? { type: 'file' as const, value: auth.oauth1?.privateKey || '' }
           : { type: 'text' as const, value: auth.oauth1?.privateKey || '' },

--- a/packages/bruno-filestore/src/formats/yml/common/auth.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/auth.ts
@@ -129,7 +129,7 @@ const buildOAuth1Auth = (config?: BrunoAuth['oauth1']): AuthOAuth1 => {
   if (isString(config.accessTokenSecret)) auth.accessTokenSecret = config.accessTokenSecret;
   if (isString(config.callbackUrl)) auth.callbackUrl = config.callbackUrl;
   if (isString(config.verifier)) auth.verifier = config.verifier;
-  if (isString(config.signatureMethod)) auth.signatureEncoding = config.signatureMethod;
+  if (isString(config.signatureMethod)) auth.signatureMethod = config.signatureMethod;
   if (isString(config.privateKey)) {
     auth.privateKey = config.privateKeyType === 'file'
       ? { type: 'file' as const, value: config.privateKey }
@@ -272,7 +272,7 @@ export const toBrunoAuth = (auth: Auth | null | undefined): BrunoAuth | null => 
         accessTokenSecret: auth.accessTokenSecret || null,
         callbackUrl: auth.callbackUrl || null,
         verifier: auth.verifier || null,
-        signatureMethod: (auth.signatureEncoding as BrunoAuthOauth1['signatureMethod']) || 'HMAC-SHA1',
+        signatureMethod: (auth.signatureMethod as BrunoAuthOauth1['signatureMethod']) || 'HMAC-SHA1',
         privateKey: (typeof auth.privateKey === 'object' && auth.privateKey ? auth.privateKey.value : auth.privateKey) || null,
         privateKeyType: (typeof auth.privateKey === 'object' && auth.privateKey ? auth.privateKey.type : 'text') as BrunoAuthOauth1['privateKeyType'],
         timestamp: auth.timestamp || null,

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA1
+    signatureMethod: HMAC-SHA1
     version: "1.0"
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 401.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 401.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: wrong_secret
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA1
+    signatureMethod: HMAC-SHA1
     version: "1.0"
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 Body 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 Body 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA1
+    signatureMethod: HMAC-SHA1
     version: "1.0"
     placement: body
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 Body JSON 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 Body JSON 200.yml
@@ -15,7 +15,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA1
+    signatureMethod: HMAC-SHA1
     version: "1.0"
     placement: body
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 POST 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 POST 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA1
+    signatureMethod: HMAC-SHA1
     version: "1.0"
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 Query Params 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA1 Query Params 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA1
+    signatureMethod: HMAC-SHA1
     version: "1.0"
     placement: query
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA256 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA256 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA256
+    signatureMethod: HMAC-SHA256
     version: "1.0"
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA256 401.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA256 401.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: wrong_secret
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA256
+    signatureMethod: HMAC-SHA256
     version: "1.0"
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA256 Body 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA256 Body 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA256
+    signatureMethod: HMAC-SHA256
     version: "1.0"
     placement: body
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA512 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA512 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA512
+    signatureMethod: HMAC-SHA512
     version: "1.0"
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA512 401.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 HMAC-SHA512 401.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: wrong_secret
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: HMAC-SHA512
+    signatureMethod: HMAC-SHA512
     version: "1.0"
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 PLAINTEXT 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 PLAINTEXT 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: PLAINTEXT
+    signatureMethod: PLAINTEXT
     version: '1.0'
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 PLAINTEXT 401.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 PLAINTEXT 401.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: wrong_secret
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: PLAINTEXT
+    signatureMethod: PLAINTEXT
     version: "1.0"
     placement: header
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 PLAINTEXT Body 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 PLAINTEXT Body 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: PLAINTEXT
+    signatureMethod: PLAINTEXT
     version: "1.0"
     placement: body
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 PLAINTEXT Query Params 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 PLAINTEXT Query Params 200.yml
@@ -12,7 +12,7 @@ http:
     consumerSecret: consumer_secret_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: PLAINTEXT
+    signatureMethod: PLAINTEXT
     version: "1.0"
     placement: query
     includeBodyHash: false

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 200.yml
@@ -11,7 +11,7 @@ http:
     consumerKey: consumer_key_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: RSA-SHA1
+    signatureMethod: RSA-SHA1
     privateKey:
       type: text
       value: |

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 Body 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 Body 200.yml
@@ -13,7 +13,7 @@ http:
     consumerKey: consumer_key_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: RSA-SHA1
+    signatureMethod: RSA-SHA1
     privateKey:
       type: text
       value: |

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 Body formurlencoded 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 Body formurlencoded 200.yml
@@ -16,7 +16,7 @@ http:
     consumerKey: consumer_key_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: RSA-SHA1
+    signatureMethod: RSA-SHA1
     privateKey:
       type: text
       value: |

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 File Key 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 File Key 200.yml
@@ -11,7 +11,7 @@ http:
     consumerKey: consumer_key_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: RSA-SHA1
+    signatureMethod: RSA-SHA1
     privateKey:
       type: file
       value: test-private-key.pem

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 Query Params 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 Query Params 200.yml
@@ -11,7 +11,7 @@ http:
     consumerKey: consumer_key_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: RSA-SHA1
+    signatureMethod: RSA-SHA1
     privateKey:
       type: text
       value: |

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 Variable Key 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA1 Variable Key 200.yml
@@ -11,7 +11,7 @@ http:
     consumerKey: consumer_key_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: RSA-SHA1
+    signatureMethod: RSA-SHA1
     privateKey:
       type: text
       value: "{{private-key}}"

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA256 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA256 200.yml
@@ -11,7 +11,7 @@ http:
     consumerKey: consumer_key_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: RSA-SHA256
+    signatureMethod: RSA-SHA256
     privateKey:
       type: text
       value: |

--- a/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA512 200.yml
+++ b/tests/auth/oauth1/fixtures/collections/yml/OAuth1 RSA-SHA512 200.yml
@@ -11,7 +11,7 @@ http:
     consumerKey: consumer_key_1
     accessToken: access_token_1
     accessTokenSecret: token_secret_1
-    signatureEncoding: RSA-SHA512
+    signatureMethod: RSA-SHA512
     privateKey:
       type: text
       value: |

--- a/tests/auth/oauth1/oauth1.spec.ts
+++ b/tests/auth/oauth1/oauth1.spec.ts
@@ -26,6 +26,7 @@ test.describe('OAuth 1.0 Authentication', () => {
   });
 
   test('Request auth UI', async ({ page, createTmpDir }) => {
+    test.setTimeout(60_000);
     // Setup
     await createCollection(page, 'oauth1-test', await createTmpDir());
     await createRequest(page, 'oauth1-request', 'oauth1-test', { url: 'https://example.com/api' });
@@ -137,6 +138,7 @@ test.describe('OAuth 1.0 Authentication', () => {
   });
 
   test('Collection settings auth', async ({ page }) => {
+    test.setTimeout(60_000);
     const collectionRow = page.getByTestId('collections').locator('#sidebar-collection-name').filter({ hasText: 'oauth1-test' });
     await collectionRow.click();
     await page.locator('.tab.auth').click();


### PR DESCRIPTION
### Description

Align with @opencollection/types 0.9.1 which renamed the OAuth1 field from signatureEncoding to signatureMethod. Update converters, filestore, and all YML test fixtures. Increase OAuth1 UI test timeouts from 30s to 60s.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@opencollection/types` dependency to version 0.9.1

* **Bug Fixes**
  * Corrected OAuth1 authentication configuration field naming for improved consistency

* **Tests**
  * Enhanced test stability with timeout adjustments for OAuth 1.0 authentication scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->