### PR TITLE
fix: center active search match in CodeMirror viewport

### DIFF
--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -148,7 +148,31 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       editor.addLineClass(currentLine, 'wrap', 'cm-search-line-highlight');
       searchLineHighlight.current = currentLine;
 
-      editor.scrollIntoView(matches[matchIndex].from, 100);
+      // previous line of code
+      // editor.scrollIntoView(matches[matchIndex].from, 100);
+
+      // This is the part we are fixing for issue #7875.
+      // Before, CodeMirror only scrolled enough to make the match visible,
+      // which often placed the result near the bottom of the JSON viewport.
+      // Now we calculate the matched line position and force it closer to
+      // the vertical centre, giving users better JSON context above and below.
+      const activeMatch = matches[matchIndex];
+      const scroller = editor.getScrollerElement();
+      const lineHeight = editor.defaultTextHeight();
+
+      // CodeMirror's heightAtLine gives us the vertical position of the line
+      // inside the full editor document, not just the visible screen.
+      const matchTop = editor.heightAtLine(activeMatch.from.line, 'local');
+
+      // We subtract half the viewport height, then add a few line heights so
+      // the highlighted line is visually centred instead of being too high.
+      const targetScrollTop = Math.max(
+        0,
+        matchTop - scroller.clientHeight / 2 + lineHeight * 3
+      );
+      // my line of work ends here
+      editor.scrollTo(null, targetScrollTop);
+
       editor.setSelection(matches[matchIndex].from, matches[matchIndex].to);
     } catch (e) {
       console.error('Search error:', e);


### PR DESCRIPTION
### Description

This PR improves the positioning of search results in the JSON response view.

Previously, when navigating search matches, the highlighted result was often positioned near the bottom of the viewport. This made it difficult to view surrounding JSON context and required additional manual scrolling.

### What changed

- The active search match is now positioned closer to the center of the editor viewport
- This provides better visibility of surrounding JSON content (above and below the match)
- Improves navigation experience when working with large JSON responses

### Why this matters

This aligns with expected behavior seen in tools like VS Code, where search navigation keeps results within a comfortable viewing context.

### Screenshot

<img width="753" height="498" alt="image" src="https://github.com/user-attachments/assets/89576203-58e1-4f7e-80e4-4609555c826b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code editor search to better center matched lines in the viewport when scrolling to results, enhancing visibility and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->