### PR TITLE
fix(runner): normalize string tags in collection runs

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/RunConfigurationPanel/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/RunConfigurationPanel/index.jsx
@@ -10,14 +10,14 @@ import { sortByNameThenSequence } from 'utils/common/index';
 import path from 'utils/common/path';
 import { cloneDeep, get } from 'lodash';
 import Button from 'ui/Button/index';
-import { isRequestTagsIncluded } from '@usebruno/common';
+import { isRequestTagsIncluded, normalizeTags } from '@usebruno/common';
 
 const isRequestDisabled = (item, tags) => {
   // WS and gRPC are not supported by the collection runner
   if (item.type === 'ws-request' || item.type === 'grpc-request') return true;
 
   // Check tag filtering
-  const requestTags = item.draft?.tags || item.tags || [];
+  const requestTags = normalizeTags(item.draft?.tags || item.tags || []);
   const includeTags = tags?.include || [];
   const excludeTags = tags?.exclude || [];
 

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -3,7 +3,7 @@ import { uuid } from 'utils/common';
 import { buildPersistedEnvVariables } from 'utils/environments';
 import { sortByNameThenSequence } from 'utils/common/index';
 import path from 'utils/common/path';
-import { isRequestTagsIncluded } from '@usebruno/common';
+import { isRequestTagsIncluded, normalizeTags } from '@usebruno/common';
 
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
   if (!str || !str.length || !isString(str)) {
@@ -1487,21 +1487,6 @@ export const calculateDraggedItemNewPathname = ({ draggedItem, targetItem, dropT
 };
 
 // item sequence utils - END
-
-/**
- * Normalize request tags to an array so downstream tag helpers can safely
- * handle YAML collections that store a single tag as a scalar string.
- */
-const normalizeTags = (tags) => {
-  if (Array.isArray(tags)) {
-    return tags;
-  }
-  if (typeof tags === 'string') {
-    const trimmed = tags.trim();
-    return trimmed ? [trimmed] : [];
-  }
-  return [];
-};
 
 export const getUniqueTagsFromItems = (items = []) => {
   const allTags = new Set();

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1488,13 +1488,24 @@ export const calculateDraggedItemNewPathname = ({ draggedItem, targetItem, dropT
 
 // item sequence utils - END
 
+const normalizeTags = (tags) => {
+  if (Array.isArray(tags)) {
+    return tags;
+  }
+  if (typeof tags === 'string') {
+    const trimmed = tags.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  return [];
+};
+
 export const getUniqueTagsFromItems = (items = []) => {
   const allTags = new Set();
   const getTags = (items) => {
     items.forEach((item) => {
       if (isItemARequest(item)) {
         const tags = item.draft ? get(item, 'draft.tags', []) : get(item, 'tags', []);
-        tags.forEach((tag) => allTags.add(tag));
+        normalizeTags(tags).forEach((tag) => allTags.add(tag));
       }
       if (item.items) {
         getTags(item.items);
@@ -1525,7 +1536,7 @@ export const getRequestItemsForCollectionRun = ({ recursive, items = [], tags })
     const includeTags = tags.include ? tags.include : [];
     const excludeTags = tags.exclude ? tags.exclude : [];
     requestItems = requestItems.filter(({ tags: requestTags = [], draft }) => {
-      requestTags = draft?.tags || requestTags || [];
+      requestTags = normalizeTags(draft?.tags || requestTags || []);
       return isRequestTagsIncluded(requestTags, includeTags, excludeTags);
     });
   }

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1488,6 +1488,10 @@ export const calculateDraggedItemNewPathname = ({ draggedItem, targetItem, dropT
 
 // item sequence utils - END
 
+/**
+ * Normalize request tags to an array so downstream tag helpers can safely
+ * handle YAML collections that store a single tag as a scalar string.
+ */
 const normalizeTags = (tags) => {
   if (Array.isArray(tags)) {
     return tags;

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem } from './index';
+import { getRequestItemsForCollectionRun, getUniqueTagsFromItems, mergeHeaders, transformRequestToSaveToFilesystem } from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -84,5 +84,40 @@ describe('transformRequestToSaveToFilesystem', () => {
 
     expect(transformed.request.params[0].annotations).toEqual([{ name: 'param-note', value: 'keep me' }]);
     expect(transformed.request.headers[0].annotations).toEqual([{ name: 'header-note', value: 'keep me' }]);
+  });
+});
+
+
+describe('tag normalization helpers', () => {
+  it('collects tags when a request stores tags as a single string', () => {
+    const tags = getUniqueTagsFromItems([
+      {
+        type: 'http-request',
+        request: {},
+        tags: 'smoke'
+      }
+    ]);
+
+    expect(tags).toEqual(['smoke']);
+  });
+
+  it('filters runnable requests when draft tags are stored as a single string', () => {
+    const requestItems = getRequestItemsForCollectionRun({
+      recursive: false,
+      items: [
+        {
+          type: 'http-request',
+          request: {},
+          isTransient: false,
+          draft: { tags: 'smoke' }
+        }
+      ],
+      tags: {
+        include: ['smoke'],
+        exclude: []
+      }
+    });
+
+    expect(requestItems).toHaveLength(1);
   });
 });

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -87,7 +87,6 @@ describe('transformRequestToSaveToFilesystem', () => {
   });
 });
 
-
 describe('tag normalization helpers', () => {
   it('collects tags when a request stores tags as a single string', () => {
     const tags = getUniqueTagsFromItems([
@@ -119,5 +118,39 @@ describe('tag normalization helpers', () => {
     });
 
     expect(requestItems).toHaveLength(1);
+  });
+
+  it('ignores non-string and non-array tag values', () => {
+    const tags = getUniqueTagsFromItems([
+      {
+        type: 'http-request',
+        request: {},
+        tags: 42
+      },
+      {
+        type: 'http-request',
+        request: {},
+        draft: { tags: null }
+      }
+    ]);
+
+    const requestItems = getRequestItemsForCollectionRun({
+      recursive: false,
+      items: [
+        {
+          type: 'http-request',
+          request: {},
+          isTransient: false,
+          draft: { tags: 42 }
+        }
+      ],
+      tags: {
+        include: ['smoke'],
+        exclude: []
+      }
+    });
+
+    expect(tags).toEqual([]);
+    expect(requestItems).toHaveLength(0);
   });
 });

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -8,7 +8,7 @@ const { exists, isFile, isDirectory } = require('../utils/filesystem');
 const { runSingleRequest } = require('../runner/run-single-request');
 const { getEnvVars } = require('../utils/bru');
 const { parseEnvironmentJson } = require('../utils/environment');
-const { isRequestTagsIncluded } = require('@usebruno/common');
+const { isRequestTagsIncluded, normalizeTags } = require('@usebruno/common');
 const makeJUnitOutput = require('../reporters/junit');
 const makeHtmlOutput = require('../reporters/html');
 const { rpad } = require('../utils/common');
@@ -635,7 +635,7 @@ const handler = async function (argv) {
     }
 
     requestItems = requestItems.filter((item) => {
-      return isRequestTagsIncluded(item.tags, includeTags, excludeTags);
+      return isRequestTagsIncluded(normalizeTags(item.tags), includeTags, excludeTags);
     });
 
     const runtime = getJsSandboxRuntime(sandbox);

--- a/packages/bruno-common/src/index.ts
+++ b/packages/bruno-common/src/index.ts
@@ -1,7 +1,7 @@
 export { mockDataFunctions, timeBasedDynamicVars } from './utils/faker-functions';
 export { default as interpolate, interpolateObject } from './interpolate';
 export { percentageToZoomLevel } from './zoom';
-export { default as isRequestTagsIncluded } from './tags';
+export { default as isRequestTagsIncluded, normalizeTags } from './tags';
 export { transformExampleStatusInCollection } from './example-status';
 
 export * as utils from './utils';

--- a/packages/bruno-common/src/tags/index.spec.ts
+++ b/packages/bruno-common/src/tags/index.spec.ts
@@ -1,4 +1,15 @@
-import isRequestTagsIncluded from './index';
+import isRequestTagsIncluded, { normalizeTags } from './index';
+
+describe('normalizeTags', () => {
+  it('should wrap a scalar string tag in an array', () => {
+    expect(normalizeTags(' smoke ')).toEqual(['smoke']);
+  });
+
+  it('should fall back to an empty array for unsupported tag values', () => {
+    expect(normalizeTags(42 as never)).toEqual([]);
+    expect(normalizeTags(null as never)).toEqual([]);
+  });
+});
 
 describe('isRequestTagsIncluded', () => {
   it('should include request when it has an included tag', () => {

--- a/packages/bruno-common/src/tags/index.ts
+++ b/packages/bruno-common/src/tags/index.ts
@@ -1,4 +1,20 @@
 /**
+ * Normalize request tags into an array for downstream helpers.
+ */
+export const normalizeTags = (tags: string[] | string | unknown): string[] => {
+  if (Array.isArray(tags)) {
+    return tags;
+  }
+
+  if (typeof tags === 'string') {
+    const trimmed = tags.trim();
+    return trimmed ? [trimmed] : [];
+  }
+
+  return [];
+};
+
+/**
  * A request should be included if it has at least one tag that is included and no tags that are excluded
  * @param requestTags Tags of the request
  * @param includeTags Tags to include

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -31,7 +31,7 @@ const { preferencesUtil } = require('../../store/preferences');
 const { getProcessEnvVars } = require('../../store/process-env');
 const { getBrunoConfig } = require('../../store/bruno-config');
 const Oauth2Store = require('../../store/oauth2');
-const { isRequestTagsIncluded } = require('@usebruno/common');
+const { isRequestTagsIncluded, normalizeTags } = require('@usebruno/common');
 const { cookiesStore } = require('../../store/cookies');
 const registerGrpcEventHandlers = require('./grpc-event-handlers');
 const { registerWsEventHandlers } = require('./ws-event-handlers');
@@ -1347,7 +1347,7 @@ const registerNetworkIpc = (mainWindow) => {
           const includeTags = tags.include ? tags.include : [];
           const excludeTags = tags.exclude ? tags.exclude : [];
           folderRequests = folderRequests.filter(({ tags: requestTags = [], draft }) => {
-            requestTags = draft?.tags || requestTags || [];
+            requestTags = normalizeTags(draft?.tags || requestTags);
             return isRequestTagsIncluded(requestTags, includeTags, excludeTags);
           });
         }


### PR DESCRIPTION
Fixes #7838

## Description

Folder runs crash when request tags come from YAML metadata as a single string.

Normalized tags before aggregating `collection.allTags` and before filtering runnable requests, then added regression coverage for both paths in `src/utils/collections/index.spec.js`. Verified with a focused Jest run against that spec in a node environment after wiring the workspace package dependencies Bruno expects. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent tag handling across collection filtering, run filtering (CLI), run configuration, and UI so tags work whether stored as a single string or an array.
* **Tests**
  * Added tests covering single-string tags and invalid tag values to verify include/exclude filtering and normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->