### PR TITLE
fix(converters): deduplicate Postman folder/request names case-insensitively

### DIFF
--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -374,7 +374,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
       let folderName = baseFolderName;
       let count = 1;
 
-      while (folderMap[folderName]) {
+      while (folderMap[folderName.toLowerCase()]) {
         folderName = `${baseFolderName}_${count}`;
         count++;
       }
@@ -429,7 +429,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
         }
       }
 
-      folderMap[folderName] = brunoFolderItem;
+      folderMap[folderName.toLowerCase()] = brunoFolderItem;
     } else if (i.request) {
       const method = i?.request?.method?.toUpperCase();
       if (!method || typeof method !== 'string' || !method.trim()) {
@@ -441,7 +441,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
       let requestName = baseRequestName;
       let count = 1;
 
-      while (requestMap[requestName]) {
+      while (requestMap[requestName.toLowerCase()]) {
         requestName = `${baseRequestName}_${count}`;
         count++;
       }
@@ -801,7 +801,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
         });
       }
 
-      requestMap[requestName] = brunoRequestItem;
+      requestMap[requestName.toLowerCase()] = brunoRequestItem;
     }
   });
 };

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
@@ -1146,6 +1146,74 @@ describe('postman-collection', () => {
     expect(headers[0].name).toBe('X-No-Value');
     expect(headers[0].value).toBe('');
   });
+
+  it('should deduplicate sibling folder names case-insensitively', async () => {
+    // Postman allows two folders to share the same name with different
+    // casing (e.g. OAuth2 vs oAuth2). On case-insensitive filesystems
+    // (default on Windows and macOS APFS) the writer collapses both to
+    // the same directory and silently overwrites the first. We rename
+    // case-only collisions at the converter level so the writer sees
+    // distinct names.
+    const collectionWithCaseCollidingFolders = {
+      info: {
+        _postman_id: 'test-case-folder-collision',
+        name: 'case-colliding folder names',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'OAuth2',
+          item: [
+            {
+              name: 'first',
+              request: { method: 'GET', header: [], url: { raw: 'https://example.com/a' } }
+            }
+          ]
+        },
+        {
+          name: 'oAuth2',
+          item: [
+            {
+              name: 'second',
+              request: { method: 'GET', header: [], url: { raw: 'https://example.com/b' } }
+            }
+          ]
+        }
+      ]
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithCaseCollidingFolders);
+
+    expect(brunoCollection.items).toHaveLength(2);
+    expect(brunoCollection.items[0].name).toBe('OAuth2');
+    expect(brunoCollection.items[1].name).toBe('oAuth2_1');
+  });
+
+  it('should deduplicate sibling request names case-insensitively', async () => {
+    const collectionWithCaseCollidingRequests = {
+      info: {
+        _postman_id: 'test-case-request-collision',
+        name: 'case-colliding request names',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'GetUser',
+          request: { method: 'GET', header: [], url: { raw: 'https://example.com/a' } }
+        },
+        {
+          name: 'getuser',
+          request: { method: 'GET', header: [], url: { raw: 'https://example.com/b' } }
+        }
+      ]
+    };
+
+    const brunoCollection = await postmanToBruno(collectionWithCaseCollidingRequests);
+
+    expect(brunoCollection.items).toHaveLength(2);
+    expect(brunoCollection.items[0].name).toBe('GetUser');
+    expect(brunoCollection.items[1].name).toBe('getuser_1');
+  });
 });
 
 // Simple Collection (postman)


### PR DESCRIPTION
### Summary

Fixes a piece of issue [#7821](https://github.com/usebruno/bruno/issues/7821) — Postman/Insomnia import silently corrupts folders with case-colliding sibling names.

The Postman v2 importer in `bruno-converters` already deduplicates sibling folder and request names against an in-memory map, but the map lookup is **case-sensitive**. A Postman collection with two sibling folders named e.g. `OAuth2` and `oAuth2` therefore produces two Bruno items with their original names, and on a case-insensitive filesystem (default on Windows and macOS APFS) the writer collapses them into the same directory and silently overwrites the first folder's contents.

This PR lowercases the key used for the collision lookup (and for recording entries), so case-only variants are renamed at the converter stage:

- `OAuth2` (kept)
- `oAuth2` → `oAuth2_1`

Same fix applied symmetrically to the request-name path. Display names keep their original casing — only the dedup map's key is normalized.

### Scope

This PR addresses the **converter-level** deduplication gap. The two follow-ups mentioned in #7821 — sibling-level dedup in the filesystem writer and the missing `recursive: true` on `mkdirSync` — are intentionally **out of scope** to keep this PR small and focused, per `contributing.md`.

### Tests

Added two unit tests in `packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js`:

- `should deduplicate sibling folder names case-insensitively` — `OAuth2` + `oAuth2` ⇒ `OAuth2`, `oAuth2_1`
- `should deduplicate sibling request names case-insensitively` — `GetUser` + `getuser` ⇒ `GetUser`, `getuser_1`

Both tests fail on `main` and pass with this change. The full `bruno-converters` test suite has the same pre-existing failure count (161) before and after this change; the only delta is **+2 passing tests** in `postman-to-bruno.spec.js`.

```
Before:  Tests: 161 failed, 22 skipped, 737 passed, 920 total
After:   Tests: 161 failed, 22 skipped, 739 passed, 922 total
```

The pre-existing failures are all in unrelated `postman-translations` / `bruno-to-postman-translations` test files and are not touched by this change.

### Test instructions

```bash
nvm use
HUSKY=0 npm install --legacy-peer-deps --ignore-scripts
npm run build --workspace=packages/bruno-common
cd packages/bruno-converters
NODE_OPTIONS=--experimental-vm-modules node ../../node_modules/jest/bin/jest.js tests/postman/postman-to-bruno/postman-to-bruno.spec.js
```

Expected: `Tests: 32 passed, 32 total` (including the two new cases).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Postman to Bruno conversion to handle folder and request names with different casing as duplicates. Names differing only by case (e.g., "Test" and "test") will now be properly deduplicated with a numeric suffix.

* **Tests**
  * Added test cases for case-insensitive deduplication of sibling folders and requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->