### PR TITLE
fix(import): dedupe sibling folder/file names case-insensitively

### DIFF
--- a/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
+++ b/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
@@ -21,9 +21,12 @@ const parseGraphQL = (text) => {
 };
 
 const addSuffixToDuplicateName = (item, index, allItems) => {
-  // Check if the request name already exist and if so add a number suffix
+  // Check if the request name already exists (case-insensitively, so siblings like
+  // `OAuth2` and `oAuth2` get distinct names on case-insensitive filesystems) and
+  // if so add a number suffix.
+  const itemNameLower = (item.name || '').toLowerCase();
   const nameSuffix = allItems.reduce((nameSuffix, otherItem, otherIndex) => {
-    if (otherItem.name === item.name && otherIndex < index) {
+    if ((otherItem.name || '').toLowerCase() === itemNameLower && otherIndex < index) {
       nameSuffix++;
     }
     return nameSuffix;

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -374,7 +374,10 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
       let folderName = baseFolderName;
       let count = 1;
 
-      while (folderMap[folderName]) {
+      // Dedupe case-insensitively so siblings like `OAuth2` and `oAuth2` get
+      // distinct names on the case-insensitive filesystems (macOS, Windows)
+      // where they'd otherwise collide on disk.
+      while (folderMap[folderName.toLowerCase()]) {
         folderName = `${baseFolderName}_${count}`;
         count++;
       }
@@ -429,7 +432,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
         }
       }
 
-      folderMap[folderName] = brunoFolderItem;
+      folderMap[folderName.toLowerCase()] = brunoFolderItem;
     } else if (i.request) {
       const method = i?.request?.method?.toUpperCase();
       if (!method || typeof method !== 'string' || !method.trim()) {
@@ -441,7 +444,9 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
       let requestName = baseRequestName;
       let count = 1;
 
-      while (requestMap[requestName]) {
+      // Dedupe case-insensitively so siblings like `GetUser` and `getuser`
+      // get distinct filenames on case-insensitive filesystems.
+      while (requestMap[requestName.toLowerCase()]) {
         requestName = `${baseRequestName}_${count}`;
         count++;
       }
@@ -801,7 +806,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
         });
       }
 
-      requestMap[requestName] = brunoRequestItem;
+      requestMap[requestName.toLowerCase()] = brunoRequestItem;
     }
   });
 };

