### PR TITLE
fix: don't expand variables in curl import

### DIFF
--- a/packages/bruno-app/src/utils/curl/parse-curl.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.js
@@ -44,7 +44,7 @@ const FLAG_CATEGORIES = {
  */
 const parseCurlCommand = (curl) => {
   const cleanedCommand = cleanCurlCommand(curl);
-  const parsedArgs = parse(cleanedCommand);
+  const parsedArgs = parse(cleanedCommand, (varname) => '$' + varname);
   const request = buildRequest(parsedArgs);
 
   return cleanRequest(postBuildProcessRequest(request));


### PR DESCRIPTION
### Description

When importing from curl, the variables were getting expanded instead of preserving the special character. This PR fixes that behavior by keeping the variable intact without parsing it.

Resolves https://github.com/usebruno/bruno/issues/6128

Example Request:
```bash
curl -H "Authorization: Bearer sk-$2a$10$randomhash" -H "Content-Type: application/json" "https://api.example.com/"
```

Before:
<img width="524" height="152" alt="Screenshot 2026-04-13 at 7 50 51 PM" src="https://github.com/user-attachments/assets/d665fe21-6842-47b2-a149-04fddbc6e9f7" />

After:
<img width="533" height="142" alt="Screenshot 2026-04-13 at 7 50 47 PM" src="https://github.com/user-attachments/assets/fc5b19d0-9f66-4382-94ae-a4eda99679b5" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
