### PR TITLE
fix: Update SaveTransientRequestModal empty state when collections don't exist

### DIFF
--- a/packages/bruno-app/src/components/SaveTransientRequest/index.js
+++ b/packages/bruno-app/src/components/SaveTransientRequest/index.js
@@ -758,6 +758,17 @@ const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOp
                 New Folder
               </Button>
             )}
+            {isSelectingCollection && !newCollection.show && availableCollections.length > 0 && (
+              <Button
+                type="button"
+                color="primary"
+                variant="ghost"
+                icon={<IconFolder size={16} strokeWidth={1.5} />}
+                onClick={handleShowNewCollection}
+              >
+                New collection
+              </Button>
+            )}
           </div>
           <div className="footer-right">
             <Button type="button" color="secondary" variant="ghost" onClick={handleCancel}>

--- a/packages/bruno-app/src/components/SaveTransientRequest/index.js
+++ b/packages/bruno-app/src/components/SaveTransientRequest/index.js
@@ -547,8 +547,18 @@ const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOp
                   </ul>
                 ) : (
                   <div className="collection-empty-state">
-                    <p>No collections Yet</p>
+                    <p>No Collections Yet</p>
                     <p className="collection-empty-state-subtitle">Collections help you organize your requests. Create your first one to save this request.</p>
+                    <Button
+                      type="button"
+                      color="primary"
+                      variant="outline"
+                      icon={<IconFolder size={16} strokeWidth={1.5} />}
+                      onClick={handleShowNewCollection}
+                      className="mt-4"
+                    >
+                      New collection
+                    </Button>
                   </div>
                 )}
               </div>
@@ -746,17 +756,6 @@ const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOp
                 onClick={handleShowNewFolder}
               >
                 New Folder
-              </Button>
-            )}
-            {isSelectingCollection && !newCollection.show && (
-              <Button
-                type="button"
-                color="primary"
-                variant="ghost"
-                icon={<IconFolder size={16} strokeWidth={1.5} />}
-                onClick={handleShowNewCollection}
-              >
-                New collection
               </Button>
             )}
           </div>


### PR DESCRIPTION


### Description

- Changed the empty text from "No collections Yet" to "No Collections Yet".
- Moved the New Collection CTA to the empty state, from the footer.

JIRA: https://usebruno.atlassian.net/browse/BRU-3350

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the "no collections" empty state for consistent title casing.
  * Added a prominent primary "New collection" button (folder icon) to create collections from the empty state.
  * Streamlined the collection-selection footer by removing redundant/new collection actions when not applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->