### PR TITLE
feat: gRPC settings tab — configurable message sizes, deadlines, and proto-loader options

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcRequestPane/index.js
@@ -5,6 +5,7 @@ import RequestHeaders from 'components/RequestPane/RequestHeaders';
 import GrpcBody from 'components/RequestPane/GrpcBody';
 import GrpcAuth from './GrpcAuth/index';
 import GrpcAuthMode from './GrpcAuth/GrpcAuthMode/index';
+import GrpcSettingsPane from 'components/RequestPane/GrpcSettingsPane';
 import StatusDot from 'components/StatusDot/index';
 import HeightBoundContainer from 'ui/HeightBoundContainer';
 import find from 'lodash/find';
@@ -40,6 +41,9 @@ const GrpcRequestPane = ({ item, collection, handleRun }) => {
       }
       case 'auth': {
         return <GrpcAuth item={item} collection={collection} />;
+      }
+      case 'settings': {
+        return <GrpcSettingsPane item={item} collection={collection} />;
       }
       case 'docs': {
         return <Documentation item={item} collection={collection} />;
@@ -89,6 +93,11 @@ const GrpcRequestPane = ({ item, collection, handleRun }) => {
         key: 'auth',
         label: 'Auth',
         indicator: auth?.mode && auth.mode !== 'none' ? <StatusDot type="default" /> : null
+      },
+      {
+        key: 'settings',
+        label: 'Settings',
+        indicator: null
       },
       {
         key: 'docs',

--- a/packages/bruno-app/src/components/RequestPane/GrpcSettingsPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcSettingsPane/index.js
@@ -1,0 +1,134 @@
+import React, { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import get from 'lodash/get';
+import SettingsInput from 'components/SettingsInput';
+import ToggleSelector from 'components/RequestPane/Settings/ToggleSelector';
+import { updateItemSettings } from 'providers/ReduxStore/slices/collections';
+import { saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+
+const getPropertyFromDraftOrRequest = (propertyKey, item) =>
+  item.draft ? get(item, `draft.${propertyKey}`, {}) : get(item, propertyKey, {});
+
+const GrpcSettingsPane = ({ item, collection }) => {
+  const dispatch = useDispatch();
+
+  const settings = getPropertyFromDraftOrRequest('settings', item);
+  const {
+    maxReceiveMessageLength = '',
+    maxSendMessageLength = '',
+    deadline = '',
+    keepaliveTime = '',
+    keepaliveTimeout = '',
+    clientIdleTimeout = '',
+    maxReconnectBackoff = '',
+    includeDefaultValues
+  } = settings;
+
+  const updateSetting = useCallback((key, value) => {
+    dispatch(updateItemSettings({
+      collectionUid: collection.uid,
+      itemUid: item.uid,
+      settings: { [key]: value }
+    }));
+  }, [dispatch, collection.uid, item.uid]);
+
+  const onNumericChange = useCallback((key) => (e) => {
+    const value = e.target.value;
+    if (value === '' || value === '-1' || /^-?\d+$/.test(value)) {
+      updateSetting(key, value === '' ? '' : value);
+    }
+  }, [updateSetting]);
+
+  const onSave = useCallback(() => {
+    dispatch(saveRequest(item.uid, collection.uid));
+  }, [dispatch, item.uid, collection.uid]);
+
+  const handleKeyDown = useCallback((e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault();
+      onSave();
+    }
+  }, [onSave]);
+
+  return (
+    <div className="h-full w-full">
+      <div className="text-xs mb-4 text-muted">Configure gRPC channel and request settings.</div>
+      <div className="bruno-form">
+        <div className="flex flex-col gap-4">
+          <SettingsInput
+            id="maxReceiveMessageLength"
+            label="Max Receive Message Size"
+            value={maxReceiveMessageLength}
+            onChange={onNumericChange('maxReceiveMessageLength')}
+            description="Maximum response message size in bytes (-1 for unlimited)"
+            onKeyDown={handleKeyDown}
+          />
+
+          <SettingsInput
+            id="maxSendMessageLength"
+            label="Max Send Message Size"
+            value={maxSendMessageLength}
+            onChange={onNumericChange('maxSendMessageLength')}
+            description="Maximum request message size in bytes (-1 for unlimited)"
+            onKeyDown={handleKeyDown}
+          />
+
+          <SettingsInput
+            id="deadline"
+            label="Deadline (ms)"
+            value={deadline}
+            onChange={onNumericChange('deadline')}
+            description="Per-request deadline in milliseconds, required by many gRPC servers"
+            onKeyDown={handleKeyDown}
+          />
+
+          <SettingsInput
+            id="keepaliveTime"
+            label="Keepalive Time (ms)"
+            value={keepaliveTime}
+            onChange={onNumericChange('keepaliveTime')}
+            description="Interval between keepalive pings to keep the connection alive"
+            onKeyDown={handleKeyDown}
+          />
+
+          <SettingsInput
+            id="keepaliveTimeout"
+            label="Keepalive Timeout (ms)"
+            value={keepaliveTimeout}
+            onChange={onNumericChange('keepaliveTimeout')}
+            description="Timeout waiting for a keepalive ping response"
+            onKeyDown={handleKeyDown}
+          />
+
+          <SettingsInput
+            id="clientIdleTimeout"
+            label="Client Idle Timeout (ms)"
+            value={clientIdleTimeout}
+            onChange={onNumericChange('clientIdleTimeout')}
+            description="Close the connection after being idle for this duration"
+            onKeyDown={handleKeyDown}
+          />
+
+          <SettingsInput
+            id="maxReconnectBackoff"
+            label="Max Reconnect Backoff (ms)"
+            value={maxReconnectBackoff}
+            onChange={onNumericChange('maxReconnectBackoff')}
+            description="Maximum delay between reconnection attempts after failure"
+            onKeyDown={handleKeyDown}
+          />
+
+          <ToggleSelector
+            checked={includeDefaultValues !== false}
+            onChange={() => updateSetting('includeDefaultValues', includeDefaultValues === false)}
+            label="Include Default Values"
+            description="Include fields with protobuf default values (0, empty string, false) in responses"
+            size="medium"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GrpcSettingsPane;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1744,13 +1744,15 @@ export const loadGrpcMethodsFromReflection = (item, collectionUid, url) => async
       return reject(error);
     }
 
+    const settings = itemCopy.draft ? itemCopy.draft.settings : itemCopy.settings;
     const { ipcRenderer } = window;
     ipcRenderer
       .invoke('grpc:load-methods-reflection', {
         request: requestItem,
         collection: collectionCopy,
         environment,
-        runtimeVariables
+        runtimeVariables,
+        settings
       })
       .then(resolve)
       .catch(reject);

--- a/packages/bruno-app/src/utils/network/index.js
+++ b/packages/bruno-app/src/utils/network/index.js
@@ -81,12 +81,14 @@ export const startGrpcRequest = async (item, collection, environment, runtimeVar
   return new Promise((resolve, reject) => {
     const { ipcRenderer } = window;
     const request = item.draft ? item.draft : item;
+    const settings = item.draft ? item.draft.settings : item.settings;
 
     ipcRenderer.invoke('grpc:start-connection', {
       request,
       collection,
       environment,
-      runtimeVariables
+      runtimeVariables,
+      settings
     })
       .then(() => {
         resolve();

--- a/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
@@ -152,7 +152,7 @@ const registerGrpcEventHandlers = (window) => {
   });
 
   // Start a new gRPC connection
-  ipcMain.handle('grpc:start-connection', async (event, { request, collection, environment, runtimeVariables }) => {
+  ipcMain.handle('grpc:start-connection', async (event, { request, collection, environment, runtimeVariables, settings }) => {
     try {
       const requestCopy = cloneDeep(request);
       const preparedRequest = await prepareGrpcRequest(requestCopy, collection, environment, runtimeVariables, {});
@@ -219,6 +219,33 @@ const registerGrpcEventHandlers = (window) => {
 
       const includeDirs = getProtobufIncludeDirs(collection);
 
+      // Build gRPC channel options from settings
+      const channelOptionsMap = {
+        maxReceiveMessageLength: 'grpc.max_receive_message_length',
+        maxSendMessageLength: 'grpc.max_send_message_length',
+        keepaliveTime: 'grpc.keepalive_time_ms',
+        keepaliveTimeout: 'grpc.keepalive_timeout_ms',
+        clientIdleTimeout: 'grpc.client_idle_timeout_ms',
+        maxReconnectBackoff: 'grpc.max_reconnect_backoff_ms'
+      };
+      const channelOptions = {};
+      if (settings) {
+        for (const [key, option] of Object.entries(channelOptionsMap)) {
+          if (settings[key] != null) {
+            channelOptions[option] = settings[key];
+          }
+        }
+      }
+
+      // Build proto-loader options from settings
+      const protoOptions = {};
+      if (settings?.includeDefaultValues != null) {
+        protoOptions.defaults = settings.includeDefaultValues;
+      }
+
+      // Extract deadline (per-RPC)
+      const deadline = settings?.deadline ?? null;
+
       // Start gRPC connection with the processed request, certificates, and proxy
       await grpcClient.startConnection({
         request: preparedRequest,
@@ -230,7 +257,10 @@ const registerGrpcEventHandlers = (window) => {
         pfx,
         verifyOptions,
         includeDirs,
-        proxyConfig: grpcProxyConfig
+        proxyConfig: grpcProxyConfig,
+        channelOptions,
+        protoOptions,
+        deadline
       });
 
       sendEvent('grpc:request', preparedRequest.uid, collection.uid, requestSent);
@@ -312,7 +342,7 @@ const registerGrpcEventHandlers = (window) => {
   });
 
   // Load methods from server reflection
-  ipcMain.handle('grpc:load-methods-reflection', async (event, { request, collection, environment, runtimeVariables }) => {
+  ipcMain.handle('grpc:load-methods-reflection', async (event, { request, collection, environment, runtimeVariables, settings }) => {
     try {
       const requestCopy = cloneDeep(request);
       const preparedRequest = await prepareGrpcRequest(requestCopy, collection, environment, runtimeVariables);
@@ -375,6 +405,12 @@ const registerGrpcEventHandlers = (window) => {
         });
       }
 
+      // Build proto-loader options from settings
+      const protoOptions = {};
+      if (settings?.includeDefaultValues != null) {
+        protoOptions.defaults = settings.includeDefaultValues;
+      }
+
       const methods = await grpcClient.loadMethodsFromReflection({
         request: preparedRequest,
         collectionUid: collection.uid,
@@ -385,7 +421,8 @@ const registerGrpcEventHandlers = (window) => {
         pfx,
         verifyOptions,
         sendEvent,
-        proxyConfig: grpcProxyConfig
+        proxyConfig: grpcProxyConfig,
+        protoOptions
       });
 
       return { success: true, methods: safeParseJSON(safeStringifyJSON(methods)) };

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -568,6 +568,28 @@ const sem = grammar.createSemantics().addAttribute('ast', {
       _settings.keepAliveInterval = keepAliveInterval;
     }
 
+    // Parse gRPC-specific numeric settings
+    const grpcNumericSettings = [
+      'maxReceiveMessageLength', 'maxSendMessageLength',
+      'keepaliveTime', 'keepaliveTimeout',
+      'clientIdleTimeout', 'maxReconnectBackoff', 'deadline'
+    ];
+    for (const key of grpcNumericSettings) {
+      if (settings[key] !== undefined) {
+        const val = parseInt(settings[key], 10);
+        if (!isNaN(val)) {
+          _settings[key] = val;
+        }
+      }
+    }
+
+    // Parse gRPC includeDefaultValues as boolean
+    if (settings.includeDefaultValues !== undefined) {
+      _settings.includeDefaultValues = typeof settings.includeDefaultValues === 'boolean'
+        ? settings.includeDefaultValues
+        : settings.includeDefaultValues === 'true';
+    }
+
     return {
       settings: _settings
     };

--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -34,6 +34,16 @@ const configOptions = {
   json: true
 };
 
+/**
+ * Default gRPC channel options.
+ * Sets unlimited message sizes since Bruno is a client-side tool
+ * and should not impose arbitrary limits on responses.
+ */
+const DEFAULT_CHANNEL_OPTIONS = {
+  'grpc.max_receive_message_length': -1,
+  'grpc.max_send_message_length': -1
+};
+
 const reflectionServices = ['grpc.reflection.v1alpha.ServerReflection', 'grpc.reflection.v1.ServerReflection'];
 
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
@@ -431,7 +441,7 @@ class GrpcClient {
    * @returns {Promise<boolean>} Whether methods were successfully refreshed
    * @private
    */
-  async #refreshMethods({ url, headers, protoPath, collectionPath, collectionUid, certificates = {}, verifyOptions, includeDirs = [], proxyConfig }) {
+  async #refreshMethods({ url, headers, protoPath, collectionPath, collectionUid, certificates = {}, verifyOptions, includeDirs = [], proxyConfig, protoOptions = {} }) {
     try {
       // Try reflection first if no proto path is specified
       if (!protoPath) {
@@ -445,7 +455,8 @@ class GrpcClient {
           pfx: certificates.pfx,
           verifyOptions,
           sendEvent: () => {}, // No-op for refresh
-          proxyConfig
+          proxyConfig,
+          protoOptions
         });
         return true;
       }
@@ -453,7 +464,7 @@ class GrpcClient {
       // Try proto file if available
       if (protoPath) {
         const absoluteProtoPath = nodePath.resolve(collectionPath, protoPath);
-        await this.loadMethodsFromProtoFile(absoluteProtoPath, includeDirs);
+        await this.loadMethodsFromProtoFile(absoluteProtoPath, includeDirs, protoOptions);
         return true;
       }
 
@@ -498,13 +509,14 @@ class GrpcClient {
   /**
    * Handle unary responses
    */
-  #handleUnaryResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid }) {
+  #handleUnaryResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid, callOptions = {} }) {
     const rpc = client.makeUnaryRequest(
       requestPath,
       method.requestSerialize,
       method.responseDeserialize,
       messages[0],
       metadata,
+      callOptions,
       (error, res) => {
         this.eventCallback('grpc:response', requestId, collectionUid, { error, res });
       }
@@ -514,12 +526,13 @@ class GrpcClient {
     setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc, () => this.#removeConnection(requestId));
   }
 
-  #handleClientStreamingResponse({ client, requestId, requestPath, method, metadata, collectionUid }) {
+  #handleClientStreamingResponse({ client, requestId, requestPath, method, metadata, collectionUid, callOptions = {} }) {
     const rpc = client.makeClientStreamRequest(
       requestPath,
       method.requestSerialize,
       method.responseDeserialize,
       metadata,
+      callOptions,
       (error, res) => {
         this.eventCallback('grpc:response', requestId, collectionUid, { error, res });
       }
@@ -529,7 +542,7 @@ class GrpcClient {
     setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc, () => this.#removeConnection(requestId));
   }
 
-  #handleServerStreamingResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid }) {
+  #handleServerStreamingResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid, callOptions = {} }) {
     const message = messages[0];
     const rpc = client.makeServerStreamRequest(
       requestPath,
@@ -537,6 +550,7 @@ class GrpcClient {
       method.responseDeserialize,
       message,
       metadata,
+      callOptions,
       (error, res) => {
         this.eventCallback('grpc:response', requestId, collectionUid, { error, res });
       }
@@ -546,12 +560,13 @@ class GrpcClient {
     setupGrpcEventHandlers(this.eventCallback, requestId, collectionUid, rpc, () => this.#removeConnection(requestId));
   }
 
-  #handleBidiStreamingResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid }) {
+  #handleBidiStreamingResponse({ client, requestId, requestPath, method, messages, metadata, collectionUid, callOptions = {} }) {
     const rpc = client.makeBidiStreamRequest(
       requestPath,
       method.requestSerialize,
       method.responseDeserialize,
-      metadata
+      metadata,
+      callOptions
     );
     this.#addConnection(requestId, { rpc, client });
 
@@ -592,7 +607,9 @@ class GrpcClient {
     verifyOptions,
     channelOptions = {},
     includeDirs = [],
-    proxyConfig
+    proxyConfig,
+    protoOptions = {},
+    deadline
   }) {
     const credentials = this.#getChannelCredentials({
       url: request.url,
@@ -630,7 +647,8 @@ class GrpcClient {
         },
         verifyOptions,
         includeDirs,
-        proxyConfig
+        proxyConfig,
+        protoOptions
       });
 
       if (!refreshSuccess) {
@@ -655,7 +673,7 @@ class GrpcClient {
     // Resolve proxy target and channel options
     const { targetHost, proxyChannelOptions } = this.#resolveProxyTarget(host, proxyConfig);
 
-    const mergedChannelOptions = { ...channelOptions, ...proxyChannelOptions };
+    const mergedChannelOptions = { ...DEFAULT_CHANNEL_OPTIONS, ...channelOptions, ...proxyChannelOptions };
     if (userAgentValue && !channelOptions?.['grpc.primary_user_agent']) {
       mergedChannelOptions['grpc.primary_user_agent'] = userAgentValue;
     }
@@ -664,6 +682,12 @@ class GrpcClient {
     const client = new Client(targetHost, credentials, mergedChannelOptions);
     if (!client) {
       throw new Error('Failed to create client');
+    }
+
+    // Build per-RPC call options (e.g. deadline)
+    const callOptions = {};
+    if (deadline != null && deadline > 0) {
+      callOptions.deadline = new Date(Date.now() + deadline);
     }
 
     let messages = request.body.grpc;
@@ -693,7 +717,8 @@ class GrpcClient {
       requestPath,
       method,
       messages,
-      metadata
+      metadata,
+      callOptions
     });
   }
 
@@ -748,7 +773,8 @@ class GrpcClient {
     verifyOptions,
     sendEvent,
     channelOptions = {},
-    proxyConfig
+    proxyConfig,
+    protoOptions = {}
   }) {
     const { host, path } = getParsedGrpcUrlObject(request.url);
 
@@ -762,7 +788,7 @@ class GrpcClient {
     // Resolve proxy target and channel options
     const { targetHost, proxyChannelOptions } = this.#resolveProxyTarget(host, proxyConfig);
 
-    const mergedChannelOptions = { ...channelOptions, ...proxyChannelOptions };
+    const mergedChannelOptions = { ...DEFAULT_CHANNEL_OPTIONS, ...channelOptions, ...proxyChannelOptions };
     if (userAgentValue && !channelOptions?.['grpc.primary_user_agent']) {
       mergedChannelOptions['grpc.primary_user_agent'] = userAgentValue;
     }
@@ -786,12 +812,15 @@ class GrpcClient {
       const { client, services, callOptions } = await this.#getReflectionClient(targetHost, credentials, metadata, mergedChannelOptions);
       reflectionClient = client;
 
+      const mergedProtoOptions = { ...configOptions, ...protoOptions };
       const methods = [];
       for (const service of services) {
         if (reflectionServices.includes(service)) {
           continue;
         }
-        const m = await client.listMethods(service, callOptions);
+        const descriptor = await client.getDescriptorBySymbol(service, callOptions);
+        const packageObject = descriptor.getPackageObject(mergedProtoOptions);
+        const m = client.getServiceMethods(packageObject, service);
         methods.push(...m);
       }
 
@@ -817,8 +846,9 @@ class GrpcClient {
     }
   }
 
-  async loadMethodsFromProtoFile(filePath, includeDirs = []) {
-    const protoDefinition = await protoLoader.load(filePath, { ...configOptions, includeDirs });
+  async loadMethodsFromProtoFile(filePath, includeDirs = [], protoOptions = {}) {
+    const mergedConfigOptions = { ...configOptions, ...protoOptions };
+    const protoDefinition = await protoLoader.load(filePath, { ...mergedConfigOptions, includeDirs });
     const methods = Object.values(protoDefinition)
       .filter((definition) => !definition?.format)
       .flatMap(Object.values);

--- a/packages/bruno-requests/src/grpc/grpc-client.spec.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.spec.js
@@ -8,13 +8,17 @@ let capturedHost = null;
 
 // Mock GrpcReflection to capture options
 const mockListServices = jest.fn().mockResolvedValue(['test.Service']);
-const mockListMethods = jest.fn().mockResolvedValue([
+const mockGetDescriptorBySymbol = jest.fn().mockResolvedValue({
+  getPackageObject: jest.fn().mockReturnValue({})
+});
+const mockGetServiceMethods = jest.fn().mockReturnValue([
   {
-    path: '/test.Service/TestMethod',
+    name: 'TestMethod',
     definition: {
       requestStream: false,
       responseStream: false
-    }
+    },
+    path: '/test.Service/TestMethod'
   }
 ]);
 
@@ -24,7 +28,8 @@ jest.mock('grpc-js-reflection-client', () => ({
     capturedHost = host;
     return {
       listServices: mockListServices,
-      listMethods: mockListMethods
+      getDescriptorBySymbol: mockGetDescriptorBySymbol,
+      getServiceMethods: mockGetServiceMethods
     };
   })
 }));

--- a/packages/bruno-schema-types/src/collection/item.ts
+++ b/packages/bruno-schema-types/src/collection/item.ts
@@ -25,7 +25,18 @@ export interface WebSocketItemSettings {
   } | null;
 }
 
-export type ItemSettings = HttpItemSettings | WebSocketItemSettings | null;
+export interface GrpcItemSettings {
+  maxReceiveMessageLength?: number | null;
+  maxSendMessageLength?: number | null;
+  keepaliveTime?: number | null;
+  keepaliveTimeout?: number | null;
+  clientIdleTimeout?: number | null;
+  maxReconnectBackoff?: number | null;
+  deadline?: number | null;
+  includeDefaultValues?: boolean | null;
+}
+
+export type ItemSettings = HttpItemSettings | WebSocketItemSettings | GrpcItemSettings | null;
 
 export interface Item {
   uid: UID;


### PR DESCRIPTION
## Summary

[Jira](https://usebruno.atlassian.net/browse/BRU-1845)

<img width="710" height="736" alt="Screenshot 2026-04-10 at 11 48 36 PM" src="https://github.com/user-attachments/assets/fcf87f43-ef63-4a0a-b377-cf8527120414" />


Adds a **Settings tab** to the gRPC request pane with configurable channel options, per-RPC deadlines, and proto-loader settings.

Closes #7718, #7737

## Changes

### Default channel options
Sets `grpc.max_receive_message_length` and `grpc.max_send_message_length` to `-1` (unlimited) by default — the `@grpc/grpc-js` library defaults to 4MB, which made Bruno unusable for large gRPC responses.

### Configurable settings

**Channel options** — Max receive/send message size, keepalive time/timeout, client idle timeout, max reconnect backoff

**Per-RPC call options** — Deadline in milliseconds. Many gRPC servers [require a deadline](https://grpc.io/blog/deadlines/) and reject requests without one.

**Proto-loader options** — Toggle whether protobuf fields with default values (0, "", false) are included in responses. Works for both proto file and reflection-based loading.

### Settings persistence
Persisted in the `.bru` file via the existing `settings` block:
```
settings {
  maxReceiveMessageLength: -1
  deadline: 5000
  includeDefaultValues: true
}
```

### Files changed
- `packages/bruno-schema-types/src/collection/item.ts` — added `GrpcItemSettings` interface
- `packages/bruno-requests/src/grpc/grpc-client.js` — default channel options, deadline support, proto options pass-through for both file and reflection loading
- `packages/bruno-requests/src/grpc/grpc-client.spec.js` — updated mocks for reflection API change
- `packages/bruno-lang/v2/src/bruToJson.js` — parse gRPC settings from `.bru` files
- `packages/bruno-electron/src/ipc/network/grpc-event-handlers.js` — map settings to channel/call/proto options
- `packages/bruno-app/src/utils/network/index.js` — pass settings via IPC
- `packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js` — pass settings for reflection loading
- `packages/bruno-app/src/components/RequestPane/GrpcRequestPane/index.js` — added Settings tab
- `packages/bruno-app/src/components/RequestPane/GrpcSettingsPane/index.js` — new Settings UI component

### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Settings tab to the gRPC request pane, enabling configuration of gRPC-specific parameters including message size limits, keepalive timing, deadline, reconnect behavior, and default value inclusion options.
  * gRPC settings are now persisted and applied when executing gRPC requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->