### PR TITLE
fix: resolve variables in HTML documentation export

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -11,7 +11,13 @@ import Modal from 'components/Modal';
 import StyledWrapper from './StyledWrapper';
 import demoImage from './demo.png';
 import { useApp } from 'providers/App';
-import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsLoading, getGlobalEnvironmentVariables } from 'utils/collections/index';
+import {
+  transformCollectionToSaveToExportAsFile,
+  findCollectionByUid,
+  areItemsLoading,
+  getGlobalEnvironmentVariables,
+  getGlobalEnvironmentVariablesMasked
+} from 'utils/collections/index';
 import { brunoToOpenCollection } from '@usebruno/converters';
 import { sanitizeName } from 'utils/common/regex';
 import { escapeHtml } from 'utils/response';
@@ -76,6 +82,14 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
       }),
     [globalEnvironments, activeGlobalEnvironmentUid]
   );
+  const globalEnvSecrets = useMemo(
+    () =>
+      getGlobalEnvironmentVariablesMasked({
+        globalEnvironments,
+        activeGlobalEnvironmentUid
+      }),
+    [globalEnvironments, activeGlobalEnvironmentUid]
+  );
 
   const isLoading = useMemo(
     () => (collection ? areItemsLoading(collection) : false),
@@ -86,6 +100,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
     try {
       const collectionCopy = cloneDeep(collection);
       collectionCopy.globalEnvironmentVariables = globalEnvironmentVariables;
+      collectionCopy.globalEnvSecrets = globalEnvSecrets;
       resolveCollectionForHtmlDocumentation(collectionCopy);
 
       const transformedCollection = transformCollectionToSaveToExportAsFile(collectionCopy);
@@ -127,7 +142,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
       console.error('Error generating documentation:', error);
       toast.error('Failed to generate documentation');
     }
-  }, [collection, globalEnvironmentVariables, version, onClose]);
+  }, [collection, globalEnvironmentVariables, globalEnvSecrets, version, onClose]);
 
   if (!collection) {
     return <CollectionNotFound onClose={onClose} />;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -11,10 +11,11 @@ import Modal from 'components/Modal';
 import StyledWrapper from './StyledWrapper';
 import demoImage from './demo.png';
 import { useApp } from 'providers/App';
-import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsLoading } from 'utils/collections/index';
+import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsLoading, getGlobalEnvironmentVariables } from 'utils/collections/index';
 import { brunoToOpenCollection } from '@usebruno/converters';
 import { sanitizeName } from 'utils/common/regex';
 import { escapeHtml } from 'utils/response';
+import { resolveCollectionForHtmlDocumentation } from 'utils/exporters/html-documentation';
 
 const CDN_BASE_URL = 'https://cdn.opencollection.com';
 
@@ -66,6 +67,15 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
   const collection = useSelector((state) =>
     findCollectionByUid(state.collections.collections, collectionUid)
   );
