### PR TITLE
fix: workspace home icon alignment in title bar when already fullscreen

### DIFF
--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -52,6 +52,14 @@ const AppTitleBar = () => {
     const { ipcRenderer } = window;
     if (!ipcRenderer) return;
 
+    ipcRenderer.invoke('renderer:window-is-fullscreen')
+      .then((fullscreen) => {
+        setIsFullScreen(fullscreen);
+      })
+      .catch((error) => {
+        console.error('Error getting initial fullscreen state:', error);
+      });
+
     const removeEnterFullScreenListener = ipcRenderer.on('main:enter-full-screen', () => {
       setIsFullScreen(true);
     });

--- a/packages/bruno-app/src/components/AppTitleBar/index.spec.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.spec.js
@@ -42,6 +42,11 @@ const renderWithProviders = () => render(
 
 const getTitleBar = (container) => container.querySelector('.app-titlebar');
 
+const mockInvokeWithFullscreen = (isFullScreen) => jest.fn((channel) => {
+  if (channel === 'renderer:window-is-fullscreen') return Promise.resolve(isFullScreen);
+  return Promise.resolve(false);
+});
+
 describe('AppTitleBar — fullscreen state sync', () => {
   let ipcListeners;
 
@@ -70,7 +75,7 @@ describe('AppTitleBar — fullscreen state sync', () => {
     });
 
     it('should apply fullscreen class when window is already fullscreen at mount', async () => {
-      window.ipcRenderer.invoke = jest.fn().mockResolvedValue(true);
+      window.ipcRenderer.invoke = mockInvokeWithFullscreen(true);
 
       const { container } = renderWithProviders();
 
@@ -83,7 +88,7 @@ describe('AppTitleBar — fullscreen state sync', () => {
       const { container } = renderWithProviders();
 
       await waitFor(() => {
-        expect(window.ipcRenderer.invoke).toHaveBeenCalled();
+        expect(window.ipcRenderer.invoke).toHaveBeenCalledWith('renderer:window-is-fullscreen');
       });
       expect(getTitleBar(container)).not.toHaveClass('fullscreen');
     });
@@ -94,7 +99,7 @@ describe('AppTitleBar — fullscreen state sync', () => {
       const { container } = renderWithProviders();
 
       await waitFor(() => {
-        expect(window.ipcRenderer.invoke).toHaveBeenCalled();
+        expect(window.ipcRenderer.invoke).toHaveBeenCalledWith('renderer:window-is-fullscreen');
       });
 
       act(() => {
@@ -105,7 +110,7 @@ describe('AppTitleBar — fullscreen state sync', () => {
     });
 
     it('should remove fullscreen class on main:leave-full-screen event', async () => {
-      window.ipcRenderer.invoke = jest.fn().mockResolvedValue(true);
+      window.ipcRenderer.invoke = mockInvokeWithFullscreen(true);
 
       const { container } = renderWithProviders();
 

--- a/packages/bruno-app/src/components/AppTitleBar/index.spec.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.spec.js
@@ -1,0 +1,123 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+jest.mock('ui/MenuDropdown', () => ({ children }) => <div>{children}</div>);
+jest.mock('ui/ActionIcon', () => ({ children, onClick, label }) => (
+  <button onClick={onClick} aria-label={label}>{children}</button>
+));
+jest.mock('components/ResponsePane/ResponseLayoutToggle', () => () => null);
+
+import AppTitleBar from './index';
+
+const theme = {
+  text: '#333',
+  sidebar: {
+    bg: '#fff',
+    color: '#333',
+    muted: '#888',
+    collection: { item: { hoverBg: '#eee' } }
+  },
+  dropdown: { color: '#333', mutedText: '#888', hoverBg: '#eee' }
+};
+
+const mockStore = configureStore({
+  reducer: {
+    workspaces: (state = { workspaces: [], activeWorkspaceUid: null }) => state,
+    app: (state = { preferences: {}, sidebarCollapsed: false }) => state,
+    logs: (state = { isConsoleOpen: false }) => state
+  }
+});
+
+const renderWithProviders = () => render(
+  <Provider store={mockStore}>
+    <ThemeProvider theme={theme}>
+      <AppTitleBar />
+    </ThemeProvider>
+  </Provider>
+);
+
+const getTitleBar = (container) => container.querySelector('.app-titlebar');
+
+describe('AppTitleBar — fullscreen state sync', () => {
+  let ipcListeners;
+
+  beforeEach(() => {
+    ipcListeners = {};
+    window.ipcRenderer = {
+      invoke: jest.fn().mockResolvedValue(false),
+      send: jest.fn(),
+      on: jest.fn((channel, cb) => {
+        ipcListeners[channel] = cb;
+        return jest.fn();
+      })
+    };
+  });
+
+  afterEach(() => {
+    delete window.ipcRenderer;
+  });
+
+  describe('initial state on mount', () => {
+    it('should query the main process for current fullscreen state', async () => {
+      renderWithProviders();
+      await waitFor(() => {
+        expect(window.ipcRenderer.invoke).toHaveBeenCalledWith('renderer:window-is-fullscreen');
+      });
+    });
+
+    it('should apply fullscreen class when window is already fullscreen at mount', async () => {
+      window.ipcRenderer.invoke = jest.fn().mockResolvedValue(true);
+
+      const { container } = renderWithProviders();
+
+      await waitFor(() => {
+        expect(getTitleBar(container)).toHaveClass('fullscreen');
+      });
+    });
+
+    it('should not apply fullscreen class when window is windowed at mount', async () => {
+      const { container } = renderWithProviders();
+
+      await waitFor(() => {
+        expect(window.ipcRenderer.invoke).toHaveBeenCalled();
+      });
+      expect(getTitleBar(container)).not.toHaveClass('fullscreen');
+    });
+  });
+
+  describe('fullscreen transitions after mount', () => {
+    it('should add fullscreen class on main:enter-full-screen event', async () => {
+      const { container } = renderWithProviders();
+
+      await waitFor(() => {
+        expect(window.ipcRenderer.invoke).toHaveBeenCalled();
+      });
+
+      act(() => {
+        ipcListeners['main:enter-full-screen']();
+      });
+
+      expect(getTitleBar(container)).toHaveClass('fullscreen');
+    });
+
+    it('should remove fullscreen class on main:leave-full-screen event', async () => {
+      window.ipcRenderer.invoke = jest.fn().mockResolvedValue(true);
+
+      const { container } = renderWithProviders();
+
+      await waitFor(() => {
+        expect(getTitleBar(container)).toHaveClass('fullscreen');
+      });
+
+      act(() => {
+        ipcListeners['main:leave-full-screen']();
+      });
+
+      expect(getTitleBar(container)).not.toHaveClass('fullscreen');
+    });
+  });
+});

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -275,6 +275,10 @@ app.on('ready', async () => {
     return mainWindow.isMaximized();
   });
 
+  ipcMain.handle('renderer:window-is-fullscreen', () => {
+    return mainWindow.isFullScreen();
+  });
+
   ipcMain.handle('renderer:open-preferences', () => {
     ipcMain.emit('main:open-preferences');
   });


### PR DESCRIPTION
### Description

Fixes inconsistent alignment of the workspace home control ( on macOS ) when the window is already in native fullscreen when the UI loads. React previously defaulted isFullScreen to false until enter-full-screen / leave-full-screen fired, so title bar padding still assumed traffic lights were present.

Tracked in: [BRU](https://usebruno.atlassian.net/browse/BRU-2342)

### Changes

- On AppTitleBar mount, call `ipcRenderer.invoke('renderer:window-is-fullscreen')` and set `isFullScreen` from the result (same pattern as maximized state).
- Add `ipcMain.handle('renderer:window-is-fullscreen')` returning `mainWindow.isFullScreen()`.
- Unit tests for initial fullscreen sync and enter/leave fullscreen behavior.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Packages changed
  - packages/bruno-app
    - AppTitleBar: on mount queries main process via ipcRenderer.invoke('renderer:window-is-fullscreen') to initialize isFullScreen (same pattern used for maximized state). Keeps existing IPC listeners for runtime enter/leave fullscreen events. Fixes misalignment of workspace home control on macOS when the window is already in native fullscreen at UI load.
    - Tests: adds Jest tests (index.spec.js) that mock ipcRenderer to verify initial fullscreen sync and enter/leave fullscreen transitions, and assert the presence/absence of the .fullscreen class on the title bar.
  - packages/bruno-electron
    - index.js: registers an IPC handler ipcMain.handle('renderer:window-is-fullscreen') that returns mainWindow.isFullScreen() so the renderer can synchronously query the initial fullscreen state.

- Cross-package interactions
  - Renderer (bruno-app) now depends on a new Electron IPC handler implemented in bruno-electron to obtain the initial fullscreen state at mount time. This aligns renderer behavior with the existing maximized-state pattern and prevents UI layout assumptions that depended on delayed fullscreen events.

- Tests & Coverage
  - Unit tests added in bruno-app cover initial fullscreen state retrieval and runtime fullscreen enter/leave events. Tests mock ipcRenderer.invoke and capture ipcRenderer.on listeners to simulate main process events.

- Notes
  - No public/exported API or signature changes detected.
  - Tracked in BRU ticket BRU-2342.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7967)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->