### PR TITLE
feat: add new parameter "apiKeyHeaderName" for "apikey" mode

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -65,6 +65,9 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
     delete request.headers[key];
     request.headers[_interpolate(key)] = _interpolate(value);
   });
+  if (request.apiKeyHeaderName) {
+    request.apiKeyHeaderName = _interpolate(request.apiKeyHeaderName);
+  }
 
   const contentType = getContentType(request.headers);
   const isGraphqlRequest = request.mode === 'graphql';

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -67,6 +67,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
     if (collectionAuth.mode === 'apikey') {
       if (collectionAuth.apikey?.placement === 'header') {
         axiosRequest.headers[collectionAuth.apikey?.key] = collectionAuth.apikey?.value;
+        axiosRequest.apiKeyHeaderName = collectionAuth.apikey?.key;
       }
 
       if (collectionAuth.apikey?.placement === 'queryparams') {
@@ -309,6 +310,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
     if (request.auth.mode === 'apikey') {
       if (request.auth.apikey?.placement === 'header') {
         axiosRequest.headers[request.auth.apikey?.key] = request.auth.apikey?.value;
+        axiosRequest.apiKeyHeaderName = request.auth.apikey?.key;
       }
 
       if (request.auth.apikey?.placement === 'queryparams') {

--- a/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
+++ b/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
@@ -1,0 +1,31 @@
+const { describe, it, expect } = require('@jest/globals');
+const interpolateVars = require('../../src/runner/interpolate-vars');
+
+describe('interpolate-vars: api key header name sidecar', () => {
+  it('interpolates apiKeyHeaderName in lockstep with interpolated header keys', () => {
+    const request = {
+      url: 'https://example.com',
+      mode: 'none',
+      headers: {
+        '{{api_header_name}}': '{{api_key_value}}'
+      },
+      apiKeyHeaderName: '{{api_header_name}}',
+      pathParams: []
+    };
+
+    interpolateVars(
+      request,
+      {
+        api_header_name: 'X-API-Key',
+        api_key_value: 'secret-key-value'
+      },
+      {},
+      {}
+    );
+
+    expect(request.headers).toEqual({
+      'X-API-Key': 'secret-key-value'
+    });
+    expect(request.apiKeyHeaderName).toEqual('X-API-Key');
+  });
+});

--- a/packages/bruno-cli/tests/runner/prepare-request.spec.js
+++ b/packages/bruno-cli/tests/runner/prepare-request.spec.js
@@ -72,6 +72,7 @@ describe('prepare-request: prepareRequest', () => {
 
         const result = await prepareRequest(item, collection);
         expect(result.headers).toHaveProperty('x-api-key', '{{apiKey}}');
+        expect(result.apiKeyHeaderName).toEqual('x-api-key');
       });
 
       it('If collection auth is apikey in header and request has existing headers', async () => {
@@ -88,6 +89,7 @@ describe('prepare-request: prepareRequest', () => {
         const result = await prepareRequest(item, collection);
         expect(result.headers).toHaveProperty('Content-Type', 'application/json');
         expect(result.headers).toHaveProperty('x-api-key', '{{apiKey}}');
+        expect(result.apiKeyHeaderName).toEqual('x-api-key');
       });
 
       it('If collection auth is apikey in query parameters', async () => {
@@ -106,6 +108,7 @@ describe('prepare-request: prepareRequest', () => {
         const expected = urlObj.toString();
         const result = await prepareRequest(item, collection);
         expect(result.url).toEqual(expected);
+        expect(result.apiKeyHeaderName).toBeUndefined();
       });
     });
 
@@ -355,6 +358,7 @@ describe('prepare-request: prepareRequest', () => {
 
         const result = await prepareRequest(item);
         expect(result.headers).toHaveProperty('x-api-key', '{{apiKey}}');
+        expect(result.apiKeyHeaderName).toEqual('x-api-key');
       });
 
       it('If request auth is apikey in header and request has existing headers', async () => {
@@ -371,6 +375,7 @@ describe('prepare-request: prepareRequest', () => {
         const result = await prepareRequest(item);
         expect(result.headers).toHaveProperty('Content-Type', 'application/json');
         expect(result.headers).toHaveProperty('x-api-key', '{{apiKey}}');
+        expect(result.apiKeyHeaderName).toEqual('x-api-key');
       });
 
       it('If request auth is apikey in query parameters', async () => {
@@ -389,6 +394,7 @@ describe('prepare-request: prepareRequest', () => {
         const expected = urlObj.toString();
         const result = await prepareRequest(item);
         expect(result.url).toEqual(expected);
+        expect(result.apiKeyHeaderName).toBeUndefined();
       });
     });
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -240,7 +240,7 @@ const configureRequest = async (
               const url = new URL(request.url);
               url.searchParams.set(tokenQueryKey, tokenValue);
               request.url = url.toString();
-            } catch (error) {}
+            } catch (error) { }
           }
         }
         break;
@@ -257,7 +257,7 @@ const configureRequest = async (
               const url = new URL(request.url);
               url.searchParams.set(tokenQueryKey, tokenValue);
               request.url = url.toString();
-            } catch (error) {}
+            } catch (error) { }
           }
         }
         break;
@@ -274,7 +274,7 @@ const configureRequest = async (
               const url = new URL(request.url);
               url.searchParams.set(tokenQueryKey, tokenValue);
               request.url = url.toString();
-            } catch (error) {}
+            } catch (error) { }
           }
         }
         break;
