### PR TITLE
feature: open in terminal from manage workspace

### DIFF
--- a/packages/bruno-app/src/components/ManageWorkspace/index.js
+++ b/packages/bruno-app/src/components/ManageWorkspace/index.js
@@ -175,7 +175,6 @@ const ManageWorkspace = () => {
                       </button>
                     </MenuDropdown>
                   )}
-
                 </div>
               </div>
             );

--- a/packages/bruno-app/src/components/ManageWorkspace/index.js
+++ b/packages/bruno-app/src/components/ManageWorkspace/index.js
@@ -16,6 +16,7 @@ import StyledWrapper from './StyledWrapper';
 import MenuDropdown from 'ui/MenuDropdown/index';
 import Button from 'ui/Button';
 import { getRevealInFolderLabel } from 'utils/common/platform';
+import { openDevtoolsAndSwitchToTerminal } from 'utils/terminal';
 
 const ManageWorkspace = () => {
   const dispatch = useDispatch();
@@ -153,12 +154,20 @@ const ManageWorkspace = () => {
                       <span>{getRevealInFolderLabel()}</span>
                     </button>
                   )}
-                  {!isDefault && (
+
+                  {(workspace.pathname || !isDefault) && (
                     <MenuDropdown
                       placement="bottom-end"
                       items={[
-                        { id: 'rename', label: 'Rename', onClick: () => handleRenameClick(workspace) },
-                        { id: 'remove', label: 'Remove', onClick: () => handleCloseClick(workspace) }
+                        ...(workspace.pathname
+                          ? [{ id: 'open-in-terminal', label: 'Open in Terminal', onClick: () => openDevtoolsAndSwitchToTerminal(dispatch, workspace.pathname) }]
+                          : []),
+                        ...(!isDefault
+                          ? [
+                              { id: 'rename', label: 'Rename', onClick: () => handleRenameClick(workspace) },
+                              { id: 'remove', label: 'Remove', onClick: () => handleCloseClick(workspace) }
+                            ]
+                          : [])
                       ]}
                     >
                       <button className="more-actions-btn">
@@ -166,6 +175,7 @@ const ManageWorkspace = () => {
                       </button>
                     </MenuDropdown>
                   )}
+
                 </div>
               </div>
             );

--- a/packages/bruno-app/src/components/ManageWorkspace/index.js
+++ b/packages/bruno-app/src/components/ManageWorkspace/index.js
@@ -154,7 +154,6 @@ const ManageWorkspace = () => {
                       <span>{getRevealInFolderLabel()}</span>
                     </button>
                   )}
-
                   {(workspace.pathname || !isDefault) && (
                     <MenuDropdown
                       placement="bottom-end"

--- a/packages/bruno-app/src/components/ManageWorkspace/index.js
+++ b/packages/bruno-app/src/components/ManageWorkspace/index.js
@@ -154,19 +154,13 @@ const ManageWorkspace = () => {
                       <span>{getRevealInFolderLabel()}</span>
                     </button>
                   )}
-                  {(workspace.pathname || !isDefault) && (
+                  {!isDefault && (
                     <MenuDropdown
                       placement="bottom-end"
                       items={[
-                        ...(workspace.pathname
-                          ? [{ id: 'open-in-terminal', label: 'Open in Terminal', onClick: () => openDevtoolsAndSwitchToTerminal(dispatch, workspace.pathname) }]
-                          : []),
-                        ...(!isDefault
-                          ? [
-                              { id: 'rename', label: 'Rename', onClick: () => handleRenameClick(workspace) },
-                              { id: 'remove', label: 'Remove', onClick: () => handleCloseClick(workspace) }
-                            ]
-                          : [])
+                        { id: 'open-in-terminal', label: 'Open in Terminal', onClick: () => openDevtoolsAndSwitchToTerminal(dispatch, workspace.pathname) },
+                        { id: 'rename', label: 'Rename', onClick: () => handleRenameClick(workspace) },
+                        { id: 'remove', label: 'Remove', onClick: () => handleCloseClick(workspace) }
                       ]}
                     >
                       <button className="more-actions-btn">

--- a/tests/workspace/manage-workspace/manage-workspace.spec.ts
+++ b/tests/workspace/manage-workspace/manage-workspace.spec.ts
@@ -1,0 +1,60 @@
+import path from 'path';
+import fs from 'fs';
+import { test, expect, closeElectronApp } from '../../../playwright';
+
+const initUserDataPath = path.join(__dirname, '../create-workspace/init-user-data');
+
+function findCreatedWorkspaceDirs(location: string): string[] {
+  return fs.readdirSync(location).filter((e) => {
+    const fullPath = path.join(location, e);
+    return (
+      fs.statSync(fullPath).isDirectory()
+      && e !== 'default-workspace'
+      && fs.existsSync(path.join(fullPath, 'workspace.yml'))
+    );
+  });
+}
+
+test.describe('Manage Workspace', () => {
+  test('should open terminal from the workspace actions menu', async ({ launchElectronApp, createTmpDir }) => {
+    const wsLocation = await createTmpDir('ws-location-terminal');
+
+    const app = await launchElectronApp({ initUserDataPath, templateVars: { wsLocation } });
+    const page = await app.firstWindow();
+    await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+
+    await test.step('Create a workspace', async () => {
+      await page.locator('.workspace-name-container').click();
+      await page.locator('.dropdown-item').filter({ hasText: 'Create workspace' }).click();
+      const renameInput = page.locator('.workspace-name-input');
+      await expect(renameInput).toBeVisible({ timeout: 5000 });
+      await renameInput.fill('Terminal Workspace');
+      await renameInput.press('Enter');
+      await expect(page.getByText('Workspace created!')).toBeVisible({ timeout: 10000 });
+    });
+
+    const wsDirs = findCreatedWorkspaceDirs(wsLocation);
+    expect(wsDirs).toHaveLength(1);
+
+    await test.step('Open Manage Workspaces', async () => {
+      await page.locator('.workspace-name-container').click();
+      await page.locator('.dropdown-item').filter({ hasText: 'Manage workspaces' }).click();
+      await expect(page.getByText('Manage Workspace')).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step('Open terminal from workspace actions', async () => {
+      const workspaceItem = page.locator('.workspace-item').filter({ hasText: 'Terminal Workspace' });
+      await expect(workspaceItem).toBeVisible({ timeout: 5000 });
+      await workspaceItem.locator('.more-actions-btn').click();
+      await page.locator('.dropdown-item').filter({ hasText: 'Open in Terminal' }).click();
+    });
+
+    await test.step('Verify terminal session opens at the workspace folder', async () => {
+      const terminalSession = page.getByTestId('session-list-0');
+      await expect(terminalSession).toBeVisible({ timeout: 5000 });
+      await expect(terminalSession).toContainText(wsDirs[0]);
+    });
+
+    await closeElectronApp(app);
+  });
+});

--- a/tests/workspace/manage-workspace/manage-workspace.spec.ts
+++ b/tests/workspace/manage-workspace/manage-workspace.spec.ts
@@ -21,40 +21,43 @@ test.describe('Manage Workspace', () => {
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { wsLocation } });
     const page = await app.firstWindow();
-    await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
 
-    await test.step('Create a workspace', async () => {
-      await page.locator('.workspace-name-container').click();
-      await page.locator('.dropdown-item').filter({ hasText: 'Create workspace' }).click();
-      const renameInput = page.locator('.workspace-name-input');
-      await expect(renameInput).toBeVisible({ timeout: 5000 });
-      await renameInput.fill('Terminal Workspace');
-      await renameInput.press('Enter');
-      await expect(page.getByText('Workspace created!')).toBeVisible({ timeout: 10000 });
-    });
+    try {
+      await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
 
-    const wsDirs = findCreatedWorkspaceDirs(wsLocation);
-    expect(wsDirs).toHaveLength(1);
+      await test.step('Create a workspace', async () => {
+        await page.locator('.workspace-name-container').click();
+        await page.locator('.dropdown-item').filter({ hasText: 'Create workspace' }).click();
+        const renameInput = page.locator('.workspace-name-input');
+        await expect(renameInput).toBeVisible({ timeout: 5000 });
+        await renameInput.fill('Terminal Workspace');
+        await renameInput.press('Enter');
+        await expect(page.getByText('Workspace created!')).toBeVisible({ timeout: 10000 });
+      });
 
-    await test.step('Open Manage Workspaces', async () => {
-      await page.locator('.workspace-name-container').click();
-      await page.locator('.dropdown-item').filter({ hasText: 'Manage workspaces' }).click();
-      await expect(page.getByText('Manage Workspace')).toBeVisible({ timeout: 5000 });
-    });
+      const wsDirs = findCreatedWorkspaceDirs(wsLocation);
+      expect(wsDirs).toHaveLength(1);
 
-    await test.step('Open terminal from workspace actions', async () => {
-      const workspaceItem = page.locator('.workspace-item').filter({ hasText: 'Terminal Workspace' });
-      await expect(workspaceItem).toBeVisible({ timeout: 5000 });
-      await workspaceItem.locator('.more-actions-btn').click();
-      await page.locator('.dropdown-item').filter({ hasText: 'Open in Terminal' }).click();
-    });
+      await test.step('Open Manage Workspaces', async () => {
+        await page.locator('.workspace-name-container').click();
+        await page.locator('.dropdown-item').filter({ hasText: 'Manage workspaces' }).click();
+        await expect(page.getByText('Manage Workspace')).toBeVisible({ timeout: 5000 });
+      });
 
-    await test.step('Verify terminal session opens at the workspace folder', async () => {
-      const terminalSession = page.getByTestId('session-list-0');
-      await expect(terminalSession).toBeVisible({ timeout: 5000 });
-      await expect(terminalSession).toContainText(wsDirs[0]);
-    });
+      await test.step('Open terminal from workspace actions', async () => {
+        const workspaceItem = page.locator('.workspace-item').filter({ hasText: 'Terminal Workspace' });
+        await expect(workspaceItem).toBeVisible({ timeout: 5000 });
+        await workspaceItem.locator('.more-actions-btn').click();
+        await page.locator('.dropdown-item').filter({ hasText: 'Open in Terminal' }).click();
+      });
 
-    await closeElectronApp(app);
+      await test.step('Verify terminal session opens at the workspace folder', async () => {
+        const terminalSession = page.getByTestId('session-list-0');
+        await expect(terminalSession).toBeVisible({ timeout: 5000 });
+        await expect(terminalSession).toContainText(wsDirs[0]);
+      });
+    } finally {
+      await closeElectronApp(app);
+    }
   });
 });

--- a/tests/workspace/manage-workspace/manage-workspace.spec.ts
+++ b/tests/workspace/manage-workspace/manage-workspace.spec.ts
@@ -44,6 +44,11 @@ test.describe('Manage Workspace', () => {
         await expect(page.getByText('Manage Workspace')).toBeVisible({ timeout: 5000 });
       });
 
+      await test.step('Verify default workspace has no actions menu', async () => {
+        const defaultWorkspaceItem = page.locator('.workspace-item').filter({ hasText: 'My Workspace' });
+        await expect(defaultWorkspaceItem.locator('.more-actions-btn')).toHaveCount(0);
+      });
+
       await test.step('Open terminal from workspace actions', async () => {
         const workspaceItem = page.locator('.workspace-item').filter({ hasText: 'Terminal Workspace' });
         await expect(workspaceItem).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
### Description

[Jira](https://usebruno.atlassian.net/browse/BRU-3193)

Fixes https://github.com/usebruno/bruno/issues/6770

Adds "Open in Terminal" in "Manage Workspace" for non-default workspaces.


https://github.com/user-attachments/assets/ba75911f-5b19-4aa4-a021-d83b91218f0a


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage Workspace menu now shows an "Open in Terminal" action for workspaces with a configured path.

* **Improvements**
  * "Rename" and "Remove" actions remain hidden for default workspaces; menu items adapt to workspace state.

* **Tests**
  * Added end-to-end test that creates a workspace, triggers "Open in Terminal" from the UI, and verifies a terminal session opens for that workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->