### PR TITLE
feat: Stabilize variable info editor transition and popup lifecycle (…

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -500,23 +500,30 @@ export const renderVarInfo = (token, options) => {
       if (isEditing) return;
 
       isEditing = true;
-      valueDisplay.style.display = 'none';
+
+      // Stage editor off-visual first to avoid a visible resize/text flash.
       editorContainer.style.display = 'block';
+      editorContainer.style.visibility = 'hidden';
 
       // Focus the editor and ensure proper sizing
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         cmEditor.refresh();
+
+        // Adjust height based on content before revealing editor
+        const sizer = cmEditor.getWrapperElement().querySelector('.CodeMirror-sizer');
+        const contentHeight = sizer ? sizer.clientHeight : cmEditor.getScrollInfo().height;
+        editorContainer.style.height = `${calculateEditorHeight(contentHeight)}rem`;
+
+        // Swap display only after editor layout is ready
+        valueDisplay.style.display = 'none';
+        editorContainer.style.visibility = 'visible';
         cmEditor.focus();
 
         // Set cursor to end of content
         const lineCount = cmEditor.lineCount();
         const lastLine = cmEditor.getLine(lineCount - 1);
         cmEditor.setCursor(lineCount - 1, lastLine ? lastLine.length : 0);
-
-        // Adjust height based on content
-        const contentHeight = cmEditor.getScrollInfo().height;
-        editorContainer.style.height = `${calculateEditorHeight(contentHeight)}rem`;
-      }, 0);
+      });
     });
 
     // Save on blur and return to display mode
