### PR TITLE
fix: allow empty header names in CLI and gRPC request preparation

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -30,7 +30,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
 
   const disabledHeaders = [];
   each(get(request, 'headers', []), (h) => {
-    if (h.enabled && h.name.length > 0) {
+    if (h.enabled && h.name?.length > 0) {
       headers[h.name] = h.value;
       if (h.name.toLowerCase() === 'content-type') {
         contentTypeDefined = true;

--- a/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
@@ -137,7 +137,7 @@ const prepareGrpcRequest = async (item, collection, environment, runtimeVariable
   }
 
   each(get(request, 'headers', []), (h) => {
-    if (h.enabled && h.name.length > 0) {
+    if (h.enabled && h.name?.length > 0) {
       headers[h.name] = h.value;
     }
   });

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -381,12 +381,12 @@ const prepareRequest = async (item, collection = {}, abortController) => {
 
   const disabledHeaders = [];
   each(get(request, 'headers', []), (h) => {
-    if (h.enabled && h.name.length > 0) {
+    if (h.enabled && h.name?.length > 0) {
       headers[h.name] = h.value;
       if (h.name.toLowerCase() === 'content-type') {
         contentTypeDefined = true;
       }
-    } else if (!h.enabled && h.name.length > 0) {
+    } else if (!h.enabled && h.name?.length > 0) {
       disabledHeaders.push({ name: h.name, value: h.value });
     }
   });


### PR DESCRIPTION
[BRU-3419](https://usebruno.atlassian.net/browse/BRU-3419)
Related to: https://github.com/usebruno/bruno/pull/7869

### Description

  - `keyValueSchema` declares `name: Yup.string().nullable()` — null is a valid name at the schema level
  - Three request-preparation files accessed `h.name.length` without a null guard, throwing `TypeError: Cannot read properties of null (reading 'length')` when a header with `name: null` reached the
  network layer
  - Changed `h.name.length` → `h.name?.length` in all three sites:
    - `packages/bruno-cli/src/runner/prepare-request.js`
    - `packages/bruno-electron/src/ipc/network/prepare-request.js`
    - `packages/bruno-electron/src/ipc/network/prepare-grpc-request.js`

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in request processing by safely handling headers with missing or undefined names, preventing potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->