### PR TITLE
fix: surface ZIP import symlink errors

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -91,6 +91,7 @@ import { updateSettingsSelectedTab } from './index';
 import { saveGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import { getTabToFocusForCurrentWorkspace } from 'providers/ReduxStore/slices/workspaces/getTabToFocusForCurrentWorkspace';
 import { clearPersistedScope } from 'hooks/usePersistedState/PersistedScopeProvider';
+import { formatIpcError } from 'utils/common/error';
 
 // generate a unique names
 const generateUniqueName = (originalName, existingItems, isFolder) => {
@@ -2767,20 +2768,25 @@ export const importCollection = (collection, collectionLocation, options = {}) =
 
 export const importCollectionFromZip = (zipFilePath, collectionLocation) => async (dispatch, getState) => {
   const { ipcRenderer } = window;
-  const state = getState();
-  const activeWorkspace = state.workspaces.workspaces.find((w) => w.uid === state.workspaces.activeWorkspaceUid);
+  try {
+    const state = getState();
+    const activeWorkspace = state.workspaces.workspaces.find((w) => w.uid === state.workspaces.activeWorkspaceUid);
 
-  const collectionPath = await ipcRenderer.invoke('renderer:import-collection-zip', zipFilePath, collectionLocation);
+    const collectionPath = await ipcRenderer.invoke('renderer:import-collection-zip', zipFilePath, collectionLocation);
 
-  if (activeWorkspace && activeWorkspace.pathname && activeWorkspace.type !== 'default') {
-    const collectionName = path.basename(collectionPath);
-    await ipcRenderer.invoke('renderer:add-collection-to-workspace', activeWorkspace.pathname, {
-      name: collectionName,
-      path: collectionPath
-    });
+    if (activeWorkspace && activeWorkspace.pathname && activeWorkspace.type !== 'default') {
+      const collectionName = path.basename(collectionPath);
+      await ipcRenderer.invoke('renderer:add-collection-to-workspace', activeWorkspace.pathname, {
+        name: collectionName,
+        path: collectionPath
+      });
+    }
+
+    return collectionPath;
+  } catch (error) {
+    toast.error(formatIpcError(error) || 'Failed to import collection');
+    throw error;
   }
-
-  return collectionPath;
 };
 
 /**

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.spec.js
@@ -1,0 +1,50 @@
+jest.mock('react-hot-toast', () => ({
+  error: jest.fn(),
+  success: jest.fn(),
+  custom: jest.fn()
+}));
+
+jest.mock('components/Errors/IpcErrorModal/index', () => () => null);
+
+const toast = require('react-hot-toast');
+const { importCollectionFromZip } = require('./actions');
+
+describe('importCollectionFromZip', () => {
+  beforeEach(() => {
+    window.ipcRenderer = {
+      invoke: jest.fn()
+    };
+  });
+
+  afterEach(() => {
+    delete window.ipcRenderer;
+    jest.clearAllMocks();
+  });
+
+  it('shows the formatted IPC error when ZIP import fails', async () => {
+    const error = new Error(
+      'Error invoking remote method \'renderer:import-collection-zip\': Error: Security error: Symlink "boilerplate.js" points outside extraction directory'
+    );
+
+    window.ipcRenderer.invoke.mockRejectedValue(error);
+
+    const thunk = importCollectionFromZip('/tmp/collection.zip', '/tmp/imports');
+    const getState = () => ({
+      workspaces: {
+        workspaces: [{ uid: 'default-workspace', type: 'default', pathname: '/tmp/workspace' }],
+        activeWorkspaceUid: 'default-workspace'
+      }
+    });
+
+    await expect(thunk(jest.fn(), getState)).rejects.toThrow(error);
+
+    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
+      'renderer:import-collection-zip',
+      '/tmp/collection.zip',
+      '/tmp/imports'
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      'Security error: Symlink "boilerplate.js" points outside extraction directory'
+    );
+  });
+});


### PR DESCRIPTION
### Description

Closes #7741

This surfaces ZIP import failures instead of leaving the import flow silent when Electron rejects the IPC call.

Before this change, a ZIP import that failed symlink validation only produced an unhandled promise in devtools.
After this change, `importCollectionFromZip` formats the IPC error and shows it as a toast before rethrowing, and the regression test covers the symlink-validation failure path.

#### Validation

- `npm test --workspace=packages/bruno-app -- --runTestsByPath src/providers/ReduxStore/slices/collections/actions.spec.js`
- `npx eslint packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.spec.js`

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during collection imports with informative error messages when import operations fail.

* **Tests**
  * Added test coverage for collection import failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->