### PR TITLE
feat(collection-scripts): backend execution engine for collection hooks

### DIFF
--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -37,6 +37,7 @@ const menuTemplate = require('./app/menu-template');
 const { openCollection } = require('./app/collections');
 const registerNetworkIpc = require('./ipc/network');
 const registerCollectionsIpc = require('./ipc/collection');
+const registerCollectionScriptsIpc = require('./ipc/scripts');
 const registerFilesystemIpc = require('./ipc/filesystem');
 const registerPreferencesIpc = require('./ipc/preferences');
 const registerSystemMonitorIpc = require('./ipc/system-monitor');
@@ -461,6 +462,7 @@ app.on('ready', async () => {
   registerNetworkIpc(mainWindow);
   registerGlobalEnvironmentsIpc(mainWindow, globalEnvironmentsManager);
   registerCollectionsIpc(mainWindow, collectionWatcher);
+  registerCollectionScriptsIpc(mainWindow);
   registerPreferencesIpc(mainWindow, collectionWatcher);
   registerWorkspaceIpc(mainWindow, workspaceWatcher);
   registerApiSpecIpc(mainWindow, apiSpecWatcher);

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1338,8 +1338,21 @@ const registerNetworkIpc = (mainWindow) => {
         for (const script of beforeRunScripts) {
           if (!isScriptPathSafe(collectionPath, script.file)) continue;
           try {
-            const { exitCode, stdout } = await runShellScript(collectionPath, script.file);
-            if (script.outputMode === 'envVars' && exitCode === 0) {
+            const { exitCode, stdout, stderr } = await runShellScript(collectionPath, script.file);
+            if (exitCode !== 0) {
+              const stderrTail = (stderr || '').slice(-500);
+              console.error(
+                `Collection script '${script.name}' exited with code ${exitCode}.${stderrTail ? ` stderr: ${stderrTail}` : ''}`
+              );
+              mainWindow.webContents.send('main:collection-script-output', {
+                collectionUid,
+                scriptUid: script.uid,
+                stream: 'stderr',
+                data: `Script '${script.name}' exited with code ${exitCode}.\n${stderrTail}`
+              });
+              continue;
+            }
+            if (script.outputMode === 'envVars') {
               const parsed = parseEnvVarsFromOutput(stdout);
               Object.assign(envVars, parsed);
               mainWindow.webContents.send('main:script-environment-update', {
@@ -1351,6 +1364,12 @@ const registerNetworkIpc = (mainWindow) => {
             }
           } catch (err) {
             console.error(`Collection script '${script.name}' failed:`, err.message);
+            mainWindow.webContents.send('main:collection-script-output', {
+              collectionUid,
+              scriptUid: script.uid,
+              stream: 'stderr',
+              data: `Script '${script.name}' failed: ${err.message}`
+            });
           }
         }
       }

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -28,6 +28,10 @@ const { createFormData } = require('../../utils/form-data');
 const { findItemInCollectionByPathname, sortFolder, getAllRequestsInFolderRecursively, getEnvVars, getTreePathFromCollectionToItem, mergeVars, sortByNameThenSequence } = require('../../utils/collection');
 const { getOAuth2TokenUsingAuthorizationCode, getOAuth2TokenUsingClientCredentials, getOAuth2TokenUsingPasswordCredentials, getOAuth2TokenUsingImplicitGrant, updateCollectionOauth2Credentials, clearOauth2CredentialsByCredentialsId } = require('../../utils/oauth2');
 const { preferencesUtil } = require('../../store/preferences');
+const CollectionSecurityStore = require('../../store/collection-security');
+const { isScriptPathSafe, parseEnvVarsFromOutput, runShellScript } = require('../../utils/collection-scripts');
+
+const collectionSecurityStore = new CollectionSecurityStore();
 const { getProcessEnvVars } = require('../../store/process-env');
 const { getBrunoConfig } = require('../../store/bruno-config');
 const Oauth2Store = require('../../store/oauth2');
@@ -1323,6 +1327,33 @@ const registerNetworkIpc = (mainWindow) => {
         folderUid,
         cancelTokenUid
       });
+
+      // Run beforeCollectionRun scripts before the request loop begins.
+      // Results are merged into envVars so the runner picks them up immediately.
+      const securityConfig = collectionSecurityStore.getSecurityConfigForCollection(collectionPath);
+      if (securityConfig?.jsSandboxMode === 'developer') {
+        const beforeRunScripts = get(brunoConfig, 'collectionScripts', []).filter(
+          (s) => s.runOn?.includes('beforeCollectionRun')
+        );
+        for (const script of beforeRunScripts) {
+          if (!isScriptPathSafe(collectionPath, script.file)) continue;
+          try {
+            const { exitCode, stdout } = await runShellScript(collectionPath, script.file);
+            if (script.outputMode === 'envVars' && exitCode === 0) {
+              const parsed = parseEnvVarsFromOutput(stdout);
+              Object.assign(envVars, parsed);
+              mainWindow.webContents.send('main:script-environment-update', {
+                envVariables: parsed, runtimeVariables: {}, persistentEnvVariables: parsed, collectionUid
+              });
+              mainWindow.webContents.send('main:persistent-env-variables-update', {
+                persistentEnvVariables: parsed, collectionUid
+              });
+            }
+          } catch (err) {
+            console.error(`Collection script '${script.name}' failed:`, err.message);
+          }
+        }
+      }
 
       try {
         let folderRequests = [];

--- a/packages/bruno-electron/src/ipc/scripts.js
+++ b/packages/bruno-electron/src/ipc/scripts.js
@@ -1,0 +1,50 @@
+const { ipcMain } = require('electron');
+const CollectionSecurityStore = require('../store/collection-security');
+const { isScriptPathSafe, parseEnvVarsFromOutput, runShellScript } = require('../utils/collection-scripts');
+
+const collectionSecurityStore = new CollectionSecurityStore();
+
+const registerCollectionScriptsIpc = (mainWindow) => {
+  ipcMain.handle('renderer:run-collection-script', async (event, { collectionUid, collectionPath, script }) => {
+    const securityConfig = collectionSecurityStore.getSecurityConfigForCollection(collectionPath);
+    if (securityConfig?.jsSandboxMode !== 'developer') {
+      return { error: 'Collection scripts require Developer Mode. Enable it in Collection Settings > Security.' };
+    }
+
+    if (!isScriptPathSafe(collectionPath, script.file)) {
+      return { error: 'Script path must be within the collection directory.' };
+    }
+
+    const sendChunk = (data, stream) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('main:collection-script-output', {
+          collectionUid, scriptUid: script.uid, data, stream
+        });
+      }
+    };
+
+    try {
+      const { exitCode, stdout } = await runShellScript(collectionPath, script.file, {
+        onStdout: (chunk) => sendChunk(chunk, 'stdout'),
+        onStderr: (chunk) => sendChunk(chunk, 'stderr')
+      });
+
+      if (script.outputMode === 'envVars' && exitCode === 0 && mainWindow && !mainWindow.isDestroyed()) {
+        const parsed = parseEnvVarsFromOutput(stdout);
+        mainWindow.webContents.send('main:script-environment-update', {
+          envVariables: parsed, runtimeVariables: {}, persistentEnvVariables: parsed, collectionUid
+        });
+        mainWindow.webContents.send('main:persistent-env-variables-update', {
+          persistentEnvVariables: parsed, collectionUid
+        });
+      }
+
+      return { exitCode };
+    } catch (err) {
+      sendChunk(`Error: ${err.message}`, 'stderr');
+      return { error: err.message, exitCode: 1 };
+    }
+  });
+};
+
+module.exports = registerCollectionScriptsIpc;

--- a/packages/bruno-electron/src/ipc/scripts.js
+++ b/packages/bruno-electron/src/ipc/scripts.js
@@ -5,7 +5,19 @@ const { isScriptPathSafe, parseEnvVarsFromOutput, runShellScript } = require('..
 const collectionSecurityStore = new CollectionSecurityStore();
 
 const registerCollectionScriptsIpc = (mainWindow) => {
-  ipcMain.handle('renderer:run-collection-script', async (event, { collectionUid, collectionPath, script }) => {
+  ipcMain.handle('renderer:run-collection-script', async (event, payload) => {
+    const { collectionUid, collectionPath, script } = payload || {};
+
+    if (typeof collectionPath !== 'string' || !collectionPath.length) {
+      return { error: 'Invalid request: collection path is required.' };
+    }
+    if (!script || typeof script !== 'object') {
+      return { error: 'Invalid request: script is required.' };
+    }
+    if (typeof script.file !== 'string' || !script.file.length) {
+      return { error: 'Invalid request: script.file is required.' };
+    }
+
     const securityConfig = collectionSecurityStore.getSecurityConfigForCollection(collectionPath);
     if (securityConfig?.jsSandboxMode !== 'developer') {
       return { error: 'Collection scripts require Developer Mode. Enable it in Collection Settings > Security.' };

--- a/packages/bruno-electron/src/utils/collection-scripts.js
+++ b/packages/bruno-electron/src/utils/collection-scripts.js
@@ -1,25 +1,42 @@
+const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
 
-/**
- * Returns true only if scriptFile resolves to a path inside collectionPath.
- * Prevents traversal attacks via `../` sequences or absolute paths that escape
- * the collection directory. The path.sep suffix in the prefix check ensures a
- * sibling directory that shares a name prefix (e.g. /col vs /col-extra) is not
- * mistakenly accepted.
- */
-function isScriptPathSafe(collectionPath, scriptFile) {
-  const resolvedCollection = path.resolve(collectionPath);
-  const resolvedScript = path.resolve(collectionPath, scriptFile);
-  return resolvedScript === resolvedCollection || resolvedScript.startsWith(resolvedCollection + path.sep);
-}
+const DEFAULT_MAX_BUFFER = 1024 * 1024; // 1 MiB per stream
+const TRUNCATION_MARKER = '\n[bruno: output truncated — exceeded maxBuffer]\n';
 
 /**
- * Parses KEY=VALUE pairs from shell script stdout.
- * Supports both plain `KEY=VALUE` and `export KEY=VALUE` syntax.
- * Only the first `=` is treated as the delimiter; values may contain `=`.
- * Blank lines and comment lines are ignored.
+ * Returns true only if scriptFile resolves — through symlinks — to a path
+ * inside collectionPath. Uses fs.realpathSync so a symlink inside the
+ * collection that points outside it is rejected. Returns false if either
+ * path cannot be realpath-resolved (e.g. script does not exist), so the
+ * caller never executes a non-existent or unreadable target.
  */
+function isScriptPathSafe(collectionPath, scriptFile) {
+  const lexicalCollection = path.resolve(collectionPath);
+  const lexicalScript = path.resolve(collectionPath, scriptFile);
+
+  let realCollection;
+  try {
+    realCollection = fs.realpathSync(lexicalCollection);
+  } catch {
+    // Collection directory does not exist on disk: fall back to lexical-only
+    // comparison. This branch exists for unit tests that use fictional paths;
+    // the IPC handler should never call this for a missing collection.
+    return lexicalScript === lexicalCollection || lexicalScript.startsWith(lexicalCollection + path.sep);
+  }
+
+  let realScript;
+  try {
+    realScript = fs.realpathSync(lexicalScript);
+  } catch {
+    // Script doesn't exist (or unreadable). Reject — never spawn missing files.
+    return false;
+  }
+
+  return realScript === realCollection || realScript.startsWith(realCollection + path.sep);
+}
+
 function parseEnvVarsFromOutput(output) {
   const vars = {};
   for (const line of output.split('\n')) {
@@ -34,33 +51,52 @@ function parseEnvVarsFromOutput(output) {
 }
 
 /**
- * Spawns a registered collection script and resolves with its exit code and
- * captured stdout/stderr. The script is executed directly so its shebang line
- * determines the interpreter (e.g. #!/bin/bash, #!/usr/bin/env node).
- *
- * Optional `onStdout` and `onStderr` callbacks receive incremental chunks as
- * they arrive, so callers can stream output to the UI while the script is
- * still running. Each chunk is also accumulated into the resolved value.
- *
- * Callers are responsible for the security check (isScriptPathSafe) before calling this.
+ * On Windows, spawning a script path directly cannot interpret shebangs or
+ * resolve file associations (.cmd/.bat/.ps1/.js); shell:true delegates to
+ * cmd.exe which does. On POSIX, the kernel honours the shebang itself.
  */
-function runShellScript(collectionPath, scriptFile, { onStdout, onStderr } = {}) {
+function buildSpawnArgs(resolvedScript, cwd, platform = process.platform) {
+  const isWindows = platform === 'win32';
+  return {
+    command: resolvedScript,
+    args: [],
+    options: {
+      cwd,
+      env: process.env,
+      ...(isWindows ? { shell: true, windowsHide: true } : {})
+    }
+  };
+}
+
+function runShellScript(collectionPath, scriptFile, { onStdout, onStderr, maxBuffer = DEFAULT_MAX_BUFFER } = {}) {
   return new Promise((resolve, reject) => {
     const resolvedScript = path.resolve(collectionPath, scriptFile);
-    const proc = spawn(resolvedScript, [], { cwd: collectionPath, env: process.env });
+    const { command, args, options } = buildSpawnArgs(resolvedScript, collectionPath);
+    const proc = spawn(command, args, options);
+
     let stdout = '';
     let stderr = '';
+    let truncated = false;
+
+    const append = (current, chunk) => {
+      if (truncated) return current;
+      const remaining = maxBuffer - current.length;
+      if (chunk.length <= remaining) return current + chunk;
+      truncated = true;
+      return current + chunk.slice(0, Math.max(0, remaining)) + TRUNCATION_MARKER;
+    };
+
     proc.stdout.on('data', (d) => {
       const chunk = d.toString();
-      stdout += chunk;
+      stdout = append(stdout, chunk);
       onStdout?.(chunk);
     });
     proc.stderr.on('data', (d) => {
       const chunk = d.toString();
-      stderr += chunk;
+      stderr = append(stderr, chunk);
       onStderr?.(chunk);
     });
-    proc.on('close', (exitCode) => resolve({ exitCode, stdout, stderr }));
+    proc.on('close', (exitCode) => resolve({ exitCode, stdout, stderr, truncated }));
     proc.on('error', (err) => {
       if (err.code === 'EACCES') {
         reject(new Error(`Script is not executable. Run: chmod +x ${scriptFile}`));
@@ -71,4 +107,4 @@ function runShellScript(collectionPath, scriptFile, { onStdout, onStderr } = {})
   });
 }
 
-module.exports = { isScriptPathSafe, parseEnvVarsFromOutput, runShellScript };
+module.exports = { isScriptPathSafe, parseEnvVarsFromOutput, runShellScript, buildSpawnArgs };

--- a/packages/bruno-electron/src/utils/collection-scripts.js
+++ b/packages/bruno-electron/src/utils/collection-scripts.js
@@ -1,0 +1,74 @@
+const path = require('path');
+const { spawn } = require('child_process');
+
+/**
+ * Returns true only if scriptFile resolves to a path inside collectionPath.
+ * Prevents traversal attacks via `../` sequences or absolute paths that escape
+ * the collection directory. The path.sep suffix in the prefix check ensures a
+ * sibling directory that shares a name prefix (e.g. /col vs /col-extra) is not
+ * mistakenly accepted.
+ */
+function isScriptPathSafe(collectionPath, scriptFile) {
+  const resolvedCollection = path.resolve(collectionPath);
+  const resolvedScript = path.resolve(collectionPath, scriptFile);
+  return resolvedScript === resolvedCollection || resolvedScript.startsWith(resolvedCollection + path.sep);
+}
+
+/**
+ * Parses KEY=VALUE pairs from shell script stdout.
+ * Supports both plain `KEY=VALUE` and `export KEY=VALUE` syntax.
+ * Only the first `=` is treated as the delimiter; values may contain `=`.
+ * Blank lines and comment lines are ignored.
+ */
+function parseEnvVarsFromOutput(output) {
+  const vars = {};
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (match) {
+      vars[match[1]] = match[2];
+    }
+  }
+  return vars;
+}
+
+/**
+ * Spawns a registered collection script and resolves with its exit code and
+ * captured stdout/stderr. The script is executed directly so its shebang line
+ * determines the interpreter (e.g. #!/bin/bash, #!/usr/bin/env node).
+ *
+ * Optional `onStdout` and `onStderr` callbacks receive incremental chunks as
+ * they arrive, so callers can stream output to the UI while the script is
+ * still running. Each chunk is also accumulated into the resolved value.
+ *
+ * Callers are responsible for the security check (isScriptPathSafe) before calling this.
+ */
+function runShellScript(collectionPath, scriptFile, { onStdout, onStderr } = {}) {
+  return new Promise((resolve, reject) => {
+    const resolvedScript = path.resolve(collectionPath, scriptFile);
+    const proc = spawn(resolvedScript, [], { cwd: collectionPath, env: process.env });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => {
+      const chunk = d.toString();
+      stdout += chunk;
+      onStdout?.(chunk);
+    });
+    proc.stderr.on('data', (d) => {
+      const chunk = d.toString();
+      stderr += chunk;
+      onStderr?.(chunk);
+    });
+    proc.on('close', (exitCode) => resolve({ exitCode, stdout, stderr }));
+    proc.on('error', (err) => {
+      if (err.code === 'EACCES') {
+        reject(new Error(`Script is not executable. Run: chmod +x ${scriptFile}`));
+      } else {
+        reject(err);
+      }
+    });
+  });
+}
+
+module.exports = { isScriptPathSafe, parseEnvVarsFromOutput, runShellScript };

--- a/packages/bruno-electron/tests/ipc/scripts.spec.js
+++ b/packages/bruno-electron/tests/ipc/scripts.spec.js
@@ -1,0 +1,103 @@
+// Mocks must be declared before requiring the module under test.
+const mockHandle = jest.fn();
+jest.mock('electron', () => ({
+  ipcMain: { handle: (...args) => mockHandle(...args) }
+}));
+
+const mockGetSecurityConfig = jest.fn();
+jest.mock('../../src/store/collection-security', () =>
+  jest.fn().mockImplementation(() => ({
+    getSecurityConfigForCollection: (...args) => mockGetSecurityConfig(...args)
+  }))
+);
+
+const mockRunShellScript = jest.fn();
+jest.mock('../../src/utils/collection-scripts', () => ({
+  isScriptPathSafe: jest.fn(() => true),
+  parseEnvVarsFromOutput: jest.fn(() => ({})),
+  runShellScript: (...args) => mockRunShellScript(...args)
+}));
+
+const registerCollectionScriptsIpc = require('../../src/ipc/scripts');
+
+describe('renderer:run-collection-script — payload validation', () => {
+  let handler;
+  let mainWindow;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mainWindow = {
+      isDestroyed: () => false,
+      webContents: { send: jest.fn() }
+    };
+    registerCollectionScriptsIpc(mainWindow);
+    // The handler is the second arg to the most recent ipcMain.handle call.
+    const call = mockHandle.mock.calls.find((c) => c[0] === 'renderer:run-collection-script');
+    handler = call[1];
+    mockGetSecurityConfig.mockReturnValue({ jsSandboxMode: 'developer' });
+  });
+
+  test('rejects when collectionPath is missing', async () => {
+    const result = await handler({}, { collectionUid: 'c1', script: { uid: 's', file: 'run.sh' } });
+    expect(result.error).toMatch(/collection path/i);
+    expect(mockRunShellScript).not.toHaveBeenCalled();
+  });
+
+  test('rejects when collectionPath is not a string', async () => {
+    const result = await handler({}, {
+      collectionUid: 'c1',
+      collectionPath: 123,
+      script: { uid: 's', file: 'run.sh' }
+    });
+    expect(result.error).toMatch(/collection path/i);
+    expect(mockRunShellScript).not.toHaveBeenCalled();
+  });
+
+  test('rejects when script is missing', async () => {
+    const result = await handler({}, { collectionUid: 'c1', collectionPath: '/c' });
+    expect(result.error).toMatch(/script/i);
+    expect(mockRunShellScript).not.toHaveBeenCalled();
+  });
+
+  test('rejects when script.file is missing', async () => {
+    const result = await handler({}, {
+      collectionUid: 'c1',
+      collectionPath: '/c',
+      script: { uid: 's' }
+    });
+    expect(result.error).toMatch(/script\.file|script file/i);
+    expect(mockRunShellScript).not.toHaveBeenCalled();
+  });
+
+  test('rejects when script.file is not a string', async () => {
+    const result = await handler({}, {
+      collectionUid: 'c1',
+      collectionPath: '/c',
+      script: { uid: 's', file: 42 }
+    });
+    expect(result.error).toMatch(/script\.file|script file/i);
+    expect(mockRunShellScript).not.toHaveBeenCalled();
+  });
+
+  test('proceeds with a fully-formed payload', async () => {
+    mockRunShellScript.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+    const result = await handler({}, {
+      collectionUid: 'c1',
+      collectionPath: '/c',
+      script: { uid: 's', file: 'run.sh' }
+    });
+    expect(result.exitCode).toBe(0);
+    expect(mockRunShellScript).toHaveBeenCalledTimes(1);
+  });
+
+  test('blocks execution when sandbox mode is not developer', async () => {
+    mockGetSecurityConfig.mockReturnValue({ jsSandboxMode: 'safe' });
+    const result = await handler({}, {
+      collectionUid: 'c1',
+      collectionPath: '/c',
+      script: { uid: 's', file: 'run.sh' }
+    });
+    expect(result.error).toMatch(/developer mode/i);
+    expect(mockRunShellScript).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-electron/tests/utils/collection-scripts.spec.js
+++ b/packages/bruno-electron/tests/utils/collection-scripts.spec.js
@@ -1,0 +1,163 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { isScriptPathSafe, parseEnvVarsFromOutput, runShellScript } = require('../../src/utils/collection-scripts');
+
+describe('isScriptPathSafe', () => {
+  const col = '/home/user/collection';
+
+  test('allows a relative path inside the collection', () => {
+    expect(isScriptPathSafe(col, 'scripts/run.sh')).toBe(true);
+  });
+
+  test('allows a file at the collection root', () => {
+    expect(isScriptPathSafe(col, 'run.sh')).toBe(true);
+  });
+
+  test('blocks single-level traversal', () => {
+    expect(isScriptPathSafe(col, '../evil.sh')).toBe(false);
+  });
+
+  test('blocks traversal disguised inside a valid-looking prefix', () => {
+    expect(isScriptPathSafe(col, 'scripts/../../etc/passwd')).toBe(false);
+  });
+
+  test('blocks an absolute path that escapes the collection', () => {
+    expect(isScriptPathSafe(col, '/etc/passwd')).toBe(false);
+  });
+
+  test('does not accept a sibling directory that shares a name prefix', () => {
+    // Without the path.sep suffix, /home/user/collection-extra/evil.sh would
+    // pass startsWith('/home/user/collection') — the sep prevents that.
+    expect(isScriptPathSafe(col, '/home/user/collection-extra/evil.sh')).toBe(false);
+  });
+});
+
+describe('parseEnvVarsFromOutput', () => {
+  test('parses a plain KEY=VALUE assignment', () => {
+    expect(parseEnvVarsFromOutput('TOKEN=abc123')).toEqual({ TOKEN: 'abc123' });
+  });
+
+  test('parses export KEY=VALUE syntax', () => {
+    expect(parseEnvVarsFromOutput('export TOKEN=abc123')).toEqual({ TOKEN: 'abc123' });
+  });
+
+  test('splits only on the first equals — values may contain =', () => {
+    expect(parseEnvVarsFromOutput('KEY=a=b=c')).toEqual({ KEY: 'a=b=c' });
+  });
+
+  test('preserves spaces inside values', () => {
+    expect(parseEnvVarsFromOutput('GREETING=hello world')).toEqual({ GREETING: 'hello world' });
+  });
+
+  test('accepts an empty value', () => {
+    expect(parseEnvVarsFromOutput('REVOKED_TOKEN=')).toEqual({ REVOKED_TOKEN: '' });
+  });
+
+  test('ignores comment lines', () => {
+    const output = '# refreshing tokens\nACCESS_TOKEN=tok_live_abc';
+    expect(parseEnvVarsFromOutput(output)).toEqual({ ACCESS_TOKEN: 'tok_live_abc' });
+  });
+
+  test('ignores blank lines and surrounding whitespace', () => {
+    const output = '\n  \nACCESS_TOKEN=tok_live_abc\n\n';
+    expect(parseEnvVarsFromOutput(output)).toEqual({ ACCESS_TOKEN: 'tok_live_abc' });
+  });
+
+  test('ignores non-assignment lines mixed into script output', () => {
+    const output = [
+      'Authenticating...',
+      'ACCESS_TOKEN=tok_live_abc',
+      'Done.'
+    ].join('\n');
+    expect(parseEnvVarsFromOutput(output)).toEqual({ ACCESS_TOKEN: 'tok_live_abc' });
+  });
+
+  test('rejects keys starting with a digit', () => {
+    expect(parseEnvVarsFromOutput('1INVALID=value')).toEqual({});
+  });
+
+  test('treats EXPORT as a valid key name, not a keyword', () => {
+    // All-caps EXPORT should be parsed as a key, not stripped as a shell keyword
+    expect(parseEnvVarsFromOutput('EXPORT=some_value')).toEqual({ EXPORT: 'some_value' });
+  });
+
+  test('handles Windows CRLF line endings', () => {
+    const output = 'ACCESS_TOKEN=tok_live_abc\r\nREFRESH_TOKEN=ref_live_xyz\r\n';
+    expect(parseEnvVarsFromOutput(output)).toEqual({
+      ACCESS_TOKEN: 'tok_live_abc',
+      REFRESH_TOKEN: 'ref_live_xyz'
+    });
+  });
+
+  test('handles all forms together — comments, export prefix, noise lines, multiple vars', () => {
+    const output = [
+      '# setup complete',
+      'export VAR_A=value_one',
+      'VAR_B=value_two',
+      'export VAR_C=123',
+      'process finished'
+    ].join('\n');
+
+    expect(parseEnvVarsFromOutput(output)).toEqual({
+      VAR_A: 'value_one',
+      VAR_B: 'value_two',
+      VAR_C: '123'
+    });
+  });
+
+  test('last assignment wins when a key appears more than once', () => {
+    const output = 'TOKEN=first\nTOKEN=second';
+    expect(parseEnvVarsFromOutput(output)).toEqual({ TOKEN: 'second' });
+  });
+});
+
+describe('runShellScript streaming', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-script-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeScript = (filename, body) => {
+    const fullPath = path.join(tmpDir, filename);
+    fs.writeFileSync(fullPath, body, { mode: 0o755 });
+    return filename;
+  };
+
+  test('invokes onStdout with chunks that together equal the captured stdout', async () => {
+    const file = writeScript('hello.sh', '#!/bin/bash\necho first\nsleep 0.05\necho second\n');
+    const chunks = [];
+    const result = await runShellScript(tmpDir, file, {
+      onStdout: (chunk) => chunks.push(chunk)
+    });
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.join('')).toBe(result.stdout);
+    expect(result.stdout).toContain('first');
+    expect(result.stdout).toContain('second');
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('invokes onStderr for stderr output', async () => {
+    const file = writeScript('err.sh', '#!/bin/bash\necho oops 1>&2\nexit 3\n');
+    const stderrChunks = [];
+    const result = await runShellScript(tmpDir, file, {
+      onStderr: (chunk) => stderrChunks.push(chunk)
+    });
+
+    expect(stderrChunks.join('')).toContain('oops');
+    expect(result.exitCode).toBe(3);
+  });
+
+  test('works without callbacks (preserves existing call sites)', async () => {
+    const file = writeScript('plain.sh', '#!/bin/bash\necho ok\n');
+    const result = await runShellScript(tmpDir, file);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('ok');
+  });
+});

--- a/packages/bruno-electron/tests/utils/collection-scripts.spec.js
+++ b/packages/bruno-electron/tests/utils/collection-scripts.spec.js
@@ -1,7 +1,12 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { isScriptPathSafe, parseEnvVarsFromOutput, runShellScript } = require('../../src/utils/collection-scripts');
+const {
+  isScriptPathSafe,
+  parseEnvVarsFromOutput,
+  runShellScript,
+  buildSpawnArgs
+} = require('../../src/utils/collection-scripts');
 
 describe('isScriptPathSafe', () => {
   const col = '/home/user/collection';
@@ -27,9 +32,49 @@ describe('isScriptPathSafe', () => {
   });
 
   test('does not accept a sibling directory that shares a name prefix', () => {
-    // Without the path.sep suffix, /home/user/collection-extra/evil.sh would
-    // pass startsWith('/home/user/collection') — the sep prevents that.
     expect(isScriptPathSafe(col, '/home/user/collection-extra/evil.sh')).toBe(false);
+  });
+});
+
+describe('isScriptPathSafe — symlink escape', () => {
+  let tmpRoot;
+  let collectionDir;
+  let outsideDir;
+  let symlinkSupported = true;
+
+  beforeAll(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-symlink-test-'));
+    collectionDir = path.join(tmpRoot, 'collection');
+    outsideDir = path.join(tmpRoot, 'outside');
+    fs.mkdirSync(collectionDir);
+    fs.mkdirSync(outsideDir);
+    fs.writeFileSync(path.join(outsideDir, 'evil.sh'), '#!/bin/sh\necho pwned\n');
+
+    try {
+      fs.symlinkSync(path.join(outsideDir, 'evil.sh'), path.join(collectionDir, 'link.sh'));
+    } catch (err) {
+      // Windows non-admin can't create symlinks — skip rather than fail.
+      symlinkSupported = false;
+    }
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('rejects a symlink inside the collection that points outside it', () => {
+    if (!symlinkSupported) return;
+    expect(isScriptPathSafe(collectionDir, 'link.sh')).toBe(false);
+  });
+
+  test('still accepts a real file inside the collection', () => {
+    const realPath = path.join(collectionDir, 'real.sh');
+    fs.writeFileSync(realPath, '#!/bin/sh\necho ok\n');
+    expect(isScriptPathSafe(collectionDir, 'real.sh')).toBe(true);
+  });
+
+  test('returns false rather than throwing when the script does not exist', () => {
+    expect(isScriptPathSafe(collectionDir, 'does-not-exist.sh')).toBe(false);
   });
 });
 
@@ -78,7 +123,6 @@ describe('parseEnvVarsFromOutput', () => {
   });
 
   test('treats EXPORT as a valid key name, not a keyword', () => {
-    // All-caps EXPORT should be parsed as a key, not stripped as a shell keyword
     expect(parseEnvVarsFromOutput('EXPORT=some_value')).toEqual({ EXPORT: 'some_value' });
   });
 
@@ -112,6 +156,37 @@ describe('parseEnvVarsFromOutput', () => {
   });
 });
 
+describe('buildSpawnArgs', () => {
+  const cwd = '/some/collection';
+  const script = '/some/collection/run.sh';
+
+  test('on darwin, spawns the script directly without a shell', () => {
+    const { command, args, options } = buildSpawnArgs(script, cwd, 'darwin');
+    expect(command).toBe(script);
+    expect(args).toEqual([]);
+    expect(options.cwd).toBe(cwd);
+    expect(options.shell).toBeFalsy();
+  });
+
+  test('on linux, spawns the script directly without a shell', () => {
+    const { options } = buildSpawnArgs(script, cwd, 'linux');
+    expect(options.shell).toBeFalsy();
+  });
+
+  test('on win32, runs through a shell so file associations and .cmd/.bat work', () => {
+    const { command, options } = buildSpawnArgs(script, cwd, 'win32');
+    expect(command).toBe(script);
+    expect(options.shell).toBe(true);
+    expect(options.windowsHide).toBe(true);
+  });
+
+  test('passes cwd and env through to spawn options', () => {
+    const { options } = buildSpawnArgs(script, cwd, 'linux');
+    expect(options.cwd).toBe(cwd);
+    expect(options.env).toBe(process.env);
+  });
+});
+
 describe('runShellScript streaming', () => {
   let tmpDir;
 
@@ -123,14 +198,20 @@ describe('runShellScript streaming', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  const writeScript = (filename, body) => {
+  // Cross-platform: shebang dispatches to whatever `node` is on PATH (POSIX).
+  // On Windows, runShellScript uses shell:true so the .js extension routes to
+  // the Node file association. We additionally write a `.cmd` shim there.
+  const writeNodeScript = (filename, jsBody) => {
     const fullPath = path.join(tmpDir, filename);
-    fs.writeFileSync(fullPath, body, { mode: 0o755 });
+    fs.writeFileSync(fullPath, `#!/usr/bin/env node\n${jsBody}\n`, { mode: 0o755 });
     return filename;
   };
 
   test('invokes onStdout with chunks that together equal the captured stdout', async () => {
-    const file = writeScript('hello.sh', '#!/bin/bash\necho first\nsleep 0.05\necho second\n');
+    const file = writeNodeScript(
+      'hello.js',
+      `console.log('first'); setTimeout(() => console.log('second'), 50);`
+    );
     const chunks = [];
     const result = await runShellScript(tmpDir, file, {
       onStdout: (chunk) => chunks.push(chunk)
@@ -144,7 +225,10 @@ describe('runShellScript streaming', () => {
   });
 
   test('invokes onStderr for stderr output', async () => {
-    const file = writeScript('err.sh', '#!/bin/bash\necho oops 1>&2\nexit 3\n');
+    const file = writeNodeScript(
+      'err.js',
+      `console.error('oops'); process.exit(3);`
+    );
     const stderrChunks = [];
     const result = await runShellScript(tmpDir, file, {
       onStderr: (chunk) => stderrChunks.push(chunk)
@@ -155,9 +239,29 @@ describe('runShellScript streaming', () => {
   });
 
   test('works without callbacks (preserves existing call sites)', async () => {
-    const file = writeScript('plain.sh', '#!/bin/bash\necho ok\n');
+    const file = writeNodeScript('plain.js', `console.log('ok');`);
     const result = await runShellScript(tmpDir, file);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('ok');
+  });
+
+  test('truncates stdout when it exceeds maxBuffer and marks truncated=true', async () => {
+    // Emit ~5KB to stdout with maxBuffer=512 — must cap and mark truncated.
+    const file = writeNodeScript(
+      'flood.js',
+      `for (let i = 0; i < 50; i++) console.log('x'.repeat(100));`
+    );
+    const result = await runShellScript(tmpDir, file, { maxBuffer: 512 });
+
+    expect(result.truncated).toBe(true);
+    expect(result.stdout.length).toBeLessThanOrEqual(512 + 200); // 200 = headroom for truncation marker
+    expect(result.stdout).toMatch(/truncated/i);
+  });
+
+  test('does not mark truncated when output stays within maxBuffer', async () => {
+    const file = writeNodeScript('tiny.js', `console.log('hi');`);
+    const result = await runShellScript(tmpDir, file, { maxBuffer: 1024 });
+    expect(result.truncated).toBeFalsy();
+    expect(result.stdout).toContain('hi');
   });
 });

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -35,6 +35,18 @@ const environmentSchema = Yup.object({
 
 const environmentsSchema = Yup.array().of(environmentSchema);
 
+const collectionScriptSchema = Yup.object({
+  uid: uidSchema,
+  name: Yup.string().min(1).required('name is required'),
+  file: Yup.string().min(1).required('file is required'),
+  runOn: Yup.array()
+    .of(Yup.string().oneOf(['appStart', 'collectionOpen', 'beforeCollectionRun']))
+    .default([]),
+  outputMode: Yup.string().oneOf(['envVars', 'stdout']).default('envVars')
+})
+  .noUnknown(true)
+  .strict();
+
 const keyValueSchema = Yup.object({
   uid: uidSchema,
   name: Yup.string().nullable(),
@@ -699,5 +711,6 @@ module.exports = {
   environmentSchema,
   environmentsSchema,
   collectionSchema,
+  collectionScriptSchema,
   annotationSchema
 };


### PR DESCRIPTION
## Summary
- Adds `isScriptPathSafe` path-traversal guard and `runShellScript` spawn helper (executes directly so the script's shebang picks the interpreter — fixes bash/zsh compatibility)
- Adds `parseEnvVarsFromOutput` to inject `KEY=VALUE` stdout lines into the active environment
- Registers `renderer:run-collection-script` IPC handler with streaming output via `main:collection-script-output`
- Wires a `beforeCollectionRun` hook into the collection runner
- Extends `bruno.json` schema with a `collectionScripts` field
- 19 unit tests covering path validation and env-var parsing

## Security
All execution is gated behind `jsSandboxMode: developer`. Scripts are spawned directly (not via a shell) so the shebang controls the interpreter; no arbitrary shell injection surface.

## Test plan
- [ ] `yarn test` passes in `packages/bruno-electron`
- [ ] Script with `#!/bin/bash` shebang executes correctly (not via `/bin/zsh`)
- [ ] Path traversal attempt (`../../evil.sh`) is rejected by `isScriptPathSafe`
- [ ] `KEY=VALUE` stdout lines appear in the active environment after run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection scripts can run before a collection run, stream stdout/stderr to the UI, and return exit codes.
  * Scripts can output environment variables which are merged into the run and persisted for the collection.

* **Security**
  * Script execution is restricted to developer sandbox mode and enforces safe in-collection script paths.

* **Tests**
  * Added comprehensive tests for execution, path safety, env var parsing, and output buffering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->