### PR TITLE
refactor(table): virtualise tables for perf for EditableTable components

### DIFF
--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -80,6 +80,8 @@ const StyledWrapper = styled.div`
 
   tbody {
     tr {
+      height: 35px;
+      max-height: 35px;
       transition: background 0.1s ease;
 
       &:last-child td {
@@ -87,6 +89,8 @@ const StyledWrapper = styled.div`
       }
 
       td {
+        height: 35px;
+        max-height: 35px;
         padding: 1px 10px !important;
         border-top: none !important;
         border-left: none !important;
@@ -96,17 +100,23 @@ const StyledWrapper = styled.div`
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        box-sizing: border-box;
 
-        &:last-child {
-          border-right: none;
+        > div {
+          height: 33px;
+          max-height: 33px;
+          overflow: hidden;
         }
 
         /* Handle CodeMirror editors overflow */
         .cm-editor {
           max-width: 100%;
+          height: 33px !important;
+          max-height: 33px !important;
 
           .cm-scroller {
             overflow: hidden !important;
+            max-height: 33px;
           }
 
           .cm-content {

--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -1,10 +1,8 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  overflow: hidden;
+  display: block;
+  width: 100%;
 
   &.is-resizing {
     cursor: col-resize !important;
@@ -12,9 +10,9 @@ const StyledWrapper = styled.div`
   }
 
   .table-container {
-    overflow: auto;
     border-radius: ${(props) => props.theme.border.radius.base};
     border: solid 1px ${(props) => props.theme.border.border0};
+    overflow: clip;
   }
 
   table {

--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 const StyledWrapper = styled.div`
   display: block;
   width: 100%;
+  isolation: isolate;
 
   &.is-resizing {
     cursor: col-resize !important;

--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -101,7 +101,7 @@ const StyledWrapper = styled.div`
         white-space: nowrap;
         box-sizing: border-box;
 
-        > div {
+        > div:not(.drag-handle) {
           height: 33px;
           max-height: 33px;
           overflow: hidden;
@@ -196,6 +196,9 @@ const StyledWrapper = styled.div`
   .drag-handle {
     opacity: 0;
     transition: opacity 0.1s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     .icon-grip,
     .icon-minus {
@@ -203,7 +206,8 @@ const StyledWrapper = styled.div`
     }
   }
 
-  tbody tr:hover .drag-handle {
+  tbody tr:hover .drag-handle,
+  tbody tr.drag-over .drag-handle {
     opacity: 1;
   }
 

--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -193,10 +193,17 @@ const StyledWrapper = styled.div`
   }
 
   .drag-handle {
+    opacity: 0;
+    transition: opacity 0.1s ease;
+
     .icon-grip,
     .icon-minus {
       color: ${(props) => props.theme.colors.text.muted};
     }
+  }
+
+  tbody tr:hover .drag-handle {
+    opacity: 1;
   }
 
   select {

--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -20,8 +20,8 @@ const findScrollParent = (element) => {
 
 const TableRow = React.memo(
   ({ children, item, context, ...rest }) => {
-    const rowIndex = rest['data-item-index'];
-    const { reorderable, reorderableRowCount, isLastEmptyRow, onDragStart, onDragOver, onDrop, onDragEnd, onRowMouseEnter, onRowMouseLeave } = context;
+    const rowIndex = Number(rest['data-item-index']);
+    const { reorderable, reorderableRowCount, isLastEmptyRow, onDragStart, onDragOver, onDrop, onDragEnd } = context;
     const isEmpty = isLastEmptyRow(item, rowIndex);
     const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount;
 
@@ -33,8 +33,6 @@ const TableRow = React.memo(
         onDragOver={canDrag ? (e) => onDragOver(e, rowIndex) : undefined}
         onDrop={canDrag ? (e) => onDrop(e, rowIndex) : undefined}
         onDragEnd={canDrag ? onDragEnd : undefined}
-        onMouseEnter={() => onRowMouseEnter(rowIndex)}
-        onMouseLeave={onRowMouseLeave}
       >
         {children}
       </tr>
@@ -65,7 +63,6 @@ const EditableTable = ({
   const virtuosoRef = useRef(null);
   const emptyRowUidRef = useRef(null);
   const prevRowCountRef = useRef(0);
-  const [hoveredRow, setHoveredRow] = useState(null);
   const [resizing, setResizing] = useState(null);
   const [tableHeight, setTableHeight] = useState(0);
   const [scrollParent, setScrollParent] = useState(null);
@@ -282,10 +279,9 @@ const EditableTable = ({
     e.dataTransfer.setData('text/plain', index);
   }, []);
 
-  const handleDragOver = useCallback((e, index) => {
+  const handleDragOver = useCallback((e) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
-    setHoveredRow(index);
   }, []);
 
   const reorderableRowCount = showAddRow ? rowsWithEmpty.length - 1 : rowsWithEmpty.length;
@@ -293,31 +289,16 @@ const EditableTable = ({
   const handleDrop = useCallback((e, toIndex) => {
     e.preventDefault();
     const fromIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
-    if (fromIndex !== toIndex && onReorder) {
-      const reorderableRows = showAddRow ? rowsWithEmpty.slice(0, -1) : rowsWithEmpty;
-      const updatedOrder = [...reorderableRows];
-      const [movedRow] = updatedOrder.splice(fromIndex, 1);
-      if (!movedRow) {
-        setHoveredRow(null);
-        return;
-      }
-      updatedOrder.splice(toIndex, 0, movedRow);
-      onReorder({ updateReorderedItem: updatedOrder.map((row) => row.uid) });
-    }
-    setHoveredRow(null);
+    if (fromIndex === toIndex || !onReorder) return;
+    const reorderableRows = showAddRow ? rowsWithEmpty.slice(0, -1) : rowsWithEmpty;
+    const updatedOrder = [...reorderableRows];
+    const [movedRow] = updatedOrder.splice(fromIndex, 1);
+    if (!movedRow) return;
+    updatedOrder.splice(toIndex, 0, movedRow);
+    onReorder({ updateReorderedItem: updatedOrder.map((row) => row.uid) });
   }, [onReorder, rowsWithEmpty, showAddRow]);
 
-  const handleDragEnd = useCallback(() => {
-    setHoveredRow(null);
-  }, []);
-
-  const handleRowMouseEnter = useCallback((rowIndex) => {
-    setHoveredRow(rowIndex);
-  }, []);
-
-  const handleRowMouseLeave = useCallback(() => {
-    setHoveredRow(null);
-  }, []);
+  const handleDragEnd = useCallback(() => {}, []);
 
   const renderCell = useCallback((column, row, rowIndex) => {
     const isEmpty = isLastEmptyRow(row, rowIndex);
@@ -380,10 +361,8 @@ const EditableTable = ({
     onDragStart: handleDragStart,
     onDragOver: handleDragOver,
     onDrop: handleDrop,
-    onDragEnd: handleDragEnd,
-    onRowMouseEnter: handleRowMouseEnter,
-    onRowMouseLeave: handleRowMouseLeave
-  }), [reorderable, reorderableRowCount, isLastEmptyRow, handleDragStart, handleDragOver, handleDrop, handleDragEnd, handleRowMouseEnter, handleRowMouseLeave]);
+    onDragEnd: handleDragEnd
+  }), [reorderable, reorderableRowCount, isLastEmptyRow, handleDragStart, handleDragOver, handleDrop, handleDragEnd]);
 
   const fixedHeaderContent = useCallback(() => (
     <tr>
@@ -424,18 +403,14 @@ const EditableTable = ({
                 draggable
                 className="drag-handle group absolute z-10 left-[-8px] top-1/2 -translate-y-1/2 p-1 cursor-grab"
               >
-                {hoveredRow === rowIndex && (
-                  <>
-                    <IconGripVertical
-                      size={14}
-                      className="icon-grip hidden group-hover:block"
-                    />
-                    <IconMinusVertical
-                      size={14}
-                      className="icon-minus block group-hover:hidden"
-                    />
-                  </>
-                )}
+                <IconGripVertical
+                  size={14}
+                  className="icon-grip hidden group-hover:block"
+                />
+                <IconMinusVertical
+                  size={14}
+                  className="icon-minus block group-hover:hidden"
+                />
               </div>
             )}
             {!isEmpty && (
@@ -469,7 +444,7 @@ const EditableTable = ({
         )}
       </>
     );
-  }, [showCheckbox, reorderable, reorderableRowCount, hoveredRow, isLastEmptyRow, checkboxKey, disableCheckbox, handleCheckboxChange, columns, renderCell, showDelete, handleRemoveRow]);
+  }, [showCheckbox, reorderable, reorderableRowCount, isLastEmptyRow, checkboxKey, disableCheckbox, handleCheckboxChange, columns, renderCell, showDelete, handleRemoveRow]);
 
   return (
     <StyledWrapper

--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -21,16 +21,21 @@ const findScrollParent = (element) => {
 const TableRow = React.memo(
   ({ children, item, context, ...rest }) => {
     const rowIndex = Number(rest['data-item-index']);
-    const { reorderable, reorderableRowCount, isLastEmptyRow, onDragStart, onDragOver, onDrop, onDragEnd } = context;
+    const { reorderable, reorderableRowCount, isLastEmptyRow, dragOverRow, onDragStart, onDragOver, onDrop, onDragEnd, onDragLeave } = context;
     const isEmpty = isLastEmptyRow(item, rowIndex);
     const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount;
+    const isDragOver = canDrag && dragOverRow === rowIndex;
+    const existingClass = rest.className || '';
+    const className = isDragOver ? `${existingClass} drag-over`.trim() : existingClass;
 
     return (
       <tr
         {...rest}
+        className={className}
         draggable={canDrag}
         onDragStart={canDrag ? (e) => onDragStart(e, rowIndex) : undefined}
         onDragOver={canDrag ? (e) => onDragOver(e, rowIndex) : undefined}
+        onDragLeave={canDrag ? (e) => onDragLeave(e, rowIndex) : undefined}
         onDrop={canDrag ? (e) => onDrop(e, rowIndex) : undefined}
         onDragEnd={canDrag ? onDragEnd : undefined}
       >
@@ -66,6 +71,7 @@ const EditableTable = ({
   const [resizing, setResizing] = useState(null);
   const [tableHeight, setTableHeight] = useState(0);
   const [scrollParent, setScrollParent] = useState(null);
+  const [dragOverRow, setDragOverRow] = useState(null);
   const widths = columnWidths || {};
 
   useLayoutEffect(() => {
@@ -279,15 +285,22 @@ const EditableTable = ({
     e.dataTransfer.setData('text/plain', index);
   }, []);
 
-  const handleDragOver = useCallback((e) => {
+  const handleDragOver = useCallback((e, index) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
+    setDragOverRow((prev) => (prev === index ? prev : index));
+  }, []);
+
+  const handleDragLeave = useCallback((e, index) => {
+    if (e.currentTarget.contains(e.relatedTarget)) return;
+    setDragOverRow((prev) => (prev === index ? null : prev));
   }, []);
 
   const reorderableRowCount = showAddRow ? rowsWithEmpty.length - 1 : rowsWithEmpty.length;
 
   const handleDrop = useCallback((e, toIndex) => {
     e.preventDefault();
+    setDragOverRow(null);
     const fromIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
     if (fromIndex === toIndex || !onReorder) return;
     const reorderableRows = showAddRow ? rowsWithEmpty.slice(0, -1) : rowsWithEmpty;
@@ -298,7 +311,9 @@ const EditableTable = ({
     onReorder({ updateReorderedItem: updatedOrder.map((row) => row.uid) });
   }, [onReorder, rowsWithEmpty, showAddRow]);
 
-  const handleDragEnd = useCallback(() => {}, []);
+  const handleDragEnd = useCallback(() => {
+    setDragOverRow(null);
+  }, []);
 
   const renderCell = useCallback((column, row, rowIndex) => {
     const isEmpty = isLastEmptyRow(row, rowIndex);
@@ -358,11 +373,13 @@ const EditableTable = ({
     reorderable,
     reorderableRowCount,
     isLastEmptyRow,
+    dragOverRow,
     onDragStart: handleDragStart,
     onDragOver: handleDragOver,
+    onDragLeave: handleDragLeave,
     onDrop: handleDrop,
     onDragEnd: handleDragEnd
-  }), [reorderable, reorderableRowCount, isLastEmptyRow, handleDragStart, handleDragOver, handleDrop, handleDragEnd]);
+  }), [reorderable, reorderableRowCount, isLastEmptyRow, dragOverRow, handleDragStart, handleDragOver, handleDragLeave, handleDrop, handleDragEnd]);
 
   const fixedHeaderContent = useCallback(() => (
     <tr>

--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { TableVirtuoso } from 'react-virtuoso';
 import { IconTrash, IconAlertCircle, IconGripVertical, IconMinusVertical } from '@tabler/icons';
 import { Tooltip } from 'react-tooltip';
@@ -7,7 +7,16 @@ import StyledWrapper from './StyledWrapper';
 
 const MIN_COLUMN_WIDTH = 80;
 const ROW_HEIGHT = 35;
-const MIN_TABLE_HEIGHT = ROW_HEIGHT * 2;
+
+const findScrollParent = (element) => {
+  let parent = element?.parentElement;
+  while (parent) {
+    const { overflowY } = getComputedStyle(parent);
+    if (overflowY === 'auto' || overflowY === 'scroll') return parent;
+    parent = parent.parentElement;
+  }
+  return null;
+};
 
 const TableRow = React.memo(
   ({ children, item, context, ...rest }) => {
@@ -58,12 +67,16 @@ const EditableTable = ({
   const prevRowCountRef = useRef(0);
   const [hoveredRow, setHoveredRow] = useState(null);
   const [resizing, setResizing] = useState(null);
-  const [tableHeight, setTableHeight] = useState(MIN_TABLE_HEIGHT);
+  const [tableHeight, setTableHeight] = useState(0);
+  const [scrollParent, setScrollParent] = useState(null);
   const widths = columnWidths || {};
 
+  useLayoutEffect(() => {
+    setScrollParent(findScrollParent(wrapperRef.current));
+  }, []);
+
   const handleTotalHeightChanged = useCallback((h) => {
-    const max = typeof window !== 'undefined' ? window.innerHeight - 200 : 600;
-    setTableHeight(Math.min(h, max));
+    setTableHeight(h);
   }, []);
 
   const handleColumnWidthsChange = useCallback((newWidths) => {
@@ -467,11 +480,11 @@ const EditableTable = ({
       <TableVirtuoso
         ref={virtuosoRef}
         className="table-container"
-        style={{ height: tableHeight }}
+        customScrollParent={scrollParent || undefined}
         data={rowsWithEmpty}
         components={{ TableRow }}
         context={virtuosoContext}
-        fixedItemHeight={ROW_HEIGHT}
+        defaultItemHeight={ROW_HEIGHT}
         totalListHeightChanged={handleTotalHeightChanged}
         computeItemKey={(_, item) => item.uid}
         fixedHeaderContent={fixedHeaderContent}

--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -1,10 +1,37 @@
-import React, { useCallback, useMemo, useRef, useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { TableVirtuoso } from 'react-virtuoso';
 import { IconTrash, IconAlertCircle, IconGripVertical, IconMinusVertical } from '@tabler/icons';
 import { Tooltip } from 'react-tooltip';
 import { uuid } from 'utils/common';
 import StyledWrapper from './StyledWrapper';
 
 const MIN_COLUMN_WIDTH = 80;
+const ROW_HEIGHT = 35;
+const MIN_TABLE_HEIGHT = ROW_HEIGHT * 2;
+
+const TableRow = React.memo(
+  ({ children, item, context, ...rest }) => {
+    const rowIndex = rest['data-item-index'];
+    const { reorderable, reorderableRowCount, isLastEmptyRow, onDragStart, onDragOver, onDrop, onDragEnd, onRowMouseEnter, onRowMouseLeave } = context;
+    const isEmpty = isLastEmptyRow(item, rowIndex);
+    const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount;
+
+    return (
+      <tr
+        {...rest}
+        draggable={canDrag}
+        onDragStart={canDrag ? (e) => onDragStart(e, rowIndex) : undefined}
+        onDragOver={canDrag ? (e) => onDragOver(e, rowIndex) : undefined}
+        onDrop={canDrag ? (e) => onDrop(e, rowIndex) : undefined}
+        onDragEnd={canDrag ? onDragEnd : undefined}
+        onMouseEnter={() => onRowMouseEnter(rowIndex)}
+        onMouseLeave={onRowMouseLeave}
+      >
+        {children}
+      </tr>
+    );
+  }
+);
 
 const EditableTable = ({
   tableId, // Not being used kept to maintain uniqueness & pass similar in onColumnWidthsChange
@@ -25,12 +52,19 @@ const EditableTable = ({
   columnWidths,
   onColumnWidthsChange
 }) => {
-  const tableRef = useRef(null);
+  const wrapperRef = useRef(null);
+  const virtuosoRef = useRef(null);
   const emptyRowUidRef = useRef(null);
+  const prevRowCountRef = useRef(0);
   const [hoveredRow, setHoveredRow] = useState(null);
   const [resizing, setResizing] = useState(null);
-  const [tableHeight, setTableHeight] = useState(0);
+  const [tableHeight, setTableHeight] = useState(MIN_TABLE_HEIGHT);
   const widths = columnWidths || {};
+
+  const handleTotalHeightChanged = useCallback((h) => {
+    const max = typeof window !== 'undefined' ? window.innerHeight - 200 : 600;
+    setTableHeight(Math.min(h, max));
+  }, []);
 
   const handleColumnWidthsChange = useCallback((newWidths) => {
     onColumnWidthsChange?.(newWidths);
@@ -71,7 +105,7 @@ const EditableTable = ({
 
     const handleMouseUp = () => {
       // Convert pixel widths to percentages for responsive scaling
-      const table = tableRef.current?.querySelector('table');
+      const table = wrapperRef.current?.querySelector('table');
       if (table) {
         const tableWidth = table.offsetWidth;
         const headerCells = table.querySelectorAll('thead td');
@@ -102,23 +136,6 @@ const EditableTable = ({
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('mouseup', handleMouseUp);
   }, [columns, showCheckbox, widths, handleColumnWidthsChange]);
-
-  // Track table height for resize handles
-  useEffect(() => {
-    const table = tableRef.current?.querySelector('table');
-    if (!table) return;
-
-    const updateHeight = () => {
-      setTableHeight(table.offsetHeight);
-    };
-
-    updateHeight();
-
-    const resizeObserver = new ResizeObserver(updateHeight);
-    resizeObserver.observe(table);
-
-    return () => resizeObserver.disconnect();
-  }, [rows.length]);
 
   const getColumnWidth = useCallback((column) => {
     return widths[column.key] || column.width || 'auto';
@@ -178,6 +195,16 @@ const EditableTable = ({
     if (!showAddRow) return false;
     return index === rowsWithEmpty.length - 1 && isEmptyRow(row);
   }, [rowsWithEmpty.length, isEmptyRow, showAddRow]);
+
+  useEffect(() => {
+    if (rowsWithEmpty.length > prevRowCountRef.current && prevRowCountRef.current > 0) {
+      virtuosoRef.current?.scrollToIndex({
+        index: rowsWithEmpty.length - 1,
+        behavior: 'smooth'
+      });
+    }
+    prevRowCountRef.current = rowsWithEmpty.length;
+  }, [rowsWithEmpty.length]);
 
   const handleValueChange = useCallback((rowUid, key, value) => {
     const rowIndex = rowsWithEmpty.findIndex((r) => r.uid === rowUid);
@@ -248,6 +275,8 @@ const EditableTable = ({
     setHoveredRow(index);
   }, []);
 
+  const reorderableRowCount = showAddRow ? rowsWithEmpty.length - 1 : rowsWithEmpty.length;
+
   const handleDrop = useCallback((e, toIndex) => {
     e.preventDefault();
     const fromIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
@@ -266,6 +295,14 @@ const EditableTable = ({
   }, [onReorder, rowsWithEmpty, showAddRow]);
 
   const handleDragEnd = useCallback(() => {
+    setHoveredRow(null);
+  }, []);
+
+  const handleRowMouseEnter = useCallback((rowIndex) => {
+    setHoveredRow(rowIndex);
+  }, []);
+
+  const handleRowMouseLeave = useCallback(() => {
     setHoveredRow(null);
   }, []);
 
@@ -323,109 +360,123 @@ const EditableTable = ({
     );
   }, [isLastEmptyRow, getRowError, handleValueChange]);
 
-  const reorderableRowCount = showAddRow ? rowsWithEmpty.length - 1 : rowsWithEmpty.length;
+  const virtuosoContext = useMemo(() => ({
+    reorderable,
+    reorderableRowCount,
+    isLastEmptyRow,
+    onDragStart: handleDragStart,
+    onDragOver: handleDragOver,
+    onDrop: handleDrop,
+    onDragEnd: handleDragEnd,
+    onRowMouseEnter: handleRowMouseEnter,
+    onRowMouseLeave: handleRowMouseLeave
+  }), [reorderable, reorderableRowCount, isLastEmptyRow, handleDragStart, handleDragOver, handleDrop, handleDragEnd, handleRowMouseEnter, handleRowMouseLeave]);
+
+  const fixedHeaderContent = useCallback(() => (
+    <tr>
+      {showCheckbox && (
+        <td className="text-center">{checkboxLabel}</td>
+      )}
+      {columns.map((column, colIndex) => (
+        <td
+          key={column.key}
+          style={{ width: getColumnWidth(column) }}
+        >
+          <span className="column-name">{column.name}</span>
+          {colIndex < columns.length - 1 && (
+            <div
+              className={`resize-handle ${resizing === column.key ? 'resizing' : ''}`}
+              style={{ height: tableHeight > 0 ? `${tableHeight}px` : undefined }}
+              onMouseDown={(e) => handleResizeStart(e, column.key)}
+            />
+          )}
+        </td>
+      ))}
+      {showDelete && (
+        <td style={{ width: '60px' }}></td>
+      )}
+    </tr>
+  ), [showCheckbox, checkboxLabel, columns, getColumnWidth, resizing, tableHeight, handleResizeStart, showDelete]);
+
+  const itemContent = useCallback((rowIndex, row) => {
+    const isEmpty = isLastEmptyRow(row, rowIndex);
+    const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount;
+
+    return (
+      <>
+        {showCheckbox && (
+          <td className="text-center relative">
+            {reorderable && canDrag && (
+              <div
+                draggable
+                className="drag-handle group absolute z-10 left-[-8px] top-1/2 -translate-y-1/2 p-1 cursor-grab"
+              >
+                {hoveredRow === rowIndex && (
+                  <>
+                    <IconGripVertical
+                      size={14}
+                      className="icon-grip hidden group-hover:block"
+                    />
+                    <IconMinusVertical
+                      size={14}
+                      className="icon-minus block group-hover:hidden"
+                    />
+                  </>
+                )}
+              </div>
+            )}
+            {!isEmpty && (
+              <input
+                type="checkbox"
+                className="mousetrap"
+                data-testid="column-checkbox"
+                checked={row[checkboxKey] ?? true}
+                disabled={disableCheckbox}
+                onChange={(e) => handleCheckboxChange(row.uid, e.target.checked)}
+              />
+            )}
+          </td>
+        )}
+        {columns.map((column) => (
+          <td key={column.key} data-testid={`column-${column.key}`}>
+            {renderCell(column, row, rowIndex)}
+          </td>
+        ))}
+        {showDelete && (
+          <td>
+            {!isEmpty && (
+              <button
+                data-testid="column-delete"
+                onClick={() => handleRemoveRow(row.uid)}
+              >
+                <IconTrash strokeWidth={1.5} size={18} />
+              </button>
+            )}
+          </td>
+        )}
+      </>
+    );
+  }, [showCheckbox, reorderable, reorderableRowCount, hoveredRow, isLastEmptyRow, checkboxKey, disableCheckbox, handleCheckboxChange, columns, renderCell, showDelete, handleRemoveRow]);
 
   return (
-    <StyledWrapper className={`${showCheckbox ? 'has-checkbox' : 'no-checkbox'} ${resizing ? 'is-resizing' : ''}`}>
-      <div className="table-container" ref={tableRef} data-testid={testId}>
-        <table>
-          <thead>
-            <tr>
-              {showCheckbox && (
-                <td className="text-center">{checkboxLabel}</td>
-              )}
-              {columns.map((column, colIndex) => (
-                <td
-                  key={column.key}
-                  style={{ width: getColumnWidth(column) }}
-                >
-                  <span className="column-name">{column.name}</span>
-                  {colIndex < columns.length - 1 && (
-                    <div
-                      className={`resize-handle ${resizing === column.key ? 'resizing' : ''}`}
-                      style={{ height: tableHeight > 0 ? `${tableHeight}px` : undefined }}
-                      onMouseDown={(e) => handleResizeStart(e, column.key)}
-                    />
-                  )}
-                </td>
-              ))}
-              {showDelete && (
-                <td style={{ width: '60px' }}></td>
-              )}
-            </tr>
-          </thead>
-          <tbody>
-            {rowsWithEmpty.map((row, rowIndex) => {
-              const isEmpty = isLastEmptyRow(row, rowIndex);
-              const canDrag = reorderable && !isEmpty && rowIndex < reorderableRowCount;
-
-              return (
-                <tr
-                  key={row.uid}
-                  draggable={canDrag}
-                  onDragStart={canDrag ? (e) => handleDragStart(e, rowIndex) : undefined}
-                  onDragOver={canDrag ? (e) => handleDragOver(e, rowIndex) : undefined}
-                  onDrop={canDrag ? (e) => handleDrop(e, rowIndex) : undefined}
-                  onDragEnd={canDrag ? handleDragEnd : undefined}
-                  onMouseEnter={() => setHoveredRow(rowIndex)}
-                  onMouseLeave={() => setHoveredRow(null)}
-                >
-                  {showCheckbox && (
-                    <td className="text-center relative">
-                      {reorderable && canDrag && (
-                        <div
-                          draggable
-                          className="drag-handle group absolute z-10 left-[-8px] top-1/2 -translate-y-1/2 p-1 cursor-grab"
-                        >
-                          {hoveredRow === rowIndex && (
-                            <>
-                              <IconGripVertical
-                                size={14}
-                                className="icon-grip hidden group-hover:block"
-                              />
-                              <IconMinusVertical
-                                size={14}
-                                className="icon-minus block group-hover:hidden"
-                              />
-                            </>
-                          )}
-                        </div>
-                      )}
-                      {!isEmpty && (
-                        <input
-                          type="checkbox"
-                          className="mousetrap"
-                          data-testid="column-checkbox"
-                          checked={row[checkboxKey] ?? true}
-                          disabled={disableCheckbox}
-                          onChange={(e) => handleCheckboxChange(row.uid, e.target.checked)}
-                        />
-                      )}
-                    </td>
-                  )}
-                  {columns.map((column) => (
-                    <td key={column.key} data-testid={`column-${column.key}`}>
-                      {renderCell(column, row, rowIndex)}
-                    </td>
-                  ))}
-                  {showDelete && (
-                    <td>
-                      {!isEmpty && (
-                        <button
-                          data-testid="column-delete"
-                          onClick={() => handleRemoveRow(row.uid)}
-                        >
-                          <IconTrash strokeWidth={1.5} size={18} />
-                        </button>
-                      )}
-                    </td>
-                  )}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
+    <StyledWrapper
+      ref={wrapperRef}
+      data-testid={testId}
+      className={`${showCheckbox ? 'has-checkbox' : 'no-checkbox'} ${resizing ? 'is-resizing' : ''}`}
+    >
+      <TableVirtuoso
+        ref={virtuosoRef}
+        className="table-container"
+        style={{ height: tableHeight }}
+        data={rowsWithEmpty}
+        components={{ TableRow }}
+        context={virtuosoContext}
+        fixedItemHeight={ROW_HEIGHT}
+        totalListHeightChanged={handleTotalHeightChanged}
+        computeItemKey={(_, item) => item.uid}
+        fixedHeaderContent={fixedHeaderContent}
+        itemContent={itemContent}
+      />
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
@@ -44,7 +44,6 @@ const Wrapper = styled.div`
     background: ${(props) => props.theme.bg};
     padding-top: 8px;
     padding-bottom: 4px;
-    z-index: 2;
   }
 
   input[type='text'] {

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
@@ -38,6 +38,15 @@ const Wrapper = styled.div`
     }
   }
 
+  .bulk-edit-bar {
+    position: sticky;
+    bottom: 0;
+    background: ${(props) => props.theme.bg};
+    padding-top: 8px;
+    padding-bottom: 4px;
+    z-index: 2;
+  }
+
   input[type='text'] {
     width: 100%;
     border: solid 1px transparent;

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -160,7 +160,7 @@ const QueryParams = ({ item, collection }) => {
           columnWidths={queryParamsWidths}
           onColumnWidthsChange={(widths) => handleColumnWidthsChange('query-params', widths)}
         />
-        <div className="flex justify-end mt-2">
+        <div className="bulk-edit-bar flex justify-end mt-2">
           <button className="btn-action text-link select-none" onClick={toggleBulkEditMode}>
             Bulk Edit
           </button>

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
@@ -35,7 +35,6 @@ const Wrapper = styled.div`
     background: ${(props) => props.theme.bg};
     padding-top: 8px;
     padding-bottom: 4px;
-    z-index: 2;
   }
 
   input[type='text'] {

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/StyledWrapper.js
@@ -29,6 +29,15 @@ const Wrapper = styled.div`
     }
   }
 
+  .bulk-edit-bar {
+    position: sticky;
+    bottom: 0;
+    background: ${(props) => props.theme.bg};
+    padding-top: 8px;
+    padding-bottom: 4px;
+    z-index: 2;
+  }
+
   input[type='text'] {
     width: 100%;
     border: solid 1px transparent;

--- a/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestHeaders/index.js
@@ -145,7 +145,7 @@ const RequestHeaders = ({ item, collection, addHeaderText }) => {
         columnWidths={headersWidths}
         onColumnWidthsChange={(widths) => handleColumnWidthsChange('request-headers', widths)}
       />
-      <div className="flex justify-end mt-2">
+      <div className="bulk-edit-bar flex justify-end mt-2">
         <button className="btn-action text-link select-none" onClick={toggleBulkEditMode}>
           Bulk Edit
         </button>


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2686)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

https://github.com/user-attachments/assets/a7bdbf3f-ddc8-4234-b60d-e986c112ee1d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Virtualized table rendering with a fixed header for smoother scrolling and large datasets; improved scroll parent detection.

* **Bug Fixes**
  * Enforced consistent row/cell heights and tighter in-cell editor sizing to prevent layout shifts.
  * Drag handle hidden by default and revealed on row hover/drag-over.

* **New Features**
  * Auto-scrolls to newly added/empty rows.
  * Bulk Edit toggle moved into a sticky bottom bar for query params and headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->