### PR TITLE
fix: don't re-encode already encoded characters

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -1113,17 +1113,17 @@ describe('generateSnippet – encodeUrl setting', () => {
     expect(result).not.toContain('%253D');
   });
 
-  it('should double-encode pre-encoded %20 when encodeUrl is true', () => {
+  it('should preserve pre-encoded sequences when encodeUrl is true', () => {
     const preEncodedUrl = 'https://example.com/api?token=abc%20123%3D%3D&type=test';
     const item = {
       ...makeItem(preEncodedUrl, { encodeUrl: true }),
       rawUrl: preEncodedUrl
     };
     const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
-    // %20 → %2520 because encodeURIComponent encodes the literal '%' in the already-encoded value
-    expect(result).toContain('%2520');
-    // %3D → %253D for the same reason
-    expect(result).toContain('%253D');
+    expect(result).toContain('%20');
+    expect(result).toContain('%3D%3D');
+    expect(result).not.toContain('%2520');
+    expect(result).not.toContain('%253D');
   });
 
   it('should preserve OData-style paths with parenthesized params when encodeUrl is false', () => {

--- a/packages/bruno-common/src/utils/url/index.spec.ts
+++ b/packages/bruno-common/src/utils/url/index.spec.ts
@@ -111,14 +111,53 @@ describe('encodeUrl', () => {
 
     it('should handle already encoded URLs', () => {
       const url = 'https://example.com/api?name=john%20doe&email=john%40example.com';
-      const expected = 'https://example.com/api?name=john%2520doe&email=john%2540example.com';
+      const expected = url;
       expect(encodeUrl(url)).toBe(expected);
     });
 
     it('should handle pipe operator in already encoded URLs', () => {
       const url = 'https://example.com/api?filter=status%7Cactive&sort=name%7Casc';
-      const expected = 'https://example.com/api?filter=status%257Cactive&sort=name%257Casc';
+      const expected = url;
       expect(encodeUrl(url)).toBe(expected);
+    });
+  });
+
+  describe('already encoded sequence preservation', () => {
+    it('should preserve %20 and %40 sequences', () => {
+      const url = 'https://example.com/api?name=john%20doe&email=john%40example.com';
+      expect(encodeUrl(url)).toBe(url);
+    });
+
+    it('should preserve %2F-heavy values in generic URLs', () => {
+      const url = 'https://example.com/api?token=abc%2Fdef%2Fghi&other=x';
+      expect(encodeUrl(url)).toBe(url);
+    });
+
+    it('should preserve encoded pipe sequences', () => {
+      const url = 'https://example.com/api?filter=status%7Cactive&sort=name%7Casc';
+      expect(encodeUrl(url)).toBe(url);
+    });
+
+    it('should preserve encoded values while still encoding raw values in the same URL', () => {
+      const url = 'https://example.com/api?pre=abc%2Fdef&raw=john doe';
+      const expected = 'https://example.com/api?pre=abc%2Fdef&raw=john%20doe';
+      expect(encodeUrl(url)).toBe(expected);
+    });
+
+    it('should encode literal percent signs while preserving valid triplets in hybrid values', () => {
+      const url = 'https://example.com/api?v=50%off%2F';
+      const expected = 'https://example.com/api?v=50%25off%2F';
+      expect(encodeUrl(url)).toBe(expected);
+    });
+
+    it('should not throw on malformed percent sequences and should encode stray percent signs', () => {
+      const trailingPercentUrl = 'https://example.com/api?v=bad%';
+      const invalidHexUrl = 'https://example.com/api?v=bad%ZZ';
+
+      expect(() => encodeUrl(trailingPercentUrl)).not.toThrow();
+      expect(() => encodeUrl(invalidHexUrl)).not.toThrow();
+      expect(encodeUrl(trailingPercentUrl)).toBe('https://example.com/api?v=bad%25');
+      expect(encodeUrl(invalidHexUrl)).toBe('https://example.com/api?v=bad%25ZZ');
     });
   });
 

--- a/packages/bruno-common/src/utils/url/index.ts
+++ b/packages/bruno-common/src/utils/url/index.ts
@@ -11,17 +11,29 @@ interface ExtractQueryParamsOptions {
   decode?: boolean;
 }
 
+const ENCODED_MARKER = '__BRUNO_ENCODED__';
+
+const smartEncodeComponent = (value: string): string => {
+  if (!value) return value;
+
+  // replace % followed two hex characters with ENCODED_MARKER so they're not re-encoded
+  const maskedValue = value.replace(/%([0-9a-fA-F]{2})/g, `${ENCODED_MARKER}$1`);
+  const encodedValue = encodeURIComponent(maskedValue);
+
+  return encodedValue.split(ENCODED_MARKER).join('%');
+};
+
 function buildQueryString(paramsArray: QueryParam[], { encode = false }: BuildQueryStringOptions = {}): string {
   return paramsArray
     .filter(({ name }) => typeof name === 'string' && name.trim().length > 0)
     .map(({ name, value }) => {
-      const finalName = encode ? encodeURIComponent(name) : name;
+      const finalName = encode ? smartEncodeComponent(name) : name;
 
       if (value === undefined) {
         return finalName;
       }
 
-      const finalValue = encode ? encodeURIComponent(value) : value;
+      const finalValue = encode ? smartEncodeComponent(value) : value;
       return `${finalName}=${finalValue}`;
     })
     .join('&');

--- a/tests/request/encoding/curl-encoding.spec.ts
+++ b/tests/request/encoding/curl-encoding.spec.ts
@@ -23,7 +23,7 @@ test.describe('Code Generation URL Encoding', () => {
       await modal.closeButton().waitFor({ state: 'hidden' });
     });
 
-    test('should double-encode pre-encoded URL (%20 to %2520)', async ({ pageWithUserData: page }) => {
+    test('should preserve pre-encoded URL (%20 stays %20)', async ({ pageWithUserData: page }) => {
       const { sidebar, request, modal } = buildCommonLocators(page);
 
       await openCollection(page, 'encoding-test');
@@ -36,7 +36,7 @@ test.describe('Code Generation URL Encoding', () => {
       await expect(codeEditor).toBeVisible();
 
       const generatedCode = await codeEditor.textContent();
-      expect(generatedCode).toContain('http://base.source?name=John%2520Doe');
+      expect(generatedCode).toContain('http://base.source?name=John%20Doe');
 
       await modal.closeButton().click();
       await modal.closeButton().waitFor({ state: 'hidden' });


### PR DESCRIPTION
### Description

We were re-encoding already encoded characters in the url, causing them to fail. For example aws pre-signed url's are already encoded.

For example:
```
https://example.com/api?filter=status%257Cactive&sort=name%257Casc
```

Now we safely ignore such pattern while encoding again, so that they don't cause an issue.

Fixes #6048

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