@@ -291,7 +291,7 @@ const configureRequest = async (
               const url = new URL(request.url);
               url.searchParams.set(tokenQueryKey, tokenValue);
               request.url = url.toString();
-            } catch (error) {}
+            } catch (error) { }
           }
         }
         break;
@@ -354,9 +354,6 @@ const configureRequest = async (
     urlObj.searchParams.set(key, value);
     request.url = urlObj.toString();
   }
-
-  // Remove apiKeyAuthValueForQueryParams, already interpolated and added to URL
-  delete request.apiKeyAuthValueForQueryParams;
 
   return axiosInstance;
 };

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -72,6 +72,9 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
     delete request.headers[key];
     request.headers[_interpolate(key)] = _interpolate(value);
   });
+  if (request.apiKeyHeaderName) {
+    request.apiKeyHeaderName = _interpolate(request.apiKeyHeaderName);
+  }
 
   const contentType = getContentType(request.headers);
   const isGraphqlRequest = request.mode === 'graphql';

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -85,6 +85,7 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         if (apiKeyAuth.key.length === 0) break;
         if (apiKeyAuth.placement === 'header') {
           axiosRequest.headers[apiKeyAuth.key] = apiKeyAuth.value;
+          axiosRequest.apiKeyHeaderName = apiKeyAuth.key;
         } else if (apiKeyAuth.placement === 'queryparams') {
           // If the API key authentication is set and its placement is 'queryparams', add it to the axios request object. This will be used in the configureRequest function to append the API key to the query parameters of the request URL.
           axiosRequest.apiKeyAuthValueForQueryParams = apiKeyAuth;
@@ -338,6 +339,7 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         if (apiKeyAuth.key.length === 0) break;
         if (apiKeyAuth.placement === 'header') {
           axiosRequest.headers[apiKeyAuth.key] = apiKeyAuth.value;
+          axiosRequest.apiKeyHeaderName = apiKeyAuth.key;
         } else if (apiKeyAuth.placement === 'queryparams') {
           // If the API key authentication is set and its placement is 'queryparams', add it to the axios request object. This will be used in the configureRequest function to append the API key to the query parameters of the request URL.
           axiosRequest.apiKeyAuthValueForQueryParams = apiKeyAuth;

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -102,6 +102,10 @@ class BrunoRequest {
       return 'bearer';
     } else if (this.headers?.['Authorization']?.startsWith('Basic') || this.req?.auth?.username) {
       return 'basic';
+    } else if (this.req?.apiKeyAuthValueForQueryParams) {
+      return 'apikey';
+    } else if (this.req?.apiKeyHeaderName && this.headers?.[this.req.apiKeyHeaderName] !== undefined) {
+      return 'apikey';
     } else if (this.req?.awsv4) {
       return 'awsv4';
     } else if (this.req?.digestConfig) {

--- a/packages/bruno-js/tests/bruno-request-auth-mode.spec.js
+++ b/packages/bruno-js/tests/bruno-request-auth-mode.spec.js
@@ -1,0 +1,53 @@
+const { describe, it, expect } = require('@jest/globals');
+const BrunoRequest = require('../src/bruno-request');
+
+const makeReq = (overrides = {}) => ({
+  url: 'http://localhost:5000/api',
+  method: 'GET',
+  headers: {
+    'Content-Type': 'application/json',
+    ...overrides.headers
+  },
+  data: undefined,
+  ...overrides
+});
+
+describe('BrunoRequest - getAuthMode()', () => {
+  it('returns apikey for header placement when the api key header is present', () => {
+    const req = new BrunoRequest(
+      makeReq({
+        headers: { 'X-API-Key': 'secret' },
+        apiKeyHeaderName: 'X-API-Key'
+      })
+    );
+
+    expect(req.getAuthMode()).toBe('apikey');
+  });
+
+  it('returns none when pre-request script deletes the api key header', () => {
+    const req = new BrunoRequest(
+      makeReq({
+        headers: { 'X-API-Key': 'secret' },
+        apiKeyHeaderName: 'X-API-Key'
+      })
+    );
+
+    req.deleteHeader('X-API-Key');
+
+    expect(req.getAuthMode()).toBe('none');
+  });
+
+  it('returns apikey for queryparams placement marker', () => {
+    const req = new BrunoRequest(
+      makeReq({
+        apiKeyAuthValueForQueryParams: {
+          key: 'api_key',
+          value: 'secret',
+          placement: 'queryparams'
+        }
+      })
+    );
+
+    expect(req.getAuthMode()).toBe('apikey');
+  });
+});

--- a/tests/auth/apikey/apikey-runner.spec.ts
+++ b/tests/auth/apikey/apikey-runner.spec.ts
@@ -1,0 +1,20 @@
+import { test } from '../../../playwright';
+import { setSandboxMode, runCollection, validateRunnerResults } from '../../utils/page';
+
+const COLLECTION_NAME = 'apikey-auth-mode-test';
+
+test.describe.serial('API Key Auth Mode Runner', () => {
+  for (const mode of ['safe', 'developer'] as const) {
+    test(`detects API key auth in ${mode} mode`, async ({ pageWithUserData: page }) => {
+      await setSandboxMode(page, COLLECTION_NAME, mode);
+      await runCollection(page, COLLECTION_NAME);
+
+      await validateRunnerResults(page, {
+        totalRequests: 2,
+        passed: 2,
+        failed: 0,
+        skipped: 0
+      });
+    });
+  }
+});

--- a/tests/auth/apikey/fixtures/collections/apikey-auth-mode-test/bruno.json
+++ b/tests/auth/apikey/fixtures/collections/apikey-auth-mode-test/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "apikey-auth-mode-test",
+  "type": "collection"
+}

--- a/tests/auth/apikey/fixtures/collections/apikey-auth-mode-test/dynamic-header-key.bru
+++ b/tests/auth/apikey/fixtures/collections/apikey-auth-mode-test/dynamic-header-key.bru
@@ -1,0 +1,29 @@
+meta {
+  name: dynamic-header-key
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:8081/ping
+  body: none
+  auth: apikey
+}
+
+auth:apikey {
+  key: {{api_key_header_name}}
+  value: {{api_key_value}}
+  placement: header
+}
+
+vars:pre-request {
+  api_key_header_name: X-API-Key
+  api_key_value: secret-key-value
+}
+
+tests {
+  test("detects API key auth when the header key is interpolated", function() {
+    expect(req.getAuthMode()).to.equal("apikey");
+    expect(req.getHeader("X-API-Key")).to.equal("secret-key-value");
+  });
+}

--- a/tests/auth/apikey/fixtures/collections/apikey-auth-mode-test/dynamic-query-key.bru
+++ b/tests/auth/apikey/fixtures/collections/apikey-auth-mode-test/dynamic-query-key.bru
@@ -1,0 +1,29 @@
+meta {
+  name: dynamic-query-key
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:8081/ping
+  body: none
+  auth: apikey
+}
+
+auth:apikey {
+  key: {{api_key_query_name}}
+  value: {{api_key_value}}
+  placement: queryparams
+}
+
+vars:pre-request {
+  api_key_query_name: api_key
+  api_key_value: secret-key-value
+}
+
+tests {
+  test("detects API key auth when the query key is interpolated", function() {
+    expect(req.getAuthMode()).to.equal("apikey");
+    expect(req.getUrl()).to.contain("api_key=secret-key-value");
+  });
+}

--- a/tests/auth/apikey/init-user-data/preferences.json
+++ b/tests/auth/apikey/init-user-data/preferences.json
@@ -1,0 +1,11 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/apikey-auth-mode-test"
+  ],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}


