### PR TITLE
fix: XML preview crash when response contains <error> root element

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/XmlPreview/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/XmlPreview/index.js
@@ -17,8 +17,8 @@ export default function XmlPreview({ data, defaultExpanded = true }) {
     return parsed;
   }, [data]);
 
-  // Check for parsing error
-  if (parsedData && typeof parsedData === 'object' && parsedData.error) {
+  // Check for parsing error (must be a string to distinguish from XML with an <error> root element)
+  if (parsedData && typeof parsedData === 'object' && typeof parsedData.error === 'string') {
     return (
       <div className="px-2">
         <ErrorBanner errors={[{ title: 'Cannot preview as XML', message: parsedData.error }]} />


### PR DESCRIPTION
### Description

- Fixes crash in XML preview when the response XML has an <error> root element (e.g. OData error responses)
- The parsed XML object {_xmlns, code, message} was colliding with the internal error sentinel check (parsedData.error), causing it to be passed as a React child to ErrorBanner
- Fix: tighten the check from parsedData.error to typeof parsedData.error === 'string' so only actual parse errors are caught

[JIRA](https://usebruno.atlassian.net/browse/BRU-3061)

### Test plan
Send a request that returns an XML error response like:

```
<error xmlns="http://docs.oasis-open.org/odata/ns/metadata">
    <code>Unauthorized</code>
    <message>The credentials provided are incorrect</message>
</error>
```

1. Toggle XML preview — should render as a tree instead of crashing
2. Verify that invalid XML still shows the parse error banner correctly

Fixes https://github.com/usebruno/bruno/issues/7735

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
