### PR TITLE
Centralize OpenAPI sync state in Redux

### DIFF
--- a/packages/bruno-app/src/components/OpenAPISyncTab/OpenAPISyncHeader/index.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/OpenAPISyncHeader/index.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { selectStoredSpecMeta } from 'providers/ReduxStore/slices/openapi-sync';
 import {
   IconCopy,
   IconDotsVertical,
@@ -37,7 +36,7 @@ const OpenAPISyncHeader = ({
     }
   }, [sourceUrl, sourceIsLocal, collection.pathname]);
 
-  const specMeta = useSelector(selectStoredSpecMeta(collection.uid));
+  const specMeta = useSelector((state) => state.openapiSync?.storedSpecMeta?.[collection.uid] || null);
   const title = specMeta?.title || spec?.info?.title || 'Unknown API';
 
   const copyUrl = async () => {

--- a/packages/bruno-app/src/components/OpenAPISyncTab/OverviewSection/index.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/OverviewSection/index.js
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { selectStoredSpecMeta } from 'providers/ReduxStore/slices/openapi-sync';
 import { getTotalRequestCountInCollection } from 'utils/collections/';
 import { countEndpoints } from '../utils';
 import moment from 'moment';
@@ -43,7 +42,7 @@ const OverviewSection = ({ collection, storedSpec, collectionDrift, specDrift, r
   const openApiSyncConfig = collection?.brunoConfig?.openapi?.[0];
 
   const reduxError = useSelector((state) => state.openapiSync?.collectionUpdates?.[collection.uid]?.error);
-  const specMeta = useSelector(selectStoredSpecMeta(collection.uid));
+  const specMeta = useSelector((state) => state.openapiSync?.storedSpecMeta?.[collection.uid] || null);
   const activeError = error || reduxError;
 
   const version = specMeta?.version;

--- a/packages/bruno-app/src/components/OpenAPISyncTab/SyncReviewPage/index.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/SyncReviewPage/index.js
@@ -15,7 +15,7 @@ import ExpandableEndpointRow from '../EndpointChangeSection/ExpandableEndpointRo
 import ConfirmSyncModal from '../ConfirmSyncModal';
 import SpecDiffModal from '../SpecDiffModal';
 import Help from 'components/Help';
-import { setReviewDecision, setReviewDecisions, selectTabUiState } from 'providers/ReduxStore/slices/openapi-sync';
+import { setReviewDecision, setReviewDecisions } from 'providers/ReduxStore/slices/openapi-sync';
 
 /**
  * Categorize remoteDrift endpoints using three-way merge.
@@ -87,7 +87,7 @@ const SyncReviewPage = ({
   onApplySync
 }) => {
   const dispatch = useDispatch();
-  const tabUiState = useSelector(selectTabUiState(collectionUid));
+  const tabUiState = useSelector((state) => state.openapiSync?.tabUiState?.[collectionUid] || {});
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showSpecDiffModal, setShowSpecDiffModal] = useState(false);
 

--- a/packages/bruno-app/src/components/OpenAPISyncTab/hooks/useOpenAPISync.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/hooks/useOpenAPISync.js
@@ -1,9 +1,16 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 import toast from 'react-hot-toast';
-import { addTab, focusTab, closeTabs } from 'providers/ReduxStore/slices/tabs';
+import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
+import { closeTabs } from 'providers/ReduxStore/slices/collections/actions';
 import { getDefaultRequestPaneTab } from 'utils/collections';
-import { clearCollectionState, setCollectionUpdate, setStoredSpecMeta } from 'providers/ReduxStore/slices/openapi-sync';
+import {
+  clearCollectionState,
+  setCollectionUpdate,
+  setStoredSpec,
+  setStoredSpecMeta,
+  setDrift
+} from 'providers/ReduxStore/slices/openapi-sync';
 import { fetchAndValidateApiSpecFromUrl } from 'utils/importers/common';
 import { isHttpUrl } from 'utils/url/index';
 import { flattenItems } from 'utils/collections/index';
@@ -19,19 +26,22 @@ const useOpenAPISync = (collection) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [fileNotFound, setFileNotFound] = useState(false);
-  const [specDrift, setSpecDrift] = useState(null);
-  // Collection drift state
-  const [collectionDrift, setCollectionDrift] = useState(null);
-  const [remoteDrift, setRemoteDrift] = useState(null);
   const [isDriftLoading, setIsDriftLoading] = useState(false);
-  const [storedSpec, setStoredSpec] = useState(null);
 
-  const tabs = useSelector((state) => state.tabs.tabs);
+  const drift = useSelector((state) => state.openapiSync?.drift?.[collection.uid] || null);
+  const specDrift = drift?.specDrift || null;
+  const collectionDrift = drift?.collectionDrift || null;
+  const remoteDrift = drift?.remoteDrift || null;
+  const storedSpec = useSelector((state) => state.openapiSync?.storedSpec?.[collection.uid] || null);
+
+  const updateDrift = (patch) => dispatch(setDrift({ collectionUid: collection.uid, patch }));
+
+  const store = useStore();
 
   const isConfigured = !!openApiSyncConfig?.sourceUrl;
 
   const updateStoredSpec = (spec) => {
-    setStoredSpec(spec);
+    dispatch(setStoredSpec({ collectionUid: collection.uid, spec }));
     dispatch(setStoredSpecMeta({
       collectionUid: collection.uid,
       title: spec?.info?.title || null,
@@ -72,6 +82,7 @@ const useOpenAPISync = (collection) => {
   const openEndpointInTab = (endpointId) => {
     const itemUid = endpointUidMap[endpointId];
     if (!itemUid) return;
+    const tabs = store.getState().tabs?.tabs || [];
     const existingTab = tabs.find((t) => t.uid === itemUid);
     if (existingTab) {
       dispatch(focusTab({ uid: itemUid }));
@@ -86,14 +97,13 @@ const useOpenAPISync = (collection) => {
     }
   };
 
-  const prevItemCountRef = useRef(httpItemCount);
   const isDriftLoadingRef = useRef(false);
   const specDriftRef = useRef(specDrift);
 
   const loadCollectionDrift = async ({ clear = false } = {}) => {
     if (isDriftLoadingRef.current && !clear) return;
     isDriftLoadingRef.current = true;
-    if (clear) setCollectionDrift(null);
+    if (clear) updateDrift({ collectionDrift: null });
     setIsDriftLoading(true);
     try {
       const { ipcRenderer } = window;
@@ -102,7 +112,7 @@ const useOpenAPISync = (collection) => {
       });
 
       if (!result.error) {
-        setCollectionDrift(result);
+        updateDrift({ collectionDrift: result, itemCountAtLastFetch: httpItemCount });
       }
     } catch (err) {
       console.error('Error loading collection drift:', err);
@@ -122,9 +132,7 @@ const useOpenAPISync = (collection) => {
     setIsLoading(true);
     setError(null);
     setFileNotFound(false);
-    setSpecDrift(null);
-    setRemoteDrift(null);
-    setCollectionDrift(null);
+    updateDrift({ fetching: true });
 
     try {
       const { ipcRenderer } = window;
@@ -146,14 +154,13 @@ const useOpenAPISync = (collection) => {
         return;
       }
 
-      setSpecDrift(result);
+      updateDrift({ specDrift: result, lastChecked: Date.now() });
       updateStoredSpec(result.storedSpec || null);
 
       // Update Redux store so toolbar status stays in sync
       dispatch(setCollectionUpdate({
         collectionUid: collection.uid,
         hasUpdates: result.isValid !== false && result.hasChanges,
-        diff: result,
         error: result.isValid === false ? result.error : null
       }));
 
@@ -167,7 +174,7 @@ const useOpenAPISync = (collection) => {
           console.error('Error computing remote drift:', remoteComparison.error);
           setError(remoteComparison.error);
         } else {
-          setRemoteDrift(remoteComparison);
+          updateDrift({ remoteDrift: remoteComparison });
         }
       }
 
@@ -181,24 +188,25 @@ const useOpenAPISync = (collection) => {
       dispatch(setCollectionUpdate({
         collectionUid: collection.uid,
         hasUpdates: false,
-        diff: null,
         error: formatIpcError(err) || 'Failed to check for updates'
       }));
     } finally {
+      updateDrift({ fetching: false });
       setIsLoading(false);
     }
   };
 
   useEffect(() => {
-    if (isConfigured) {
+    if (isConfigured && !drift?.specDrift && !drift?.fetching) {
       checkForUpdates();
     }
   }, [isConfigured]);
 
-  // Reload drift when collection items change (e.g., endpoint deleted from sidebar)
+  // Reload drift when the collection's HTTP item count differs from what was recorded at the last fetch.
   useEffect(() => {
-    if (prevItemCountRef.current !== httpItemCount && isConfigured) {
-      prevItemCountRef.current = httpItemCount;
+    if (!isConfigured) return;
+    const cachedCount = drift?.itemCountAtLastFetch;
+    if (cachedCount !== undefined && cachedCount !== httpItemCount && !drift?.fetching) {
       loadCollectionDrift();
     }
   }, [httpItemCount, isConfigured]);
@@ -245,7 +253,7 @@ const useOpenAPISync = (collection) => {
       });
 
       if (result.isValid === false) {
-        setSpecDrift(result);
+        updateDrift({ specDrift: result });
         setError(result.error);
         return;
       }
@@ -263,15 +271,15 @@ const useOpenAPISync = (collection) => {
 
       // Check if collection already matches the spec
       if (result.newSpec) {
-        const drift = await ipcRenderer.invoke('renderer:get-collection-drift', {
+        const initialDrift = await ipcRenderer.invoke('renderer:get-collection-drift', {
           collectionPath: collection.pathname,
           compareSpec: result.newSpec
         });
 
-        const isInSync = !drift.error
-          && (!drift.missing || drift.missing.length === 0)
-          && (!drift.modified || drift.modified.length === 0)
-          && (!drift.localOnly || drift.localOnly.length === 0);
+        const isInSync = !initialDrift.error
+          && (!initialDrift.missing || initialDrift.missing.length === 0)
+          && (!initialDrift.modified || initialDrift.modified.length === 0)
+          && (!initialDrift.localOnly || initialDrift.localOnly.length === 0);
 
         if (isInSync) {
           // Collection matches — save spec file silently to complete setup
@@ -299,15 +307,12 @@ const useOpenAPISync = (collection) => {
         deleteSpecFile: true
       });
       setSourceUrl('');
-      setSpecDrift(null);
-      setCollectionDrift(null);
-      setRemoteDrift(null);
-      setStoredSpec(null);
 
       // Clear Redux state for this collection
       dispatch(clearCollectionState({ collectionUid: collection.uid }));
 
       // Close the openapi-spec tab if open (spec file no longer exists)
+      const tabs = store.getState().tabs?.tabs || [];
       const specTab = tabs.find((t) => t.collectionUid === collection.uid && t.type === 'openapi-spec');
       if (specTab) {
         dispatch(closeTabs({ tabUids: [specTab.uid] }));
@@ -337,7 +342,7 @@ const useOpenAPISync = (collection) => {
           compareSpec: currentSpecDrift.newSpec
         });
         if (!remoteComparison.error) {
-          setRemoteDrift(remoteComparison);
+          updateDrift({ remoteDrift: remoteComparison });
         }
       } catch (err) {
         console.error('Error reloading remote drift:', err);

--- a/packages/bruno-app/src/components/OpenAPISyncTab/hooks/useOpenAPISync.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/hooks/useOpenAPISync.js
@@ -36,6 +36,7 @@ const useOpenAPISync = (collection) => {
 
   const updateDrift = (patch) => dispatch(setDrift({ collectionUid: collection.uid, patch }));
 
+  // useStore: tabs are read only inside handlers — useSelector would re-render on every tab change.
   const store = useStore();
 
   const isConfigured = !!openApiSyncConfig?.sourceUrl;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -66,6 +66,7 @@ import {
 
 import { each } from 'lodash';
 import { closeAllCollectionTabs, closeTabs as _closeTabs, focusTab, reopenLastClosedTab } from 'providers/ReduxStore/slices/tabs';
+import { clearOpenApiSyncTabState } from 'providers/ReduxStore/slices/openapi-sync';
 import { removeCollectionFromWorkspace } from 'providers/ReduxStore/slices/workspaces';
 import { resolveRequestFilename } from 'utils/common/platform';
 import { interpolateUrl, parsePathParams, splitOnFirst } from 'utils/url/index';
@@ -3170,6 +3171,9 @@ export const ensureActiveTabInCurrentWorkspace = () => (dispatch, getState) => {
 /**
  * Close tabs and delete any transient request files from the filesystem.
  * This thunk wraps the closeTabs reducer to handle transient file cleanup automatically.
+ * Also drops openapi-sync redux state (drift, storedSpec, tabUiState) for any
+ * openapi-sync tab that's about to close — collected BEFORE the close so we can
+ * still read the closing tabs' collectionUids from state.
  */
 export const closeTabs = ({ tabUids }) => async (dispatch, getState) => {
   const { ipcRenderer } = window;
@@ -3195,6 +3199,10 @@ export const closeTabs = ({ tabUids }) => async (dispatch, getState) => {
     }
   });
 
+  const closingOpenApiSyncCollectionUids = (state.tabs?.tabs || [])
+    .filter((t) => tabUids.includes(t.uid) && t.type === 'openapi-sync' && t.collectionUid)
+    .map((t) => t.collectionUid);
+
   // Close the tabs first
   await dispatch(_closeTabs({ tabUids }));
 
@@ -3205,6 +3213,11 @@ export const closeTabs = ({ tabUids }) => async (dispatch, getState) => {
   // After close, the reducer may have set active tab to one from another workspace. Ensure it belongs to this workspace: prefer any open in-workspace tab, then workspace overview if none.
   // Dispatch is synchronous; state is already updated by _closeTabs above.
   await dispatch(ensureActiveTabInCurrentWorkspace());
+
+  // Drop openapi-sync per-collection state (drift, storedSpec, tabUiState) for any closed openapi-sync tabs.
+  for (const collectionUid of closingOpenApiSyncCollectionUids) {
+    dispatch(clearOpenApiSyncTabState({ collectionUid }));
+  }
 
   // Delete transient files after tabs are closed
   for (const [tempDir, filePaths] of Object.entries(transientByTempDir)) {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/openapi-sync.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/openapi-sync.js
@@ -2,7 +2,9 @@ import { createSlice } from '@reduxjs/toolkit';
 import { normalizePath } from 'utils/common/path';
 
 const initialState = {
-  // Map of collectionUid -> { hasUpdates, diff, lastChecked, error }
+  // Map of collectionUid -> { hasUpdates, lastChecked, error }
+  // Lightweight indicator state for the toolbar status badge — fed by
+  // background polling. Full drift data lives in `drift` (this slice).
   collectionUpdates: {},
   // Whether App level OpenAPI polling is enabled
   pollingEnabled: true,
@@ -10,8 +12,12 @@ const initialState = {
   lastPollTime: null,
   // Map of collectionUid -> { activeTab, expandedSections, expandedRows }
   tabUiState: {},
-  // Map of collectionUid -> { title, version, endpointCount } (persists across tab navigations)
-  storedSpecMeta: {}
+  // Map of collectionUid -> { title, version, endpointCount }
+  storedSpecMeta: {},
+  // Map of collectionUid -> full parsed OpenAPI spec object
+  storedSpec: {},
+  // Map of collectionUid -> { specDrift, collectionDrift, remoteDrift, fetching, lastChecked }
+  drift: {}
 };
 
 export const openapiSyncSlice = createSlice({
@@ -19,10 +25,9 @@ export const openapiSyncSlice = createSlice({
   initialState,
   reducers: {
     setCollectionUpdate: (state, action) => {
-      const { collectionUid, hasUpdates, diff, error } = action.payload;
+      const { collectionUid, hasUpdates, error } = action.payload;
       state.collectionUpdates[collectionUid] = {
         hasUpdates,
-        diff,
         error,
         lastChecked: Date.now()
       };
@@ -36,6 +41,30 @@ export const openapiSyncSlice = createSlice({
       delete state.collectionUpdates[collectionUid];
       delete state.tabUiState[collectionUid];
       delete state.storedSpecMeta[collectionUid];
+      delete state.storedSpec[collectionUid];
+      delete state.drift[collectionUid];
+    },
+    setDrift: (state, action) => {
+      const { collectionUid, patch } = action.payload;
+      state.drift[collectionUid] = { ...state.drift[collectionUid], ...patch };
+    },
+    clearDrift: (state, action) => {
+      const { collectionUid } = action.payload;
+      delete state.drift[collectionUid];
+    },
+    clearOpenApiSyncTabState: (state, action) => {
+      const { collectionUid } = action.payload;
+      delete state.drift[collectionUid];
+      delete state.storedSpec[collectionUid];
+      delete state.tabUiState[collectionUid];
+    },
+    setStoredSpec: (state, action) => {
+      const { collectionUid, spec } = action.payload;
+      if (spec === null || spec === undefined) {
+        delete state.storedSpec[collectionUid];
+      } else {
+        state.storedSpec[collectionUid] = spec;
+      }
     },
     setStoredSpecMeta: (state, action) => {
       const { collectionUid, title, version, endpointCount } = action.payload;
@@ -124,7 +153,11 @@ export const {
   setLastPollTime,
   setReviewDecision,
   setReviewDecisions,
-  setStoredSpecMeta
+  setStoredSpec,
+  setStoredSpecMeta,
+  setDrift,
+  clearDrift,
+  clearOpenApiSyncTabState
 } = openapiSyncSlice.actions;
 
 // Lightweight thunk for polling — only checks hash, no deep comparison
@@ -152,7 +185,6 @@ export const checkCollectionForUpdates = (collection) => async (dispatch) => {
     dispatch(setCollectionUpdate({
       collectionUid: collection.uid,
       hasUpdates: result.hasUpdates || false,
-      diff: null,
       error: result.error || null
     }));
 
@@ -162,7 +194,6 @@ export const checkCollectionForUpdates = (collection) => async (dispatch) => {
     dispatch(setCollectionUpdate({
       collectionUid: collection.uid,
       hasUpdates: false,
-      diff: null,
       error: error.message
     }));
     return null;
@@ -200,16 +231,6 @@ export const checkActiveWorkspaceCollectionsForUpdates = () => async (dispatch, 
   }
 
   dispatch(setLastPollTime(Date.now()));
-};
-
-// Selector to get UI state for a specific collection's sync tab
-export const selectTabUiState = (collectionUid) => (state) => {
-  return state.openapiSync?.tabUiState?.[collectionUid] || {};
-};
-
-// Selector for stored spec metadata (title, version, endpointCount)
-export const selectStoredSpecMeta = (collectionUid) => (state) => {
-  return state.openapiSync?.storedSpecMeta?.[collectionUid] || null;
 };
 
 export default openapiSyncSlice.reducer;


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2889)

https://github.com/user-attachments/assets/d066a641-8e59-4114-9016-8b0dc8c1abb1

## Problem

The OpenAPI Sync tab freezes for 1–3 seconds every time the user switches between a request tab and the OpenAPI Sync tab. Reproduces on any collection with OpenAPI sync configured.

## Root cause

`<RequestTabPanel key={activeTabUid} />` is keyed on the active tab uid, so React fully unmounts and remounts whatever the active tab renders on every switch. `useOpenAPISync` kept its drift data in local React state,
which was lost on unmount. On remount, a `useEffect` auto-fired `checkForUpdates()` — which calls two heavy IPC handlers (`renderer:compare-openapi-specs` + `renderer:get-collection-drift`) that block the Electron main thread.

Net effect: every tab switch repeated minutes of work the user just paid for. The "freeze" was the main thread blocking on the recompute.

## Fix

Lift drift state into the existing `openapiSync` redux slice so it survives unmount/remount. The auto-fire effect now skips when cached drift exists; manual refresh (Check button), settings change, item-count change, and tab close still trigger fresh fetches as before.

### What changed

1. **New `drift[uid]` redux slot** holds `{ specDrift, collectionDrift, remoteDrift, fetching, lastChecked, itemCountAtLastFetch }`. Survives unmount.
2. **Auto-fire gated** on `!drift?.specDrift && !drift?.fetching`. The `fetching` flag survives unmount too, blocking the rapid-tab-switch race where a second mount mid-fetch would otherwise duplicate the IPC.
3. **`storedSpec` split out from drift** into its own slot. Heavy spec (parsed OpenAPI object) is evicted on tab close; the lightweight `storedSpecMeta` (`title`, `version`, `endpointCount`) survives so the toolbar update badge keeps working when the OAPI Sync tab is closed.
4. **Tab-close eviction** wired into the existing `closeTabs` thunk in `collections/actions.js`. On close, drops `drift` + `storedSpec` + `tabUiState` for that collection. `collectionUpdates` and `storedSpecMeta` are preserved (background polling continues feeding the toolbar).
5. **Manual refresh keeps stale data visible** during reload. Sets `fetching: true` instead of clearing drift to `null` — no flash of empty state, success path overwrites.
6. **Stale-drift detection across closed-tab item changes.** Stamps `itemCountAtLastFetch` on each successful fetch; on reopen, if current `httpItemCount` differs from the cached count, drift refreshes automatically. Catches the case where the user adds/deletes endpoints via the sidebar while the OAPI tab was closed.
7. **Drops the dead `diff` field** from `setCollectionUpdate`. No consumers anywhere — `collectionUpdates[uid].diff` was duplicating what `drift[uid].specDrift` now holds. Saves redundant memory.
8. **Drops a hot tabs subscription.** `useSelector(state.tabs.tabs)` was re-rendering the hook on every tab open/close/focus/edit anywhere in the app, even though `tabs` was only used in callbacks. Swapped to `useStore()` (same pattern as `useIpcEvents.js`).

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * OpenAPI sync now uses centralized per-collection state for specs and drift, improving consistency.
  * Tab interactions and sync checks are driven from central state, reducing duplicated local state and race conditions.
  * Closing sync-related tabs now triggers cleanup so stale sync data is removed.

* **Bug Fixes**
  * Drift detection and automatic reloads are more accurate when collection item counts change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->