### PR TITLE
fix: handle unquoted template variables in req.getBody parsing

### DIFF
--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -240,7 +240,14 @@ class BrunoRequest {
     try {
       return JSON.parse(str);
     } catch (e) {
-      return str;
+      try {
+        // Replace unquoted Bruno template variables with JSON-safe placeholders
+        const normalized = str.replace(/:\s*\{\{([^}]+)\}\}/g, ': "__BRUNO_VAR__$1"');
+
+        return JSON.parse(normalized);
+      } catch (err) {
+        return str;
+      }
     }
   }
 

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -241,10 +241,22 @@ class BrunoRequest {
       return JSON.parse(str);
     } catch (e) {
       try {
-        // Replace unquoted Bruno template variables with JSON-safe placeholders
-        const normalized = str.replace(/:\s*\{\{([^}]+)\}\}/g, ': "__BRUNO_VAR__$1"');
+        const placeholderPrefix = '__BRUNO_VAR__';
+        const normalized = str.replace(
+          /:\s*\{\{\s*([^}]+?)\s*\}\}/g,
+          ': "' + placeholderPrefix + '$1"'
+        );
 
-        return JSON.parse(normalized);
+        return JSON.parse(normalized, (key, value) => {
+          if (
+            typeof value === 'string' &&
+            value.startsWith(placeholderPrefix)
+          ) {
+            return `{{${value.slice(placeholderPrefix.length)}}}`;
+          }
+
+          return value;
+        });
       } catch (err) {
         return str;
       }


### PR DESCRIPTION
## Summary

Fixes inconsistent behavior in `req.getBody()` when JSON request bodies contain unquoted Bruno template variables.

Previously, payloads like:

```json
{
  "parent_foo_id": {{foo_id}}
}
```

would fail JSON parsing and cause `req.getBody()` to return a raw string instead of an object.

This change adds a fallback normalization step for unquoted Bruno template variables before parsing, preserving object return behavior for JSON request bodies.

## Changes

* Added fallback normalization logic in `__safeParseJSON`
* Preserved existing behavior for valid JSON payloads
* Maintained raw string fallback for unrecoverable parse failures

## Validation

Validated locally using isolated runtime tests with request bodies containing unquoted template variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parsing for request payloads so template variables embedded in JSON are recognized and preserved, preventing parse failures and ensuring reliable variable substitution during requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7965)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->