### PR TITLE
fix: snapshot fix for new-request

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/tasks/middleware.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/tasks/middleware.js
@@ -34,6 +34,8 @@ taskMiddleware.startListening({
               addTab({
                 uid: item.uid,
                 collectionUid: collection.uid,
+                type: item.type,
+                pathname: item.pathname,
                 requestPaneTab: getDefaultRequestPaneTab(item),
                 preview: task?.preview ?? true,
                 ...(item.isTransient ? { isTransient: true } : {})

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -64,7 +64,7 @@ export const tabsSlice = createSlice({
         state.tabs[state.tabs.length - 1] = {
           uid,
           collectionUid,
-          type: type || 'request',
+          type: type || 'http-request',
           pathname: pathname || null,
           requestPaneWidth: null,
           requestPaneHeight: null,
@@ -94,7 +94,7 @@ export const tabsSlice = createSlice({
       state.tabs.push({
         uid,
         collectionUid,
-        type: type || 'request',
+        type: type || 'http-request',
         pathname: pathname || null,
         requestPaneWidth: null,
         requestPaneHeight: null,

--- a/tests/snapshots/basic.spec.ts
+++ b/tests/snapshots/basic.spec.ts
@@ -179,7 +179,7 @@ test.describe('Snapshot: Tab Persistence', () => {
     });
   });
 
-  test.only('newly created request can be sent and remains sendable after restart', async ({ launchElectronApp, createTmpDir }) => {
+  test('newly created request can be sent and remains sendable after restart', async ({ launchElectronApp, createTmpDir }) => {
     test.setTimeout(60000);
     const userDataPath = await createTmpDir('snap-new-request-send');
     const colPath = await createTmpDir('col');

--- a/tests/snapshots/basic.spec.ts
+++ b/tests/snapshots/basic.spec.ts
@@ -6,6 +6,7 @@ import {
   createRequest,
   openRequest,
   openCollection,
+  sendRequest,
   switchWorkspace,
   selectRequestPaneTab
 } from '../utils/page';
@@ -173,6 +174,44 @@ test.describe('Snapshot: Tab Persistence', () => {
       const locators = buildCommonLocators(page2);
       await expect(locators.tabs.requestTab('ReqKeep')).toBeVisible({ timeout: 10000 });
       await expect(locators.tabs.requestTab('ReqClose')).not.toBeVisible();
+
+      await closeElectronApp(app2);
+    });
+  });
+
+  test.only('newly created request can be sent and remains sendable after restart', async ({ launchElectronApp, createTmpDir }) => {
+    test.setTimeout(60000);
+    const userDataPath = await createTmpDir('snap-new-request-send');
+    const colPath = await createTmpDir('col');
+
+    const app = await launchElectronApp({ userDataPath });
+    const page = await app.firstWindow();
+    await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+
+    await test.step('Create request via New Request modal and send via Send button', async () => {
+      await createCollection(page, 'TestCol', colPath);
+      await createRequest(page, 'PingReq', 'TestCol', { url: 'http://localhost:8081/ping', method: 'GET' });
+
+      const locators = buildCommonLocators(page);
+      await expect(locators.tabs.activeRequestTab()).toContainText('PingReq');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('Close and restart app', async () => {
+      await page.waitForTimeout(2000);
+      await closeElectronApp(app);
+    });
+
+    await test.step('After restart, send the restored request via Send button', async () => {
+      const app2 = await launchElectronApp({ userDataPath });
+      const page2 = await app2.firstWindow();
+      await page2.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+
+      const locators = buildCommonLocators(page2);
+      await expect(locators.tabs.requestTab('PingReq')).toBeVisible({ timeout: 15000 });
+      await locators.tabs.requestTab('PingReq').click({ force: true });
+      await expect(locators.tabs.activeRequestTab()).toContainText('PingReq');
+      await sendRequest(page2, 200);
 
       await closeElectronApp(app2);
     });


### PR DESCRIPTION
### Description

#### Root cause
The snapshot PR tightened the request-type check in RequestTabPanel to ['http-request', 'grpc-request', 'ws-request', 'graphql-request']. The tasks middleware that opens a tab after the New Request modal dispatches addTab without a type, so the reducer falls back to the default 'request' — not in the gate's list — leaving Cmd+Enter unbound for newly-created tabs of any type. Sidebar clicks pass type: item.type (the actual request type), which is why reopening worked.

#### Fix
Pass type: item.type (and pathname: item.pathname for snapshot/restore consistency) in the addTab dispatch inside tasks/middleware.js.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assignment of request tab types when new tabs are created, ensuring consistency across creation and replace/preview flows.

* **Tests**
  * Added a snapshot test verifying a newly created request tab persists after restart and remains selectable and sendable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->