### PR TITLE
Add 'None' option to 'Add token to' options in the OAuth2 settings

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
@@ -280,13 +280,14 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
           <MenuDropdown
             items={[
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
-              { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
+              { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') },
+              { id: 'none', label: 'None', onClick: () => handleChange('tokenPlacement', 'none') }
             ]}
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >
             <div className="flex items-center justify-end token-placement-label select-none">
-              {tokenPlacement == 'url' ? 'URL' : 'Headers'}
+              {tokenPlacement == 'url' ? 'URL' : tokenPlacement == 'none' ? 'None' : 'Headers'}
               <IconCaretDown className="caret ml-1 mr-1" size={14} strokeWidth={2} />
             </div>
           </MenuDropdown>
@@ -310,22 +311,24 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
                 </div>
               </div>
             )
-          : (
-              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
-                <label className="block min-w-[140px]">Query Param Key</label>
-                <div className="single-line-editor-wrapper flex-1">
-                  <SingleLineEditor
-                    value={oAuth['tokenQueryKey'] || ''}
-                    theme={storedTheme}
-                    onSave={handleSave}
-                    onChange={(val) => handleChange('tokenQueryKey', val)}
-                    onRun={handleRun}
-                    collection={collection}
-                    isCompact
-                  />
+          : tokenPlacement === 'url'
+            ? (
+                <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
+                  <label className="block min-w-[140px]">Query Param Key</label>
+                  <div className="single-line-editor-wrapper flex-1">
+                    <SingleLineEditor
+                      value={oAuth['tokenQueryKey'] || ''}
+                      theme={storedTheme}
+                      onSave={handleSave}
+                      onChange={(val) => handleChange('tokenQueryKey', val)}
+                      onRun={handleRun}
+                      collection={collection}
+                      isCompact
+                    />
+                  </div>
                 </div>
-              </div>
-            )
+              )
+            : null
       }
       <div className="flex items-center gap-2.5 mt-4 mb-2">
         <div className="flex items-center px-2.5 py-1.5 oauth2-icon-container rounded-md">

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/ClientCredentials/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/ClientCredentials/index.js
@@ -170,13 +170,14 @@ const OAuth2ClientCredentials = ({ save, item = {}, request, handleRun, updateAu
           <MenuDropdown
             items={[
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
-              { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
+              { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') },
+              { id: 'none', label: 'None', onClick: () => handleChange('tokenPlacement', 'none') }
             ]}
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >
             <div className="flex items-center justify-end token-placement-label select-none">
-              {tokenPlacement == 'url' ? 'URL' : 'Headers'}
+              {tokenPlacement == 'url' ? 'URL' : tokenPlacement == 'none' ? 'None' : 'Headers'}
               <IconCaretDown className="caret ml-1 mr-1" size={14} strokeWidth={2} />
             </div>
           </MenuDropdown>
@@ -200,22 +201,24 @@ const OAuth2ClientCredentials = ({ save, item = {}, request, handleRun, updateAu
                 </div>
               </div>
             )
-          : (
-              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
-                <label className="block min-w-[140px]">Query Param Key</label>
-                <div className="single-line-editor-wrapper flex-1">
-                  <SingleLineEditor
-                    value={oAuth['tokenQueryKey'] || ''}
-                    theme={storedTheme}
-                    onSave={handleSave}
-                    onChange={(val) => handleChange('tokenQueryKey', val)}
-                    onRun={handleRun}
-                    collection={collection}
-                    isCompact
-                  />
+          : tokenPlacement === 'url'
+            ? (
+                <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
+                  <label className="block min-w-[140px]">Query Param Key</label>
+                  <div className="single-line-editor-wrapper flex-1">
+                    <SingleLineEditor
+                      value={oAuth['tokenQueryKey'] || ''}
+                      theme={storedTheme}
+                      onSave={handleSave}
+                      onChange={(val) => handleChange('tokenQueryKey', val)}
+                      onRun={handleRun}
+                      collection={collection}
+                      isCompact
+                    />
+                  </div>
                 </div>
-              </div>
-            )
+              )
+            : null
       }
       <div className="flex items-center gap-2.5 mt-4 mb-2">
         <div className="flex items-center px-2.5 py-1.5 oauth2-icon-container rounded-md">

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Implicit/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Implicit/index.js
@@ -215,13 +215,14 @@ const OAuth2Implicit = ({ save, item = {}, request, handleRun, updateAuth, colle
           <MenuDropdown
             items={[
               { id: 'header', label: 'Headers', onClick: () => handleChange('tokenPlacement', 'header') },
-              { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
+              { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') },
+              { id: 'none', label: 'None', onClick: () => handleChange('tokenPlacement', 'none') }
             ]}
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >
             <div className="flex items-center justify-end token-placement-label select-none">
-              {tokenPlacement == 'url' ? 'URL' : 'Headers'}
+              {tokenPlacement == 'url' ? 'URL' : tokenPlacement == 'none' ? 'None' : 'Headers'}
               <IconCaretDown className="caret ml-1 mr-1" size={14} strokeWidth={2} />
             </div>
           </MenuDropdown>
@@ -244,7 +245,7 @@ const OAuth2Implicit = ({ save, item = {}, request, handleRun, updateAuth, colle
             />
           </div>
         </div>
-      ) : (
+      ) : tokenPlacement == 'url' ? (
         <div className="flex items-center gap-4 w-full" key="input-token-query-key">
           <label className="block min-w-[140px]">URL Query Key</label>
           <div className="oauth2-input-wrapper flex-1">
@@ -260,7 +261,7 @@ const OAuth2Implicit = ({ save, item = {}, request, handleRun, updateAuth, colle
             />
           </div>
         </div>
-      )}
+      ) : null}
 
       <div className="flex items-center gap-2.5 mt-2">
         <div className="flex items-center px-2.5 py-1.5 oauth2-icon-container rounded-md">

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/PasswordCredentials/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/PasswordCredentials/index.js
@@ -174,13 +174,14 @@ const OAuth2PasswordCredentials = ({ save, item = {}, request, handleRun, update
           <MenuDropdown
             items={[
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
-              { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
+              { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') },
+              { id: 'none', label: 'None', onClick: () => handleChange('tokenPlacement', 'none') }
             ]}
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >
             <div className="flex items-center justify-end token-placement-label select-none">
-              {tokenPlacement == 'url' ? 'URL' : 'Headers'}
+              {tokenPlacement == 'url' ? 'URL' : tokenPlacement == 'none' ? 'None' : 'Headers'}
               <IconCaretDown className="caret ml-1 mr-1" size={14} strokeWidth={2} />
             </div>
           </MenuDropdown>
@@ -204,22 +205,24 @@ const OAuth2PasswordCredentials = ({ save, item = {}, request, handleRun, update
                 </div>
               </div>
             )
-          : (
-              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
-                <label className="block min-w-[140px]">Query Param Key</label>
-                <div className="single-line-editor-wrapper flex-1">
-                  <SingleLineEditor
-                    value={oAuth['tokenQueryKey'] || ''}
-                    theme={storedTheme}
-                    onSave={handleSave}
-                    onChange={(val) => handleChange('tokenQueryKey', val)}
-                    onRun={handleRun}
-                    collection={collection}
-                    isCompact
-                  />
+          : tokenPlacement === 'url'
+            ? (
+                <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
+                  <label className="block min-w-[140px]">Query Param Key</label>
+                  <div className="single-line-editor-wrapper flex-1">
+                    <SingleLineEditor
+                      value={oAuth['tokenQueryKey'] || ''}
+                      theme={storedTheme}
+                      onSave={handleSave}
+                      onChange={(val) => handleChange('tokenQueryKey', val)}
+                      onRun={handleRun}
+                      collection={collection}
+                      isCompact
+                    />
+                  </div>
                 </div>
-              </div>
-            )
+              )
+            : null
       }
       <div className="flex items-center gap-2.5 mt-4 mb-2">
         <div className="flex items-center px-2.5 py-1.5 oauth2-icon-container rounded-md">

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -235,7 +235,7 @@ const configureRequest = async (
           const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
           if (tokenPlacement == 'header' && tokenValue) {
             request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
-          } else if (tokenValue) {
+          } else if (tokenPlacement == 'url' && tokenValue) {
             try {
               const url = new URL(request.url);
               url.searchParams.set(tokenQueryKey, tokenValue);
@@ -252,7 +252,7 @@ const configureRequest = async (
           const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
           if (tokenPlacement == 'header' && tokenValue) {
             request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
-          } else if (tokenValue) {
+          } else if (tokenPlacement == 'url' && tokenValue) {
             try {
               const url = new URL(request.url);
               url.searchParams.set(tokenQueryKey, tokenValue);
@@ -269,7 +269,7 @@ const configureRequest = async (
           const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
           if (tokenPlacement == 'header' && tokenValue) {
             request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
-          } else if (tokenValue) {
+          } else if (tokenPlacement == 'url' && tokenValue) {
             try {
               const url = new URL(request.url);
               url.searchParams.set(tokenQueryKey, tokenValue);
@@ -286,7 +286,7 @@ const configureRequest = async (
           const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
           if (tokenPlacement == 'header' && tokenValue) {
             request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
-          } else if (tokenValue) {
+          } else if (tokenPlacement == 'url' && tokenValue) {
             try {
               const url = new URL(request.url);
               url.searchParams.set(tokenQueryKey, tokenValue);

--- a/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
@@ -18,7 +18,7 @@ const processHeaders = (headers) => {
 const placeOAuth2Token = (grpcRequest, credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey) => {
   if (tokenPlacement === 'header') {
     grpcRequest.headers['Authorization'] = `${tokenHeaderPrefix} ${credentials?.access_token}`;
-  } else {
+  } else if (tokenPlacement === 'url') {
     try {
       const url = new URL(grpcRequest.url);
       url?.searchParams?.set(tokenQueryKey, credentials?.access_token);

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
@@ -176,7 +176,7 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
         };
         if (tokenPlacement == 'header') {
           wsRequest.headers['Authorization'] = `${tokenHeaderPrefix} ${credentials?.access_token}`;
-        } else {
+        } else if (tokenPlacement == 'url') {
           try {
             const url = new URL(request.url);
             url?.searchParams?.set(tokenQueryKey, credentials?.access_token);
@@ -207,7 +207,7 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
         };
         if (tokenPlacement == 'header') {
           wsRequest.headers['Authorization'] = `${tokenHeaderPrefix} ${credentials?.access_token}`;
-        } else {
+        } else if (tokenPlacement == 'url') {
           try {
             const url = new URL(request.url);
             url?.searchParams?.set(tokenQueryKey, credentials?.access_token);
@@ -238,7 +238,7 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
         };
         if (tokenPlacement == 'header') {
           wsRequest.headers['Authorization'] = `${tokenHeaderPrefix} ${credentials?.access_token}`;
-        } else {
+        } else if (tokenPlacement == 'url') {
           try {
             const url = new URL(request.url);
             url?.searchParams?.set(tokenQueryKey, credentials?.access_token);

--- a/packages/bruno-electron/tests/network/index.spec.js
+++ b/packages/bruno-electron/tests/network/index.spec.js
@@ -1,4 +1,19 @@
+jest.mock('../../src/utils/oauth2', () => ({
+  getOAuth2TokenUsingAuthorizationCode: jest.fn(),
+  getOAuth2TokenUsingClientCredentials: jest.fn(),
+  getOAuth2TokenUsingPasswordCredentials: jest.fn(),
+  getOAuth2TokenUsingImplicitGrant: jest.fn(),
+  updateCollectionOauth2Credentials: jest.fn(),
+  clearOauth2CredentialsByCredentialsId: jest.fn()
+}));
+
+jest.mock('../../src/ipc/network/cert-utils', () => ({
+  getCertsAndProxyConfig: jest.fn().mockResolvedValue({}),
+  buildCertsAndProxyConfig: jest.fn()
+}));
+
 const { configureRequest } = require('../../src/ipc/network/index');
+const { getOAuth2TokenUsingClientCredentials } = require('../../src/utils/oauth2');
 
 describe('index: configureRequest', () => {
   it('Should add \'http://\' to the URL if no protocol is specified', async () => {
@@ -11,5 +26,36 @@ describe('index: configureRequest', () => {
     const request = { method: 'GET', url: 'ftp://test-domain', body: {} };
     await configureRequest(null, {}, request, null, null, null, null);
     expect(request.url).toEqual('ftp://test-domain');
+  });
+
+  it('Should not add the OAuth2 token to headers or URL if tokenPlacement is none', async () => {
+    getOAuth2TokenUsingClientCredentials.mockResolvedValue({
+      credentials: { access_token: 'test-token' },
+      url: 'https://auth.example.com/token',
+      credentialsId: 'credentials',
+      debugInfo: {}
+    });
+
+    const request = {
+      method: 'GET',
+      url: 'https://api.example.com/users?existing=1',
+      headers: {},
+      body: {},
+      oauth2: {
+        grantType: 'client_credentials',
+        accessTokenUrl: 'https://auth.example.com/token',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        tokenPlacement: 'none',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token'
+      }
+    };
+
+    await configureRequest('collection-uid', { promptVariables: {} }, request, {}, {}, {}, null, {});
+
+    expect(request.headers.Authorization).toBeUndefined();
+    expect(request.url).toEqual('https://api.example.com/users?existing=1');
+    expect(request.oauth2Credentials.credentials.access_token).toBe('test-token');
   });
 });

--- a/packages/bruno-electron/tests/network/prepare-grpc-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-grpc-request.spec.js
@@ -2,15 +2,19 @@ const { describe, it, expect, beforeEach } = require('@jest/globals');
 
 // Mock dependencies
 jest.mock('../../src/ipc/network/interpolate-vars');
+jest.mock('../../src/ipc/network/cert-utils');
 jest.mock('../../src/utils/collection');
 jest.mock('../../src/store/process-env');
 jest.mock('../../src/utils/oauth2');
 jest.mock('../../src/ipc/network/prepare-request');
 
 const prepareGrpcRequest = require('../../src/ipc/network/prepare-grpc-request');
+const { configureRequest } = require('../../src/ipc/network/prepare-grpc-request');
 const interpolateVars = require('../../src/ipc/network/interpolate-vars');
+const { getCertsAndProxyConfig } = require('../../src/ipc/network/cert-utils');
 const { getEnvVars, getTreePathFromCollectionToItem } = require('../../src/utils/collection');
 const { getProcessEnvVars } = require('../../src/store/process-env');
+const { getOAuth2TokenUsingClientCredentials } = require('../../src/utils/oauth2');
 const { setAuthHeaders } = require('../../src/ipc/network/prepare-request');
 
 describe('prepare-grpc-request: prepareGrpcRequest', () => {
@@ -25,7 +29,17 @@ describe('prepare-grpc-request: prepareGrpcRequest', () => {
     getEnvVars.mockReturnValue({});
     getTreePathFromCollectionToItem.mockReturnValue([]);
     getProcessEnvVars.mockReturnValue({});
-    setAuthHeaders.mockImplementation((request) => request);
+    getCertsAndProxyConfig.mockResolvedValue({});
+    setAuthHeaders.mockImplementation((grpcRequest, request) => {
+      if (request?.auth?.mode === 'oauth2') {
+        return {
+          ...grpcRequest,
+          oauth2: request.auth.oauth2
+        };
+      }
+
+      return grpcRequest;
+    });
     interpolateVars.mockImplementation((request) => request);
 
     mockItem = {
@@ -89,6 +103,47 @@ describe('prepare-grpc-request: prepareGrpcRequest', () => {
       const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
 
       expect(result.headers).toEqual({});
+    });
+
+    it('should not add the OAuth2 token when tokenPlacement is none', async () => {
+      getOAuth2TokenUsingClientCredentials.mockResolvedValue({
+        credentials: { access_token: 'token123' },
+        url: 'https://auth.example.com/token',
+        credentialsId: 'credentials',
+        debugInfo: {}
+      });
+
+      mockItem.request.url = 'grpc://localhost:50051?existing=1';
+      mockItem.request.headers = [];
+      mockItem.request.auth = {
+        mode: 'oauth2',
+        oauth2: {
+          grantType: 'client_credentials',
+          accessTokenUrl: 'https://auth.example.com/token',
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+          tokenPlacement: 'none',
+          tokenHeaderPrefix: 'Bearer',
+          tokenQueryKey: 'access_token'
+        }
+      };
+
+      const result = await prepareGrpcRequest(mockItem, mockCollection, mockEnvironment, mockRuntimeVariables);
+
+      await configureRequest(
+        result,
+        mockItem.request,
+        mockCollection,
+        result.envVars,
+        mockRuntimeVariables,
+        result.processEnvVars,
+        result.promptVariables,
+        {}
+      );
+
+      expect(result.headers['Authorization']).toBeUndefined();
+      expect(result.url).toBe('grpc://localhost:50051?existing=1');
+      expect(result.oauth2Credentials.credentials.access_token).toBe('token123');
     });
   });
 });

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -293,7 +293,7 @@ ${indentString(`token_source: ${auth?.oauth2?.tokenSource || 'access_token'}`)}
 ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement == 'header' ? '\n' + indentString(`token_header_prefix: ${auth?.oauth2?.tokenHeaderPrefix || ''}`) : ''
 }${
-  auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
+  (auth?.oauth2?.tokenPlacement === 'url' || auth?.oauth2?.tokenPlacement === 'query') ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken ?? true).toString()}`)}
 ${indentString(`auto_refresh_token: ${(auth?.oauth2?.autoRefreshToken ?? false).toString()}`)}
@@ -319,7 +319,7 @@ ${indentString(`token_source: ${auth?.oauth2?.tokenSource || 'access_token'}`)}
 ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement == 'header' ? '\n' + indentString(`token_header_prefix: ${auth?.oauth2?.tokenHeaderPrefix || ''}`) : ''
 }${
-  auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
+  auth?.oauth2?.tokenPlacement == 'url' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken ?? true).toString()}`)}
 ${indentString(`auto_refresh_token: ${(auth?.oauth2?.autoRefreshToken ?? false).toString()}`)}
@@ -341,7 +341,7 @@ ${indentString(`token_source: ${auth?.oauth2?.tokenSource || 'access_token'}`)}
 ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement == 'header' ? '\n' + indentString(`token_header_prefix: ${auth?.oauth2?.tokenHeaderPrefix || ''}`) : ''
 }${
-  auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
+  auth?.oauth2?.tokenPlacement == 'url' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken ?? true).toString()}`)}
 ${indentString(`auto_refresh_token: ${(auth?.oauth2?.autoRefreshToken ?? false).toString()}`)}
@@ -362,7 +362,7 @@ ${indentString(`token_source: ${auth?.oauth2?.tokenSource || 'access_token'}`)}
 ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement == 'header' ? '\n' + indentString(`token_header_prefix: ${auth?.oauth2?.tokenHeaderPrefix || ''}`) : ''
 }${
-  auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
+  auth?.oauth2?.tokenPlacement == 'url' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken ?? true).toString()}`)}
 }

--- a/packages/bruno-lang/v2/src/jsonToCollectionBru.js
+++ b/packages/bruno-lang/v2/src/jsonToCollectionBru.js
@@ -182,7 +182,7 @@ ${indentString(`token_source: ${auth?.oauth2?.tokenSource || 'access_token'}`)}
 ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement == 'header' ? '\n' + indentString(`token_header_prefix: ${auth?.oauth2?.tokenHeaderPrefix || ''}`) : ''
 }${
-  auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
+  (auth?.oauth2?.tokenPlacement === 'url' || auth?.oauth2?.tokenPlacement === 'query') ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken ?? true).toString()}`)}
 ${indentString(`auto_refresh_token: ${(auth?.oauth2?.autoRefreshToken ?? false).toString()}`)}
@@ -208,7 +208,7 @@ ${indentString(`token_source: ${auth?.oauth2?.tokenSource || 'access_token'}`)}
 ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement == 'header' ? '\n' + indentString(`token_header_prefix: ${auth?.oauth2?.tokenHeaderPrefix || ''}`) : ''
 }${
-  auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
+  auth?.oauth2?.tokenPlacement == 'url' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken ?? true).toString()}`)}
 ${indentString(`auto_refresh_token: ${(auth?.oauth2?.autoRefreshToken ?? false).toString()}`)}
@@ -229,7 +229,7 @@ ${indentString(`token_source: ${auth?.oauth2?.tokenSource || 'access_token'}`)}
 ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement == 'header' ? '\n' + indentString(`token_header_prefix: ${auth?.oauth2?.tokenHeaderPrefix || ''}`) : ''
 }${
-  auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
+  auth?.oauth2?.tokenPlacement == 'url' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken ?? true).toString()}`)}
 }
@@ -250,7 +250,7 @@ ${indentString(`token_source: ${auth?.oauth2?.tokenSource || 'access_token'}`)}
 ${indentString(`token_placement: ${auth?.oauth2?.tokenPlacement || ''}`)}${
   auth?.oauth2?.tokenPlacement == 'header' ? '\n' + indentString(`token_header_prefix: ${auth?.oauth2?.tokenHeaderPrefix || ''}`) : ''
 }${
-  auth?.oauth2?.tokenPlacement !== 'header' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
+  auth?.oauth2?.tokenPlacement == 'url' ? '\n' + indentString(`token_query_key: ${auth?.oauth2?.tokenQueryKey || ''}`) : ''
 }
 ${indentString(`auto_fetch_token: ${(auth?.oauth2?.autoFetchToken ?? true).toString()}`)}
 ${indentString(`auto_refresh_token: ${(auth?.oauth2?.autoRefreshToken ?? false).toString()}`)}

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -136,4 +136,42 @@ describe('jsonToBru stringify', () => {
       `);
     });
   });
+
+  describe('oauth2 token placement', () => {
+    it('omits token placement fields when tokenPlacement is none', () => {
+      const input = {
+        meta: {
+          name: 'oauth2-none',
+          type: 'http',
+          seq: 1
+        },
+        http: {
+          method: 'get',
+          url: 'https://api.example.com/users',
+          body: 'none',
+          auth: 'oauth2'
+        },
+        auth: {
+          mode: 'oauth2',
+          oauth2: {
+            grantType: 'client_credentials',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            credentialsPlacement: 'body',
+            credentialsId: 'credentials',
+            tokenPlacement: 'none',
+            tokenHeaderPrefix: 'Bearer',
+            tokenQueryKey: 'access_token'
+          }
+        }
+      };
+
+      const output = stringify(input);
+
+      expect(output).toContain('token_placement: none');
+      expect(output).not.toContain('token_header_prefix:');
+      expect(output).not.toContain('token_query_key:');
+    });
+  });
 });


### PR DESCRIPTION
### Description

Hi!

While setting up a particular set of endpoints for testing an application of mine, i need to send an OAuth2 token in a bit of a weird way (required to authenticate again). I implemented this with the use of pre-request scripts. Currently in Bruno, when using OAuth2, it's not possible to disable sending the token in the request. I'd prefer to not send an invalid (for my workflow) token to the server.

This PR adds the ability to disable sending the OAuth2 token automatically within the request. This allows me to purely use pre-requests to manipulate and send the OAuth2 token.

<img width="598" height="283" alt="image" src="https://github.com/user-attachments/assets/efa3c869-8cdc-4d9c-abbe-f8cf8c403984" />

#### Contribution Checklist:

- [X] **I've used AI significantly to create this pull request**
    - I have tested the changes and they work as expected (verified via the dev tools menu)
- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
    - I have not created an issue, if this is useful for you, let me know, i'll make one.

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "None" option to the OAuth2 token placement selector for all grant types.

* **Bug Fixes**
  * Token placement now strictly respects the selected option; tokens are only added to URL query parameters when explicitly set to URL.

* **Tests**
  * Added tests covering the "None" placement to ensure no header or URL injection while preserving stored credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->