### PR TITLE
performance: for large sse, the ui becomes unresponsive

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useEffect, useCallback, memo } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo, memo } from 'react';
+import { hexy as hexdump } from 'hexy';
 import classnames from 'classnames';
 import StyledWrapper from './StyledWrapper';
 import { IconExclamationCircle, IconChevronRight, IconInfoCircle, IconChevronDown, IconArrowUpRight, IconArrowDownLeft } from '@tabler/icons';
@@ -59,9 +60,10 @@ const TypeIcon = ({ type }) => {
   }[type];
 };
 
-const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
+const WSMessageItem = memo(({ message, onOpenChange }) => {
+  const [isOpen, setIsOpen] = useState(false);
   const [showHex, setShowHex] = useState(false);
-  const preferences = useSelector((state) => state.app.preferences);
+  const codeFont = useSelector((state) => state.app.preferences?.codeFont);
   const { displayedTheme } = useTheme();
   const [isNew, setIsNew] = useState(false);
   const notified = useRef(false);
@@ -70,9 +72,13 @@ const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
   const isInfo = message.type === 'info';
   const isError = message.type === 'error';
   const isOutgoing = message.type === 'outgoing';
-  let contentHexdump = message.messageHexdump;
-  let parsedContent = parseContent(message.message);
+  const canOpenMessage = !isInfo && !isError;
+
+  // Parsed content is memoized — avoids JSON.parse/stringify on every render.
+  const parsedContent = useMemo(() => parseContent(message.message), [message.message]);
   const dataType = getDataTypeText(parsedContent.type);
+  // Hexdump is computed lazily — only when the message is expanded and the hex tab is active.
+  const contentHexdump = useMemo(() => (showHex ? hexdump(message.message) : null), [showHex, message.message]);
 
   useEffect(() => {
     if (notified.current === true) return;
@@ -87,12 +93,14 @@ const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
     }
   }, [message.timestamp]);
 
-  const canOpenMessage = !isInfo && !isError;
-
-  const handleToggle = () => {
+  const handleToggle = useCallback(() => {
     if (!canOpenMessage) return;
-    onToggle?.(message.timestamp);
-  };
+    setIsOpen((prev) => {
+      const next = !prev;
+      onOpenChange?.(next ? 1 : -1);
+      return next;
+    });
+  }, [canOpenMessage, onOpenChange]);
 
   return (
     <div
@@ -164,7 +172,7 @@ const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
               mode={showHex ? 'text/plain' : parsedContent.type}
               theme={displayedTheme}
               enableLineWrapping={showHex ? false : true}
-              font={preferences.codeFont || 'default'}
+              font={codeFont || 'default'}
               value={showHex ? contentHexdump : parsedContent.content}
             />
           </div>
@@ -177,61 +185,45 @@ const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
 const WSMessagesList = ({ messages = [] }) => {
   const virtuosoRef = useRef(null);
   const [scrollerElement, setScrollerElement] = useState(null);
-  const [openMessages, setOpenMessages] = useState(new Set());
   const userScrolledAwayRef = useRef(false);
+  const openCountRef = useRef(0);
 
-  // Toggle message open/closed state by timestamp
-  const handleMessageToggle = useCallback((timestamp) => {
-    setOpenMessages((prev) => {
-      const next = new Set(prev);
-      if (next.has(timestamp)) {
-        next.delete(timestamp);
-      } else {
-        next.add(timestamp);
-      }
-      return next;
-    });
+  const handleOpenChange = useCallback((delta) => {
+    openCountRef.current += delta;
   }, []);
 
   useEffect(() => {
     if (!scrollerElement) return;
 
     const handleWheel = (e) => {
-      // deltaY < 0 means scrolling up
       if (e.deltaY < 0) {
         userScrolledAwayRef.current = true;
       }
     };
 
     scrollerElement.addEventListener('wheel', handleWheel, { passive: true });
-
-    return () => {
-      scrollerElement.removeEventListener('wheel', handleWheel);
-    };
+    return () => scrollerElement.removeEventListener('wheel', handleWheel);
   }, [scrollerElement]);
 
   const handleAtBottomStateChange = useCallback((atBottom) => {
     if (atBottom) {
-      // User scrolled back to bottom, re-enable auto-scroll
       userScrolledAwayRef.current = false;
     }
   }, []);
 
+  // Fully stable — no state dependencies, reads only refs.
   const followOutput = useCallback((isAtBottom) => {
-    // Don't auto-scroll if user has scrolled away or has messages open
-    if (userScrolledAwayRef.current || openMessages.size > 0) {
+    if (userScrolledAwayRef.current || openCountRef.current > 0) {
       return false;
     }
-    if (isAtBottom) {
-      return 'smooth';
-    }
-    return false;
-  }, [openMessages.size]);
+    return isAtBottom ? 'smooth' : false;
+  }, []);
 
+  // Stable renderItem: WSMessageItem manages its own open/closed state,
+  // so toggling one message never re-renders the others.
   const renderItem = useCallback((_, msg) => {
-    const isOpen = openMessages.has(msg.timestamp);
-    return <WSMessageItem message={msg} isOpen={isOpen} onToggle={handleMessageToggle} />;
-  }, [openMessages, handleMessageToggle]);
+    return <WSMessageItem message={msg} onOpenChange={handleOpenChange} />;
+  }, [handleOpenChange]);
 
   const computeItemKey = useCallback((_, msg) => {
     return msg.seq ?? msg.timestamp;

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -32,6 +32,7 @@ const ResponsePane = ({ item, collection }) => {
   const dispatch = useDispatch();
   const tabs = useSelector((state) => state.tabs.tabs);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
+  const streamEntry = useSelector((state) => state.streamMessages[item.uid]);
   const isLoading = ['queued', 'sending'].includes(item.requestState);
   const [showScriptErrorCard, setShowScriptErrorCard] = useState(false);
   const rightContentRef = useRef(null);
@@ -100,6 +101,11 @@ const ResponsePane = ({ item, collection }) => {
     );
   };
   const responseSize = useMemo(() => {
+    // For streaming responses, size is tracked in the separate streamMessages slice
+    if (streamEntry?.size) {
+      return streamEntry.size;
+    }
+
     if (typeof response.size === 'number') {
       return response.size;
     }
@@ -113,7 +119,7 @@ const ResponsePane = ({ item, collection }) => {
     } catch (error) {
       return 0;
     }
-  }, [response.size, response.dataBuffer]);
+  }, [streamEntry?.size, response.size, response.dataBuffer]);
   const responseHeadersCount = typeof response.headers === 'object' ? Object.entries(response.headers).length : 0;
 
   const hasScriptError = item?.preRequestScriptErrorMessage || item?.postResponseScriptErrorMessage || item?.testScriptErrorMessage;
@@ -155,7 +161,7 @@ const ResponsePane = ({ item, collection }) => {
       case 'response': {
         const isStream = item.response?.stream ?? false;
         if (isStream) {
-          return <WSMessagesList order={-1} messages={item.response.data} />;
+          return <WSMessagesList order={-1} messages={streamEntry?.messages ?? []} />;
         }
         return (
           <QueryResult

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -22,9 +22,9 @@ import {
   runFolderEvent,
   runRequestEvent,
   scriptEnvironmentUpdateEvent,
-  streamDataReceived,
   setDotEnvVariables
 } from 'providers/ReduxStore/slices/collections';
+import { streamMessagesReceived } from 'providers/ReduxStore/slices/streamMessages';
 import { collectionAddEnvFileEvent, openCollectionEvent, hydrateCollectionWithUiStateSnapshot, mergeAndPersistEnvironment } from 'providers/ReduxStore/slices/collections/actions';
 import {
   workspaceOpenedEvent,
@@ -322,11 +322,48 @@ const useIpcEvents = () => {
       dispatch(collectionClearOauth2CredentialsByCredentialsId(val));
     });
 
+    const streamBatchBuffers = {};
+    const streamFlushTimers = {};
+
     const removeHttpStreamNewDataListener = ipcRenderer.on('main:http-stream-new-data', (val) => {
-      dispatch(streamDataReceived(val));
+      const key = `${val.collectionUid}:${val.itemUid}`;
+      if (!streamBatchBuffers[key]) {
+        streamBatchBuffers[key] = [];
+      }
+      streamBatchBuffers[key].push(val);
+
+      if (!streamFlushTimers[key]) {
+        streamFlushTimers[key] = setTimeout(() => {
+          const batch = streamBatchBuffers[key];
+          if (batch?.length) {
+            dispatch(streamMessagesReceived({
+              collectionUid: val.collectionUid,
+              itemUid: val.itemUid,
+              items: batch
+            }));
+            streamBatchBuffers[key] = [];
+          }
+          streamFlushTimers[key] = null;
+        }, 100);
+      }
     });
 
     const removeHttpStreamEndListener = ipcRenderer.on('main:http-stream-end', (val) => {
+      // Flush any pending batch before marking the stream as ended
+      const key = `${val.collectionUid}:${val.itemUid}`;
+      if (streamFlushTimers[key]) {
+        clearTimeout(streamFlushTimers[key]);
+        streamFlushTimers[key] = null;
+        const batch = streamBatchBuffers[key];
+        if (batch?.length) {
+          dispatch(streamMessagesReceived({
+            collectionUid: val.collectionUid,
+            itemUid: val.itemUid,
+            items: batch
+          }));
+          streamBatchBuffers[key] = [];
+        }
+      }
       dispatch(requestCancelled(val));
     });
 
@@ -367,6 +404,7 @@ const useIpcEvents = () => {
       removeCollectionOauth2CredentialsClearListener();
       removeHttpStreamNewDataListener();
       removeHttpStreamEndListener();
+      Object.values(streamFlushTimers).forEach(clearTimeout);
       removeCollectionLoadingStateListener();
       removePersistentEnvVariablesUpdateListener();
       removeSystemResourcesListener();

--- a/packages/bruno-app/src/providers/ReduxStore/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/index.js
@@ -11,6 +11,7 @@ import performanceReducer from './slices/performance';
 import workspacesReducer from './slices/workspaces';
 import apiSpecReducer from './slices/apiSpec';
 import openapiSyncReducer from './slices/openapi-sync';
+import streamMessagesReducer from './slices/streamMessages';
 import { draftDetectMiddleware } from './middlewares/draft/middleware';
 import { autosaveMiddleware } from './middlewares/autosave/middleware';
 
@@ -34,7 +35,8 @@ export const store = configureStore({
     performance: performanceReducer,
     workspaces: workspacesReducer,
     apiSpec: apiSpecReducer,
-    openapiSync: openapiSyncReducer
+    openapiSync: openapiSyncReducer,
+    streamMessages: streamMessagesReducer
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(middleware)
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -2,7 +2,6 @@ import { parseQueryParams, buildQueryString as stringifyQueryParams } from '@use
 import { uuid } from 'utils/common';
 import { find, map, forOwn, concat, filter, each, cloneDeep, get, set, findIndex } from 'lodash';
 import { createSlice } from '@reduxjs/toolkit';
-import { hexy as hexdump } from 'hexy';
 import {
   addDepth,
   areItemsTheSameExceptSeqUpdate,
@@ -513,7 +512,6 @@ export const collectionsSlice = createSlice({
 
             const startTimestamp = item.requestSent.timestamp;
             item.response.duration = startTimestamp ? Date.now() - startTimestamp : item.response.duration;
-            item.response.data = [{ type: 'info', timestamp: Date.now(), seq: seq, message: 'Connection Closed' }].concat(item.response.data);
           } else {
             item.response = null;
             item.requestUid = null;
@@ -3299,28 +3297,6 @@ export const collectionsSlice = createSlice({
         set(folder, 'draft.request.auth.mode', action.payload.mode);
       }
     },
-    streamDataReceived: (state, action) => {
-      const { itemUid, collectionUid, seq, timestamp, data } = action.payload;
-      const collection = findCollectionByUid(state.collections, collectionUid);
-
-      if (collection) {
-        const item = findItemInCollection(collection, itemUid);
-        if (data.data) {
-          item.response.data ||= [];
-          item.response.data.push({
-            type: 'incoming',
-            seq,
-            message: data.data,
-            messageHexdump: hexdump(data.data),
-            timestamp: timestamp || Date.now()
-          });
-        }
-        if (data.dataBuffer) {
-          item.response.dataBuffer = Buffer.concat([Buffer.from(item.response.dataBuffer), Buffer.from(data.dataBuffer)]);
-        }
-        item.response.size = data.data?.length + (item.response.size || 0);
-      }
-    },
     addRequestTag: (state, action) => {
       const { tag, collectionUid, itemUid } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
@@ -3717,7 +3693,6 @@ export const {
   updateRequestDocs,
   updateFolderDocs,
   moveCollection,
-  streamDataReceived,
   collectionAddOauth2CredentialsByUrl,
   collectionClearOauth2CredentialsByUrlAndCredentialsId,
   collectionClearOauth2CredentialsByCredentialsId,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/streamMessages.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/streamMessages.js
@@ -1,0 +1,59 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { requestCancelled, responseReceived } from './collections';
+
+const MAX_STREAM_MESSAGES = 10000;
+
+const streamMessagesSlice = createSlice({
+  name: 'streamMessages',
+  initialState: {},
+  reducers: {
+    streamMessagesReceived: (state, action) => {
+      const { itemUid, items } = action.payload;
+      if (!state[itemUid]) {
+        state[itemUid] = { messages: [], size: 0 };
+      }
+      const entry = state[itemUid];
+      for (const { seq, timestamp, data } of items) {
+        if (data.data) {
+          entry.messages.push({
+            type: 'incoming',
+            seq,
+            message: data.data,
+            timestamp: timestamp || Date.now()
+          });
+          entry.size += data.data?.length || 0;
+        }
+        if (data.dataBuffer) {
+          entry.dataBufferChunks ||= [];
+          entry.dataBufferChunks.push(Buffer.from(data.dataBuffer));
+        }
+      }
+      // Evict oldest messages to bound memory
+      if (entry.messages.length > MAX_STREAM_MESSAGES) {
+        entry.messages.splice(0, entry.messages.length - MAX_STREAM_MESSAGES);
+      }
+    }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(responseReceived, (state, action) => {
+      const { itemUid, response } = action.payload;
+      if (response?.stream) {
+        delete state[itemUid];
+      }
+    });
+    builder.addCase(requestCancelled, (state, action) => {
+      const { itemUid, seq } = action.payload;
+      if (state[itemUid]) {
+        state[itemUid].messages.unshift({
+          type: 'info',
+          timestamp: Date.now(),
+          seq,
+          message: 'Connection Closed'
+        });
+      }
+    });
+  }
+});
+
+export const { streamMessagesReceived } = streamMessagesSlice.actions;
+export default streamMessagesSlice.reducer;


### PR DESCRIPTION
### Description
I was recently testing SSEs on Bruno, and the app crashed so badly that I had to force restart my laptop. This PR attempts to fix the issue by moving SSEs to a separate slice partition, preventing other slices from getting bloated.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
