### PR TITLE
feat: add keyboard shortcut to open Cookies modal.

### DIFF
--- a/packages/bruno-app/src/components/StatusBar/index.js
+++ b/packages/bruno-app/src/components/StatusBar/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import find from 'lodash/find';
 import { IconSettings, IconCookie, IconTool, IconSearch, IconPalette, IconBrandGithub } from '@tabler/icons';
@@ -12,6 +12,7 @@ import ThemeDropdown from './ThemeDropdown';
 import { openConsole } from 'providers/ReduxStore/slices/logs';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import { useApp } from 'providers/App';
+import { openCookiesModal, closeCookiesModal } from 'providers/ReduxStore/slices/app';
 import StyledWrapper from './StyledWrapper';
 
 const StatusBar = () => {
@@ -21,11 +22,11 @@ const StatusBar = () => {
   const showHomePage = useSelector((state) => state.app.showHomePage);
   const showManageWorkspacePage = useSelector((state) => state.app.showManageWorkspacePage);
   const showApiSpecPage = useSelector((state) => state.app.showApiSpecPage);
+  const isCookiesModalOpen = useSelector((state) => state.app.isCookiesModalOpen);
   const tabs = useSelector((state) => state.tabs.tabs);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const activeTab = find(tabs, (t) => t.uid === activeTabUid);
   const logs = useSelector((state) => state.logs.logs);
-  const [cookiesOpen, setCookiesOpen] = useState(false);
   const { version } = useApp();
 
   const activeWorkspace = workspaces.find((w) => w.uid === activeWorkspaceUid);
@@ -57,11 +58,11 @@ const StatusBar = () => {
 
   return (
     <StyledWrapper>
-      {cookiesOpen && (
+      {isCookiesModalOpen && (
         <Portal>
           <Cookies
             onClose={() => {
-              setCookiesOpen(false);
+              dispatch(closeCookiesModal());
               document.querySelector('[data-trigger="cookies"]').focus();
             }}
             aria-modal="true"
@@ -137,7 +138,7 @@ const StatusBar = () => {
             <button
               className="status-bar-button"
               data-trigger="cookies"
-              onClick={() => setCookiesOpen(true)}
+              onClick={() => dispatch(openCookiesModal())}
               tabIndex={0}
               aria-label="Open Cookies"
             >

--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -10,7 +10,7 @@ import each from 'lodash/each';
 import { findCollectionByUid, findItemInCollection, flattenItems, isItemARequest, hasRequestChanges, findEnvironmentInCollection } from 'utils/collections';
 import { addTab, focusTab, reorderTabs } from 'providers/ReduxStore/slices/tabs';
 import { saveMultipleRequests, saveMultipleCollections, saveMultipleFolders, saveEnvironment, reopenClosedTab } from 'providers/ReduxStore/slices/collections/actions';
-import { toggleSidebarCollapse, toggleSidebarSearch, savePreferences } from 'providers/ReduxStore/slices/app';
+import { toggleSidebarCollapse, toggleSidebarSearch, savePreferences, toggleCookiesModal } from 'providers/ReduxStore/slices/app';
 import { openDevtoolsAndSwitchToTerminal } from 'utils/terminal';
 import { getKeyBindingsForActionAllOS } from './keyMappings';
 
@@ -120,6 +120,18 @@ export const HotkeysProvider = (props) => {
       unbindAction('globalSearch');
     };
   }, [userKeyBindings, keybindingsEnabled]);
+
+  // Toggle cookies modal
+  useEffect(() => {
+    bindAction('openCookies', () => {
+      dispatch(toggleCookiesModal());
+      return false;
+    });
+
+    return () => {
+      unbindAction('openCookies');
+    };
+  }, [dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to the previous tab (active-collection-tabs-only)
   useEffect(() => {

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -56,6 +56,12 @@ export const KEY_BINDING_SECTIONS = [
     }
   },
   {
+    heading: 'Cookies',
+    bindings: {
+      openCookies: { mac: 'shift+bind+alt+bind+c', windows: 'shift+bind+alt+bind+c', name: 'Open Cookies' }
+    }
+  },
+  {
     heading: 'View',
     bindings: {
       zoomIn: { mac: 'command+bind+=', windows: 'ctrl+bind+=', name: 'Zoom In' },

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -58,7 +58,7 @@ export const KEY_BINDING_SECTIONS = [
   {
     heading: 'Cookies',
     bindings: {
-      openCookies: { mac: 'shift+bind+alt+bind+c', windows: 'shift+bind+alt+bind+c', name: 'Open Cookies' }
+      openCookies: { mac: 'command+bind+shift+bind+c', windows: 'shift+bind+alt+bind+c', name: 'Open Cookies' }
     }
   },
   {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -57,6 +57,7 @@ const initialState = {
     library: 'curl',
     shouldInterpolate: true
   },
+  isCookiesModalOpen: false,
   cookies: [],
   taskQueue: [],
   gitOperationProgress: {},
@@ -119,6 +120,15 @@ export const appSlice = createSlice({
     },
     updateCookies: (state, action) => {
       state.cookies = action.payload;
+    },
+    openCookiesModal: (state) => {
+      state.isCookiesModalOpen = true;
+    },
+    closeCookiesModal: (state) => {
+      state.isCookiesModalOpen = false;
+    },
+    toggleCookiesModal: (state) => {
+      state.isCookiesModalOpen = !state.isCookiesModalOpen;
     },
     insertTaskIntoQueue: (state, action) => {
       state.taskQueue.push(action.payload);
@@ -206,6 +216,9 @@ export const {
   updatePreferences,
   updateActivePreferencesTab,
   updateCookies,
+  openCookiesModal,
+  closeCookiesModal,
+  toggleCookiesModal,
   insertTaskIntoQueue,
   removeTaskFromQueue,
   removeAllTasksFromQueue,


### PR DESCRIPTION
## 📝 PR Description

Added a keyboard shortcut to quickly open and close the Cookies modal, improving developer workflow and accessibility.

## ✨ Changes

- Introduced default shortcut:
  - **Windows/Linux:** `Shift + Alt + C`
  - **macOS:** `Shift + Option + C`
- Shortcut toggles the Cookies modal (open/close)
- Added support for customizing the shortcut via:
  - `Preferences → Keybindings → Cookies → "Open Cookies"`

## 📸 Screenshots

> - Opening Cookies modal using shortcut
<img width="1251" height="714" alt="Screenshot 2026-04-20 at 3 52 38 PM" src="https://github.com/user-attachments/assets/7e9cd174-87a5-4bab-aae8-edfc511e6212" />


> - Keybinding customization in Preferences
<img width="1259" height="712" alt="Screenshot 2026-04-20 at 3 52 26 PM" src="https://github.com/user-attachments/assets/315333a6-7efa-41cb-8946-dcb3e736227b" />


<!-- Example:
![Shortcut Demo](link-to-gif-or-image)
![Keybinding Settings](link-to-image)
-->

## 🚀 Impact

- Reduces friction when frequently accessing Cookies
- Improves keyboard-first navigation
- Enhances overall developer experience

## 🔗 Closes

Closes #7799 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut to open/close the Cookies modal (Cmd+Shift+C on Mac, Shift+Alt+C on Windows).

* **Improvements**
  * Cookies modal is now driven by global app state for consistent behavior.
  * The Cookies button and keyboard shortcut both open/close the same modal state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->