### PR TITLE
fix: restore default axios request headers

### DIFF
--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -92,10 +92,11 @@ function makeAxiosInstance({
     headers: {}
   });
 
-  // Set User-Agent manually (using transformRequest to delete headers instead)
-  instance.defaults.headers.common = {
-    'User-Agent': `bruno-runtime/${CLI_VERSION}`
-  };
+  // Extend common headers with User-Agent rather than replacing the object.
+  // axios.create() preserves defaults.headers.common = { Accept: 'application/json, text/plain, */*' }.
+  // Assigning a new object (= { 'User-Agent': ... }) would nuke that default, causing servers that
+  // rely on content-negotiation to receive requests with no Accept header.
+  instance.defaults.headers.common['User-Agent'] = `bruno-runtime/${CLI_VERSION}`;
 
   instance.interceptors.request.use((config) => {
     config.headers['request-start-time'] = Date.now();

--- a/packages/bruno-cli/tests/utils/axios-instance.spec.js
+++ b/packages/bruno-cli/tests/utils/axios-instance.spec.js
@@ -1,0 +1,37 @@
+const { describe, it, expect } = require('@jest/globals');
+const { makeAxiosInstance } = require('../../src/utils/axios-instance');
+
+function createStubAdapter() {
+  let capturedConfig = null;
+
+  const adapter = (config) => {
+    capturedConfig = config;
+    return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: {}, config });
+  };
+
+  adapter.getConfig = () => capturedConfig;
+
+  return adapter;
+}
+
+describe('makeAxiosInstance', () => {
+  it('setting User-Agent does not clobber the axios default Accept header', async () => {
+    const stubAdapter = createStubAdapter();
+    const instance = makeAxiosInstance();
+
+    await instance({ url: 'https://api.example.com/test', method: 'get', adapter: stubAdapter });
+
+    // axios.create() sets Accept by default; assigning a new object to defaults.headers.common
+    // would nuke it. Guard against that regression.
+    expect(stubAdapter.getConfig().headers['Accept']).toMatch(/application\/json/);
+  });
+
+  it('sets User-Agent header to bruno-runtime version', async () => {
+    const stubAdapter = createStubAdapter();
+    const instance = makeAxiosInstance();
+
+    await instance({ url: 'https://api.example.com/test', method: 'get', adapter: stubAdapter });
+
+    expect(stubAdapter.getConfig().headers['User-Agent']).toMatch(/^bruno-runtime\//);
+  });
+});

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -99,10 +99,11 @@ function makeAxiosInstance({
     headers: {}
   });
 
-  // Set User-Agent manually (using transformRequest to delete headers instead)
-  instance.defaults.headers.common = {
-    'User-Agent': `bruno-runtime/${version}`
-  };
+  // Extend common headers with User-Agent rather than replacing the object.
+  // axios.create() preserves defaults.headers.common = { Accept: 'application/json, text/plain, */*' }.
+  // Assigning a new object (= { 'User-Agent': ... }) would nuke that default, causing servers that
+  // rely on content-negotiation to receive requests with no Accept header.
+  instance.defaults.headers.common['User-Agent'] = `bruno-runtime/${version}`;
 
   instance.interceptors.request.use(async (config) => {
     const url = URL.parse(config.url);

--- a/packages/bruno-electron/tests/network/axios-instance.spec.js
+++ b/packages/bruno-electron/tests/network/axios-instance.spec.js
@@ -51,6 +51,28 @@ function createStubAdapter() {
   return adapter;
 }
 
+describe('axios-instance: default headers', () => {
+  test('setting User-Agent does not clobber the axios default Accept header', async () => {
+    const stubAdapter = createStubAdapter();
+    const instance = makeAxiosInstance();
+
+    await instance({ url: 'https://api.example.com/test', method: 'get', adapter: stubAdapter });
+
+    // axios.create() sets Accept by default; assigning a new object to defaults.headers.common
+    // would nuke it. Guard against that regression.
+    expect(stubAdapter.getConfig().headers['Accept']).toMatch(/application\/json/);
+  });
+
+  test('sets User-Agent header to bruno-runtime version', async () => {
+    const stubAdapter = createStubAdapter();
+    const instance = makeAxiosInstance();
+
+    await instance({ url: 'https://api.example.com/test', method: 'get', adapter: stubAdapter });
+
+    expect(stubAdapter.getConfig().headers['User-Agent']).toMatch(/^bruno-runtime\//);
+  });
+});
+
 describe('axios-instance: DNS lookup behavior (GitHub #7343)', () => {
   let axiosInstance;
 

--- a/packages/bruno-tests/collection/echo/echo default request headers.bru
+++ b/packages/bruno-tests/collection/echo/echo default request headers.bru
@@ -1,0 +1,28 @@
+meta {
+  name: echo default request headers
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{echo-host}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("sends Accept header with application/json by default", function() {
+    // The echo server reflects request headers back as response headers.
+    // Verifies that axios's default Accept header is not clobbered when
+    // setting User-Agent (regression for: defaults.headers.common object replacement).
+    const accept = res.getHeaders()["accept"];
+    expect(accept).to.be.a("string");
+    expect(accept).to.include("application/json");
+  });
+
+  test("sends User-Agent header with bruno-runtime prefix", function() {
+    const userAgent = res.getHeaders()["user-agent"];
+    expect(userAgent).to.be.a("string");
+    expect(userAgent).to.match(/^bruno-runtime\//);
+  });
+}


### PR DESCRIPTION
[BRU-3149](https://usebruno.atlassian.net/browse/BRU-3149)
Fixes #7819.

### Description

- Commit ca0412b5 replaced the axios instance's defaults.headers.common object entirely. This inadvertently removed the default Accept header from axios.
- Fix by assigning the User-Agent header as an additional property to the existing common headers rather than replacing it. This preserves the axios defaults.



#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing default HTTP headers when configuring requests and ensure a consistent bruno-runtime User-Agent is added without removing other defaults (e.g., Accept).

* **Tests**
  * Added unit and integration tests plus an HTTP request check to validate that Accept remains present and User-Agent is set as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->