### PR TITLE
fix: remove dragbar z-index that was bleeding through modals

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/StyledWrapper.js
@@ -46,7 +46,6 @@ const StyledWrapper = styled.div`
     cursor: col-resize;
     background: transparent;
     position: relative;
-    z-index: 1;
 
     div.dragbar-handle {
       display: flex;
@@ -85,7 +84,6 @@ const StyledWrapper = styled.div`
       cursor: row-resize;
       padding: 0 1rem;
       position: relative;
-      z-index: 1;
 
       div.dragbar-handle {
         width: 100%;


### PR DESCRIPTION
### Description

Fixes for drag bar between request and response overlapping the unsaved changed modal. 
Reported [Jira](https://usebruno.atlassian.net/browse/BRU-3063?focusedCommentId=31796)

### Screenshots

Before
<img width="688" height="315" alt="image" src="https://github.com/user-attachments/assets/5df70b02-f7e6-4297-a134-1e660c647092" />

After
<img width="688" height="315" alt="image" src="https://github.com/user-attachments/assets/4318ff0a-54ce-4e72-bd0b-5df227f75505" />



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual stacking issue with draggable elements in the request panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->