### PR TITLE
fix: show whitespace-only error on Create workspace and collection modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -62,7 +62,7 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
     }),
     onSubmit: async (values) => {
       try {
-        await dispatch(createCollection(values.collectionName,
+        await dispatch(createCollection(values.collectionName.trim(),
           values.collectionFolderName,
           values.collectionLocation,
           { format: values.format }));

--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -144,8 +144,17 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
                 ref={inputRef}
                 className="block textbox mt-2 w-full"
                 onChange={(e) => {
+                  const collectionName = e.target.value;
+                  if (!isEditing) {
+                    formik.setValues((values) => ({
+                      ...values,
+                      collectionName,
+                      collectionFolderName: sanitizeName(collectionName)
+                    }));
+                    return;
+                  }
+
                   formik.handleChange(e);
-                  !isEditing && formik.setFieldValue('collectionFolderName', sanitizeName(e.target.value));
                 }}
                 autoComplete="off"
                 autoCorrect="off"

--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -45,7 +45,8 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
     },
     validationSchema: Yup.object({
       collectionName: Yup.string()
-        .min(1, 'must be at least 1 character')
+        .trim()
+        .min(1, 'Collection name can\'t be empty')
         .max(255, 'must be 255 characters or less')
         .required('collection name is required'),
       collectionFolderName: Yup.string()
@@ -73,6 +74,23 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
       }
     }
   });
+
+  const handleSubmit = async (e) => {
+    e?.preventDefault?.();
+
+    const errors = await formik.validateForm();
+    if (Object.keys(errors).length > 0) {
+      formik.setTouched({
+        collectionName: true,
+        collectionFolderName: true,
+        collectionLocation: true,
+        format: true
+      });
+      return;
+    }
+
+    formik.handleSubmit();
+  };
 
   const browse = () => {
     dispatch(browseDirectory())
@@ -114,7 +132,7 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
     <Portal>
       <StyledWrapper>
         <Modal size="md" title="Create Collection" hideFooter={true} handleCancel={onClose}>
-          <form className="bruno-form" onSubmit={formik.handleSubmit}>
+          <form className="bruno-form" onSubmit={handleSubmit}>
             <div>
               <label htmlFor="collection-name" className="flex items-center font-medium">
                 Name

--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -47,18 +47,18 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
       collectionName: Yup.string()
         .trim()
         .min(1, 'Collection name can\'t be empty')
-        .max(255, 'must be 255 characters or less')
-        .required('collection name is required'),
+        .max(255, 'Must be 255 characters or less')
+        .required('Collection name is required'),
       collectionFolderName: Yup.string()
-        .min(1, 'must be at least 1 character')
-        .max(255, 'must be 255 characters or less')
+        .min(1, 'Must be at least 1 character')
+        .max(255, 'Must be 255 characters or less')
         .test('is-valid-collection-name', function (value) {
           const isValid = validateName(value);
           return isValid ? true : this.createError({ message: validateNameError(value) });
         })
-        .required('folder name is required'),
-      collectionLocation: Yup.string().min(1, 'location is required').required('location is required'),
-      format: Yup.string().oneOf(['bru', 'yml'], 'invalid format').required('format is required')
+        .required('Folder name is required'),
+      collectionLocation: Yup.string().min(1, 'Location is required').required('Location is required'),
+      format: Yup.string().oneOf(['bru', 'yml'], 'invalid format').required('Format is required')
     }),
     onSubmit: async (values) => {
       try {
@@ -74,23 +74,6 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
       }
     }
   });