+  const { globalEnvironments, activeGlobalEnvironmentUid } = useSelector((state) => state.globalEnvironments);
+  const globalEnvironmentVariables = useMemo(
+    () =>
+      getGlobalEnvironmentVariables({
+        globalEnvironments,
+        activeGlobalEnvironmentUid
+      }),
+    [globalEnvironments, activeGlobalEnvironmentUid]
+  );
 
   const isLoading = useMemo(
     () => (collection ? areItemsLoading(collection) : false),
@@ -75,6 +85,9 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
   const handleGenerate = useCallback(() => {
     try {
       const collectionCopy = cloneDeep(collection);
+      collectionCopy.globalEnvironmentVariables = globalEnvironmentVariables;
+      resolveCollectionForHtmlDocumentation(collectionCopy);
+
       const transformedCollection = transformCollectionToSaveToExportAsFile(collectionCopy);
       const openCollection = brunoToOpenCollection(transformedCollection);
 
@@ -114,7 +127,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
       console.error('Error generating documentation:', error);
       toast.error('Failed to generate documentation');
     }
-  }, [collection, version, onClose]);
+  }, [collection, globalEnvironmentVariables, version, onClose]);
 
   if (!collection) {
     return <CollectionNotFound onClose={onClose} />;

--- a/packages/bruno-app/src/utils/exporters/html-documentation.js
+++ b/packages/bruno-app/src/utils/exporters/html-documentation.js
@@ -1,0 +1,178 @@
+import { interpolate, interpolateObject } from '@usebruno/common';
+import { each } from 'lodash';
+import { flattenItems, getAllVariables, isItemARequest } from 'utils/collections';
+import { interpolateUrl, interpolateUrlPathParams } from 'utils/url';
+
+const interpolateString = (value, variables, options = {}) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  return interpolate(value, variables, options);
+};
+
+const interpolateEntries = (entries = [], variables = {}) => {
+  if (!Array.isArray(entries)) {
+    return entries;
+  }
+
+  return entries.map((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return entry;
+    }
+
+    return {
+      ...entry,
+      name: interpolateString(entry.name, variables),
+      value: Array.isArray(entry.value)
+        ? entry.value.map((value) => interpolateString(value, variables))
+        : interpolateString(entry.value, variables)
+    };
+  });
+};
+
+const interpolateWsMessages = (messages = [], variables = {}) => {
+  if (!Array.isArray(messages)) {
+    return messages;
+  }
+
+  return messages.map((message) => {
+    if (!message || typeof message !== 'object') {
+      return message;
+    }
+
+    let escapeJSONStrings = message?.type === 'json';
+
+    if (!escapeJSONStrings && typeof message?.content === 'string') {
+      try {
+        JSON.parse(message.content);
+        escapeJSONStrings = true;
+      } catch (error) {
+        // no-op, plain text payload
+      }
+    }
+
+    return {
+      ...message,
+      name: interpolateString(message.name, variables),
+      content: interpolateString(message.content, variables, { escapeJSONStrings })
+    };
+  });
+};
+
+const interpolateRequestBody = (body, variables = {}) => {
+  if (!body || typeof body !== 'object') {
+    return;
+  }
+
+  switch (body.mode) {
+    case 'json':
+      body.json = interpolateString(body.json, variables, { escapeJSONStrings: true });
+      break;
+    case 'text':
+      body.text = interpolateString(body.text, variables);
+      break;
+    case 'xml':
+      body.xml = interpolateString(body.xml, variables);
+      break;
+    case 'graphql':
+      body.graphql = interpolateString(body.graphql, variables, { escapeJSONStrings: true });
+      break;
+    case 'sparql':
+      body.sparql = interpolateString(body.sparql, variables);
+      break;
+    case 'formUrlEncoded':
+      body.formUrlEncoded = interpolateEntries(body.formUrlEncoded, variables);
+      break;
+    case 'multipartForm':
+      body.multipartForm = Array.isArray(body.multipartForm)
+        ? body.multipartForm.map((entry) => {
+            if (!entry || typeof entry !== 'object') {
+              return entry;
+            }
+
+            if (entry.type && entry.type !== 'text') {
+              return entry;
+            }
+
+            return {
+              ...entry,
+              name: interpolateString(entry.name, variables),
+              value: interpolateString(entry.value, variables)
+            };
+          })
+        : body.multipartForm;
+      break;
+    case 'grpc':
+      body.grpc = Array.isArray(body.grpc)
+        ? body.grpc.map((message) => ({
+            ...message,
+            name: interpolateString(message?.name, variables),
+            content: interpolateString(message?.content, variables, { escapeJSONStrings: true })
+          }))
+        : body.grpc;
+      break;
+    case 'ws':
+      body.ws = interpolateWsMessages(body.ws, variables);
+      break;
+    default:
+      break;
+  }
+};
+
+const resolveRequestForHtmlDocumentation = (request, variables = {}) => {
+  if (!request || typeof request !== 'object') {
+    return;
+  }
+
+  const interpolatedUrl = interpolateUrl({
+    url: request.url,
+    variables
+  }) || request.url;
+  const hasPathParams = Array.isArray(request.params)
+    ? request.params.some((param) => param?.type === 'path' && param?.enabled !== false)
+    : false;
+  const hasNonHttpProtocol = /^(ws|wss|grpc|grpcs):\/\//i.test(interpolatedUrl || '');
+
+  request.url = hasPathParams && !hasNonHttpProtocol
+    ? interpolateUrlPathParams(interpolatedUrl, request.params || [], variables, { raw: true })
+    : interpolatedUrl;
+  request.headers = interpolateEntries(request.headers, variables);
+  request.params = interpolateEntries(request.params, variables);
+
+  if (request.auth && typeof request.auth === 'object') {
+    request.auth = interpolateObject(request.auth, variables);
+  }
+
+  if (request.body) {
+    interpolateRequestBody(request.body, variables);
+  }
+
+  request.docs = interpolateString(request.docs, variables);
+};
+
+export const resolveCollectionForHtmlDocumentation = (collection) => {
+  if (!collection?.items?.length) {
+    return collection;
+  }
+
+  const items = flattenItems(collection.items);
+
+  each(items, (item) => {
+    if (!isItemARequest(item) || item.isTransient) {
+      return;
+    }
+
+    const variables = getAllVariables(collection, item);
+
+    resolveRequestForHtmlDocumentation(item.request, variables);
+
+    if (Array.isArray(item.examples)) {
+      each(item.examples, (example) => {
+        resolveRequestForHtmlDocumentation(example?.request, variables);
+      });
+    }
+  });
+
+  return collection;
+};

