### PR TITLE
feat: add keyboard shortcuts for tab navigation (Ctrl+PgUp, Ctrl+PgDown, Ctrl+Tab) (#736)

### DIFF
--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -21,6 +21,7 @@ export const HotkeysProvider = (props) => {
   const tabs = useSelector((state) => state.tabs.tabs);
   const collections = useSelector((state) => state.collections.collections);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
+  const activeTabHistory = useSelector((state) => state.tabs.activeTabHistory);
   const userKeyBindings = useSelector((state) => state.app.preferences?.keyBindings);
   const keybindingsEnabled = useSelector((state) => state.app.preferences?.keybindingsEnabled !== false);
   const [showNewRequestModal, setShowNewRequestModal] = useState(false);
@@ -123,35 +124,62 @@ export const HotkeysProvider = (props) => {
 
   // Switch to the previous tab (active-collection-tabs-only)
   useEffect(() => {
-    bindAction('switchToPreviousTab', (e) => {
+    const handler = (e) => {
       const collectionTabs = getCollectionTabs();
       if (collectionTabs.length === 0) return false;
       const currentIndex = collectionTabs.findIndex((t) => t.uid === activeTabUid);
       const prevIndex = (currentIndex - 1 + collectionTabs.length) % collectionTabs.length;
       dispatch(focusTab({ uid: collectionTabs[prevIndex].uid }));
       return false;
-    });
+    };
+
+    bindAction('switchToPreviousTab', handler);
+    bindAction('switchToPreviousTabAlternate', handler);
 
     return () => {
       unbindAction('switchToPreviousTab');
+      unbindAction('switchToPreviousTabAlternate');
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to the next tab (active-collection-tabs-only)
   useEffect(() => {
-    bindAction('switchToNextTab', (e) => {
+    const handler = (e) => {
       const collectionTabs = getCollectionTabs();
       if (collectionTabs.length === 0) return false;
       const currentIndex = collectionTabs.findIndex((t) => t.uid === activeTabUid);
       const nextIndex = (currentIndex + 1) % collectionTabs.length;
       dispatch(focusTab({ uid: collectionTabs[nextIndex].uid }));
       return false;
-    });
+    };
+
+    bindAction('switchToNextTab', handler);
+    bindAction('switchToNextTabAlternate', handler);
 
     return () => {
       unbindAction('switchToNextTab');
+      unbindAction('switchToNextTabAlternate');
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
+
+  // Switch to recently used tab
+  useEffect(() => {
+    bindAction('switchToRecentlyUsedTab', (e) => {
+      if (activeTabHistory.length < 2) return false;
+
+      // The first element is the current tab, so we switch to the second one
+      const recentTabUid = activeTabHistory[0] === activeTabUid ? activeTabHistory[1] : activeTabHistory[0];
+
+      if (recentTabUid) {
+        dispatch(focusTab({ uid: recentTabUid }));
+      }
+      return false;
+    });
+
+    return () => {
+      unbindAction('switchToRecentlyUsedTab');
+    };
+  }, [activeTabUid, activeTabHistory, dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to tab at position (Cmd+1 through Cmd+8) and last tab (Cmd+9) — collection-scoped
   useEffect(() => {

--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -162,16 +162,50 @@ export const HotkeysProvider = (props) => {
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
 
-  // Switch to recently used tab
+  const [cyclingIndex, setCyclingIndex] = useState(0);
+  const [isCycling, setIsCycling] = useState(false);
+  const [cyclingHistory, setCyclingHistory] = useState([]);
+
+  // Detect when the modifier key is released to stop cycling and commit the MRU order
+  useEffect(() => {
+    const handleKeyUp = (e) => {
+      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+      const modifierKey = isMac ? e.metaKey : e.ctrlKey;
+
+      if (!modifierKey && isCycling) {
+        setIsCycling(false);
+        setCyclingIndex(0);
+        setCyclingHistory([]);
+      }
+    };
+
+    window.addEventListener('keyup', handleKeyUp);
+    return () => window.removeEventListener('keyup', handleKeyUp);
+  }, [isCycling]);
+
+  // Switch to recently used tab with cycling support
   useEffect(() => {
     bindAction('switchToRecentlyUsedTab', (e) => {
       if (activeTabHistory.length < 2) return false;
 
-      // The first element is the current tab, so we switch to the second one
-      const recentTabUid = activeTabHistory[0] === activeTabUid ? activeTabHistory[1] : activeTabHistory[0];
+      let nextIndex;
+      let historyToUse;
 
-      if (recentTabUid) {
-        dispatch(focusTab({ uid: recentTabUid }));
+      if (!isCycling) {
+        setIsCycling(true);
+        historyToUse = [...activeTabHistory];
+        setCyclingHistory(historyToUse);
+        nextIndex = 1; // start from the second most recent
+      } else {
+        historyToUse = cyclingHistory;
+        nextIndex = (cyclingIndex + 1) % historyToUse.length;
+      }
+
+      setCyclingIndex(nextIndex);
+      const targetUid = historyToUse[nextIndex];
+
+      if (targetUid) {
+        dispatch(focusTab({ uid: targetUid }));
       }
       return false;
     });
@@ -179,7 +213,7 @@ export const HotkeysProvider = (props) => {
     return () => {
       unbindAction('switchToRecentlyUsedTab');
     };
-  }, [activeTabUid, activeTabHistory, dispatch, userKeyBindings, keybindingsEnabled]);
+  }, [activeTabUid, activeTabHistory, isCycling, cyclingIndex, cyclingHistory, dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to tab at position (Cmd+1 through Cmd+8) and last tab (Cmd+9) — collection-scoped
   useEffect(() => {

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -11,6 +11,9 @@ export const KEY_BINDING_SECTIONS = [
       switchToLastTab: { mac: 'command+bind+9', windows: 'ctrl+bind+9', name: 'Switch to Last Tab' }, // D
       switchToPreviousTab: { mac: 'shift+bind+command+bind+[', windows: 'shift+bind+ctrl+bind+[', name: 'Switch to Previous Tab' }, // D
       switchToNextTab: { mac: 'shift+bind+command+bind+]', windows: 'shift+bind+ctrl+bind+]', name: 'Switch to Next Tab' },
+      switchToPreviousTabAlternate: { mac: 'command+bind+pageup', windows: 'ctrl+bind+pageup', name: 'Switch to Previous Tab (Alt)', hidden: true },
+      switchToNextTabAlternate: { mac: 'command+bind+pagedown', windows: 'ctrl+bind+pagedown', name: 'Switch to Next Tab (Alt)', hidden: true },
+      switchToRecentlyUsedTab: { mac: 'command+bind+tab', windows: 'ctrl+bind+tab', name: 'Switch to Recently Used Tab' },
       moveTabLeft: { mac: 'command+bind+[', windows: 'ctrl+bind+[', name: 'Move Tab Left' }, // D
       moveTabRight: { mac: 'command+bind+]', windows: 'ctrl+bind+]', name: 'Move Tab Right' }, // D
       switchToTab1: { mac: 'command+bind+1', windows: 'ctrl+bind+1', name: 'Switch to Tab at Position', readOnly: true, hidden: true },

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -13,7 +13,7 @@ export const KEY_BINDING_SECTIONS = [
       switchToNextTab: { mac: 'shift+bind+command+bind+]', windows: 'shift+bind+ctrl+bind+]', name: 'Switch to Next Tab' },
       switchToPreviousTabAlternate: { mac: 'command+bind+pageup', windows: 'ctrl+bind+pageup', name: 'Switch to Previous Tab (Alt)', hidden: true },
       switchToNextTabAlternate: { mac: 'command+bind+pagedown', windows: 'ctrl+bind+pagedown', name: 'Switch to Next Tab (Alt)', hidden: true },
-      switchToRecentlyUsedTab: { mac: 'command+bind+tab', windows: 'ctrl+bind+tab', name: 'Switch to Recently Used Tab' },
+      switchToRecentlyUsedTab: { mac: 'shift+bind+command+bind+tab', windows: 'ctrl+bind+tab', name: 'Switch to Recently Used Tab' },
       moveTabLeft: { mac: 'command+bind+[', windows: 'ctrl+bind+[', name: 'Move Tab Left' }, // D
       moveTabRight: { mac: 'command+bind+]', windows: 'ctrl+bind+]', name: 'Move Tab Right' }, // D
       switchToTab1: { mac: 'command+bind+1', windows: 'ctrl+bind+1', name: 'Switch to Tab at Position', readOnly: true, hidden: true },

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -10,6 +10,7 @@ const MAX_RECENTLY_CLOSED_TABS = 50;
 const initialState = {
   tabs: [],
   activeTabUid: null,
+  activeTabHistory: [], // stack of active tab UIDs (MRU)
   recentlyClosedTabs: [] // LIFO stack of closed tabs, grouped by collection
 };
 
@@ -39,6 +40,7 @@ export const tabsSlice = createSlice({
       const existingTab = find(state.tabs, (tab) => tab.uid === uid);
       if (existingTab) {
         state.activeTabUid = existingTab.uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
         return;
       }
 
@@ -46,6 +48,7 @@ export const tabsSlice = createSlice({
         const existingTab = tabTypeAlreadyExists(state.tabs, collectionUid, type);
         if (existingTab) {
           state.activeTabUid = existingTab.uid;
+          state.activeTabHistory = [existingTab.uid, ...state.activeTabHistory.filter((id) => id !== existingTab.uid)];
           return;
         }
       }
@@ -80,6 +83,7 @@ export const tabsSlice = createSlice({
         };
 
         state.activeTabUid = uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
         return;
       }
 
@@ -108,12 +112,14 @@ export const tabsSlice = createSlice({
         ...(isTransient ? { isTransient: true } : {})
       });
       state.activeTabUid = uid;
+      state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
     },
     focusTab: (state, action) => {
       const { uid } = action.payload;
       const tabExists = state.tabs.some((t) => t.uid === uid);
       if (tabExists) {
         state.activeTabUid = uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
       }
     },
     switchTab: (state, action) => {
@@ -287,6 +293,7 @@ export const tabsSlice = createSlice({
       state.tabs = filter(state.tabs, (t) =>
         !tabUids.includes(t.uid) || nonClosableTypes.includes(t.type)
       );
+      state.activeTabHistory = filter(state.activeTabHistory, (id) => !tabUids.includes(id));
 
       if (activeTab && state.tabs.length) {
         const { collectionUid } = activeTab;
@@ -315,7 +322,11 @@ export const tabsSlice = createSlice({
     closeAllCollectionTabs: (state, action) => {
       const { collectionUid } = action.payload;
       const prevActiveTabUid = state.activeTabUid;
+      const tabsToClose = filter(state.tabs, (t) => t.collectionUid === collectionUid);
+      const tabUidsToClose = tabsToClose.map((t) => t.uid);
+
       state.tabs = filter(state.tabs, (t) => t.collectionUid !== collectionUid);
+      state.activeTabHistory = filter(state.activeTabHistory, (id) => !tabUidsToClose.includes(id));
 
       const activeTabStillExists = state.tabs.some((t) => t.uid === prevActiveTabUid);
       if (!activeTabStillExists) {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -63,6 +63,7 @@ export const tabsSlice = createSlice({
 
       const lastTab = state.tabs[state.tabs.length - 1];
       if (state.tabs.length > 0 && lastTab.preview) {
+        const replacedUid = lastTab.uid;
         state.tabs[state.tabs.length - 1] = {
           uid,
           collectionUid,
@@ -83,7 +84,7 @@ export const tabsSlice = createSlice({
         };
 
         state.activeTabUid = uid;
-        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid && id !== replacedUid)];
         return;
       }
 
@@ -141,6 +142,7 @@ export const tabsSlice = createSlice({
       }
 
       state.activeTabUid = state.tabs[toBeActivatedTabIndex].uid;
+      state.activeTabHistory = [state.activeTabUid, ...state.activeTabHistory.filter((id) => id !== state.activeTabUid)];
     },
     updateRequestPaneTabWidth: (state, action) => {
       const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
@@ -386,6 +388,7 @@ export const tabsSlice = createSlice({
 
       state.tabs.push(tab);
       state.activeTabUid = tab.uid;
+      state.activeTabHistory = [tab.uid, ...state.activeTabHistory.filter((id) => id !== tab.uid)];
     }
   }
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
@@ -1,0 +1,61 @@
+import { configureStore } from '@reduxjs/toolkit';
+import tabsReducer, { addTab, focusTab, closeTabs, closeAllCollectionTabs } from './tabs';
+
+describe('tabs reducer with store', () => {
+  let store;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: {
+        tabs: tabsReducer
+      }
+    });
+  });
+
+  it('should update activeTabHistory when adding a tab', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1']);
+
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab2', 'tab1']);
+  });
+
+  it('should move tab to front of history when focusing an existing tab', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab3', 'tab2', 'tab1']);
+
+    store.dispatch(focusTab({ uid: 'tab1' }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1', 'tab3', 'tab2']);
+  });
+
+  it('should remove tab from history when closed', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(closeTabs({ tabUids: ['tab2'] }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab3', 'tab1']);
+    expect(store.getState().tabs.tabs.map((t) => t.uid)).toEqual(['tab1', 'tab3']);
+  });
+
+  it('should remove all collection tabs from history when collection is closed', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c2', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(closeAllCollectionTabs({ collectionUid: 'c1' }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab2']);
+    expect(store.getState().tabs.tabs.map((t) => t.uid)).toEqual(['tab2']);
+  });
+
+  it('should handle adding a tab that already exists by moving it to front of history', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1', 'tab2']);
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
-import tabsReducer, { addTab, focusTab, closeTabs, closeAllCollectionTabs } from './tabs';
+import tabsReducer, { addTab, focusTab, closeTabs, closeAllCollectionTabs, switchTab, reopenLastClosedTab } from './tabs';
 
 describe('tabs reducer with store', () => {
   let store;
@@ -57,5 +57,39 @@ describe('tabs reducer with store', () => {
 
     store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
     expect(store.getState().tabs.activeTabHistory).toEqual(['tab1', 'tab2']);
+  });
+
+  it('should filter out the replaced preview tab from history', () => {
+    store.dispatch(addTab({ uid: 'preview1', collectionUid: 'c1', type: 'request', preview: true }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['preview1']);
+
+    // Adding a second tab which will replace the preview tab
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab2']);
+    expect(store.getState().tabs.tabs.map((t) => t.uid)).toEqual(['tab2']);
+  });
+
+  it('should update history when using switchTab', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab3', 'tab2', 'tab1']);
+
+    store.dispatch(switchTab({ direction: 'pagedown' })); // Points to tab1 (circular from tab3)
+    expect(store.getState().tabs.activeTabUid).toBe('tab1');
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1', 'tab3', 'tab2']);
+  });
+
+  it('should restore history when using reopenLastClosedTab', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(closeTabs({ tabUids: ['tab2'] }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1']);
+
+    store.dispatch(reopenLastClosedTab());
+    expect(store.getState().tabs.activeTabUid).toBe('tab2');
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab2', 'tab1']);
   });
 });


### PR DESCRIPTION
This PR adds keyboard shortcuts for switching between tabs, as requested in issue #736.

Key changes:
- Added Ctrl+PageUp / Ctrl+PageDown for sequential tab navigation.
- Added Ctrl+Tab for switching to the most recently used (MRU) tab.
- Implemented activeTabHistory in tabsSlice to track the MRU order of tabs.
- Updated HotkeysProvider to handle the new navigation actions.
- Added unit tests for the tabs reducer to ensure correct history management.

Reference: Fixes #736


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cmd/Ctrl+Tab now switches to the most-recently-used tab with modifier-hold cycling; new alternate shortcuts for previous/next tab (PageUp/PageDown combos) added.
  * Tab history is maintained as an MRU stack so closes, replacements, and switches preserve expected order and restoration behavior.

* **Tests**
  * Added comprehensive tests for tab history, navigation, closures, replacements, and restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->