### PR TITLE
feat: make CodeEditor toggle-comment shortcut configurable

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -6,6 +6,7 @@
  */
 
 import React, { createRef } from 'react';
+import { connect } from 'react-redux';
 import { isEqual, escapeRegExp } from 'lodash';
 import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
 import { setupAutoComplete, showRootHints } from 'utils/codemirror/autocomplete';
@@ -17,6 +18,7 @@ import { getAllVariables } from 'utils/collections';
 import { setupLinkAware } from 'utils/codemirror/linkAware';
 import { setupLintErrorTooltip } from 'utils/codemirror/lint-errors';
 import CodeMirrorSearch from 'components/CodeMirrorSearch/index';
+import { getCodeMirrorKeyForAction } from 'providers/Hotkeys/keyMappings';
 
 const CodeMirror = require('codemirror');
 window.jsonlint = jsonlint;
@@ -24,7 +26,7 @@ window.JSHINT = JSHINT;
 
 const TAB_SIZE = 2;
 
-export default class CodeEditor extends React.Component {
+class CodeEditor extends React.Component {
   constructor(props) {
     super(props);
 
@@ -56,6 +58,13 @@ export default class CodeEditor extends React.Component {
         return;
       }
       return CodeMirror.Pass;
+    };
+    const toggleComment = () => {
+      if (['application/ld+json', 'application/json'].includes(this.props.mode)) {
+        this.editor.toggleComment({ lineComment: '//', blockComment: '/*' });
+      } else {
+        this.editor.toggleComment();
+      }
     };
 
     const editor = (this.editor = CodeMirror(this._node, {
@@ -111,20 +120,7 @@ export default class CodeEditor extends React.Component {
         'Cmd-Y': 'foldAll',
         'Ctrl-I': 'unfoldAll',
         'Cmd-I': 'unfoldAll',
-        'Ctrl-/': () => {
-          if (['application/ld+json', 'application/json'].includes(this.props.mode)) {
-            this.editor.toggleComment({ lineComment: '//', blockComment: '/*' });
-          } else {
-            this.editor.toggleComment();
-          }
-        },
-        'Cmd-/': () => {
-          if (['application/ld+json', 'application/json'].includes(this.props.mode)) {
-            this.editor.toggleComment({ lineComment: '//', blockComment: '/*' });
-          } else {
-            this.editor.toggleComment();
-          }
-        },
+        ...(this.props.commentToggleKey ? { [this.props.commentToggleKey]: toggleComment } : {}),
         'Esc': () => {
           if (this.state.searchBarVisible) {
             this.setState({ searchBarVisible: false });
@@ -355,3 +351,9 @@ export default class CodeEditor extends React.Component {
     }
   };
 }
+
+const mapStateToProps = (state) => ({
+  commentToggleKey: getCodeMirrorKeyForAction('toggleComment', state.app.preferences?.keyBindings)
+});
+
+export default connect(mapStateToProps, null, null, { forwardRef: true })(CodeEditor);

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -50,6 +50,14 @@ class CodeEditor extends React.Component {
     };
   }
 
+  toggleComment = () => {
+    if (['application/ld+json', 'application/json'].includes(this.props.mode)) {
+      this.editor.toggleComment({ lineComment: '//', blockComment: '/*' });
+    } else {
+      this.editor.toggleComment();
+    }
+  };
+
   componentDidMount() {
     const variables = getAllVariables(this.props.collection, this.props.item);
     const runShortcut = () => {
@@ -58,13 +66,6 @@ class CodeEditor extends React.Component {
         return;
       }
       return CodeMirror.Pass;
-    };
-    const toggleComment = () => {
-      if (['application/ld+json', 'application/json'].includes(this.props.mode)) {
-        this.editor.toggleComment({ lineComment: '//', blockComment: '/*' });
-      } else {
-        this.editor.toggleComment();
-      }
     };
 
     const editor = (this.editor = CodeMirror(this._node, {
@@ -120,7 +121,7 @@ class CodeEditor extends React.Component {
         'Cmd-Y': 'foldAll',
         'Ctrl-I': 'unfoldAll',
         'Cmd-I': 'unfoldAll',
-        ...(this.props.commentToggleKey ? { [this.props.commentToggleKey]: toggleComment } : {}),
+        ...(this.props.commentToggleKey ? { [this.props.commentToggleKey]: this.toggleComment } : {}),
         'Esc': () => {
           if (this.state.searchBarVisible) {
             this.setState({ searchBarVisible: false });
@@ -274,6 +275,13 @@ class CodeEditor extends React.Component {
 
     if (this.props.readOnly !== prevProps.readOnly && this.editor) {
       this.editor.setOption('readOnly', this.props.readOnly);
+    }
+
+    if (this.props.commentToggleKey !== prevProps.commentToggleKey && this.editor) {
+      const extraKeys = { ...(this.editor.getOption('extraKeys') || {}) };
+      if (prevProps.commentToggleKey) delete extraKeys[prevProps.commentToggleKey];
+      if (this.props.commentToggleKey) extraKeys[this.props.commentToggleKey] = this.toggleComment;
+      this.editor.setOption('extraKeys', extraKeys);
     }
 
     this.ignoreChangeEvent = false;

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -180,16 +180,25 @@ export const getKeyBindingsForActionAllOS = (action, userKeyBindings) => {
 
 const CM_MODIFIERS = { command: 'Cmd', ctrl: 'Ctrl', alt: 'Alt', shift: 'Shift' };
 const CM_MODIFIER_ORDER = ['Shift', 'Cmd', 'Ctrl', 'Alt'];
+const CM_SPECIAL_KEYS = {
+  enter: 'Enter', esc: 'Esc', escape: 'Esc', space: 'Space', tab: 'Tab',
+  backspace: 'Backspace', delete: 'Delete', insert: 'Insert',
+  arrowup: 'Up', arrowdown: 'Down', arrowleft: 'Left', arrowright: 'Right',
+  pageup: 'PageUp', pagedown: 'PageDown', home: 'Home', end: 'End'
+};
 
 export const getCodeMirrorKeyForAction = (action, userKeyBindings) => {
   const binding = getMergedKeyBindings(userKeyBindings)[action];
   if (!binding) return null;
   const isMac = navigator.platform.toLowerCase().includes('mac');
-  const parts = (isMac ? binding.mac : binding.windows).split('+bind+').filter(Boolean);
+  const platformBinding = isMac ? binding.mac : binding.windows;
+  if (typeof platformBinding !== 'string' || !platformBinding.trim()) return null;
+  const parts = platformBinding.split('+bind+').filter(Boolean);
   const mods = [], keys = [];
   for (const p of parts) {
-    const cm = CM_MODIFIERS[p.toLowerCase()];
-    cm ? mods.push(cm) : keys.push(p);
+    const lower = p.toLowerCase();
+    const cm = CM_MODIFIERS[lower];
+    cm ? mods.push(cm) : keys.push(CM_SPECIAL_KEYS[lower] || p);
   }
   if (!keys.length) return null;
   mods.sort((a, b) => CM_MODIFIER_ORDER.indexOf(a) - CM_MODIFIER_ORDER.indexOf(b));

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -70,6 +70,12 @@ export const KEY_BINDING_SECTIONS = [
     }
   },
   {
+    heading: 'Editor',
+    bindings: {
+      toggleComment: { mac: 'command+bind+/', windows: 'ctrl+bind+/', name: 'Toggle Comment' }
+    }
+  },
+  {
     heading: 'Others',
     bindings: {
       openPreferences: { mac: 'command+bind+,', windows: 'ctrl+bind+,', name: 'Open Preferences' }, // D
@@ -170,4 +176,22 @@ export const getKeyBindingsForActionAllOS = (action, userKeyBindings) => {
 
   // console.log('[keyMappings] getKeyBindingsForActionAllOS:', action, '->', combos);
   return combos.length > 0 ? combos : null;
+};
+
+const CM_MODIFIERS = { command: 'Cmd', ctrl: 'Ctrl', alt: 'Alt', shift: 'Shift' };
+const CM_MODIFIER_ORDER = ['Shift', 'Cmd', 'Ctrl', 'Alt'];
+
+export const getCodeMirrorKeyForAction = (action, userKeyBindings) => {
+  const binding = getMergedKeyBindings(userKeyBindings)[action];
+  if (!binding) return null;
+  const isMac = navigator.platform.toLowerCase().includes('mac');
+  const parts = (isMac ? binding.mac : binding.windows).split('+bind+').filter(Boolean);
+  const mods = [], keys = [];
+  for (const p of parts) {
+    const cm = CM_MODIFIERS[p.toLowerCase()];
+    cm ? mods.push(cm) : keys.push(p);
+  }
+  if (!keys.length) return null;
+  mods.sort((a, b) => CM_MODIFIER_ORDER.indexOf(a) - CM_MODIFIER_ORDER.indexOf(b));
+  return [...mods, ...keys].join('-');
 };


### PR DESCRIPTION
Fixes: https://github.com/usebruno/bruno/issues/7874

Heavily build with AI, but i ran it and it worked. I could change keybindings and use it in the json editor.

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code editor comment-toggle shortcut now respects users’ custom hotkey preferences (platform-aware).
  * Editor hotkey mappings added with sensible defaults for comment toggling and logic to derive platform-appropriate shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->