### PR TITLE
fix: "URL encoding off" ignored for multi-param URLs in generated code

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -88,7 +88,7 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
     const settings = item.draft ? get(item, 'draft.settings') : get(item, 'settings');
     const rawUrl = item.rawUrl || request.url;
     const parsed = parse(request.url, true, true);
-    const search = stringify(parsed.query);
+    const search = stringify(parsed.query, { sort: false });
     const httpSnippetPath = search ? `${parsed.pathname}?${search}` : parsed.pathname;
 
     let desiredPath;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -919,7 +919,7 @@ describe('generateSnippet – encodeUrl setting', () => {
     if (!parsed.query || Object.keys(parsed.query).length === 0) {
       return parsed.pathname;
     }
-    const search = stringify(parsed.query);
+    const search = stringify(parsed.query, { sort: false });
     return search ? `${parsed.pathname}?${search}` : parsed.pathname;
   };
 
@@ -1239,5 +1239,32 @@ describe('generateSnippet – encodeUrl setting', () => {
 
     const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
     expect(result).toBe(`curl -X GET '${rawUrl}'`);
+  });
+
+  it('should preserve raw URL with multiple query params in non-alphabetical order when encodeUrl is false', () => {
+    const rawUrl = 'https://example.com/api?start=2026-02-01T00:00:00.000Z&a=b';
+    const item = makeItem(rawUrl, { encodeUrl: false });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toContain('start=2026-02-01T00:00:00.000Z&a=b');
+    expect(result).not.toContain('%3A');
+  });
+
+  it('should encode URL with multiple query params in non-alphabetical order when encodeUrl is true', () => {
+    const rawUrl = 'https://example.com/api?start=2026-02-01T00:00:00.000Z&a=b';
+    const item = makeItem(rawUrl, { encodeUrl: true });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toContain('%3A');
+    expect(result).toContain('start=');
+    expect(result).toContain('a=b');
+  });
+
+  it('should preserve param order in raw URL when encodeUrl is false and params are reverse-alphabetical', () => {
+    const rawUrl = 'https://example.com/api?z=last&a=first&m=middle';
+    const item = makeItem(rawUrl, { encodeUrl: false });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toContain('?z=last&a=first&m=middle');
   });
 });

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -1246,8 +1246,7 @@ describe('generateSnippet – encodeUrl setting', () => {
     const item = makeItem(rawUrl, { encodeUrl: false });
 
     const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
-    expect(result).toContain('start=2026-02-01T00:00:00.000Z&a=b');
-    expect(result).not.toContain('%3A');
+    expect(result).toBe(`curl -X GET '${rawUrl}'`);
   });
 
   it('should encode URL with multiple query params in non-alphabetical order when encodeUrl is true', () => {
@@ -1255,9 +1254,7 @@ describe('generateSnippet – encodeUrl setting', () => {
     const item = makeItem(rawUrl, { encodeUrl: true });
 
     const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
-    expect(result).toContain('%3A');
-    expect(result).toContain('start=');
-    expect(result).toContain('a=b');
+    expect(result).toBe('curl -X GET \'https://example.com/api?start=2026-02-01T00%3A00%3A00.000Z&a=b\'');
   });
 
   it('should preserve param order in raw URL when encodeUrl is false and params are reverse-alphabetical', () => {
@@ -1265,6 +1262,6 @@ describe('generateSnippet – encodeUrl setting', () => {
     const item = makeItem(rawUrl, { encodeUrl: false });
 
     const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
-    expect(result).toContain('?z=last&a=first&m=middle');
+    expect(result).toBe(`curl -X GET '${rawUrl}'`);
   });
 });


### PR DESCRIPTION
### Description

Fixes #7524
[BRU-3158](https://usebruno.atlassian.net/browse/BRU-3158)

**Root cause**
In snippet-generator.js, we compute httpSnippetPath via query-string's stringify, then replaceAll it with the raw URL when encoding is off. stringify sorts keys alphabetically by default, so the predicted string (a=b&start=...) no longer matches HTTPSnippet's actual output (start=...&a=b), replaceAll silently no-ops and the encoded URL remains. With a single param there's nothing to sort, which is why the bug was masked.

**Fix**
One-line change: pass { sort: false } to stringify so param order is preserved.

**After:**
<img width="802" height="511" alt="Screenshot 2026-04-15 at 4 01 56 PM" src="https://github.com/user-attachments/assets/9f405f51-0120-43ac-bf01-aff962c963da" />

**Before:**
<img width="804" height="469" alt="Screenshot 2026-04-15 at 4 02 25 PM" src="https://github.com/user-attachments/assets/f6c089e7-8d9e-4088-9170-698f9eadef3d" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated code snippets now preserve original URL query parameter order (no automatic sorting), so snippets match the original request sequence.
  * Query value handling now respects the encodeUrl setting, producing encoded or raw parameter values as expected.

* **Tests**
  * Added tests validating parameter ordering and encoding behavior in generated snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->