### PR TITLE
fix: handle empty mime type in insomnia importer

### DIFF
--- a/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
+++ b/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
@@ -118,7 +118,8 @@ const transformInsomniaRequestItem = (request, index, allRequests) => {
     };
   }
 
-  const mimeType = get(request, 'body.mimeType', '').split(';')[0];
+  const bodyMimeType = get(request, 'body.mimeType');
+  const mimeType = (bodyMimeType || '').split(';')[0];
 
   if (mimeType === 'application/json') {
     brunoRequestItem.request.body.mode = 'json';
@@ -146,7 +147,7 @@ const transformInsomniaRequestItem = (request, index, allRequests) => {
         enabled: !param.disabled
       });
     });
-  } else if (mimeType === 'text/plain') {
+  } else if (mimeType === 'text/plain' || (bodyMimeType === '' && request.body?.text)) {
     brunoRequestItem.request.body.mode = 'text';
     brunoRequestItem.request.body.text = normalizeVariables(request.body.text);
   } else if (mimeType === 'text/xml' || mimeType === 'application/xml') {

--- a/packages/bruno-converters/tests/insomnia/insomnia-collection-v5.spec.js
+++ b/packages/bruno-converters/tests/insomnia/insomnia-collection-v5.spec.js
@@ -7,6 +7,28 @@ describe('insomnia-collection', () => {
 
     expect(brunoCollection).toMatchObject(expectedOutput);
   });
+
+  it('should import v5 empty mimeType bodies as Bruno text bodies', async () => {
+    const brunoCollection = insomniaToBruno(insomniaCollectionWithEmptyMimeTypeBody);
+
+    expect(brunoCollection.items[0].request.body).toMatchObject({
+      mode: 'text',
+      text: 'line1\nline2\n{{base_url}}',
+      json: null,
+      xml: null
+    });
+  });
+
+  it('should ignore v5 empty raw bodies when mimeType is blank', async () => {
+    const brunoCollection = insomniaToBruno(insomniaCollectionWithEmptyMimeTypeAndEmptyTextBody);
+
+    expect(brunoCollection.items[0].request.body).toMatchObject({
+      mode: 'none',
+      text: null,
+      json: null,
+      xml: null
+    });
+  });
 });
 
 const insomniaCollection = `
@@ -193,3 +215,30 @@ const expectedOutput = {
   uid: 'mockeduuidvalue123456',
   version: '1'
 };
+
+const insomniaCollectionWithEmptyMimeTypeBody = `
+type: collection.insomnia.rest/5.0
+name: Text Body Workspace
+collection:
+  - url: https://example.com/raw
+    name: Raw Text Body
+    method: POST
+    body:
+      mimeType: ""
+      text: |-
+        line1
+        line2
+        {{ base_url }}
+`;
+
+const insomniaCollectionWithEmptyMimeTypeAndEmptyTextBody = `
+type: collection.insomnia.rest/5.0
+name: Empty Text Body Workspace
+collection:
+  - url: https://example.com/raw-empty
+    name: Empty Raw Text Body
+    method: POST
+    body:
+      mimeType: ""
+      text: ""
+`;

--- a/packages/bruno-converters/tests/insomnia/insomnia-collection.spec.js
+++ b/packages/bruno-converters/tests/insomnia/insomnia-collection.spec.js
@@ -7,6 +7,28 @@ describe('insomnia-collection', () => {
 
     expect(brunoCollection).toMatchObject(expectedOutput);
   });
+
+  it('should import empty mimeType bodies as Bruno text bodies', async () => {
+    const brunoCollection = insomniaToBruno(insomniaCollectionWithEmptyMimeTypeBody);
+
+    expect(brunoCollection.items[0].request.body).toMatchObject({
+      mode: 'text',
+      text: 'line1\nline2\n{{base_url}}',
+      json: null,
+      xml: null
+    });
+  });
+
+  it('should ignore empty raw bodies when mimeType is blank', async () => {
+    const brunoCollection = insomniaToBruno(insomniaCollectionWithEmptyMimeTypeAndEmptyTextBody);
+
+    expect(brunoCollection.items[0].request.body).toMatchObject({
+      mode: 'none',
+      text: null,
+      json: null,
+      xml: null
+    });
+  });
 });
 
 const insomniaCollection = {
@@ -221,4 +243,54 @@ const expectedOutput = {
   name: 'Hello World Workspace Insomnia',
   uid: 'mockeduuidvalue123456',
   version: '1'
+};
+
+const insomniaCollectionWithEmptyMimeTypeBody = {
+  _type: 'export',
+  __export_format: 4,
+  resources: [
+    {
+      _id: 'req_text_1',
+      _type: 'request',
+      parentId: 'wrk_text_1',
+      name: 'Raw Text Body',
+      method: 'POST',
+      url: 'https://example.com/raw',
+      parameters: [],
+      body: {
+        mimeType: '',
+        text: 'line1\nline2\n{{ base_url }}'
+      }
+    },
+    {
+      _id: 'wrk_text_1',
+      _type: 'workspace',
+      name: 'Text Body Workspace'
+    }
+  ]
+};
+
+const insomniaCollectionWithEmptyMimeTypeAndEmptyTextBody = {
+  _type: 'export',
+  __export_format: 4,
+  resources: [
+    {
+      _id: 'req_text_2',
+      _type: 'request',
+      parentId: 'wrk_text_2',
+      name: 'Empty Raw Text Body',
+      method: 'POST',
+      url: 'https://example.com/raw-empty',
+      parameters: [],
+      body: {
+        mimeType: '',
+        text: ''
+      }
+    },
+    {
+      _id: 'wrk_text_2',
+      _type: 'workspace',
+      name: 'Empty Text Body Workspace'
+    }
+  ]
 };


### PR DESCRIPTION
### Description

[BRU-3143](https://usebruno.atlassian.net/browse/BRU-3143)

When Insomnia had mimeType as '' for 'Other' body type, we were not handling it.

Now we treat the "Other" body type as "Text" in bruno while importing.

Fixes #7825 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Insomnia request bodies with empty or missing MIME types during conversion to ensure accurate body mode detection.

* **Tests**
  * Added comprehensive test coverage for empty MIME type scenarios across Insomnia v5 and standard collection formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->