--- a/packages/bruno-converters/src/wsdl/wsdl-to-bruno.js
+++ b/packages/bruno-converters/src/wsdl/wsdl-to-bruno.js
@@ -114,9 +114,12 @@ const parseXML = (xmlString) => {
 };
 
 const addSuffixToDuplicateName = (item, index, allItems) => {
-  // Check if the request name already exist and if so add a number suffix
+  // Check if the request name already exists (case-insensitively, so siblings like
+  // `OAuth2` and `oAuth2` get distinct names on case-insensitive filesystems) and
+  // if so add a number suffix.
+  const itemNameLower = (item.name || '').toLowerCase();
   const nameSuffix = allItems.reduce((nameSuffix, otherItem, otherIndex) => {
-    if (otherItem.name === item.name && otherIndex < index) {
+    if ((otherItem.name || '').toLowerCase() === itemNameLower && otherIndex < index) {
       nameSuffix++;
     }
     return nameSuffix;

--- a/packages/bruno-converters/tests/insomnia/dedupe-names.spec.js
+++ b/packages/bruno-converters/tests/insomnia/dedupe-names.spec.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from '@jest/globals';
+import insomniaToBruno from '../../src/insomnia/insomnia-to-bruno';
+
+// Regression test for case-insensitive name collisions on import. See the matching
+// Postman spec for the full rationale.
+describe('insomnia converter — sibling name deduplication', () => {
+  it('dedupes case-only folder-name collisions at the same parent', () => {
+    const collection = {
+      _type: 'export',
+      __export_format: 4,
+      resources: [
+        { _id: 'wrk_1', _type: 'workspace', name: 'dedupe', parentId: null },
+        { _id: 'fld_1', _type: 'request_group', parentId: 'wrk_1', name: 'OAuth2' },
+        { _id: 'fld_2', _type: 'request_group', parentId: 'wrk_1', name: 'oAuth2' }
+      ]
+    };
+
+    const bruno = insomniaToBruno(collection);
+    const names = bruno.items.filter((i) => i.type === 'folder').map((i) => i.name);
+
+    expect(names).toHaveLength(2);
+    expect(names[0]).toBe('OAuth2');
+    expect(names[1]).toBe('oAuth2_1');
+  });
+
+  it('dedupes case-only request-name collisions at the same parent', () => {
+    const collection = {
+      _type: 'export',
+      __export_format: 4,
+      resources: [
+        { _id: 'wrk_1', _type: 'workspace', name: 'dedupe', parentId: null },
+        {
+          _id: 'req_1',
+          _type: 'request',
+          parentId: 'wrk_1',
+          name: 'GetUser',
+          method: 'GET',
+          url: 'https://example.com/a'
+        },
+        {
+          _id: 'req_2',
+          _type: 'request',
+          parentId: 'wrk_1',
+          name: 'getuser',
+          method: 'GET',
+          url: 'https://example.com/b'
+        }
+      ]
+    };
+
+    const bruno = insomniaToBruno(collection);
+    const names = bruno.items.filter((i) => i.type === 'http-request').map((i) => i.name);
+
+    expect(names).toHaveLength(2);
+    expect(names[0]).toBe('GetUser');
+    expect(names[1]).toBe('getuser_1');
+  });
+});

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/dedupe-folder-names.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/dedupe-folder-names.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from '@jest/globals';
+import postmanToBruno from '../../../src/postman/postman-to-bruno';
+
+// Regression test for collisions on case-insensitive filesystems (macOS APFS/HFS+,
+// Windows NTFS). Prior to this fix, a Postman collection with siblings like
+// `OAuth2` and `oAuth2` (or two identically-named `Returns` folders) would silently
+// overwrite each other on disk — or crash with EEXIST on import paths that used
+// a non-recursive mkdir.
+describe('postman converter — sibling name deduplication', () => {
+  const buildFolder = (name) => ({
+    name,
+    item: [
+      {
+        name: `${name} request`,
+        request: { method: 'GET', url: 'https://example.com' }
+      }
+    ]
+  });
+
+  const collectionWith = (folderNames) => ({
+    info: {
+      _postman_id: 'dedupe-test',
+      name: 'dedupe',
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+    },
+    item: folderNames.map(buildFolder)
+  });
+
+  it('dedupes exact-duplicate sibling folder names', async () => {
+    const result = await postmanToBruno(collectionWith(['Returns', 'Returns']));
+    const names = result.items.map((i) => i.name);
+    expect(names).toEqual(['Returns', 'Returns_1']);
+  });
+
+  it('dedupes case-only collisions so disk paths never overlap', async () => {
+    const result = await postmanToBruno(collectionWith(['OAuth2', 'oAuth2']));
+    const names = result.items.map((i) => i.name);
+    // Both names survive; the second gets a suffix since it collides case-insensitively.
+    expect(names[0]).toBe('OAuth2');
+    expect(names[1]).toBe('oAuth2_1');
+    expect(names[0].toLowerCase()).not.toBe(names[1].toLowerCase());
+  });
+
+  it('dedupes case-insensitive request-name collisions', async () => {
+    const collection = {
+      info: {
+        _postman_id: 'dedupe-req',
+        name: 'dedupe',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        { name: 'GetUser', request: { method: 'GET', url: 'https://example.com/a' } },
+        { name: 'getuser', request: { method: 'GET', url: 'https://example.com/b' } }
+      ]
+    };
+    const result = await postmanToBruno(collection);
+    const names = result.items.map((i) => i.name);
+    expect(names[0]).toBe('GetUser');
+    expect(names[1]).toBe('getuser_1');
+  });
+});

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -50,6 +50,7 @@ const {
   removePath,
   getPaths,
   generateUniqueName,
+  getUniqueSiblingName,
   isDotEnvFile,
   isValidDotEnvFilename,
   isBrunoConfigFile,
@@ -1160,18 +1161,28 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           return `${item.name}.${format}`;
         };
 
-        // Recursive function to parse the collection items and create files/folders
+        // Recursive function to parse the collection items and create files/folders.
+        // A per-directory Set of already-claimed sibling names (lowercased) deduplicates
+        // imports case-insensitively, so collections containing siblings like `OAuth2`
+        // and `oAuth2` don't silently overwrite each other on case-insensitive
+        // filesystems (macOS APFS/HFS+, Windows NTFS by default).
         const parseCollectionItems = async (items = [], currentPath) => {
+          const usedNamesLowercase = new Set();
+
           await Promise.all(items.map(async (item) => {
             if (['http-request', 'graphql-request', 'grpc-request', 'ws-request'].includes(item.type)) {
-              let sanitizedFilename = sanitizeName(getFilenameWithFormat(item, format));
+              const sanitizedFilename = sanitizeName(getFilenameWithFormat(item, format));
+              const ext = path.extname(sanitizedFilename);
+              const base = ext ? sanitizedFilename.slice(0, -ext.length) : sanitizedFilename;
+              const uniqueFilename = getUniqueSiblingName(base, ext, usedNamesLowercase);
               const content = await stringifyRequestViaWorker(item, { format });
-              const filePath = path.join(currentPath, sanitizedFilename);
+              const filePath = path.join(currentPath, uniqueFilename);
               safeWriteFileSync(filePath, content);
             }
             if (item.type === 'folder') {
-              let sanitizedFolderName = sanitizeName(item?.filename || item?.name);
-              const folderPath = path.join(currentPath, sanitizedFolderName);
+              const sanitizedFolderName = sanitizeName(item?.filename || item?.name);
+              const uniqueFolderName = getUniqueSiblingName(sanitizedFolderName, '', usedNamesLowercase);
+              const folderPath = path.join(currentPath, uniqueFolderName);
               fs.mkdirSync(folderPath, { recursive: true });
 
               if (item?.root?.meta?.name) {
@@ -1187,8 +1198,11 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             }
             // Handle items of type 'js'
             if (item.type === 'js') {
-              let sanitizedFilename = sanitizeName(item?.filename || `${item.name}.js`);
-              const filePath = path.join(currentPath, sanitizedFilename);
+              const sanitizedFilename = sanitizeName(item?.filename || `${item.name}.js`);
+              const ext = path.extname(sanitizedFilename);
+              const base = ext ? sanitizedFilename.slice(0, -ext.length) : sanitizedFilename;
+              const uniqueFilename = getUniqueSiblingName(base, ext, usedNamesLowercase);
+              const filePath = path.join(currentPath, uniqueFilename);
               safeWriteFileSync(filePath, item.fileContent);
             }
           }));

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { ipcMain } = require('electron');
-const { sanitizeName, createDirectory, writeFile, safeWriteFileSync, getCollectionStats } = require('./filesystem');
+const { sanitizeName, createDirectory, writeFile, safeWriteFileSync, getCollectionStats, getUniqueSiblingName } = require('./filesystem');
 const { generateUidBasedOnHash, stringifyJson } = require('./common');
 const { stringifyRequestViaWorker, stringifyCollection, stringifyEnvironment, stringifyFolder, DEFAULT_COLLECTION_FORMAT } = require('@usebruno/filestore');
 
@@ -33,19 +33,29 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
     throw new Error(`collection: ${collectionPath} already exists`);
   }
 
-  // Recursive function to parse the collection items and create files/folders
+  // Recursive function to parse the collection items and create files/folders.
+  // A per-directory Set of already-claimed sibling names (lowercased) deduplicates
+  // imports case-insensitively, so collections containing siblings like `OAuth2`
+  // and `oAuth2` don't silently overwrite each other on case-insensitive
+  // filesystems (macOS APFS/HFS+, Windows NTFS by default).
   const parseCollectionItems = async (items = [], currentPath) => {
+    const usedNamesLowercase = new Set();
+
     for (const item of items) {
       if (['http-request', 'graphql-request', 'grpc-request'].includes(item.type)) {
-        let sanitizedFilename = sanitizeName(item.filename || `${item.name}.${format}`);
+        const sanitizedFilename = sanitizeName(item.filename || `${item.name}.${format}`);
+        const ext = path.extname(sanitizedFilename);
+        const base = ext ? sanitizedFilename.slice(0, -ext.length) : sanitizedFilename;
+        const uniqueFilename = getUniqueSiblingName(base, ext, usedNamesLowercase);
         const content = await stringifyRequestViaWorker(item, { format });
-        const filePath = path.join(currentPath, sanitizedFilename);
+        const filePath = path.join(currentPath, uniqueFilename);
         safeWriteFileSync(filePath, content);
       }
       if (item.type === 'folder') {
-        let sanitizedFolderName = sanitizeName(item.filename || item.name);
-        const folderPath = path.join(currentPath, sanitizedFolderName);
-        fs.mkdirSync(folderPath);
+        const sanitizedFolderName = sanitizeName(item.filename || item.name);
+        const uniqueFolderName = getUniqueSiblingName(sanitizedFolderName, '', usedNamesLowercase);
+        const folderPath = path.join(currentPath, uniqueFolderName);
+        fs.mkdirSync(folderPath, { recursive: true });
 
         if (item.root?.meta?.name) {
           const folderFilePath = path.join(folderPath, `folder.${format}`);
@@ -60,8 +70,11 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
       }
       // Handle items of type 'js'
       if (item.type === 'js') {
-        let sanitizedFilename = sanitizeName(item.filename || `${item.name}.js`);
-        const filePath = path.join(currentPath, sanitizedFilename);
+        const sanitizedFilename = sanitizeName(item.filename || `${item.name}.js`);
+        const ext = path.extname(sanitizedFilename);
+        const base = ext ? sanitizedFilename.slice(0, -ext.length) : sanitizedFilename;
+        const uniqueFilename = getUniqueSiblingName(base, ext, usedNamesLowercase);
+        const filePath = path.join(currentPath, uniqueFilename);
         safeWriteFileSync(filePath, item.fileContent);
       }
     }

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -233,6 +233,33 @@ const generateUniqueName = (baseName, checkExists) => {
   return uniqueName;
 };
 
+/**
+ * Return a unique name for a sibling entry (folder or file) within a parent
+ * directory, appending " - N" when a collision is detected. Case-insensitive
+ * matching is used so that imports do not corrupt each other on case-insensitive
+ * filesystems (macOS APFS/HFS+, Windows NTFS by default) — where e.g. `OAuth2`
+ * and `oAuth2` resolve to the same path.
+ *
+ * The `usedNamesLowercase` Set is mutated: the returned name is added to it so
+ * the caller can pass the same Set for every sibling in a given parent.
+ *
+ * @param {string} baseName - Desired name without extension.
+ * @param {string} extension - File extension including leading dot ('' for folders).
+ * @param {Set<string>} usedNamesLowercase - Already-used names in this parent, lowercased.
+ * @returns {string} A unique name (original case preserved).
+ */
+const getUniqueSiblingName = (baseName, extension, usedNamesLowercase) => {
+  const ext = extension || '';
+  let candidate = `${baseName}${ext}`;
+  let counter = 1;
+  while (usedNamesLowercase.has(candidate.toLowerCase())) {
+    counter++;
+    candidate = `${baseName} - ${counter}${ext}`;
+  }
+  usedNamesLowercase.add(candidate.toLowerCase());
+  return candidate;
+};
+
 const getCollectionFormat = (collectionPath) => {
   const ocYmlPath = path.join(collectionPath, 'opencollection.yml');
   if (fs.existsSync(ocYmlPath)) {
@@ -539,6 +566,7 @@ module.exports = {
   getPaths,
   isLargeFile,
   generateUniqueName,
+  getUniqueSiblingName,
   getCollectionFormat,
   isDotEnvFile,
   isValidDotEnvFilename,

--- a/packages/bruno-electron/tests/utils/filesystem.spec.js
+++ b/packages/bruno-electron/tests/utils/filesystem.spec.js
@@ -1,0 +1,50 @@
+const { getUniqueSiblingName } = require('../../src/utils/filesystem');
+
+describe('getUniqueSiblingName', () => {
+  test('returns the name unchanged when no collision', () => {
+    const used = new Set();
+    expect(getUniqueSiblingName('Users', '', used)).toBe('Users');
+    expect(used.has('users')).toBe(true);
+  });
+
+  test('suffixes " - 2" on a same-case collision', () => {
+    const used = new Set();
+    getUniqueSiblingName('Users', '', used);
+    expect(getUniqueSiblingName('Users', '', used)).toBe('Users - 2');
+  });
+
+  test('suffixes " - 2" on a case-only collision', () => {
+    const used = new Set();
+    getUniqueSiblingName('OAuth2', '', used);
+    expect(getUniqueSiblingName('oAuth2', '', used)).toBe('oAuth2 - 2');
+    expect(getUniqueSiblingName('OAUTH2', '', used)).toBe('OAUTH2 - 3');
+  });
+
+  test('keeps counting past pre-reserved suffixes', () => {
+    const used = new Set();
+    getUniqueSiblingName('Users', '', used);
+    getUniqueSiblingName('Users', '', used); // -> Users - 2
+    expect(getUniqueSiblingName('Users', '', used)).toBe('Users - 3');
+  });
+
+  test('inserts suffix before the extension for files', () => {
+    const used = new Set();
+    getUniqueSiblingName('GetUser', '.bru', used);
+    expect(getUniqueSiblingName('getuser', '.bru', used)).toBe('getuser - 2.bru');
+  });
+
+  test('folders and files share the namespace', () => {
+    const used = new Set();
+    getUniqueSiblingName('auth', '', used);
+    // An exact-name file would collide on disk, so the dedup should catch it.
+    expect(used.has('auth')).toBe(true);
+    // A file with extension has a distinct name, so no collision.
+    expect(getUniqueSiblingName('auth', '.bru', used)).toBe('auth.bru');
+  });
+
+  test('empty extension arg is treated as none', () => {
+    const used = new Set();
+    expect(getUniqueSiblingName('folder', undefined, used)).toBe('folder');
+    expect(getUniqueSiblingName('folder', null, used)).toBe('folder - 2');
+  });
+});


### PR DESCRIPTION
[BRU-3177](https://usebruno.atlassian.net/browse/BRU-3177)
Fixes #7821

### Description



Collections imported from Postman/Insomnia/OpenAPI/WSDL that contain siblings with duplicate names or case-only variants (e.g. `OAuth2` vs `oAuth2`) used to either crash with `EEXIST` (onboarding path) or silently merge two source folders into one on-disk directory (main UI path, case-insensitive filesystems like macOS APFS and default Windows NTFS). Either way the user ended up with a corrupted import.

This PR addresses both failure modes:

1. **Writer-layer dedup (primary fix)** — in both `parseCollectionItems` implementations (IPC handler and onboarding util), track sibling names per parent directory via a `Set<string>` keyed on `toLowerCase()`, and resolve collisions via a new `getUniqueSiblingName` helper in `utils/filesystem.js`. Appends ` - N` on collision (matches the existing `findUniqueFolderName` convention used for top-level collection names). Applies to folders, requests, and `.js` sidecar files. Covers all importers since they share the writer path.
2. **Converter-layer dedup upgrade** — `postman-to-bruno.js` now keys `folderMap`/`requestMap` case-insensitively; `insomnia-to-bruno.js` and `wsdl-to-bruno.js` compare `addSuffixToDuplicateName` case-insensitively. This keeps the in-memory tree consistent with what gets written to disk.
3. Adds `{ recursive: true }` to the `mkdirSync` call in `utils/collection-import.js` for parity with the IPC handler (same fix as #7499 for the OpenAPI path).

The dedup is case-insensitive on all platforms, not gated on OS — collections get shared across machines, and a Linux-clean import that breaks for a macOS teammate on re-import is a worse failure mode than seeing a numeric suffix on Linux.

### Tests

- `packages/bruno-electron/tests/utils/filesystem.spec.js` — 7 tests for the helper (no-collision, same-case collision, case-only collision, counter propagation past pre-reserved suffixes, file-extension handling, folder/file shared namespace, null/undefined ext handling).
- `packages/bruno-converters/tests/postman/postman-to-bruno/dedupe-folder-names.spec.js` — 3 tests (exact dupe folders, case-only dupe folders, case-only dupe requests).
- `packages/bruno-converters/tests/insomnia/dedupe-names.spec.js` — 2 tests (case-only dupe folders, case-only dupe requests).

All existing converter tests (890) still pass.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** (N/A — no UI change)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed collection import logic to properly handle items with names differing only by letter casing, preventing file overwrites on case-insensitive filesystems.
  * Improved deduplication in Insomnia, Postman, and WSDL converters to treat names case-insensitively.

* **Tests**
  * Added comprehensive test coverage for deduplication behavior across collection imports and converters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->