### PR TITLE
fix(cli): skip headers with empty name when building request

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -29,7 +29,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
   }
 
   each(get(request, 'headers', []), (h) => {
-    if (h.enabled) {
+    if (h.enabled && h.name.length > 0) {
       headers[h.name] = h.value;
       if (h.name.toLowerCase() === 'content-type') {
         contentTypeDefined = true;

--- a/packages/bruno-cli/tests/runner/prepare-request.spec.js
+++ b/packages/bruno-cli/tests/runner/prepare-request.spec.js
@@ -601,6 +601,71 @@ describe('prepare-request: prepareRequest', () => {
     });
   });
 
+  describe('Header filtering', () => {
+    it('skips headers with empty name', async () => {
+      const item = {
+        request: {
+          method: 'GET',
+          url: 'https://example.com',
+          headers: [
+            { name: '', value: 'ghost', enabled: true },
+            { name: 'X-Valid', value: 'yes', enabled: true }
+          ]
+        }
+      };
+      const result = await prepareRequest(item);
+      expect(result.headers).not.toHaveProperty('');
+      expect(result.headers).toHaveProperty('X-Valid', 'yes');
+    });
+
+    it('skips disabled headers regardless of name', async () => {
+      const item = {
+        request: {
+          method: 'GET',
+          url: 'https://example.com',
+          headers: [
+            { name: 'X-Disabled', value: 'nope', enabled: false },
+            { name: 'X-Enabled', value: 'yes', enabled: true }
+          ]
+        }
+      };
+      const result = await prepareRequest(item);
+      expect(result.headers).not.toHaveProperty('X-Disabled');
+      expect(result.headers).toHaveProperty('X-Enabled', 'yes');
+    });
+
+    it('includes all valid enabled headers', async () => {
+      const item = {
+        request: {
+          method: 'GET',
+          url: 'https://example.com',
+          headers: [
+            { name: 'X-One', value: '1', enabled: true },
+            { name: 'X-Two', value: '2', enabled: true }
+          ]
+        }
+      };
+      const result = await prepareRequest(item);
+      expect(result.headers).toHaveProperty('X-One', '1');
+      expect(result.headers).toHaveProperty('X-Two', '2');
+    });
+
+    it('produces no headers when all have empty names', async () => {
+      const item = {
+        request: {
+          method: 'GET',
+          url: 'https://example.com',
+          headers: [
+            { name: '', value: '', enabled: true },
+            { name: '', value: 'some-value', enabled: true }
+          ]
+        }
+      };
+      const result = await prepareRequest(item);
+      expect(Object.keys(result.headers).filter((k) => k === '')).toHaveLength(0);
+    });
+  });
+
   describe('GraphQL request', () => {
     it('keeps variables as string for interpolation', async () => {
       const item = {


### PR DESCRIPTION
Fixes: #7868
Partially fixes: #7720
https://usebruno.atlassian.net/browse/BRU-3419

### Description

This PR is implemented to skip empty headers (`{:}`) on CLI runs, similar to how we handle them in the Bruno client.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header processing to properly handle headers with empty names. Empty header names are now skipped during request preparation, preventing invalid header assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->