### PR TITLE
fix: show filename validation error when filesystem name input is hidden

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
@@ -132,6 +132,10 @@ const RenameCollectionItem = ({ collectionUid, item, onClose }) => {
                 value={formik.values.name || ''}
               />
               {formik.touched.name && formik.errors.name ? <div className="text-red-500">{formik.errors.name}</div> : null}
+              {/* If the filesystem name input is not shown, but the generated filename is invalid, show the filename error here */}
+              {formik.touched.name && formik.errors.filename && !showFilesystemName ? (
+                <div className="text-red-500">{formik.errors.filename}</div>
+              ) : null}
             </div>
 
             {showFilesystemName && (


### PR DESCRIPTION
### Description

When trying to rename a request to "collection", I was not allowed to submit the form, but no error message was shown:

<img width="535" height="236" alt="bilde" src="https://github.com/user-attachments/assets/973ac843-a5be-4408-b963-e834d61e7d8b" />

The error message was only shown when I expanded the dialog to show system file name:

<img width="539" height="340" alt="bilde" src="https://github.com/user-attachments/assets/83a3ede5-08fb-4bbf-be42-c01801d5e727" />

To improve the user experience here, I made a small change so that invalid filesystem errors are shown below request name if the dialog is not expanded, like this:

<img width="551" height="269" alt="bilde" src="https://github.com/user-attachments/assets/124020ef-e7a1-4c4b-bf2c-dd52a8f4f02e" />

When the dialog is expanded, the error is still only shown once below the file name input as before.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
    I have not created an issue since this PR is very small, but let me know if I should still create one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error visibility in the rename dialog—invalid filenames now display immediately without requiring additional user interaction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7959)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->