### PR TITLE
Fix: Variables Text Missing Whitespace

### DIFF
--- a/packages/bruno-app/src/components/VariablesEditor/index.js
+++ b/packages/bruno-app/src/components/VariablesEditor/index.js
@@ -99,8 +99,8 @@ const VariablesEditor = ({ collection }) => {
       <div className="mt-8 muted text-xs">
         Note: As of today, runtime variables can only be set via the API - <span className="font-medium">getVar()</span>{' '}
         and <span className="font-medium">setVar()</span>. <br />
-        You can use the <span className="font-medium">var</span> variable with
-        the <span className="font-medium">{'{{var}}'}</span> syntax.<br />
+        You can use the <span className="font-medium">var</span> variable with the{' '}
+        <span className="font-medium">{'{{var}}'}</span> syntax.<br />
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/VariablesEditor/index.js
+++ b/packages/bruno-app/src/components/VariablesEditor/index.js
@@ -99,8 +99,8 @@ const VariablesEditor = ({ collection }) => {
       <div className="mt-8 muted text-xs">
         Note: As of today, runtime variables can only be set via the API - <span className="font-medium">getVar()</span>{' '}
         and <span className="font-medium">setVar()</span>. <br />
-        You can use the <span className="font-medium">var</span> variable with the
-        <span className="font-medium">{'{{var}}'}</span> syntax.<br />
+        You can use the <span className="font-medium">var</span> variable with
+        the <span className="font-medium">{'{{var}}'}</span> syntax.<br />
       </div>
     </StyledWrapper>
   );


### PR DESCRIPTION
### Description

Added a space so the text will render properly in the bruno app.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** https://github.com/usebruno/bruno/issues/7843

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

Fixed:
<img width="556" height="257" alt="bruno var with space" src="https://github.com/user-attachments/assets/45fdb9c0-869f-40f8-8d79-24779bddd36d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spacing issue in the Variables Editor for improved text readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->