### PR TITLE
feat: add Postman v2.0 and v2.1 export support

### DIFF
--- a/packages/bruno-app/src/components/ShareCollection/index.js
+++ b/packages/bruno-app/src/components/ShareCollection/index.js
@@ -14,7 +14,8 @@ import toast from 'react-hot-toast';
 const EXPORT_FORMATS = {
   ZIP: 'zip',
   YAML: 'yaml',
-  POSTMAN: 'postman'
+  POSTMAN_V2_0: 'postman-v2-0',
+  POSTMAN_V2_1: 'postman-v2-1'
 };
 
 const ShareCollection = ({ onClose, collectionUid }) => {
@@ -62,9 +63,9 @@ const ShareCollection = ({ onClose, collectionUid }) => {
     exportOpenCollection(transformCollectionToSaveToExportAsFile(collectionCopy));
   };
 
-  const handleExportPostman = () => {
+  const handleExportPostman = (version) => {
     const collectionCopy = cloneDeep(collection);
-    exportPostmanCollection(collectionCopy);
+    exportPostmanCollection(collectionCopy, version);
   };
 
   const handleProceed = async () => {
@@ -79,8 +80,11 @@ const ShareCollection = ({ onClose, collectionUid }) => {
         case EXPORT_FORMATS.YAML:
           handleExportYaml();
           break;
-        case EXPORT_FORMATS.POSTMAN:
-          handleExportPostman();
+        case EXPORT_FORMATS.POSTMAN_V2_0:
+          handleExportPostman('2.0');
+          break;
+        case EXPORT_FORMATS.POSTMAN_V2_1:
+          handleExportPostman('2.1');
           break;
       }
       onClose();
@@ -165,20 +169,32 @@ const ShareCollection = ({ onClose, collectionUid }) => {
         <div className="section-title">Other Format</div>
         <div className="other-format-grid">
           <div
-            className={`other-format-card ${selectedFormat === EXPORT_FORMATS.POSTMAN ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-            onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.POSTMAN)}
+            className={`other-format-card ${selectedFormat === EXPORT_FORMATS.POSTMAN_V2_0 ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+            onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.POSTMAN_V2_0)}
           >
             <div className="format-icon">
               <IconFileExport size={28} strokeWidth={1.5} />
             </div>
             <div className="format-info">
-              <div className="format-name">Postman</div>
-              <div className="format-description">Export for Postman</div>
+              <div className="format-name">Postman v2.0</div>
+              <div className="format-description">Export for Postman Collection v2.0</div>
+            </div>
+          </div>
+          <div
+            className={`other-format-card ${selectedFormat === EXPORT_FORMATS.POSTMAN_V2_1 ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+            onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.POSTMAN_V2_1)}
+          >
+            <div className="format-icon">
+              <IconFileExport size={28} strokeWidth={1.5} />
+            </div>
+            <div className="format-info">
+              <div className="format-name">Postman v2.1</div>
+              <div className="format-description">Export for Postman Collection v2.1</div>
             </div>
           </div>
         </div>
 
-        {selectedFormat === EXPORT_FORMATS.POSTMAN && hasNonExportableRequestTypes.has && (
+        {(selectedFormat === EXPORT_FORMATS.POSTMAN_V2_0 || selectedFormat === EXPORT_FORMATS.POSTMAN_V2_1) && hasNonExportableRequestTypes.has && (
           <div className="flex items-center mt-4 p-3 rounded" style={{ backgroundColor: 'rgba(251, 191, 36, 0.1)' }}>
             <IconAlertTriangle size={16} className="mr-2 flex-shrink-0" style={{ color: '#f59e0b' }} />
             <span className="text-sm" style={{ color: '#f59e0b' }}>

--- a/packages/bruno-app/src/utils/exporters/postman-collection.js
+++ b/packages/bruno-app/src/utils/exporters/postman-collection.js
@@ -2,11 +2,11 @@ import * as FileSaver from 'file-saver';
 import { brunoToPostman } from '@usebruno/converters';
 import { filterTransientItems } from 'utils/collections';
 
-export const exportCollection = (collection) => {
+export const exportCollection = (collection, version = '2.1') => {
   // Filter out transient items before export
   collection.items = filterTransientItems(collection.items);
 
-  const collectionToExport = brunoToPostman(collection);
+  const collectionToExport = brunoToPostman(collection, version);
 
   const fileName = `${collection.name}.json`;
   const fileBlob = new Blob([JSON.stringify(collectionToExport, null, 2)], { type: 'application/json' });

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -147,18 +147,23 @@ export const sanitizeUrl = (url) => {
   return sanitizedUrl;
 };
 
-export const brunoToPostman = (collection) => {
+export const brunoToPostman = (collection, version = '2.1') => {
   delete collection.uid;
   delete collection.processEnvVariables;
   deleteUidsInItems(collection.items);
   deleteUidsInEnvs(collection.environments);
   deleteSecretsInEnvs(collection.environments);
 
+  const schemaMap = {
+    '2.0': 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json',
+    '2.1': 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+  };
+
   const generateInfoSection = () => {
     return {
       name: collection.name,
       description: collection.root?.docs,
-      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      schema: schemaMap[version] || schemaMap['2.1']
     };
   };
 
@@ -377,44 +382,85 @@ export const brunoToPostman = (collection) => {
 
   const generateAuth = (itemAuth) => {
     switch (itemAuth?.mode) {
-      case 'bearer':
+      case 'bearer': {
+        const token = itemAuth.bearer?.token || '';
+        if (version === '2.0') {
+          return {
+            type: 'bearer',
+            bearer: {
+              token: token
+            }
+          };
+        }
         return {
           type: 'bearer',
-          bearer: {
-            key: 'token',
-            value: itemAuth.bearer?.token || '',
-            type: 'string'
-          }
+          bearer: [
+            {
+              key: 'token',
+              value: token,
+              type: 'string'
+            }
+          ]
         };
+      }
       case 'basic': {
+        const username = itemAuth.basic?.username || '';
+        const password = itemAuth.basic?.password || '';
+        if (version === '2.0') {
+          return {
+            type: 'basic',
+            basic: {
+              username: username,
+              password: password
+            }
+          };
+        }
         return {
           type: 'basic',
           basic: [
             {
-              key: 'password',
-              value: itemAuth.basic?.password || '',
+              key: 'username',
+              value: username,
               type: 'string'
             },
             {
-              key: 'username',
-              value: itemAuth.basic?.username || '',
+              key: 'password',
+              value: password,
               type: 'string'
             }
           ]
         };
       }
       case 'apikey': {
+        const key = itemAuth.apikey?.key || '';
+        const value = itemAuth.apikey?.value || '';
+        const inValue = itemAuth.apikey?.in || 'header';
+        if (version === '2.0') {
+          return {
+            type: 'apikey',
+            apikey: {
+              key: key,
+              value: value,
+              in: inValue
+            }
+          };
+        }
         return {
           type: 'apikey',
           apikey: [
             {
               key: 'key',
-              value: itemAuth.apikey?.key || '',
+              value: key,
               type: 'string'
             },
             {
               key: 'value',
-              value: itemAuth.apikey?.value || '',
+              value: value,
+              type: 'string'
+            },
+            {
+              key: 'in',
+              value: inValue,
               type: 'string'
             }
           ]

--- a/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
+++ b/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
@@ -412,11 +412,13 @@ describe('brunoToPostman null checks and fallbacks', () => {
     const result = brunoToPostman(simpleCollection);
     expect(result.item[0].request.auth).toEqual({
       type: 'bearer',
-      bearer: {
-        key: 'token',
-        value: '',
-        type: 'string'
-      }
+      bearer: [
+        {
+          key: 'token',
+          value: '',
+          type: 'string'
+        }
+      ]
     });
   });
 
@@ -443,12 +445,12 @@ describe('brunoToPostman null checks and fallbacks', () => {
       type: 'basic',
       basic: [
         {
-          key: 'password',
+          key: 'username',
           value: '',
           type: 'string'
         },
         {
-          key: 'username',
+          key: 'password',
           value: '',
           type: 'string'
         }
@@ -486,6 +488,11 @@ describe('brunoToPostman null checks and fallbacks', () => {
         {
           key: 'value',
           value: '',
+          type: 'string'
+        },
+        {
+          key: 'in',
+          value: 'header',
           type: 'string'
         }
       ]
@@ -1045,5 +1052,180 @@ describe('brunoToPostman item ordering', () => {
     const names = result.item.map((i) => i.name);
 
     expect(names).toEqual(['Apple', 'Mango', 'Zebra']);
+  });
+});
+
+describe('brunoToPostman v2.0 format', () => {
+  it('should use v2.0 schema URL', () => {
+    const simpleCollection = {
+      name: 'Test Collection',
+      items: []
+    };
+
+    const result = brunoToPostman(simpleCollection, '2.0');
+    expect(result.info.schema).toBe('https://schema.getpostman.com/json/collection/v2.0.0/collection.json');
+  });
+
+  it('should use object format for bearer auth in v2.0', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: {
+              mode: 'bearer',
+              bearer: { token: 'test-token' }
+            }
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection, '2.0');
+    expect(result.item[0].request.auth).toEqual({
+      type: 'bearer',
+      bearer: {
+        token: 'test-token'
+      }
+    });
+  });
+
+  it('should use object format for basic auth in v2.0', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: {
+              mode: 'basic',
+              basic: { username: 'user', password: 'pass' }
+            }
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection, '2.0');
+    expect(result.item[0].request.auth).toEqual({
+      type: 'basic',
+      basic: {
+        username: 'user',
+        password: 'pass'
+      }
+    });
+  });
+
+  it('should use object format for apikey auth in v2.0', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: {
+              mode: 'apikey',
+              apikey: { key: 'api-key', value: 'secret', in: 'header' }
+            }
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection, '2.0');
+    expect(result.item[0].request.auth).toEqual({
+      type: 'apikey',
+      apikey: {
+        key: 'api-key',
+        value: 'secret',
+        in: 'header'
+      }
+    });
+  });
+});
+
+describe('brunoToPostman v2.1 format', () => {
+  it('should use v2.1 schema URL by default', () => {
+    const simpleCollection = {
+      name: 'Test Collection',
+      items: []
+    };
+
+    const result = brunoToPostman(simpleCollection);
+    expect(result.info.schema).toBe('https://schema.getpostman.com/json/collection/v2.1.0/collection.json');
+  });
+
+  it('should use array format for bearer auth in v2.1', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: {
+              mode: 'bearer',
+              bearer: { token: 'test-token' }
+            }
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection, '2.1');
+    expect(result.item[0].request.auth).toEqual({
+      type: 'bearer',
+      bearer: [
+        {
+          key: 'token',
+          value: 'test-token',
+          type: 'string'
+        }
+      ]
+    });
+  });
+
+  it('should use array format for basic auth in v2.1', () => {
+    const simpleCollection = {
+      items: [
+        {
+          name: 'Test Request',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com',
+            auth: {
+              mode: 'basic',
+              basic: { username: 'user', password: 'pass' }
+            }
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(simpleCollection, '2.1');
+    expect(result.item[0].request.auth).toEqual({
+      type: 'basic',
+      basic: [
+        {
+          key: 'username',
+          value: 'user',
+          type: 'string'
+        },
+        {
+          key: 'password',
+          value: 'pass',
+          type: 'string'
+        }
+      ]
+    });
   });
 });


### PR DESCRIPTION
- Add version parameter to brunoToPostman converter
- Support v2.0 auth format (object-based) and v2.1 (array-based)
- Update UI with separate export buttons for v2.0 and v2.1
- Add comprehensive tests for both Postman collection versions

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Postman export functionality now supports v2.0 and v2.1 schema formats. Users can select their preferred Postman version when exporting collections via distinct options in the sharing interface, ensuring compatibility with their specific environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->