### PR TITLE
fix: sync copy with filtered view

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseCopy/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseCopy/index.js
@@ -7,20 +7,20 @@ import ActionIcon from 'ui/ActionIcon/index';
 import { formatResponse } from 'utils/common';
 
 // Helper function to get text to copy
-const getTextToCopy = (selectedTab, selectedFormat, data, dataBuffer) => {
+const getTextToCopy = (selectedTab, selectedFormat, data, dataBuffer, filter) => {
   // If preview is on, copy raw data (what's shown in TextPreview)
   if (selectedTab === 'preview') {
     return typeof data === 'string' ? data : JSON.stringify(data, null, 2);
   }
   // If editor is on, copy formatted data based on selected format
   if (selectedFormat && data && dataBuffer) {
-    return formatResponse(data, dataBuffer, selectedFormat, null);
+    return formatResponse(data, dataBuffer, selectedFormat, filter);
   }
   return typeof data === 'string' ? data : JSON.stringify(data, null, 2);
 };
 
 // Hook to get copy response function
-export const useResponseCopy = (item, selectedFormat, selectedTab, data, dataBuffer) => {
+export const useResponseCopy = (item, selectedFormat, selectedTab, data, dataBuffer, filter) => {
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
@@ -34,20 +34,20 @@ export const useResponseCopy = (item, selectedFormat, selectedTab, data, dataBuf
 
   const copyResponse = useCallback(async () => {
     try {
-      const textToCopy = getTextToCopy(selectedTab, selectedFormat, data, dataBuffer);
+      const textToCopy = getTextToCopy(selectedTab, selectedFormat, data, dataBuffer, filter);
       await navigator.clipboard.writeText(textToCopy);
       toast.success('Response copied to clipboard');
       setCopied(true);
     } catch (error) {
       toast.error('Failed to copy response');
     }
-  }, [selectedTab, selectedFormat, data, dataBuffer]);
+  }, [selectedTab, selectedFormat, data, dataBuffer, filter]);
 
   return { copyResponse, copied, hasData: !!data };
 };
 
-const ResponseCopy = forwardRef(({ item, children, selectedFormat, selectedTab, data, dataBuffer }, ref) => {
-  const { copyResponse, copied, hasData } = useResponseCopy(item, selectedFormat, selectedTab, data, dataBuffer);
+const ResponseCopy = forwardRef(({ item, children, selectedFormat, selectedTab, data, dataBuffer, filter }, ref) => {
+  const { copyResponse, copied, hasData } = useResponseCopy(item, selectedFormat, selectedTab, data, dataBuffer, filter);
   const elementRef = useRef(null);
 
   const isDisabled = !hasData ? true : false;

--- a/packages/bruno-app/src/components/ResponsePane/ResponsePaneActions/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponsePaneActions/index.js
@@ -37,7 +37,7 @@ const MenuIcon = forwardRef((props, ref) => (
 
 MenuIcon.displayName = 'MenuIcon';
 
-const ResponsePaneActions = ({ item, collection, responseSize, selectedFormat, selectedTab, data, dataBuffer }) => {
+const ResponsePaneActions = ({ item, collection, responseSize, selectedFormat, selectedTab, data, dataBuffer, filter }) => {
   const { orientation } = useResponseLayoutToggle();
 
   // Refs to access child component imperative handles (click, isDisabled)
@@ -161,6 +161,7 @@ const ResponsePaneActions = ({ item, collection, responseSize, selectedFormat, s
           selectedTab={selectedTab}
           data={data}
           dataBuffer={dataBuffer}
+          filter={filter}
         />
         {item.type !== 'graphql-request' && <ResponseBookmark ref={bookmarkButtonRef} item={item} collection={collection} responseSize={responseSize} />}
         <ResponseDownload ref={downloadButtonRef} item={item} />

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -278,6 +278,7 @@ const ResponsePane = ({ item, collection }) => {
             selectedTab={selectedViewTab}
             data={response.data}
             dataBuffer={response.dataBuffer}
+            filter={focusedTab?.responseFilter}
           />
         ) : null}
       </div>

--- a/tests/response/response-actions.spec.ts
+++ b/tests/response/response-actions.spec.ts
@@ -5,6 +5,7 @@ import {
   createCollection,
   createRequest,
   sendRequest,
+  selectRequestPaneTab,
   switchResponseFormat,
   switchToEditorTab
 } from '../utils/page/actions';
@@ -58,6 +59,47 @@ test.describe('Response Pane Actions', () => {
       const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
       // "pong" in Base64 is "cG9uZw=="
       expect(clipboardText).toBe('cG9uZw==');
+    });
+  });
+
+  test('should copy filtered JSONPath result when response filter is applied', async ({ page, createTmpDir }) => {
+    const collectionName = 'response-copy-jsonpath-filter-test';
+
+    await test.step('Create collection and request', async () => {
+      await createCollection(page, collectionName, await createTmpDir(collectionName));
+      await createRequest(page, 'jsonpath-filter-copy-test', collectionName, {
+        url: 'https://testbench-sanity.usebruno.com/api/echo/json',
+        method: 'POST'
+      });
+    });
+
+    await test.step('Set request body to nested JSON', async () => {
+      await selectRequestPaneTab(page, 'Body');
+      await page.getByTestId('request-body-mode-selector').click();
+      await page.locator('.dropdown-item').filter({ hasText: 'JSON' }).click();
+
+      const bodyEditor = page.getByTestId('request-body-editor').locator('.CodeMirror').first();
+      await bodyEditor.click();
+      await page.keyboard.press(process.platform === 'darwin' ? 'Meta+a' : 'Control+a');
+      await page.keyboard.type('{"store":{"book":[{"author":"A"},{"author":"B"}]}}');
+    });
+
+    await test.step('Send request and apply JSONPath filter in response', async () => {
+      await sendRequest(page, 200);
+      await switchResponseFormat(page, 'JSON');
+
+      await page.locator('#request-filter-icon').click();
+      await page.locator('#response-filter').fill('$.store.book..author');
+      await expect(page.getByTestId('response-preview-container')).toContainText('"A"');
+      await expect(page.getByTestId('response-preview-container')).toContainText('"B"');
+    });
+
+    await test.step('Copy response and verify clipboard contains filtered output', async () => {
+      await clickResponseAction(page, 'response-copy-btn');
+      await expect(page.getByText('Response copied to clipboard')).toBeVisible();
+
+      const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+      expect(clipboardText.replace(/\r\n/g, '\n')).toBe('[\n  "A",\n  "B"\n]');
     });
   });
 });


### PR DESCRIPTION
fixes : #7832 

### Description

- Fixes an inconsistency where the response pane showed filtered JSONPath output, but Copy response copied the unfiltered body.
- Ensures the active responseFilter is applied consistently across the response view and copy functionality.
- Updates the copy flow so it uses the same filtered/processed data shown in the UI.

before : Copy returns the full response even if filter is applied
after : Copy returns filtered result as shown

sc : 
<img width="1266" height="777" alt="image" src="https://github.com/user-attachments/assets/6572f1df-e387-4fa9-a0b6-a8f6ab3af720" />


Testing
- Added test: tests/response/response-actions.spec.ts  
  should copy filtered JSONPath result when response filter is applied

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Response filtering is now integrated with the copy function—when you apply a response filter (such as JSONPath) and copy the response, the clipboard contains only the filtered data rather than the complete response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->