-
-  const handleSubmit = async (e) => {
-    e?.preventDefault?.();
-
-    const errors = await formik.validateForm();
-    if (Object.keys(errors).length > 0) {
-      formik.setTouched({
-        collectionName: true,
-        collectionFolderName: true,
-        collectionLocation: true,
-        format: true
-      });
-      return;
-    }
-
-    formik.handleSubmit();
-  };
 
   const browse = () => {
     dispatch(browseDirectory())
@@ -132,7 +115,7 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
     <Portal>
       <StyledWrapper>
         <Modal size="md" title="Create Collection" hideFooter={true} handleCancel={onClose}>
-          <form className="bruno-form" onSubmit={handleSubmit}>
+          <form className="bruno-form" onSubmit={formik.handleSubmit}>
             <div>
               <label htmlFor="collection-name" className="flex items-center font-medium">
                 Name

--- a/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
+++ b/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
@@ -119,11 +119,11 @@ const CreateWorkspace = ({ onClose }) => {
               onChange={(e) => {
                 const workspaceName = e.target.value;
                 if (!isEditing) {
-                  formik.setValues({
-                    ...formik.values,
+                  formik.setValues((values) => ({
+                    ...values,
                     workspaceName,
                     workspaceFolderName: sanitizeName(workspaceName)
-                  });
+                  }));
                   return;
                 }
 

--- a/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
+++ b/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
@@ -26,7 +26,6 @@ const CreateWorkspace = ({ onClose }) => {
 
   const formik = useFormik({
     enableReinitialize: true,
-    validateOnMount: true,
     initialValues: {
       workspaceName: '',
       workspaceFolderName: '',
@@ -34,7 +33,8 @@ const CreateWorkspace = ({ onClose }) => {
     },
     validationSchema: Yup.object({
       workspaceName: Yup.string()
-        .min(1, 'Must be at least 1 character')
+        .trim()
+        .min(1, 'Workspace name can\'t be empty')
         .max(255, 'Must be 255 characters or less')
         .required('Workspace name is required')
         .test('unique-name', 'A workspace with this name already exists', function (value) {
@@ -70,6 +70,22 @@ const CreateWorkspace = ({ onClose }) => {
     }
   });
 
+  const handleSubmit = async (e) => {
+    e?.preventDefault?.();
+
+    const errors = await formik.validateForm();
+    if (Object.keys(errors).length > 0) {
+      formik.setTouched({
+        workspaceName: true,
+        workspaceFolderName: true,
+        workspaceLocation: true
+      });
+      return;
+    }
+
+    formik.handleSubmit();
+  };
+
   const browse = () => {
     dispatch(browseDirectory())
       .then((dirPath) => {
@@ -95,13 +111,13 @@ const CreateWorkspace = ({ onClose }) => {
       title="Create Workspace"
       description="Give your new workspace a name and choose its type to get started."
       confirmText={isSubmitting ? 'Creating...' : 'Create Workspace'}
-      handleConfirm={formik.handleSubmit}
+      handleConfirm={handleSubmit}
       handleCancel={onClose}
       style="new"
-      confirmDisabled={isSubmitting || !formik.isValid}
+      confirmDisabled={isSubmitting}
     >
       <div>
-        <form className="bruno-form" onSubmit={formik.handleSubmit}>
+        <form className="bruno-form" onSubmit={handleSubmit}>
           <div className="mb-4">
             <label htmlFor="workspaceName" className="block font-semibold mb-2">
               Name

--- a/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
+++ b/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
@@ -26,6 +26,7 @@ const CreateWorkspace = ({ onClose }) => {
 
   const formik = useFormik({
     enableReinitialize: true,
+    validateOnMount: true,
     initialValues: {
       workspaceName: '',
       workspaceFolderName: '',
@@ -97,7 +98,7 @@ const CreateWorkspace = ({ onClose }) => {
       handleConfirm={formik.handleSubmit}
       handleCancel={onClose}
       style="new"
-      confirmDisabled={isSubmitting}
+      confirmDisabled={isSubmitting || !formik.isValid}
     >
       <div>
         <form className="bruno-form" onSubmit={formik.handleSubmit}>
@@ -116,10 +117,17 @@ const CreateWorkspace = ({ onClose }) => {
               autoCapitalize="off"
               spellCheck="false"
               onChange={(e) => {
-                formik.handleChange(e);
+                const workspaceName = e.target.value;
                 if (!isEditing) {
-                  formik.setFieldValue('workspaceFolderName', sanitizeName(e.target.value));
+                  formik.setValues({
+                    ...formik.values,
+                    workspaceName,
+                    workspaceFolderName: sanitizeName(workspaceName)
+                  });
+                  return;
                 }
+
+                formik.handleChange(e);
               }}
               value={formik.values.workspaceName || ''}
             />

--- a/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
+++ b/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
@@ -70,22 +70,6 @@ const CreateWorkspace = ({ onClose }) => {
     }
   });
 
-  const handleSubmit = async (e) => {
-    e?.preventDefault?.();
-
-    const errors = await formik.validateForm();
-    if (Object.keys(errors).length > 0) {
-      formik.setTouched({
-        workspaceName: true,
-        workspaceFolderName: true,
-        workspaceLocation: true
-      });
-      return;
-    }
-
-    formik.handleSubmit();
-  };
-
   const browse = () => {
     dispatch(browseDirectory())
       .then((dirPath) => {
@@ -111,13 +95,13 @@ const CreateWorkspace = ({ onClose }) => {
       title="Create Workspace"
       description="Give your new workspace a name and choose its type to get started."
       confirmText={isSubmitting ? 'Creating...' : 'Create Workspace'}
-      handleConfirm={handleSubmit}
+      handleConfirm={formik.handleSubmit}
       handleCancel={onClose}
       style="new"
       confirmDisabled={isSubmitting}
     >
       <div>
-        <form className="bruno-form" onSubmit={handleSubmit}>
+        <form className="bruno-form" onSubmit={formik.handleSubmit}>
           <div className="mb-4">
             <label htmlFor="workspaceName" className="block font-semibold mb-2">
               Name

--- a/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
+++ b/packages/bruno-app/src/components/WorkspaceSidebar/CreateWorkspace/index.js
@@ -59,7 +59,7 @@ const CreateWorkspace = ({ onClose }) => {
       try {
         setIsSubmitting(true);
 
-        await dispatch(createWorkspaceAction(values.workspaceName, values.workspaceFolderName, values.workspaceLocation));
+        await dispatch(createWorkspaceAction(values.workspaceName.trim(), values.workspaceFolderName, values.workspaceLocation));
         toast.success('Workspace created!');
         onClose();
       } catch (error) {

--- a/tests/collection/create/create-collection.spec.ts
+++ b/tests/collection/create/create-collection.spec.ts
@@ -7,6 +7,29 @@ test.describe('Create collection', () => {
     await closeAllCollections(page);
   });
 
+  test('should show validation error for whitespace-only name in modal and keep modal open', async ({ page }) => {
+    await page.getByTestId('collections-header-add-menu').click();
+    await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Create collection' }).click();
+
+    const inlineCreator = page.locator('.inline-collection-creator');
+    await inlineCreator.waitFor({ state: 'visible', timeout: 5000 });
+    await inlineCreator.locator('.cog-btn').click();
+
+    const createCollectionModal = page.locator('.bruno-modal-card').filter({ hasText: 'Create Collection' });
+    await createCollectionModal.waitFor({ state: 'visible', timeout: 5000 });
+
+    const submitButton = createCollectionModal.getByRole('button', { name: 'Create', exact: true });
+    await createCollectionModal.getByLabel('Name').fill('   ');
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(createCollectionModal).toBeVisible();
+    await expect(submitButton).toBeEnabled();
+    await expect(createCollectionModal.getByText('Collection name can\'t be empty')).toBeVisible({ timeout: 2000 });
+
+    await createCollectionModal.getByRole('button', { name: 'Cancel' }).click();
+  });
+
   test('Create collection and add a simple HTTP request', async ({ page, createTmpDir }) => {
     const collectionName = 'test-collection';
     const requestName = 'ping';

--- a/tests/collection/create/create-collection.spec.ts
+++ b/tests/collection/create/create-collection.spec.ts
@@ -7,6 +7,29 @@ test.describe('Create collection', () => {
     await closeAllCollections(page);
   });
 
+  test('should show validation error for empty name in modal and keep modal open', async ({ page }) => {
+    await page.getByTestId('collections-header-add-menu').click();
+    await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Create collection' }).click();
+
+    const inlineCreator = page.locator('.inline-collection-creator');
+    await inlineCreator.waitFor({ state: 'visible', timeout: 5000 });
+    await inlineCreator.locator('.cog-btn').click();
+
+    const createCollectionModal = page.locator('.bruno-modal-card').filter({ hasText: 'Create Collection' });
+    await createCollectionModal.waitFor({ state: 'visible', timeout: 5000 });
+
+    const submitButton = createCollectionModal.getByRole('button', { name: 'Create', exact: true });
+    await createCollectionModal.getByLabel('Name').fill('');
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(createCollectionModal).toBeVisible();
+    await expect(submitButton).toBeEnabled();
+    await expect(createCollectionModal.getByText('Collection name is required')).toBeVisible({ timeout: 2000 });
+
+    await createCollectionModal.getByRole('button', { name: 'Cancel' }).click();
+  });
+
   test('should show validation error for whitespace-only name in modal and keep modal open', async ({ page }) => {
     await page.getByTestId('collections-header-add-menu').click();
     await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Create collection' }).click();

--- a/tests/workspace/create-workspace/create-workspace.spec.ts
+++ b/tests/workspace/create-workspace/create-workspace.spec.ts
@@ -362,7 +362,7 @@ test.describe('Create Workspace', () => {
       await closeElectronApp(app);
     });
 
-    test('should show validation error for empty name in modal', async ({ launchElectronApp, createTmpDir }) => {
+    test('should show validation error for whitespace-only name in modal and keep modal open', async ({ launchElectronApp, createTmpDir }) => {
       const wsLocation = await createTmpDir('ws-location-modal-empty');
 
       const app = await launchElectronApp({ initUserDataPath, templateVars: { wsLocation } });
@@ -376,20 +376,22 @@ test.describe('Create Workspace', () => {
         await page.locator('.cog-btn').click();
       });
 
-      await test.step('Clear name and try to submit', async () => {
+      await test.step('Enter whitespace-only name and submit', async () => {
         const modal = page.locator('.bruno-modal-card').filter({ hasText: 'Create Workspace' });
         await modal.waitFor({ state: 'visible', timeout: 5000 });
+        const submitButton = modal.getByRole('button', { name: 'Create Workspace' });
 
-        // Ensure name field is empty
-        await modal.locator('#workspace-name').fill('');
-        await modal.getByRole('button', { name: 'Create Workspace' }).click();
+        await modal.locator('#workspace-name').fill('   ');
+        await expect(submitButton).toBeEnabled();
+        await submitButton.click();
       });
 
       await test.step('Verify validation error appears and modal stays open', async () => {
         const modal = page.locator('.bruno-modal-card').filter({ hasText: 'Create Workspace' });
+        const submitButton = modal.getByRole('button', { name: 'Create Workspace' });
         await expect(modal).toBeVisible();
-        const error = modal.locator('.text-red-500');
-        await expect(error.first()).toBeVisible({ timeout: 2000 });
+        await expect(submitButton).toBeEnabled();
+        await expect(modal.getByText('Workspace name can\'t be empty')).toBeVisible({ timeout: 2000 });
       });
 
       await closeElectronApp(app);

--- a/tests/workspace/create-workspace/create-workspace.spec.ts
+++ b/tests/workspace/create-workspace/create-workspace.spec.ts
@@ -362,8 +362,43 @@ test.describe('Create Workspace', () => {
       await closeElectronApp(app);
     });
 
-    test('should show validation error for whitespace-only name in modal and keep modal open', async ({ launchElectronApp, createTmpDir }) => {
+    test('should show validation error for empty name in modal and keep modal open', async ({ launchElectronApp, createTmpDir }) => {
       const wsLocation = await createTmpDir('ws-location-modal-empty');
+
+      const app = await launchElectronApp({ initUserDataPath, templateVars: { wsLocation } });
+      const page = await app.firstWindow();
+      await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+
+      await test.step('Start inline creation and open advanced modal', async () => {
+        await page.locator('.workspace-name-container').click();
+        await page.locator('.dropdown-item').filter({ hasText: 'Create workspace' }).click();
+        await expect(page.locator('.workspace-name-input')).toBeVisible({ timeout: 5000 });
+        await page.locator('.cog-btn').click();
+      });
+
+      await test.step('Clear name and submit', async () => {
+        const modal = page.locator('.bruno-modal-card').filter({ hasText: 'Create Workspace' });
+        await modal.waitFor({ state: 'visible', timeout: 5000 });
+        const submitButton = modal.getByRole('button', { name: 'Create Workspace' });
+
+        await modal.locator('#workspace-name').fill('');
+        await expect(submitButton).toBeEnabled();
+        await submitButton.click();
+      });
+
+      await test.step('Verify validation error appears and modal stays open', async () => {
+        const modal = page.locator('.bruno-modal-card').filter({ hasText: 'Create Workspace' });
+        const submitButton = modal.getByRole('button', { name: 'Create Workspace' });
+        await expect(modal).toBeVisible();
+        await expect(submitButton).toBeEnabled();
+        await expect(modal.getByText('Workspace name is required')).toBeVisible({ timeout: 2000 });
+      });
+
+      await closeElectronApp(app);
+    });
+
+    test('should show validation error for whitespace-only name in modal and keep modal open', async ({ launchElectronApp, createTmpDir }) => {
+      const wsLocation = await createTmpDir('ws-location-modal-whitespace');
 
       const app = await launchElectronApp({ initUserDataPath, templateVars: { wsLocation } });
       const page = await app.firstWindow();


### PR DESCRIPTION
### Description

[Jira](https://usebruno.atlassian.net/browse/BRU-2465)

What this does:
- Validate whitespace-only collection/workspace name input
- Fix stale formik values, by updating logic of onChange

After:

Create collection modal:

https://github.com/user-attachments/assets/b962d31d-e038-4dec-97fd-801446545d5b

Create workspace modal:

https://github.com/user-attachments/assets/e80ebe03-6c48-4229-a67b-083e90b07299


Before:

Create collection modal:

https://github.com/user-attachments/assets/a23d5edc-4081-4daa-ab23-45ff2b779711


Create workspace modal:

https://github.com/user-attachments/assets/be166b7b-ff5e-4a63-a950-2c6cf04acbda



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