--- a/packages/bruno-app/src/utils/exporters/html-documentation.js
+++ b/packages/bruno-app/src/utils/exporters/html-documentation.js
@@ -3,12 +3,49 @@ import { each } from 'lodash';
 import { flattenItems, getAllVariables, isItemARequest } from 'utils/collections';
 import { interpolateUrl, interpolateUrlPathParams } from 'utils/url';
 
+const REDACTED_VALUE = '[REDACTED]';
+
 const interpolateString = (value, variables, options = {}) => {
   if (typeof value !== 'string') {
     return value;
   }
 
   return interpolate(value, variables, options);
+};
+
+const interpolateJsonValue = (value, variables, options = {}) => {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  try {
+    const interpolated = interpolateString(JSON.stringify(value), variables, options);
+    return JSON.parse(interpolated);
+  } catch (error) {
+    return value;
+  }
+};
+
+const createSafeDocumentationVariables = (variables = {}) => {
+  const safeVariables = {
+    ...variables
+  };
+
+  // Documentation should not resolve process.env values from the local machine.
+  delete safeVariables.process;
+
+  // Do not expose secret env/global variable values in generated docs.
+  const maskedNames = Array.isArray(variables.maskedEnvVariables)
+    ? variables.maskedEnvVariables
+    : [];
+
+  maskedNames.forEach((name) => {
+    safeVariables[name] = REDACTED_VALUE;
+  });
+
+  delete safeVariables.maskedEnvVariables;
+
+  return safeVariables;
 };
 
 const interpolateEntries = (entries = [], variables = {}) => {
@@ -76,7 +113,17 @@ const interpolateRequestBody = (body, variables = {}) => {
       body.xml = interpolateString(body.xml, variables);
       break;
     case 'graphql':
-      body.graphql = interpolateString(body.graphql, variables, { escapeJSONStrings: true });
+      if (typeof body.graphql === 'string') {
+        body.graphql = interpolateString(body.graphql, variables, { escapeJSONStrings: true });
+      } else if (body.graphql && typeof body.graphql === 'object') {
+        body.graphql.query = interpolateString(body.graphql.query, variables, { escapeJSONStrings: true });
+
+        if (typeof body.graphql.variables === 'string') {
+          body.graphql.variables = interpolateString(body.graphql.variables, variables, { escapeJSONStrings: true });
+        } else {
+          body.graphql.variables = interpolateJsonValue(body.graphql.variables, variables, { escapeJSONStrings: true });
+        }
+      }
       break;
     case 'sparql':
       body.sparql = interpolateString(body.sparql, variables);
@@ -163,7 +210,7 @@ export const resolveCollectionForHtmlDocumentation = (collection) => {
       return;
     }
 
-    const variables = getAllVariables(collection, item);
+    const variables = createSafeDocumentationVariables(getAllVariables(collection, item));
 
     resolveRequestForHtmlDocumentation(item.request, variables);
 

--- a/packages/bruno-app/src/utils/exporters/html-documentation.js
+++ b/packages/bruno-app/src/utils/exporters/html-documentation.js
@@ -138,14 +138,13 @@ const interpolateRequestBody = (body, variables = {}) => {
               return entry;
             }
 
-            if (entry.type && entry.type !== 'text') {
-              return entry;
-            }
-
             return {
               ...entry,
               name: interpolateString(entry.name, variables),
-              value: interpolateString(entry.value, variables)
+              value:
+                entry.type === 'text'
+                  ? interpolateString(entry.value, variables)
+                  : entry.value
             };
           })
         : body.multipartForm;

