### PR TITLE
fix: focus url bar shortcut

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -30,7 +30,7 @@ import ProtoFileDropdown from './ProtoFileDropdown';
 const STREAMING_METHOD_TYPES = ['client-streaming', 'server-streaming', 'bidi-streaming'];
 const CLIENT_STREAMING_METHOD_TYPES = ['client-streaming', 'bidi-streaming'];
 
-const GrpcQueryUrl = ({ item, collection, handleRun }) => {
+const GrpcQueryUrl = ({ item, collection, handleRun, urlBarFocusRef }) => {
   const { theme, storedTheme } = useTheme();
   const dispatch = useDispatch();
   const method = getPropertyFromDraftOrRequest(item, 'request.method');
@@ -40,6 +40,17 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   const saveShortcut = isMac ? 'Cmd + S' : 'Ctrl + S';
   const editorRef = useRef(null);
   const isConnectionActive = useSelector((state) => state.collections.activeConnections.includes(item.uid));
+
+  // Register focus function for the focusUrlBar shortcut
+  // Places the cursor at the end of the URL text
+  if (urlBarFocusRef) {
+    urlBarFocusRef.current = () => {
+      const editor = editorRef.current?.editor;
+      if (!editor) return;
+      editor.focus();
+      editor.setCursor({ line: editor.lastLine(), ch: editor.getLine(editor.lastLine()).length });
+    };
+  }
 
   const [grpcMethods, setGrpcMethods] = useState([]);
   const [selectedGrpcMethod, setSelectedGrpcMethod] = useState({

--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -25,7 +25,7 @@ import StyledWrapper from './StyledWrapper';
 import GenerateCodeItem from 'components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index';
 import toast from 'react-hot-toast';
 
-const QueryUrl = ({ item, collection, handleRun }) => {
+const QueryUrl = ({ item, collection, handleRun, urlBarFocusRef }) => {
   const { theme, storedTheme } = useTheme();
   const dispatch = useDispatch();
   const method = item.draft ? get(item, 'draft.request.method') : get(item, 'request.method');
@@ -34,6 +34,17 @@ const QueryUrl = ({ item, collection, handleRun }) => {
   const saveShortcut = isMac ? 'Cmd + S' : 'Ctrl + S';
   const editorRef = useRef(null);
   const isLoading = ['queued', 'sending'].includes(item.requestState);
+
+  // Register focus function for the focusUrlBar shortcut
+  // Places the cursor at the end of the URL text
+  if (urlBarFocusRef) {
+    urlBarFocusRef.current = () => {
+      const editor = editorRef.current?.editor;
+      if (!editor) return;
+      editor.focus();
+      editor.setCursor({ line: editor.lastLine(), ch: editor.getLine(editor.lastLine()).length });
+    };
+  }
 
   const [generateCodeItemModalOpen, setGenerateCodeItemModalOpen] = useState(false);
   const hasChanges = useMemo(() => hasRequestChanges(item), [item]);

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
@@ -37,7 +37,7 @@ const useWsConnectionStatus = (requestId) => {
   return [connectionStatus, setConnectionStatus];
 };
 
-const WsQueryUrl = ({ item, collection, handleRun }) => {
+const WsQueryUrl = ({ item, collection, handleRun, urlBarFocusRef }) => {
   const dispatch = useDispatch();
   const { theme, displayedTheme } = useTheme();
   // TODO: reaper, better state for connecting
@@ -46,6 +46,19 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
 
   const [connectionStatus, setConnectionStatus] = useWsConnectionStatus(item.uid);
   const url = item.draft ? get(item, 'draft.request.url', '') : get(item, 'request.url', '');
+
+  const editorRef = useRef(null);
+
+  // Register focus function for the focusUrlBar shortcut
+  // Places the cursor at the end of the URL text
+  if (urlBarFocusRef) {
+    urlBarFocusRef.current = () => {
+      const editor = editorRef.current?.editor;
+      if (!editor) return;
+      editor.focus();
+      editor.setCursor({ line: editor.lastLine(), ch: editor.getLine(editor.lastLine()).length });
+    };
+  }
 
   const allVariables = useMemo(() => {
     return getAllVariables(collection, item);
@@ -129,6 +142,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
             <span className="text-xs font-medium method-ws">WS</span>
           </div>
           <SingleLineEditor
+            ref={editorRef}
             value={url}
             onSave={(finalValue) => onSave(finalValue)}
             onChange={handleUrlChange}

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -66,6 +66,13 @@ const RequestTabPanel = () => {
     return false;
   }, { enabled: !!isRequestTab, deps: [isRequestTab] });
 
+  // Focus the URL bar of the currently rendered request type (http / grpc / ws / graphql)
+  const urlBarFocusRef = useRef(null);
+  useKeybinding('focusUrlBar', () => {
+    urlBarFocusRef.current?.();
+    return false;
+  }, { enabled: !!isRequestTab, deps: [isRequestTab] });
+
   // Use ref to avoid stale closure in event handlers
   const isVerticalLayoutRef = useRef(isVerticalLayout);
   useEffect(() => {
@@ -308,12 +315,12 @@ const RequestTabPanel = () => {
   };
   const renderQueryUrl = () => {
     if (isGrpcRequest) {
-      return <GrpcQueryUrl item={item} collection={collection} handleRun={handleRun} />;
+      return <GrpcQueryUrl item={item} collection={collection} handleRun={handleRun} urlBarFocusRef={urlBarFocusRef} />;
     }
     if (isWsRequest) {
-      return <WsQueryUrl item={item} collection={collection} handleRun={handleRun} />;
+      return <WsQueryUrl item={item} collection={collection} handleRun={handleRun} urlBarFocusRef={urlBarFocusRef} />;
     }
-    return <QueryUrl item={item} collection={collection} handleRun={handleRun} />;
+    return <QueryUrl item={item} collection={collection} handleRun={handleRun} urlBarFocusRef={urlBarFocusRef} />;
   };
 
   const renderRequestPane = () => {

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -38,7 +38,8 @@ export const KEY_BINDING_SECTIONS = [
     heading: 'Requests',
     bindings: {
       sendRequest: { mac: 'command+bind+enter', windows: 'ctrl+bind+enter', name: 'Send Request' }, // D
-      changeLayout: { mac: 'command+bind+j', windows: 'ctrl+bind+j', name: 'Change Orientation' } // D
+      changeLayout: { mac: 'command+bind+j', windows: 'ctrl+bind+j', name: 'Change Orientation' }, // D
+      focusUrlBar: { mac: 'command+bind+l', windows: 'ctrl+bind+l', name: 'Focus URL Bar' } // D
     }
   },
   {

--- a/tests/shortcuts/bound-actions.spec.ts
+++ b/tests/shortcuts/bound-actions.spec.ts
@@ -1741,7 +1741,7 @@ test.describe('Shortcut Keys - BOUND_ACTIONS', () => {
   });
 
   test.describe('SHORTCUT: Focus URL Bar', () => {
-    test.only('default Cmd/Ctrl+L focuses URL bar on HTTP request', async ({ page }) => {
+    test('default Cmd/Ctrl+L focuses URL bar on HTTP request', async ({ page }) => {
       // Close any open tabs first via Alt+Y (customized closeAllTabs from earlier tests)
       await page.keyboard.down('Alt');
       await page.keyboard.down('KeyY');
@@ -1767,7 +1767,7 @@ test.describe('Shortcut Keys - BOUND_ACTIONS', () => {
       await expect(page.locator('#request-url textarea')).toHaveValue('http://localhost:8081', { timeout: 2000 });
     });
 
-    test.only('default Cmd/Ctrl+L focuses URL bar on WebSocket request', async ({ page }) => {
+    test('default Cmd/Ctrl+L focuses URL bar on WebSocket request', async ({ page }) => {
       await page.keyboard.down('Alt');
       await page.keyboard.down('KeyY');
       await page.keyboard.up('KeyY');
@@ -1792,7 +1792,7 @@ test.describe('Shortcut Keys - BOUND_ACTIONS', () => {
       await expect(page.locator('.input-container textarea').first()).toHaveValue('ws://localhost:8081', { timeout: 2000 });
     });
 
-    test.only('default Cmd/Ctrl+L focuses URL bar on gRPC request', async ({ page }) => {
+    test('default Cmd/Ctrl+L focuses URL bar on gRPC request', async ({ page }) => {
       await page.keyboard.down('Alt');
       await page.keyboard.down('KeyY');
       await page.keyboard.up('KeyY');
@@ -1816,7 +1816,7 @@ test.describe('Shortcut Keys - BOUND_ACTIONS', () => {
       await expect(page.locator('.input-container textarea').first()).toHaveValue('localhost:8081', { timeout: 2000 });
     });
 
-    test.only('customized Alt+U focuses URL bar on HTTP request', async ({ page }) => {
+    test('customized Alt+U focuses URL bar on HTTP request', async ({ page }) => {
       await page.keyboard.down('Alt');
       await page.keyboard.down('KeyY');
       await page.keyboard.up('KeyY');

--- a/tests/shortcuts/bound-actions.spec.ts
+++ b/tests/shortcuts/bound-actions.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, Page } from '../../playwright';
 import {
   createCollection,
   createRequest,
+  createTransientRequest,
   openRequest as openRequestBase,
   closeAllCollections,
   createFolder,
@@ -1734,6 +1735,124 @@ test.describe('Shortcut Keys - BOUND_ACTIONS', () => {
       await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible({ timeout: 2000 });
 
       // Rest Default - just in case to not fail shortcuts in other places
+      await openKeybindingsTab(page);
+      await page.getByTestId('reset-all-keybindings-btn').click({ timeout: 2000 });
+    });
+  });
+
+  test.describe('SHORTCUT: Focus URL Bar', () => {
+    test.only('default Cmd/Ctrl+L focuses URL bar on HTTP request', async ({ page }) => {
+      // Close any open tabs first via Alt+Y (customized closeAllTabs from earlier tests)
+      await page.keyboard.down('Alt');
+      await page.keyboard.down('KeyY');
+      await page.keyboard.up('KeyY');
+      await page.keyboard.up('Alt');
+
+      // Create a transient HTTP request (empty URL by default)
+      await createTransientRequest(page, { requestType: 'HTTP' });
+
+      // Click elsewhere to move focus away from the URL bar
+      await page.locator('body').click();
+
+      // Press Cmd/Ctrl+L to focus the URL bar
+      await page.keyboard.down(modifier);
+      await page.keyboard.down('KeyL');
+      await page.keyboard.up('KeyL');
+      await page.keyboard.up(modifier);
+
+      // Type a URL — if focus worked, the URL input will receive the characters
+      await page.keyboard.type('http://localhost:8081');
+
+      // Verify the URL input contains the typed value
+      await expect(page.locator('#request-url textarea')).toHaveValue('http://localhost:8081', { timeout: 2000 });
+    });
+
+    test.only('default Cmd/Ctrl+L focuses URL bar on WebSocket request', async ({ page }) => {
+      await page.keyboard.down('Alt');
+      await page.keyboard.down('KeyY');
+      await page.keyboard.up('KeyY');
+      await page.keyboard.up('Alt');
+
+      // Create a transient WebSocket request
+      await createTransientRequest(page, { requestType: 'WebSocket' });
+
+      // Click elsewhere to move focus away from the URL bar
+      await page.locator('body').click();
+
+      // Press Cmd/Ctrl+L to focus the URL bar
+      await page.keyboard.down(modifier);
+      await page.keyboard.down('KeyL');
+      await page.keyboard.up('KeyL');
+      await page.keyboard.up(modifier);
+
+      // Type a WS URL
+      await page.keyboard.type('ws://localhost:8081');
+
+      // WS/gRPC URL bar is in `.input-container textarea`
+      await expect(page.locator('.input-container textarea').first()).toHaveValue('ws://localhost:8081', { timeout: 2000 });
+    });
+
+    test.only('default Cmd/Ctrl+L focuses URL bar on gRPC request', async ({ page }) => {
+      await page.keyboard.down('Alt');
+      await page.keyboard.down('KeyY');
+      await page.keyboard.up('KeyY');
+      await page.keyboard.up('Alt');
+
+      // Create a transient gRPC request
+      await createTransientRequest(page, { requestType: 'gRPC' });
+
+      // Click elsewhere to move focus away from the URL bar
+      await page.locator('body').click();
+
+      // Press Cmd/Ctrl+L to focus the URL bar
+      await page.keyboard.down(modifier);
+      await page.keyboard.down('KeyL');
+      await page.keyboard.up('KeyL');
+      await page.keyboard.up(modifier);
+
+      // Type a gRPC URL
+      await page.keyboard.type('localhost:8081');
+
+      await expect(page.locator('.input-container textarea').first()).toHaveValue('localhost:8081', { timeout: 2000 });
+    });
+
+    test.only('customized Alt+U focuses URL bar on HTTP request', async ({ page }) => {
+      await page.keyboard.down('Alt');
+      await page.keyboard.down('KeyY');
+      await page.keyboard.up('KeyY');
+      await page.keyboard.up('Alt');
+
+      // Remap focusUrlBar to Alt+U
+      await openKeybindingsTab(page);
+      const row = page.getByTestId('keybinding-row-focusUrlBar');
+      await row.hover();
+      await page.getByTestId('keybinding-edit-focusUrlBar').click();
+      await expect(page.getByTestId('keybinding-input-focusUrlBar')).toBeVisible({ timeout: 2000 });
+
+      await page.keyboard.down('Backspace');
+
+      await page.keyboard.down('Alt');
+      await page.keyboard.down('KeyU');
+      await page.keyboard.up('KeyU');
+      await page.keyboard.up('Alt');
+
+      await closePreferencesTab(page);
+
+      // Create a transient HTTP request
+      await createTransientRequest(page, { requestType: 'HTTP' });
+      await page.locator('body').click();
+
+      // Press customized Alt+U to focus the URL bar
+      await page.keyboard.down('Alt');
+      await page.keyboard.down('KeyU');
+      await page.keyboard.up('KeyU');
+      await page.keyboard.up('Alt');
+
+      await page.keyboard.type('http://localhost:8081');
+
+      await expect(page.locator('#request-url textarea')).toHaveValue('http://localhost:8081', { timeout: 2000 });
+
+      // Reset Default - just in case to not fail shortcuts in other places
       await openKeybindingsTab(page);
       await page.getByTestId('reset-all-keybindings-btn').click({ timeout: 2000 });
     });


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Cmd/Ctrl+L) to focus the request URL bar for HTTP, WebSocket, and gRPC requests.
  * Shortcut is configurable and can be remapped to a different key combo.

* **Tests**
  * End-to-end tests added to verify focus behavior across request types and keybinding remapping/reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->