### PR TITLE
fix: correctly parse insomnia exported yaml

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ImportCollection/FileTab.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollection/FileTab.js
@@ -23,7 +23,7 @@ const convertFileToObject = async (file) => {
       return JSON.parse(text);
     }
 
-    const parsed = jsyaml.load(text);
+    const parsed = jsyaml.load(text, { schema: jsyaml.JSON_SCHEMA });
     if (typeof parsed !== 'object' || parsed === null) {
       throw new Error();
     }

--- a/packages/bruno-app/src/utils/importers/common.js
+++ b/packages/bruno-app/src/utils/importers/common.js
@@ -224,7 +224,7 @@ export const fetchAndValidateApiSpecFromUrl = ({ url }) => {
     ipcRenderer
       .invoke('renderer:fetch-api-spec', url)
       .then(async (res) => {
-        const data = await jsyaml.load(res);
+        const data = await jsyaml.load(res, { schema: jsyaml.JSON_SCHEMA });
         const specType = getCollectionSpecType(data);
         resolve({ data, specType, rawContent: res });
       })

--- a/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
+++ b/packages/bruno-converters/src/insomnia/insomnia-to-bruno.js
@@ -34,7 +34,7 @@ const addSuffixToDuplicateName = (item, index, allItems) => {
 const regexVariable = new RegExp('{{.*?}}', 'g');
 
 const normalizeVariables = (value) => {
-  value = value || '';
+  value = String(value ?? '');
   const variables = value.match(regexVariable) || [];
   each(variables, (variable) => {
     value = value.replace(variable, variable.replace('_.', '').replaceAll(' ', ''));

--- a/tests/import/insomnia/fixtures/insomnia-v5-dates.yaml
+++ b/tests/import/insomnia/fixtures/insomnia-v5-dates.yaml
@@ -1,0 +1,52 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Date Type Test
+meta:
+  id: wrk_date_test
+  created: 1776845227518
+  modified: 1776845227518
+collection:
+  - url: http://example.com/test
+    name: Date Request
+    meta:
+      id: req_date_test_001
+      created: 1776845260825
+      modified: 1778146479401
+      isPrivate: false
+      sortKey: -1776845260825
+    method: GET
+    parameters:
+      - name: date
+        value: 2024-01-01
+        disabled: false
+      - name: is_active
+        value: "false"
+        disabled: false
+      - name: limit
+        value: "0"
+        disabled: false
+      - name: version
+        value: "2.0"
+        disabled: false
+      - name: count
+        value: 42
+        disabled: false
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+environments:
+  name: Base
+  meta:
+    id: env_date_test_001
+    created: 1776845235974
+    modified: 1776845235974
+    isPrivate: false
+  data:
+    expiry_date: 2024-12-31
+    max_retries: "3"
+    enabled: "true"

--- a/tests/import/insomnia/import-insomnia-v5-date-types.spec.ts
+++ b/tests/import/insomnia/import-insomnia-v5-date-types.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+import * as fs from 'fs';
+import { closeAllCollections, importCollection } from '../../utils/page';
+
+test.describe('Import Insomnia Collection - date types preserved', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('should keep date-like strings and quoted values intact through the full FileTab.js import flow', async ({
+    page,
+    createTmpDir
+  }) => {
+    const insomniaFile = path.resolve(__dirname, 'fixtures', 'insomnia-v5-dates.yaml');
+    const collectionName = 'Date Type Test';
+    const collectionDir = await createTmpDir('insomnia-dates-test');
+
+    await importCollection(page, insomniaFile, collectionDir, {
+      expectedCollectionName: collectionName
+    });
+
+    const requestFilePath = path.join(collectionDir, collectionName, 'Date Request.yml');
+    const yamlContent = fs.readFileSync(requestFilePath, 'utf8');
+
+    expect(yamlContent).toContain('value: 2024-01-01');
+    expect(yamlContent).not.toContain('Mon Jan');
+    expect(yamlContent).not.toContain('GMT');
+
+    expect(yamlContent).toMatch(/value:\s*"false"/);
+    expect(yamlContent).toMatch(/value:\s*"0"/);
+    expect(yamlContent).toMatch(/value:\s*"2\.0"/);
+    expect(yamlContent).toContain('value: "42"');
+  });
+});

--- a/tests/import/insomnia/import-insomnia-v5-date-types.spec.ts
+++ b/tests/import/insomnia/import-insomnia-v5-date-types.spec.ts
@@ -23,13 +23,34 @@ test.describe('Import Insomnia Collection - date types preserved', () => {
     const requestFilePath = path.join(collectionDir, collectionName, 'Date Request.yml');
     const yamlContent = fs.readFileSync(requestFilePath, 'utf8');
 
-    expect(yamlContent).toContain('value: 2024-01-01');
-    expect(yamlContent).not.toContain('Mon Jan');
-    expect(yamlContent).not.toContain('GMT');
+    expect(yamlContent).toContain(`  params:
+    - name: date
+      value: 2024-01-01
+      type: query
+    - name: is_active
+      value: "false"
+      type: query
+    - name: limit
+      value: "0"
+      type: query
+    - name: version
+      value: "2.0"
+      type: query
+    - name: count
+      value: "42"
+      type: query
+`);
 
-    expect(yamlContent).toMatch(/value:\s*"false"/);
-    expect(yamlContent).toMatch(/value:\s*"0"/);
-    expect(yamlContent).toMatch(/value:\s*"2\.0"/);
-    expect(yamlContent).toContain('value: "42"');
+    const envFilePath = path.join(collectionDir, collectionName, 'environments', 'Base.yml');
+    const envContent = fs.readFileSync(envFilePath, 'utf8');
+
+    expect(envContent).toContain(`variables:
+  - name: expiry_date
+    value: 2024-12-31
+  - name: max_retries
+    value: "3"
+  - name: enabled
+    value: "true"
+`);
   });
 });


### PR DESCRIPTION
### Description

[Jira](https://usebruno.atlassian.net/browse/BRU-3171)

Fixes https://github.com/usebruno/bruno/issues/7687 https://github.com/usebruno/bruno/issues/6095

Insomnia yaml export didn't had quotes for string so values like: 2024-01-01 were getting parsed as date by our parser.

What this does:
- Update our file and url import flow to use JSON_SCHEMA, which will preserver 2024-01-01 as String and not Date.
- Also update normalizeVariables to correctly convert the value to string, so parameters are treated as strings

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML/API spec parsing during imports for more accurate type interpretation
  * Enhanced variable handling so falsy values (0, false) are preserved correctly when importing
  * Improved date type preservation when importing Insomnia collections

* **Tests**
  * Added test coverage and fixture to validate date and scalar handling for Insomnia v5 imports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->