### PR TITLE
fix: handle missing location header in redirect error response

### DIFF
--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -326,6 +326,12 @@ function makeAxiosInstance({
           redirectCount++;
 
           const locationHeader = error.response.headers.location;
+
+          if (!locationHeader) {
+            error.response.timeline = timeline;
+            return Promise.reject(error);
+          }
+
           let redirectUrl = locationHeader;
 
           // Handle relative URLs by resolving them against the original request URL


### PR DESCRIPTION
[BRU](https://usebruno.atlassian.net/browse/BRU-3052)
fixes: https://github.com/usebruno/bruno/issues/5880

### Description

- Added a check for the presence of the location header in the error response during redirect handling. If the header is absent, the error response is augmented with the timeline and the promise is rejected accordingly.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for HTTP redirect responses that are missing required headers, ensuring more reliable and graceful handling of network requests in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->