@@ -525,6 +532,7 @@ export const renderVarInfo = (token, options) => {
 
       // Switch back to display mode
       editorContainer.style.display = 'none';
+      editorContainer.style.visibility = 'visible';
       editorContainer.style.height = `${EDITOR_MIN_HEIGHT}rem`; // Reset to minimum height
       valueDisplay.style.display = 'block';
       isEditing = false;
@@ -810,8 +818,10 @@ if (!SERVER_RENDERED) {
   }
 
   function showPopup(cm, box, brunoVarInfo) {
-    // If there's already an active popup, remove it first
-    if (activePopup && activePopup.parentNode) {
+    // If there's already an active popup, hide it first to ensure listeners are cleaned up
+    if (activePopup && typeof activePopup._hidePopup === 'function') {
+      activePopup._hidePopup({ immediate: true });
+    } else if (activePopup && activePopup.parentNode) {
       activePopup.parentNode.removeChild(activePopup);
       activePopup = null;
     }
@@ -865,20 +875,49 @@ if (!SERVER_RENDERED) {
     popup.style.left = `${leftPos / 16}rem`;
 
     let popupTimeout;
+    let isPinned = false;
+    let isHidden = false;
 
     const onMouseOverPopup = function () {
       clearTimeout(popupTimeout);
     };
 
     const onMouseOut = function () {
+      if (isPinned) {
+        return;
+      }
       clearTimeout(popupTimeout);
       popupTimeout = setTimeout(hidePopup, 500);
     };
 
-    const hidePopup = function () {
+    const onPopupClick = function (e) {
+      if (!popup.contains(e.target)) {
+        return;
+      }
+      isPinned = true;
+      clearTimeout(popupTimeout);
+    };
+
+    const onDocumentClick = function (e) {
+      if (!popup.contains(e.target)) {
+        isPinned = false;
+        hidePopup();
+      }
+    };
+
+    const hidePopup = function (options = {}) {
+      if (isHidden) {
+        return;
+      }
+      isHidden = true;
+
+      const { immediate = false } = options;
+      clearTimeout(popupTimeout);
       CodeMirror.off(popup, 'mouseover', onMouseOverPopup);
       CodeMirror.off(popup, 'mouseout', onMouseOut);
+      CodeMirror.off(popup, 'click', onPopupClick);
       CodeMirror.off(cm.getWrapperElement(), 'mouseout', onMouseOut);
+      CodeMirror.off(document, 'click', onDocumentClick);
       CodeMirror.off(cm, 'change', onEditorChange);
 
       // Cleanup CodeMirror and MaskedEditor instances
@@ -908,6 +947,13 @@ if (!SERVER_RENDERED) {
         activePopup = null;
       }
 
+      if (immediate) {
+        if (popup.parentNode) {
+          popup.parentNode.removeChild(popup);
+        }
+        return;
+      }
+
       if (popup.style.opacity) {
         popup.style.opacity = 0;
         setTimeout(function () {
@@ -922,12 +968,19 @@ if (!SERVER_RENDERED) {
 
     // Hide popup when user types in the main editor
     const onEditorChange = function () {
-      hidePopup();
+      if (!isPinned) {
+        hidePopup();
+      }
     };
+
+    // Allow replacing existing popup with full cleanup
+    popup._hidePopup = hidePopup;
 
     CodeMirror.on(popup, 'mouseover', onMouseOverPopup);
     CodeMirror.on(popup, 'mouseout', onMouseOut);
+    CodeMirror.on(popup, 'click', onPopupClick);
     CodeMirror.on(cm.getWrapperElement(), 'mouseout', onMouseOut);
+    CodeMirror.on(document, 'click', onDocumentClick);
     CodeMirror.on(cm, 'change', onEditorChange);
   }
 }


### PR DESCRIPTION
…#7458)

* fix: prevent var-info split second UI flicker.

### Description

This PR improves the variable tooltip experience in the CodeMirror var info popup by addressing two UX issues:
1. Tooltip closes too aggressively during interaction (issue #7458).
2. Variable value editor briefly flickers/jumps when entering edit mode.

#### What changed:
1. Existing popup is now closed with full cleanup before opening a new one `brunoVarInfo.js:822`
    - Before: old popup DOM could be removed directly.
    - Now: it calls a stored hide handler first when available, so listeners and editor resources are cleaned safely.

2. Added pin and hide guards `brunoVarInfo.js:872`
    -   isPinned: tracks whether user clicked inside popup.
    -   isHidden: prevents hide logic from running twice.

3. Mouse-out no longer auto-hides when pinned `brunoVarInfo.js:886`
    - If pinned, mouse leaving editor/popup does nothing.

4. Clicking inside popup pins it `brunoVarInfo.js:893`
    - onPopupClick sets isPinned true and clears any pending hide timeout.

5. Clicking outside always closes it `brunoVarInfo.js:901`
    - onDocumentClick checks popup containment.
    - Outside click unpins and closes immediately.

6. Hide function now supports immediate close and full listener cleanup `brunoVarInfo.js:909->950`
    - Adds an immediate option for forced teardown.
    - Removes popup click and document click handlers in cleanup too.

7. Stored internal hide hook on popup node `brunoVarInfo.js:977`
    - Used to safely replace an active popup

#### Net behavior now:

1. Hover variable -> popup appears.
2. If you do not click popup, old auto-hide behavior remains.
3. If you click popup, it becomes pinned.
4. While pinned, mouseout and editor typing do not close it.
5. Clicking anywhere outside closes it.

#### Additonally:

Implemented a fix for that split-second UI flicker when entering variable edit mode.

1. In `brunoVarInfo.js:499`, I changed the click-to-edit flow so the editor is prepared off-visual first.
2. At `brunoVarInfo.js:506`, the editor now opens with visibility: hidden (instead of instantly swapping the visible content).
3. At `brunoVarInfo.js:509`, layout/height is computed in requestAnimationFrame, then the UI swaps to editor only after it is ready.
4. At `brunoVarInfo.js:519`, the editor is revealed after sizing is done.
5. At `brunoVarInfo.js:535`, visibility is reset on blur to keep future transitions consistent.

#### Result:

- No more “expand + empty + snap back” flash when clicking into the field.
- Transition to edit mode should look stable.

#### User Impact:

1. Hover still opens tooltip as before.
2. If user does not interact, tooltip auto-hide behavior remains unchanged.
3. Once user clicks inside tooltip, it stays open while interacting.
4. Clicking outside closes tooltip reliably.
5. Entering variable edit mode no longer shows split-second expansion/empty flash.

https://github.com/user-attachments/assets/f8eb59ac-e574-4fd1-8c23-f5ee115d72ff

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Closes #7458 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor mode transitions with smoother visual updates and reliable layout handling.
  * Enhanced popup behavior with pinning capability and better dismissal controls.
  * Fixed popup lifecycle management with improved listener cleanup and state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->