### PR TITLE
fix: include overview docs in html documentation export (#7774)

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -15,6 +15,7 @@ import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsL
 import { brunoToOpenCollection } from '@usebruno/converters';
 import { sanitizeName } from 'utils/common/regex';
 import { escapeHtml } from 'utils/response';
+import { resolveCollectionForHtmlDocumentation } from 'utils/exporters/html-documentation';
 
 const CDN_BASE_URL = 'https://cdn.opencollection.com';
 
@@ -76,7 +77,9 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
     try {
       const collectionCopy = cloneDeep(collection);
       const transformedCollection = transformCollectionToSaveToExportAsFile(collectionCopy);
-      const openCollection = brunoToOpenCollection(transformedCollection);
+      const openCollection = resolveCollectionForHtmlDocumentation(
+        brunoToOpenCollection(transformedCollection)
+      );
 
       openCollection.extensions = {
         ...openCollection.extensions,

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -522,12 +522,14 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
         }
       }
 
-      if (si.type == 'folder' && si?.root) {
+      const folderRoot = si?.draft || si?.root;
+
+      if (si.type == 'folder' && folderRoot) {
         di.root = {
           request: {}
         };
 
-        let { request, meta, docs } = si?.root || {};
+        let { request, meta, docs } = folderRoot;
         let { auth, headers, script = {}, vars = {}, tests } = request || {};
 
         // folder level auth
@@ -613,7 +615,8 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
     request: {}
   };
 
-  let { request, docs, meta } = collection?.root || {};
+  const collectionRoot = collection?.draft?.root || collection?.root || {};
+  let { request, docs, meta } = collectionRoot;
   let { auth, headers, script = {}, vars = {}, tests } = request || {};
 
   // collection level auth

--- a/packages/bruno-app/src/utils/exporters/html-documentation.js
+++ b/packages/bruno-app/src/utils/exporters/html-documentation.js
@@ -1,0 +1,60 @@
+const OVERVIEW_FOLDER_NAME = 'Overview';
+
+const getDocsContent = (docs) => {
+  if (!docs) {
+    return '';
+  }
+
+  if (typeof docs === 'string') {
+    return docs;
+  }
+
+  if (typeof docs === 'object' && typeof docs.content === 'string') {
+    return docs.content;
+  }
+
+  return '';
+};
+
+const hasTopLevelOverviewFolderWithDocs = (items = []) => {
+  return items.some((item) => {
+    if (item?.info?.type !== 'folder' || item?.info?.name !== OVERVIEW_FOLDER_NAME) {
+      return false;
+    }
+
+    return getDocsContent(item.docs).trim().length > 0;
+  });
+};
+
+export const resolveCollectionForHtmlDocumentation = (openCollection) => {
+  if (!openCollection || typeof openCollection !== 'object') {
+    return openCollection;
+  }
+
+  const docsContent = getDocsContent(openCollection.docs).trim();
+  if (!docsContent.length) {
+    return openCollection;
+  }
+
+  const items = Array.isArray(openCollection.items) ? openCollection.items : [];
+  if (hasTopLevelOverviewFolderWithDocs(items)) {
+    return openCollection;
+  }
+
+  const overviewItem = {
+    info: {
+      name: OVERVIEW_FOLDER_NAME,
+      type: 'folder'
+    },
+    docs: {
+      content: docsContent,
+      type: 'text/markdown'
+    }
+  };
+
+  return {
+    ...openCollection,
+    docs: undefined,
+    items: [overviewItem, ...items]
+  };
+};

--- a/packages/bruno-app/src/utils/tests/collections/examples-export-import.spec.js
+++ b/packages/bruno-app/src/utils/tests/collections/examples-export-import.spec.js
@@ -1,6 +1,7 @@
 import { transformCollectionToSaveToExportAsFile, transformRequestToSaveToFilesystem } from '../../collections/index';
 import { transformItemsInCollection } from '../../importers/common';
 import { deleteUidsInItems, transformItem } from '../../collections/export';
+import { resolveCollectionForHtmlDocumentation } from '../../exporters/html-documentation';
 
 describe('Examples Export/Import', () => {
   describe('transformCollectionToSaveToExportAsFile', () => {
@@ -238,6 +239,71 @@ describe('Examples Export/Import', () => {
 
       expect(httpRequest.examples).toHaveLength(0);
     });
+
+    it('should export collection docs from draft root', () => {
+      const collection = {
+        uid: 'test-collection',
+        name: 'Test Collection',
+        items: [],
+        root: {
+          docs: 'Saved docs'
+        },
+        draft: {
+          root: {
+            docs: '# Overview\nDraft overview docs'
+          }
+        }
+      };
+
+      const result = transformCollectionToSaveToExportAsFile(collection);
+
+      expect(result.root.docs).toBe('# Overview\nDraft overview docs');
+    });
+
+    it('should export folder docs from folder draft', () => {
+      const collection = {
+        uid: 'test-collection',
+        name: 'Test Collection',
+        items: [
+          {
+            uid: 'folder-1',
+            type: 'folder',
+            name: 'Folder One',
+            seq: 1,
+            root: {
+              docs: 'Saved folder docs'
+            },
+            draft: {
+              docs: '# Folder Overview\nDraft folder overview docs'
+            }
+          }
+        ]
+      };
+
+      const result = transformCollectionToSaveToExportAsFile(collection);
+
+      expect(result.items[0].root.docs).toBe('# Folder Overview\nDraft folder overview docs');
+    });
+
+    it('should omit collection docs when draft docs are empty', () => {
+      const collection = {
+        uid: 'test-collection',
+        name: 'Test Collection',
+        items: [],
+        root: {
+          docs: 'Saved docs that should not be exported'
+        },
+        draft: {
+          root: {
+            docs: ''
+          }
+        }
+      };
+
+      const result = transformCollectionToSaveToExportAsFile(collection);
+
+      expect(result.root).toBeUndefined();
+    });
   });
 
   describe('transformRequestToSaveToFilesystem', () => {
@@ -282,6 +348,86 @@ describe('Examples Export/Import', () => {
       expect(result.examples).toHaveLength(1);
       expect(result.examples[0].name).toBe('Test Example');
       expect(result.examples[0].response.status).toEqual(200);
+    });
+  });
+
+  describe('resolveCollectionForHtmlDocumentation', () => {
+    it('should create a top-level Overview folder from collection docs', () => {
+      const openCollection = {
+        info: { name: 'Test Collection' },
+        docs: {
+          content: '# Overview\nCollection overview docs',
+          type: 'text/markdown'
+        },
+        items: [
+          {
+            info: { name: 'Get users', type: 'http' },
+            http: { method: 'GET', url: 'https://api.example.com/users' }
+          }
+        ]
+      };
+
+      const result = resolveCollectionForHtmlDocumentation(openCollection);
+
+      expect(result.docs).toBeUndefined();
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].info.name).toBe('Overview');
+      expect(result.items[0].info.type).toBe('folder');
+      expect(result.items[0].docs.content).toBe('# Overview\nCollection overview docs');
+      expect(result.items[0].docs.type).toBe('text/markdown');
+    });
+
+    it('should handle docs as string', () => {
+      const openCollection = {
+        info: { name: 'Test Collection' },
+        docs: 'Collection overview docs',
+        items: []
+      };
+
+      const result = resolveCollectionForHtmlDocumentation(openCollection);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].info.name).toBe('Overview');
+      expect(result.items[0].docs.content).toBe('Collection overview docs');
+    });
+
+    it('should not create duplicate Overview folder when one already exists', () => {
+      const openCollection = {
+        info: { name: 'Test Collection' },
+        docs: {
+          content: '# Overview\nCollection overview docs',
+          type: 'text/markdown'
+        },
+        items: [
+          {
+            info: { name: 'Overview', type: 'folder' },
+            docs: {
+              content: 'Existing overview docs',
+              type: 'text/markdown'
+            }
+          }
+        ]
+      };
+
+      const result = resolveCollectionForHtmlDocumentation(openCollection);
+
+      expect(result).toBe(openCollection);
+      expect(result.items).toHaveLength(1);
+    });
+
+    it('should leave collection unchanged when docs are empty', () => {
+      const openCollection = {
+        info: { name: 'Test Collection' },
+        docs: {
+          content: '   ',
+          type: 'text/markdown'
+        },
+        items: []
+      };
+
+      const result = resolveCollectionForHtmlDocumentation(openCollection);
+
+      expect(result).toBe(openCollection);
     });
   });
 


