### PR TITLE
fix(converters): Make OpenAPI→Bruno conversion use correct default parameter serialization methods

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -88,11 +88,10 @@ const getParameterEntries = (param) => {
   }
 
   // For non-enum cases, return single entry with comprehensive value extraction
-  // Merges HEAD's detailed handling with MERGE_HEAD's broader example sources
   let value = '';
   let enabled = param.required || false;
 
-  // Priority 1: Top-level param examples (from upstream, mutually exclusive per spec)
+  // Priority 1: Top-level param examples (mutually exclusive per spec)
   if (param.example !== undefined) {
     value = String(param.example);
     enabled = true;
@@ -104,7 +103,7 @@ const getParameterEntries = (param) => {
     }
   }
 
-  // Priority 2: schema.default (from HEAD, handles array defaults with JSON.stringify)
+  // Priority 2: schema.default (handles array defaults with JSON.stringify)
   if (value === '' && schema.default !== undefined) {
     if (schema.type === 'array' && Array.isArray(schema.default)) {
       value = JSON.stringify(schema.default);
@@ -114,13 +113,13 @@ const getParameterEntries = (param) => {
     enabled = true;
   }
 
-  // Priority 3: schema.example (from upstream)
+  // Priority 3: schema.example
   if (value === '' && schema.example !== undefined) {
     value = String(schema.example);
     enabled = true;
   }
 
-  // Priority 4: Array type handling (merged from both sides)
+  // Priority 4: Array type handling
   if (value === '' && schema.type === 'array' && schema.items) {
     if (schema.items.example !== undefined) {
       value = String(schema.items.example);
@@ -134,19 +133,19 @@ const getParameterEntries = (param) => {
     enabled = param.required || false;
   }
 
-  // Priority 5: schema.examples (OAS 3.1+, from upstream)
+  // Priority 5: schema.examples (OAS 3.1+)
   if (value === '' && Array.isArray(schema.examples) && schema.examples.length > 0) {
     value = String(schema.examples[0]);
     enabled = true;
   }
 
-  // Priority 6: schema.minimum fallback for numeric types (from upstream)
+  // Priority 6: schema.minimum fallback for numeric types
   if (value === '' && schema.minimum !== undefined) {
     value = String(schema.minimum);
     enabled = param.required || false;
   }
 
-  // Priority 7: Edge cases (from HEAD)
+  // Priority 7: Edge cases
   if (value === '') {
     if (schema.nullable === true && !param.required) {
       enabled = false;

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -28,6 +28,17 @@ const getSchemaPropertyExampleValue = (prop, propName, parentExample = {}) => {
   return '';
 };
 
+// Converts an example or default value into Bruno parameter entries.
+// Respects OAS default serialization: query/cookie default to explode:true (one entry per item),
+// path/header default to explode:false (comma-joined single entry).
+const paramEntriesFromValue = (val, paramIn) => {
+  const explodeByDefault = paramIn === 'query' || paramIn === 'cookie';
+  if (Array.isArray(val) && explodeByDefault) {
+    return val.map((item) => ({ value: String(item), enabled: true }));
+  }
+  return [{ value: String(val), enabled: true }];
+};
+
 /**
  * Extracts parameter entries based on OpenAPI parameter schema
  * For enum parameters, creates multiple entries (one per enum value)
@@ -65,11 +76,7 @@ const getParameterEntries = (param) => {
 
     // If there's a default at array level, use it
     if (arrayDefault) {
-      entries.push({
-        value: JSON.stringify(arrayDefault),
-        enabled: true
-      });
-      return entries;
+      return paramEntriesFromValue(arrayDefault, param.in);
     }
 
     // Otherwise, create entries for each enum value in items
@@ -87,40 +94,36 @@ const getParameterEntries = (param) => {
     return entries;
   }
 
-  // For non-enum cases, return single entry with comprehensive value extraction
-  let value = '';
-  let enabled = param.required || false;
-
   // Priority 1: Top-level param examples (mutually exclusive per spec)
   if (param.example !== undefined) {
-    value = String(param.example);
-    enabled = true;
-  } else if (param.examples) {
+    return paramEntriesFromValue(param.example, param.in);
+  }
+
+  if (param.examples) {
     const firstExample = Object.values(param.examples)[0];
     if (firstExample?.value !== undefined) {
-      value = String(firstExample.value);
-      enabled = true;
+      return paramEntriesFromValue(firstExample.value, param.in);
     }
   }
 
-  // Priority 2: schema.default (handles array defaults with JSON.stringify)
-  if (value === '' && schema.default !== undefined) {
-    if (schema.type === 'array' && Array.isArray(schema.default)) {
-      value = JSON.stringify(schema.default);
-    } else {
-      value = String(schema.default);
-    }
-    enabled = true;
+  // Priority 2: schema.default
+  if (schema.default !== undefined) {
+    return paramEntriesFromValue(schema.default, param.in);
   }
 
   // Priority 3: schema.example
-  if (value === '' && schema.example !== undefined) {
-    value = String(schema.example);
-    enabled = true;
+  if (schema.example !== undefined) {
+    return paramEntriesFromValue(schema.example, param.in);
   }
 
-  // Priority 4: Array type handling
-  if (value === '' && schema.type === 'array' && schema.items) {
+  // Priority 4: schema.examples (OAS 3.1+)
+  if (Array.isArray(schema.examples) && schema.examples.length > 0) {
+    return paramEntriesFromValue(schema.examples[0], param.in);
+  }
+
+  // Priority 5: Array type handling (items-based fallback)
+  if (schema.type === 'array' && schema.items) {
+    let value;
     if (schema.items.example !== undefined) {
       value = String(schema.items.example);
     } else if (schema.items.enum && schema.items.enum.length > 0) {
@@ -128,33 +131,30 @@ const getParameterEntries = (param) => {
     } else if (schema.items.default !== undefined) {
       value = String(schema.items.default);
     } else {
-      value = '[]';
+      value = '';
     }
-    enabled = param.required || false;
-  }
-
-  // Priority 5: schema.examples (OAS 3.1+)
-  if (value === '' && Array.isArray(schema.examples) && schema.examples.length > 0) {
-    value = String(schema.examples[0]);
-    enabled = true;
+    return [{ value, enabled: param.required || false }];
   }
 
   // Priority 6: schema.minimum fallback for numeric types
-  if (value === '' && schema.minimum !== undefined) {
-    value = String(schema.minimum);
-    enabled = param.required || false;
+  if (schema.minimum !== undefined) {
+    return [
+      {
+        value: String(schema.minimum),
+        enabled: param.required || false
+      }
+    ];
   }
 
   // Priority 7: Edge cases
-  if (value === '') {
-    if (schema.nullable === true && !param.required) {
-      enabled = false;
-    } else if (param.allowEmptyValue === true && !param.required) {
-      enabled = false;
-    }
+  let enabled = param.required || false;
+  if (schema.nullable === true && !param.required) {
+    enabled = false;
+  } else if (param.allowEmptyValue === true && !param.required) {
+    enabled = false;
   }
 
-  return [{ value, enabled }];
+  return [{ value: '', enabled }];
 };
 
 const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {}) => {

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-path-parameters.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-path-parameters.spec.js
@@ -609,6 +609,514 @@ paths:
   });
 });
 
+describe('array param serialization — OAS defaults per location', () => {
+  describe('path — simple style, explode:false (comma-join)', () => {
+    it('param.example array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/users/{ids}': {
+            get: {
+              summary: 'Get users',
+              operationId: 'getUsers',
+              parameters: [
+                {
+                  name: 'ids',
+                  in: 'path',
+                  required: true,
+                  example: [3, 4, 5],
+                  schema: { type: 'array', items: { type: 'integer' } }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const idsParams = result.items.find((i) => i.name === 'Get users').request.params.filter((p) => p.name === 'ids');
+      expect(idsParams).toHaveLength(1);
+      expect(idsParams[0].value).toBe('3,4,5');
+      expect(idsParams[0].enabled).toBe(true);
+    });
+
+    it('param.examples[0].value array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/users/{ids}': {
+            get: {
+              summary: 'Get users',
+              operationId: 'getUsers',
+              parameters: [
+                {
+                  name: 'ids',
+                  in: 'path',
+                  required: true,
+                  examples: { sample: { value: [10, 20, 30] } },
+                  schema: { type: 'array', items: { type: 'integer' } }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const idsParams = result.items.find((i) => i.name === 'Get users').request.params.filter((p) => p.name === 'ids');
+      expect(idsParams).toHaveLength(1);
+      expect(idsParams[0].value).toBe('10,20,30');
+      expect(idsParams[0].enabled).toBe(true);
+    });
+
+    it('schema.default array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/users/{roles}': {
+            get: {
+              summary: 'Get by roles',
+              operationId: 'getByRoles',
+              parameters: [
+                {
+                  name: 'roles',
+                  in: 'path',
+                  required: true,
+                  schema: { type: 'array', items: { type: 'string' }, default: ['admin', 'user'] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const rolesParam = result.items.find((i) => i.name === 'Get by roles').request.params.find((p) => p.name === 'roles');
+      expect(rolesParam.value).toBe('admin,user');
+      expect(rolesParam.enabled).toBe(true);
+    });
+
+    it('items.enum default array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items/{types}': {
+            get: {
+              summary: 'Get by types',
+              operationId: 'getByTypes',
+              parameters: [
+                {
+                  name: 'types',
+                  in: 'path',
+                  required: true,
+                  schema: { type: 'array', items: { type: 'string', enum: ['a', 'b', 'c'] }, default: ['a', 'b'] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const typesParam = result.items.find((i) => i.name === 'Get by types').request.params.find((p) => p.name === 'types');
+      expect(typesParam.value).toBe('a,b');
+      expect(typesParam.enabled).toBe(true);
+    });
+
+    it('schema.example array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/users/{ids}': {
+            get: {
+              summary: 'Get users',
+              operationId: 'getUsers',
+              parameters: [
+                {
+                  name: 'ids',
+                  in: 'path',
+                  required: true,
+                  schema: { type: 'array', items: { type: 'integer' }, example: [7, 8, 9] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const params = result.items.find((i) => i.name === 'Get users').request.params.filter((p) => p.name === 'ids');
+      expect(params).toHaveLength(1);
+      expect(params[0].value).toBe('7,8,9');
+      expect(params[0].enabled).toBe(true);
+    });
+
+    it('schema.examples[0] array', () => {
+      const spec = {
+        openapi: '3.1.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/users/{ids}': {
+            get: {
+              summary: 'Get users',
+              operationId: 'getUsers',
+              parameters: [
+                {
+                  name: 'ids',
+                  in: 'path',
+                  required: true,
+                  schema: { type: 'array', items: { type: 'integer' }, examples: [[1, 2, 3]] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const params = result.items.find((i) => i.name === 'Get users').request.params.filter((p) => p.name === 'ids');
+      expect(params).toHaveLength(1);
+      expect(params[0].value).toBe('1,2,3');
+      expect(params[0].enabled).toBe(true);
+    });
+  });
+
+  describe('header — simple style, explode:false (comma-join)', () => {
+    it('param.example array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'X-Ids',
+                  in: 'header',
+                  example: [1, 2, 3],
+                  schema: { type: 'array', items: { type: 'integer' } }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const header = result.items.find((i) => i.name === 'List items').request.headers.find((h) => h.name === 'X-Ids');
+      expect(header.value).toBe('1,2,3');
+      expect(header.enabled).toBe(true);
+    });
+
+    it('param.examples[0].value array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'X-Ids',
+                  in: 'header',
+                  examples: { sample: { value: ['a', 'b', 'c'] } },
+                  schema: { type: 'array', items: { type: 'string' } }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const header = result.items.find((i) => i.name === 'List items').request.headers.find((h) => h.name === 'X-Ids');
+      expect(header.value).toBe('a,b,c');
+      expect(header.enabled).toBe(true);
+    });
+
+    it('schema.default array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'X-Roles',
+                  in: 'header',
+                  schema: { type: 'array', items: { type: 'string' }, default: ['read', 'write'] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const header = result.items.find((i) => i.name === 'List items').request.headers.find((h) => h.name === 'X-Roles');
+      expect(header.value).toBe('read,write');
+      expect(header.enabled).toBe(true);
+    });
+
+    it('schema.example array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'X-Ids',
+                  in: 'header',
+                  schema: { type: 'array', items: { type: 'integer' }, example: [4, 5, 6] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const header = result.items.find((i) => i.name === 'List items').request.headers.find((h) => h.name === 'X-Ids');
+      expect(header.value).toBe('4,5,6');
+      expect(header.enabled).toBe(true);
+    });
+
+    it('schema.examples[0] array', () => {
+      const spec = {
+        openapi: '3.1.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'X-Tags',
+                  in: 'header',
+                  schema: { type: 'array', items: { type: 'string' }, examples: [['x', 'y', 'z']] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const header = result.items.find((i) => i.name === 'List items').request.headers.find((h) => h.name === 'X-Tags');
+      expect(header.value).toBe('x,y,z');
+      expect(header.enabled).toBe(true);
+    });
+  });
+
+  describe('query — form style, explode:true (one entry per item)', () => {
+    it('param.example array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'ids',
+                  in: 'query',
+                  example: [3, 4, 5],
+                  schema: { type: 'array', items: { type: 'integer' } }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const params = result.items.find((i) => i.name === 'List items').request.params.filter((p) => p.name === 'ids');
+      expect(params).toHaveLength(3);
+      expect(params.map((p) => p.value)).toEqual(['3', '4', '5']);
+      params.forEach((p) => expect(p.enabled).toBe(true));
+    });
+
+    it('param.examples[0].value array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'tags',
+                  in: 'query',
+                  examples: { sample: { value: ['foo', 'bar', 'baz'] } },
+                  schema: { type: 'array', items: { type: 'string' } }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const params = result.items.find((i) => i.name === 'List items').request.params.filter((p) => p.name === 'tags');
+      expect(params).toHaveLength(3);
+      expect(params.map((p) => p.value)).toEqual(['foo', 'bar', 'baz']);
+      params.forEach((p) => expect(p.enabled).toBe(true));
+    });
+
+    it('schema.default array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'status',
+                  in: 'query',
+                  schema: { type: 'array', items: { type: 'string' }, default: ['active', 'pending'] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const params = result.items.find((i) => i.name === 'List items').request.params.filter((p) => p.name === 'status');
+      expect(params).toHaveLength(2);
+      expect(params.map((p) => p.value)).toEqual(['active', 'pending']);
+      params.forEach((p) => expect(p.enabled).toBe(true));
+    });
+
+    it('schema.example array', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'colors',
+                  in: 'query',
+                  schema: { type: 'array', items: { type: 'string' }, example: ['red', 'green', 'blue'] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const params = result.items.find((i) => i.name === 'List items').request.params.filter((p) => p.name === 'colors');
+      expect(params).toHaveLength(3);
+      expect(params.map((p) => p.value)).toEqual(['red', 'green', 'blue']);
+      params.forEach((p) => expect(p.enabled).toBe(true));
+    });
+
+    it('schema.examples[0] array', () => {
+      const spec = {
+        openapi: '3.1.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'tags',
+                  in: 'query',
+                  schema: { type: 'array', items: { type: 'string' }, examples: [['foo', 'bar', 'baz']] }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const params = result.items.find((i) => i.name === 'List items').request.params.filter((p) => p.name === 'tags');
+      expect(params).toHaveLength(3);
+      expect(params.map((p) => p.value)).toEqual(['foo', 'bar', 'baz']);
+      params.forEach((p) => expect(p.enabled).toBe(true));
+    });
+  });
+
+  describe('cookie — not mapped (Bruno has no cookie param type)', () => {
+    it('cookie params are not added to request.params or request.headers', () => {
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'API', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+        paths: {
+          '/items': {
+            get: {
+              summary: 'List items',
+              operationId: 'listItems',
+              parameters: [
+                {
+                  name: 'session',
+                  in: 'cookie',
+                  example: ['x', 'y'],
+                  schema: { type: 'array', items: { type: 'string' } }
+                }
+              ],
+              responses: { 200: { description: 'OK' } }
+            }
+          }
+        }
+      };
+      const result = openApiToBruno(spec);
+      const req = result.items.find((i) => i.name === 'List items').request;
+      expect(req.params.filter((p) => p.name === 'session')).toHaveLength(0);
+      expect(req.headers.filter((h) => h.name === 'session')).toHaveLength(0);
+    });
+  });
+});
+
 // Tests backward-compat handling of non-standard in: 'querystring' (some importers emit this instead of 'query')
 describe('openapi querystring parameter location', () => {
   it('should map in: "querystring" to query type', () => {


### PR DESCRIPTION
### Description

The OpenAPI specification v3 states certain methods for how parameter values should be serialized. As of now Bruno aims to support only primitive and array values, while ignoring `style` and `explode` instructions. Therefore I was looking at the standard serialization method for each type of parameter in [their documentation on parameter serialization](https://swagger.io/docs/specification/v3_0/serialization/).

The aim of this PR is to fix the default serialization methods for several scenarios/parameter types, as seen below:

<table>
  <thead>
    <tr>
      <th>Location</th>
      <th>OAS default</th>
      <th>Value source</th>
      <th>Expected</th>
      <th>Actual</th>
      <th></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td rowspan="6"><strong>path</strong></td>
      <td rowspan="6">style: simple<br>explode: false<br>→ comma-join</td>
      <td><code>param.example: [3,4,5]</code></td>
      <td><code>"3,4,5"</code></td>
      <td><code>"3,4,5"</code></td>
      <td>✅</td>
    </tr>
    <tr>
      <td><code>param.examples[0].value: [10,20,30]</code></td>
      <td><code>"10,20,30"</code></td>
      <td><code>"10,20,30"</code></td>
      <td>✅</td>
    </tr>
    <tr>
      <td><code>schema.default: ["admin","user"]</code></td>
      <td><code>"admin,user"</code></td>
      <td><code>'["admin","user"]'</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td><code>schema.example: [7,8,9]</code></td>
      <td><code>"7,8,9"</code></td>
      <td><code>"7,8,9"</code></td>
      <td>✅</td>
    </tr>
    <tr>
      <td><code>schema.examples: [[1,2,3]]</code></td>
      <td><code>"1,2,3"</code></td>
      <td><code>"[]"</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td><code>items.enum</code> + <code>schema.default: ["a","b"]</code></td>
      <td><code>"a,b"</code></td>
      <td><code>'["a","b"]'</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td rowspan="5"><strong>header</strong></td>
      <td rowspan="5">style: simple<br>explode: false<br>→ comma-join</td>
      <td><code>param.example: [1,2,3]</code></td>
      <td><code>"1,2,3"</code></td>
      <td><code>"1,2,3"</code></td>
      <td>✅</td>
    </tr>
    <tr>
      <td><code>param.examples[0].value: ["a","b","c"]</code></td>
      <td><code>"a,b,c"</code></td>
      <td><code>"a,b,c"</code></td>
      <td>✅</td>
    </tr>
    <tr>
      <td><code>schema.default: ["read","write"]</code></td>
      <td><code>"read,write"</code></td>
      <td><code>'["read","write"]'</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td><code>schema.example: [4,5,6]</code></td>
      <td><code>"4,5,6"</code></td>
      <td><code>"4,5,6"</code></td>
      <td>✅</td>
    </tr>
    <tr>
      <td><code>schema.examples: [["x","y","z"]]</code></td>
      <td><code>"x,y,z"</code></td>
      <td><code>"[]"</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td rowspan="5"><strong>query</strong></td>
      <td rowspan="5">style: form<br>explode: true<br>→ one entry per item</td>
      <td><code>param.example: [3,4,5]</code></td>
      <td>3 entries: <code>["3","4","5"]</code></td>
      <td>1 entry: <code>"3,4,5"</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td><code>param.examples[0].value: ["foo","bar","baz"]</code></td>
      <td>3 entries: <code>["foo","bar","baz"]</code></td>
      <td>1 entry: <code>"foo,bar,baz"</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td><code>schema.default: ["active","pending"]</code></td>
      <td>2 entries: <code>["active","pending"]</code></td>
      <td>1 entry: <code>'["active","pending"]'</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td><code>schema.example: ["red","green","blue"]</code></td>
      <td>3 entries: <code>["red","green","blue"]</code></td>
      <td>1 entry: <code>"red,green,blue"</code></td>
      <td>❌</td>
    </tr>
    <tr>
      <td><code>schema.examples: [["foo","bar","baz"]]</code></td>
      <td>3 entries: <code>["foo","bar","baz"]</code></td>
      <td>1 entry: <code>"[]"</code></td>
      <td>❌</td>
    </tr>
  </tbody>
</table>

This can be validated by running the updated tests of this branch on the current `main` branch:

```bash
git checkout main
git checkout fix/openapi-parameters-default-serialization-methods -- packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-path-parameters.spec.js
npm run test --workspace=packages/bruno-converters
```



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array parameter serialization in OpenAPI conversions to properly handle different parameter locations (query, path, header)
  * Improved example and default value processing for enhanced conversion accuracy
  * Enhanced parameter entry generation for better compatibility with OpenAPI specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->