### PR DESCRIPTION
### Description

Fixes https://github.com/usebruno/bruno/issues/7579
[BRU-3156](https://usebruno.atlassian.net/browse/BRU-3156)

**Problem:**
Before we were not able to detect whether the auth mode is "apikey", cause api can have dynamic key in headers, so it wasn't determinstic in "header" placement.

<img width="450" height="190" alt="Screenshot 2026-04-14 at 10 22 27 PM" src="https://github.com/user-attachments/assets/c03bd2e4-864e-4864-bde0-371ad13cb639" />


**Solution:**
Add a new field "apiKeyHeaderName" that tracks the key for the header added in api key auth mode. This way we can determine if that header exist or not and determine auth mode as "apikey".

Also added interpolation of this key so that if someone passes a variable like {{apiKey}} it can be expanded in "apiKeyHeaderName" as well.

This PR adds detection of "header" as well as "query params" placement.

<img width="486" height="127" alt="Screenshot 2026-04-14 at 10 21 56 PM" src="https://github.com/user-attachments/assets/2a57836a-0a60-4631-8e1d-cbb3a8e671da" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic API key header names and values can be defined with variables and will be applied to requests
  * API key auth is now detected reliably for both header and query-parameter placements

* **Tests**
  * Added end-to-end and unit tests validating API key header name interpolation and auth-mode detection across runner and client paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->