--- a/packages/bruno-app/src/utils/exporters/html-documentation.spec.js
+++ b/packages/bruno-app/src/utils/exporters/html-documentation.spec.js
@@ -138,8 +138,10 @@ describe('resolveCollectionForHtmlDocumentation', () => {
       uid: 'collection-3',
       activeEnvironmentUid: 'env-1',
       globalEnvironmentVariables: {
-        url: 'https://postman-echo.com'
+        url: 'https://postman-echo.com',
+        globalSecret: 'super-secret-global-token'
       },
+      globalEnvSecrets: ['globalSecret'],
       processEnvVariables: {
         API_KEY: 'local-machine-value'
       },
@@ -176,12 +178,18 @@ describe('resolveCollectionForHtmlDocumentation', () => {
                 name: 'Authorization',
                 value: 'Bearer {{token}}',
                 enabled: true
+              },
+              {
+                uid: 'header-2',
+                name: 'X-Global',
+                value: '{{globalSecret}}',
+                enabled: true
               }
             ],
             params: [],
             body: {
               mode: 'text',
-              text: '{{token}}/{{process.env.API_KEY}}'
+              text: '{{token}}/{{globalSecret}}/{{process.env.API_KEY}}'
             },
             auth: {
               mode: 'none'
@@ -200,7 +208,8 @@ describe('resolveCollectionForHtmlDocumentation', () => {
     const request = collection.items[0].request;
 
     expect(request.headers[0].value).toBe('Bearer [REDACTED]');
-    expect(request.body.text).toBe('[REDACTED]/{{process.env.API_KEY}}');
+    expect(request.headers[1].value).toBe('[REDACTED]');
+    expect(request.body.text).toBe('[REDACTED]/[REDACTED]/{{process.env.API_KEY}}');
     expect(request.url).toBe('https://postman-echo.com/get?apiKey={{process.env.API_KEY}}');
   });
 
@@ -264,5 +273,67 @@ describe('resolveCollectionForHtmlDocumentation', () => {
 
     expect(request.body.graphql.query).toBe('query User { user(id: "42") { id token } }');
     expect(request.body.graphql.variables).toContain('"auth": "env-token"');
+  });
+
+  it('interpolates multipart field names for non-text entries and preserves non-text values', () => {
+    const collection = {
+      uid: 'collection-5',
+      activeEnvironmentUid: 'env-1',
+      globalEnvironmentVariables: {
+        fileFieldName: 'upload_file',
+        filePathVar: '/tmp/secret.txt'
+      },
+      environments: [
+        {
+          uid: 'env-1',
+          variables: []
+        }
+      ],
+      root: {
+        request: {
+          vars: {
+            req: []
+          }
+        }
+      },
+      items: [
+        {
+          uid: 'request-5',
+          type: 'http-request',
+          request: {
+            url: 'https://postman-echo.com/post',
+            method: 'post',
+            headers: [],
+            params: [],
+            body: {
+              mode: 'multipartForm',
+              multipartForm: [
+                {
+                  uid: 'entry-1',
+                  type: 'file',
+                  name: '{{fileFieldName}}',
+                  value: '{{filePathVar}}',
+                  enabled: true
+                }
+              ]
+            },
+            auth: {
+              mode: 'none'
+            },
+            vars: {
+              req: []
+            }
+          },
+          examples: []
+        }
+      ]
+    };
+
+    resolveCollectionForHtmlDocumentation(collection);
+
+    const multipartEntry = collection.items[0].request.body.multipartForm[0];
+
+    expect(multipartEntry.name).toBe('upload_file');
+    expect(multipartEntry.value).toBe('{{filePathVar}}');
   });
 });

--- a/packages/bruno-app/src/utils/exporters/html-documentation.spec.js
+++ b/packages/bruno-app/src/utils/exporters/html-documentation.spec.js
@@ -1,0 +1,135 @@
+import { resolveCollectionForHtmlDocumentation } from './html-documentation';
+
+describe('resolveCollectionForHtmlDocumentation', () => {
+  it('resolves global variables in request URLs for HTML docs export', () => {
+    const collection = {
+      uid: 'collection-1',
+      activeEnvironmentUid: 'env-1',
+      globalEnvironmentVariables: {
+        url: 'https://postman-echo.com'
+      },
+      environments: [
+        {
+          uid: 'env-1',
+          variables: []
+        }
+      ],
+      root: {
+        request: {
+          vars: {
+            req: []
+          }
+        }
+      },
+      items: [
+        {
+          uid: 'request-1',
+          type: 'http-request',
+          request: {
+            url: '{{url}}/get',
+            method: 'get',
+            headers: [],
+            params: [],
+            body: {
+              mode: 'none'
+            },
+            auth: {
+              mode: 'none'
+            },
+            vars: {
+              req: []
+            }
+          },
+          examples: []
+        }
+      ]
+    };
+
+    resolveCollectionForHtmlDocumentation(collection);
+
+    expect(collection.items[0].request.url).toBe('https://postman-echo.com/get');
+    expect(collection.items[0].request.url).not.toContain('{{url}}');
+  });
+
+  it('resolves global, collection, and environment variables in request payloads', () => {
+    const collection = {
+      uid: 'collection-2',
+      activeEnvironmentUid: 'env-1',
+      globalEnvironmentVariables: {
+        url: 'https://postman-echo.com'
+      },
+      environments: [
+        {
+          uid: 'env-1',
+          variables: [
+            {
+              name: 'token',
+              value: 'env-token',
+              enabled: true
+            }
+          ]
+        }
+      ],
+      root: {
+        request: {
+          vars: {
+            req: [
+              {
+                name: 'endpoint',
+                value: 'get',
+                enabled: true
+              }
+            ]
+          }
+        }
+      },
+      items: [
+        {
+          uid: 'request-2',
+          type: 'http-request',
+          request: {
+            url: '{{url}}/:resource',
+            method: 'get',
+            headers: [
+              {
+                uid: 'header-1',
+                name: 'Authorization',
+                value: 'Bearer {{token}}',
+                enabled: true
+              }
+            ],
+            params: [
+              {
+                uid: 'param-1',
+                type: 'path',
+                name: 'resource',
+                value: '{{endpoint}}',
+                enabled: true
+              }
+            ],
+            body: {
+              mode: 'text',
+              text: '{{url}}/{{endpoint}}?token={{token}}'
+            },
+            auth: {
+              mode: 'none'
+            },
+            vars: {
+              req: []
+            }
+          },
+          examples: []
+        }
+      ]
+    };
+
+    resolveCollectionForHtmlDocumentation(collection);
+
+    const request = collection.items[0].request;
+
+    expect(request.url).toBe('https://postman-echo.com/get');
+    expect(request.headers[0].value).toBe('Bearer env-token');
+    expect(request.body.text).toBe('https://postman-echo.com/get?token=env-token');
+    expect(JSON.stringify(request)).not.toContain('{{');
+  });
+});

--- a/packages/bruno-app/src/utils/exporters/html-documentation.spec.js
+++ b/packages/bruno-app/src/utils/exporters/html-documentation.spec.js
@@ -132,4 +132,137 @@ describe('resolveCollectionForHtmlDocumentation', () => {
     expect(request.body.text).toBe('https://postman-echo.com/get?token=env-token');
     expect(JSON.stringify(request)).not.toContain('{{');
   });
+
+  it('redacts secret variables and does not resolve process.env variables', () => {
+    const collection = {
+      uid: 'collection-3',
+      activeEnvironmentUid: 'env-1',
+      globalEnvironmentVariables: {
+        url: 'https://postman-echo.com'
+      },
+      processEnvVariables: {
+        API_KEY: 'local-machine-value'
+      },
+      environments: [
+        {
+          uid: 'env-1',
+          variables: [
+            {
+              name: 'token',
+              value: 'super-secret-token',
+              enabled: true,
+              secret: true
+            }
+          ]
+        }
+      ],
+      root: {
+        request: {
+          vars: {
+            req: []
+          }
+        }
+      },
+      items: [
+        {
+          uid: 'request-3',
+          type: 'http-request',
+          request: {
+            url: '{{url}}/get?apiKey={{process.env.API_KEY}}',
+            method: 'get',
+            headers: [
+              {
+                uid: 'header-1',
+                name: 'Authorization',
+                value: 'Bearer {{token}}',
+                enabled: true
+              }
+            ],
+            params: [],
+            body: {
+              mode: 'text',
+              text: '{{token}}/{{process.env.API_KEY}}'
+            },
+            auth: {
+              mode: 'none'
+            },
+            vars: {
+              req: []
+            }
+          },
+          examples: []
+        }
+      ]
+    };
+
+    resolveCollectionForHtmlDocumentation(collection);
+
+    const request = collection.items[0].request;
+
+    expect(request.headers[0].value).toBe('Bearer [REDACTED]');
+    expect(request.body.text).toBe('[REDACTED]/{{process.env.API_KEY}}');
+    expect(request.url).toBe('https://postman-echo.com/get?apiKey={{process.env.API_KEY}}');
+  });
+
+  it('resolves GraphQL body when represented as an object', () => {
+    const collection = {
+      uid: 'collection-4',
+      activeEnvironmentUid: 'env-1',
+      globalEnvironmentVariables: {
+        userId: '42'
+      },
+      environments: [
+        {
+          uid: 'env-1',
+          variables: [
+            {
+              name: 'token',
+              value: 'env-token',
+              enabled: true
+            }
+          ]
+        }
+      ],
+      root: {
+        request: {
+          vars: {
+            req: []
+          }
+        }
+      },
+      items: [
+        {
+          uid: 'request-4',
+          type: 'graphql-request',
+          request: {
+            url: 'https://postman-echo.com/graphql',
+            method: 'post',
+            headers: [],
+            params: [],
+            body: {
+              mode: 'graphql',
+              graphql: {
+                query: 'query User { user(id: "{{userId}}") { id token } }',
+                variables: '{ "auth": "{{token}}" }'
+              }
+            },
+            auth: {
+              mode: 'none'
+            },
+            vars: {
+              req: []
+            }
+          },
+          examples: []
+        }
+      ]
+    };
+
+    resolveCollectionForHtmlDocumentation(collection);
+
+    const request = collection.items[0].request;
+
+    expect(request.body.graphql.query).toBe('query User { user(id: "42") { id token } }');
+    expect(request.body.graphql.variables).toContain('"auth": "env-token"');
+  });
 });


