### PR TITLE
fix: enable DPI-aware NSIS installer

### DIFF
--- a/packages/bruno-electron/electron-builder-config.js
+++ b/packages/bruno-electron/electron-builder-config.js
@@ -104,6 +104,7 @@ const config = {
     publisherName: 'Bruno Software Inc'
   },
   nsis: {
+    include: 'resources/installer.nsh',
     oneClick: false,
     allowToChangeInstallationDirectory: true,
     allowElevation: true,

--- a/packages/bruno-electron/resources/installer.nsh
+++ b/packages/bruno-electron/resources/installer.nsh
@@ -1,0 +1,3 @@
+; Keep the Windows installer sharp on high-DPI displays instead of letting
+; Windows bitmap-scale the full NSIS UI.
+ManifestDPIAware true


### PR DESCRIPTION
Fixes #7802 
[JIRA](https://usebruno.atlassian.net/browse/BRU-3238)

## Summary

Fixes blurry / low-DPI rendering of the Windows NSIS installer on displays using scaling above 100%.

## What changed

- added a custom NSIS include script for Windows builds
- declared the installer as DPI-aware with `ManifestDPIAware true`
- wired the script into `electron-builder` through the `nsis.include` option

## Why

The installer did not declare DPI awareness, so Windows applied DPI virtualization and bitmap scaling to the setup UI. That caused text and controls to look blurry on high-DPI displays.

## Scope

This change affects the **Windows installer UI only**. It does not change the installed app UI or the installer flow.



## Before

<img width="749" height="582" alt="Screenshot 2026-04-20 123823" src="https://github.com/user-attachments/assets/1a80ac24-4c96-4c33-af3a-f1bfe0cb278d" />

## After

<img width="749" height="566" alt="Screenshot 2026-04-20 123841" src="https://github.com/user-attachments/assets/72d1c295-4306-47be-b35d-e43f68402fde" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer appearance on high-DPI displays to prevent pixelation and scaling issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->