### PR TITLE
feat: add save-all command to collection menu and unsaved indicator to sidebar (#737)

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
@@ -103,7 +103,7 @@ const Wrapper = styled.div`
       width: 8px;
       height: 8px;
       border-radius: 50%;
-      background-color: #f59e0b;
+      background-color: ${(props) => props.theme.colors.text.warning};
       margin-left: 4px;
       flex-shrink: 0;
     }

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
@@ -99,6 +99,15 @@ const Wrapper = styled.div`
       overflow: hidden;
     }
 
+    .unsaved-indicator {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: #f59e0b;
+      margin-left: 4px;
+      flex-shrink: 0;
+    }
+
     /* Single source of truth for hover/focus states: background and menu icon visibility */
     &:hover,
     &.item-hovered,

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -36,7 +36,7 @@ import RunCollectionItem from './RunCollectionItem';
 import GenerateCodeItem from './GenerateCodeItem';
 import { isItemARequest, isItemAFolder } from 'utils/tabs';
 import { doesRequestMatchSearchText, doesFolderHaveItemsMatchSearchText } from 'utils/collections/search';
-import { getDefaultRequestPaneTab } from 'utils/collections';
+import { getDefaultRequestPaneTab, hasRequestChanges } from 'utils/collections';
 import toast from 'react-hot-toast';
 import StyledWrapper from './StyledWrapper';
 import NetworkError from 'components/ResponsePane/NetworkError/index';
@@ -92,6 +92,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
   // Check if request has examples (only for HTTP requests)
   const hasExamples = isItemARequest(item) && item.type === 'http-request' && item.examples && item.examples.length > 0;
