### PR TITLE
fix: refresh code editor and query editor on resize

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -16,6 +16,7 @@ import stripJsonComments from 'strip-json-comments';
 import { getAllVariables } from 'utils/collections';
 import { setupLinkAware } from 'utils/codemirror/linkAware';
 import { setupLintErrorTooltip } from 'utils/codemirror/lint-errors';
+import { setupCodeMirrorResizeRefresh } from 'utils/codemirror/resize';
 import CodeMirrorSearch from 'components/CodeMirrorSearch/index';
 import {
   applyEditorState,
@@ -248,6 +249,8 @@ class CodeEditor extends React.Component {
       if (cmInput) {
         cmInput.classList.add('mousetrap');
       }
+
+      this.cleanupResizeRefresh = setupCodeMirrorResizeRefresh(editor, this._node);
     }
   }
 
@@ -373,6 +376,7 @@ class CodeEditor extends React.Component {
 
       // Clean up lint error tooltip
       this.cleanupLintErrorTooltip?.();
+      this.cleanupResizeRefresh?.();
 
       const wrapper = this.editor.getWrapperElement();
       wrapper?.parentNode?.removeChild(wrapper);

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
@@ -16,6 +16,7 @@ import toast from 'react-hot-toast';
 import StyledWrapper from './StyledWrapper';
 import onHasCompletion from './onHasCompletion';
 import { setupLinkAware } from 'utils/codemirror/linkAware';
+import { setupCodeMirrorResizeRefresh } from 'utils/codemirror/resize';
 
 const CodeMirror = require('codemirror');
 
@@ -137,6 +138,7 @@ export default class QueryEditor extends React.Component {
     this.addOverlay();
 
     setupLinkAware(editor);
+    this.cleanupResizeRefresh = setupCodeMirrorResizeRefresh(editor, this._node);
 
     // Add mousetrap class so Mousetrap captures shortcuts even when CodeMirror is focused
     const cmInput = editor.getInputField();
@@ -180,6 +182,7 @@ export default class QueryEditor extends React.Component {
       if (this.editor?._destroyLinkAware) {
         this.editor._destroyLinkAware();
       }
+      this.cleanupResizeRefresh?.();
       this.editor.off('change', this._onEdit);
       this.editor.off('keyup', this._onKeyUp);
       this.editor.off('hasCompletion', this._onHasCompletion);

--- a/packages/bruno-app/src/utils/codemirror/resize.js
+++ b/packages/bruno-app/src/utils/codemirror/resize.js
@@ -1,0 +1,38 @@
+/**
+ * Refreshes a CodeMirror editor when its container size changes.
+ * CodeMirror measures its DOM during refresh(), so resize callbacks are
+ * coalesced into a single animation frame to avoid repeated layout work.
+ *
+ * @param {Object} editor - CodeMirror editor instance
+ * @param {HTMLElement} element - Element whose size changes should refresh the editor
+ * @returns {Function} Cleanup function
+ */
+export const setupCodeMirrorResizeRefresh = (editor, element) => {
+  if (!editor || !element || typeof ResizeObserver === 'undefined') {
+    return () => {};
+  }
+
+  let resizeRefreshFrameId = null;
+
+  const resizeObserver = new ResizeObserver(() => {
+    if (resizeRefreshFrameId) {
+      cancelAnimationFrame(resizeRefreshFrameId);
+    }
+
+    resizeRefreshFrameId = requestAnimationFrame(() => {
+      editor.refresh?.();
+      resizeRefreshFrameId = null;
+    });
+  });
+
+  resizeObserver.observe(element);
+
+  return () => {
+    resizeObserver.disconnect();
+
+    if (resizeRefreshFrameId) {
+      cancelAnimationFrame(resizeRefreshFrameId);
+      resizeRefreshFrameId = null;
+    }
+  };
+};


### PR DESCRIPTION
### Description

[Jira](https://usebruno.atlassian.net/browse/BRU-2911)

CodeEditor remains in a stale state when the resize happens due to the layout change horizontally <-> vertical.

This is because CodeEditor auto-refreshes only when window resize happens and not actually when the view switch resize happens to the size.

This PR adds a resize listener to CodeEditor and refreshes it on resize.

Before:

https://github.com/user-attachments/assets/0f966f26-9473-4491-9a4e-2f2d0d7d8206

After:

https://github.com/user-attachments/assets/8435d05f-0f8f-4bbb-a733-bcff2348c4b4



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code editor now reliably refreshes when its container or layout changes, preventing stale layouts and improving responsiveness during resizes and layout toggles.

* **Tests**
  * Added end-to-end test coverage verifying the editor remeasures and renders correctly after layout changes, checking rendered line count and height calculations to prevent visual regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->