### PR TITLE
Add missing space in help text of Variables Editor window

### DIFF
--- a/packages/bruno-app/src/components/VariablesEditor/index.js
+++ b/packages/bruno-app/src/components/VariablesEditor/index.js
@@ -99,7 +99,7 @@ const VariablesEditor = ({ collection }) => {
       <div className="mt-8 muted text-xs">
         Note: As of today, runtime variables can only be set via the API - <span className="font-medium">getVar()</span>{' '}
         and <span className="font-medium">setVar()</span>. <br />
-        You can use the <span className="font-medium">var</span> variable with the{' '}
+        You can use the <span className="font-medium">var</span> variable with the {' '}
         <span className="font-medium">{'{{var}}'}</span> syntax.<br />
       </div>
     </StyledWrapper>


### PR DESCRIPTION
 fixes: #7870

### Description

This pull request fixes #7870 by updating the help text in the Variables Editor to add a missing space (see attached screenshot).

#### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<img width="1132" height="536" alt="variables" src="https://github.com/user-attachments/assets/7a4bbc4d-d501-432e-9964-17d7b2719293" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the VariablesEditor information display for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->