### PR TITLE
fix: parse OpenAPI response body JSON pointers

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -781,13 +781,41 @@ const getSecurity = (apiSpec) => {
 
 const openAPIRuntimeExpressionToScript = (expression) => {
   // see https://swagger.io/docs/specification/links/#runtime-expressions
+  const prefix = '$response.body#';
+
   if (expression === '$response.body') {
     return 'res.body';
-  } else if (expression.startsWith('$response.body#')) {
-    let pointer = expression.substring(15);
-    // could use https://www.npmjs.com/package/json-pointer for better support
-    return `res.body${pointer.replace('/', '.')}`;
   }
+
+  if (expression.startsWith(prefix)) {
+    const pointer = expression.slice(prefix.length);
+
+    if (!pointer || pointer === '/') {
+      return 'res.body';
+    }
+
+    const segments = pointer
+      .replace(/^\//, '')
+      .split('/')
+      .map((segment) =>
+        segment
+          .replace(/~1/g, '/')
+          .replace(/~0/g, '~')
+      );
+
+    return segments.reduce((script, segment) => {
+      if (/^\d+$/.test(segment)) {
+        return `${script}[${segment}]`;
+      }
+
+      if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(segment)) {
+        return `${script}.${segment}`;
+      }
+
+      return `${script}[${JSON.stringify(segment)}]`;
+    }, 'res.body');
+  }
+
   return expression;
 };
 

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-links.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-links.spec.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from '@jest/globals';
+import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
+
+describe('openapi-to-bruno links', () => {
+  it('converts response body runtime JSON Pointers into valid response scripts', () => {
+    const spec = `
+openapi: 3.0.3
+info:
+  title: Links API
+  version: '1.0'
+paths:
+  /orders:
+    post:
+      operationId: createOrder
+      responses:
+        '201':
+          description: Created
+          links:
+            GetOrder:
+              operationId: getOrder
+              parameters:
+                root: '$response.body'
+                emptyPointer: '$response.body#'
+                rootPointer: '$response.body#/'
+                id: '$response.body#/data/0/id'
+                hyphenated: '$response.body#/user-name'
+                escaped: '$response.body#/links/self~1href/meta~0key'
+servers:
+  - url: https://example.com
+`;
+
+    const collection = openApiToBruno(spec);
+    const request = collection.items[0];
+
+    expect(request.request.script.res).toBe(
+      [
+        'if (res.status === 201) {',
+        '  bru.setVar(\'getOrder_root\', res.body);',
+        '  bru.setVar(\'getOrder_emptyPointer\', res.body);',
+        '  bru.setVar(\'getOrder_rootPointer\', res.body);',
+        '  bru.setVar(\'getOrder_id\', res.body.data[0].id);',
+        '  bru.setVar(\'getOrder_hyphenated\', res.body["user-name"]);',
+        '  bru.setVar(\'getOrder_escaped\', res.body.links["self/href"]["meta~key"]);',
+        '}'
+      ].join('\n')
+    );
+  });
+});


### PR DESCRIPTION
### Description

Closes #7905.

Fixes OpenAPI link response body runtime expression conversion so JSON Pointer fragments are parsed by segment. This handles root pointers, array indexes, valid JavaScript identifiers, escaped `~1` / `~0` segments, and non-identifier property names with bracket notation.

Tests:
- `mise exec node@22.12.0 -- npm run lint -- packages/bruno-converters/src/openapi/openapi-to-bruno.js packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-links.spec.js`
- `mise exec node@22.12.0 -- npm run test --workspace=packages/bruno-converters -- openapi-links.spec.js --runInBand`
- `mise exec node@22.12.0 -- npm run build:bruno-common`
- `mise exec node@22.12.0 -- npm run test --workspace=packages/bruno-converters -- --runInBand`

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.** N/A, converter logic only.
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI specification conversion for runtime expressions with complex JSON Pointer-style paths. Enhanced parsing to correctly handle nested paths, special character escaping, and various syntax variations found in response link definitions.

* **Tests**
  * Added test coverage for OpenAPI response links conversion scenarios with multiple runtime expression formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->