### PR TITLE
fix: apply per-field Content-Type in multipart/form-data serialization

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -8,6 +8,7 @@ const fs = require('node:fs');
 const { mergeHeaders, mergeScripts, mergeVars, mergeAuth, getTreePathFromCollectionToItem } = require('../utils/collection');
 const path = require('node:path');
 const { isLargeFile } = require('../utils/filesystem');
+const { createFormData } = require('../utils/form-data');
 const { getFormattedOauth2Credentials } = require('../utils/oauth2');
 
 const STREAMING_FILE_SIZE_THRESHOLD = 20 * 1024 * 1024; // 20MB
@@ -403,37 +404,8 @@ const prepareRequest = async (item = {}, collection = {}) => {
   }
 
   if (request.body.mode === 'multipartForm') {
-    const FormData = require('form-data');
     const enabledParams = filter(request.body.multipartForm, (p) => p.enabled);
-    const form = new FormData();
-    each(enabledParams, (param) => {
-      if (param.type === 'file') {
-        const filePaths = Array.isArray(param.value) ? param.value : [param.value];
-        each(filePaths, (filePath) => {
-          if (filePath) {
-            if (!path.isAbsolute(filePath)) {
-              filePath = path.join(collectionPath, filePath);
-            }
-            const opts = { filename: path.basename(filePath) };
-            if (param.contentType) opts.contentType = param.contentType;
-            try {
-              form.append(
-                param.name,
-                isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)
-                  ? fs.createReadStream(filePath)
-                  : fs.readFileSync(filePath),
-                opts
-              );
-            } catch (error) {
-              console.error('Error reading file:', error);
-            }
-          }
-        });
-      } else {
-        const opts = param.contentType ? { contentType: param.contentType } : {};
-        form.append(param.name, param.value || '', Object.keys(opts).length ? opts : undefined);
-      }
-    });
+    const form = createFormData(enabledParams, collectionPath, STREAMING_FILE_SIZE_THRESHOLD);
     Object.assign(axiosRequest.headers, form.getHeaders());
     axiosRequest.data = form;
   }

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -403,9 +403,32 @@ const prepareRequest = async (item = {}, collection = {}) => {
   }
 
   if (request.body.mode === 'multipartForm') {
-    axiosRequest.headers['content-type'] = 'multipart/form-data';
+    const FormData = require('form-data');
     const enabledParams = filter(request.body.multipartForm, (p) => p.enabled);
-    axiosRequest.data = enabledParams;
+    const form = new FormData();
+    each(enabledParams, (param) => {
+      if (param.type === 'file') {
+        const filePaths = Array.isArray(param.value) ? param.value : [param.value];
+        each(filePaths, (filePath) => {
+          if (filePath) {
+            const opts = { filename: path.basename(filePath) };
+            if (param.contentType) opts.contentType = param.contentType;
+            form.append(
+              param.name,
+              isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)
+                ? fs.createReadStream(filePath)
+                : fs.readFileSync(filePath),
+              opts
+            );
+          }
+        });
+      } else {
+        const opts = param.contentType ? { contentType: param.contentType } : {};
+        form.append(param.name, param.value || '', Object.keys(opts).length ? opts : undefined);
+      }
+    });
+    Object.assign(axiosRequest.headers, form.getHeaders());
+    axiosRequest.data = form;
   }
 
   if (request.body.mode === 'graphql') {

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -411,15 +411,22 @@ const prepareRequest = async (item = {}, collection = {}) => {
         const filePaths = Array.isArray(param.value) ? param.value : [param.value];
         each(filePaths, (filePath) => {
           if (filePath) {
+            if (!path.isAbsolute(filePath)) {
+              filePath = path.join(collectionPath, filePath);
+            }
             const opts = { filename: path.basename(filePath) };
             if (param.contentType) opts.contentType = param.contentType;
-            form.append(
-              param.name,
-              isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)
-                ? fs.createReadStream(filePath)
-                : fs.readFileSync(filePath),
-              opts
-            );
+            try {
+              form.append(
+                param.name,
+                isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)
+                  ? fs.createReadStream(filePath)
+                  : fs.readFileSync(filePath),
+                opts
+              );
+            } catch (error) {
+              console.error('Error reading file:', error);
+            }
           }
         });
       } else {

--- a/packages/bruno-cli/src/utils/form-data.js
+++ b/packages/bruno-cli/src/utils/form-data.js
@@ -2,8 +2,11 @@ const { forEach } = require('lodash');
 const FormData = require('form-data');
 const fs = require('fs');
 const path = require('path');
+const { isLargeFile } = require('./filesystem');
 
-const createFormData = (data, collectionPath) => {
+const STREAMING_FILE_SIZE_THRESHOLD = 20 * 1024 * 1024; // 20MB
+
+const createFormData = (data, collectionPath, streamThreshold = STREAMING_FILE_SIZE_THRESHOLD) => {
   // make axios work in node using form data
   // reference: https://github.com/axios/axios/issues/1006#issuecomment-320165427
   const form = new FormData();
@@ -13,25 +16,33 @@ const createFormData = (data, collectionPath) => {
     if (contentType) {
       options.contentType = contentType;
     }
-    if (type === 'text') {
-      if (Array.isArray(value)) {
-        value.forEach((val) => form.append(name, val, options));
-      } else {
-        form.append(name, value, options);
-      }
-      return;
-    }
-
     if (type === 'file') {
-      const filePaths = value || [];
+      const filePaths = Array.isArray(value) ? value : (value ? [value] : []);
       filePaths.forEach((filePath) => {
+        if (!filePath) return;
         let trimmedFilePath = filePath.trim();
         if (!path.isAbsolute(trimmedFilePath)) {
           trimmedFilePath = path.join(collectionPath, trimmedFilePath);
         }
         options.filename = path.basename(trimmedFilePath);
-        form.append(name, fs.createReadStream(trimmedFilePath), options);
+        try {
+          form.append(
+            name,
+            isLargeFile(trimmedFilePath, streamThreshold)
+              ? fs.createReadStream(trimmedFilePath)
+              : fs.readFileSync(trimmedFilePath),
+            options
+          );
+        } catch (error) {
+          console.error('Error reading file:', error);
+        }
       });
+    } else {
+      if (Array.isArray(value)) {
+        value.forEach((val) => form.append(name, val ?? '', options));
+      } else {
+        form.append(name, value ?? '', options);
+      }
     }
   });
   return form;

--- a/packages/bruno-cli/tests/utils/form-data.spec.js
+++ b/packages/bruno-cli/tests/utils/form-data.spec.js
@@ -1,4 +1,7 @@
 const { createFormData } = require('../../src/utils/form-data');
+const os = require('os');
+
+const collectionPath = os.tmpdir();
 
 describe('utils: createFormData', () => {
   test('includes per-part Content-Type for text field with contentType', () => {
@@ -10,23 +13,23 @@ describe('utils: createFormData', () => {
         contentType: 'application/json; charset=utf-8'
       }
     ];
-    const form = createFormData(data, '/tmp');
+    const form = createFormData(data, collectionPath);
     const buffer = form.getBuffer().toString();
     expect(buffer).toContain('Content-Type: application/json; charset=utf-8');
   });
 
   test('omits Content-Type header for text field without contentType', () => {
     const data = [{ name: 'field', type: 'text', value: 'hello' }];
-    const form = createFormData(data, '/tmp');
+    const form = createFormData(data, collectionPath);
     const buffer = form.getBuffer().toString();
-    // Verify the field value is present but no spurious Content-Type appears
     expect(buffer).toContain('name="field"');
     expect(buffer).toContain('hello');
+    expect(buffer).not.toContain('Content-Type:');
   });
 
   test('appends multiple text values from an array as separate parts', () => {
     const data = [{ name: 'tag', type: 'text', value: ['a', 'b'] }];
-    const form = createFormData(data, '/tmp');
+    const form = createFormData(data, collectionPath);
     const buffer = form.getBuffer().toString();
     const matches = buffer.match(/name="tag"/g) || [];
     expect(matches.length).toBe(2);
@@ -34,10 +37,12 @@ describe('utils: createFormData', () => {
 
   test('handles single-string file value (not wrapped in array)', () => {
     const data = [{ name: 'file', type: 'file', value: 'nonexistent.txt' }];
-    // createFormData should attempt to read the file; we just verify it doesn't throw
-    // a TypeError (the original bug) and instead logs an error via try/catch
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    expect(() => createFormData(data, '/tmp')).not.toThrow();
-    consoleSpy.mockRestore();
+    try {
+      expect(() => createFormData(data, collectionPath)).not.toThrow();
+      expect(consoleSpy).toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 });

--- a/packages/bruno-cli/tests/utils/form-data.spec.js
+++ b/packages/bruno-cli/tests/utils/form-data.spec.js
@@ -1,0 +1,43 @@
+const { createFormData } = require('../../src/utils/form-data');
+
+describe('utils: createFormData', () => {
+  test('includes per-part Content-Type for text field with contentType', () => {
+    const data = [
+      {
+        name: 'message',
+        type: 'text',
+        value: '{"key":"val"}',
+        contentType: 'application/json; charset=utf-8'
+      }
+    ];
+    const form = createFormData(data, '/tmp');
+    const buffer = form.getBuffer().toString();
+    expect(buffer).toContain('Content-Type: application/json; charset=utf-8');
+  });
+
+  test('omits Content-Type header for text field without contentType', () => {
+    const data = [{ name: 'field', type: 'text', value: 'hello' }];
+    const form = createFormData(data, '/tmp');
+    const buffer = form.getBuffer().toString();
+    // Verify the field value is present but no spurious Content-Type appears
+    expect(buffer).toContain('name="field"');
+    expect(buffer).toContain('hello');
+  });
+
+  test('appends multiple text values from an array as separate parts', () => {
+    const data = [{ name: 'tag', type: 'text', value: ['a', 'b'] }];
+    const form = createFormData(data, '/tmp');
+    const buffer = form.getBuffer().toString();
+    const matches = buffer.match(/name="tag"/g) || [];
+    expect(matches.length).toBe(2);
+  });
+
+  test('handles single-string file value (not wrapped in array)', () => {
+    const data = [{ name: 'file', type: 'file', value: 'nonexistent.txt' }];
+    // createFormData should attempt to read the file; we just verify it doesn't throw
+    // a TypeError (the original bug) and instead logs an error via try/catch
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => createFormData(data, '/tmp')).not.toThrow();
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -481,15 +481,22 @@ const prepareRequest = async (item, collection = {}, abortController) => {
         const filePaths = Array.isArray(param.value) ? param.value : [param.value];
         each(filePaths, (filePath) => {
           if (filePath) {
+            if (!path.isAbsolute(filePath)) {
+              filePath = path.join(collectionPath, filePath);
+            }
             const opts = { filename: path.basename(filePath) };
             if (param.contentType) opts.contentType = param.contentType;
-            form.append(
-              param.name,
-              isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)
-                ? fs.createReadStream(filePath)
-                : fs.readFileSync(filePath),
-              opts
-            );
+            try {
+              form.append(
+                param.name,
+                isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)
+                  ? fs.createReadStream(filePath)
+                  : fs.readFileSync(filePath),
+                opts
+              );
+            } catch (error) {
+              console.error('Error reading file:', error);
+            }
           }
         });
       } else {
@@ -497,9 +504,7 @@ const prepareRequest = async (item, collection = {}, abortController) => {
         form.append(param.name, param.value || '', Object.keys(opts).length ? opts : undefined);
       }
     });
-    if (!contentTypeDefined) {
-      Object.assign(axiosRequest.headers, form.getHeaders());
-    }
+    Object.assign(axiosRequest.headers, form.getHeaders());
     axiosRequest.data = form;
   }
 

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -473,11 +473,34 @@ const prepareRequest = async (item, collection = {}, abortController) => {
   }
 
   if (request.body.mode === 'multipartForm') {
-    if (!contentTypeDefined) {
-      axiosRequest.headers['content-type'] = 'multipart/form-data';
-    }
+    const FormData = require('form-data');
     const enabledParams = filter(request.body.multipartForm, (p) => p.enabled);
-    axiosRequest.data = enabledParams;
+    const form = new FormData();
+    each(enabledParams, (param) => {
+      if (param.type === 'file') {
+        const filePaths = Array.isArray(param.value) ? param.value : [param.value];
+        each(filePaths, (filePath) => {
+          if (filePath) {
+            const opts = { filename: path.basename(filePath) };
+            if (param.contentType) opts.contentType = param.contentType;
+            form.append(
+              param.name,
+              isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)
+                ? fs.createReadStream(filePath)
+                : fs.readFileSync(filePath),
+              opts
+            );
+          }
+        });
+      } else {
+        const opts = param.contentType ? { contentType: param.contentType } : {};
+        form.append(param.name, param.value || '', Object.keys(opts).length ? opts : undefined);
+      }
+    });
+    if (!contentTypeDefined) {
+      Object.assign(axiosRequest.headers, form.getHeaders());
+    }
+    axiosRequest.data = form;
   }
 
   if (request.body.mode === 'graphql') {

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -475,6 +475,8 @@ const prepareRequest = async (item, collection = {}, abortController) => {
 
   if (request.body.mode === 'multipartForm') {
     const enabledParams = filter(request.body.multipartForm, (p) => p.enabled);
+    axiosRequest._originalMultipartData = enabledParams;
+    axiosRequest.collectionPath = collectionPath;
     const form = createFormData(enabledParams, collectionPath, STREAMING_FILE_SIZE_THRESHOLD);
     Object.assign(axiosRequest.headers, form.getHeaders());
     axiosRequest.data = form;

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const { getTreePathFromCollectionToItem, mergeHeaders, mergeScripts, mergeVars, getFormattedCollectionOauth2Credentials, mergeAuth } = require('../../utils/collection');
 const path = require('node:path');
 const { isLargeFile } = require('../../utils/filesystem');
+const { createFormData } = require('../../utils/form-data');
 
 const STREAMING_FILE_SIZE_THRESHOLD = 20 * 1024 * 1024; // 20MB
 
@@ -473,37 +474,8 @@ const prepareRequest = async (item, collection = {}, abortController) => {
   }
 
   if (request.body.mode === 'multipartForm') {
-    const FormData = require('form-data');
     const enabledParams = filter(request.body.multipartForm, (p) => p.enabled);
-    const form = new FormData();
-    each(enabledParams, (param) => {
-      if (param.type === 'file') {
-        const filePaths = Array.isArray(param.value) ? param.value : [param.value];
-        each(filePaths, (filePath) => {
-          if (filePath) {
-            if (!path.isAbsolute(filePath)) {
-              filePath = path.join(collectionPath, filePath);
-            }
-            const opts = { filename: path.basename(filePath) };
-            if (param.contentType) opts.contentType = param.contentType;
-            try {
-              form.append(
-                param.name,
-                isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)
-                  ? fs.createReadStream(filePath)
-                  : fs.readFileSync(filePath),
-                opts
-              );
-            } catch (error) {
-              console.error('Error reading file:', error);
-            }
-          }
-        });
-      } else {
-        const opts = param.contentType ? { contentType: param.contentType } : {};
-        form.append(param.name, param.value || '', Object.keys(opts).length ? opts : undefined);
-      }
-    });
+    const form = createFormData(enabledParams, collectionPath, STREAMING_FILE_SIZE_THRESHOLD);
     Object.assign(axiosRequest.headers, form.getHeaders());
     axiosRequest.data = form;
   }

--- a/packages/bruno-electron/src/utils/form-data.js
+++ b/packages/bruno-electron/src/utils/form-data.js
@@ -2,6 +2,9 @@ const { forEach } = require('lodash');
 const FormData = require('form-data');
 const fs = require('fs');
 const path = require('path');
+const { isLargeFile } = require('./filesystem');
+
+const STREAMING_FILE_SIZE_THRESHOLD = 20 * 1024 * 1024; // 20MB
 
 const formatMultipartData = (multipartData, boundary) => {
   if (!Array.isArray(multipartData) || multipartData.length === 0) {
@@ -58,7 +61,7 @@ const formatMultipartData = (multipartData, boundary) => {
   return parts.join('\n');
 };
 
-const createFormData = (data, collectionPath) => {
+const createFormData = (data, collectionPath, streamThreshold = STREAMING_FILE_SIZE_THRESHOLD) => {
   // make axios work in node using form data
   // reference: https://github.com/axios/axios/issues/1006#issuecomment-320165427
   const form = new FormData();
@@ -68,25 +71,33 @@ const createFormData = (data, collectionPath) => {
     if (contentType) {
       options.contentType = contentType;
     }
-    if (type === 'text') {
-      if (Array.isArray(value)) {
-        value.forEach((val) => form.append(name, val, options));
-      } else {
-        form.append(name, value, options);
-      }
-      return;
-    }
-
     if (type === 'file') {
-      const filePaths = value || [];
+      const filePaths = Array.isArray(value) ? value : (value ? [value] : []);
       filePaths.forEach((filePath) => {
+        if (!filePath) return;
         let trimmedFilePath = filePath.trim();
         if (!path.isAbsolute(trimmedFilePath)) {
           trimmedFilePath = path.join(collectionPath, trimmedFilePath);
         }
         options.filename = path.basename(trimmedFilePath);
-        form.append(name, fs.createReadStream(trimmedFilePath), options);
+        try {
+          form.append(
+            name,
+            isLargeFile(trimmedFilePath, streamThreshold)
+              ? fs.createReadStream(trimmedFilePath)
+              : fs.readFileSync(trimmedFilePath),
+            options
+          );
+        } catch (error) {
+          console.error('Error reading file:', error);
+        }
       });
+    } else {
+      if (Array.isArray(value)) {
+        value.forEach((val) => form.append(name, val ?? '', options));
+      } else {
+        form.append(name, value ?? '', options);
+      }
     }
   });
   return form;

--- a/packages/bruno-electron/src/utils/form-data.js
+++ b/packages/bruno-electron/src/utils/form-data.js
@@ -23,37 +23,31 @@ const formatMultipartData = (multipartData, boundary) => {
     return 'file';
   };
 
-  const formatValue = (value) => {
-    if (Array.isArray(value)) {
-      return value.map((v) => String(v ?? '')).join(', ');
-    }
-    return String(value ?? '');
-  };
-
   const boundaryValue = normalizeBoundary(boundary);
   const parts = [];
 
   multipartData.forEach((field) => {
     if (!field || !field.name) return;
 
-    parts.push(`----${boundaryValue}`);
-    parts.push('Content-Disposition: form-data');
-
     if (field.type === 'file') {
       const filePaths = Array.isArray(field.value) ? field.value : (field.value ? [field.value] : ['']);
       filePaths.forEach((filePath) => {
-        parts.push(`----${boundaryValue}`);
-        parts.push('Content-Disposition: form-data');
         const fileName = getFileName(filePath);
-        parts.push(`name: ${field.name}`);
+        parts.push(`----${boundaryValue}`);
+        parts.push(`Content-Disposition: form-data; name: ${field.name}; filename: ${fileName}`);
+        if (field.contentType) parts.push(`Content-Type: ${field.contentType}`);
         parts.push(`value: [File: ${fileName}]`);
         parts.push('');
       });
     } else {
-      const value = formatValue(field.value);
-      parts.push(`name: ${field.name}`);
-      parts.push(`value: ${value}`);
-      parts.push('');
+      const values = Array.isArray(field.value) ? field.value : [field.value ?? ''];
+      values.forEach((val) => {
+        parts.push(`----${boundaryValue}`);
+        parts.push(`Content-Disposition: form-data; name: ${field.name}`);
+        if (field.contentType) parts.push(`Content-Type: ${field.contentType}`);
+        parts.push(`value: ${String(val ?? '')}`);
+        parts.push('');
+      });
     }
   });
 

--- a/packages/bruno-electron/tests/utils/form-data.spec.js
+++ b/packages/bruno-electron/tests/utils/form-data.spec.js
@@ -52,6 +52,20 @@ describe('utils: formatMultipartData', () => {
     expect(result).toContain('Content-Type: application/json; charset=utf-8');
   });
 
+  test('should only include Content-Type for parts that define contentType', () => {
+    const data = [
+      { name: 'json', type: 'text', value: '{"k":"v"}', contentType: 'application/json; charset=utf-8' },
+      { name: 'plain', type: 'text', value: 'hello' }
+    ];
+    const result = formatMultipartData(data, 'boundary');
+
+    expect(result).toContain('name: json');
+    expect(result).toContain('name: plain');
+    expect(result).toContain('Content-Type: application/json; charset=utf-8');
+    const contentTypeMatches = result.match(/Content-Type:/g) || [];
+    expect(contentTypeMatches.length).toBe(1);
+  });
+
   test('should render array text values as separate parts', () => {
     const data = [{ name: 'tag', type: 'text', value: ['a', 'b'] }];
     const result = formatMultipartData(data, 'boundary');

--- a/packages/bruno-electron/tests/utils/form-data.spec.js
+++ b/packages/bruno-electron/tests/utils/form-data.spec.js
@@ -17,6 +17,7 @@ describe('utils: formatMultipartData', () => {
     const result = formatMultipartData(data, 'boundary');
 
     expect(result).toContain('name: file');
+    expect(result).toContain('filename: Dumy.xml');
     expect(result).toContain('value: [File: Dumy.xml]');
   });
 
@@ -42,5 +43,32 @@ describe('utils: formatMultipartData', () => {
     const data = [{ name: 'field', type: 'text', value: 'value' }];
     expect(formatMultipartData(data, '--boundary')).toContain('----boundary');
     expect(formatMultipartData(data, 'boundary--')).toContain('----boundary');
+  });
+
+  test('should include per-part Content-Type when contentType is set on text field', () => {
+    const data = [{ name: 'message', type: 'text', value: '{"k":"v"}', contentType: 'application/json; charset=utf-8' }];
+    const result = formatMultipartData(data, 'boundary');
+
+    expect(result).toContain('Content-Type: application/json; charset=utf-8');
+  });
+
+  test('should render array text values as separate parts', () => {
+    const data = [{ name: 'tag', type: 'text', value: ['a', 'b'] }];
+    const result = formatMultipartData(data, 'boundary');
+
+    const matches = result.match(/name: tag/g) || [];
+    expect(matches.length).toBe(2);
+    expect(result).toContain('value: a');
+    expect(result).toContain('value: b');
+  });
+
+  test('should render each file as a separate part with filename in disposition', () => {
+    const data = [{ name: 'attach', type: 'file', value: ['a.jpg', 'b.jpg'] }];
+    const result = formatMultipartData(data, 'boundary');
+
+    expect(result).toContain('filename: a.jpg');
+    expect(result).toContain('filename: b.jpg');
+    const matches = result.match(/name: attach/g) || [];
+    expect(matches.length).toBe(2);
   });
 });


### PR DESCRIPTION
  ## Problem

  When using `body:multipart-form` with a text field that has `contentType` set (e.g. `application/json;
   charset=utf-8`), the per-field `Content-Type` header is missing from the actual multipart body sent
  to the server.

  Servers that inspect individual part headers to determine the encoding of that field (common in APIs
  that accept JSON in a multipart field alongside binary files) will fail to parse the field and return
  errors.

  **Actual part in the sent body:**
  Content-Disposition: form-data; name="message"

  {"key":"value"}

  **Expected part in the sent body:**
  Content-Disposition: form-data; name="message"
  Content-Type: application/json; charset=utf-8

  {"key":"value"}

  ## Root Cause

  In both `bruno-cli` and `bruno-electron` `prepare-request.js`, the filtered `multipartForm` params
  array was passed directly to `axiosRequest.data`. axios/form-data does not read the `contentType`
  property from plain param objects when serializing, so per-part `Content-Type` headers are never
  emitted.

  ## Fix

  Build a `FormData` instance explicitly and use `form.append(name, value, { contentType })` for each
  field. `form-data` (already a dependency at `4.0.4`) supports per-part content type via the third
  `options` argument. File fields preserve the existing large-file streaming and filename inference
  behavior.

  ## Verification

  Verified with a local echo server capturing the raw multipart body:

  **Before:**
  Content-Disposition: form-data; name="message"

  {"MessageType":4,...}

  **After:**
  Content-Disposition: form-data; name="message"
  Content-Type: application/json; charset=utf-8

  {"MessageType":4,...}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved multipart form-data uploads: streams large files based on a configurable threshold and supports single/array file fields with per-part filename/Content-Type.
  * Requests now retain original multipart params and collection context for diagnostics.
* **Bug Fixes**
  * Correct multipart headers (including boundary) are merged into request headers.
  * Safer file handling with guarded read/stream operations and robust empty-field handling.
* **Tests**
  * Added tests validating multipart formatting for files, arrays, and content-type behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->