### PR TITLE
Code editor search bar (Cmd+F) does not select existing text on re-open, causing typed input to append

### DIFF
--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -163,6 +163,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     focus: () => {
       if (inputRef.current) {
         inputRef.current.focus();
+        inputRef.current.select();
       }
     }
   }));


### PR DESCRIPTION
### I have checked the following:

- [x] I have searched existing issues and found nothing related to my issue.

### This bug is:

- [x] annoying

### Bruno version

<your version, e.g. 3.3.0>

### Operating System

macOS 26.3.1 (a)  

### Describe the bug

In the Response pane (and any `CodeEditor` surface — request body, pre/post-request scripts, tests editor) the custom search bar (`CodeMirrorSearch`) does not select its existing text when re-opened with `Cmd+F` / `Ctrl+F`.

The component preserves `searchText` state across open/close cycles, and on re-open the input is re-focused but the caret lands at the end of the existing query. Typing new characters then **appends** to the old query instead of replacing it.

This diverges from native browser and IDE search-bar behavior (Chrome's Cmd+F, VS Code, etc., all pre-select the existing query on re-open).

### Steps to reproduce

1. Open any collection and send a request that returns a non-trivial response body.
2. Click into the Response pane and press `Cmd+F` (macOS) / `Ctrl+F` (Win/Linux).
3. Type `item_1`.
4. Press `Esc` to dismiss the search bar.
5. Press `Cmd+F` / `Ctrl+F` again.
6. Type `item_2`.

**Expected:** Step 5 selects the existing `item_1` so step 6 replaces it. The search input reads `item_2`.

**Actual:** Step 5 places the caret at the end of `item_1`. Step 6 appends, producing `item_1item_2`.

### Affected surfaces

The bug reproduces in every `CodeEditor` instance, since they all share `CodeMirrorSearch`:
- Response pane
- Request body editor
- Pre-request / post-request script editors
- Tests editor

### .bru file to reproduce the bug

_Not required — reproducible against any request that returns a body._

### Proposed fix

In `packages/bruno-app/src/components/CodeMirrorSearch/index.js`, the imperative `focus()` exposed via `useImperativeHandle` only calls `inputRef.current.focus()`. Adding `inputRef.current.select()` immediately after it makes the existing search term selected on every re-open via the keyboard shortcut.

PR: #7919