### PR TITLE
feat: allow duplicate http names by method

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
@@ -8,6 +8,7 @@ import { renameItem, saveRequest, closeTabs } from 'providers/ReduxStore/slices/
 import path from 'utils/common/path';
 import { IconArrowBackUp, IconEdit, IconCaretDown } from '@tabler/icons';
 import { sanitizeName, validateName, validateNameError } from 'utils/common/regex';
+import { getHttpRequestFilenameBase } from 'utils/common/requestFilename';
 import toast from 'react-hot-toast';
 import Help from 'components/Help';
 import PathDisplay from 'components/PathDisplay';
@@ -25,6 +26,10 @@ const RenameCollectionItem = ({ collectionUid, item, onClose }) => {
   const itemName = item?.name;
   const itemType = item?.type;
   const itemFilename = item?.filename ? path.parse(item?.filename).name : '';
+  const isHttpRequest = itemType === 'http-request';
+  const expectedHttpFilename = isHttpRequest ? getHttpRequestFilenameBase(itemName, item?.request?.method) : null;
+  const hasCustomFilename = isHttpRequest && itemFilename !== expectedHttpFilename;
+  const [isFilenameManuallyEdited, setFilenameManuallyEdited] = useState(hasCustomFilename);
   const [showFilesystemName, toggleShowFilesystemName] = useState(false);
 
   const dropdownTippyRef = useRef();
@@ -127,7 +132,12 @@ const RenameCollectionItem = ({ collectionUid, item, onClose }) => {
                 spellCheck="false"
                 onChange={(e) => {
                   formik.setFieldValue('name', e.target.value);
-                  !isEditing && formik.setFieldValue('filename', sanitizeName(e.target.value));
+                  if (!isFilenameManuallyEdited) {
+                    const filename = isHttpRequest
+                      ? getHttpRequestFilenameBase(e.target.value, item?.request?.method)
+                      : sanitizeName(e.target.value);
+                    formik.setFieldValue('filename', filename);
+                  }
                 }}
                 value={formik.values.name || ''}
               />
@@ -185,7 +195,10 @@ const RenameCollectionItem = ({ collectionUid, item, onClose }) => {
                       autoCorrect="off"
                       autoCapitalize="off"
                       spellCheck="false"
-                      onChange={formik.handleChange}
+                      onChange={(e) => {
+                        setFilenameManuallyEdited(true);
+                        formik.handleChange(e);
+                      }}
                       value={formik.values.filename || ''}
                     />
                     {itemType !== 'folder' && <span className="absolute right-2 top-4 flex justify-center items-center file-extension">.{collection?.format || 'bru'}</span>}

--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -3,7 +3,6 @@ import get from 'lodash/get';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import toast from 'react-hot-toast';
-import path from 'utils/common/path';
 import { uuid } from 'utils/common';
 import Modal from 'components/Modal';
 import { useDispatch, useSelector } from 'react-redux';
@@ -14,7 +13,8 @@ import HttpMethodSelector from 'components/RequestPane/QueryUrl/HttpMethodSelect
 import { getDefaultRequestPaneTab } from 'utils/collections';
 import { getRequestFromCurlCommand } from 'utils/curl';
 import { IconArrowBackUp, IconCaretDown, IconEdit } from '@tabler/icons';
-import { sanitizeName, validateName, validateNameError } from 'utils/common/regex';
+import { validateName, validateNameError } from 'utils/common/regex';
+import { getRequestFilenameBase } from 'utils/common/requestFilename';
 import Dropdown from 'components/Dropdown';
 import PathDisplay from 'components/PathDisplay';
 import Portal from 'components/Portal';
@@ -55,19 +55,23 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
   });
 
   // This function analyzes a given cURL command string and determines whether the request is a GraphQL or HTTP request.
-  const identifyCurlRequestType = (url, headers, body) => {
+  const getCurlRequestType = (url, headers, body) => {
     if (url.endsWith('/graphql')) {
-      setCurlRequestTypeDetected('graphql-request');
-      return;
+      return 'graphql-request';
     }
 
     const contentType = headers?.find((h) => h.name.toLowerCase() === 'content-type')?.value;
     if (contentType && contentType.includes('application/graphql')) {
-      setCurlRequestTypeDetected('graphql-request');
-      return;
+      return 'graphql-request';
     }
 
-    setCurlRequestTypeDetected('http-request');
+    return 'http-request';
+  };
+
+  const identifyCurlRequestType = (url, headers, body) => {
+    const requestType = getCurlRequestType(url, headers, body);
+    setCurlRequestTypeDetected(requestType);
+    return requestType;
   };
 
   const curlRequestTypeChange = (type) => {
@@ -75,6 +79,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
   };
 
   const [isEditing, toggleEditing] = useState(false);
+  const [isFilenameManuallyEdited, setFilenameManuallyEdited] = useState(false);
 
   const getRequestType = (collectionPresets) => {
     if (!collectionPresets || !collectionPresets.requestType) {
@@ -149,7 +154,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
     onSubmit: (values) => {
       const isGrpcRequest = values.requestType === 'grpc-request';
       const isWsRequest = values.requestType === 'ws-request';
-      const filename = values.filename;
+      let filename = values.filename;
 
       if (isGrpcRequest) {
         dispatch(
@@ -211,6 +216,13 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
       } else if (values.requestType === 'from-curl') {
         const request = getRequestFromCurlCommand(values.curlCommand, curlRequestTypeDetected);
         const settings = { encodeUrl: false };
+        filename = isFilenameManuallyEdited
+          ? values.filename
+          : getRequestFilenameBase({
+              requestName: values.requestName,
+              requestMethod: request.method,
+              requestType: curlRequestTypeDetected || 'http-request'
+            });
 
         dispatch(
           newHttpRequest({
@@ -261,6 +273,25 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
 
   const onSubmit = () => formik.handleSubmit();
 
+  const setAutoFilename = ({
+    requestName = formik.values.requestName,
+    requestMethod = formik.values.requestMethod,
+    requestType = formik.values.requestType
+  }) => {
+    if (isFilenameManuallyEdited) {
+      return;
+    }
+
+    const filenameRequestType = requestType === 'from-curl' ? curlRequestTypeDetected || 'http-request' : requestType;
+    formik.setFieldValue('filename', getRequestFilenameBase({ requestName, requestMethod, requestType: filenameRequestType }));
+  };
+
+  const handleRequestTypeChange = (event) => {
+    const requestType = event.target.value;
+    formik.setFieldValue('requestType', requestType);
+    setAutoFilename({ requestType });
+  };
+
   const handlePaste = useCallback(
     (event) => {
       const clipboardData = event.clipboardData || window.clipboardData;
@@ -276,14 +307,24 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
         // Identify the request type
         const request = getRequestFromCurlCommand(pastedData);
         if (request) {
-          identifyCurlRequestType(request.url, request.headers, request.body);
+          const requestType = identifyCurlRequestType(request.url, request.headers, request.body);
+          if (!isFilenameManuallyEdited) {
+            formik.setFieldValue(
+              'filename',
+              getRequestFilenameBase({
+                requestName: formik.values.requestName,
+                requestMethod: request.method,
+                requestType
+              })
+            );
+          }
         }
 
         // Prevent the default paste behavior to avoid pasting into the textarea
         event.preventDefault();
       }
     },
-    [formik]
+    [formik, isFilenameManuallyEdited, curlRequestTypeDetected]
   );
 
   const handleCurlCommandChange = (event) => {
@@ -293,7 +334,17 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
       const curlCommand = event.target.value;
       const request = getRequestFromCurlCommand(curlCommand);
       if (request) {
-        identifyCurlRequestType(request.url, request.headers, request.body);
+        const requestType = identifyCurlRequestType(request.url, request.headers, request.body);
+        if (!isFilenameManuallyEdited) {
+          formik.setFieldValue(
+            'filename',
+            getRequestFilenameBase({
+              requestName: formik.values.requestName,
+              requestMethod: request.method,
+              requestType
+            })
+          );
+        }
       }
     }
   };
@@ -331,7 +382,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="http-request"
                       checked={formik.values.requestType === 'http-request'}
-                      onChange={formik.handleChange}
+                      onChange={handleRequestTypeChange}
                       data-testid="http-request"
                     />
                     <label htmlFor="http-request" className="ml-1 cursor-pointer select-none">
@@ -345,7 +396,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="graphql-request"
                       checked={formik.values.requestType === 'graphql-request'}
-                      onChange={formik.handleChange}
+                      onChange={handleRequestTypeChange}
                       data-testid="graphql-request"
                     />
                     <label htmlFor="graphql-request" className="ml-1 cursor-pointer select-none">
@@ -362,7 +413,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="grpc-request"
                       checked={formik.values.requestType === 'grpc-request'}
-                      onChange={formik.handleChange}
+                      onChange={handleRequestTypeChange}
                       data-testid="grpc-request"
                     />
                     <label htmlFor="grpc-request" className="ml-1 cursor-pointer select-none">
@@ -377,7 +428,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="ws-request"
                       checked={formik.values.requestType === 'ws-request'}
-                      onChange={formik.handleChange}
+                      onChange={handleRequestTypeChange}
                       data-testid="ws-request"
                     />
                     <label htmlFor="ws-request" className="ml-1 cursor-pointer select-none">
@@ -394,7 +445,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       name="requestType"
                       value="from-curl"
                       checked={formik.values.requestType === 'from-curl'}
-                      onChange={formik.handleChange}
+                      onChange={handleRequestTypeChange}
                       data-testid="from-curl"
                     />
                     <label htmlFor="from-curl" className="ml-1 cursor-pointer select-none">
@@ -421,7 +472,7 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                 spellCheck="false"
                 onChange={(e) => {
                   formik.setFieldValue('requestName', e.target.value);
-                  !isEditing && formik.setFieldValue('filename', sanitizeName(e.target.value));
+                  setAutoFilename({ requestName: e.target.value });
                 }}
                 value={formik.values.requestName || ''}
                 data-testid="request-name"
@@ -471,7 +522,10 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       autoCorrect="off"
                       autoCapitalize="off"
                       spellCheck="false"
-                      onChange={formik.handleChange}
+                      onChange={(e) => {
+                        setFilenameManuallyEdited(true);
+                        formik.handleChange(e);
+                      }}
                       value={formik.values.filename || ''}
                       data-testid="file-name"
                     />
@@ -500,7 +554,10 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
                       <div className="flex items-center h-full method-selector-container">
                         <HttpMethodSelector
                           method={formik.values.requestMethod}
-                          onMethodSelect={(val) => formik.setFieldValue('requestMethod', val)}
+                          onMethodSelect={(val) => {
+                            formik.setFieldValue('requestMethod', val);
+                            setAutoFilename({ requestMethod: val });
+                          }}
                           showCaret
                         />
                       </div>

--- a/packages/bruno-app/src/utils/common/requestFilename.js
+++ b/packages/bruno-app/src/utils/common/requestFilename.js
@@ -1,0 +1,26 @@
+import path from './path';
+import { sanitizeName } from './regex';
+
+export const getHttpRequestFilenameBase = (requestName, method = 'GET') => {
+  const sanitizedRequestName = sanitizeName(requestName || '') || 'request';
+  const normalizedMethod = String(method || 'GET').trim().toUpperCase() || 'GET';
+  return sanitizeName(`${normalizedMethod} ${sanitizedRequestName}`);
+};
+
+export const getRequestFilenameBase = ({ requestName, requestMethod, requestType }) => {
+  if (requestType === 'http-request') {
+    return getHttpRequestFilenameBase(requestName, requestMethod);
+  }
+
+  return sanitizeName(requestName || '');
+};
+
+export const normalizeRequestFilename = (filename, format = 'bru') => {
+  const targetExtension = format === 'yml' ? 'yml' : 'bru';
+  const extension = path.extname(filename || '').toLowerCase();
+  const baseName = ['.bru', '.yml', '.yaml'].includes(extension)
+    ? path.basename(filename, extension)
+    : filename;
+
+  return `${sanitizeName(baseName || 'request')}.${targetExtension}`;
+};

--- a/packages/bruno-app/src/utils/common/requestFilename.spec.js
+++ b/packages/bruno-app/src/utils/common/requestFilename.spec.js
@@ -1,0 +1,14 @@
+import { getHttpRequestFilenameBase, normalizeRequestFilename } from './requestFilename';
+
+describe('request filename helpers', () => {
+  it('generates method-aware HTTP request filenames from display names', () => {
+    expect(getHttpRequestFilenameBase('/projects', 'GET')).toBe('GET projects');
+    expect(getHttpRequestFilenameBase('/projects', 'POST')).toBe('POST projects');
+    expect(getHttpRequestFilenameBase('/projects/{id}', 'PUT')).toBe('PUT projects-{id}');
+  });
+
+  it('normalizes request filename extensions for collection format', () => {
+    expect(normalizeRequestFilename('GET projects.bru', 'yml')).toBe('GET projects.yml');
+    expect(normalizeRequestFilename('POST projects', 'bru')).toBe('POST projects.bru');
+  });
+});

--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -3,6 +3,7 @@ const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const { sanitizeName } = require('./filesystem');
+const { getUniqueRequestFilename } = require('./request-filename');
 const { parseRequest, parseCollection, parseFolder, stringifyCollection, stringifyFolder, stringifyEnvironment, stringifyRequest } = require('@usebruno/filestore');
 const constants = require('../constants');
 const chalk = require('chalk');
@@ -11,7 +12,7 @@ const FORMAT_CONFIG = {
   yml: { ext: '.yml', collectionFile: 'opencollection.yml', folderFile: 'folder.yml' },
   bru: { ext: '.bru', collectionFile: 'collection.bru', folderFile: 'folder.bru' }
 };
-const REQUEST_ITEM_TYPES = ['http-request', 'graphql-request'];
+const REQUEST_ITEM_TYPES = ['http-request', 'graphql-request', 'grpc-request', 'ws-request'];
 
 const getCollectionFormat = (collectionPath) => {
   if (fs.existsSync(path.join(collectionPath, 'opencollection.yml'))) return 'yml';
@@ -596,6 +597,7 @@ const createCollectionFromBrunoObject = async (collection, dirPath, options = {}
  */
 const processCollectionItems = async (items = [], currentPath, options = {}) => {
   const { format = 'bru' } = options;
+  const filenamesInFolder = new Set();
   for (const item of items) {
     if (item.type === 'folder') {
       // Create folder
@@ -620,18 +622,10 @@ const processCollectionItems = async (items = [], currentPath, options = {}) => 
       }
     } else if (REQUEST_ITEM_TYPES.includes(item.type)) {
       // Create request file
-      let sanitizedFilename;
-      if (format == 'yml') {
-        sanitizedFilename = sanitizeName(item?.filename || `${item.name}.yml`);
-        if (!sanitizedFilename.endsWith('.yml')) {
-          sanitizedFilename += '.yml';
-        }
-      } else {
-        sanitizedFilename = sanitizeName(item?.filename || `${item.name}.bru`);
-        if (!sanitizedFilename.endsWith('.bru')) {
-          sanitizedFilename += '.bru';
-        }
-      }
+      let sanitizedFilename = getUniqueRequestFilename(item, format, (filename) => {
+        return filenamesInFolder.has(filename) || fs.existsSync(path.join(currentPath, filename));
+      });
+      filenamesInFolder.add(sanitizedFilename);
 
       // Convert to YML format
       const itemJson = {

--- a/packages/bruno-cli/src/utils/request-filename.js
+++ b/packages/bruno-cli/src/utils/request-filename.js
@@ -1,0 +1,68 @@
+const path = require('path');
+
+const REQUEST_EXTENSIONS = ['.bru', '.yml', '.yaml'];
+const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g;
+
+const sanitizeName = (name = '') => {
+  return String(name)
+    .replace(invalidCharacters, '-')
+    .replace(/^[\s\-]+/, '')
+    .replace(/[.\s]+$/, '');
+};
+
+const getRequestExtension = (format = 'bru') => (format === 'yml' ? 'yml' : 'bru');
+
+const getHttpRequestFilenameBase = (requestName, method = 'GET') => {
+  const sanitizedRequestName = sanitizeName(requestName || '') || 'request';
+  const normalizedMethod = String(method || 'GET').trim().toUpperCase() || 'GET';
+  return sanitizeName(`${normalizedMethod} ${sanitizedRequestName}`);
+};
+
+const normalizeRequestFilename = (filename, format = 'bru') => {
+  const targetExtension = getRequestExtension(format);
+  const extension = path.extname(filename || '').toLowerCase();
+  const baseName = REQUEST_EXTENSIONS.includes(extension)
+    ? path.basename(filename, extension)
+    : filename;
+
+  return `${sanitizeName(baseName || 'request')}.${targetExtension}`;
+};
+
+const getRequestFilename = (item, format = 'bru') => {
+  if (item?.filename) {
+    return normalizeRequestFilename(item.filename, format);
+  }
+
+  if (item?.type === 'http-request') {
+    return normalizeRequestFilename(getHttpRequestFilenameBase(item.name, item.request?.method), format);
+  }
+
+  return normalizeRequestFilename(item?.name || 'request', format);
+};
+
+const getUniqueRequestFilename = (item, format, checkExists) => {
+  const extension = getRequestExtension(format);
+  const filename = getRequestFilename(item, format);
+  const baseName = path.basename(filename, `.${extension}`);
+
+  if (!checkExists(filename)) {
+    return filename;
+  }
+
+  let counter = 1;
+  let uniqueFilename = `${baseName} ${counter}.${extension}`;
+
+  while (checkExists(uniqueFilename)) {
+    counter++;
+    uniqueFilename = `${baseName} ${counter}.${extension}`;
+  }
+
+  return uniqueFilename;
+};
+
+module.exports = {
+  getHttpRequestFilenameBase,
+  getRequestFilename,
+  getUniqueRequestFilename,
+  normalizeRequestFilename
+};

--- a/packages/bruno-converters/src/openapi/openapi-common.js
+++ b/packages/bruno-converters/src/openapi/openapi-common.js
@@ -535,7 +535,7 @@ export const groupRequestsByTags = (requests) => {
 /**
  * Groups requests by URL path segments and builds nested folder structures
  * @param {Array} requests - Array of parsed request objects
- * @param {Function} transformFn - Function to transform a request into a Bruno item: (request, usedNames, options) => brunoItem
+ * @param {Function} transformFn - Function to transform a request into a Bruno item: (request, usedFilenames, options) => brunoItem
  * @param {Object} options - Import options
  * @returns {Array} Array of Bruno folder items
  */
@@ -597,9 +597,9 @@ export const groupRequestsByPath = (requests, transformFn, options = {}) => {
 
   // Convert the nested structure to Bruno folder format
   const buildFolderStructure = (group) => {
-    // Create a new usedNames set for each folder/subfolder scope
-    const localUsedNames = new Set();
-    const items = group.requests.map((req) => transformFn(req, localUsedNames, options));
+    // Create a new filename namespace for each folder/subfolder scope
+    const localUsedFilenames = new Set();
+    const items = group.requests.map((req) => transformFn(req, localUsedFilenames, options));
 
     // Add sub-folders
     const subFolders = [];

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -11,6 +11,7 @@ import {
   groupRequestsByTags,
   groupRequestsByPath
 } from './openapi-common';
+import { getUniqueHttpRequestFilename } from '../utils/request-filename';
 
 const getContentLevelExample = (bodyContent) => {
   if (bodyContent.example !== undefined) return bodyContent.example;
@@ -158,7 +159,7 @@ const getParameterEntries = (param) => {
   return [{ value, enabled }];
 };
 
-const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {}) => {
+const transformOpenapiRequestItem = (request, usedFilenames = new Set(), options = {}) => {
   let _operationObject = request.operationObject;
 
   let operationName = _operationObject.summary || _operationObject.operationId || _operationObject.description;
@@ -171,28 +172,13 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
     // Replace line breaks and normalize whitespace
     operationName = operationName.replace(/[\r\n\s]+/g, ' ').trim();
   }
-  if (usedNames.has(operationName)) {
-    // Make name unique to prevent filename collisions
-    // Try adding method info first
-    let uniqueName = `${operationName} (${request.method.toUpperCase()})`;
-
-    // If still not unique, add counter
-    let counter = 1;
-    while (usedNames.has(uniqueName)) {
-      uniqueName = `${operationName} (${counter})`;
-      counter++;
-    }
-
-    operationName = uniqueName;
-  }
-  usedNames.add(operationName);
-
   // replace OpenAPI links in path by Bruno variables
   let path = request.path.replace(/{([a-zA-Z]+)}/g, `{{${_operationObject.operationId}_$1}}`);
 
   const brunoRequestItem = {
     uid: uuid(),
     name: operationName,
+    filename: getUniqueHttpRequestFilename(operationName, request.method, usedFilenames),
     type: 'http-request',
     tags: sanitizeTags(request.operationObject.tags || [], options),
     request: {
@@ -792,7 +778,6 @@ const openAPIRuntimeExpressionToScript = (expression) => {
 };
 
 export const parseOpenApiCollection = (data, options = {}) => {
-  const usedNames = new Set();
   const brunoCollection = {
     name: '',
     uid: uuid(),
@@ -882,6 +867,7 @@ export const parseOpenApiCollection = (data, options = {}) => {
       // Default tag-based grouping
       let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
       let brunoFolders = groups.map((group) => {
+        const usedFilenames = new Set();
         return {
           uid: uuid(),
           name: group.name,
@@ -901,11 +887,12 @@ export const parseOpenApiCollection = (data, options = {}) => {
               name: group.name
             }
           },
-          items: group.requests.map((req) => transformOpenapiRequestItem(req, usedNames, options))
+          items: group.requests.map((req) => transformOpenapiRequestItem(req, usedFilenames, options))
         };
       });
 
-      let ungroupedItems = ungroupedRequests.map((req) => transformOpenapiRequestItem(req, usedNames, options));
+      const usedFilenames = new Set();
+      let ungroupedItems = ungroupedRequests.map((req) => transformOpenapiRequestItem(req, usedFilenames, options));
       let brunoCollectionItems = brunoFolders.concat(ungroupedItems);
       brunoCollection.items = brunoCollectionItems;
     }

--- a/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
@@ -13,6 +13,7 @@ import {
   groupRequestsByTags,
   groupRequestsByPath
 } from './openapi-common';
+import { getUniqueHttpRequestFilename } from '../utils/request-filename';
 
 /**
  * Gets the value for a Swagger 2.0 parameter based on example, default, or enum
@@ -120,11 +121,11 @@ const addParamToRequest = (brunoRequestItem, location, name, value, description,
 /**
  * Transforms a single Swagger 2.0 operation into a Bruno request item
  * @param {Object} request - The parsed request object with operationObject, method, path, global
- * @param {Set} usedNames - Set of already-used operation names (for deduplication)
+ * @param {Set} usedFilenames - Set of already-used request filenames in the current folder
  * @param {Object} options - Import options
  * @returns {Object} Bruno request item
  */
-const transformSwaggerRequestItem = (request, usedNames = new Set(), options = {}) => {
+const transformSwaggerRequestItem = (request, usedFilenames = new Set(), options = {}) => {
   const op = request.operationObject;
   const consumes = op.consumes || request.global.consumes || ['application/json'];
   const produces = op.produces || request.global.produces || ['application/json'];
@@ -136,23 +137,12 @@ const transformSwaggerRequestItem = (request, usedNames = new Set(), options = {
   // Sanitize operation name to prevent Bruno parsing issues
   if (operationName) operationName = operationName.replace(/[\r\n\s]+/g, ' ').trim();
 
-  // Make names unique to prevent filename collisions
-  if (usedNames.has(operationName)) {
-    let uniqueName = `${operationName} (${request.method.toUpperCase()})`;
-    let counter = 1;
-    while (usedNames.has(uniqueName)) {
-      uniqueName = `${operationName} (${counter})`;
-      counter++;
-    }
-    operationName = uniqueName;
-  }
-  usedNames.add(operationName);
-
   let path = request.path;
 
   const brunoRequestItem = {
     uid: uuid(),
     name: operationName,
+    filename: getUniqueHttpRequestFilename(operationName, request.method, usedFilenames),
     type: 'http-request',
     tags: sanitizeTags(op.tags || [], options),
     request: {
@@ -537,7 +527,6 @@ const buildCollectionAuth = (def) => {
  * @returns {Object} Bruno collection
  */
 export const parseSwagger2Collection = (data, options = {}) => {
-  const usedNames = new Set();
   const brunoCollection = {
     name: '',
     uid: uuid(),
@@ -611,20 +600,24 @@ export const parseSwagger2Collection = (data, options = {}) => {
       brunoCollection.items = groupRequestsByPath(allRequests, transformSwaggerRequestItem, options);
     } else {
       let [groups, ungroupedRequests] = groupRequestsByTags(allRequests);
-      let brunoFolders = groups.map((group) => ({
-        uid: uuid(),
-        name: group.name,
-        type: 'folder',
-        root: {
-          request: {
-            auth: { mode: 'inherit', basic: null, bearer: null, digest: null, apikey: null, oauth2: null }
+      let brunoFolders = groups.map((group) => {
+        const usedFilenames = new Set();
+        return {
+          uid: uuid(),
+          name: group.name,
+          type: 'folder',
+          root: {
+            request: {
+              auth: { mode: 'inherit', basic: null, bearer: null, digest: null, apikey: null, oauth2: null }
+            },
+            meta: { name: group.name }
           },
-          meta: { name: group.name }
-        },
-        items: group.requests.map((req) => transformSwaggerRequestItem(req, usedNames, options))
-      }));
+          items: group.requests.map((req) => transformSwaggerRequestItem(req, usedFilenames, options))
+        };
+      });
 
-      let ungroupedItems = ungroupedRequests.map((req) => transformSwaggerRequestItem(req, usedNames, options));
+      const usedFilenames = new Set();
+      let ungroupedItems = ungroupedRequests.map((req) => transformSwaggerRequestItem(req, usedFilenames, options));
       brunoCollection.items = brunoFolders.concat(ungroupedItems);
     }
 

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -4,6 +4,7 @@ import { transformExampleStatusInCollection } from '@usebruno/common';
 import each from 'lodash/each';
 import postmanTranslation from './postman-translations';
 import { invalidVariableCharacterRegex } from '../constants/index';
+import { getUniqueHttpRequestFilename } from '../utils/request-filename';
 
 const AUTH_TYPES = Object.freeze({
   BASIC: 'basic',
@@ -366,7 +367,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
 const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false } = {}, scriptMap) => {
   brunoParent.items = brunoParent.items || [];
   const folderMap = {};
-  const requestMap = {};
+  const usedRequestFilenames = new Set();
 
   item.forEach((i, index) => {
     if (isItemAFolder(i)) {
@@ -438,19 +439,15 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
       }
 
       const baseRequestName = i.name || 'Untitled Request';
-      let requestName = baseRequestName;
-      let count = 1;
-
-      while (requestMap[requestName]) {
-        requestName = `${baseRequestName}_${count}`;
-        count++;
-      }
+      const requestName = baseRequestName;
+      const filename = getUniqueHttpRequestFilename(requestName, method, usedRequestFilenames);
 
       const url = constructUrl(i.request.url);
 
       const brunoRequestItem = {
         uid: uuid(),
         name: requestName,
+        filename,
         type: 'http-request',
         seq: index + 1,
         request: {
@@ -800,8 +797,6 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
           brunoRequestItem.examples.push(example);
         });
       }
-
-      requestMap[requestName] = brunoRequestItem;
     }
   });
 };

--- a/packages/bruno-converters/src/utils/request-filename.js
+++ b/packages/bruno-converters/src/utils/request-filename.js
@@ -1,0 +1,28 @@
+const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g;
+
+export const sanitizeRequestFilename = (name = '') => {
+  return String(name)
+    .replace(invalidCharacters, '-')
+    .replace(/^[\s\-]+/, '')
+    .replace(/[.\s]+$/, '');
+};
+
+export const getHttpRequestFilenameBase = (requestName, method = 'GET') => {
+  const sanitizedRequestName = sanitizeRequestFilename(requestName) || 'request';
+  const normalizedMethod = String(method || 'GET').trim().toUpperCase() || 'GET';
+  return sanitizeRequestFilename(`${normalizedMethod} ${sanitizedRequestName}`);
+};
+
+export const getUniqueHttpRequestFilename = (requestName, method, usedFilenames = new Set()) => {
+  const baseName = getHttpRequestFilenameBase(requestName, method);
+  let filename = baseName;
+  let counter = 1;
+
+  while (usedFilenames.has(filename)) {
+    filename = `${baseName} ${counter}`;
+    counter++;
+  }
+
+  usedFilenames.add(filename);
+  return filename;
+};

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-to-bruno.spec.js
@@ -116,6 +116,32 @@ servers:
     expect(result.name).toBe('Untitled Collection');
   });
 
+  it('keeps duplicate operation display names clean when HTTP methods differ', () => {
+    const result = openApiToBruno({
+      openapi: '3.0.0',
+      info: { title: 'Projects API', version: '1.0.0' },
+      paths: {
+        '/projects': {
+          get: {
+            summary: '/projects',
+            responses: { 200: { description: 'OK' } }
+          },
+          post: {
+            summary: '/projects',
+            responses: { 201: { description: 'Created' } }
+          }
+        }
+      }
+    });
+
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: '/projects', filename: 'GET projects', request: expect.objectContaining({ method: 'GET' }) }),
+        expect.objectContaining({ name: '/projects', filename: 'POST projects', request: expect.objectContaining({ method: 'POST' }) })
+      ])
+    );
+  });
+
   describe('authentication inheritance', () => {
     it('should set auth mode to inherit when no security is defined', () => {
       const openApiWithoutSecurity = `

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-to-bruno.spec.js
@@ -72,6 +72,33 @@ paths:
     expect(collection.environments.length).toBeGreaterThan(0);
   });
 
+  it('keeps duplicate operation display names clean when HTTP methods differ', () => {
+    const collection = swagger2ToBruno({
+      swagger: '2.0',
+      info: { title: 'Projects API', version: '1.0' },
+      host: 'api.example.com',
+      paths: {
+        '/projects': {
+          get: {
+            summary: '/projects',
+            responses: { 200: { description: 'OK' } }
+          },
+          post: {
+            summary: '/projects',
+            responses: { 201: { description: 'Created' } }
+          }
+        }
+      }
+    });
+
+    expect(collection.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: '/projects', filename: 'GET projects', request: expect.objectContaining({ method: 'GET' }) }),
+        expect.objectContaining({ name: '/projects', filename: 'POST projects', request: expect.objectContaining({ method: 'POST' }) })
+      ])
+    );
+  });
+
   it('trims whitespace from info.title and uses the trimmed value as the collection name', () => {
     const spec = {
       swagger: '2.0',

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
@@ -27,6 +27,38 @@ describe('postman-collection', () => {
     ]);
   });
 
+  it('keeps duplicate request display names clean when HTTP methods differ', async () => {
+    const brunoCollection = await postmanToBruno({
+      info: {
+        name: 'Projects API',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: '/projects',
+          request: {
+            method: 'GET',
+            url: 'https://api.example.com/projects'
+          }
+        },
+        {
+          name: '/projects',
+          request: {
+            method: 'POST',
+            url: 'https://api.example.com/projects'
+          }
+        }
+      ]
+    });
+
+    expect(brunoCollection.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: '/projects', filename: 'GET projects', request: expect.objectContaining({ method: 'GET' }) }),
+        expect.objectContaining({ name: '/projects', filename: 'POST projects', request: expect.objectContaining({ method: 'POST' }) })
+      ])
+    );
+  });
+
   it('should handle falsy values in collection variables', async () => {
     const collectionWithFalsyVars = {
       info: {

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -59,6 +59,7 @@ const {
 } = require('../utils/filesystem');
 const { openCollectionDialog, openCollectionsByPathname, registerScratchCollectionPath } = require('../app/collections');
 const { generateUidBasedOnHash, stringifyJson, safeStringifyJSON, safeParseJSON } = require('../utils/common');
+const { getUniqueRequestFilename } = require('../utils/request-filename');
 const { moveRequestUid, deleteRequestUid, syncExampleUidsCache } = require('../cache/requestUids');
 const { deleteCookiesForDomain, getDomainsWithCookies, addCookieForDomain, modifyCookieForDomain, parseCookieString, createCookieString, deleteCookie } = require('../utils/cookies');
 const EnvironmentSecretsStore = require('../store/env-secrets');
@@ -1156,22 +1157,15 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           coll.name = uniqueName;
         }
 
-        const getFilenameWithFormat = (item, format) => {
-          if (item?.filename) {
-            const ext = path.extname(item.filename);
-            if (ext === '.bru' || ext === '.yml') {
-              return item.filename.replace(ext, `.${format}`);
-            }
-            return item.filename;
-          }
-          return `${item.name}.${format}`;
-        };
-
         // Recursive function to parse the collection items and create files/folders
         const parseCollectionItems = async (items = [], currentPath) => {
-          await Promise.all(items.map(async (item) => {
+          const filenamesInFolder = new Set();
+          for (const item of items) {
             if (['http-request', 'graphql-request', 'grpc-request', 'ws-request'].includes(item.type)) {
-              let sanitizedFilename = sanitizeName(getFilenameWithFormat(item, format));
+              let sanitizedFilename = getUniqueRequestFilename(item, format, (filename) => {
+                return filenamesInFolder.has(filename) || fs.existsSync(path.join(currentPath, filename));
+              });
+              filenamesInFolder.add(sanitizedFilename);
               const content = await stringifyRequestViaWorker(item, { format });
               const filePath = path.join(currentPath, sanitizedFilename);
               safeWriteFileSync(filePath, content);
@@ -1198,7 +1192,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               const filePath = path.join(currentPath, sanitizedFilename);
               safeWriteFileSync(filePath, item.fileContent);
             }
-          }));
+          }
         };
 
         const parseEnvironments = async (environments = [], collectionPath) => {
@@ -1328,14 +1322,16 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       const format = getCollectionFormat(collectionPathname);
 
       // Recursive function to parse the folder and create files/folders
-      const parseCollectionItems = (items = [], currentPath) => {
-        items.forEach(async (item) => {
-          if (['http-request', 'graphql-request', 'grpc-request'].includes(item.type)) {
+      const parseCollectionItems = async (items = [], currentPath) => {
+        const filenamesInFolder = new Set();
+        for (const item of items) {
+          if (['http-request', 'graphql-request', 'grpc-request', 'ws-request'].includes(item.type)) {
             const content = await stringifyRequestViaWorker(item, { format });
 
-            // Use the correct file extension based on target format
-            const baseName = path.parse(item.filename).name;
-            const newFilename = format === 'yml' ? `${baseName}.yml` : `${baseName}.bru`;
+            const newFilename = getUniqueRequestFilename(item, format, (filename) => {
+              return filenamesInFolder.has(filename) || fs.existsSync(path.join(currentPath, filename));
+            });
+            filenamesInFolder.add(newFilename);
             const filePath = path.join(currentPath, newFilename);
 
             safeWriteFileSync(filePath, content);
@@ -1355,10 +1351,10 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             }
 
             if (item.items && item.items.length) {
-              parseCollectionItems(item.items, folderPath);
+              await parseCollectionItems(item.items, folderPath);
             }
           }
-        });
+        }
       };
 
       await createDirectory(collectionPath);

--- a/packages/bruno-electron/src/ipc/openapi-sync.js
+++ b/packages/bruno-electron/src/ipc/openapi-sync.js
@@ -13,6 +13,7 @@ const {
 } = require('@usebruno/filestore');
 const { openApiToBruno } = require('@usebruno/converters');
 const { writeFile, sanitizeName, getCollectionFormat, posixifyPath } = require('../utils/filesystem');
+const { getUniqueRequestFilename } = require('../utils/request-filename');
 const { getEnvVars } = require('../utils/collection');
 const { getProcessEnvVars } = require('../store/process-env');
 const { getCertsAndProxyConfig } = require('./network/cert-utils');
@@ -1241,7 +1242,7 @@ const registerOpenAPISyncIpc = (mainWindow) => {
           }
 
           const requestContent = await stringifyRequestViaWorker(specItem, { format });
-          const sanitizedFilename = `${sanitizeName(specItem.name || path.basename(specItem.filename || '', `.${format}`))}.${format}`;
+          const sanitizedFilename = getUniqueRequestFilename(specItem, format, (filename) => fs.existsSync(path.join(targetFolder, filename)));
           await writeFile(path.join(targetFolder, sanitizedFilename), requestContent);
         }
 
@@ -1372,7 +1373,7 @@ const registerOpenAPISyncIpc = (mainWindow) => {
               }
 
               const requestContent = await stringifyRequestViaWorker(newItem, { format });
-              const sanitizedFilename = `${sanitizeName(newItem.name || path.basename(newItem.filename || '', `.${format}`))}.${format}`;
+              const sanitizedFilename = getUniqueRequestFilename(newItem, format, (filename) => fs.existsSync(path.join(targetFolder, filename)));
               await writeFile(path.join(targetFolder, sanitizedFilename), requestContent);
             }
           }
@@ -1618,7 +1619,7 @@ const registerOpenAPISyncIpc = (mainWindow) => {
           }
 
           const requestContent = await stringifyRequestViaWorker(specItem, { format });
-          const sanitizedFilename = `${sanitizeName(specItem.name || path.basename(specItem.filename || '', `.${format}`))}.${format}`;
+          const sanitizedFilename = getUniqueRequestFilename(specItem, format, (filename) => fs.existsSync(path.join(targetFolder, filename)));
           await writeFile(path.join(targetFolder, sanitizedFilename), requestContent);
           addedCount++;
         }

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -2,6 +2,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { ipcMain } = require('electron');
 const { sanitizeName, createDirectory, writeFile, safeWriteFileSync, getCollectionStats } = require('./filesystem');
+const { getUniqueRequestFilename } = require('./request-filename');
 const { generateUidBasedOnHash, stringifyJson } = require('./common');
 const { stringifyRequestViaWorker, stringifyCollection, stringifyEnvironment, stringifyFolder, DEFAULT_COLLECTION_FORMAT } = require('@usebruno/filestore');
 
@@ -35,9 +36,13 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
 
   // Recursive function to parse the collection items and create files/folders
   const parseCollectionItems = async (items = [], currentPath) => {
+    const filenamesInFolder = new Set();
     for (const item of items) {
-      if (['http-request', 'graphql-request', 'grpc-request'].includes(item.type)) {
-        let sanitizedFilename = sanitizeName(item.filename || `${item.name}.${format}`);
+      if (['http-request', 'graphql-request', 'grpc-request', 'ws-request'].includes(item.type)) {
+        let sanitizedFilename = getUniqueRequestFilename(item, format, (filename) => {
+          return filenamesInFolder.has(filename) || fs.existsSync(path.join(currentPath, filename));
+        });
+        filenamesInFolder.add(sanitizedFilename);
         const content = await stringifyRequestViaWorker(item, { format });
         const filePath = path.join(currentPath, sanitizedFilename);
         safeWriteFileSync(filePath, content);

--- a/packages/bruno-electron/src/utils/request-filename.js
+++ b/packages/bruno-electron/src/utils/request-filename.js
@@ -1,0 +1,68 @@
+const path = require('path');
+
+const REQUEST_EXTENSIONS = ['.bru', '.yml', '.yaml'];
+const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g;
+
+const sanitizeName = (name = '') => {
+  return String(name)
+    .replace(invalidCharacters, '-')
+    .replace(/^[\s\-]+/, '')
+    .replace(/[.\s]+$/, '');
+};
+
+const getRequestExtension = (format = 'bru') => (format === 'yml' ? 'yml' : 'bru');
+
+const getHttpRequestFilenameBase = (requestName, method = 'GET') => {
+  const sanitizedRequestName = sanitizeName(requestName || '') || 'request';
+  const normalizedMethod = String(method || 'GET').trim().toUpperCase() || 'GET';
+  return sanitizeName(`${normalizedMethod} ${sanitizedRequestName}`);
+};
+
+const normalizeRequestFilename = (filename, format = 'bru') => {
+  const targetExtension = getRequestExtension(format);
+  const extension = path.extname(filename || '').toLowerCase();
+  const baseName = REQUEST_EXTENSIONS.includes(extension)
+    ? path.basename(filename, extension)
+    : filename;
+
+  return `${sanitizeName(baseName || 'request')}.${targetExtension}`;
+};
+
+const getRequestFilename = (item, format = 'bru') => {
+  if (item?.filename) {
+    return normalizeRequestFilename(item.filename, format);
+  }
+
+  if (item?.type === 'http-request') {
+    return normalizeRequestFilename(getHttpRequestFilenameBase(item.name, item.request?.method), format);
+  }
+
+  return normalizeRequestFilename(item?.name || 'request', format);
+};
+
+const getUniqueRequestFilename = (item, format, checkExists) => {
+  const extension = getRequestExtension(format);
+  const filename = getRequestFilename(item, format);
+  const baseName = path.basename(filename, `.${extension}`);
+
+  if (!checkExists(filename)) {
+    return filename;
+  }
+
+  let counter = 1;
+  let uniqueFilename = `${baseName} ${counter}.${extension}`;
+
+  while (checkExists(uniqueFilename)) {
+    counter++;
+    uniqueFilename = `${baseName} ${counter}.${extension}`;
+  }
+
+  return uniqueFilename;
+};
+
+module.exports = {
+  getHttpRequestFilenameBase,
+  getRequestFilename,
+  getUniqueRequestFilename,
+  normalizeRequestFilename
+};

--- a/packages/bruno-electron/src/utils/request-filename.test.js
+++ b/packages/bruno-electron/src/utils/request-filename.test.js
@@ -1,0 +1,25 @@
+const { getHttpRequestFilenameBase, getUniqueRequestFilename, normalizeRequestFilename } = require('./request-filename');
+
+describe('request filename helpers', () => {
+  it('generates method-aware HTTP request filenames from display names', () => {
+    expect(getHttpRequestFilenameBase('/projects', 'GET')).toBe('GET projects');
+    expect(getHttpRequestFilenameBase('/projects', 'POST')).toBe('POST projects');
+    expect(getHttpRequestFilenameBase('/projects/{id}', 'PUT')).toBe('PUT projects-{id}');
+  });
+
+  it('normalizes request filename extensions for collection format', () => {
+    expect(normalizeRequestFilename('GET projects.bru', 'yml')).toBe('GET projects.yml');
+    expect(normalizeRequestFilename('POST projects', 'bru')).toBe('POST projects.bru');
+  });
+
+  it('adds counters to filenames only when paths collide', () => {
+    const existing = new Set(['GET projects.bru']);
+    const item = {
+      type: 'http-request',
+      name: '/projects',
+      request: { method: 'GET' }
+    };
+
+    expect(getUniqueRequestFilename(item, 'bru', (filename) => existing.has(filename))).toBe('GET projects 1.bru');
+  });
+});


### PR DESCRIPTION
### Description

Allows HTTP requests in the same collection folder to share the same visible display name when they use different HTTP methods.

This addresses related requests/discussions:

- Closes #3502
- Relates to #1858
- Relates to #5864

This keeps request metadata names unchanged (`meta.name` / `info.name`) and makes the filesystem filename method-aware for auto-generated HTTP request files, for example:

- `GET /projects` -> `GET projects.bru`
- `POST /projects` -> `POST projects.bru`
- `PUT /projects/{id}` -> `PUT projects-{id}.bru`

#### Screenshot
<img width="522" height="186" alt="изображение" src="https://github.com/user-attachments/assets/398612ed-e53a-4d86-87e1-9b5f9ed3405e" />


The change preserves filesystem collision protection and respects manually edited filesystem names. It also updates OpenAPI, Swagger 2, and Postman import paths so duplicate operation/request names with different methods keep clean display names while receiving unique method-aware filenames.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request filenames now auto-generate intelligently based on HTTP method and request name
  * Automatic filename updates when renaming requests, with manual editing support to disable auto-generation

* **Improvements**
  * Enhanced request deduplication prevents filename collisions when importing from Postman, OpenAPI, and Swagger collections
  * Improved naming consistency across collection imports, folder cloning, and synchronization operations ensures unique, readable filenames

<!-- end of auto-generated comment: release notes by coderabbit.ai -->