### PR TITLE
feat(ws): add protobuf body mode for websocket messages

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/WsBody/BodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/BodyMode/index.js
@@ -16,6 +16,10 @@ const RAW_MODES = [
   {
     label: 'TEXT',
     key: 'text'
+  },
+  {
+    label: 'PROTOBUF',
+    key: 'protobuf'
   }
 ];
 

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -98,7 +98,7 @@ export const SingleWSMessage = ({
     text: 'application/text',
     xml: 'application/xml',
     json: 'application/ld+json',
-    protobuf: 'application/ld+json'
+    protobuf: 'text/plain'
   };
 
   const onPrettify = () => {
@@ -153,7 +153,7 @@ export const SingleWSMessage = ({
           <WSRequestBodyMode mode={messageFormat} onModeChange={onUpdateMessageType} />
 
           <ToolHint text="Format" toolhintId={`prettify-msg-${index}`}>
-            <button onClick={onPrettify} className="toolbar-btn">
+            <button onClick={onPrettify} className="toolbar-btn" disabled={!['json', 'xml'].includes(codeType)}>
               <IconWand size={16} strokeWidth={1.5} />
             </button>
           </ToolHint>

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -18,7 +18,8 @@ import StyledWrapper from './StyledWrapper';
 export const TYPE_BY_DECODER = {
   base64: 'binary',
   json: 'json',
-  xml: 'xml'
+  xml: 'xml',
+  protobuf: 'protobuf'
 };
 
 export const DECODER_BY_TYPE = invert(TYPE_BY_DECODER);
@@ -96,7 +97,8 @@ export const SingleWSMessage = ({
   const codemirrorMode = {
     text: 'application/text',
     xml: 'application/xml',
-    json: 'application/ld+json'
+    json: 'application/ld+json',
+    protobuf: 'application/ld+json'
   };
 
   const onPrettify = () => {

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -902,6 +902,10 @@ export const humanizeRequestBodyMode = (mode) => {
       label = 'XML';
       break;
     }
+    case 'protobuf': {
+      label = 'PROTOBUF';
+      break;
+    }
     case 'sparql': {
       label = 'SPARQL';
       break;


### PR DESCRIPTION
## Description

Adds `PROTOBUF` as a selectable body mode for WebSocket messages.

This improves consistency between WebSocket and gRPC workflows by allowing protobuf-formatted WebSocket payloads to be selected and displayed correctly in the editor UI.

### Changes

* Added `PROTOBUF` option to the WebSocket body mode dropdown
* Added protobuf type mapping for WebSocket messages
* Added protobuf label handling in `humanizeRequestBodyMode`

### Screenshot

<img width="363" height="280" alt="image" src="https://github.com/user-attachments/assets/91a40aa7-c1d5-485d-a15c-d33ff9fcd26a" />


#### Contribution Checklist:

* [x] **I've used AI significantly to create this pull request**
* [x] **The pull request only addresses one issue or adds one feature.**
* [x] **The pull request does not introduce any breaking changes**
* [x] **I have added screenshots or gifs to help explain the change if applicable.**
* [x] **I have read the contribution guidelines.**
* [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Protocol Buffer (Protobuf) support for WebSocket message bodies — users can select and work with protobuf-formatted messages and see appropriate editor highlighting.

* **Improvements**
  * Editor “Format”/prettify control is now only enabled for JSON or XML payloads to prevent invalid formatting attempts.
  * Human-readable request body mode list now includes a Protobuf label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->