### PR TITLE
fix: apply proxy settings to URL spec import

### DIFF
--- a/packages/bruno-electron/src/ipc/apiSpec.js
+++ b/packages/bruno-electron/src/ipc/apiSpec.js
@@ -3,6 +3,8 @@ const { openApiSpecDialog, openApiSpec } = require('../app/apiSpecs');
 const { writeFile } = require('../utils/filesystem');
 const { removeApiSpecUid } = require('../cache/apiSpecUids');
 const { removeApiSpecFromWorkspace } = require('../utils/workspace-config');
+const { getCertsAndProxyConfig } = require('./network/cert-utils');
+const { makeAxiosInstance } = require('./network/axios-instance');
 const path = require('path');
 const fs = require('fs');
 
@@ -62,8 +64,25 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedApiSpecs) 
 
   ipcMain.handle('renderer:fetch-api-spec', async (event, url) => {
     try {
-      const data = await fetch(url).then((res) => res.text());
-      return data;
+      // Use a proxy-aware axios instance so that the user's configured proxy
+      const { proxyMode, proxyConfig, httpsAgentRequestFields, interpolationOptions }
+        = await getCertsAndProxyConfig({
+          collectionUid: null,
+          collection: { promptVariables: {} },
+          request: {},
+          envVars: {},
+          runtimeVariables: {},
+          processEnvVars: {},
+          collectionPath: '',
+          globalEnvironmentVariables: {}
+        });
+
+      const axiosInstance = makeAxiosInstance({ proxyMode, proxyConfig, httpsAgentRequestFields, interpolationOptions });
+      const response = await axiosInstance.get(url, {
+        timeout: 30000,
+        transformResponse: [(data) => data]
+      });
+      return response.data;
     } catch (error) {
       return Promise.reject(error);
     }


### PR DESCRIPTION
fixes: #7704 #5134
[JIRA](https://usebruno.atlassian.net/browse/BRU-3067)

### Description

URL imports were using a bare fetch() call that bypassed Bruno's configured proxy entirely. Replaced with a proxy-aware axios instance using getCertsAndProxyConfig + makeAxiosInstance, consistent with how regular requests and OpenAPI sync already work.

Confirmed via mitmproxy — CONNECT requests now appear when importing through a proxy.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API specification fetching to properly respect proxy and certificate configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->