### PR TITLE
feat: add "Duplicate as Tab" action to request tab menu

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -709,6 +709,9 @@ function RequestTabMenu({ menuDropdownRef, tabLabelRef, collectionRequestTabs, t
   const isRequestTab = currentTabItem && (currentTabItem.type === 'http-request' || currentTabItem.type === 'graphql-request' || currentTabItem.type === 'grpc-request' || currentTabItem.type === 'ws-request');
 
   const handleDuplicateAsTab = () => {
+    if (!currentTabItem?.uid || !collection?.uid) {
+      return;
+    }
     dispatch(cloneItemAsTransient(currentTabItem.uid, collection.uid)).catch((err) => {
       toast.error(err?.message || 'An error occurred while duplicating the request');
     });

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useState, useRef, Fragment, useMemo, useEffect } from 'react';
 import get from 'lodash/get';
 import { makeTabPermanent, syncTabUid } from 'providers/ReduxStore/slices/tabs';
-import { saveRequest, saveCollectionRoot, saveFolderRoot, saveEnvironment, saveCollectionSettings, closeTabs } from 'providers/ReduxStore/slices/collections/actions';
+import { saveRequest, saveCollectionRoot, saveFolderRoot, saveEnvironment, saveCollectionSettings, closeTabs, cloneItemAsTransient } from 'providers/ReduxStore/slices/collections/actions';
 import useKeybinding from 'hooks/useKeybinding';
 import { deleteRequestDraft, deleteCollectionDraft, deleteFolderDraft, clearEnvironmentsDraft } from 'providers/ReduxStore/slices/collections';
 import { clearGlobalEnvironmentDraft } from 'providers/ReduxStore/slices/global-environments';
@@ -706,6 +706,14 @@ function RequestTabMenu({ menuDropdownRef, tabLabelRef, collectionRequestTabs, t
     await handleCloseMultipleTabs(collectionRequestTabs);
   }
 
+  const isRequestTab = currentTabItem && (currentTabItem.type === 'http-request' || currentTabItem.type === 'graphql-request' || currentTabItem.type === 'grpc-request' || currentTabItem.type === 'ws-request');
+
+  const handleDuplicateAsTab = () => {
+    dispatch(cloneItemAsTransient(currentTabItem.uid, collection.uid)).catch((err) => {
+      toast.error(err?.message || 'An error occurred while duplicating the request');
+    });
+  };
+
   const menuItems = useMemo(() => [
     {
       id: 'new-request',
@@ -716,6 +724,12 @@ function RequestTabMenu({ menuDropdownRef, tabLabelRef, collectionRequestTabs, t
       id: 'clone-request',
       label: 'Clone Request',
       onClick: () => setShowCloneRequestModal(true)
+    },
+    {
+      id: 'duplicate-as-tab',
+      label: 'Duplicate as Tab',
+      onClick: handleDuplicateAsTab,
+      disabled: !isRequestTab
     },
     {
       id: 'revert-changes',
@@ -756,7 +770,7 @@ function RequestTabMenu({ menuDropdownRef, tabLabelRef, collectionRequestTabs, t
       label: 'Close All',
       onClick: handleCloseAllTabs
     }
-  ], [currentTabUid, currentTabItem, hasOtherTabs, hasLeftTabs, hasRightTabs, collection, collectionRequestTabs, tabIndex, dispatch]);
+  ], [currentTabUid, currentTabItem, isRequestTab, hasOtherTabs, hasLeftTabs, hasRightTabs, collection, collectionRequestTabs, tabIndex, dispatch]);
 
   const menuDropdown = (
     <MenuDropdown

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -8,7 +8,7 @@ import { clearGlobalEnvironmentDraft } from 'providers/ReduxStore/slices/global-
 import { saveGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import { useTheme } from 'providers/Theme';
 import { useDispatch, useSelector } from 'react-redux';
-import { findItemInCollection, findItemInCollectionByPathname, hasRequestChanges, areItemsLoading } from 'utils/collections';
+import { findItemInCollection, findItemInCollectionByPathname, hasRequestChanges, areItemsLoading, isItemARequest } from 'utils/collections';
 import ConfirmRequestClose from './ConfirmRequestClose';
 import ConfirmCollectionClose from './ConfirmCollectionClose';
 import ConfirmFolderClose from './ConfirmFolderClose';
@@ -706,7 +706,7 @@ function RequestTabMenu({ menuDropdownRef, tabLabelRef, collectionRequestTabs, t
     await handleCloseMultipleTabs(collectionRequestTabs);
   }
 
-  const isRequestTab = currentTabItem && (currentTabItem.type === 'http-request' || currentTabItem.type === 'graphql-request' || currentTabItem.type === 'grpc-request' || currentTabItem.type === 'ws-request');
+  const isRequestTab = currentTabItem && isItemARequest(currentTabItem);
 
   const handleDuplicateAsTab = () => {
     if (!currentTabItem?.uid || !collection?.uid) {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -967,6 +967,68 @@ export const cloneItem = (newName, newFilename, itemUid, collectionUid) => (disp
   });
 };
 
+// Duplicates a request into the collection's temp directory as a transient (unsaved) request,
+// mirroring Postman's "Duplicate Tab" behavior. Folders are not supported — they require a
+// committed name on disk to be meaningful.
+export const cloneItemAsTransient = (itemUid, collectionUid) => (dispatch, getState) => {
+  const state = getState();
+  const collection = findCollectionByUid(state.collections.collections, collectionUid);
+
+  return new Promise((resolve, reject) => {
+    if (!collection) {
+      return reject(new Error('Collection not found'));
+    }
+
+    const tempDirectory = state.collections.tempDirectories?.[collectionUid];
+    if (!tempDirectory) {
+      return reject(new Error('Temporary directory is not initialized for this collection'));
+    }
+
+    const item = findItemInCollection(cloneDeep(collection), itemUid);
+    if (!item) {
+      return reject(new Error('Unable to locate item'));
+    }
+    if (isItemAFolder(item)) {
+      return reject(new Error('Folders cannot be duplicated as a tab'));
+    }
+
+    const transientRequests = filter(
+      flattenItems(collection.items),
+      (i) => isItemARequest(i) && i.pathname && i.pathname.startsWith(tempDirectory)
+    );
+    const { newName, newFilename } = generateUniqueName(`${item.name} copy`, transientRequests, false);
+    const filename = resolveRequestFilename(newFilename, collection.format);
+
+    // The `isTransient` flag is inferred at load time from the file's path
+    // (it's never persisted to disk), so we don't set it here — the schema is strict.
+    const itemToSave = refreshUidsInItem(transformRequestToSaveToFilesystem(item));
+    set(itemToSave, 'name', trim(newName));
+    set(itemToSave, 'filename', trim(filename));
+    const items = filter(collection.items, (i) => isItemAFolder(i) || isItemARequest(i));
+    itemToSave.seq = items.length + 1;
+
+    const fullPathname = path.join(tempDirectory, filename);
+    const { ipcRenderer } = window;
+
+    itemSchema
+      .validate(itemToSave)
+      .then(() => ipcRenderer.invoke('renderer:new-request', fullPathname, itemToSave))
+      .then(() => {
+        dispatch(
+          insertTaskIntoQueue({
+            uid: uuid(),
+            type: 'OPEN_REQUEST',
+            collectionUid,
+            itemPathname: fullPathname,
+            preview: false
+          })
+        );
+        resolve();
+      })
+      .catch(reject);
+  });
+};
+
 export const pasteItem = (targetCollectionUid, targetItemUid = null) => (dispatch, getState) => {
   const state = getState();
 


### PR DESCRIPTION
### Description

Adds a **"Duplicate as Tab"** option to the request tab right-click menu, mirroring Postman's "Duplicate Tab" idiom.

The existing **Clone Request** action requires a name in a modal and persists immediately to disk — well-suited for committing a copy. This new option duplicates the request into the collection's temp directory as a transient (unsaved) tab, pre-seeded with the source request's full state (including any unsaved draft changes), and opens it in a new tab. The user only commits to a name and folder if they later choose to save via the existing transient-save flow.

Reuses Bruno's existing transient-request infrastructure (temp directory + `SaveTransientRequest` modal); no new IPC, no schema changes.

#### Demo
https://github.com/user-attachments/assets/a39c8db8-c2cd-4189-a1b0-786266e525cd

Related: #184

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Duplicate as Tab" action to create temporary, unsaved copies of the focused request and open them as tabs; menu enables/disables based on focused tab type.

* **Bug Fixes**
  * Duplication failures now show an error toast with a descriptive message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->