### PR TITLE
fix: curl import with --data-binary and json content-type crashes

### DIFF
--- a/packages/bruno-app/src/utils/curl/index.js
+++ b/packages/bruno-app/src/utils/curl/index.js
@@ -68,9 +68,6 @@ export const getRequestFromCurlCommand = (curlCommand, requestType = 'http-reque
       } else if (normalizedContentType.includes('application/x-ndjson') || normalizedContentType.includes('application/ndjson')) {
         body.mode = 'text';
         body.text = parsedBody;
-      } else if (requestType === 'http-request' && request.isDataBinary) {
-        body.mode = 'file';
-        body.file = parsedBody;
       } else if (isJsonLikeContentType(contentType)) {
         body.mode = 'json';
         body.json = prettifyJsonString(parsedBody);


### PR DESCRIPTION
## Summary

- Fix crash (`e.file?.map is not a function`) when importing a curl command that uses `--data-binary` with `application/json` content-type
- The parser was incorrectly treating `--data-binary` as a file upload before checking content-type, causing the Redux store to call `.map()` on a string value

## Problem

When importing this curl command:
```bash
curl 'https://example.com/api' \
  -H 'content-type: application/json' \
  --data-binary '{"data":{"status":12}}'
```

The `--data-binary` flag caused the parser to set `body.mode = 'file'` and `body.file = parsedBody` (a JSON string), skipping the content-type check entirely. The Redux store then crashed because it expected `body.file` to be an array.

## Fix

Removed the premature `request.isDataBinary` check so that content-type-based detection (`application/json` → json mode, etc.) takes priority. The `--data-binary` flag in curl controls data transmission behavior, not the body type.

## Test plan

- [x] Import curl command with `--data-binary` + `application/json` content-type → correctly parsed as JSON body
- [x] Import curl command with `--data-binary` + `application/xml` content-type → correctly parsed as XML body
- [x] Import regular curl commands without `--data-binary` → unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of binary data when importing curl commands. Binary data now processes based on content-type instead of being treated as a file upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->