### PR TITLE
fix: graphql schema error messages

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/useGraphqlSchema.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/useGraphqlSchema.js
@@ -50,14 +50,20 @@ const useGraphqlSchema = (endpoint, environment, request, collection) => {
   const loadSchemaFromIntrospection = async () => {
     const response = await fetchGqlSchema(endpoint, environment, request, collection);
     if (!response) {
-      throw new Error('Introspection query failed');
+      throw new Error('Introspection query failed. Please check the URL and try again.');
     }
     if (response.status !== 200) {
-      throw new Error(response.statusText);
+      throw new Error('The URL may not be a valid GraphQL endpoint.');
+    }
+    if (response.data?.errors?.length) {
+      const messages = response.data.errors.map((e) => e.message).join('; ');
+      throw new Error(`GraphQL introspection returned errors: ${messages}`);
     }
     const data = response.data?.data;
     if (!data) {
-      throw new Error('No data returned from introspection query');
+      throw new Error(
+        'The response does not contain valid GraphQL introspection data. Please verify this is a GraphQL endpoint.'
+      );
     }
     setSchemaSource('introspection');
     return data;
@@ -89,7 +95,14 @@ const useGraphqlSchema = (endpoint, environment, request, collection) => {
         data = await loadSchemaFromIntrospection();
       }
       if (data) {
-        const { schema, validationErrors } = buildAndValidateSchema(data);
+        let schema, validationErrors;
+        try {
+          ({ schema, validationErrors } = buildAndValidateSchema(data));
+        } catch (buildErr) {
+          throw new Error(
+            'The response could not be parsed as a valid GraphQL schema. Please verify the endpoint returns a valid GraphQL introspection result.'
+          );
+        }
         setSchema(schema);
         localStorage.setItem(localStorageKey, JSON.stringify(data));
 
@@ -106,7 +119,12 @@ const useGraphqlSchema = (endpoint, environment, request, collection) => {
     } catch (err) {
       setError(err);
       console.error(err);
-      toast.error(`Error occurred while loading GraphQL Schema: ${err.message}`);
+      let errorMessage = err.message || 'Unknown error';
+      const ipcPrefix = /^Error invoking remote method '[^']+': /;
+      errorMessage = errorMessage.replace(ipcPrefix, '');
+      // Strip redundant "Error: " prefix if present after stripping IPC wrapper
+      errorMessage = errorMessage.replace(/^Error: /, '');
+      toast.error(errorMessage);
     }
 
     setIsLoading(false);

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -75,6 +75,7 @@ const { transformBrunoConfigBeforeSave } = require('../utils/transformBrunoConfi
 const { REQUEST_TYPES } = require('../utils/constants');
 const { cancelOAuth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress } = require('../utils/oauth2-protocol-handler');
 const { findUniqueFolderName } = require('../utils/collection-import');
+const { loadGqlSchemaFile } = require('../utils/graphql');
 const { saveSpecAndUpdateMetadata, cleanupSpecFilesForCollection } = require('./openapi-sync');
 
 const environmentSecretsStore = new EnvironmentSecretsStore();
@@ -1533,19 +1534,17 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
   });
 
   ipcMain.handle('renderer:load-gql-schema-file', async () => {
-    try {
-      const { filePaths } = await dialog.showOpenDialog(mainWindow, {
-        properties: ['openFile']
-      });
-      if (filePaths.length === 0) {
-        return;
-      }
-
-      const jsonData = fs.readFileSync(filePaths[0], 'utf8');
-      return safeParseJSON(jsonData);
-    } catch (err) {
-      return Promise.reject(new Error('Failed to load GraphQL schema file'));
+    const { filePaths } = await dialog.showOpenDialog(mainWindow, {
+      properties: ['openFile'],
+      filters: [
+        { name: 'GraphQL Schema Files', extensions: ['json', 'graphql', 'gql', 'sdl'] },
+        { name: 'All Files', extensions: ['*'] }
+      ]
+    });
+    if (filePaths.length === 0) {
+      return;
     }
+    return loadGqlSchemaFile(filePaths[0]);
   });
 
   const updateCookiesAndNotify = async () => {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -439,6 +439,20 @@ const fetchGqlSchemaHandler = async (event, endpoint, environment, _request, col
       };
     }
 
+    if (error.code === 'ENOTFOUND') {
+      const hostname = error.cause?.hostname || error.hostname || endpoint;
+      return Promise.reject(new Error(`Unable to reach the server at '${hostname}'. Please check the URL and your network connection.`));
+    }
+    if (error.code === 'ECONNREFUSED') {
+      return Promise.reject(new Error(`Connection refused by the server. The server may be down or not accepting connections.`));
+    }
+    if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED') {
+      return Promise.reject(new Error(`Request timed out. The server may be slow or unreachable.`));
+    }
+    if (error.code === 'CERT_HAS_EXPIRED' || error.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+      return Promise.reject(new Error(`SSL certificate error. You can disable SSL verification in Preferences if needed.`));
+    }
+
     return Promise.reject(error);
   }
 };