+  const hasUnsavedChanges = isItemARequest(item) && hasRequestChanges(item);
 
   // Sidebar shortcuts — only active when this sidebar item has keyboard focus
   useKeybinding('cloneItem', () => {
@@ -689,6 +690,11 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
               <span className="item-name" title={item.name}>
                 {item.name}
               </span>
+              {hasUnsavedChanges ? (
+                <ActionIcon style={{ width: 16, minWidth: 16 }}>
+                  <span className="unsaved-indicator" />
+                </ActionIcon>
+              ) : null}
             </div>
           </div>
           <div className="pr-2">

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -24,8 +24,7 @@ import {
 } from '@tabler/icons';
 import OpenAPISyncIcon from 'components/Icons/OpenAPISync';
 import { toggleCollection, collapseFullCollection } from 'providers/ReduxStore/slices/collections';
-import { mountCollection, moveCollectionAndPersist, handleCollectionItemDrop, pasteItem, showInFolder, saveCollectionSecurityConfig } from 'providers/ReduxStore/slices/collections/actions';
-import { saveMultipleRequests, saveMultipleCollections, saveMultipleFolders, saveEnvironment } from 'providers/ReduxStore/slices/collections/actions';
+import { mountCollection, moveCollectionAndPersist, handleCollectionItemDrop, pasteItem, showInFolder, saveCollectionSecurityConfig, saveAllCollectionChanges } from 'providers/ReduxStore/slices/collections/actions';
 import { IconDeviceFloppy } from '@tabler/icons';
 import { flattenItems, isItemARequest, hasRequestChanges, findEnvironmentInCollection } from 'utils/collections';
 import { useDispatch, useSelector } from 'react-redux';
@@ -119,55 +118,8 @@ const Collection = ({ collection, searchText }) => {
   };
 
   const handleSaveAll = async () => {
-    const collectionUid = collection.uid;
-
-    const requestDrafts = [];
-    const collectionDrafts = [];
-    const folderDrafts = [];
-    const promises = [];
-
-    // Collection settings draft
-    if (collection.draft) {
-      collectionDrafts.push({ collectionUid });
-    }
-
-    // Environment draft
-    if (collection.environmentsDraft) {
-      const { environmentUid, variables } = collection.environmentsDraft;
-      const environment = findEnvironmentInCollection(collection, environmentUid);
-      if (environment && variables) {
-        promises.push(dispatch(saveEnvironment(variables, environmentUid, collectionUid)));
-      }
-    }
-
-    // Request and folder drafts
-    const items = flattenItems(collection.items);
-    const requests = items.filter((item) => isItemARequest(item) && hasRequestChanges(item));
-    requests.forEach((draft) => {
-      requestDrafts.push({ ...draft, collectionUid });
-    });
-
-    const folders = items.filter((item) => item.type === 'folder' && item.draft);
-    folders.forEach((folder) => {
-      folderDrafts.push({ folderUid: folder.uid, collectionUid });
-    });
-
-    if (collectionDrafts.length > 0) {
-      promises.push(dispatch(saveMultipleCollections(collectionDrafts)));
-    }
-    if (folderDrafts.length > 0) {
-      promises.push(dispatch(saveMultipleFolders(folderDrafts)));
-    }
-    if (requestDrafts.length > 0) {
-      promises.push(dispatch(saveMultipleRequests(requestDrafts)));
-    }
-
-    if (promises.length === 0) {
-      return;
-    }
-
     try {
-      await Promise.all(promises);
+      await dispatch(saveAllCollectionChanges(collection));
       toast.success('All changes saved');
     } catch (err) {
       toast.error('Failed to save all changes');

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -25,6 +25,9 @@ import {
 import OpenAPISyncIcon from 'components/Icons/OpenAPISync';
 import { toggleCollection, collapseFullCollection } from 'providers/ReduxStore/slices/collections';
 import { mountCollection, moveCollectionAndPersist, handleCollectionItemDrop, pasteItem, showInFolder, saveCollectionSecurityConfig } from 'providers/ReduxStore/slices/collections/actions';
+import { saveMultipleRequests, saveMultipleCollections, saveMultipleFolders, saveEnvironment } from 'providers/ReduxStore/slices/collections/actions';
+import { IconDeviceFloppy } from '@tabler/icons';
+import { flattenItems, isItemARequest, hasRequestChanges, findEnvironmentInCollection } from 'utils/collections';
 import { useDispatch, useSelector } from 'react-redux';
 import { addTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
 import { setFocusedSidebarPath } from 'providers/ReduxStore/slices/app';
@@ -113,6 +116,52 @@ const Collection = ({ collection, searchText }) => {
       collectionPathname: collection.pathname,
       brunoConfig: collection.brunoConfig
     }));
+  };
+
+  const handleSaveAll = () => {
+    const collectionUid = collection.uid;
+
+    const requestDrafts = [];
+    const collectionDrafts = [];
+    const folderDrafts = [];
+
+    // Collection settings draft
+    if (collection.draft) {
+      collectionDrafts.push({ collectionUid });
+    }
+
+    // Environment draft
+    if (collection.environmentsDraft) {
+      const { environmentUid, variables } = collection.environmentsDraft;
+      const environment = findEnvironmentInCollection(collection, environmentUid);
+      if (environment && variables) {
+        dispatch(saveEnvironment(variables, environmentUid, collectionUid));
+      }
+    }
+
+    // Request and folder drafts
+    const items = flattenItems(collection.items);
+    const requests = items.filter((item) => isItemARequest(item) && hasRequestChanges(item));
+    requests.forEach((draft) => {
+      requestDrafts.push({ ...draft, collectionUid });
+    });
+
+    const folders = items.filter((item) => item.type === 'folder' && item.draft);
+    folders.forEach((folder) => {
+      folderDrafts.push({ folderUid: folder.uid, collectionUid });
+    });
+
+    if (collectionDrafts.length > 0) {
+      dispatch(saveMultipleCollections(collectionDrafts));
+    }
+    if (folderDrafts.length > 0) {
+      dispatch(saveMultipleFolders(folderDrafts));
+    }
+    if (requestDrafts.length > 0) {
+      dispatch(saveMultipleRequests(requestDrafts));
+    }
+
+    toast.success('All changes saved');
   };
 
   const hasSearchText = searchText && searchText?.trim()?.length;
@@ -363,6 +412,13 @@ const Collection = ({ collection, searchText }) => {
       onClick: () => {
         setShowCloneCollectionModalOpen(true);
       }
+    },
+    {
+      id: 'save-all',
+      leftSection: IconDeviceFloppy,
+      label: 'Save All',
+      rightSection: <span className="shortcut">{navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? 'Cmd+Shift+S' : 'Ctrl+Shift+S'}</span>,
+      onClick: handleSaveAll
     },
     ...(isOpenAPISyncEnabled ? [{
       id: 'sync-openapi',

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -37,7 +37,7 @@ import NewFolder from 'components/Sidebar/NewFolder';
 import CollectionItem from './CollectionItem';
 import RemoveCollection from './RemoveCollection';
 import { doesCollectionHaveItemsMatchingSearchText } from 'utils/collections/search';
-import { isItemAFolder, isItemARequest, areItemsLoading } from 'utils/collections';
+import { isItemAFolder, areItemsLoading } from 'utils/collections';
 import { isTabForItemActive } from 'src/selectors/tab';
 
 import RenameCollection from './RenameCollection';
@@ -118,12 +118,13 @@ const Collection = ({ collection, searchText }) => {
     }));
   };
 
-  const handleSaveAll = () => {
+  const handleSaveAll = async () => {
     const collectionUid = collection.uid;
 
     const requestDrafts = [];
     const collectionDrafts = [];
     const folderDrafts = [];
+    const promises = [];
 
     // Collection settings draft
     if (collection.draft) {
@@ -135,7 +136,7 @@ const Collection = ({ collection, searchText }) => {
       const { environmentUid, variables } = collection.environmentsDraft;
       const environment = findEnvironmentInCollection(collection, environmentUid);
       if (environment && variables) {
-        dispatch(saveEnvironment(variables, environmentUid, collectionUid));
+        promises.push(dispatch(saveEnvironment(variables, environmentUid, collectionUid)));
       }
     }
 
@@ -152,16 +153,26 @@ const Collection = ({ collection, searchText }) => {
     });
 
     if (collectionDrafts.length > 0) {
-      dispatch(saveMultipleCollections(collectionDrafts));
+      promises.push(dispatch(saveMultipleCollections(collectionDrafts)));
     }
     if (folderDrafts.length > 0) {
-      dispatch(saveMultipleFolders(folderDrafts));
+      promises.push(dispatch(saveMultipleFolders(folderDrafts)));
     }
     if (requestDrafts.length > 0) {
-      dispatch(saveMultipleRequests(requestDrafts));
+      promises.push(dispatch(saveMultipleRequests(requestDrafts)));
     }
 
-    toast.success('All changes saved');
+    if (promises.length === 0) {
+      return;
+    }
+
+    try {
+      await Promise.all(promises);
+      toast.success('All changes saved');
+    } catch (err) {
+      toast.error('Failed to save all changes');
+      console.error(err);
+    }
   };
 
   const hasSearchText = searchText && searchText?.trim()?.length;

--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -21,6 +21,7 @@ export const HotkeysProvider = (props) => {
   const tabs = useSelector((state) => state.tabs.tabs);
   const collections = useSelector((state) => state.collections.collections);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
+  const activeTabHistory = useSelector((state) => state.tabs.activeTabHistory);
   const userKeyBindings = useSelector((state) => state.app.preferences?.keyBindings);
   const keybindingsEnabled = useSelector((state) => state.app.preferences?.keybindingsEnabled !== false);
   const [showNewRequestModal, setShowNewRequestModal] = useState(false);
@@ -123,35 +124,62 @@ export const HotkeysProvider = (props) => {
 
   // Switch to the previous tab (active-collection-tabs-only)
   useEffect(() => {
-    bindAction('switchToPreviousTab', (e) => {
+    const handler = (e) => {
       const collectionTabs = getCollectionTabs();
       if (collectionTabs.length === 0) return false;
       const currentIndex = collectionTabs.findIndex((t) => t.uid === activeTabUid);
       const prevIndex = (currentIndex - 1 + collectionTabs.length) % collectionTabs.length;
       dispatch(focusTab({ uid: collectionTabs[prevIndex].uid }));
       return false;
-    });
+    };
+
+    bindAction('switchToPreviousTab', handler);
+    bindAction('switchToPreviousTabAlternate', handler);
 
     return () => {
       unbindAction('switchToPreviousTab');
+      unbindAction('switchToPreviousTabAlternate');
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to the next tab (active-collection-tabs-only)
   useEffect(() => {
-    bindAction('switchToNextTab', (e) => {
+    const handler = (e) => {
       const collectionTabs = getCollectionTabs();
       if (collectionTabs.length === 0) return false;
       const currentIndex = collectionTabs.findIndex((t) => t.uid === activeTabUid);
       const nextIndex = (currentIndex + 1) % collectionTabs.length;
       dispatch(focusTab({ uid: collectionTabs[nextIndex].uid }));
       return false;
-    });
+    };
+
+    bindAction('switchToNextTab', handler);
+    bindAction('switchToNextTabAlternate', handler);
 
     return () => {
       unbindAction('switchToNextTab');
+      unbindAction('switchToNextTabAlternate');
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
+
+  // Switch to recently used tab
+  useEffect(() => {
+    bindAction('switchToRecentlyUsedTab', (e) => {
+      if (activeTabHistory.length < 2) return false;
+
+      // The first element is the current tab, so we switch to the second one
+      const recentTabUid = activeTabHistory[0] === activeTabUid ? activeTabHistory[1] : activeTabHistory[0];
+
+      if (recentTabUid) {
+        dispatch(focusTab({ uid: recentTabUid }));
+      }
+      return false;
+    });
+
+    return () => {
+      unbindAction('switchToRecentlyUsedTab');
+    };
+  }, [activeTabUid, activeTabHistory, dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to tab at position (Cmd+1 through Cmd+8) and last tab (Cmd+9) — collection-scoped
   useEffect(() => {

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -11,6 +11,9 @@ export const KEY_BINDING_SECTIONS = [
       switchToLastTab: { mac: 'command+bind+9', windows: 'ctrl+bind+9', name: 'Switch to Last Tab' }, // D
       switchToPreviousTab: { mac: 'shift+bind+command+bind+[', windows: 'shift+bind+ctrl+bind+[', name: 'Switch to Previous Tab' }, // D
       switchToNextTab: { mac: 'shift+bind+command+bind+]', windows: 'shift+bind+ctrl+bind+]', name: 'Switch to Next Tab' },
+      switchToPreviousTabAlternate: { mac: 'command+bind+pageup', windows: 'ctrl+bind+pageup', name: 'Switch to Previous Tab (Alt)', hidden: true },
+      switchToNextTabAlternate: { mac: 'command+bind+pagedown', windows: 'ctrl+bind+pagedown', name: 'Switch to Next Tab (Alt)', hidden: true },
+      switchToRecentlyUsedTab: { mac: 'command+bind+tab', windows: 'ctrl+bind+tab', name: 'Switch to Recently Used Tab' },
       moveTabLeft: { mac: 'command+bind+[', windows: 'ctrl+bind+[', name: 'Move Tab Left' }, // D
       moveTabRight: { mac: 'command+bind+]', windows: 'ctrl+bind+]', name: 'Move Tab Right' }, // D
       switchToTab1: { mac: 'command+bind+1', windows: 'ctrl+bind+1', name: 'Switch to Tab at Position', readOnly: true, hidden: true },

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -3227,3 +3227,54 @@ export const reopenClosedTab = ({ collectionUid } = {}) => async (dispatch) => {
   dispatch(reopenLastClosedTab({ collectionUid }));
   await dispatch(ensureActiveTabInCurrentWorkspace());
 };
+
+export const saveAllCollectionChanges = (collection) => async (dispatch) => {
+  const collectionUid = collection.uid;
+
+  const requestDrafts = [];
+  const collectionDrafts = [];
+  const folderDrafts = [];
+  const promises = [];
+
+  // Collection settings draft
+  if (collection.draft) {
+    collectionDrafts.push({ collectionUid });
+  }
+
+  // Environment draft
+  if (collection.environmentsDraft) {
+    const { environmentUid, variables } = collection.environmentsDraft;
+    const environment = findEnvironmentInCollection(collection, environmentUid);
+    if (environment && variables) {
+      promises.push(dispatch(saveEnvironment(variables, environmentUid, collectionUid)));
+    }
+  }
+
+  // Request and folder drafts
+  const items = flattenItems(collection.items || []);
+  const requests = items.filter((item) => isItemARequest(item) && item.draft);
+  requests.forEach((draft) => {
+    requestDrafts.push({ ...draft, collectionUid });
+  });
+
+  const folders = items.filter((item) => item.type === 'folder' && item.draft);
+  folders.forEach((folder) => {
+    folderDrafts.push({ folderUid: folder.uid, collectionUid });
+  });
+
+  if (collectionDrafts.length > 0) {
+    promises.push(dispatch(saveMultipleCollections(collectionDrafts)));
+  }
+  if (folderDrafts.length > 0) {
+    promises.push(dispatch(saveMultipleFolders(folderDrafts)));
+  }
+  if (requestDrafts.length > 0) {
+    promises.push(dispatch(saveMultipleRequests(requestDrafts)));
+  }
+
+  if (promises.length === 0) {
+    return;
+  }
+
+  return Promise.all(promises);
+};

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -10,6 +10,7 @@ const MAX_RECENTLY_CLOSED_TABS = 50;
 const initialState = {
   tabs: [],
   activeTabUid: null,
+  activeTabHistory: [], // stack of active tab UIDs (MRU)
   recentlyClosedTabs: [] // LIFO stack of closed tabs, grouped by collection
 };
 
@@ -39,6 +40,7 @@ export const tabsSlice = createSlice({
       const existingTab = find(state.tabs, (tab) => tab.uid === uid);
       if (existingTab) {
         state.activeTabUid = existingTab.uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
         return;
       }
 
@@ -46,6 +48,7 @@ export const tabsSlice = createSlice({
         const existingTab = tabTypeAlreadyExists(state.tabs, collectionUid, type);
         if (existingTab) {
           state.activeTabUid = existingTab.uid;
+          state.activeTabHistory = [existingTab.uid, ...state.activeTabHistory.filter((id) => id !== existingTab.uid)];
           return;
         }
       }
@@ -80,6 +83,7 @@ export const tabsSlice = createSlice({
         };
 
         state.activeTabUid = uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
         return;
       }
 
@@ -108,12 +112,14 @@ export const tabsSlice = createSlice({
         ...(isTransient ? { isTransient: true } : {})
       });
       state.activeTabUid = uid;
+      state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
     },
     focusTab: (state, action) => {
       const { uid } = action.payload;
       const tabExists = state.tabs.some((t) => t.uid === uid);
       if (tabExists) {
         state.activeTabUid = uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
       }
     },
     switchTab: (state, action) => {
@@ -287,6 +293,7 @@ export const tabsSlice = createSlice({
       state.tabs = filter(state.tabs, (t) =>
         !tabUids.includes(t.uid) || nonClosableTypes.includes(t.type)
       );
+      state.activeTabHistory = filter(state.activeTabHistory, (id) => !tabUids.includes(id));
 
       if (activeTab && state.tabs.length) {
         const { collectionUid } = activeTab;
@@ -315,7 +322,11 @@ export const tabsSlice = createSlice({
     closeAllCollectionTabs: (state, action) => {
       const { collectionUid } = action.payload;
       const prevActiveTabUid = state.activeTabUid;
+      const tabsToClose = filter(state.tabs, (t) => t.collectionUid === collectionUid);
+      const tabUidsToClose = tabsToClose.map((t) => t.uid);
+
       state.tabs = filter(state.tabs, (t) => t.collectionUid !== collectionUid);
+      state.activeTabHistory = filter(state.activeTabHistory, (id) => !tabUidsToClose.includes(id));
 
       const activeTabStillExists = state.tabs.some((t) => t.uid === prevActiveTabUid);
       if (!activeTabStillExists) {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
@@ -1,0 +1,61 @@
+import { configureStore } from '@reduxjs/toolkit';
+import tabsReducer, { addTab, focusTab, closeTabs, closeAllCollectionTabs } from './tabs';
+
+describe('tabs reducer with store', () => {
+  let store;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: {
+        tabs: tabsReducer
+      }
+    });
+  });
+
+  it('should update activeTabHistory when adding a tab', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1']);
+
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab2', 'tab1']);
+  });
+
+  it('should move tab to front of history when focusing an existing tab', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab3', 'tab2', 'tab1']);
+
+    store.dispatch(focusTab({ uid: 'tab1' }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1', 'tab3', 'tab2']);
+  });
+
+  it('should remove tab from history when closed', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(closeTabs({ tabUids: ['tab2'] }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab3', 'tab1']);
+    expect(store.getState().tabs.tabs.map((t) => t.uid)).toEqual(['tab1', 'tab3']);
+  });
+
+  it('should remove all collection tabs from history when collection is closed', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c2', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(closeAllCollectionTabs({ collectionUid: 'c1' }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab2']);
+    expect(store.getState().tabs.tabs.map((t) => t.uid)).toEqual(['tab2']);
+  });
+
+  it('should handle adding a tab that already exists by moving it to front of history', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1', 'tab2']);
+  });
+});


### PR DESCRIPTION
This PR implements the requested features in issue #737:

Key changes:
- Added a visual 'unsaved-indicator' (orange dot) in the sidebar for requests with pending changes.
- Added a 'Save All' command to the collection context menu, with keyboard shortcut display (Ctrl+Shift+S / Cmd+Shift+S).
- Implemented  logic in the Collection component to save all drafts within that collection.

Reference: Fixes #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual unsaved indicator for modified requests in the sidebar
  * "Save All" action in collection menu to batch-save unsaved collection changes with success/failure notifications
  * New keyboard shortcuts for tab navigation: Switch to recently used tab (Cmd/Ctrl+Tab) and alternate previous/next tab keys

* **Tests**
  * Added tests for tab state management and active-tab history tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->