### PR TITLE
fix: shortcut in query builder

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryBuilder/FieldNode.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryBuilder/FieldNode.js
@@ -231,12 +231,12 @@ const FieldNode = ({
         role="treeitem"
         aria-expanded={isExpanded}
         onClick={handleExpand}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleExpand(e);
-          }
-        }}
+        // onKeyDown={(e) => {
+        //   if (e.key === 'Enter' || e.key === ' ') {
+        //     e.preventDefault();
+        //     handleExpand(e);
+        //   }
+        // }}
         tabIndex={0}
       >
         <span className="field-indent" style={{ width: indent }} />
@@ -269,12 +269,12 @@ const FieldNode = ({
         role="treeitem"
         aria-expanded={canExpand ? isExpanded : undefined}
         onClick={handleExpand}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleExpand(e);
-          }
-        }}
+        // onKeyDown={(e) => {
+        //   if (e.key === 'Enter' || e.key === ' ') {
+        //     e.preventDefault();
+        //     handleExpand(e);
+        //   }
+        // }}
         tabIndex={0}
       >
         <span className="field-indent" style={{ width: indent }} />
@@ -420,12 +420,12 @@ const InputObjectArgRow = ({ arg, argKey, fieldPath, isArgEnabled, sectionIndent
         className="arg-row"
         style={{ paddingLeft: sectionIndent + 8 }}
         onClick={toggleExpand}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            toggleExpand(e);
-          }
-        }}
+        // onKeyDown={(e) => {
+        //   if (e.key === 'Enter' || e.key === ' ') {
+        //     e.preventDefault();
+        //     toggleExpand(e);
+        //   }
+        // }}
         tabIndex={0}
         role="button"
         aria-expanded={isExpanded}
@@ -487,12 +487,12 @@ const ListArgRow = ({ arg, fieldPath, isArgEnabled, argValue, sectionIndent, onT
         className="arg-row"
         style={{ paddingLeft: sectionIndent + 8 }}
         onClick={toggleExpand}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            toggleExpand(e);
-          }
-        }}
+        // onKeyDown={(e) => {
+        //   if (e.key === 'Enter' || e.key === ' ') {
+        //     e.preventDefault();
+        //     toggleExpand(e);
+        //   }
+        // }}
         tabIndex={0}
         role="button"
         aria-expanded={isExpanded}

--- a/packages/bruno-app/src/components/RequestPane/QueryBuilder/FieldNode.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryBuilder/FieldNode.js
@@ -231,12 +231,6 @@ const FieldNode = ({
         role="treeitem"
         aria-expanded={isExpanded}
         onClick={handleExpand}
-        // onKeyDown={(e) => {
-        //   if (e.key === 'Enter' || e.key === ' ') {
-        //     e.preventDefault();
-        //     handleExpand(e);
-        //   }
-        // }}
         tabIndex={0}
       >
         <span className="field-indent" style={{ width: indent }} />
@@ -269,12 +263,6 @@ const FieldNode = ({
         role="treeitem"
         aria-expanded={canExpand ? isExpanded : undefined}
         onClick={handleExpand}
-        // onKeyDown={(e) => {
-        //   if (e.key === 'Enter' || e.key === ' ') {
-        //     e.preventDefault();
-        //     handleExpand(e);
-        //   }
-        // }}
         tabIndex={0}
       >
         <span className="field-indent" style={{ width: indent }} />
@@ -420,12 +408,6 @@ const InputObjectArgRow = ({ arg, argKey, fieldPath, isArgEnabled, sectionIndent
         className="arg-row"
         style={{ paddingLeft: sectionIndent + 8 }}
         onClick={toggleExpand}
-        // onKeyDown={(e) => {
-        //   if (e.key === 'Enter' || e.key === ' ') {
-        //     e.preventDefault();
-        //     toggleExpand(e);
-        //   }
-        // }}
         tabIndex={0}
         role="button"
         aria-expanded={isExpanded}
@@ -487,12 +469,6 @@ const ListArgRow = ({ arg, fieldPath, isArgEnabled, argValue, sectionIndent, onT
         className="arg-row"
         style={{ paddingLeft: sectionIndent + 8 }}
         onClick={toggleExpand}
-        // onKeyDown={(e) => {
-        //   if (e.key === 'Enter' || e.key === ' ') {
-        //     e.preventDefault();
-        //     toggleExpand(e);
-        //   }
-        // }}
         tabIndex={0}
         role="button"
         aria-expanded={isExpanded}

--- a/packages/bruno-app/src/components/RequestPane/QueryBuilder/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryBuilder/StyledWrapper.js
@@ -211,7 +211,12 @@ const StyledWrapper = styled.div`
     padding: 3px 8px;
     font-size: 13px;
     min-width: 0;
-    cursor: default;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+      background: ${(props) => props.theme.background.surface0};
+    }
 
     .input-object-chevron {
       width: 14px;


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed keyboard shortcuts (Enter/spacebar) for expanding query builder rows to prevent unintended interactions.

* **Style**
  * Enhanced visual feedback for interactive query builder rows with improved cursor styling and focus/hover highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->