### PR DESCRIPTION
### Description

fixes : #7636 

Fixes HTML documentation export to resolve variable placeholders before rendering docs.

Problem - Generated HTML docs were showing raw placeholders like `{{url}}/get` instead of resolved values.

Changes
- Added `resolveCollectionForHtmlDocumentation` in `utils/exporters/html-documentation`.
- Applied resolver in `GenerateDocumentation` before converting to OpenCollection/YAML.
- Resolver interpolates request/examples using existing variable scope precedence (global, collection, environment, folder/request vars).

Tests
- Added `html-documentation.spec.js` regression tests to verify: no unresolved `{{...}}` placeholders remain in resolved request fields.

Note : Request execution behavior is unchanged; this only affects docs export output

- before 
<img width="1573" height="294" alt="image" src="https://github.com/user-attachments/assets/3b06efec-b6f4-46d6-b636-c1304241db2e" />

- after
<img width="1508" height="280" alt="Screenshot 2026-04-15 144508" src="https://github.com/user-attachments/assets/01dcf3bb-27a2-4520-bd4d-61c4fb734829" />


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTML documentation export now incorporates the active global environment and resolves its variables across request URLs, headers, path params, bodies and examples; secret values are redacted as [REDACTED], while process.env-style templates are preserved.

* **Tests**
  * Added end-to-end tests verifying interpolation across fields, secret redaction, GraphQL variable/query resolution, and multipart/form handling in HTML documentation generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->