### PR TITLE
feat: allow specifying default request tab in preferences (#332)

### DIFF
--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -60,6 +60,7 @@ const General = () => {
     oauth2: Yup.object({
       useSystemBrowser: Yup.boolean()
     }),
+    defaultRequestPaneTab: Yup.string().oneOf(['params', 'body', 'headers', 'auth', 'vars', 'script', 'tests', 'docs']),
     defaultLocation: Yup.string().max(1024)
   });
 
@@ -74,6 +75,7 @@ const General = () => {
         enabled: get(preferences, 'request.keepDefaultCaCertificates.enabled', true)
       },
       timeout: preferences.request.timeout,
+      defaultRequestPaneTab: get(preferences, 'request.defaultRequestPaneTab', 'params'),
       storeCookies: get(preferences, 'request.storeCookies', true),
       sendCookies: get(preferences, 'request.sendCookies', true),
       autoSave: {
@@ -110,6 +112,7 @@ const General = () => {
             enabled: newPreferences.keepDefaultCaCertificates.enabled
           },
           timeout: newPreferences.timeout,
+          defaultRequestPaneTab: newPreferences.defaultRequestPaneTab,
           storeCookies: newPreferences.storeCookies,
           sendCookies: newPreferences.sendCookies,
           oauth2: {
@@ -321,6 +324,26 @@ const General = () => {
         {formik.touched.timeout && formik.errors.timeout ? (
           <div className="text-red-500">{formik.errors.timeout}</div>
         ) : null}
+        <div className="flex flex-col mt-6">
+          <label className="block select-none" htmlFor="defaultRequestPaneTab">
+            Default Request Tab
+          </label>
+          <select
+            name="defaultRequestPaneTab"
+            className="block textbox mt-2 w-32"
+            onChange={formik.handleChange}
+            value={formik.values.defaultRequestPaneTab}
+          >
+            <option value="params">Params</option>
+            <option value="body">Body</option>
+            <option value="headers">Headers</option>
+            <option value="auth">Auth</option>
+            <option value="vars">Vars</option>
+            <option value="script">Script</option>
+            <option value="tests">Tests</option>
+            <option value="docs">Docs</option>
+          </select>
+        </div>
         <div className="flex items-center mt-6">
           <input
             id="autoSaveEnabled"

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -68,6 +68,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
   const isSidebarDragging = useSelector((state) => state.app.isDragging);
   const collection = useSelector((state) => state.collections.collections?.find((c) => c.uid === collectionUid));
+  const defaultRequestPaneTab = useSelector((state) => state.app.preferences.request.defaultRequestPaneTab || 'params');
   const { hasCopiedItems } = useSelector((state) => state.app.clipboard);
   const dispatch = useDispatch();
 
@@ -251,7 +252,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
         addTab({
           uid: item.uid,
           collectionUid: collectionUid,
-          requestPaneTab: getDefaultRequestPaneTab(item),
+          requestPaneTab: getDefaultRequestPaneTab(item, defaultRequestPaneTab),
           type: 'request'
         })
       );

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -74,6 +74,7 @@ const Collection = ({ collection, searchText }) => {
   const [showEmptyState, setShowEmptyState] = useState(false);
   const dispatch = useDispatch();
   const isLoading = collection.isLoading;
+  const defaultRequestPaneTab = useSelector((state) => state.app.preferences.request.defaultRequestPaneTab || 'params');
   const collectionRef = useRef(null);
   // Only count persisted items; transients don't affect empty state
   const itemCount = collection.items?.filter((i) => !i.isTransient).length || 0;
@@ -89,6 +90,7 @@ const Collection = ({ collection, searchText }) => {
       addTab({
         uid: uuid(),
         collectionUid: collection.uid,
+        defaultRequestPaneTab,
         type: 'openapi-sync'
       })
     );
@@ -99,6 +101,7 @@ const Collection = ({ collection, searchText }) => {
       addTab({
         uid: uuid(),
         collectionUid: collection.uid,
+        defaultRequestPaneTab,
         type: 'collection-runner'
       })
     );
@@ -145,6 +148,7 @@ const Collection = ({ collection, searchText }) => {
         addTab({
           uid: collection.uid,
           collectionUid: collection.uid,
+          defaultRequestPaneTab,
           type: 'collection-settings'
         })
       );
@@ -182,6 +186,7 @@ const Collection = ({ collection, searchText }) => {
       addTab({
         uid: collection.uid,
         collectionUid: collection.uid,
+        defaultRequestPaneTab,
         type: 'collection-settings'
       })
     );

--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -21,6 +21,7 @@ export const HotkeysProvider = (props) => {
   const tabs = useSelector((state) => state.tabs.tabs);
   const collections = useSelector((state) => state.collections.collections);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
+  const activeTabHistory = useSelector((state) => state.tabs.activeTabHistory);
   const userKeyBindings = useSelector((state) => state.app.preferences?.keyBindings);
   const keybindingsEnabled = useSelector((state) => state.app.preferences?.keybindingsEnabled !== false);
   const [showNewRequestModal, setShowNewRequestModal] = useState(false);
@@ -123,35 +124,62 @@ export const HotkeysProvider = (props) => {
 
   // Switch to the previous tab (active-collection-tabs-only)
   useEffect(() => {
-    bindAction('switchToPreviousTab', (e) => {
+    const handler = (e) => {
       const collectionTabs = getCollectionTabs();
       if (collectionTabs.length === 0) return false;
       const currentIndex = collectionTabs.findIndex((t) => t.uid === activeTabUid);
       const prevIndex = (currentIndex - 1 + collectionTabs.length) % collectionTabs.length;
       dispatch(focusTab({ uid: collectionTabs[prevIndex].uid }));
       return false;
-    });
+    };
+
+    bindAction('switchToPreviousTab', handler);
+    bindAction('switchToPreviousTabAlternate', handler);
 
     return () => {
       unbindAction('switchToPreviousTab');
+      unbindAction('switchToPreviousTabAlternate');
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to the next tab (active-collection-tabs-only)
   useEffect(() => {
-    bindAction('switchToNextTab', (e) => {
+    const handler = (e) => {
       const collectionTabs = getCollectionTabs();
       if (collectionTabs.length === 0) return false;
       const currentIndex = collectionTabs.findIndex((t) => t.uid === activeTabUid);
       const nextIndex = (currentIndex + 1) % collectionTabs.length;
       dispatch(focusTab({ uid: collectionTabs[nextIndex].uid }));
       return false;
-    });
+    };
+
+    bindAction('switchToNextTab', handler);
+    bindAction('switchToNextTabAlternate', handler);
 
     return () => {
       unbindAction('switchToNextTab');
+      unbindAction('switchToNextTabAlternate');
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
+
+  // Switch to recently used tab
+  useEffect(() => {
+    bindAction('switchToRecentlyUsedTab', (e) => {
+      if (activeTabHistory.length < 2) return false;
+
+      // The first element is the current tab, so we switch to the second one
+      const recentTabUid = activeTabHistory[0] === activeTabUid ? activeTabHistory[1] : activeTabHistory[0];
+
+      if (recentTabUid) {
+        dispatch(focusTab({ uid: recentTabUid }));
+      }
+      return false;
+    });
+
+    return () => {
+      unbindAction('switchToRecentlyUsedTab');
+    };
+  }, [activeTabUid, activeTabHistory, dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to tab at position (Cmd+1 through Cmd+8) and last tab (Cmd+9) — collection-scoped
   useEffect(() => {

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -11,6 +11,9 @@ export const KEY_BINDING_SECTIONS = [
       switchToLastTab: { mac: 'command+bind+9', windows: 'ctrl+bind+9', name: 'Switch to Last Tab' }, // D
       switchToPreviousTab: { mac: 'shift+bind+command+bind+[', windows: 'shift+bind+ctrl+bind+[', name: 'Switch to Previous Tab' }, // D
       switchToNextTab: { mac: 'shift+bind+command+bind+]', windows: 'shift+bind+ctrl+bind+]', name: 'Switch to Next Tab' },
+      switchToPreviousTabAlternate: { mac: 'command+bind+pageup', windows: 'ctrl+bind+pageup', name: 'Switch to Previous Tab (Alt)', hidden: true },
+      switchToNextTabAlternate: { mac: 'command+bind+pagedown', windows: 'ctrl+bind+pagedown', name: 'Switch to Next Tab (Alt)', hidden: true },
+      switchToRecentlyUsedTab: { mac: 'command+bind+tab', windows: 'ctrl+bind+tab', name: 'Switch to Recently Used Tab' },
       moveTabLeft: { mac: 'command+bind+[', windows: 'ctrl+bind+[', name: 'Move Tab Left' }, // D
       moveTabRight: { mac: 'command+bind+]', windows: 'ctrl+bind+]', name: 'Move Tab Right' }, // D
       switchToTab1: { mac: 'command+bind+1', windows: 'ctrl+bind+1', name: 'Switch to Tab at Position', readOnly: true, hidden: true },

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -28,6 +28,7 @@ const initialState = {
         enabled: true
       },
       timeout: 0,
+      defaultRequestPaneTab: 'params',
       oauth2: {
         useSystemBrowser: false
       }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -10,6 +10,7 @@ const MAX_RECENTLY_CLOSED_TABS = 50;
 const initialState = {
   tabs: [],
   activeTabUid: null,
+  activeTabHistory: [], // stack of active tab UIDs (MRU)
   recentlyClosedTabs: [] // LIFO stack of closed tabs, grouped by collection
 };
 
@@ -39,6 +40,7 @@ export const tabsSlice = createSlice({
       const existingTab = find(state.tabs, (tab) => tab.uid === uid);
       if (existingTab) {
         state.activeTabUid = existingTab.uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
         return;
       }
 
@@ -46,6 +48,7 @@ export const tabsSlice = createSlice({
         const existingTab = tabTypeAlreadyExists(state.tabs, collectionUid, type);
         if (existingTab) {
           state.activeTabUid = existingTab.uid;
+          state.activeTabHistory = [existingTab.uid, ...state.activeTabHistory.filter((id) => id !== existingTab.uid)];
           return;
         }
       }
@@ -80,6 +83,7 @@ export const tabsSlice = createSlice({
         };
 
         state.activeTabUid = uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
         return;
       }
 
@@ -108,12 +112,14 @@ export const tabsSlice = createSlice({
         ...(isTransient ? { isTransient: true } : {})
       });
       state.activeTabUid = uid;
+      state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
     },
     focusTab: (state, action) => {
       const { uid } = action.payload;
       const tabExists = state.tabs.some((t) => t.uid === uid);
       if (tabExists) {
         state.activeTabUid = uid;
+        state.activeTabHistory = [uid, ...state.activeTabHistory.filter((id) => id !== uid)];
       }
     },
     switchTab: (state, action) => {
@@ -287,6 +293,7 @@ export const tabsSlice = createSlice({
       state.tabs = filter(state.tabs, (t) =>
         !tabUids.includes(t.uid) || nonClosableTypes.includes(t.type)
       );
+      state.activeTabHistory = filter(state.activeTabHistory, (id) => !tabUids.includes(id));
 
       if (activeTab && state.tabs.length) {
         const { collectionUid } = activeTab;
@@ -315,7 +322,11 @@ export const tabsSlice = createSlice({
     closeAllCollectionTabs: (state, action) => {
       const { collectionUid } = action.payload;
       const prevActiveTabUid = state.activeTabUid;
+      const tabsToClose = filter(state.tabs, (t) => t.collectionUid === collectionUid);
+      const tabUidsToClose = tabsToClose.map((t) => t.uid);
+
       state.tabs = filter(state.tabs, (t) => t.collectionUid !== collectionUid);
+      state.activeTabHistory = filter(state.activeTabHistory, (id) => !tabUidsToClose.includes(id));
 
       const activeTabStillExists = state.tabs.some((t) => t.uid === prevActiveTabUid);
       if (!activeTabStillExists) {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -23,7 +23,7 @@ export const tabsSlice = createSlice({
   initialState,
   reducers: {
     addTab: (state, action) => {
-      const { uid, collectionUid, type, requestPaneTab, preview, exampleUid, itemUid, isTransient } = action.payload;
+      const { uid, collectionUid, type, requestPaneTab, preview, exampleUid, itemUid, isTransient, defaultRequestPaneTab: preferredDefaultTab } = action.payload;
 
       const nonReplaceableTabTypes = [
         'variables',
@@ -54,11 +54,11 @@ export const tabsSlice = createSlice({
       }
 
       // Determine the default requestPaneTab based on request type
-      let defaultRequestPaneTab = 'params';
+      let defaultPaneTab = requestPaneTab || preferredDefaultTab || 'params';
       if (type === 'grpc-request' || type === 'ws-request') {
-        defaultRequestPaneTab = 'body';
+        defaultPaneTab = 'body';
       } else if (type === 'graphql-request') {
-        defaultRequestPaneTab = 'query';
+        defaultPaneTab = 'query';
       }
 
       const lastTab = state.tabs[state.tabs.length - 1];
@@ -67,7 +67,7 @@ export const tabsSlice = createSlice({
           uid,
           collectionUid,
           requestPaneWidth: null,
-          requestPaneTab: requestPaneTab || defaultRequestPaneTab,
+          requestPaneTab: defaultPaneTab,
           responsePaneTab: 'response',
           responseFormat: null,
           responseViewTab: null,
@@ -91,7 +91,7 @@ export const tabsSlice = createSlice({
         uid,
         collectionUid,
         requestPaneWidth: null,
-        requestPaneTab: requestPaneTab || defaultRequestPaneTab,
+        requestPaneTab: defaultPaneTab,
         responsePaneTab: 'response',
         responsePaneScrollPosition: null,
         responseFormat: null,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
@@ -1,0 +1,61 @@
+import { configureStore } from '@reduxjs/toolkit';
+import tabsReducer, { addTab, focusTab, closeTabs, closeAllCollectionTabs } from './tabs';
+
+describe('tabs reducer with store', () => {
+  let store;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: {
+        tabs: tabsReducer
+      }
+    });
+  });
+
+  it('should update activeTabHistory when adding a tab', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1']);
+
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab2', 'tab1']);
+  });
+
+  it('should move tab to front of history when focusing an existing tab', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab3', 'tab2', 'tab1']);
+
+    store.dispatch(focusTab({ uid: 'tab1' }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1', 'tab3', 'tab2']);
+  });
+
+  it('should remove tab from history when closed', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(closeTabs({ tabUids: ['tab2'] }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab3', 'tab1']);
+    expect(store.getState().tabs.tabs.map((t) => t.uid)).toEqual(['tab1', 'tab3']);
+  });
+
+  it('should remove all collection tabs from history when collection is closed', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c2', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab3', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(closeAllCollectionTabs({ collectionUid: 'c1' }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab2']);
+    expect(store.getState().tabs.tabs.map((t) => t.uid)).toEqual(['tab2']);
+  });
+
+  it('should handle adding a tab that already exists by moving it to front of history', () => {
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    store.dispatch(addTab({ uid: 'tab2', collectionUid: 'c1', type: 'request', preview: false }));
+
+    store.dispatch(addTab({ uid: 'tab1', collectionUid: 'c1', type: 'request', preview: false }));
+    expect(store.getState().tabs.activeTabHistory).toEqual(['tab1', 'tab2']);
+  });
+});

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1112,7 +1112,7 @@ export const hasExampleChanges = (_item, exampleUid) => {
   return !isEqual(originalExample, draftExample);
 };
 
-export const getDefaultRequestPaneTab = (item) => {
+export const getDefaultRequestPaneTab = (item, preferredDefaultTab = 'params') => {
   if (item.type === 'http-request') {
     // If no params are enabled and body mode is set, default to 'body' tab
     // This provides better UX for POST/PUT requests with a body
@@ -1124,7 +1124,7 @@ export const getDefaultRequestPaneTab = (item) => {
     if (!hasEnabledParams && bodyMode && bodyMode !== 'none') {
       return 'body';
     }
-    return 'params';
+    return preferredDefaultTab;
   }
 
   if (item.type === 'graphql-request') {


### PR DESCRIPTION
This PR implements the ability to choose which tab (Params, Body, Headers, etc.) is opened by default when a request is clicked in the sidebar.

Key changes:
- Added  to General Preferences.
- Added a selector in the Preferences UI (General tab).
- Updated the [3gH        H        H        H        H        H        H        H        H        H        H        H        H        H        H        H        H        H        H        H        H        H slice and  utility to respect the user's preference.
- Updated sidebar components ( and ) to pass the preference when adding a new tab.

Reference: Fixes #332