### PR TITLE
fix: use stable index in requests tab in report

### DIFF
--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -2,11 +2,8 @@ import { getFilteredRequestResults } from './template';
 import vm from 'vm';
 
 describe('getFilteredRequestResults', () => {
-  it('serialized function works in a plain JS context', () => {
-    const ctx = vm.createContext({});
-    vm.runInContext(`var fn = ${getFilteredRequestResults.toString()}`, ctx);
-
-    const result = vm.runInContext(`fn([
+  it('preserves original request indexes when filtering failed results', () => {
+    const results = [
       {
         path: '01-passing',
         status: 'pass',
@@ -19,11 +16,15 @@ describe('getFilteredRequestResults', () => {
         testResults: [{ description: 'forced failure', status: 'fail' }],
         assertionResults: []
       }
-    ], true)`, ctx);
+    ];
+    const ctx = vm.createContext({ results });
+    vm.runInContext(`var fn = ${getFilteredRequestResults.toString()}`, ctx);
+
+    const result = vm.runInContext('fn(results, true)', ctx);
 
     expect(result).toEqual([
       {
-        value: expect.objectContaining({ path: '02-failing', status: 'pass' }),
+        value: results[1],
         index: 1
       }
     ]);

--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -1,8 +1,7 @@
-import htmlTemplateString from './template';
+import { getFilteredRequestResults } from './template';
 
-describe('HTML report template', () => {
+describe('getFilteredRequestResults', () => {
   it('preserves original request indexes when filtering failed results', () => {
-    const htmlString = htmlTemplateString('');
     const results = [
       {
         path: '01-passing',
@@ -18,13 +17,7 @@ describe('HTML report template', () => {
       }
     ];
 
-    const indexedResults = results.map((value, index) => ({ value, index }));
-    const failedResults = indexedResults.filter(
-      ({ value }) =>
-        value.status === 'error'
-        || !!value?.testResults?.find((t) => t.status !== 'pass')
-        || !!value?.assertionResults?.find((t) => t.status !== 'pass')
-    );
+    const failedResults = getFilteredRequestResults(results, true);
 
     expect(failedResults).toEqual([
       {
@@ -32,6 +25,5 @@ describe('HTML report template', () => {
         index: 1
       }
     ]);
-    expect(htmlString).toContain('<x-result v-for="result in results" :result="result.value" :index="result.index" :key="result.index"></x-result>');
   });
 });

--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -1,0 +1,37 @@
+import htmlTemplateString from './template';
+
+describe('HTML report template', () => {
+  it('preserves original request indexes when filtering failed results', () => {
+    const htmlString = htmlTemplateString('');
+    const results = [
+      {
+        path: '01-passing',
+        status: 'pass',
+        testResults: [{ description: 'status is 200', status: 'pass' }],
+        assertionResults: []
+      },
+      {
+        path: '02-failing',
+        status: 'pass',
+        testResults: [{ description: 'forced failure', status: 'fail' }],
+        assertionResults: []
+      }
+    ];
+
+    const indexedResults = results.map((value, index) => ({ value, index }));
+    const failedResults = indexedResults.filter(
+      ({ value }) =>
+        value.status === 'error'
+        || !!value?.testResults?.find((t) => t.status !== 'pass')
+        || !!value?.assertionResults?.find((t) => t.status !== 'pass')
+    );
+
+    expect(failedResults).toEqual([
+      {
+        value: results[1],
+        index: 1
+      }
+    ]);
+    expect(htmlString).toContain('<x-result v-for="result in results" :result="result.value" :index="result.index" :key="result.index"></x-result>');
+  });
+});

--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -1,8 +1,12 @@
 import { getFilteredRequestResults } from './template';
+import vm from 'vm';
 
 describe('getFilteredRequestResults', () => {
-  it('preserves original request indexes when filtering failed results', () => {
-    const results = [
+  it('serialized function works in a plain JS context', () => {
+    const ctx = vm.createContext({});
+    vm.runInContext(`var fn = ${getFilteredRequestResults.toString()}`, ctx);
+
+    const result = vm.runInContext(`fn([
       {
         path: '01-passing',
         status: 'pass',
@@ -15,13 +19,11 @@ describe('getFilteredRequestResults', () => {
         testResults: [{ description: 'forced failure', status: 'fail' }],
         assertionResults: []
       }
-    ];
+    ], true)`, ctx);
 
-    const failedResults = getFilteredRequestResults(results, true);
-
-    expect(failedResults).toEqual([
+    expect(result).toEqual([
       {
-        value: results[1],
+        value: expect.objectContaining({ path: '02-failing', status: 'pass' }),
         index: 1
       }
     ]);

--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -1,10 +1,6 @@
-type ReportRequestResult = {
-  status?: string;
-  testResults?: { status?: string }[];
-  assertionResults?: { status?: string }[];
-};
+import type { T_RunnerRequestExecutionResult } from '../../types';
 
-export const getFilteredRequestResults = (results: ReportRequestResult[] = [], onlyFailed = false) => {
+export const getFilteredRequestResults = (results: T_RunnerRequestExecutionResult[] = [], onlyFailed = false) => {
   const indexedResults = (Array.isArray(results) ? results : []).map((value, index) => ({ value, index }));
 
   if (!onlyFailed) {

--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -1,14 +1,10 @@
-type T_ReportCheckResult = {
+type ReportRequestResult = {
   status?: string;
+  testResults?: { status?: string }[];
+  assertionResults?: { status?: string }[];
 };
 
-type T_ReportRequestResult = {
-  status?: string;
-  testResults?: T_ReportCheckResult[];
-  assertionResults?: T_ReportCheckResult[];
-};
-
-export const getFilteredRequestResults = (results: T_ReportRequestResult[] = [], onlyFailed = false) => {
+export const getFilteredRequestResults = (results: ReportRequestResult[] = [], onlyFailed = false) => {
   const indexedResults = (Array.isArray(results) ? results : []).map((value, index) => ({ value, index }));
 
   if (!onlyFailed) {

--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -1,3 +1,28 @@
+type T_ReportCheckResult = {
+  status?: string;
+};
+
+type T_ReportRequestResult = {
+  status?: string;
+  testResults?: T_ReportCheckResult[];
+  assertionResults?: T_ReportCheckResult[];
+};
+
+export const getFilteredRequestResults = (results: T_ReportRequestResult[] = [], onlyFailed = false) => {
+  const indexedResults = (Array.isArray(results) ? results : []).map((value, index) => ({ value, index }));
+
+  if (!onlyFailed) {
+    return indexedResults;
+  }
+
+  return indexedResults.filter(
+    ({ value }) =>
+      value?.status === 'error'
+      || !!value?.testResults?.find((t) => t.status !== 'pass')
+      || !!value?.assertionResults?.find((t) => t.status !== 'pass')
+  );
+};
+
 export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -423,6 +448,8 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
     <script>
       const { createApp, ref, computed, onMounted } = Vue;
 
+      const getFilteredRequestResults = ${getFilteredRequestResults.toString()};
+
       function mergeTests(runnerResults) {
         if (!Array.isArray(runnerResults)) return runnerResults; 
 
@@ -645,16 +672,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
         setup(props) {
           const onlyFailed = ref(false);
           const filteredResults = computed(() => {
-            const results = (props?.res?.results || []).map((value, index) => ({ value, index }));
-            if (onlyFailed.value) {
-              return results.filter(
-                ({ value }) =>
-                  value.status === 'error' ||
-                  !!value?.testResults?.find((t) => t.status !== 'pass') ||
-                  !!value?.assertionResults?.find((t) => t.status !== 'pass')
-              );
-            }
-            return results;
+            return getFilteredRequestResults(props?.res?.results, onlyFailed.value);
           });
           const iterationIndex = Number(props.res.iterationIndex) + 1;
           return {

--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -294,7 +294,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
           </n-switch>
 
           <n-collapse>
-            <x-result v-for="(result, index) in results" :result="result" :index="index" :key="index"></x-result>
+            <x-result v-for="result in results" :result="result.value" :index="result.index" :key="result.index"></x-result>
           </n-collapse>
         </n-flex>
       </n-card>
@@ -645,15 +645,16 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
         setup(props) {
           const onlyFailed = ref(false);
           const filteredResults = computed(() => {
+            const results = (props?.res?.results || []).map((value, index) => ({ value, index }));
             if (onlyFailed.value) {
-              return props?.res?.results?.filter(
-                (r) =>
-                  r.status === 'error' ||
-                  !!r?.testResults?.find((t) => t.status !== 'pass') ||
-                  !!r?.assertionResults?.find((t) => t.status !== 'pass')
+              return results.filter(
+                ({ value }) =>
+                  value.status === 'error' ||
+                  !!value?.testResults?.find((t) => t.status !== 'pass') ||
+                  !!value?.assertionResults?.find((t) => t.status !== 'pass')
               );
             }
-            return props.res.results;
+            return results;
           });
           const iterationIndex = Number(props.res.iterationIndex) + 1;
           return {


### PR DESCRIPTION
### Description

[Jira](https://usebruno.atlassian.net/browse/BRU-3225)

Fixes #7851 

Previously we were using non-stable id's for elements, causing wrong title or data for the requests when "only failed" was toggled.

After this PR, each request will have a stable identifier, so item at index 0 will always have same index even after "Only failed" is toggled.

After:

https://github.com/user-attachments/assets/5a146a32-7430-437f-afab-ecabfb6e77d6

Before:

https://github.com/user-attachments/assets/60498498-d39d-4499-925e-535ba69f385b




<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized filter for request results used by HTML reports.

* **Bug Fixes**
  * When showing only failed results, original request indexes are preserved in the UI.

* **Refactor**
  * Report rendering now uses the centralized filter, simplifying result handling and component data flow.

* **Tests**
  * New unit test verifies filtered results preserve original indexes for failed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->