--- a/packages/bruno-electron/src/utils/graphql.js
+++ b/packages/bruno-electron/src/utils/graphql.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { buildSchema } = require('graphql');
 const { safeParseJSON } = require('./common');
 
 const loadGqlSchemaFile = (filePath) => {
@@ -12,6 +13,13 @@ const loadGqlSchemaFile = (filePath) => {
   const parsed = safeParseJSON(fileContent);
   if (typeof parsed === 'object' && parsed !== null) {
     return parsed;
+  }
+
+  // Validate as SDL before returning
+  try {
+    buildSchema(fileContent);
+  } catch (sdlErr) {
+    throw new Error('The file does not contain a valid GraphQL schema. Please upload a JSON introspection result or SDL file.');
   }
 
   return fileContent;

--- a/packages/bruno-electron/src/utils/graphql.js
+++ b/packages/bruno-electron/src/utils/graphql.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const { safeParseJSON } = require('./common');
+
+const loadGqlSchemaFile = (filePath) => {
+  let fileContent;
+  try {
+    fileContent = fs.readFileSync(filePath, 'utf8');
+  } catch (readErr) {
+    throw new Error(`Unable to read file: ${readErr.message}`);
+  }
+
+  const parsed = safeParseJSON(fileContent);
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('The file does not contain valid JSON. Please upload a valid GraphQL schema file (JSON introspection result or SDL).');
+  }
+  return parsed;
+};
+
+module.exports = { loadGqlSchemaFile };

--- a/packages/bruno-electron/src/utils/graphql.js
+++ b/packages/bruno-electron/src/utils/graphql.js
@@ -10,10 +10,11 @@ const loadGqlSchemaFile = (filePath) => {
   }
 
   const parsed = safeParseJSON(fileContent);
-  if (typeof parsed !== 'object' || parsed === null) {
-    throw new Error('The file does not contain valid JSON. Please upload a valid GraphQL schema file (JSON introspection result or SDL).');
+  if (typeof parsed === 'object' && parsed !== null) {
+    return parsed;
   }
-  return parsed;
+
+  return fileContent;
 };
 
 module.exports = { loadGqlSchemaFile };

--- a/packages/bruno-electron/tests/network/fetch-gql-schema-error-handling.spec.js
+++ b/packages/bruno-electron/tests/network/fetch-gql-schema-error-handling.spec.js
@@ -1,0 +1,97 @@
+const { fetchGqlSchemaHandler } = require('../../src/ipc/network');
+
+jest.mock('../../src/ipc/network/prepare-gql-introspection-request', () => {
+  return jest.fn().mockImplementation((endpoint, vars, request, root) => {
+    return {
+      url: endpoint,
+      method: 'POST',
+      headers: request?.headers || {},
+      data: {
+        query: '{ __schema { types { name } } }'
+      }
+    };
+  });
+});
+
+const makeCollection = () => ({
+  uid: 'test-collection',
+  pathname: '/test',
+  runtimeVariables: {},
+  globalEnvironmentVariables: {},
+  items: [
+    {
+      uid: 'test-request',
+      request: { vars: { req: [] } }
+    }
+  ],
+  root: {
+    request: {
+      headers: [],
+      vars: { req: [] }
+    }
+  }
+});
+
+const makeRequest = () => ({
+  uid: 'test-request',
+  vars: { req: [] }
+});
+
+const environment = { variables: [] };
+
+describe('fetchGqlSchemaHandler - network error handling', () => {
+  beforeAll(async () => {
+    try {
+      await fetchGqlSchemaHandler(null, 'http://127.0.0.1:19999/graphql', environment, makeRequest(), makeCollection());
+    } catch (e) {
+      // Expected to fail — just warming up the handler
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return a friendly error for ECONNREFUSED', async () => {
+    const endpoint = 'http://127.0.0.1:19999/graphql';
+
+    await expect(
+      fetchGqlSchemaHandler(null, endpoint, environment, makeRequest(), makeCollection())
+    ).rejects.toThrow('Connection refused by the server. The server may be down or not accepting connections.');
+  });
+
+  it('should return a friendly error for ENOTFOUND (DNS resolution failure)', async () => {
+    const endpoint = 'https://this-domain-does-not-exist-12345.com/graphql';
+
+    await expect(
+      fetchGqlSchemaHandler(null, endpoint, environment, makeRequest(), makeCollection())
+    ).rejects.toThrow(/Unable to reach the server.*Please check the URL and your network connection/);
+  }, 10000);
+
+  it('should not expose raw error codes in ECONNREFUSED message', async () => {
+    const endpoint = 'http://127.0.0.1:19999/graphql';
+
+    try {
+      await fetchGqlSchemaHandler(null, endpoint, environment, makeRequest(), makeCollection());
+    } catch (err) {
+      expect(err.message).not.toMatch(/ECONNREFUSED/);
+      expect(err.message).toContain('Connection refused');
+    }
+  });
+
+  it('should not expose raw error codes in ENOTFOUND message', async () => {
+    const endpoint = 'https://this-domain-does-not-exist-12345.com/graphql';
+
+    try {
+      await fetchGqlSchemaHandler(null, endpoint, environment, makeRequest(), makeCollection());
+    } catch (err) {
+      expect(err.message).not.toMatch(/ENOTFOUND/);
+      expect(err.message).not.toMatch(/getaddrinfo/);
+      expect(err.message).toContain('Unable to reach the server');
+    }
+  }, 10000);
+});

--- a/packages/bruno-electron/tests/network/fetch-gql-schema-error-handling.spec.js
+++ b/packages/bruno-electron/tests/network/fetch-gql-schema-error-handling.spec.js
@@ -73,6 +73,7 @@ describe('fetchGqlSchemaHandler - network error handling', () => {
   }, 10000);
 
   it('should not expose raw error codes in ECONNREFUSED message', async () => {
+    expect.assertions(2);
     const endpoint = 'http://127.0.0.1:19999/graphql';
 
     try {
@@ -84,6 +85,7 @@ describe('fetchGqlSchemaHandler - network error handling', () => {
   });
 
   it('should not expose raw error codes in ENOTFOUND message', async () => {
+    expect.assertions(3);
     const endpoint = 'https://this-domain-does-not-exist-12345.com/graphql';
 
     try {

--- a/packages/bruno-electron/tests/network/load-gql-schema-file.spec.js
+++ b/packages/bruno-electron/tests/network/load-gql-schema-file.spec.js
@@ -1,0 +1,77 @@
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { loadGqlSchemaFile } = require('../../src/utils/graphql');
+
+describe('loadGqlSchemaFile', () => {
+  let tmpDir;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-test-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should parse a valid JSON introspection file', () => {
+    const filePath = path.join(tmpDir, 'valid-schema.json');
+    const schemaData = { data: { __schema: { types: [] } } };
+    fs.writeFileSync(filePath, JSON.stringify(schemaData), 'utf8');
+
+    const result = loadGqlSchemaFile(filePath);
+    expect(result).toEqual(schemaData);
+  });
+
+  it('should throw a clear error for invalid JSON files', () => {
+    const filePath = path.join(tmpDir, 'invalid.json');
+    fs.writeFileSync(filePath, 'this is not json', 'utf8');
+
+    expect(() => loadGqlSchemaFile(filePath)).toThrow(
+      'The file does not contain valid JSON. Please upload a valid GraphQL schema file (JSON introspection result or SDL).'
+    );
+  });
+
+  it('should throw a clear error for binary files (e.g. PNG)', () => {
+    const filePath = path.join(tmpDir, 'image.png');
+    // Write some binary content
+    fs.writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]));
+
+    expect(() => loadGqlSchemaFile(filePath)).toThrow(
+      'The file does not contain valid JSON'
+    );
+  });
+
+  it('should throw a clear error for HTML files', () => {
+    const filePath = path.join(tmpDir, 'page.html');
+    fs.writeFileSync(filePath, '<html><body>Not a schema</body></html>', 'utf8');
+
+    expect(() => loadGqlSchemaFile(filePath)).toThrow(
+      'The file does not contain valid JSON'
+    );
+  });
+
+  it('should throw a clear error for empty files', () => {
+    const filePath = path.join(tmpDir, 'empty.json');
+    fs.writeFileSync(filePath, '', 'utf8');
+
+    expect(() => loadGqlSchemaFile(filePath)).toThrow(
+      'The file does not contain valid JSON'
+    );
+  });
+
+  it('should throw a clear error when file does not exist', () => {
+    const filePath = path.join(tmpDir, 'does-not-exist.json');
+
+    expect(() => loadGqlSchemaFile(filePath)).toThrow('Unable to read file:');
+  });
+
+  it('should throw a clear error for CSV files', () => {
+    const filePath = path.join(tmpDir, 'data.csv');
+    fs.writeFileSync(filePath, 'name,value\nfoo,bar\n', 'utf8');
+
+    expect(() => loadGqlSchemaFile(filePath)).toThrow(
+      'The file does not contain valid JSON'
+    );
+  });
+});

--- a/packages/bruno-electron/tests/network/load-gql-schema-file.spec.js
+++ b/packages/bruno-electron/tests/network/load-gql-schema-file.spec.js
@@ -23,22 +23,21 @@ describe('loadGqlSchemaFile', () => {
     expect(result).toEqual(schemaData);
   });
 
-  it('should throw a clear error for invalid JSON files', () => {
-    const filePath = path.join(tmpDir, 'invalid.json');
-    fs.writeFileSync(filePath, 'this is not json', 'utf8');
+  it('should return raw string for valid SDL files', () => {
+    const filePath = path.join(tmpDir, 'schema.graphql');
+    const sdlContent = 'type Query { hello: String }';
+    fs.writeFileSync(filePath, sdlContent, 'utf8');
 
-    expect(() => loadGqlSchemaFile(filePath)).toThrow(
-      'The file does not contain valid JSON. Please upload a valid GraphQL schema file (JSON introspection result or SDL).'
-    );
+    const result = loadGqlSchemaFile(filePath);
+    expect(result).toBe(sdlContent);
   });
 
   it('should throw a clear error for binary files (e.g. PNG)', () => {
     const filePath = path.join(tmpDir, 'image.png');
-    // Write some binary content
     fs.writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]));
 
     expect(() => loadGqlSchemaFile(filePath)).toThrow(
-      'The file does not contain valid JSON'
+      'The file does not contain a valid GraphQL schema'
     );
   });
 
@@ -47,7 +46,7 @@ describe('loadGqlSchemaFile', () => {
     fs.writeFileSync(filePath, '<html><body>Not a schema</body></html>', 'utf8');
 
     expect(() => loadGqlSchemaFile(filePath)).toThrow(
-      'The file does not contain valid JSON'
+      'The file does not contain a valid GraphQL schema'
     );
   });
 
@@ -56,7 +55,7 @@ describe('loadGqlSchemaFile', () => {
     fs.writeFileSync(filePath, '', 'utf8');
 
     expect(() => loadGqlSchemaFile(filePath)).toThrow(
-      'The file does not contain valid JSON'
+      'The file does not contain a valid GraphQL schema'
     );
   });
 
@@ -71,7 +70,7 @@ describe('loadGqlSchemaFile', () => {
     fs.writeFileSync(filePath, 'name,value\nfoo,bar\n', 'utf8');
 
     expect(() => loadGqlSchemaFile(filePath)).toThrow(
-      'The file does not contain valid JSON'
+      'The file does not contain a valid GraphQL schema'
     );
   });
 });


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3010)

- Improved error messages when fetching GraphQL schema from invalid or non-functional URLs.       
- Added clear error messages when uploading invalid files as GraphQL schema (e.g., PNG, CSV, HTML, invalid JSON)   

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/60645217-9611-47bd-9ccb-ee5eddce84b8


https://github.com/user-attachments/assets/b502be7f-8600-45f0-a606-e2b71df4a82f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File picker now filters for GraphQL schema files (JSON, GraphQL, GQL, SDL).
  * Added ability to load and validate GraphQL schema files (introspection JSON or SDL).

* **Bug Fixes**
  * Clearer, user-friendly messages for network/TLS, DNS and connection errors.
  * Improved detection and reporting of invalid introspection payloads and schema parse/validation failures.
  * Sanitized error text to remove internal prefixes and present concise messages.

* **Tests**
  * Added tests for network error handling and schema file parsing/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->