### PR TITLE
feat: add Monaco Editor as beta alternative for script editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24158,6 +24158,18 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -24560,6 +24572,25 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/mousetrap": {
@@ -32862,6 +32893,7 @@
         "mime-types": "^3.0.2",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.47",
+        "monaco-editor": "^0.55.1",
         "mousetrap": "^1.6.5",
         "nanoid": "3.3.8",
         "path": "^0.12.7",

--- a/packages/bruno-app/package.json
+++ b/packages/bruno-app/package.json
@@ -60,6 +60,7 @@
     "mime-types": "^3.0.2",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.47",
+    "monaco-editor": "^0.55.1",
     "mousetrap": "^1.6.5",
     "nanoid": "3.3.8",
     "path": "^0.12.7",

--- a/packages/bruno-app/rsbuild.config.mjs
+++ b/packages/bruno-app/rsbuild.config.mjs
@@ -32,6 +32,16 @@ export default defineConfig({
   tools: {
     rspack: {
       module: {
+        rules: [
+          {
+            test: /monaco-editor\/esm\/vs\/.*\.worker/,
+            parser: {
+              javascript: {
+                dynamicImportMode: 'lazy'
+              }
+            }
+          },
+        ],
         parser: {
           javascript: {
             // This loads the JavaScript contents from a library along with the main JavaScript bundle.

--- a/packages/bruno-app/src/components/CollectionSettings/Script/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Script/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import get from 'lodash/get';
 import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
-import CodeEditor from 'components/CodeEditor';
+import ScriptEditor from 'components/ScriptEditor';
 import { updateCollectionRequestScript, updateCollectionResponseScript } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
 import { updateScriptPaneTab } from 'providers/ReduxStore/slices/tabs';
@@ -100,7 +100,7 @@ const Script = ({ collection }) => {
         </TabsList>
 
         <TabsContent value="pre-request" className="mt-2">
-          <CodeEditor
+          <ScriptEditor
             ref={preRequestEditorRef}
             collection={collection}
             value={requestScript || ''}
@@ -115,7 +115,7 @@ const Script = ({ collection }) => {
         </TabsContent>
 
         <TabsContent value="post-response" className="mt-2">
-          <CodeEditor
+          <ScriptEditor
             ref={postResponseEditorRef}
             collection={collection}
             value={responseScript || ''}

--- a/packages/bruno-app/src/components/CollectionSettings/Tests/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Tests/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
-import CodeEditor from 'components/CodeEditor';
+import ScriptEditor from 'components/ScriptEditor';
 import { updateCollectionTests } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
 import { useTheme } from 'providers/Theme';
@@ -29,7 +29,7 @@ const Tests = ({ collection }) => {
   return (
     <StyledWrapper className="w-full flex flex-col h-full">
       <div className="text-xs mb-4 text-muted">These tests will run any time a request in this collection is sent.</div>
-      <CodeEditor
+      <ScriptEditor
         collection={collection}
         value={tests || ''}
         theme={displayedTheme}

--- a/packages/bruno-app/src/components/FolderSettings/Script/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import get from 'lodash/get';
 import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
-import CodeEditor from 'components/CodeEditor';
+import ScriptEditor from 'components/ScriptEditor';
 import { updateFolderRequestScript, updateFolderResponseScript } from 'providers/ReduxStore/slices/collections';
 import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions';
 import { updateScriptPaneTab } from 'providers/ReduxStore/slices/tabs';
@@ -103,7 +103,7 @@ const Script = ({ collection, folder }) => {
         </TabsList>
 
         <TabsContent value="pre-request" className="mt-2">
-          <CodeEditor
+          <ScriptEditor
             ref={preRequestEditorRef}
             collection={collection}
             value={requestScript || ''}
@@ -118,7 +118,7 @@ const Script = ({ collection, folder }) => {
         </TabsContent>
 
         <TabsContent value="post-response" className="mt-2">
-          <CodeEditor
+          <ScriptEditor
             ref={postResponseEditorRef}
             collection={collection}
             value={responseScript || ''}

--- a/packages/bruno-app/src/components/FolderSettings/Script/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Script/index.js
@@ -106,6 +106,7 @@ const Script = ({ collection, folder }) => {
           <ScriptEditor
             ref={preRequestEditorRef}
             collection={collection}
+            item={folder}
             value={requestScript || ''}
             theme={displayedTheme}
             onEdit={onRequestScriptEdit}
@@ -121,6 +122,7 @@ const Script = ({ collection, folder }) => {
           <ScriptEditor
             ref={postResponseEditorRef}
             collection={collection}
+            item={folder}
             value={responseScript || ''}
             theme={displayedTheme}
             onEdit={onResponseScriptEdit}

--- a/packages/bruno-app/src/components/FolderSettings/Tests/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Tests/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
-import CodeEditor from 'components/CodeEditor';
+import ScriptEditor from 'components/ScriptEditor';
 import { updateFolderTests } from 'providers/ReduxStore/slices/collections';
 import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions';
 import { useTheme } from 'providers/Theme';
@@ -30,7 +30,7 @@ const Tests = ({ collection, folder }) => {
   return (
     <StyledWrapper className="w-full flex flex-col h-full">
       <div className="text-xs mb-4 text-muted">These tests will run any time a request in this collection is sent.</div>
-      <CodeEditor
+      <ScriptEditor
         collection={collection}
         value={tests || ''}
         theme={displayedTheme}

--- a/packages/bruno-app/src/components/FolderSettings/Tests/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Tests/index.js
@@ -32,6 +32,7 @@ const Tests = ({ collection, folder }) => {
       <div className="text-xs mb-4 text-muted">These tests will run any time a request in this collection is sent.</div>
       <ScriptEditor
         collection={collection}
+        item={folder}
         value={tests || ''}
         theme={displayedTheme}
         onEdit={onEdit}

--- a/packages/bruno-app/src/components/MonacoEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MonacoEditor/StyledWrapper.js
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .monaco-editor-container {
+    flex: 1 1 0;
+    min-height: 0;
+    border: solid 1px ${(props) => props.theme.codemirror.border};
+    background: ${(props) => props.theme.codemirror.bg};
+  }
+
+  /* Flush line numbers to the left edge like CodeMirror */
+  .monaco-editor .margin-view-overlays .line-numbers {
+    text-align: left !important;
+    padding-left: 3px !important;
+  }
+
+  /* Bruno variable highlighting decorations */
+  .bruno-variable-valid {
+    color: ${(props) => props.theme.codemirror.variable.valid} !important;
+    font-weight: 500;
+  }
+
+  .bruno-variable-invalid {
+    color: ${(props) => props.theme.codemirror.variable.invalid} !important;
+    font-weight: 500;
+    text-decoration: wavy underline ${(props) => props.theme.codemirror.variable.invalid};
+    text-underline-offset: 3px;
+  }
+
+  .bruno-variable-prompt {
+    color: ${(props) => props.theme.codemirror.variable.prompt} !important;
+    font-weight: 500;
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/MonacoEditor/index.js
+++ b/packages/bruno-app/src/components/MonacoEditor/index.js
@@ -1,9 +1,9 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
 import { useDispatch } from 'react-redux';
 import 'utils/monaco/workers';
 import * as monaco from 'monaco-editor';
 import { mapCodeMirrorModeToMonaco } from 'utils/monaco/languageMapping';
-import { registerBrunoTheme } from 'utils/monaco/brunoTheme';
+import { registerBrunoTheme, getCurrentThemeName } from 'utils/monaco/brunoTheme';
 import { registerBrunoApiTypes } from 'utils/monaco/brunoApiTypes';
 import { setupVariableHighlighting, setupVariableTooltip } from 'utils/monaco/variableHighlighting';
 import { setupAutoComplete } from 'utils/monaco/autocomplete';
@@ -12,7 +12,7 @@ import StyledWrapper from './StyledWrapper';
 
 const TAB_SIZE = 2;
 
-const MonacoEditor = ({
+const MonacoEditor = forwardRef(({
   value = '',
   mode,
   theme,
@@ -28,7 +28,7 @@ const MonacoEditor = ({
   initialScroll = 0,
   collection,
   item
-}) => {
+}, ref) => {
   const containerRef = useRef(null);
   const editorRef = useRef(null);
   const cachedValueRef = useRef(value);
@@ -44,6 +44,17 @@ const MonacoEditor = ({
 
   const styledTheme = useStyledTheme();
   const dispatch = useDispatch();
+
+  // Expose a ref-compatible interface matching CodeEditor's class instance shape.
+  // Consumers call ref.current.editor.refresh() — Monaco's automaticLayout handles this,
+  // so layout() is called as a safe equivalent.
+  useImperativeHandle(ref, () => ({
+    editor: {
+      refresh: () => {
+        editorRef.current?.layout();
+      }
+    }
+  }));
 
   // Keep callback refs up to date
   useEffect(() => { onEditRef.current = onEdit; }, [onEdit]);
@@ -62,13 +73,12 @@ const MonacoEditor = ({
     // Register Bruno API types (idempotent, only runs once)
     registerBrunoApiTypes();
 
-    // Register Bruno theme from the styled-components theme
-    const themeName = registerBrunoTheme(styledTheme, theme);
-
     const editor = monaco.editor.create(containerRef.current, {
       value: value || '',
       language,
-      theme: themeName,
+      // Use a stable base theme for creation; the theme-sync effect registers
+      // and applies the full Bruno theme before the browser paints.
+      theme: getCurrentThemeName(theme),
       readOnly,
       tabSize: TAB_SIZE,
       automaticLayout: true,
@@ -168,29 +178,54 @@ const MonacoEditor = ({
     // Only run on mount/unmount
   }, []);
 
-  // Re-apply variable highlighting when collection/item changes
+  // Re-apply variable highlighting and tooltip when collection/item/flag changes
   useEffect(() => {
     const editor = editorRef.current;
-    if (!editor || !collection || !enableVariableHighlighting) return;
+    if (!editor || !collection) return;
 
-    // Clean up old highlighting (tooltip uses refs, so no re-setup needed)
-    variableCleanupRef.current?.();
+    if (enableVariableHighlighting) {
+      // Clean up and re-setup highlighting with updated variables
+      variableCleanupRef.current?.();
+      variableCleanupRef.current = setupVariableHighlighting(editor, collection, item);
 
-    // Setup new highlighting with updated variables
-    variableCleanupRef.current = setupVariableHighlighting(editor, collection, item);
-  }, [collection, item]);
+      // Setup tooltip if not already active
+      if (!tooltipCleanupRef.current) {
+        tooltipCleanupRef.current = setupVariableTooltip(
+          editor,
+          () => collectionRef.current,
+          () => itemRef.current,
+          dispatch
+        );
+      }
+    } else {
+      // Tear down when disabled
+      variableCleanupRef.current?.();
+      variableCleanupRef.current = null;
+      tooltipCleanupRef.current?.();
+      tooltipCleanupRef.current = null;
+    }
+  }, [collection, item, enableVariableHighlighting]);
 
-  // Sync external value changes
+  // Sync external value changes without resetting scroll, selections, or undo history
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor) return;
     if (value !== cachedValueRef.current) {
       cachedValueRef.current = value;
-      const position = editor.getPosition();
-      editor.setValue(value || '');
-      if (position) {
-        editor.setPosition(position);
-      }
+      const model = editor.getModel();
+      if (!model) return;
+
+      const selections = editor.getSelections();
+      const scrollTop = editor.getScrollTop();
+      const fullRange = model.getFullModelRange();
+
+      model.pushEditOperations(
+        selections,
+        [{ range: fullRange, text: value || '' }],
+        () => selections
+      );
+
+      editor.setScrollTop(scrollTop);
     }
   }, [value]);
 
@@ -241,16 +276,15 @@ const MonacoEditor = ({
     <StyledWrapper
       className="h-full w-full flex flex-col"
       aria-label="Monaco Editor"
-      font={font}
-      fontSize={fontSize}
     >
       <div
         ref={containerRef}
         className="monaco-editor-container"
+        data-testid="monaco-editor-container"
         style={{ height: '100%', width: '100%' }}
       />
     </StyledWrapper>
   );
-};
+});
 
 export default MonacoEditor;

--- a/packages/bruno-app/src/components/MonacoEditor/index.js
+++ b/packages/bruno-app/src/components/MonacoEditor/index.js
@@ -59,7 +59,7 @@ const MonacoEditor = ({
   useEffect(() => {
     if (!containerRef.current) return;
 
-    // Register Bruno API types for intellisense (idempotent, only runs once)
+    // Register Bruno API types (idempotent, only runs once)
     registerBrunoApiTypes();
 
     // Register Bruno theme from the styled-components theme

--- a/packages/bruno-app/src/components/MonacoEditor/index.js
+++ b/packages/bruno-app/src/components/MonacoEditor/index.js
@@ -1,10 +1,12 @@
 import React, { useRef, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import 'utils/monaco/workers';
 import * as monaco from 'monaco-editor';
 import { mapCodeMirrorModeToMonaco } from 'utils/monaco/languageMapping';
 import { registerBrunoTheme } from 'utils/monaco/brunoTheme';
 import { registerBrunoApiTypes } from 'utils/monaco/brunoApiTypes';
-import { setupVariableHighlighting, registerVariableHoverProvider } from 'utils/monaco/variableHighlighting';
+import { setupVariableHighlighting, setupVariableTooltip } from 'utils/monaco/variableHighlighting';
+import { setupAutoComplete } from 'utils/monaco/autocomplete';
 import { useTheme as useStyledTheme } from 'styled-components';
 import StyledWrapper from './StyledWrapper';
 
@@ -21,6 +23,7 @@ const MonacoEditor = ({
   font,
   fontSize,
   enableLineWrapping = true,
+  enableVariableHighlighting = false,
   onScroll,
   initialScroll = 0,
   collection,
@@ -36,9 +39,11 @@ const MonacoEditor = ({
   const collectionRef = useRef(collection);
   const itemRef = useRef(item);
   const variableCleanupRef = useRef(null);
-  const hoverProviderRef = useRef(null);
+  const tooltipCleanupRef = useRef(null);
+  const autocompleteCleanupRef = useRef(null);
 
   const styledTheme = useStyledTheme();
+  const dispatch = useDispatch();
 
   // Keep callback refs up to date
   useEffect(() => { onEditRef.current = onEdit; }, [onEdit]);
@@ -81,6 +86,11 @@ const MonacoEditor = ({
       autoClosingBrackets: 'always',
       folding: true,
       fixedOverflowWidgets: true,
+      quickSuggestions: {
+        other: true,
+        comments: false,
+        strings: true
+      },
       scrollbar: {
         verticalScrollbarSize: 8,
         horizontalScrollbarSize: 8
@@ -114,10 +124,25 @@ const MonacoEditor = ({
       textarea.classList.add('mousetrap');
     }
 
-    // Setup variable highlighting
-    if (collectionRef.current) {
+    // Setup variable highlighting and tooltip — gated by enableVariableHighlighting
+    if (collectionRef.current && enableVariableHighlighting) {
       variableCleanupRef.current = setupVariableHighlighting(editor, collectionRef.current, itemRef.current);
-      hoverProviderRef.current = registerVariableHoverProvider(collectionRef.current, itemRef.current);
+      tooltipCleanupRef.current = setupVariableTooltip(
+        editor,
+        () => collectionRef.current,
+        () => itemRef.current,
+        dispatch
+      );
+    }
+
+    // Setup variable autocomplete ({{variable}} suggestions)
+    // API hints (req, res, bru) are handled by Monaco's built-in IntelliSense via brunoApiTypes
+    if (collectionRef.current) {
+      autocompleteCleanupRef.current = setupAutoComplete(
+        editor,
+        () => collectionRef.current,
+        () => itemRef.current
+      );
     }
 
     // Apply initial scroll position
@@ -132,9 +157,10 @@ const MonacoEditor = ({
           doc: { scrollTop: editor.getScrollTop() }
         });
       }
-      // Clean up variable highlighting
+      // Clean up variable highlighting, tooltip, and autocomplete
       variableCleanupRef.current?.();
-      hoverProviderRef.current?.dispose();
+      tooltipCleanupRef.current?.();
+      autocompleteCleanupRef.current?.();
       contentDisposable.dispose();
       editor.dispose();
       editorRef.current = null;
@@ -145,15 +171,13 @@ const MonacoEditor = ({
   // Re-apply variable highlighting when collection/item changes
   useEffect(() => {
     const editor = editorRef.current;
-    if (!editor || !collection) return;
+    if (!editor || !collection || !enableVariableHighlighting) return;
 
-    // Clean up old highlighting
+    // Clean up old highlighting (tooltip uses refs, so no re-setup needed)
     variableCleanupRef.current?.();
-    hoverProviderRef.current?.dispose();
 
     // Setup new highlighting with updated variables
     variableCleanupRef.current = setupVariableHighlighting(editor, collection, item);
-    hoverProviderRef.current = registerVariableHoverProvider(collection, item);
   }, [collection, item]);
 
   // Sync external value changes

--- a/packages/bruno-app/src/components/MonacoEditor/index.js
+++ b/packages/bruno-app/src/components/MonacoEditor/index.js
@@ -1,0 +1,232 @@
+import React, { useRef, useEffect } from 'react';
+import 'utils/monaco/workers';
+import * as monaco from 'monaco-editor';
+import { mapCodeMirrorModeToMonaco } from 'utils/monaco/languageMapping';
+import { registerBrunoTheme } from 'utils/monaco/brunoTheme';
+import { registerBrunoApiTypes } from 'utils/monaco/brunoApiTypes';
+import { setupVariableHighlighting, registerVariableHoverProvider } from 'utils/monaco/variableHighlighting';
+import { useTheme as useStyledTheme } from 'styled-components';
+import StyledWrapper from './StyledWrapper';
+
+const TAB_SIZE = 2;
+
+const MonacoEditor = ({
+  value = '',
+  mode,
+  theme,
+  onEdit,
+  onRun,
+  onSave,
+  readOnly = false,
+  font,
+  fontSize,
+  enableLineWrapping = true,
+  onScroll,
+  initialScroll = 0,
+  collection,
+  item
+}) => {
+  const containerRef = useRef(null);
+  const editorRef = useRef(null);
+  const cachedValueRef = useRef(value);
+  const onEditRef = useRef(onEdit);
+  const onRunRef = useRef(onRun);
+  const onSaveRef = useRef(onSave);
+  const onScrollRef = useRef(onScroll);
+  const collectionRef = useRef(collection);
+  const itemRef = useRef(item);
+  const variableCleanupRef = useRef(null);
+  const hoverProviderRef = useRef(null);
+
+  const styledTheme = useStyledTheme();
+
+  // Keep callback refs up to date
+  useEffect(() => { onEditRef.current = onEdit; }, [onEdit]);
+  useEffect(() => { onRunRef.current = onRun; }, [onRun]);
+  useEffect(() => { onSaveRef.current = onSave; }, [onSave]);
+  useEffect(() => { onScrollRef.current = onScroll; }, [onScroll]);
+  useEffect(() => { collectionRef.current = collection; }, [collection]);
+  useEffect(() => { itemRef.current = item; }, [item]);
+
+  const language = mapCodeMirrorModeToMonaco(mode);
+
+  // Create editor on mount, dispose on unmount
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Register Bruno API types for intellisense (idempotent, only runs once)
+    registerBrunoApiTypes();
+
+    // Register Bruno theme from the styled-components theme
+    const themeName = registerBrunoTheme(styledTheme, theme);
+
+    const editor = monaco.editor.create(containerRef.current, {
+      value: value || '',
+      language,
+      theme: themeName,
+      readOnly,
+      tabSize: TAB_SIZE,
+      automaticLayout: true,
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      wordWrap: enableLineWrapping ? 'on' : 'off',
+      fontFamily: font && font !== 'default' ? font : undefined,
+      fontSize: fontSize || 13,
+      lineNumbers: 'on',
+      lineNumbersMinChars: 1,
+      lineDecorationsWidth: 0,
+      glyphMargin: false,
+      renderLineHighlight: 'line',
+      matchBrackets: 'always',
+      autoClosingBrackets: 'always',
+      folding: true,
+      fixedOverflowWidgets: true,
+      scrollbar: {
+        verticalScrollbarSize: 8,
+        horizontalScrollbarSize: 8
+      }
+    });
+
+    editorRef.current = editor;
+
+    // Listen for content changes
+    const contentDisposable = editor.onDidChangeModelContent(() => {
+      const newValue = editor.getValue();
+      cachedValueRef.current = newValue;
+      if (onEditRef.current) {
+        onEditRef.current(newValue);
+      }
+    });
+
+    // Keybinding: Cmd/Ctrl+Enter → onRun
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+      if (onRunRef.current) onRunRef.current();
+    });
+
+    // Keybinding: Cmd/Ctrl+S → onSave
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+      if (onSaveRef.current) onSaveRef.current();
+    });
+
+    // Add mousetrap class for global shortcut passthrough
+    const textarea = editor.getDomNode()?.querySelector('textarea');
+    if (textarea) {
+      textarea.classList.add('mousetrap');
+    }
+
+    // Setup variable highlighting
+    if (collectionRef.current) {
+      variableCleanupRef.current = setupVariableHighlighting(editor, collectionRef.current, itemRef.current);
+      hoverProviderRef.current = registerVariableHoverProvider(collectionRef.current, itemRef.current);
+    }
+
+    // Apply initial scroll position
+    if (initialScroll > 0) {
+      editor.setScrollTop(initialScroll);
+    }
+
+    return () => {
+      // Save scroll position before disposing
+      if (onScrollRef.current && editor) {
+        onScrollRef.current({
+          doc: { scrollTop: editor.getScrollTop() }
+        });
+      }
+      // Clean up variable highlighting
+      variableCleanupRef.current?.();
+      hoverProviderRef.current?.dispose();
+      contentDisposable.dispose();
+      editor.dispose();
+      editorRef.current = null;
+    };
+    // Only run on mount/unmount
+  }, []);
+
+  // Re-apply variable highlighting when collection/item changes
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || !collection) return;
+
+    // Clean up old highlighting
+    variableCleanupRef.current?.();
+    hoverProviderRef.current?.dispose();
+
+    // Setup new highlighting with updated variables
+    variableCleanupRef.current = setupVariableHighlighting(editor, collection, item);
+    hoverProviderRef.current = registerVariableHoverProvider(collection, item);
+  }, [collection, item]);
+
+  // Sync external value changes
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    if (value !== cachedValueRef.current) {
+      cachedValueRef.current = value;
+      const position = editor.getPosition();
+      editor.setValue(value || '');
+      if (position) {
+        editor.setPosition(position);
+      }
+    }
+  }, [value]);
+
+  // Sync theme — re-register Bruno theme when it changes
+  useEffect(() => {
+    const themeName = registerBrunoTheme(styledTheme, theme);
+    monaco.editor.setTheme(themeName);
+  }, [theme, styledTheme]);
+
+  // Sync language
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const model = editor.getModel();
+    if (model) {
+      monaco.editor.setModelLanguage(model, language);
+    }
+  }, [language]);
+
+  // Sync readOnly
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (editor) {
+      editor.updateOptions({ readOnly });
+    }
+  }, [readOnly]);
+
+  // Sync word wrap
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (editor) {
+      editor.updateOptions({ wordWrap: enableLineWrapping ? 'on' : 'off' });
+    }
+  }, [enableLineWrapping]);
+
+  // Sync font settings
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (editor) {
+      editor.updateOptions({
+        fontFamily: font && font !== 'default' ? font : undefined,
+        fontSize: fontSize || 13
+      });
+    }
+  }, [font, fontSize]);
+
+  return (
+    <StyledWrapper
+      className="h-full w-full flex flex-col"
+      aria-label="Monaco Editor"
+      font={font}
+      fontSize={fontSize}
+    >
+      <div
+        ref={containerRef}
+        className="monaco-editor-container"
+        style={{ height: '100%', width: '100%' }}
+      />
+    </StyledWrapper>
+  );
+};
+
+export default MonacoEditor;

--- a/packages/bruno-app/src/components/MonacoEditor/index.spec.js
+++ b/packages/bruno-app/src/components/MonacoEditor/index.spec.js
@@ -17,16 +17,25 @@ const mockGetScrollTop = jest.fn(() => 0);
 const mockUpdateOptions = jest.fn();
 const mockAddCommand = jest.fn();
 const mockOnDidChangeModelContent = jest.fn(() => ({ dispose: jest.fn() }));
+const mockClassListAdd = jest.fn();
 const mockGetDomNode = jest.fn(() => ({
   querySelector: jest.fn(() => ({
-    classList: { add: jest.fn() }
+    classList: { add: mockClassListAdd }
   }))
 }));
 const mockGetModel = jest.fn(() => ({
   getValue: jest.fn(() => ''),
-  getPositionAt: jest.fn(() => ({ lineNumber: 1, column: 1 }))
+  getPositionAt: jest.fn(() => ({ lineNumber: 1, column: 1 })),
+  getFullModelRange: jest.fn(() => ({ startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 })),
+  pushEditOperations: jest.fn()
 }));
-const mockDeltaDecorations = jest.fn(() => []);
+const mockCreateDecorationsCollection = jest.fn(() => ({
+  set: jest.fn(),
+  clear: jest.fn()
+}));
+const mockLayout = jest.fn();
+
+const mockGetSelections = jest.fn(() => [{ startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 }]);
 
 const mockEditor = {
   dispose: mockDispose,
@@ -36,12 +45,14 @@ const mockEditor = {
   setPosition: mockSetPosition,
   setScrollTop: mockSetScrollTop,
   getScrollTop: mockGetScrollTop,
+  getSelections: mockGetSelections,
   updateOptions: mockUpdateOptions,
   addCommand: mockAddCommand,
   onDidChangeModelContent: mockOnDidChangeModelContent,
   getDomNode: mockGetDomNode,
   getModel: mockGetModel,
-  deltaDecorations: mockDeltaDecorations
+  createDecorationsCollection: mockCreateDecorationsCollection,
+  layout: mockLayout
 };
 
 jest.mock('utils/monaco/workers', () => {});
@@ -70,7 +81,8 @@ jest.mock('monaco-editor', () => ({
 }));
 
 jest.mock('utils/monaco/brunoTheme', () => ({
-  registerBrunoTheme: jest.fn(() => 'bruno-light-123')
+  registerBrunoTheme: jest.fn(() => 'bruno-light'),
+  getCurrentThemeName: jest.fn(() => 'vs')
 }));
 
 jest.mock('utils/monaco/brunoApiTypes', () => ({
@@ -249,6 +261,7 @@ describe('MonacoEditor', () => {
   it('adds mousetrap class to textarea', () => {
     renderEditor();
     expect(mockGetDomNode).toHaveBeenCalled();
+    expect(mockClassListAdd).toHaveBeenCalledWith('mousetrap');
   });
 
   it('applies initial scroll position', () => {

--- a/packages/bruno-app/src/components/MonacoEditor/index.spec.js
+++ b/packages/bruno-app/src/components/MonacoEditor/index.spec.js
@@ -1,0 +1,228 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+const mockDispose = jest.fn();
+const mockGetValue = jest.fn(() => '');
+const mockSetValue = jest.fn();
+const mockGetPosition = jest.fn(() => ({ lineNumber: 1, column: 1 }));
+const mockSetPosition = jest.fn();
+const mockSetScrollTop = jest.fn();
+const mockGetScrollTop = jest.fn(() => 0);
+const mockUpdateOptions = jest.fn();
+const mockAddCommand = jest.fn();
+const mockOnDidChangeModelContent = jest.fn(() => ({ dispose: jest.fn() }));
+const mockGetDomNode = jest.fn(() => ({
+  querySelector: jest.fn(() => ({
+    classList: { add: jest.fn() }
+  }))
+}));
+const mockGetModel = jest.fn(() => ({
+  getValue: jest.fn(() => ''),
+  getPositionAt: jest.fn(() => ({ lineNumber: 1, column: 1 }))
+}));
+const mockDeltaDecorations = jest.fn(() => []);
+
+const mockEditor = {
+  dispose: mockDispose,
+  getValue: mockGetValue,
+  setValue: mockSetValue,
+  getPosition: mockGetPosition,
+  setPosition: mockSetPosition,
+  setScrollTop: mockSetScrollTop,
+  getScrollTop: mockGetScrollTop,
+  updateOptions: mockUpdateOptions,
+  addCommand: mockAddCommand,
+  onDidChangeModelContent: mockOnDidChangeModelContent,
+  getDomNode: mockGetDomNode,
+  getModel: mockGetModel,
+  deltaDecorations: mockDeltaDecorations
+};
+
+jest.mock('utils/monaco/workers', () => {});
+
+jest.mock('monaco-editor', () => ({
+  editor: {
+    create: jest.fn(() => mockEditor),
+    setTheme: jest.fn(),
+    setModelLanguage: jest.fn(),
+    defineTheme: jest.fn()
+  },
+  languages: {
+    typescript: {
+      javascriptDefaults: {
+        addExtraLib: jest.fn(),
+        setDiagnosticsOptions: jest.fn(),
+        setCompilerOptions: jest.fn()
+      },
+      ScriptTarget: { ES2020: 7 }
+    },
+    registerHoverProvider: jest.fn(() => ({ dispose: jest.fn() }))
+  },
+  KeyMod: { CtrlCmd: 2048 },
+  KeyCode: { Enter: 3, KeyS: 49 },
+  Range: jest.fn()
+}));
+
+jest.mock('utils/monaco/brunoTheme', () => ({
+  registerBrunoTheme: jest.fn(() => 'bruno-light-123')
+}));
+
+jest.mock('utils/monaco/brunoApiTypes', () => ({
+  registerBrunoApiTypes: jest.fn()
+}));
+
+jest.mock('utils/monaco/variableHighlighting', () => ({
+  setupVariableHighlighting: jest.fn(() => jest.fn()),
+  registerVariableHoverProvider: jest.fn(() => ({ dispose: jest.fn() }))
+}));
+
+const MOCK_THEME = {
+  codemirror: {
+    bg: '#1e1e1e',
+    border: '#333',
+    variable: {
+      valid: '#247c2f',
+      invalid: '#b82e28',
+      prompt: '#0078d4'
+    },
+    tokens: {
+      definition: '#0078d4',
+      property: '#0078d4',
+      string: '#6f402f',
+      number: '#d63384',
+      atom: '#a6142a',
+      variable: '#d63384',
+      keyword: '#a6142a',
+      comment: '#808080',
+      operator: '#838383',
+      tag: '#a6142a',
+      tagBracket: '#838383'
+    }
+  },
+  textLink: '#007acc'
+};
+
+// Import after mocks are set up
+const MonacoEditor = require('./index').default;
+const monaco = require('monaco-editor');
+const { registerBrunoTheme } = require('utils/monaco/brunoTheme');
+const { setupVariableHighlighting, registerVariableHoverProvider } = require('utils/monaco/variableHighlighting');
+
+describe('MonacoEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetValue.mockReturnValue('');
+  });
+
+  const renderEditor = (props = {}) => {
+    return render(
+      <ThemeProvider theme={MOCK_THEME}>
+        <MonacoEditor {...props} />
+      </ThemeProvider>
+    );
+  };
+
+  it('renders without crashing', () => {
+    const { container } = renderEditor();
+    expect(container.querySelector('.monaco-editor-container')).toBeTruthy();
+  });
+
+  it('creates a Monaco editor instance on mount', () => {
+    renderEditor({ value: 'const x = 1;' });
+    expect(monaco.editor.create).toHaveBeenCalledTimes(1);
+    expect(monaco.editor.create).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        value: 'const x = 1;'
+      })
+    );
+  });
+
+  it('registers Bruno theme on mount', () => {
+    renderEditor({ theme: 'dark' });
+    expect(registerBrunoTheme).toHaveBeenCalledWith(MOCK_THEME, 'dark');
+  });
+
+  it('uses the correct language for javascript mode', () => {
+    renderEditor({ mode: 'application/javascript' });
+    expect(monaco.editor.create).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        language: 'javascript'
+      })
+    );
+  });
+
+  it('applies readOnly option', () => {
+    renderEditor({ readOnly: true });
+    expect(monaco.editor.create).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        readOnly: true
+      })
+    );
+  });
+
+  it('applies font and fontSize', () => {
+    renderEditor({ font: 'Fira Code', fontSize: 16 });
+    expect(monaco.editor.create).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        fontFamily: 'Fira Code',
+        fontSize: 16
+      })
+    );
+  });
+
+  it('applies word wrap settings', () => {
+    renderEditor({ enableLineWrapping: true });
+    expect(monaco.editor.create).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        wordWrap: 'on'
+      })
+    );
+  });
+
+  it('registers keybindings for onRun and onSave', () => {
+    renderEditor({ onRun: jest.fn(), onSave: jest.fn() });
+    expect(mockAddCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('disposes editor on unmount', () => {
+    const { unmount } = renderEditor();
+    act(() => {
+      unmount();
+    });
+    expect(mockDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets up variable highlighting when collection is provided', () => {
+    const collection = { uid: 'col-1' };
+    const item = { uid: 'item-1' };
+    renderEditor({ collection, item });
+    expect(setupVariableHighlighting).toHaveBeenCalledWith(mockEditor, collection, item);
+    expect(registerVariableHoverProvider).toHaveBeenCalledWith(collection, item);
+  });
+
+  it('does not set up variable highlighting when collection is not provided', () => {
+    renderEditor({});
+    expect(setupVariableHighlighting).not.toHaveBeenCalled();
+  });
+
+  it('adds mousetrap class to textarea', () => {
+    renderEditor();
+    expect(mockGetDomNode).toHaveBeenCalled();
+  });
+
+  it('applies initial scroll position', () => {
+    renderEditor({ initialScroll: 100 });
+    expect(mockSetScrollTop).toHaveBeenCalledWith(100);
+  });
+
+  it('does not apply scroll when initialScroll is 0', () => {
+    renderEditor({ initialScroll: 0 });
+    expect(mockSetScrollTop).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-app/src/components/MonacoEditor/index.spec.js
+++ b/packages/bruno-app/src/components/MonacoEditor/index.spec.js
@@ -2,6 +2,11 @@ import React from 'react';
 import { render, act } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch
+}));
+
 const mockDispose = jest.fn();
 const mockGetValue = jest.fn(() => '');
 const mockSetValue = jest.fn();
@@ -74,7 +79,11 @@ jest.mock('utils/monaco/brunoApiTypes', () => ({
 
 jest.mock('utils/monaco/variableHighlighting', () => ({
   setupVariableHighlighting: jest.fn(() => jest.fn()),
-  registerVariableHoverProvider: jest.fn(() => ({ dispose: jest.fn() }))
+  setupVariableTooltip: jest.fn(() => jest.fn())
+}));
+
+jest.mock('utils/monaco/autocomplete', () => ({
+  setupAutoComplete: jest.fn(() => jest.fn())
 }));
 
 const MOCK_THEME = {
@@ -107,7 +116,8 @@ const MOCK_THEME = {
 const MonacoEditor = require('./index').default;
 const monaco = require('monaco-editor');
 const { registerBrunoTheme } = require('utils/monaco/brunoTheme');
-const { setupVariableHighlighting, registerVariableHoverProvider } = require('utils/monaco/variableHighlighting');
+const { setupVariableHighlighting, setupVariableTooltip } = require('utils/monaco/variableHighlighting');
+const { setupAutoComplete } = require('utils/monaco/autocomplete');
 
 describe('MonacoEditor', () => {
   beforeEach(() => {
@@ -198,17 +208,42 @@ describe('MonacoEditor', () => {
     expect(mockDispose).toHaveBeenCalledTimes(1);
   });
 
-  it('sets up variable highlighting when collection is provided', () => {
+  it('sets up variable highlighting and tooltip when enableVariableHighlighting is true', () => {
+    const collection = { uid: 'col-1' };
+    const item = { uid: 'item-1' };
+    renderEditor({ collection, item, enableVariableHighlighting: true });
+    expect(setupVariableHighlighting).toHaveBeenCalledWith(mockEditor, collection, item);
+    expect(setupVariableTooltip).toHaveBeenCalled();
+  });
+
+  it('does not set up highlighting or tooltip when enableVariableHighlighting is not set', () => {
     const collection = { uid: 'col-1' };
     const item = { uid: 'item-1' };
     renderEditor({ collection, item });
-    expect(setupVariableHighlighting).toHaveBeenCalledWith(mockEditor, collection, item);
-    expect(registerVariableHoverProvider).toHaveBeenCalledWith(collection, item);
+    expect(setupVariableHighlighting).not.toHaveBeenCalled();
+    expect(setupVariableTooltip).not.toHaveBeenCalled();
   });
 
-  it('does not set up variable highlighting when collection is not provided', () => {
+  it('does not set up highlighting or tooltip when collection is not provided', () => {
     renderEditor({});
     expect(setupVariableHighlighting).not.toHaveBeenCalled();
+    expect(setupVariableTooltip).not.toHaveBeenCalled();
+  });
+
+  it('sets up autocomplete when collection is provided', () => {
+    const collection = { uid: 'col-1' };
+    const item = { uid: 'item-1' };
+    renderEditor({ collection, item });
+    expect(setupAutoComplete).toHaveBeenCalledWith(
+      mockEditor,
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it('does not set up autocomplete when collection is not provided', () => {
+    renderEditor({});
+    expect(setupAutoComplete).not.toHaveBeenCalled();
   });
 
   it('adds mousetrap class to textarea', () => {

--- a/packages/bruno-app/src/components/Preferences/Beta/index.js
+++ b/packages/bruno-app/src/components/Preferences/Beta/index.js
@@ -19,6 +19,11 @@ const BETA_FEATURES = [
     id: BETA_FEATURE_IDS.OPENAPI_SYNC,
     label: 'OpenAPI Sync',
     description: 'Synchronize your Bruno collection with an OpenAPI specification. Detect drift, review changes, and sync with a single click.'
+  },
+  {
+    id: BETA_FEATURE_IDS.MONACO_EDITOR,
+    label: 'Monaco Editor (Beta)',
+    description: 'Use Monaco Editor (VS Code editor) for scripting. Provides multi-cursor editing, better autocomplete, and other VS Code features for pre-request, post-response, and test scripts.'
   }
 ];
 

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
@@ -1,24 +1,19 @@
-import React, { Suspense, lazy } from 'react';
+import React from 'react';
 import get from 'lodash/get';
 import find from 'lodash/find';
-import CodeEditor from 'components/CodeEditor';
+import ScriptEditor from 'components/ScriptEditor';
 import FormUrlEncodedParams from 'components/RequestPane/FormUrlEncodedParams';
 import MultipartFormParams from 'components/RequestPane/MultipartFormParams';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTheme } from 'providers/Theme';
-import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
 import { updateRequestBody } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { updateRequestBodyScrollPosition } from 'providers/ReduxStore/slices/tabs';
 import StyledWrapper from './StyledWrapper';
 import FileBody from '../FileBody/index';
 
-const LazyMonacoEditor = lazy(() => import('components/MonacoEditor'));
-
 const RequestBody = ({ item, collection }) => {
   const dispatch = useDispatch();
-  const useMonaco = useBetaFeature(BETA_FEATURES.MONACO_EDITOR);
-  const Editor = useMonaco ? LazyMonacoEditor : CodeEditor;
   const body = item.draft ? get(item, 'draft.request.body') : get(item, 'request.body');
   const bodyMode = item.draft ? get(item, 'draft.request.body.mode') : get(item, 'request.body.mode');
   const { displayedTheme } = useTheme();
@@ -66,24 +61,22 @@ const RequestBody = ({ item, collection }) => {
 
     return (
       <StyledWrapper className="w-full" data-testid="request-body-editor">
-        <Suspense fallback={null}>
-          <Editor
-            collection={collection}
-            item={item}
-            theme={displayedTheme}
-            font={get(preferences, 'font.codeFont', 'default')}
-            fontSize={get(preferences, 'font.codeFontSize')}
-            value={bodyContent[bodyMode] || ''}
-            onEdit={onEdit}
-            onRun={onRun}
-            onSave={onSave}
-            onScroll={onScroll}
-            initialScroll={focusedTab?.requestBodyScrollPosition || 0}
-            mode={codeMirrorMode[bodyMode]}
-            enableVariableHighlighting={true}
-            showHintsFor={['variables']}
-          />
-        </Suspense>
+        <ScriptEditor
+          collection={collection}
+          item={item}
+          theme={displayedTheme}
+          font={get(preferences, 'font.codeFont', 'default')}
+          fontSize={get(preferences, 'font.codeFontSize')}
+          value={bodyContent[bodyMode] || ''}
+          onEdit={onEdit}
+          onRun={onRun}
+          onSave={onSave}
+          onScroll={onScroll}
+          initialScroll={focusedTab?.requestBodyScrollPosition || 0}
+          mode={codeMirrorMode[bodyMode]}
+          enableVariableHighlighting={true}
+          showHintsFor={['variables']}
+        />
       </StyledWrapper>
     );
   }

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import get from 'lodash/get';
 import find from 'lodash/find';
 import CodeEditor from 'components/CodeEditor';
-import MonacoEditor from 'components/MonacoEditor';
 import FormUrlEncodedParams from 'components/RequestPane/FormUrlEncodedParams';
 import MultipartFormParams from 'components/RequestPane/MultipartFormParams';
 import { useDispatch, useSelector } from 'react-redux';
@@ -14,10 +13,12 @@ import { updateRequestBodyScrollPosition } from 'providers/ReduxStore/slices/tab
 import StyledWrapper from './StyledWrapper';
 import FileBody from '../FileBody/index';
 
+const LazyMonacoEditor = lazy(() => import('components/MonacoEditor'));
+
 const RequestBody = ({ item, collection }) => {
   const dispatch = useDispatch();
   const useMonaco = useBetaFeature(BETA_FEATURES.MONACO_EDITOR);
-  const Editor = useMonaco ? MonacoEditor : CodeEditor;
+  const Editor = useMonaco ? LazyMonacoEditor : CodeEditor;
   const body = item.draft ? get(item, 'draft.request.body') : get(item, 'request.body');
   const bodyMode = item.draft ? get(item, 'draft.request.body.mode') : get(item, 'request.body.mode');
   const { displayedTheme } = useTheme();
@@ -65,22 +66,24 @@ const RequestBody = ({ item, collection }) => {
 
     return (
       <StyledWrapper className="w-full" data-testid="request-body-editor">
-        <Editor
-          collection={collection}
-          item={item}
-          theme={displayedTheme}
-          font={get(preferences, 'font.codeFont', 'default')}
-          fontSize={get(preferences, 'font.codeFontSize')}
-          value={bodyContent[bodyMode] || ''}
-          onEdit={onEdit}
-          onRun={onRun}
-          onSave={onSave}
-          onScroll={onScroll}
-          initialScroll={focusedTab?.requestBodyScrollPosition || 0}
-          mode={codeMirrorMode[bodyMode]}
-          enableVariableHighlighting={true}
-          showHintsFor={['variables']}
-        />
+        <Suspense fallback={null}>
+          <Editor
+            collection={collection}
+            item={item}
+            theme={displayedTheme}
+            font={get(preferences, 'font.codeFont', 'default')}
+            fontSize={get(preferences, 'font.codeFontSize')}
+            value={bodyContent[bodyMode] || ''}
+            onEdit={onEdit}
+            onRun={onRun}
+            onSave={onSave}
+            onScroll={onScroll}
+            initialScroll={focusedTab?.requestBodyScrollPosition || 0}
+            mode={codeMirrorMode[bodyMode]}
+            enableVariableHighlighting={true}
+            showHintsFor={['variables']}
+          />
+        </Suspense>
       </StyledWrapper>
     );
   }

--- a/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/index.js
@@ -2,10 +2,12 @@ import React from 'react';
 import get from 'lodash/get';
 import find from 'lodash/find';
 import CodeEditor from 'components/CodeEditor';
+import MonacoEditor from 'components/MonacoEditor';
 import FormUrlEncodedParams from 'components/RequestPane/FormUrlEncodedParams';
 import MultipartFormParams from 'components/RequestPane/MultipartFormParams';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTheme } from 'providers/Theme';
+import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
 import { updateRequestBody } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { updateRequestBodyScrollPosition } from 'providers/ReduxStore/slices/tabs';
@@ -14,6 +16,8 @@ import FileBody from '../FileBody/index';
 
 const RequestBody = ({ item, collection }) => {
   const dispatch = useDispatch();
+  const useMonaco = useBetaFeature(BETA_FEATURES.MONACO_EDITOR);
+  const Editor = useMonaco ? MonacoEditor : CodeEditor;
   const body = item.draft ? get(item, 'draft.request.body') : get(item, 'request.body');
   const bodyMode = item.draft ? get(item, 'draft.request.body.mode') : get(item, 'request.body.mode');
   const { displayedTheme } = useTheme();
@@ -61,7 +65,7 @@ const RequestBody = ({ item, collection }) => {
 
     return (
       <StyledWrapper className="w-full" data-testid="request-body-editor">
-        <CodeEditor
+        <Editor
           collection={collection}
           item={item}
           theme={displayedTheme}

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import get from 'lodash/get';
 import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
-import CodeEditor from 'components/CodeEditor';
+import ScriptEditor from 'components/ScriptEditor';
 import { updateRequestScript, updateResponseScript } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { updateScriptPaneTab } from 'providers/ReduxStore/slices/tabs';
@@ -96,7 +96,7 @@ const Script = ({ item, collection }) => {
         </TabsList>
 
         <TabsContent value="pre-request" className="mt-2" dataTestId="pre-request-script-editor">
-          <CodeEditor
+          <ScriptEditor
             ref={preRequestEditorRef}
             collection={collection}
             value={requestScript || ''}
@@ -112,7 +112,7 @@ const Script = ({ item, collection }) => {
         </TabsContent>
 
         <TabsContent value="post-response" className="mt-2" dataTestId="post-response-script-editor">
-          <CodeEditor
+          <ScriptEditor
             ref={postResponseEditorRef}
             collection={collection}
             value={responseScript || ''}

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -99,6 +99,7 @@ const Script = ({ item, collection }) => {
           <ScriptEditor
             ref={preRequestEditorRef}
             collection={collection}
+            item={item}
             value={requestScript || ''}
             theme={displayedTheme}
             font={get(preferences, 'font.codeFont', 'default')}
@@ -115,6 +116,7 @@ const Script = ({ item, collection }) => {
           <ScriptEditor
             ref={postResponseEditorRef}
             collection={collection}
+            item={item}
             value={responseScript || ''}
             theme={displayedTheme}
             font={get(preferences, 'font.codeFont', 'default')}

--- a/packages/bruno-app/src/components/RequestPane/Tests/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Tests/index.js
@@ -30,6 +30,7 @@ const Tests = ({ item, collection }) => {
     <div data-testid="test-script-editor">
       <ScriptEditor
         collection={collection}
+        item={item}
         value={tests || ''}
         theme={displayedTheme}
         font={get(preferences, 'font.codeFont', 'default')}

--- a/packages/bruno-app/src/components/RequestPane/Tests/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Tests/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
-import CodeEditor from 'components/CodeEditor';
+import ScriptEditor from 'components/ScriptEditor';
 import { updateRequestTests } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { useTheme } from 'providers/Theme';
@@ -28,7 +28,7 @@ const Tests = ({ item, collection }) => {
 
   return (
     <div data-testid="test-script-editor">
-      <CodeEditor
+      <ScriptEditor
         collection={collection}
         value={tests || ''}
         theme={displayedTheme}

--- a/packages/bruno-app/src/components/ScriptEditor/index.js
+++ b/packages/bruno-app/src/components/ScriptEditor/index.js
@@ -1,12 +1,21 @@
-import React from 'react';
+import React, { Suspense, forwardRef, lazy } from 'react';
 import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
 import CodeEditor from 'components/CodeEditor';
-import MonacoEditor from 'components/MonacoEditor';
 
-const ScriptEditor = (props) => {
+const LazyMonacoEditor = lazy(() => import('components/MonacoEditor'));
+
+const ScriptEditor = forwardRef((props, ref) => {
   const useMonaco = useBetaFeature(BETA_FEATURES.MONACO_EDITOR);
-  const Editor = useMonaco ? MonacoEditor : CodeEditor;
-  return <Editor {...props} />;
-};
+
+  if (!useMonaco) {
+    return <CodeEditor ref={ref} {...props} />;
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <LazyMonacoEditor ref={ref} {...props} />
+    </Suspense>
+  );
+});
 
 export default ScriptEditor;

--- a/packages/bruno-app/src/components/ScriptEditor/index.js
+++ b/packages/bruno-app/src/components/ScriptEditor/index.js
@@ -4,6 +4,12 @@ import CodeEditor from 'components/CodeEditor';
 
 const LazyMonacoEditor = lazy(() => import('components/MonacoEditor'));
 
+const EditorLoadingFallback = () => (
+  <div style={{ padding: '8px 12px', opacity: 0.5, fontSize: '13px' }}>
+    Loading editor...
+  </div>
+);
+
 const ScriptEditor = forwardRef((props, ref) => {
   const useMonaco = useBetaFeature(BETA_FEATURES.MONACO_EDITOR);
 
@@ -12,10 +18,12 @@ const ScriptEditor = forwardRef((props, ref) => {
   }
 
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<EditorLoadingFallback />}>
       <LazyMonacoEditor ref={ref} {...props} />
     </Suspense>
   );
 });
+
+ScriptEditor.displayName = 'ScriptEditor';
 
 export default ScriptEditor;

--- a/packages/bruno-app/src/components/ScriptEditor/index.js
+++ b/packages/bruno-app/src/components/ScriptEditor/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
+import CodeEditor from 'components/CodeEditor';
+import MonacoEditor from 'components/MonacoEditor';
+
+const ScriptEditor = (props) => {
+  const useMonaco = useBetaFeature(BETA_FEATURES.MONACO_EDITOR);
+  const Editor = useMonaco ? MonacoEditor : CodeEditor;
+  return <Editor {...props} />;
+};
+
+export default ScriptEditor;

--- a/packages/bruno-app/src/components/ScriptEditor/index.spec.js
+++ b/packages/bruno-app/src/components/ScriptEditor/index.spec.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { ThemeProvider } from 'styled-components';
+
+jest.mock('components/CodeEditor', () => {
+  return function MockCodeEditor(props) {
+    return <div data-testid="codemirror-editor" />;
+  };
+});
+
+jest.mock('components/MonacoEditor', () => {
+  return function MockMonacoEditor(props) {
+    return <div data-testid="monaco-editor" />;
+  };
+});
+
+const MOCK_THEME = {
+  codemirror: {
+    bg: '#1e1e1e',
+    border: '#333'
+  }
+};
+
+const createMockStore = (monacoEnabled = false) => {
+  return configureStore({
+    reducer: {
+      app: (state = {
+        preferences: {
+          beta: {
+            'monaco-editor': monacoEnabled
+          }
+        }
+      }) => state
+    }
+  });
+};
+
+const ScriptEditor = require('./index').default;
+
+describe('ScriptEditor', () => {
+  it('renders CodeEditor when Monaco beta feature is disabled', () => {
+    const store = createMockStore(false);
+    const { getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <ThemeProvider theme={MOCK_THEME}>
+          <ScriptEditor />
+        </ThemeProvider>
+      </Provider>
+    );
+
+    expect(getByTestId('codemirror-editor')).toBeTruthy();
+    expect(queryByTestId('monaco-editor')).toBeNull();
+  });
+
+  it('renders MonacoEditor when Monaco beta feature is enabled', () => {
+    const store = createMockStore(true);
+    const { getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <ThemeProvider theme={MOCK_THEME}>
+          <ScriptEditor />
+        </ThemeProvider>
+      </Provider>
+    );
+
+    expect(getByTestId('monaco-editor')).toBeTruthy();
+    expect(queryByTestId('codemirror-editor')).toBeNull();
+  });
+
+  it('passes props through to the selected editor', () => {
+    const store = createMockStore(false);
+    const mockOnEdit = jest.fn();
+
+    jest.isolateModules(() => {
+      jest.doMock('components/CodeEditor', () => {
+        return function MockCodeEditor(props) {
+          return <div data-testid="codemirror-editor" data-mode={props.mode} />;
+        };
+      });
+    });
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ThemeProvider theme={MOCK_THEME}>
+          <ScriptEditor mode="javascript" onEdit={mockOnEdit} />
+        </ThemeProvider>
+      </Provider>
+    );
+
+    expect(getByTestId('codemirror-editor')).toBeTruthy();
+  });
+});

--- a/packages/bruno-app/src/components/ScriptEditor/index.spec.js
+++ b/packages/bruno-app/src/components/ScriptEditor/index.spec.js
@@ -1,20 +1,21 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { ThemeProvider } from 'styled-components';
 
-jest.mock('components/CodeEditor', () => {
-  return function MockCodeEditor(props) {
-    return <div data-testid="codemirror-editor" />;
-  };
+const mockCodeEditor = jest.fn((props) => {
+  return <div data-testid="codemirror-editor" />;
 });
 
-jest.mock('components/MonacoEditor', () => {
-  return function MockMonacoEditor(props) {
+jest.mock('components/CodeEditor', () => mockCodeEditor);
+
+jest.mock('components/MonacoEditor', () => ({
+  __esModule: true,
+  default: function MockMonacoEditor(props) {
     return <div data-testid="monaco-editor" />;
-  };
-});
+  }
+}));
 
 const MOCK_THEME = {
   codemirror: {
@@ -54,9 +55,9 @@ describe('ScriptEditor', () => {
     expect(queryByTestId('monaco-editor')).toBeNull();
   });
 
-  it('renders MonacoEditor when Monaco beta feature is enabled', () => {
+  it('renders MonacoEditor when Monaco beta feature is enabled', async () => {
     const store = createMockStore(true);
-    const { getByTestId, queryByTestId } = render(
+    const { findByTestId, queryByTestId } = render(
       <Provider store={store}>
         <ThemeProvider theme={MOCK_THEME}>
           <ScriptEditor />
@@ -64,23 +65,16 @@ describe('ScriptEditor', () => {
       </Provider>
     );
 
-    expect(getByTestId('monaco-editor')).toBeTruthy();
+    expect(await findByTestId('monaco-editor')).toBeTruthy();
     expect(queryByTestId('codemirror-editor')).toBeNull();
   });
 
   it('passes props through to the selected editor', () => {
     const store = createMockStore(false);
     const mockOnEdit = jest.fn();
+    mockCodeEditor.mockClear();
 
-    jest.isolateModules(() => {
-      jest.doMock('components/CodeEditor', () => {
-        return function MockCodeEditor(props) {
-          return <div data-testid="codemirror-editor" data-mode={props.mode} />;
-        };
-      });
-    });
-
-    const { getByTestId } = render(
+    render(
       <Provider store={store}>
         <ThemeProvider theme={MOCK_THEME}>
           <ScriptEditor mode="javascript" onEdit={mockOnEdit} />
@@ -88,6 +82,9 @@ describe('ScriptEditor', () => {
       </Provider>
     );
 
-    expect(getByTestId('codemirror-editor')).toBeTruthy();
+    expect(mockCodeEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'javascript', onEdit: mockOnEdit }),
+      undefined
+    );
   });
 });

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -549,6 +549,24 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.25rem;
   }
 
+  /* Monaco tooltip textarea editor (used instead of CodeMirror inline editor) */
+  .CodeMirror-brunoVarInfo .var-value-editor-textarea {
+    display: none;
+    width: 100%;
+    min-height: 1.75rem;
+    max-height: 11.125rem;
+    resize: vertical;
+    box-sizing: border-box;
+    padding: 0.375rem 0.5rem;
+    border: none;
+    outline: none;
+    background: inherit;
+    color: inherit;
+    font-family: Inter, sans-serif;
+    font-size: inherit;
+    line-height: 1.25rem;
+  }
+
   // Active/selected hint - using theme colors instead of hardcoded blue
   .CodeMirror-hint-active {
     background: ${(props) => props.theme.dropdown.hoverBg} !important;

--- a/packages/bruno-app/src/utils/beta-features.js
+++ b/packages/bruno-app/src/utils/beta-features.js
@@ -6,7 +6,8 @@ import { useSelector } from 'react-redux';
  */
 export const BETA_FEATURES = Object.freeze({
   NODE_VM: 'nodevm',
-  OPENAPI_SYNC: 'openapi-sync'
+  OPENAPI_SYNC: 'openapi-sync',
+  MONACO_EDITOR: 'monaco-editor'
 });
 
 /**

--- a/packages/bruno-app/src/utils/monaco/autocomplete.js
+++ b/packages/bruno-app/src/utils/monaco/autocomplete.js
@@ -109,6 +109,12 @@ export const setupAutoComplete = (editor, collectionRef, itemRef) => {
   const completionProvider = {
     triggerCharacters: ['{', '.', '$'],
     provideCompletionItems(model, position) {
+      // Only provide completions for this editor's model — prevents cross-editor leaking
+      // when multiple MonacoEditors are mounted simultaneously
+      if (model !== editor.getModel()) {
+        return { suggestions: [] };
+      }
+
       const textUntilPosition = model.getValueInRange({
         startLineNumber: position.lineNumber,
         startColumn: 1,

--- a/packages/bruno-app/src/utils/monaco/autocomplete.js
+++ b/packages/bruno-app/src/utils/monaco/autocomplete.js
@@ -1,0 +1,200 @@
+import * as monaco from 'monaco-editor';
+import { mockDataFunctions } from '@usebruno/common';
+import { getAllVariables } from 'utils/collections';
+
+const MOCK_DATA_HINTS = Object.keys(mockDataFunctions).map((key) => `$${key}`);
+
+const VARIABLE_PATTERN = /\{\{([\w$.-]*)$/;
+
+// ─── Variable Hints ─────────────────────────────────────────
+
+const shouldSkipVariableKey = (key) => {
+  return key === 'pathParams' || key === 'maskedEnvVariables' || key === 'process';
+};
+
+const transformVariablesToHints = (allVariables = {}) => {
+  const hints = [];
+  Object.keys(allVariables).forEach((key) => {
+    if (!shouldSkipVariableKey(key)) {
+      hints.push(key);
+    }
+  });
+  if (allVariables.process && allVariables.process.env) {
+    Object.keys(allVariables.process.env).forEach((key) => {
+      hints.push(`process.env.${key}`);
+    });
+  }
+  return hints;
+};
+
+const generateProgressiveHints = (fullHint) => {
+  const parts = fullHint.split('.');
+  const progressiveHints = [];
+  for (let i = 1; i <= parts.length; i++) {
+    progressiveHints.push(parts.slice(0, i).join('.'));
+  }
+  return progressiveHints;
+};
+
+// ─── Segment Extraction (matches CodeMirror logic) ──────────
+
+const extractNextSegmentSuggestions = (filteredHints, currentInput) => {
+  const prefixMatches = new Set();
+  const substringMatches = new Set();
+  const lowerInput = currentInput.toLowerCase();
+
+  filteredHints.forEach((hint) => {
+    const lowerHint = hint.toLowerCase();
+
+    if (lowerHint.startsWith(lowerInput)) {
+      if (lowerHint === lowerInput) {
+        prefixMatches.add(hint.substring(hint.lastIndexOf('.') + 1));
+        return;
+      }
+
+      const inputLength = currentInput.length;
+
+      if (currentInput.endsWith('.')) {
+        const afterDot = hint.substring(inputLength);
+        const nextDot = afterDot.indexOf('.');
+        const segment = nextDot === -1 ? afterDot : afterDot.substring(0, nextDot);
+        prefixMatches.add(segment);
+      } else {
+        const lastDotInInput = currentInput.lastIndexOf('.');
+        const currentSegmentStart = lastDotInInput + 1;
+        const nextDotAfterInput = hint.indexOf('.', currentSegmentStart);
+        const segment = nextDotAfterInput === -1
+          ? hint.substring(currentSegmentStart)
+          : hint.substring(currentSegmentStart, nextDotAfterInput);
+        prefixMatches.add(segment);
+      }
+    } else if (lowerHint.includes(lowerInput)) {
+      substringMatches.add(hint);
+    }
+  });
+
+  return [...Array.from(prefixMatches).sort(), ...Array.from(substringMatches).sort()];
+};
+
+// ─── Build Hints ────────────────────────────────────────────
+
+const buildVariableHints = (allVariables) => {
+  const hints = new Set();
+  MOCK_DATA_HINTS.forEach((h) => generateProgressiveHints(h).forEach((p) => hints.add(p)));
+  transformVariablesToHints(allVariables).forEach((h) => generateProgressiveHints(h).forEach((p) => hints.add(p)));
+  return Array.from(hints).sort();
+};
+
+// ─── Monaco Completion Provider ─────────────────────────────
+
+/**
+ * Sets up variable autocomplete for the Monaco editor.
+ * Provides {{variable}} suggestions inside double braces, including:
+ * - Collection/environment/runtime variables
+ * - $mockFunction names
+ * - process.env.* keys
+ *
+ * API hints (req, res, bru) are handled by Monaco's built-in IntelliSense
+ * via the type definitions registered in brunoApiTypes.js.
+ *
+ * Returns a dispose function.
+ */
+// All languages the Monaco editor may use (from languageMapping.js)
+const SUPPORTED_LANGUAGES = ['javascript', 'json', 'xml', 'html', 'yaml', 'plaintext', 'markdown', 'shell'];
+
+export const setupAutoComplete = (editor, collectionRef, itemRef) => {
+  const getCollection = () => (typeof collectionRef === 'function' ? collectionRef() : collectionRef);
+  const getItem = () => (typeof itemRef === 'function' ? itemRef() : itemRef);
+
+  const completionProvider = {
+    triggerCharacters: ['{', '.', '$'],
+    provideCompletionItems(model, position) {
+      const textUntilPosition = model.getValueInRange({
+        startLineNumber: position.lineNumber,
+        startColumn: 1,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column
+      });
+
+      const variableMatch = textUntilPosition.match(VARIABLE_PATTERN);
+      if (!variableMatch) {
+        return { suggestions: [] };
+      }
+
+      const typed = variableMatch[1]; // text after {{
+      // Convert 0-indexed string position to 1-indexed Monaco column
+      const braceStartCol = textUntilPosition.lastIndexOf('{{') + 2 + 1;
+
+      const collection = getCollection();
+      const item = getItem();
+      const allVariables = getAllVariables(collection, item);
+      const { pathParams, maskedEnvVariables, ...varLookup } = allVariables;
+
+      const allHints = buildVariableHints(varLookup);
+      const filtered = allHints.filter((h) => h.toLowerCase().includes(typed.toLowerCase()));
+      const segments = extractNextSegmentSuggestions(filtered, typed).slice(0, 50);
+
+      // Determine replacement range — replace from last dot or from start of typed text
+      let replaceStartCol;
+      if (typed.endsWith('.')) {
+        replaceStartCol = position.column;
+      } else {
+        const lastDot = typed.lastIndexOf('.');
+        replaceStartCol = lastDot !== -1
+          ? braceStartCol + lastDot + 1
+          : braceStartCol;
+      }
+
+      const range = new monaco.Range(
+        position.lineNumber,
+        replaceStartCol,
+        position.lineNumber,
+        position.column
+      );
+
+      return {
+        // incomplete: true tells Monaco to re-invoke the provider on each keystroke,
+        // so suggestions update as the user types inside {{...}}
+        incomplete: true,
+        suggestions: segments.map((segment, i) => ({
+          label: segment,
+          kind: monaco.languages.CompletionItemKind.Variable,
+          insertText: segment,
+          range,
+          sortText: String(i).padStart(4, '0')
+        }))
+      };
+    }
+  };
+
+  // Register for all supported languages so {{variables}} work in body editors (json, xml, etc.)
+  const disposables = SUPPORTED_LANGUAGES.map((lang) =>
+    monaco.languages.registerCompletionItemProvider(lang, completionProvider)
+  );
+
+  // Auto-trigger suggestions when typing inside {{...}}
+  // This ensures the suggest widget opens regardless of language-specific quickSuggestions settings
+  const contentChangeDisposable = editor.onDidChangeModelContent(() => {
+    const position = editor.getPosition();
+    if (!position) return;
+
+    const model = editor.getModel();
+    if (!model) return;
+
+    const textUntilPosition = model.getValueInRange({
+      startLineNumber: position.lineNumber,
+      startColumn: 1,
+      endLineNumber: position.lineNumber,
+      endColumn: position.column
+    });
+
+    if (VARIABLE_PATTERN.test(textUntilPosition)) {
+      editor.trigger('bruno-autocomplete', 'editor.action.triggerSuggest', {});
+    }
+  });
+
+  return () => {
+    disposables.forEach((d) => d.dispose());
+    contentChangeDisposable.dispose();
+  };
+};

--- a/packages/bruno-app/src/utils/monaco/autocomplete.js
+++ b/packages/bruno-app/src/utils/monaco/autocomplete.js
@@ -85,98 +85,108 @@ const buildVariableHints = (allVariables) => {
   return Array.from(hints).sort();
 };
 
-// ─── Monaco Completion Provider ─────────────────────────────
+// ─── Singleton Completion Provider ──────────────────────────
+// Providers are registered once globally per language. Each editor
+// registers/unregisters itself in the registry so the provider can
+// resolve the correct collection and item for the active model.
+
+const editorRegistry = new Map();
+let providersRegistered = false;
+
+const SUPPORTED_LANGUAGES = ['javascript', 'json', 'xml', 'html', 'yaml', 'plaintext', 'markdown', 'shell'];
+
+const completionProvider = {
+  triggerCharacters: ['{', '.', '$'],
+  provideCompletionItems(model, position) {
+    const entry = editorRegistry.get(model.uri.toString());
+    if (!entry) {
+      return { suggestions: [] };
+    }
+
+    const textUntilPosition = model.getValueInRange({
+      startLineNumber: position.lineNumber,
+      startColumn: 1,
+      endLineNumber: position.lineNumber,
+      endColumn: position.column
+    });
+
+    const variableMatch = textUntilPosition.match(VARIABLE_PATTERN);
+    if (!variableMatch) {
+      return { suggestions: [] };
+    }
+
+    const typed = variableMatch[1]; // text after {{
+    // Convert 0-indexed string position to 1-indexed Monaco column
+    const braceStartCol = textUntilPosition.lastIndexOf('{{') + 2 + 1;
+
+    const collection = entry.getCollection();
+    const item = entry.getItem();
+    const allVariables = getAllVariables(collection, item);
+    const { pathParams, maskedEnvVariables, ...varLookup } = allVariables;
+
+    const allHints = buildVariableHints(varLookup);
+    const filtered = allHints.filter((h) => h.toLowerCase().includes(typed.toLowerCase()));
+    const segments = extractNextSegmentSuggestions(filtered, typed).slice(0, 50);
+
+    // Determine replacement range — replace from last dot or from start of typed text
+    let replaceStartCol;
+    if (typed.endsWith('.')) {
+      replaceStartCol = position.column;
+    } else {
+      const lastDot = typed.lastIndexOf('.');
+      replaceStartCol = lastDot !== -1
+        ? braceStartCol + lastDot + 1
+        : braceStartCol;
+    }
+
+    const range = new monaco.Range(
+      position.lineNumber,
+      replaceStartCol,
+      position.lineNumber,
+      position.column
+    );
+
+    return {
+      // incomplete: true tells Monaco to re-invoke the provider on each keystroke,
+      // so suggestions update as the user types inside {{...}}
+      incomplete: true,
+      suggestions: segments.map((segment, i) => ({
+        label: segment,
+        kind: monaco.languages.CompletionItemKind.Variable,
+        insertText: segment,
+        range,
+        sortText: String(i).padStart(4, '0')
+      }))
+    };
+  }
+};
+
+const ensureProvidersRegistered = () => {
+  if (providersRegistered) return;
+  providersRegistered = true;
+  SUPPORTED_LANGUAGES.forEach((lang) =>
+    monaco.languages.registerCompletionItemProvider(lang, completionProvider)
+  );
+};
 
 /**
  * Sets up variable autocomplete for the Monaco editor.
- * Provides {{variable}} suggestions inside double braces, including:
- * - Collection/environment/runtime variables
- * - $mockFunction names
- * - process.env.* keys
- *
- * API hints (req, res, bru) are handled by Monaco's built-in IntelliSense
- * via the type definitions registered in brunoApiTypes.js.
+ * Providers are registered once globally (singleton); each editor instance
+ * registers itself in a model-keyed registry so the shared provider can
+ * resolve the correct collection/item context.
  *
  * Returns a dispose function.
  */
-// All languages the Monaco editor may use (from languageMapping.js)
-const SUPPORTED_LANGUAGES = ['javascript', 'json', 'xml', 'html', 'yaml', 'plaintext', 'markdown', 'shell'];
-
 export const setupAutoComplete = (editor, collectionRef, itemRef) => {
   const getCollection = () => (typeof collectionRef === 'function' ? collectionRef() : collectionRef);
   const getItem = () => (typeof itemRef === 'function' ? itemRef() : itemRef);
 
-  const completionProvider = {
-    triggerCharacters: ['{', '.', '$'],
-    provideCompletionItems(model, position) {
-      // Only provide completions for this editor's model — prevents cross-editor leaking
-      // when multiple MonacoEditors are mounted simultaneously
-      if (model !== editor.getModel()) {
-        return { suggestions: [] };
-      }
+  const modelUri = editor.getModel()?.uri.toString();
+  if (modelUri) {
+    editorRegistry.set(modelUri, { getCollection, getItem });
+  }
 
-      const textUntilPosition = model.getValueInRange({
-        startLineNumber: position.lineNumber,
-        startColumn: 1,
-        endLineNumber: position.lineNumber,
-        endColumn: position.column
-      });
-
-      const variableMatch = textUntilPosition.match(VARIABLE_PATTERN);
-      if (!variableMatch) {
-        return { suggestions: [] };
-      }
-
-      const typed = variableMatch[1]; // text after {{
-      // Convert 0-indexed string position to 1-indexed Monaco column
-      const braceStartCol = textUntilPosition.lastIndexOf('{{') + 2 + 1;
-
-      const collection = getCollection();
-      const item = getItem();
-      const allVariables = getAllVariables(collection, item);
-      const { pathParams, maskedEnvVariables, ...varLookup } = allVariables;
-
-      const allHints = buildVariableHints(varLookup);
-      const filtered = allHints.filter((h) => h.toLowerCase().includes(typed.toLowerCase()));
-      const segments = extractNextSegmentSuggestions(filtered, typed).slice(0, 50);
-
-      // Determine replacement range — replace from last dot or from start of typed text
-      let replaceStartCol;
-      if (typed.endsWith('.')) {
-        replaceStartCol = position.column;
-      } else {
-        const lastDot = typed.lastIndexOf('.');
-        replaceStartCol = lastDot !== -1
-          ? braceStartCol + lastDot + 1
-          : braceStartCol;
-      }
-
-      const range = new monaco.Range(
-        position.lineNumber,
-        replaceStartCol,
-        position.lineNumber,
-        position.column
-      );
-
-      return {
-        // incomplete: true tells Monaco to re-invoke the provider on each keystroke,
-        // so suggestions update as the user types inside {{...}}
-        incomplete: true,
-        suggestions: segments.map((segment, i) => ({
-          label: segment,
-          kind: monaco.languages.CompletionItemKind.Variable,
-          insertText: segment,
-          range,
-          sortText: String(i).padStart(4, '0')
-        }))
-      };
-    }
-  };
-
-  // Register for all supported languages so {{variables}} work in body editors (json, xml, etc.)
-  const disposables = SUPPORTED_LANGUAGES.map((lang) =>
-    monaco.languages.registerCompletionItemProvider(lang, completionProvider)
-  );
+  ensureProvidersRegistered();
 
   // Auto-trigger suggestions when typing inside {{...}}
   // This ensures the suggest widget opens regardless of language-specific quickSuggestions settings
@@ -200,7 +210,9 @@ export const setupAutoComplete = (editor, collectionRef, itemRef) => {
   });
 
   return () => {
-    disposables.forEach((d) => d.dispose());
+    if (modelUri) {
+      editorRegistry.delete(modelUri);
+    }
     contentChangeDisposable.dispose();
   };
 };

--- a/packages/bruno-app/src/utils/monaco/brunoApiTypes.js
+++ b/packages/bruno-app/src/utils/monaco/brunoApiTypes.js
@@ -1,0 +1,657 @@
+import * as monaco from 'monaco-editor';
+
+let typesRegistered = false;
+
+/**
+ * Registers the Bruno scripting API type definitions with Monaco's
+ * JavaScript language service. Enables autocomplete and hover docs
+ * for bru, req, and res objects.
+ *
+ * Type definitions are derived from the source implementations in
+ * packages/bruno-js/src/ (bru.js, bruno-request.js, bruno-response.js).
+ *
+ * Must be called after Monaco is loaded (not at module top level).
+ */
+export const registerBrunoApiTypes = () => {
+  if (typesRegistered) return;
+  typesRegistered = true;
+
+  const typeDefs = `
+/**
+ * Bruno Request object — available in pre-request and post-response scripts.
+ *
+ * Shorthand properties (url, method, headers, body, timeout) are read-only.
+ * Use the setter methods to modify request properties.
+ *
+ * @see https://docs.usebruno.com/scripting/request
+ */
+declare const req: BrunoRequest;
+
+/**
+ * Bruno Response object — available in post-response scripts and tests.
+ *
+ * The response object is also callable as a function for query operations:
+ * \`res('data.users[0].name')\`
+ *
+ * @see https://docs.usebruno.com/scripting/response
+ */
+declare const res: BrunoResponse;
+
+/**
+ * Bruno Runtime API — available in all scripts (pre-request, post-response, tests).
+ *
+ * Provides access to variables, environment, cookies, and utility functions.
+ *
+ * @see https://docs.usebruno.com/scripting/bru
+ */
+declare const bru: BrunoRuntime;
+
+/**
+ * Chai-compatible expect assertion function.
+ * @example
+ * expect(res.getStatus()).to.equal(200);
+ * expect(res.getBody().name).to.be.a('string');
+ */
+declare const expect: any;
+
+/**
+ * Define a test case.
+ * @param name - The name of the test
+ * @param fn - The test function (can be async)
+ * @example
+ * test('should return 200', () => {
+ *   expect(res.getStatus()).to.equal(200);
+ * });
+ */
+declare function test(name: string, fn: () => void | Promise<void>): void;
+
+interface BrunoRequest {
+  /** The request URL (read-only shorthand — use setUrl() to modify) */
+  readonly url: string;
+  /** The HTTP method (read-only shorthand — use setMethod() to modify) */
+  readonly method: string;
+  /** The request headers (read-only shorthand — use setHeader()/setHeaders() to modify) */
+  readonly headers: Record<string, string>;
+  /**
+   * The request body. Automatically parsed to an object if Content-Type is JSON.
+   * (read-only shorthand — use setBody() to modify)
+   */
+  readonly body: any;
+  /** The request timeout in ms (read-only shorthand — use setTimeout() to modify) */
+  readonly timeout: number;
+  /** The request name */
+  readonly name: string;
+  /** Path parameters as key-value pairs */
+  readonly pathParams: Record<string, string>;
+  /** Tags associated with this request */
+  readonly tags: string[];
+
+  /** Get the full request URL */
+  getUrl(): string;
+
+  /**
+   * Set the request URL.
+   * @param url - The new URL
+   * @example req.setUrl('https://api.example.com/users');
+   */
+  setUrl(url: string): void;
+
+  /**
+   * Get the hostname from the URL.
+   * @example req.getHost() // 'api.example.com'
+   */
+  getHost(): string;
+
+  /**
+   * Get the path from the URL. Path parameters are interpolated.
+   * @example req.getPath() // '/api/users/123'
+   */
+  getPath(): string;
+
+  /**
+   * Get the query string from the URL (without the leading '?').
+   * @example req.getQueryString() // 'page=1&limit=10'
+   */
+  getQueryString(): string;
+
+  /** Get the HTTP method (GET, POST, PUT, etc.) */
+  getMethod(): string;
+
+  /**
+   * Set the HTTP method.
+   * @param method - The HTTP method (GET, POST, PUT, DELETE, PATCH, etc.)
+   */
+  setMethod(method: string): void;
+
+  /**
+   * Get the authentication mode used for this request.
+   * @returns One of: 'oauth2', 'oauth1', 'bearer', 'basic', 'awsv4', 'digest', 'wsse', 'none'
+   */
+  getAuthMode(): 'oauth2' | 'oauth1' | 'bearer' | 'basic' | 'awsv4' | 'digest' | 'wsse' | 'none';
+
+  /**
+   * Get a specific header value by name.
+   * @param name - The header name (case-sensitive)
+   */
+  getHeader(name: string): string | undefined;
+
+  /** Get all request headers as a key-value object */
+  getHeaders(): Record<string, string>;
+
+  /**
+   * Set a single request header.
+   * @param name - The header name
+   * @param value - The header value
+   * @example req.setHeader('Authorization', 'Bearer token123');
+   */
+  setHeader(name: string, value: string): void;
+
+  /**
+   * Replace all request headers.
+   * @param headers - Object containing all headers
+   */
+  setHeaders(headers: Record<string, string>): void;
+
+  /**
+   * Delete a single request header.
+   * Also prevents default headers (like User-Agent) from being re-added.
+   * @param name - The header name to delete
+   */
+  deleteHeader(name: string): void;
+
+  /**
+   * Delete multiple request headers.
+   * @param names - Array of header names to delete
+   * @example req.deleteHeaders(['X-Custom-Header', 'Authorization']);
+   */
+  deleteHeaders(names: string[]): void;
+
+  /**
+   * Get the request body.
+   * JSON bodies are automatically parsed to objects.
+   * Pass \`{ raw: true }\` to get the raw string body.
+   * @example
+   * req.getBody()             // { name: 'John' } (parsed)
+   * req.getBody({ raw: true }) // '{"name":"John"}' (raw string)
+   */
+  getBody(options?: { raw?: boolean }): any;
+
+  /**
+   * Set the request body.
+   * For JSON content types, objects are automatically stringified.
+   * Pass \`{ raw: true }\` to set the body as-is without processing.
+   * @example
+   * req.setBody({ name: 'John' });
+   * req.setBody('raw string data', { raw: true });
+   */
+  setBody(data: any, options?: { raw?: boolean }): void;
+
+  /**
+   * Set the maximum number of redirects to follow.
+   * @param maxRedirects - Maximum redirects (0 to disable)
+   */
+  setMaxRedirects(maxRedirects: number): void;
+
+  /** Get the request timeout in milliseconds */
+  getTimeout(): number;
+
+  /**
+   * Set the request timeout.
+   * @param timeout - Timeout in milliseconds
+   */
+  setTimeout(timeout: number): void;
+
+  /**
+   * Get the execution mode of the request.
+   * @returns The execution mode string (e.g., 'standalone' or 'runner')
+   */
+  getExecutionMode(): string;
+
+  /** Get the request name as defined in the collection */
+  getName(): string;
+
+  /**
+   * Get the path parameters for this request.
+   * @returns Array of path parameter objects with name, value, and type
+   */
+  getPathParams(): Array<{ name: string; value: string; type: string }>;
+
+  /**
+   * Get the tags associated with this request.
+   * @returns Array of tag strings
+   */
+  getTags(): string[];
+
+  /**
+   * Disable automatic JSON parsing of the response body.
+   * Useful when you need the raw response string.
+   */
+  disableParsingResponseJson(): void;
+
+  /**
+   * Register an error handler that runs if the request fails.
+   * @param callback - Function called with the error object
+   * @example
+   * req.onFail((err) => {
+   *   console.log('Request failed:', err.message);
+   * });
+   */
+  onFail(callback: (err: Error) => void): void;
+}
+
+interface BrunoResponse {
+  /** The HTTP status code (e.g., 200, 404) */
+  readonly status: number;
+  /** The HTTP status text (e.g., 'OK', 'Not Found') */
+  readonly statusText: string;
+  /** The response headers */
+  readonly headers: Record<string, string>;
+  /** The response body (automatically parsed if JSON) */
+  readonly body: any;
+  /** The response time in milliseconds */
+  readonly responseTime: number;
+  /** The final URL after redirects */
+  readonly url: string;
+
+  /** Get the HTTP status code */
+  getStatus(): number;
+
+  /** Get the HTTP status text */
+  getStatusText(): string;
+
+  /**
+   * Get a specific response header value.
+   * @param name - The header name
+   */
+  getHeader(name: string): string | undefined;
+
+  /** Get all response headers */
+  getHeaders(): Record<string, string>;
+
+  /** Get the response body */
+  getBody(): any;
+
+  /**
+   * Replace the response body. Also updates the underlying data buffer.
+   * @param data - The new body data
+   */
+  setBody(data: any): void;
+
+  /** Get the response time in milliseconds */
+  getResponseTime(): number;
+
+  /**
+   * Get the response size breakdown in bytes.
+   * @returns Object with header, body, and total sizes
+   * @example
+   * const size = res.getSize();
+   * console.log(size.body);  // body size in bytes
+   * console.log(size.total); // total size in bytes
+   */
+  getSize(): { header: number; body: number; total: number };
+
+  /** Get the final URL after redirects */
+  getUrl(): string;
+
+  /**
+   * Get the raw response data buffer.
+   * @returns The underlying Buffer object
+   */
+  getDataBuffer(): any;
+}
+
+interface BrunoCookieJar {
+  getCookie(url: string, name: string, callback?: Function): any;
+  getCookies(url: string, callback?: Function): any[];
+  setCookie(rawCookie: string, url: string, callback?: Function): void;
+  setCookies(cookies: string[]): void;
+  clear(): void;
+  deleteCookies(url: string): void;
+  deleteCookie(url: string, name: string): void;
+  hasCookie(url: string, name: string): boolean;
+}
+
+interface BrunoCookies {
+  /** Get a cookie value by name */
+  get(name: string): string | undefined;
+  /** Check if a cookie exists */
+  has(name: string): boolean;
+  /** Get the first cookie */
+  one(): any;
+  /** Get all cookies as an array */
+  all(): any[];
+  /** Get the number of cookies */
+  count(): number;
+  /** Get a cookie by index */
+  idx(index: number): any;
+  /** Find the index of a cookie by name */
+  indexOf(name: string): number;
+  /** Find a cookie matching a predicate */
+  find(predicate: (cookie: any) => boolean): any;
+  /** Filter cookies matching a predicate */
+  filter(predicate: (cookie: any) => boolean): any[];
+  /** Iterate over each cookie */
+  each(callback: (cookie: any) => void): void;
+  /** Map cookies to a new array */
+  map<T>(callback: (cookie: any) => T): T[];
+  /** Reduce cookies to a single value */
+  reduce<T>(callback: (acc: T, cookie: any) => T, initial: T): T;
+  /** Convert all cookies to a key-value object */
+  toObject(): Record<string, string>;
+  /** Convert all cookies to a string */
+  toString(): string;
+  /** Add a new cookie */
+  add(name: string, value: string): void;
+  /** Add or update a cookie */
+  upsert(name: string, value: string): void;
+  /** Remove a cookie by name */
+  remove(name: string): void;
+  /** Delete a cookie by name */
+  delete(name: string): void;
+  /** Clear all cookies */
+  clear(): void;
+  /** Get the underlying cookie jar for advanced operations */
+  jar(): BrunoCookieJar;
+}
+
+interface BrunoRunner {
+  /**
+   * Set the next request to execute in the runner.
+   * @param requestName - The name of the next request
+   */
+  setNextRequest(requestName: string): void;
+  /** Skip the current request in the runner */
+  skipRequest(): void;
+  /** Stop the runner execution entirely */
+  stopExecution(): void;
+}
+
+interface BrunoUtils {
+  /**
+   * Minify a JSON string or object by removing whitespace.
+   * @param json - A JSON string or object to minify
+   * @returns The minified JSON string
+   * @throws Error if the input is not valid JSON
+   * @example bru.utils.minifyJson('{ "key": "value" }') // '{"key":"value"}'
+   */
+  minifyJson(json: string | object): string;
+
+  /**
+   * Minify an XML string by removing whitespace and indentation.
+   * @param xml - The XML string to minify
+   * @returns The minified XML string
+   * @throws Error if the input is not a valid string
+   */
+  minifyXml(xml: string): string;
+}
+
+interface BrunoRuntime {
+  /**
+   * Get the current working directory of the collection.
+   * @returns The absolute path to the collection folder
+   */
+  cwd(): string;
+
+  /**
+   * Get the collection name.
+   * @returns The name of the current collection
+   */
+  getCollectionName(): string;
+
+  /**
+   * Check if running in safe mode (QuickJS sandbox).
+   * @returns true if safe mode (QuickJS), false if Node VM
+   */
+  isSafeMode(): boolean;
+
+  // ─── Environment Variables ─────────────────────────────────
+
+  /**
+   * Get the active environment name.
+   * @returns The name of the currently selected environment
+   * @example
+   * const envName = bru.getEnvName(); // 'Production'
+   */
+  getEnvName(): string;
+
+  /**
+   * Get an environment variable value. Values containing \`{{references}}\` are interpolated.
+   * @param key - The variable name
+   * @example bru.getEnvVar('baseUrl') // 'https://api.example.com'
+   */
+  getEnvVar(key: string): any;
+
+  /**
+   * Set an environment variable. The value is available for the duration of the request lifecycle.
+   * @param key - The variable name (alphanumeric, hyphens, underscores, dots only)
+   * @param value - The variable value
+   * @example bru.setEnvVar('token', 'abc123');
+   */
+  setEnvVar(key: string, value: any): void;
+  /**
+   * Set an environment variable with options.
+   * @param key - The variable name
+   * @param value - The variable value (must be a string when persist is true)
+   * @param options - Options object
+   * @param options.persist - If true, the value is persisted to the environment file on disk
+   * @example bru.setEnvVar('token', 'abc123', { persist: true });
+   */
+  setEnvVar(key: string, value: any, options: { persist?: boolean }): void;
+
+  /**
+   * Delete an environment variable.
+   * @param key - The variable name to delete
+   */
+  deleteEnvVar(key: string): void;
+
+  /**
+   * Get all environment variables as a key-value object.
+   * @returns Object containing all environment variables (excludes internal __name__)
+   */
+  getAllEnvVars(): Record<string, any>;
+
+  /** Delete all environment variables (the environment name is preserved) */
+  deleteAllEnvVars(): void;
+
+  /**
+   * Check if an environment variable exists.
+   * @param key - The variable name
+   */
+  hasEnvVar(key: string): boolean;
+
+  // ─── Global Environment Variables ──────────────────────────
+
+  /**
+   * Get a global environment variable value. Values are interpolated.
+   * @param key - The variable name
+   */
+  getGlobalEnvVar(key: string): any;
+
+  /**
+   * Set a global environment variable.
+   * @param key - The variable name
+   * @param value - The variable value
+   */
+  setGlobalEnvVar(key: string, value: any): void;
+
+  /**
+   * Get all global environment variables as a key-value object.
+   */
+  getAllGlobalEnvVars(): Record<string, any>;
+
+  // ─── Collection / Folder / Request Variables ───────────────
+
+  /**
+   * Get a collection-level variable value. Values are interpolated.
+   * @param key - The variable name
+   */
+  getCollectionVar(key: string): any;
+
+  /**
+   * Check if a collection-level variable exists.
+   * @param key - The variable name
+   */
+  hasCollectionVar(key: string): boolean;
+
+  /**
+   * Get a folder-level variable value. Values are interpolated.
+   * @param key - The variable name
+   */
+  getFolderVar(key: string): any;
+
+  /**
+   * Get a request-level variable value. Values are interpolated.
+   * @param key - The variable name
+   */
+  getRequestVar(key: string): any;
+
+  // ─── Runtime Variables ─────────────────────────────────────
+
+  /**
+   * Check if a runtime variable exists.
+   * @param key - The variable name
+   */
+  hasVar(key: string): boolean;
+
+  /**
+   * Get a runtime variable value. Values are interpolated.
+   * @param key - The variable name (alphanumeric, hyphens, underscores, dots only)
+   */
+  getVar(key: string): any;
+
+  /**
+   * Set a runtime variable. Available for the duration of the request lifecycle.
+   * @param key - The variable name (alphanumeric, hyphens, underscores, dots only)
+   * @param value - The variable value
+   * @example bru.setVar('userId', response.body.id);
+   */
+  setVar(key: string, value: any): void;
+
+  /**
+   * Delete a runtime variable.
+   * @param key - The variable name
+   */
+  deleteVar(key: string): void;
+
+  /** Delete all runtime variables */
+  deleteAllVars(): void;
+
+  /**
+   * Get all runtime variables as a key-value object.
+   */
+  getAllVars(): Record<string, any>;
+
+  // ─── Process Environment ───────────────────────────────────
+
+  /**
+   * Get a process environment variable (from system or .env file).
+   * @param key - The environment variable name
+   * @example bru.getProcessEnv('API_KEY')
+   */
+  getProcessEnv(key: string): string | undefined;
+
+  // ─── OAuth2 ────────────────────────────────────────────────
+
+  /**
+   * Get an OAuth2 credential variable (e.g., access token).
+   * @param key - The credential variable key (e.g., '$oauth2.credentialId.access_token')
+   */
+  getOauth2CredentialVar(key: string): any;
+
+  /**
+   * Reset an OAuth2 credential, clearing its cached token.
+   * @param credentialId - The credential ID to reset
+   */
+  resetOauth2Credential(credentialId: string): void;
+
+  // ─── Request Control ───────────────────────────────────────
+
+  /**
+   * Set the next request to execute (in runner mode).
+   * @param nextRequest - The name of the next request to execute
+   */
+  setNextRequest(nextRequest: string): void;
+
+  /** Runner control methods for managing collection runner execution */
+  runner: BrunoRunner;
+
+  // ─── HTTP Requests from Scripts ────────────────────────────
+
+  /**
+   * Send an arbitrary HTTP request from within a script.
+   * Uses the collection's proxy and TLS settings if configured.
+   * @param requestConfig - Axios-compatible request config object
+   * @returns Promise resolving to the response
+   * @example
+   * const response = await bru.sendRequest({
+   *   method: 'GET',
+   *   url: 'https://api.example.com/users',
+   *   headers: { 'Authorization': 'Bearer token' }
+   * });
+   */
+  sendRequest(requestConfig: any): Promise<any>;
+  /**
+   * Send an HTTP request with a callback.
+   * @param requestConfig - Axios-compatible request config object
+   * @param callback - Callback receiving (error, response)
+   * @example
+   * bru.sendRequest({ method: 'GET', url: '/api/users' }, (err, res) => {
+   *   if (err) console.log(err);
+   *   else console.log(res.status);
+   * });
+   */
+  sendRequest(requestConfig: any, callback: (err: any, res: any) => void): Promise<any>;
+
+  // ─── Test Results ──────────────────────────────────────────
+
+  /** Get assertion results from the current run */
+  getAssertionResults(): any[];
+  /** Get test results from the current run */
+  getTestResults(): any[];
+
+  // ─── Utilities ─────────────────────────────────────────────
+
+  /**
+   * Sleep for the specified duration.
+   * @param ms - Duration in milliseconds
+   * @example await bru.sleep(1000); // wait 1 second
+   */
+  sleep(ms: number): Promise<void>;
+
+  /**
+   * Interpolate Bruno variables in a string or object.
+   * Replaces \`{{variableName}}\` with resolved values from all variable scopes.
+   * @param str - The string or object to interpolate
+   * @returns The interpolated string or object
+   * @example bru.interpolate('Hello {{name}}') // 'Hello John'
+   */
+  interpolate(str: string): string;
+  /**
+   * Interpolate Bruno variables in an object (deep interpolation).
+   * @param obj - The object to interpolate
+   * @returns A new object with all string values interpolated
+   */
+  interpolate(obj: object): object;
+
+  /** Cookie management for the current request URL */
+  cookies: BrunoCookies;
+
+  /** Utility functions for data transformation */
+  utils: BrunoUtils;
+}
+`;
+
+  monaco.languages.typescript.javascriptDefaults.addExtraLib(typeDefs, 'bruno-api.d.ts');
+
+  monaco.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
+    noSemanticValidation: false,
+    noSyntaxValidation: false
+  });
+
+  monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
+    target: monaco.languages.typescript.ScriptTarget.ES2020,
+    allowNonTsExtensions: true,
+    allowJs: true,
+    checkJs: false
+  });
+};

--- a/packages/bruno-app/src/utils/monaco/brunoApiTypes.js
+++ b/packages/bruno-app/src/utils/monaco/brunoApiTypes.js
@@ -1,7 +1,5 @@
 import * as monaco from 'monaco-editor';
 
-let typesRegistered = false;
-
 /**
  * Registers the Bruno scripting API type definitions with Monaco's
  * JavaScript language service. Enables autocomplete and hover docs
@@ -10,8 +8,14 @@ let typesRegistered = false;
  * Type definitions are derived from the source implementations in
  * packages/bruno-js/src/ (bru.js, bruno-request.js, bruno-response.js).
  *
+ * Idempotent — addExtraLib with the same filename replaces the previous
+ * registration, and setDiagnosticsOptions/setCompilerOptions are safe to
+ * call multiple times.
+ *
  * Must be called after Monaco is loaded (not at module top level).
  */
+let typesRegistered = false;
+
 export const registerBrunoApiTypes = () => {
   if (typesRegistered) return;
   typesRegistered = true;

--- a/packages/bruno-app/src/utils/monaco/brunoTheme.js
+++ b/packages/bruno-app/src/utils/monaco/brunoTheme.js
@@ -98,33 +98,64 @@ function normalizeHex(color) {
   return s;
 }
 
+// Memoize color conversions to avoid repeated computation
+const colorCache = new Map();
+
 /**
  * Normalize a color to Monaco's #rrggbb format for theme colors.
- * Handles hex, hsl(), and common named colors.
+ * Handles hex and hsl() strings. Results are memoized.
  */
 function normalizeColor(color) {
   if (!color) return '#1e1e1e';
   const s = String(color).trim();
-  if (s.startsWith('#')) return s.length <= 7 ? s : s.slice(0, 7);
-  // Convert hsl()/hsla() to hex via a temporary DOM element
-  if (s.startsWith('hsl')) {
-    try {
-      const el = document.createElement('div');
-      el.style.color = s;
-      document.body.appendChild(el);
-      const computed = getComputedStyle(el).color;
-      document.body.removeChild(el);
-      const match = computed.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-      if (match) {
-        const r = parseInt(match[1]).toString(16).padStart(2, '0');
-        const g = parseInt(match[2]).toString(16).padStart(2, '0');
-        const b = parseInt(match[3]).toString(16).padStart(2, '0');
-        return `#${r}${g}${b}`;
-      }
-    } catch {
-      // Fall through to default
-    }
-    return '#1e1e1e';
+
+  const cached = colorCache.get(s);
+  if (cached) return cached;
+
+  let result;
+  if (s.startsWith('#')) {
+    result = s.length <= 7 ? s : s.slice(0, 7);
+  } else if (s.startsWith('hsl')) {
+    result = hslStringToHex(s);
+  } else {
+    result = s;
   }
-  return s;
+
+  colorCache.set(s, result);
+  return result;
+}
+
+/**
+ * Convert an hsl()/hsla() string to #rrggbb hex using pure math.
+ * Avoids DOM manipulation and layout thrashing.
+ */
+function hslStringToHex(hslString) {
+  const match = hslString.match(/hsla?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)%\s*[,\s]\s*([\d.]+)%/);
+  if (!match) return '#1e1e1e';
+
+  const h = parseFloat(match[1]) / 360;
+  const s = parseFloat(match[2]) / 100;
+  const l = parseFloat(match[3]) / 100;
+
+  let r, g, b;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p, q, t) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+
+  const toHex = (c) => Math.round(c * 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }

--- a/packages/bruno-app/src/utils/monaco/brunoTheme.js
+++ b/packages/bruno-app/src/utils/monaco/brunoTheme.js
@@ -1,0 +1,115 @@
+import * as monaco from 'monaco-editor';
+
+let registeredThemeId = null;
+
+/**
+ * Registers a custom Monaco theme based on the active Bruno styled-components theme.
+ * Maps the codemirror.tokens.* colors from the Bruno theme to Monaco token rules.
+ *
+ * @param {Object} brunoTheme - The styled-components theme object (props.theme)
+ * @param {string} displayedTheme - 'dark' or 'light'
+ * @returns {string} The registered Monaco theme name
+ */
+export const registerBrunoTheme = (brunoTheme, displayedTheme) => {
+  const isDark = displayedTheme === 'dark';
+  const base = isDark ? 'vs-dark' : 'vs';
+  const tokens = brunoTheme?.codemirror?.tokens || {};
+  const bg = brunoTheme?.codemirror?.bg || (isDark ? '#1a1a1a' : '#ffffff');
+  const fg = brunoTheme?.text || (isDark ? '#d4d4d4' : '#1e1e1e');
+  const gutterBg = brunoTheme?.codemirror?.gutter?.bg || bg;
+
+  // Normalize bg — Monaco needs hex, not hsl() strings
+  const editorBg = normalizeColor(bg);
+  const editorFg = normalizeColor(fg);
+  const gutterBgNorm = normalizeColor(gutterBg);
+
+  const themeName = `bruno-${displayedTheme}-${Date.now()}`;
+
+  monaco.editor.defineTheme(themeName, {
+    base,
+    inherit: true,
+    rules: [
+      { token: 'comment', foreground: normalizeHex(tokens.comment) },
+      { token: 'comment.js', foreground: normalizeHex(tokens.comment) },
+      { token: 'comment.block', foreground: normalizeHex(tokens.comment) },
+      { token: 'string', foreground: normalizeHex(tokens.string) },
+      { token: 'string.js', foreground: normalizeHex(tokens.string) },
+      { token: 'number', foreground: normalizeHex(tokens.number) },
+      { token: 'number.js', foreground: normalizeHex(tokens.number) },
+      { token: 'keyword', foreground: normalizeHex(tokens.keyword) },
+      { token: 'keyword.js', foreground: normalizeHex(tokens.keyword) },
+      { token: 'identifier', foreground: normalizeHex(tokens.variable) },
+      { token: 'identifier.js', foreground: normalizeHex(tokens.variable) },
+      { token: 'type.identifier', foreground: normalizeHex(tokens.definition) },
+      { token: 'type.identifier.js', foreground: normalizeHex(tokens.definition) },
+      { token: 'delimiter', foreground: normalizeHex(tokens.operator) },
+      { token: 'delimiter.js', foreground: normalizeHex(tokens.operator) },
+      { token: 'delimiter.bracket', foreground: normalizeHex(tokens.tagBracket) },
+      { token: 'tag', foreground: normalizeHex(tokens.tag) },
+      { token: 'attribute.name', foreground: normalizeHex(tokens.property) },
+      { token: 'attribute.value', foreground: normalizeHex(tokens.string) },
+      // JSON specific
+      { token: 'string.key.json', foreground: normalizeHex(tokens.property) },
+      { token: 'string.value.json', foreground: normalizeHex(tokens.string) },
+      { token: 'number.json', foreground: normalizeHex(tokens.number) },
+      { token: 'keyword.json', foreground: normalizeHex(tokens.atom) }
+    ],
+    colors: {
+      'editor.background': editorBg,
+      'editor.foreground': editorFg,
+      'editorGutter.background': gutterBgNorm,
+      'editorLineNumber.foreground': isDark ? '#858585' : '#999999',
+      // Hover widget (JSDoc tooltips)
+      'editorHoverWidget.background': normalizeColor(brunoTheme?.dropdown?.bg) || editorBg,
+      'editorHoverWidget.border': normalizeColor(brunoTheme?.dropdown?.border) || (isDark ? '#454545' : '#c8c8c8'),
+      'editorHoverWidget.foreground': editorFg,
+      // Suggest widget (autocomplete)
+      'editorSuggestWidget.background': normalizeColor(brunoTheme?.dropdown?.bg) || editorBg,
+      'editorSuggestWidget.border': normalizeColor(brunoTheme?.dropdown?.border) || (isDark ? '#454545' : '#c8c8c8'),
+      'editorSuggestWidget.foreground': editorFg,
+      'editorSuggestWidget.selectedBackground': normalizeColor(brunoTheme?.dropdown?.hoverBg) || (isDark ? '#04395e' : '#d6ebff'),
+      'editorSuggestWidget.highlightForeground': normalizeColor(brunoTheme?.textLink) || (isDark ? '#569cd6' : '#0078d4'),
+      // Widget (shared - parameter hints, find widget, etc.)
+      'editorWidget.background': normalizeColor(brunoTheme?.dropdown?.bg) || editorBg,
+      'editorWidget.border': normalizeColor(brunoTheme?.dropdown?.border) || (isDark ? '#454545' : '#c8c8c8'),
+      'editorWidget.foreground': editorFg
+    }
+  });
+
+  registeredThemeId = themeName;
+  return themeName;
+};
+
+/**
+ * Gets the currently registered theme name, or a fallback.
+ */
+export const getCurrentThemeName = (displayedTheme) => {
+  return registeredThemeId || (displayedTheme === 'dark' ? 'vs-dark' : 'vs');
+};
+
+/**
+ * Strip '#' prefix and return 6-char hex for Monaco token rules.
+ * Handles undefined/null gracefully.
+ */
+function normalizeHex(color) {
+  if (!color) return undefined;
+  const s = String(color).trim();
+  if (s.startsWith('#')) return s.slice(1);
+  return s;
+}
+
+/**
+ * Normalize a color to Monaco's #rrggbb format for theme colors.
+ * Handles hex, hsl(), and common named colors.
+ */
+function normalizeColor(color) {
+  if (!color) return '#1e1e1e';
+  const s = String(color).trim();
+  if (s.startsWith('#')) return s.length <= 7 ? s : s.slice(0, 7);
+  // For hsl() strings, provide a reasonable fallback since Monaco doesn't support them
+  if (s.startsWith('hsl')) {
+    // Return a fallback — the base theme will handle most styling
+    return undefined;
+  }
+  return s;
+}

--- a/packages/bruno-app/src/utils/monaco/brunoTheme.js
+++ b/packages/bruno-app/src/utils/monaco/brunoTheme.js
@@ -23,7 +23,7 @@ export const registerBrunoTheme = (brunoTheme, displayedTheme) => {
   const editorFg = normalizeColor(fg);
   const gutterBgNorm = normalizeColor(gutterBg);
 
-  const themeName = `bruno-${displayedTheme}-${Date.now()}`;
+  const themeName = `bruno-${displayedTheme}`;
 
   monaco.editor.defineTheme(themeName, {
     base,
@@ -106,10 +106,25 @@ function normalizeColor(color) {
   if (!color) return '#1e1e1e';
   const s = String(color).trim();
   if (s.startsWith('#')) return s.length <= 7 ? s : s.slice(0, 7);
-  // For hsl() strings, provide a reasonable fallback since Monaco doesn't support them
+  // Convert hsl()/hsla() to hex via a temporary DOM element
   if (s.startsWith('hsl')) {
-    // Return a fallback — the base theme will handle most styling
-    return undefined;
+    try {
+      const el = document.createElement('div');
+      el.style.color = s;
+      document.body.appendChild(el);
+      const computed = getComputedStyle(el).color;
+      document.body.removeChild(el);
+      const match = computed.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+      if (match) {
+        const r = parseInt(match[1]).toString(16).padStart(2, '0');
+        const g = parseInt(match[2]).toString(16).padStart(2, '0');
+        const b = parseInt(match[3]).toString(16).padStart(2, '0');
+        return `#${r}${g}${b}`;
+      }
+    } catch {
+      // Fall through to default
+    }
+    return '#1e1e1e';
   }
   return s;
 }

--- a/packages/bruno-app/src/utils/monaco/brunoTheme.js
+++ b/packages/bruno-app/src/utils/monaco/brunoTheme.js
@@ -23,28 +23,67 @@ export const registerBrunoTheme = (brunoTheme, displayedTheme) => {
   const editorFg = normalizeColor(fg);
   const gutterBgNorm = normalizeColor(gutterBg);
 
+  // hexOr avoids the `normalizeColor(x) || fallback` trap — normalizeColor
+  // returns '#1e1e1e' for missing input, which is truthy, so the fallback
+  // would never fire.
+  const hexOr = (source, fallback) => (source ? normalizeColor(source) : fallback);
+
+  const widgetBg = hexOr(brunoTheme?.dropdown?.bg, editorBg);
+  const widgetBorder = hexOr(brunoTheme?.dropdown?.border, isDark ? '#454545' : '#c8c8c8');
+  const widgetFg = hexOr(brunoTheme?.dropdown?.color, editorFg);
+  const widgetSelectedBg = hexOr(brunoTheme?.dropdown?.hoverBg, isDark ? '#04395e' : '#d6ebff');
+  const widgetHighlightFg = hexOr(brunoTheme?.textLink, isDark ? '#569cd6' : '#0078d4');
+  const bracketFg = hexOr(tokens.tagBracket, editorFg);
+  const bracketErrorFg = hexOr(brunoTheme?.codemirror?.variable?.invalid, isDark ? '#f14c4c' : '#e51400');
+
   const themeName = `bruno-${displayedTheme}`;
 
   monaco.editor.defineTheme(themeName, {
     base,
     inherit: true,
     rules: [
+      // Comments
       { token: 'comment', foreground: normalizeHex(tokens.comment) },
       { token: 'comment.js', foreground: normalizeHex(tokens.comment) },
       { token: 'comment.block', foreground: normalizeHex(tokens.comment) },
+      { token: 'comment.doc.js', foreground: normalizeHex(tokens.comment) },
+      // Strings
       { token: 'string', foreground: normalizeHex(tokens.string) },
       { token: 'string.js', foreground: normalizeHex(tokens.string) },
+      { token: 'string.escape', foreground: normalizeHex(tokens.number) },
+      { token: 'string.escape.js', foreground: normalizeHex(tokens.number) },
+      { token: 'string.escape.invalid.js', foreground: normalizeHex(tokens.variable) },
+      // Numbers
       { token: 'number', foreground: normalizeHex(tokens.number) },
       { token: 'number.js', foreground: normalizeHex(tokens.number) },
+      { token: 'number.hex.js', foreground: normalizeHex(tokens.number) },
+      { token: 'number.octal.js', foreground: normalizeHex(tokens.number) },
+      { token: 'number.binary.js', foreground: normalizeHex(tokens.number) },
+      { token: 'number.float.js', foreground: normalizeHex(tokens.number) },
+      // Keywords & identifiers
       { token: 'keyword', foreground: normalizeHex(tokens.keyword) },
       { token: 'keyword.js', foreground: normalizeHex(tokens.keyword) },
+      { token: 'keyword.flow.js', foreground: normalizeHex(tokens.keyword) },
       { token: 'identifier', foreground: normalizeHex(tokens.variable) },
       { token: 'identifier.js', foreground: normalizeHex(tokens.variable) },
       { token: 'type.identifier', foreground: normalizeHex(tokens.definition) },
       { token: 'type.identifier.js', foreground: normalizeHex(tokens.definition) },
+      // Regex
+      { token: 'regexp', foreground: normalizeHex(tokens.string) },
+      { token: 'regexp.js', foreground: normalizeHex(tokens.string) },
+      { token: 'regexp.escape.js', foreground: normalizeHex(tokens.number) },
+      // Decorators
+      { token: 'annotation', foreground: normalizeHex(tokens.keyword) },
+      { token: 'annotation.js', foreground: normalizeHex(tokens.keyword) },
+      // Delimiters — brackets/parens/braces all use tagBracket so nothing goes yellow
       { token: 'delimiter', foreground: normalizeHex(tokens.operator) },
       { token: 'delimiter.js', foreground: normalizeHex(tokens.operator) },
       { token: 'delimiter.bracket', foreground: normalizeHex(tokens.tagBracket) },
+      { token: 'delimiter.bracket.js', foreground: normalizeHex(tokens.tagBracket) },
+      { token: 'delimiter.parenthesis.js', foreground: normalizeHex(tokens.tagBracket) },
+      { token: 'delimiter.square.js', foreground: normalizeHex(tokens.tagBracket) },
+      { token: 'delimiter.angle.js', foreground: normalizeHex(tokens.tagBracket) },
+      // Markup
       { token: 'tag', foreground: normalizeHex(tokens.tag) },
       { token: 'attribute.name', foreground: normalizeHex(tokens.property) },
       { token: 'attribute.value', foreground: normalizeHex(tokens.string) },
@@ -59,20 +98,43 @@ export const registerBrunoTheme = (brunoTheme, displayedTheme) => {
       'editor.foreground': editorFg,
       'editorGutter.background': gutterBgNorm,
       'editorLineNumber.foreground': isDark ? '#858585' : '#999999',
+      // Suppress the default focus/contrast borders that would otherwise
+      // ring the suggest widget with an unwanted color.
+      'focusBorder': widgetBorder,
+      'contrastBorder': widgetBorder,
+      'contrastActiveBorder': widgetBorder,
+      // Override the default rainbow bracket pair colorization — all 6 levels
+      // collapse to the theme's tagBracket color so brackets stay monochrome
+      // and don't leak yellow/gold into themes that don't want it.
+      'editorBracketHighlight.foreground1': bracketFg,
+      'editorBracketHighlight.foreground2': bracketFg,
+      'editorBracketHighlight.foreground3': bracketFg,
+      'editorBracketHighlight.foreground4': bracketFg,
+      'editorBracketHighlight.foreground5': bracketFg,
+      'editorBracketHighlight.foreground6': bracketFg,
+      'editorBracketHighlight.unexpectedBracket.foreground': bracketErrorFg,
       // Hover widget (JSDoc tooltips)
-      'editorHoverWidget.background': normalizeColor(brunoTheme?.dropdown?.bg) || editorBg,
-      'editorHoverWidget.border': normalizeColor(brunoTheme?.dropdown?.border) || (isDark ? '#454545' : '#c8c8c8'),
-      'editorHoverWidget.foreground': editorFg,
+      'editorHoverWidget.background': widgetBg,
+      'editorHoverWidget.border': widgetBorder,
+      'editorHoverWidget.foreground': widgetFg,
       // Suggest widget (autocomplete)
-      'editorSuggestWidget.background': normalizeColor(brunoTheme?.dropdown?.bg) || editorBg,
-      'editorSuggestWidget.border': normalizeColor(brunoTheme?.dropdown?.border) || (isDark ? '#454545' : '#c8c8c8'),
-      'editorSuggestWidget.foreground': editorFg,
-      'editorSuggestWidget.selectedBackground': normalizeColor(brunoTheme?.dropdown?.hoverBg) || (isDark ? '#04395e' : '#d6ebff'),
-      'editorSuggestWidget.highlightForeground': normalizeColor(brunoTheme?.textLink) || (isDark ? '#569cd6' : '#0078d4'),
+      'editorSuggestWidget.background': widgetBg,
+      'editorSuggestWidget.border': widgetBorder,
+      'editorSuggestWidget.foreground': widgetFg,
+      'editorSuggestWidget.selectedBackground': widgetSelectedBg,
+      'editorSuggestWidget.selectedForeground': widgetFg,
+      'editorSuggestWidget.selectedIconForeground': widgetFg,
+      'editorSuggestWidget.highlightForeground': widgetHighlightFg,
+      'editorSuggestWidget.focusHighlightForeground': widgetHighlightFg,
+      // Suggest widget uses list.* colors for hover/focus states
+      'list.hoverBackground': widgetSelectedBg,
+      'list.hoverForeground': widgetFg,
+      'list.focusBackground': widgetSelectedBg,
+      'list.focusForeground': widgetFg,
       // Widget (shared - parameter hints, find widget, etc.)
-      'editorWidget.background': normalizeColor(brunoTheme?.dropdown?.bg) || editorBg,
-      'editorWidget.border': normalizeColor(brunoTheme?.dropdown?.border) || (isDark ? '#454545' : '#c8c8c8'),
-      'editorWidget.foreground': editorFg
+      'editorWidget.background': widgetBg,
+      'editorWidget.border': widgetBorder,
+      'editorWidget.foreground': widgetFg
     }
   });
 
@@ -88,14 +150,13 @@ export const getCurrentThemeName = (displayedTheme) => {
 };
 
 /**
- * Strip '#' prefix and return 6-char hex for Monaco token rules.
- * Handles undefined/null gracefully.
+ * Return a 6-char hex (no '#') for Monaco token rules.
+ * Accepts hex or hsl()/hsla() strings; returns undefined for missing input.
  */
 function normalizeHex(color) {
   if (!color) return undefined;
-  const s = String(color).trim();
-  if (s.startsWith('#')) return s.slice(1);
-  return s;
+  const normalized = normalizeColor(color);
+  return normalized.startsWith('#') ? normalized.slice(1) : normalized;
 }
 
 // Memoize color conversions to avoid repeated computation
@@ -114,9 +175,11 @@ function normalizeColor(color) {
 
   let result;
   if (s.startsWith('#')) {
-    result = s.length <= 7 ? s : s.slice(0, 7);
+    result = expandHex(s);
   } else if (s.startsWith('hsl')) {
     result = hslStringToHex(s);
+  } else if (s.startsWith('rgb')) {
+    result = rgbStringToHex(s);
   } else {
     result = s;
   }
@@ -126,11 +189,49 @@ function normalizeColor(color) {
 }
 
 /**
+ * Expand shorthand hex (#rgb / #rgba) to full #rrggbb, and truncate 8-char to 6-char.
+ * Monaco requires exactly 6-char hex in theme colors.
+ */
+function expandHex(hex) {
+  if (hex.length === 4) {
+    // #rgb -> #rrggbb
+    return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  if (hex.length === 5) {
+    // #rgba -> #rrggbb (drop alpha)
+    return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  return hex.length <= 7 ? hex : hex.slice(0, 7);
+}
+
+/**
+ * Convert an rgb()/rgba() string to #rrggbb hex. Alpha is dropped — Monaco's
+ * theme colors don't accept it in this format. Supports both legacy
+ * (comma) and modern (space + slash) CSS syntax.
+ */
+function rgbStringToHex(rgbString) {
+  const match = rgbString.match(
+    /rgba?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)\s*[,\s]\s*([\d.]+)/
+  );
+  if (!match) return '#1e1e1e';
+
+  const toHex = (n) => {
+    const v = Math.max(0, Math.min(255, Math.round(parseFloat(n))));
+    return v.toString(16).padStart(2, '0');
+  };
+  return `#${toHex(match[1])}${toHex(match[2])}${toHex(match[3])}`;
+}
+
+/**
  * Convert an hsl()/hsla() string to #rrggbb hex using pure math.
- * Avoids DOM manipulation and layout thrashing.
+ * Supports both legacy (comma) and modern (space) CSS syntax, with an
+ * optional `deg` unit on the hue — e.g. `hsl(210, 90%, 76%)`,
+ * `hsl(0deg 0% 80%)`, `hsl(0 0% 80%)`.
  */
 function hslStringToHex(hslString) {
-  const match = hslString.match(/hsla?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)%\s*[,\s]\s*([\d.]+)%/);
+  const match = hslString.match(
+    /hsla?\(\s*([\d.]+)(?:deg)?\s*[,\s]\s*([\d.]+)%\s*[,\s]\s*([\d.]+)%/
+  );
   if (!match) return '#1e1e1e';
 
   const h = parseFloat(match[1]) / 360;

--- a/packages/bruno-app/src/utils/monaco/languageMapping.js
+++ b/packages/bruno-app/src/utils/monaco/languageMapping.js
@@ -1,0 +1,28 @@
+const MODE_MAP = {
+  'application/javascript': 'javascript',
+  'javascript': 'javascript',
+  'application/ld+json': 'json',
+  'application/json': 'json',
+  'application/xml': 'xml',
+  'xml': 'xml',
+  'application/html': 'html',
+  'html': 'html',
+  'application/yaml': 'yaml',
+  'yaml': 'yaml',
+  'application/text': 'plaintext',
+  'text/plain': 'plaintext',
+  'markdown': 'markdown',
+  'shell': 'shell',
+  'application/sparql-query': 'plaintext',
+  'graphql': 'plaintext'
+};
+
+/**
+ * Maps a CodeMirror mode string to a Monaco Editor language ID.
+ * @param {string} mode - CodeMirror mode (e.g. 'application/javascript')
+ * @returns {string} Monaco language ID (e.g. 'javascript')
+ */
+export const mapCodeMirrorModeToMonaco = (mode) => {
+  if (!mode) return 'plaintext';
+  return MODE_MAP[mode] || 'plaintext';
+};

--- a/packages/bruno-app/src/utils/monaco/languageMapping.spec.js
+++ b/packages/bruno-app/src/utils/monaco/languageMapping.spec.js
@@ -1,0 +1,52 @@
+import { mapCodeMirrorModeToMonaco } from './languageMapping';
+
+describe('mapCodeMirrorModeToMonaco', () => {
+  it('maps JavaScript modes', () => {
+    expect(mapCodeMirrorModeToMonaco('application/javascript')).toBe('javascript');
+    expect(mapCodeMirrorModeToMonaco('javascript')).toBe('javascript');
+  });
+
+  it('maps JSON modes', () => {
+    expect(mapCodeMirrorModeToMonaco('application/ld+json')).toBe('json');
+    expect(mapCodeMirrorModeToMonaco('application/json')).toBe('json');
+  });
+
+  it('maps XML modes', () => {
+    expect(mapCodeMirrorModeToMonaco('application/xml')).toBe('xml');
+    expect(mapCodeMirrorModeToMonaco('xml')).toBe('xml');
+  });
+
+  it('maps YAML modes', () => {
+    expect(mapCodeMirrorModeToMonaco('application/yaml')).toBe('yaml');
+    expect(mapCodeMirrorModeToMonaco('yaml')).toBe('yaml');
+  });
+
+  it('maps HTML modes', () => {
+    expect(mapCodeMirrorModeToMonaco('application/html')).toBe('html');
+    expect(mapCodeMirrorModeToMonaco('html')).toBe('html');
+  });
+
+  it('maps plaintext modes', () => {
+    expect(mapCodeMirrorModeToMonaco('application/text')).toBe('plaintext');
+    expect(mapCodeMirrorModeToMonaco('text/plain')).toBe('plaintext');
+  });
+
+  it('maps markdown mode', () => {
+    expect(mapCodeMirrorModeToMonaco('markdown')).toBe('markdown');
+  });
+
+  it('maps shell mode', () => {
+    expect(mapCodeMirrorModeToMonaco('shell')).toBe('shell');
+  });
+
+  it('falls back to plaintext for unsupported modes', () => {
+    expect(mapCodeMirrorModeToMonaco('application/sparql-query')).toBe('plaintext');
+    expect(mapCodeMirrorModeToMonaco('graphql')).toBe('plaintext');
+    expect(mapCodeMirrorModeToMonaco('unknown-mode')).toBe('plaintext');
+  });
+
+  it('falls back to plaintext for null/undefined', () => {
+    expect(mapCodeMirrorModeToMonaco(null)).toBe('plaintext');
+    expect(mapCodeMirrorModeToMonaco(undefined)).toBe('plaintext');
+  });
+});

--- a/packages/bruno-app/src/utils/monaco/variableHighlighting.js
+++ b/packages/bruno-app/src/utils/monaco/variableHighlighting.js
@@ -226,7 +226,7 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
     const scopeInfo = detectScope(varName);
     const scopeType = scopeInfo.type;
     const scopeLabel = SCOPE_LABELS[scopeType] || 'Unknown';
-    const rawValue = scopeInfo.value !== undefined ? String(scopeInfo.value) : '';
+    let rawValue = scopeInfo.value !== undefined ? String(scopeInfo.value) : '';
     const isReadOnly = READ_ONLY_SCOPES.has(scopeType)
       || (collection?.runtimeVariables && collection.runtimeVariables[varName]);
     const isSecret = scopeType !== 'undefined' && isVariableSecret(scopeInfo);
@@ -234,8 +234,8 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
     const shouldMask = isSecret || hasSecretRefs;
 
     let isRevealed = false;
-    const interpolatedValue = getInterpolatedValue(rawValue);
-    const displayValue = typeof scopeInfo.value === 'object'
+    let interpolatedValue = getInterpolatedValue(rawValue);
+    let displayValue = typeof scopeInfo.value === 'object'
       ? JSON.stringify(scopeInfo.value, null, 2)
       : interpolatedValue;
 
@@ -344,6 +344,10 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
         const newValue = editorEl.value;
         if (newValue !== rawValue && dispatch) {
           dispatch(updateVariableInScope(varName, newValue, scopeInfo, collection.uid));
+          rawValue = newValue;
+          interpolatedValue = getInterpolatedValue(rawValue);
+          displayValue = interpolatedValue;
+          updateValueDisplay();
         }
         editorEl.style.display = 'none';
         valueDisplay.style.display = '';

--- a/packages/bruno-app/src/utils/monaco/variableHighlighting.js
+++ b/packages/bruno-app/src/utils/monaco/variableHighlighting.js
@@ -242,6 +242,7 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
     // ─── Build DOM ─────────────────────────────
 
     const popup = document.createElement('div');
+    // Reuses the CodeMirror tooltip class to share global styles defined in globalStyles.js
     popup.className = 'CodeMirror-brunoVarInfo';
 
     // Header: name + scope badge
@@ -304,20 +305,6 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
       editorEl = document.createElement('textarea');
       editorEl.className = 'var-value-editor-textarea';
       editorEl.value = rawValue;
-      editorEl.style.display = 'none';
-      editorEl.style.width = '100%';
-      editorEl.style.minHeight = '1.75rem';
-      editorEl.style.maxHeight = '11.125rem';
-      editorEl.style.resize = 'vertical';
-      editorEl.style.boxSizing = 'border-box';
-      editorEl.style.padding = '0.375rem 0.5rem';
-      editorEl.style.border = 'none';
-      editorEl.style.outline = 'none';
-      editorEl.style.background = 'inherit';
-      editorEl.style.color = 'inherit';
-      editorEl.style.fontFamily = 'Inter, sans-serif';
-      editorEl.style.fontSize = 'inherit';
-      editorEl.style.lineHeight = '1.25rem';
 
       valueDisplay.addEventListener('click', () => {
         valueDisplay.style.display = 'none';

--- a/packages/bruno-app/src/utils/monaco/variableHighlighting.js
+++ b/packages/bruno-app/src/utils/monaco/variableHighlighting.js
@@ -216,6 +216,10 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
   const showTooltip = (varInfo) => {
     hidePopup();
     const { varName, lineNumber, startCol } = varInfo;
+
+    // Prompt variables ({{?name}}) don't need a tooltip
+    if (varName.startsWith('?')) return;
+
     const collection = getCollection();
     const scopeInfo = detectScope(varName);
     const scopeType = scopeInfo.type;

--- a/packages/bruno-app/src/utils/monaco/variableHighlighting.js
+++ b/packages/bruno-app/src/utils/monaco/variableHighlighting.js
@@ -1,22 +1,45 @@
 import * as monaco from 'monaco-editor';
 import get from 'lodash/get';
-import { mockDataFunctions } from '@usebruno/common';
-import { getAllVariables } from 'utils/collections';
+import { mockDataFunctions, interpolate, timeBasedDynamicVars } from '@usebruno/common';
+import { getAllVariables, getVariableScope, isVariableSecret } from 'utils/collections';
 
 const VARIABLE_REGEX = /\{\{([^}]*)\}\}/g;
+const HOVER_DELAY = 50;
+const HIDE_DELAY = 500;
+const COPY_SUCCESS_TIMEOUT = 1000;
+
+const SCOPE_LABELS = {
+  'global': 'Global',
+  'environment': 'Environment',
+  'collection': 'Collection',
+  'folder': 'Folder',
+  'request': 'Request',
+  'runtime': 'Runtime',
+  'process.env': 'Process Env',
+  'dynamic': 'Dynamic',
+  'oauth2': 'OAuth2',
+  'undefined': 'Undefined',
+  'pathParam': 'Path Param'
+};
+
+const READ_ONLY_SCOPES = new Set(['process.env', 'runtime', 'dynamic', 'oauth2', 'undefined']);
 
 const pathFoundInVariables = (path, obj) => {
   return get(obj, path) !== undefined;
 };
 
+// ─── SVG Icons ───────────────────────────────────────────────
+
+const COPY_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`;
+const EYE_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>`;
+const EYE_OFF_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>`;
+
+// ─── Decoration Highlighting ─────────────────────────────────
+
 /**
  * Applies decorations to highlight {{variable}} patterns in the editor.
  * Green for valid, red for invalid, blue for prompt variables.
- *
- * @param {monaco.editor.IStandaloneCodeEditor} editor
- * @param {Object} collection - Bruno collection object
- * @param {Object} item - Bruno request item object
- * @returns {Function} cleanup function
  */
 export const setupVariableHighlighting = (editor, collection, item) => {
   let decorationIds = [];
@@ -52,8 +75,7 @@ export const setupVariableHighlighting = (editor, collection, item) => {
       newDecorations.push({
         range: new monaco.Range(startPos.lineNumber, startPos.column, endPos.lineNumber, endPos.column),
         options: {
-          inlineClassName: className,
-          hoverMessage: { value: getHoverMessage(varName, varLookup, pathParams) }
+          inlineClassName: className
         }
       });
     }
@@ -61,87 +83,457 @@ export const setupVariableHighlighting = (editor, collection, item) => {
     decorationIds = editor.deltaDecorations(decorationIds, newDecorations);
   };
 
-  // Initial decoration
   updateDecorations();
 
-  // Update on content change
   const disposable = editor.onDidChangeModelContent(() => {
     updateDecorations();
   });
 
   return () => {
     disposable.dispose();
-    // Clear decorations
     if (editor.getModel()) {
       decorationIds = editor.deltaDecorations(decorationIds, []);
     }
   };
 };
 
-/**
- * Generates a hover message for a variable.
- */
-function getHoverMessage(varName, variables, pathParams) {
-  if (varName.startsWith('?')) {
-    return `**Prompt Variable**: \`${varName.substring(1)}\`\n\nUser will be prompted for this value at runtime.`;
-  }
+// ─── Rich DOM Tooltip ────────────────────────────────────────
 
-  if (varName.startsWith('$')) {
-    const fnName = varName.substring(1);
-    if (mockDataFunctions.hasOwnProperty(fnName)) {
-      return `**Dynamic Variable**: \`${varName}\`\n\nGenerates a random/dynamic value at runtime.`;
+/**
+ * Sets up a rich interactive tooltip for {{variable}} patterns,
+ * matching the CodeMirror brunoVarInfo tooltip behavior.
+ */
+export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) => {
+  let activePopup = null;
+  let hoverTimeout = null;
+  let hideTimeout = null;
+  let currentVarName = null;
+
+  const getCollection = () => (typeof collectionRef === 'function' ? collectionRef() : collectionRef);
+  const getItem = () => (typeof itemRef === 'function' ? itemRef() : itemRef);
+
+  /**
+   * Find the {{variable}} at a given position in the editor.
+   * Returns { varName, startCol, endCol } or null.
+   */
+  const getVariableAtPosition = (position) => {
+    const model = editor.getModel();
+    if (!model) return null;
+
+    const line = model.getLineContent(position.lineNumber);
+    const matches = [...line.matchAll(/\{\{([^}]*)\}\}/g)];
+
+    for (const match of matches) {
+      const startCol = match.index + 1;
+      const endCol = startCol + match[0].length;
+      if (position.column >= startCol && position.column <= endCol) {
+        return { varName: match[1], startCol, endCol, lineNumber: position.lineNumber };
+      }
     }
-    return `**Unknown dynamic variable**: \`${varName}\``;
-  }
+    return null;
+  };
 
-  const value = get(variables, varName);
-  if (value !== undefined) {
-    const displayValue = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);
-    return `**Variable**: \`${varName}\`\n\n**Value**: \`${displayValue}\``;
-  }
+  /**
+   * Detect the scope of a variable, handling special prefixes.
+   */
+  const detectScope = (varName) => {
+    const collection = getCollection();
+    const item = getItem();
 
-  // Check path params
-  const pathValue = get(pathParams, varName);
-  if (pathValue !== undefined) {
-    return `**Path Parameter**: \`${varName}\`\n\n**Value**: \`${pathValue}\``;
-  }
+    if (varName.startsWith('$oauth2.')) {
+      const variables = getAllVariables(collection, item);
+      const value = get(variables, varName);
+      return { type: 'oauth2', value, data: {} };
+    }
 
-  return `**Undefined variable**: \`${varName}\``;
-}
+    if (varName.startsWith('$')) {
+      const fnName = varName.substring(1);
+      const exists = mockDataFunctions.hasOwnProperty(fnName);
+      const isTimeBased = timeBasedDynamicVars.has(fnName);
+      return { type: 'dynamic', value: '', data: { exists, fnName, isTimeBased } };
+    }
 
-/**
- * Registers a hover provider for {{variable}} patterns.
- * This supplements the decoration hover with richer hover content.
- *
- * @param {Object} collection
- * @param {Object} item
- * @returns {monaco.IDisposable}
- */
-export const registerVariableHoverProvider = (collection, item) => {
-  return monaco.languages.registerHoverProvider('javascript', {
-    provideHover(model, position) {
-      const line = model.getLineContent(position.lineNumber);
-      const matches = [...line.matchAll(/\{\{([^}]*)\}\}/g)];
+    if (varName.startsWith('process.env.')) {
+      const envKey = varName.replace('process.env.', '');
+      const variables = getAllVariables(collection, item);
+      const value = get(variables, varName);
+      return { type: 'process.env', value, data: { envKey } };
+    }
 
-      for (const match of matches) {
-        const startCol = match.index + 1;
-        const endCol = startCol + match[0].length;
+    const scopeInfo = getVariableScope(varName, collection, item);
+    if (scopeInfo) return scopeInfo;
 
-        if (position.column >= startCol && position.column <= endCol) {
-          const varName = match[1];
-          const variables = getAllVariables(collection, item);
-          const { pathParams = {}, maskedEnvVariables = [], ...varLookup } = variables;
+    // If variable doesn't exist in any scope, determine default scope based on context
+    // (matches CodeMirror brunoVarInfo behavior)
+    if (item && item.uid) {
+      const isFolder = item.type === 'folder';
+      if (isFolder) {
+        return { type: 'folder', value: '', data: { folder: item, variable: null } };
+      } else {
+        return { type: 'request', value: '', data: { item, variable: null } };
+      }
+    } else if (collection) {
+      return { type: 'collection', value: '', data: { collection, variable: null } };
+    }
 
-          return {
-            range: new monaco.Range(position.lineNumber, startCol, position.lineNumber, endCol),
-            contents: [
-              { value: getHoverMessage(varName, varLookup, pathParams) }
-            ]
-          };
-        }
+    return { type: 'undefined', value: undefined, data: {} };
+  };
+
+  /**
+   * Get the interpolated value of a variable.
+   */
+  const getInterpolatedValue = (rawValue) => {
+    if (rawValue === undefined || rawValue === null) return '';
+    const collection = getCollection();
+    const variables = getAllVariables(collection, getItem());
+    const { pathParams, maskedEnvVariables, ...varLookup } = variables;
+    try {
+      return interpolate(String(rawValue), varLookup);
+    } catch {
+      return String(rawValue);
+    }
+  };
+
+  /**
+   * Check if the raw value contains references to secret variables.
+   */
+  const containsSecretReferences = (rawValue) => {
+    if (!rawValue || typeof rawValue !== 'string') return false;
+    const collection = getCollection();
+    const item = getItem();
+    const matches = rawValue.matchAll(/\{\{([^}]+)\}\}/g);
+    for (const match of matches) {
+      const refName = match[1].trim();
+      const refScope = getVariableScope(refName, collection, item);
+      if (refScope && isVariableSecret(refScope)) return true;
+    }
+    return false;
+  };
+
+  /**
+   * Create and show the tooltip popup.
+   */
+  const showTooltip = (varInfo) => {
+    hidePopup();
+    const { varName, lineNumber, startCol } = varInfo;
+    const collection = getCollection();
+    const scopeInfo = detectScope(varName);
+    const scopeType = scopeInfo.type;
+    const scopeLabel = SCOPE_LABELS[scopeType] || 'Unknown';
+    const rawValue = scopeInfo.value !== undefined ? String(scopeInfo.value) : '';
+    const isReadOnly = READ_ONLY_SCOPES.has(scopeType)
+      || (collection?.runtimeVariables && collection.runtimeVariables[varName]);
+    const isSecret = scopeType !== 'undefined' && isVariableSecret(scopeInfo);
+    const hasSecretRefs = containsSecretReferences(rawValue);
+    const shouldMask = isSecret || hasSecretRefs;
+
+    let isRevealed = false;
+    const interpolatedValue = getInterpolatedValue(rawValue);
+    const displayValue = typeof scopeInfo.value === 'object'
+      ? JSON.stringify(scopeInfo.value, null, 2)
+      : interpolatedValue;
+
+    // ─── Build DOM ─────────────────────────────
+
+    const popup = document.createElement('div');
+    popup.className = 'CodeMirror-brunoVarInfo';
+
+    // Header: name + scope badge
+    const header = document.createElement('div');
+    header.className = 'var-info-header';
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'var-name';
+    nameEl.textContent = varName;
+    nameEl.title = varName;
+    header.appendChild(nameEl);
+
+    const badge = document.createElement('span');
+    badge.className = 'var-scope-badge';
+    badge.textContent = scopeLabel;
+    header.appendChild(badge);
+
+    popup.appendChild(header);
+
+    // Dynamic variables: show only a note, no value container (matches CodeMirror)
+    if (scopeType === 'dynamic') {
+      if (!scopeInfo.data.exists) {
+        const warning = document.createElement('div');
+        warning.className = 'var-warning-note';
+        warning.textContent = `Unknown dynamic variable "${varName}". Check the variable name.`;
+        popup.appendChild(warning);
+      } else {
+        const note = document.createElement('div');
+        note.className = 'var-readonly-note';
+        note.textContent = scopeInfo.data.isTimeBased
+          ? 'Generates current timestamp on each request'
+          : 'Generates random value on each request';
+        popup.appendChild(note);
       }
 
-      return null;
+      positionAndShowPopup(popup, varName, lineNumber, startCol);
+      return;
+    }
+
+    // Value container
+    const valueContainer = document.createElement('div');
+    valueContainer.className = 'var-value-container';
+
+    // Value display
+    const valueDisplay = document.createElement('div');
+    valueDisplay.className = isReadOnly ? 'var-value-display' : 'var-value-editable-display';
+
+    const updateValueDisplay = () => {
+      if (shouldMask && !isRevealed) {
+        valueDisplay.textContent = displayValue ? '*'.repeat(Math.min(displayValue.length, 20)) : '';
+      } else {
+        valueDisplay.textContent = displayValue || '';
+      }
+    };
+    updateValueDisplay();
+
+    // Editor (textarea) — hidden by default
+    let editorEl = null;
+    if (!isReadOnly && scopeType !== 'undefined') {
+      editorEl = document.createElement('textarea');
+      editorEl.className = 'var-value-editor-textarea';
+      editorEl.value = rawValue;
+      editorEl.style.display = 'none';
+      editorEl.style.width = '100%';
+      editorEl.style.minHeight = '1.75rem';
+      editorEl.style.maxHeight = '11.125rem';
+      editorEl.style.resize = 'vertical';
+      editorEl.style.boxSizing = 'border-box';
+      editorEl.style.padding = '0.375rem 0.5rem';
+      editorEl.style.border = 'none';
+      editorEl.style.outline = 'none';
+      editorEl.style.background = 'inherit';
+      editorEl.style.color = 'inherit';
+      editorEl.style.fontFamily = 'Inter, sans-serif';
+      editorEl.style.fontSize = 'inherit';
+      editorEl.style.lineHeight = '1.25rem';
+
+      valueDisplay.addEventListener('click', () => {
+        valueDisplay.style.display = 'none';
+        editorEl.style.display = 'block';
+        editorEl.value = rawValue;
+        editorEl.focus();
+        editorEl.setSelectionRange(editorEl.value.length, editorEl.value.length);
+      });
+
+      editorEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          editorEl.blur();
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          editorEl.value = rawValue;
+          editorEl.style.display = 'none';
+          valueDisplay.style.display = '';
+        }
+      });
+
+      editorEl.addEventListener('blur', () => {
+        const newValue = editorEl.value;
+        if (newValue !== rawValue && dispatch) {
+          dispatch(updateVariableInScope(varName, newValue, scopeInfo, collection.uid));
+        }
+        editorEl.style.display = 'none';
+        valueDisplay.style.display = '';
+      });
+    }
+
+    valueContainer.appendChild(valueDisplay);
+    if (editorEl) {
+      valueContainer.appendChild(editorEl);
+    }
+
+    // Icons container
+    const icons = document.createElement('div');
+    icons.className = 'var-icons';
+
+    // Secret toggle button
+    if (shouldMask) {
+      const toggleBtn = document.createElement('button');
+      toggleBtn.className = 'secret-toggle-button';
+      toggleBtn.innerHTML = EYE_ICON;
+      toggleBtn.title = 'Reveal value';
+      toggleBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        isRevealed = !isRevealed;
+        toggleBtn.innerHTML = isRevealed ? EYE_OFF_ICON : EYE_ICON;
+        toggleBtn.title = isRevealed ? 'Mask value' : 'Reveal value';
+        updateValueDisplay();
+      });
+      icons.appendChild(toggleBtn);
+    }
+
+    // Copy button
+    if (scopeType !== 'undefined') {
+      const copyBtn = document.createElement('button');
+      copyBtn.className = 'copy-button';
+      copyBtn.innerHTML = COPY_ICON;
+      copyBtn.title = 'Copy value';
+      let copyTimeout = null;
+      copyBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (copyTimeout) return;
+        const textToCopy = typeof scopeInfo.value === 'object'
+          ? JSON.stringify(scopeInfo.value) : interpolatedValue;
+        navigator.clipboard.writeText(textToCopy).then(() => {
+          copyBtn.innerHTML = CHECK_ICON;
+          copyBtn.classList.add('copy-success');
+          copyTimeout = setTimeout(() => {
+            copyBtn.innerHTML = COPY_ICON;
+            copyBtn.classList.remove('copy-success');
+            copyTimeout = null;
+          }, COPY_SUCCESS_TIMEOUT);
+        });
+      });
+      icons.appendChild(copyBtn);
+    }
+
+    valueContainer.appendChild(icons);
+    popup.appendChild(valueContainer);
+
+    // Notes
+    if (isReadOnly && scopeType !== 'undefined') {
+      const note = document.createElement('div');
+      note.className = 'var-readonly-note';
+      if (scopeType === 'runtime') {
+        note.textContent = 'Set by scripts (read-only)';
+      } else if (scopeType === 'process.env') {
+        note.textContent = 'Process environment variable (read-only)';
+      } else if (scopeType === 'oauth2') {
+        note.textContent = 'OAuth2 credential (read-only)';
+      }
+      if (note.textContent) popup.appendChild(note);
+    }
+
+    if (scopeType === 'undefined') {
+      const warning = document.createElement('div');
+      warning.className = 'var-warning-note';
+      warning.textContent = 'Variable is not defined in any scope';
+      popup.appendChild(warning);
+    }
+
+    // ─── Position & Show ───────────────────────
+
+    positionAndShowPopup(popup, varName, lineNumber, startCol);
+  };
+
+  const positionAndShowPopup = (popup, varName, lineNumber, startCol) => {
+    document.body.appendChild(popup);
+    activePopup = popup;
+    currentVarName = varName;
+
+    // Get screen coordinates from editor
+    const editorDom = editor.getDomNode();
+    const scrolledPos = editor.getScrolledVisiblePosition({ lineNumber, column: startCol });
+
+    if (scrolledPos && editorDom) {
+      const editorRect = editorDom.getBoundingClientRect();
+      let top = editorRect.top + scrolledPos.top + scrolledPos.height + 4;
+      let left = editorRect.left + scrolledPos.left;
+
+      // If tooltip would overflow bottom, show above
+      const popupRect = popup.getBoundingClientRect();
+      if (top + popupRect.height > window.innerHeight) {
+        top = editorRect.top + scrolledPos.top - popupRect.height - 4;
+      }
+
+      // Prevent right overflow
+      if (left + popupRect.width > window.innerWidth) {
+        left = window.innerWidth - popupRect.width - 8;
+      }
+
+      // Prevent left overflow
+      if (left < 4) left = 4;
+
+      popup.style.position = 'fixed';
+      popup.style.top = `${top / 16}rem`;
+      popup.style.left = `${left / 16}rem`;
+    }
+
+    popup.style.opacity = '1';
+
+    // Keep popup alive while mouse is over it
+    popup.addEventListener('mouseover', () => {
+      clearTimeout(hideTimeout);
+    });
+    popup.addEventListener('mouseout', (e) => {
+      // Don't hide if moving within the popup
+      if (popup.contains(e.relatedTarget)) return;
+      startHideTimer();
+    });
+  };
+
+  const hidePopup = () => {
+    clearTimeout(hoverTimeout);
+    clearTimeout(hideTimeout);
+    if (activePopup) {
+      activePopup.style.opacity = '0';
+      const popupToRemove = activePopup;
+      setTimeout(() => {
+        popupToRemove.remove();
+      }, 150);
+      activePopup = null;
+      currentVarName = null;
+    }
+  };
+
+  const startHideTimer = () => {
+    clearTimeout(hideTimeout);
+    hideTimeout = setTimeout(hidePopup, HIDE_DELAY);
+  };
+
+  // ─── Event Handlers ──────────────────────────
+
+  const onMouseMove = editor.onMouseMove((e) => {
+    if (!e.target.position) {
+      clearTimeout(hoverTimeout);
+      if (activePopup) startHideTimer();
+      return;
+    }
+
+    const varInfo = getVariableAtPosition(e.target.position);
+
+    if (varInfo) {
+      // Same variable — keep current popup
+      if (activePopup && currentVarName === varInfo.varName) {
+        clearTimeout(hideTimeout);
+        return;
+      }
+
+      clearTimeout(hoverTimeout);
+      clearTimeout(hideTimeout);
+      hoverTimeout = setTimeout(() => {
+        showTooltip(varInfo);
+      }, HOVER_DELAY);
+    } else {
+      clearTimeout(hoverTimeout);
+      if (activePopup) startHideTimer();
     }
   });
+
+  const onMouseLeave = editor.onMouseLeave(() => {
+    clearTimeout(hoverTimeout);
+    if (activePopup) startHideTimer();
+  });
+
+  // Hide immediately when user types
+  const onChange = editor.onDidChangeModelContent(() => {
+    hidePopup();
+  });
+
+  return () => {
+    onMouseMove.dispose();
+    onMouseLeave.dispose();
+    onChange.dispose();
+    hidePopup();
+  };
 };
+
+// Import for the dispatch action
+import { updateVariableInScope } from 'providers/ReduxStore/slices/collections/actions';

--- a/packages/bruno-app/src/utils/monaco/variableHighlighting.js
+++ b/packages/bruno-app/src/utils/monaco/variableHighlighting.js
@@ -2,6 +2,7 @@ import * as monaco from 'monaco-editor';
 import get from 'lodash/get';
 import { mockDataFunctions, interpolate, timeBasedDynamicVars } from '@usebruno/common';
 import { getAllVariables, getVariableScope, isVariableSecret } from 'utils/collections';
+import { updateVariableInScope } from 'providers/ReduxStore/slices/collections/actions';
 
 const VARIABLE_REGEX = /\{\{([^}]*)\}\}/g;
 const HOVER_DELAY = 50;
@@ -42,7 +43,7 @@ const EYE_OFF_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none
  * Green for valid, red for invalid, blue for prompt variables.
  */
 export const setupVariableHighlighting = (editor, collection, item) => {
-  let decorationIds = [];
+  const decorationCollection = editor.createDecorationsCollection([]);
 
   const updateDecorations = () => {
     const model = editor.getModel();
@@ -67,7 +68,7 @@ export const setupVariableHighlighting = (editor, collection, item) => {
       if (varName.startsWith('?')) {
         className = 'bruno-variable-prompt';
       } else {
-        const isMockVariable = varName.startsWith('$') && mockDataFunctions.hasOwnProperty(varName.substring(1));
+        const isMockVariable = varName.startsWith('$') && Object.hasOwn(mockDataFunctions, varName.substring(1));
         const isValid = isMockVariable || pathFoundInVariables(varName, varLookup);
         className = isValid ? 'bruno-variable-valid' : 'bruno-variable-invalid';
       }
@@ -80,20 +81,21 @@ export const setupVariableHighlighting = (editor, collection, item) => {
       });
     }
 
-    decorationIds = editor.deltaDecorations(decorationIds, newDecorations);
+    decorationCollection.set(newDecorations);
   };
 
   updateDecorations();
 
+  let debounceTimer = null;
   const disposable = editor.onDidChangeModelContent(() => {
-    updateDecorations();
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(updateDecorations, 120);
   });
 
   return () => {
+    clearTimeout(debounceTimer);
     disposable.dispose();
-    if (editor.getModel()) {
-      decorationIds = editor.deltaDecorations(decorationIds, []);
-    }
+    decorationCollection.clear();
   };
 };
 
@@ -148,7 +150,7 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
 
     if (varName.startsWith('$')) {
       const fnName = varName.substring(1);
-      const exists = mockDataFunctions.hasOwnProperty(fnName);
+      const exists = Object.hasOwn(mockDataFunctions, fnName);
       const isTimeBased = timeBasedDynamicVars.has(fnName);
       return { type: 'dynamic', value: '', data: { exists, fnName, isTimeBased } };
     }
@@ -456,8 +458,8 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
       if (left < 4) left = 4;
 
       popup.style.position = 'fixed';
-      popup.style.top = `${top / 16}rem`;
-      popup.style.left = `${left / 16}rem`;
+      popup.style.top = `${top}px`;
+      popup.style.left = `${left}px`;
     }
 
     popup.style.opacity = '1';
@@ -538,6 +540,3 @@ export const setupVariableTooltip = (editor, collectionRef, itemRef, dispatch) =
     hidePopup();
   };
 };
-
-// Import for the dispatch action
-import { updateVariableInScope } from 'providers/ReduxStore/slices/collections/actions';

--- a/packages/bruno-app/src/utils/monaco/variableHighlighting.js
+++ b/packages/bruno-app/src/utils/monaco/variableHighlighting.js
@@ -1,0 +1,147 @@
+import * as monaco from 'monaco-editor';
+import get from 'lodash/get';
+import { mockDataFunctions } from '@usebruno/common';
+import { getAllVariables } from 'utils/collections';
+
+const VARIABLE_REGEX = /\{\{([^}]*)\}\}/g;
+
+const pathFoundInVariables = (path, obj) => {
+  return get(obj, path) !== undefined;
+};
+
+/**
+ * Applies decorations to highlight {{variable}} patterns in the editor.
+ * Green for valid, red for invalid, blue for prompt variables.
+ *
+ * @param {monaco.editor.IStandaloneCodeEditor} editor
+ * @param {Object} collection - Bruno collection object
+ * @param {Object} item - Bruno request item object
+ * @returns {Function} cleanup function
+ */
+export const setupVariableHighlighting = (editor, collection, item) => {
+  let decorationIds = [];
+
+  const updateDecorations = () => {
+    const model = editor.getModel();
+    if (!model) return;
+
+    const variables = getAllVariables(collection, item);
+    const { pathParams = {}, maskedEnvVariables = [], ...varLookup } = variables;
+    const text = model.getValue();
+    const newDecorations = [];
+
+    let match;
+    VARIABLE_REGEX.lastIndex = 0;
+
+    while ((match = VARIABLE_REGEX.exec(text)) !== null) {
+      const varName = match[1];
+      const startOffset = match.index;
+      const endOffset = startOffset + match[0].length;
+      const startPos = model.getPositionAt(startOffset);
+      const endPos = model.getPositionAt(endOffset);
+
+      let className;
+      if (varName.startsWith('?')) {
+        className = 'bruno-variable-prompt';
+      } else {
+        const isMockVariable = varName.startsWith('$') && mockDataFunctions.hasOwnProperty(varName.substring(1));
+        const isValid = isMockVariable || pathFoundInVariables(varName, varLookup);
+        className = isValid ? 'bruno-variable-valid' : 'bruno-variable-invalid';
+      }
+
+      newDecorations.push({
+        range: new monaco.Range(startPos.lineNumber, startPos.column, endPos.lineNumber, endPos.column),
+        options: {
+          inlineClassName: className,
+          hoverMessage: { value: getHoverMessage(varName, varLookup, pathParams) }
+        }
+      });
+    }
+
+    decorationIds = editor.deltaDecorations(decorationIds, newDecorations);
+  };
+
+  // Initial decoration
+  updateDecorations();
+
+  // Update on content change
+  const disposable = editor.onDidChangeModelContent(() => {
+    updateDecorations();
+  });
+
+  return () => {
+    disposable.dispose();
+    // Clear decorations
+    if (editor.getModel()) {
+      decorationIds = editor.deltaDecorations(decorationIds, []);
+    }
+  };
+};
+
+/**
+ * Generates a hover message for a variable.
+ */
+function getHoverMessage(varName, variables, pathParams) {
+  if (varName.startsWith('?')) {
+    return `**Prompt Variable**: \`${varName.substring(1)}\`\n\nUser will be prompted for this value at runtime.`;
+  }
+
+  if (varName.startsWith('$')) {
+    const fnName = varName.substring(1);
+    if (mockDataFunctions.hasOwnProperty(fnName)) {
+      return `**Dynamic Variable**: \`${varName}\`\n\nGenerates a random/dynamic value at runtime.`;
+    }
+    return `**Unknown dynamic variable**: \`${varName}\``;
+  }
+
+  const value = get(variables, varName);
+  if (value !== undefined) {
+    const displayValue = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);
+    return `**Variable**: \`${varName}\`\n\n**Value**: \`${displayValue}\``;
+  }
+
+  // Check path params
+  const pathValue = get(pathParams, varName);
+  if (pathValue !== undefined) {
+    return `**Path Parameter**: \`${varName}\`\n\n**Value**: \`${pathValue}\``;
+  }
+
+  return `**Undefined variable**: \`${varName}\``;
+}
+
+/**
+ * Registers a hover provider for {{variable}} patterns.
+ * This supplements the decoration hover with richer hover content.
+ *
+ * @param {Object} collection
+ * @param {Object} item
+ * @returns {monaco.IDisposable}
+ */
+export const registerVariableHoverProvider = (collection, item) => {
+  return monaco.languages.registerHoverProvider('javascript', {
+    provideHover(model, position) {
+      const line = model.getLineContent(position.lineNumber);
+      const matches = [...line.matchAll(/\{\{([^}]*)\}\}/g)];
+
+      for (const match of matches) {
+        const startCol = match.index + 1;
+        const endCol = startCol + match[0].length;
+
+        if (position.column >= startCol && position.column <= endCol) {
+          const varName = match[1];
+          const variables = getAllVariables(collection, item);
+          const { pathParams = {}, maskedEnvVariables = [], ...varLookup } = variables;
+
+          return {
+            range: new monaco.Range(position.lineNumber, startCol, position.lineNumber, endCol),
+            contents: [
+              { value: getHoverMessage(varName, varLookup, pathParams) }
+            ]
+          };
+        }
+      }
+
+      return null;
+    }
+  });
+};

--- a/packages/bruno-app/src/utils/monaco/workers.js
+++ b/packages/bruno-app/src/utils/monaco/workers.js
@@ -1,0 +1,11 @@
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === 'json') {
+      return new Worker(new URL('monaco-editor/esm/vs/language/json/json.worker.js', import.meta.url));
+    }
+    if (label === 'javascript' || label === 'typescript') {
+      return new Worker(new URL('monaco-editor/esm/vs/language/typescript/ts.worker.js', import.meta.url));
+    }
+    return new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker.js', import.meta.url));
+  }
+};

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -47,7 +47,8 @@ const defaultPreferences = {
     responsePaneOrientation: 'horizontal'
   },
   beta: {
-    'openapi-sync': false
+    'openapi-sync': false,
+    'monaco-editor': false
   },
   onboarding: {
     hasLaunchedBefore: false,
@@ -114,7 +115,8 @@ const preferencesSchema = Yup.object().shape({
     responsePaneOrientation: Yup.string().oneOf(['horizontal', 'vertical'])
   }),
   beta: Yup.object({
-    'openapi-sync': Yup.boolean()
+    'openapi-sync': Yup.boolean(),
+    'monaco-editor': Yup.boolean()
   }),
   onboarding: Yup.object({
     hasLaunchedBefore: Yup.boolean(),


### PR DESCRIPTION
[Jira](https://usebruno.atlassian.net/browse/BRU-3078)
## Summary

- Adds Monaco Editor (VS Code's editor) as a beta feature for script editing and request body editing
- Users can toggle between CodeMirror and Monaco via **Preferences > Beta > Monaco Editor**
- Both editors remain available — CodeMirror continues to be the default

## What's included

- **MonacoEditor component** with full prop compatibility with the existing CodeEditor
- **ScriptEditor switcher** that renders Monaco or CodeMirror based on the beta feature flag
- **Request body editor** also switches to Monaco when the beta flag is enabled
- **Custom Bruno themes** — maps all CodeMirror token colors (syntax highlighting) to Monaco for both light and dark themes
- **Bruno API intellisense** — full TypeScript declarations for `bru`, `req`, `res` objects with JSDoc, overloads, and `@example` tags
- **Variable highlighting** — `{{var}}` patterns highlighted green (valid), red (invalid), blue (prompt) with hover tooltips showing variable value, scope, and inline editing (gated by `enableVariableHighlighting` prop — enabled for body editors, disabled for scripts)
- **Variable autocomplete** — `{{` triggers variable suggestions across all editor languages (JSON, XML, plaintext, JavaScript, etc.), including environment/collection/runtime variables, `$mockFunction` names, and `process.env.*` keys
- **Dynamic variable tooltips** — `{{$randomInt}}` etc. show "Generates random value on each request" (or "Generates current timestamp on each request" for time-based vars) matching CodeMirror behavior — no value input or copy button
- **Scope-aware variable creation** — new variables default to request/folder/collection scope based on editor context, matching CodeMirror's `brunoVarInfo` behavior
- **Widget theming** — hover tooltips, suggest widget, and parameter hints styled to match Bruno's theme
- **Keybindings** — Cmd/Ctrl+Enter to run, Cmd/Ctrl+S to save, built-in Cmd+F search
- **Web worker configuration** — Rsbuild configured for Monaco's language service workers
- **Unit tests** — 20 tests covering MonacoEditor, ScriptEditor switcher, and language mapping

## Architecture

```
CodeEditor (unchanged, CodeMirror — fallback when beta is off)
MonacoEditor (new — used when beta is on)

ScriptEditor (switcher — used by 6 script editor locations)
  ├── CodeEditor (CodeMirror) — when beta is off (default)
  └── MonacoEditor — when beta is on

RequestBody (also switches based on beta flag)
  ├── CodeEditor (CodeMirror) — when beta is off (default)
  └── MonacoEditor — when beta is on
```

### Feature parity with CodeMirror

| Feature | CodeMirror | Monaco |
|---|---|---|
| Variable text coloring (`{{var}}`) | Via overlay mode (`enableVariableHighlighting`) | Via decorations (`enableVariableHighlighting`) |
| Variable hover tooltip | `brunoVarInfo` option | `setupVariableTooltip` |
| Variable autocomplete inside `{{}}` | `setupAutoComplete` (keyup-based) | `registerCompletionItemProvider` + content change trigger |
| API intellisense (`bru.`, `req.`, `res.`) | Static hint lists | TypeScript type definitions (`brunoApiTypes.js`) |
| Inline variable editing | Click-to-edit in tooltip | Click-to-edit textarea in tooltip |
| Dynamic variable display | Note only, no value input | Note only, no value input |
| Scope fallback for new variables | request/folder/collection based on context | request/folder/collection based on context |

### Files changed
- 6 script consumers pass `item`/`folder` for correct scope detection: `RequestPane/Script`, `RequestPane/Tests`, `FolderSettings/Script`, `FolderSettings/Tests`, `CollectionSettings/Script`, `CollectionSettings/Tests`
- `RequestPane/RequestBody` switches between CodeEditor and MonacoEditor based on beta flag

## Deferred (not in this PR)

- Monaco for other editors (response viewer, documentation, GraphQL)
- Custom Monarch tokenizer for full `{{var}}` syntax integration
- GraphQL language support

## Before (CodeMirror)

https://github.com/user-attachments/assets/5e17a18c-b8fd-4cef-90cd-3f96b892877f

## After (Monaco)

https://github.com/user-attachments/assets/c69aaaf2-137f-4602-986a-29a062f5f335

## Variable highlighting

https://github.com/user-attachments/assets/2e393988-dff2-468c-92aa-adcd82ac88a6

## Test plan

- [ ] Open Preferences > Beta > enable "Monaco Editor (Beta)"
- [ ] Open a request's Script tab — Monaco renders with JS syntax highlighting
- [ ] Type `bru.` — autocomplete shows all Bruno API methods with JSDoc
- [ ] Type `{{varName}}` in script — no text coloring, but autocomplete suggests variables
- [ ] Switch to Body tab (JSON) — Monaco renders with variable highlighting (green/red)
- [ ] Type `{{` in body — variable autocomplete suggests env/collection/runtime variables
- [ ] Type `{{ho` — suggestions filter to matching variables (e.g., `host`)
- [ ] Hover over a `{{var}}` in body — tooltip shows variable value, scope, and allows editing
- [ ] Hover over `{{$randomInt}}` — tooltip shows "Generates random value on each request" with no value input
- [ ] Hover over undefined `{{newVar}}` — tooltip shows "Request" scope, allows adding a value
- [ ] Cmd/Ctrl+Enter runs the request, Cmd/Ctrl+S saves
- [ ] Switch theme (light/dark) — Monaco theme updates
- [ ] Disable the beta feature — CodeMirror restored everywhere

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monaco Editor available as a beta toggle — optional replacement editor across scripts, tests, request bodies and folders.
  * Monaco adds a theme, variable highlighting, rich variable tooltips (inspect/edit/mask/copy), autocomplete for {{...}} variables, and keyboard shortcuts for Run (Ctrl/Cmd+Enter) and Save (Ctrl/Cmd+S).

* **Chores**
  * Added the Monaco dependency and updated build/runtime wiring.

* **Tests**
  * Added unit tests for editor selection, Monaco integration, and language mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->