### PR TITLE
fix: prevent Cmd/Ctrl+Enter from adding newline when sending requests

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -50,6 +50,14 @@ export default class CodeEditor extends React.Component {
 
   componentDidMount() {
     const variables = getAllVariables(this.props.collection, this.props.item);
+    const runShortcut = () => {
+      if (this.props.onRun) {
+        this.props.onRun();
+        return;
+      }
+
+      return CodeMirror.Pass;
+    };
 
     const editor = (this.editor = CodeMirror(this._node, {
       value: this.props.value || '',
@@ -86,6 +94,8 @@ export default class CodeEditor extends React.Component {
         },
         'Cmd-H': this.props.readOnly ? false : 'replace',
         'Ctrl-H': this.props.readOnly ? false : 'replace',
+        'Cmd-Enter': runShortcut,
+        'Ctrl-Enter': runShortcut,
         'Tab': function (cm) {
           cm.getSelection().includes('\n') || editor.getLine(cm.getCursor().line) == cm.getSelection()
             ? cm.execCommand('indentMore')

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -30,6 +30,14 @@ class MultiLineEditor extends Component {
     // Initialize CodeMirror as a single line editor
     /** @type {import("codemirror").Editor} */
     const variables = getAllVariables(this.props.collection, this.props.item);
+    const runShortcut = () => {
+      if (this.props.onRun) {
+        this.props.onRun();
+        return;
+      }
+
+      return CodeMirror.Pass;
+    };
 
     this.editor = CodeMirror(this.editorRef.current, {
       lineWrapping: false,
@@ -47,6 +55,8 @@ class MultiLineEditor extends Component {
       extraKeys: {
         'Cmd-F': () => {},
         'Ctrl-F': () => {},
+        'Cmd-Enter': runShortcut,
+        'Ctrl-Enter': runShortcut,
         // Tabbing disabled to make tabindex work
         'Tab': false,
         'Shift-Tab': false

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -61,7 +61,9 @@ const RequestTabPanel = () => {
   const isConsoleOpen = useSelector((state) => state.logs.isConsoleOpen);
 
   const isRequestTab = focusedTab && ['request', 'grpc-request', 'ws-request', 'graphql-request'].includes(focusedTab.type);
-  useKeybinding('sendRequest', () => {
+  useKeybinding('sendRequest', (e) => {
+    e?.preventDefault?.();
+    e?.stopPropagation?.();
     handleRun();
     return false;
   }, { enabled: !!isRequestTab, deps: [isRequestTab] });


### PR DESCRIPTION
### Description

Handle Cmd/Ctrl+Enter directly in editors and stop event propagation in the request tab hotkey so sending a request does not also insert a new line.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [X] **I've used AI significantly to create this pull request**
- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts (Cmd-Enter on Mac, Ctrl-Enter on Linux/Windows) to execute requests and code directly from the editor, streamlining your workflow.
  * Improved keyboard event handling to ensure shortcuts properly trigger execution without interfering with browser behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->