### PR DESCRIPTION
### Description

fixes: #7774 

This fixes an issue where content written in the **Overview** tab (especially at the collection level) was missing from generated `docs.html`.

### Root cause
The HTML docs export had two gaps:
1. It exported docs from saved roots only (`root`) and could miss unsaved Overview edits in `draft`.
2. Collection-level docs were present in `openCollection.docs`, but the docs UI rendering path reliably displays docs attached to items/folders. As a result, collection Overview content was not consistently visible in exported HTML.

### What changed
- Export transformation now prefers draft state over saved state:
  - collection: `collection.draft.root || collection.root`
  - folder: `folder.draft || folder.root`
- Added HTML docs normalization for export:
  - collection-level docs are converted into a top-level `Overview` folder item with markdown docs
  - avoids duplicate insertion if an `Overview` folder with docs already exists
  - skips insertion for empty/missing docs
- Wired the normalization step into `GenerateDocumentation` before YAML is embedded into `docs.html`.

### Behavior after fix
- Collection/folder Overview markdown is included in exported `docs.html`
- Empty/missing Overview content is handled safely

Screenshot:
<img width="1919" height="895" alt="image" src="https://github.com/user-attachments/assets/846111c7-3f42-4b57-a076-b8d403b86dc9" />
 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML documentation generation to properly include collection-level documentation in exports.
  * Fixed handling of draft documentation during collection export to ensure no data loss.

* **Tests**
  * Added comprehensive test coverage for documentation export and HTML documentation generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->