### PR TITLE
fix: make "Remove Collection" consistent with "Remove Workspace"

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/DeleteCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/DeleteCollection/index.js
@@ -36,19 +36,11 @@ const DeleteCollection = ({ onClose, collectionUid, workspaceUid }) => {
     return null;
   }
 
-  const customHeader = (
-    <div className="flex items-center gap-2">
-      <IconAlertTriangle size={18} strokeWidth={1.5} className="text-red-500" />
-      <span>Delete Collection</span>
-    </div>
-  );
-
   return (
     <StyledWrapper>
       <Modal
         size="sm"
         title="Delete Collection"
-        customHeader={customHeader}
         confirmText="Delete"
         cancelText="Cancel"
         confirmButtonColor="danger"

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
@@ -43,20 +43,12 @@ const RemoveCollection = ({ onClose, collectionUid }) => {
     return <ConfirmCollectionCloseDrafts onClose={onClose} collection={collection} collectionUid={collectionUid} />;
   }
 
-  const customHeader = (
-    <div className="flex items-center gap-2" data-testid="close-collection-modal-title">
-      <IconAlertCircle size={18} strokeWidth={1.5} className="warning-icon" />
-      <span>Remove Collection</span>
-    </div>
-  );
-
   // Otherwise, show the standard remove confirmation modal
   return (
     <StyledWrapper>
       <Modal
         size="sm"
         title="Remove Collection"
-        customHeader={customHeader}
         confirmText="Remove"
         confirmButtonColor="danger"
         handleConfirm={onConfirm}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
@@ -58,7 +58,7 @@ const RemoveCollection = ({ onClose, collectionUid }) => {
         title="Remove Collection"
         customHeader={customHeader}
         confirmText="Remove"
-        confirmButtonColor="warning"
+        confirmButtonColor="danger"
         handleConfirm={onConfirm}
         handleCancel={onClose}
       >


### PR DESCRIPTION
### Description

[BRU-3054](https://usebruno.atlassian.net/browse/BRU-3054)

The "Remove Collection" dialog was inconsistent with "Remove Workspace" one in these areas:
- It had a warning icon in header
- The "Remove" button color was of type warning instead of danger

Before:
<img width="506" height="301" alt="Screenshot 2026-04-13 at 6 54 59 PM" src="https://github.com/user-attachments/assets/441a0089-4740-4337-87a6-549e48d2ddaf" />
<img width="526" alt="Screenshot 2026-04-27 at 7 14 30 PM" src="https://github.com/user-attachments/assets/0f9e059d-19fb-4dc6-9e8f-9fae1d1e290b" />

After:
<img width="526" height="318" alt="Screenshot 2026-04-13 at 6 56 14 PM" src="https://github.com/user-attachments/assets/f814e07d-0b32-4670-8265-c7f7418304ab" />

<img width="526" alt="Screenshot 2026-04-27 at 7 12 37 PM" src="https://github.com/user-attachments/assets/aa6f01fe-8e1a-4a38-8c36-22a56467785c" />


Reference (Remove workspace):
<img width="501" height="277" alt="Screenshot 2026-04-13 at 6 59 07 PM" src="https://github.com/user-attachments/assets/3a38cff4-0d0e-4ecf-bd4c-2eb6ffe4744d" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the remove collection confirmation dialog button styling to better indicate the destructive action.
  * Simplified the dialog header to use standard formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->