### PR TITLE
fix: 3014 - Postman import ignores API Key "in" placement setting and defaults to header

### DIFF
--- a/packages/bruno-app/src/components/Modal/index.js
+++ b/packages/bruno-app/src/components/Modal/index.js
@@ -29,7 +29,7 @@ const ModalFooter = ({
   hideCancel,
   hideFooter,
   confirmButtonColor = 'primary',
-  submitButtonTestId
+  dataTestId = 'modal'
 }) => {
   confirmText = confirmText || 'Save';
   cancelText = cancelText || 'Cancel';
@@ -52,7 +52,7 @@ const ModalFooter = ({
           disabled={confirmDisabled}
           onClick={handleSubmit}
           className="submit"
-          data-testid={submitButtonTestId}
+          data-testid={`${dataTestId}-submit-btn`}
         >
           {confirmText}
         </Button>
@@ -79,8 +79,7 @@ const Modal = ({
   onClick,
   closeModalFadeTimeout = 500,
   dataTestId,
-  confirmButtonColor = 'primary',
-  submitButtonTestId
+  confirmButtonColor = 'primary'
 }) => {
   const modalRef = useRef(null);
   const [isClosing, setIsClosing] = useState(false);
@@ -154,7 +153,7 @@ const Modal = ({
           hideCancel={hideCancel}
           hideFooter={hideFooter}
           confirmButtonColor={confirmButtonColor}
-          submitButtonTestId={submitButtonTestId}
+          dataTestId={dataTestId}
         />
       </div>
 

--- a/packages/bruno-app/src/components/Modal/index.js
+++ b/packages/bruno-app/src/components/Modal/index.js
@@ -28,7 +28,8 @@ const ModalFooter = ({
   confirmDisabled,
   hideCancel,
   hideFooter,
-  confirmButtonColor = 'primary'
+  confirmButtonColor = 'primary',
+  submitButtonTestId
 }) => {
   confirmText = confirmText || 'Save';
   cancelText = cancelText || 'Cancel';
@@ -51,6 +52,7 @@ const ModalFooter = ({
           disabled={confirmDisabled}
           onClick={handleSubmit}
           className="submit"
+          data-testid={submitButtonTestId}
         >
           {confirmText}
         </Button>
@@ -77,7 +79,8 @@ const Modal = ({
   onClick,
   closeModalFadeTimeout = 500,
   dataTestId,
-  confirmButtonColor = 'primary'
+  confirmButtonColor = 'primary',
+  submitButtonTestId
 }) => {
   const modalRef = useRef(null);
   const [isClosing, setIsClosing] = useState(false);
@@ -151,6 +154,7 @@ const Modal = ({
           hideCancel={hideCancel}
           hideFooter={hideFooter}
           confirmButtonColor={confirmButtonColor}
+          submitButtonTestId={submitButtonTestId}
         />
       </div>
 

--- a/packages/bruno-app/src/components/RequestPane/Auth/ApiKeyAuth/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/ApiKeyAuth/index.js
@@ -25,7 +25,7 @@ const ApiKeyAuth = ({ item, collection, updateAuth, request, save }) => {
 
   const Icon = forwardRef((props, ref) => {
     return (
-      <div ref={ref} className="flex items-center justify-end auth-type-label select-none">
+      <div ref={ref} data-testid="auth-placement-label" className="flex items-center justify-end auth-type-label select-none">
         {humanizeRequestAPIKeyPlacement(apikeyAuth?.placement)}
         <IconCaretDown className="caret ml-1 mr-1" size={14} strokeWidth={2} />
       </div>
@@ -89,7 +89,7 @@ const ApiKeyAuth = ({ item, collection, updateAuth, request, save }) => {
       </div>
 
       <label className="block mb-1">Add To</label>
-      <div className="inline-flex items-center cursor-pointer auth-placement-selector w-fit">
+      <div data-testid="auth-placement-selector" className="inline-flex items-center cursor-pointer auth-placement-selector w-fit">
         <Dropdown onCreate={onDropdownCreate} icon={<Icon />} placement="bottom-end">
           <div
             className="dropdown-item"

--- a/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollection/index.js
@@ -70,6 +70,7 @@ const ImportCollection = ({ onClose, handleSubmit }) => {
 
         {errorMessage && (
           <div
+            data-testid="import-error-message"
             className="mb-4 p-2 border rounded-md"
             style={{
               backgroundColor: theme.status.danger.background,

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -224,7 +224,6 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
         handleConfirm={onSubmit}
         handleCancel={onClose}
         dataTestId="import-collection-location-modal"
-        submitButtonTestId="import-collection-submit-button"
       >
         <form className="bruno-form" onSubmit={(e) => e.preventDefault()}>
           <div>

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -224,6 +224,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
         handleConfirm={onSubmit}
         handleCancel={onClose}
         dataTestId="import-collection-location-modal"
+        submitButtonTestId="import-collection-submit-button"
       >
         <form className="bruno-form" onSubmit={(e) => e.preventDefault()}>
           <div>
@@ -261,7 +262,11 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
             ) : null}
 
             <div className="mt-1">
-              <span className="text-link cursor-pointer hover:underline" onClick={browse}>
+              <span
+                data-testid="import-collection-browse-link"
+                className="text-link cursor-pointer hover:underline"
+                onClick={browse}
+              >
                 Browse
               </span>
             </div>

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -267,7 +267,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
       requestObject.auth.apikey = {
         key: ensureString(authValues.key),
         value: ensureString(authValues.value),
-        placement: 'header' // By default we are placing the apikey values in headers!
+        placement: ensureString(authValues.in === 'query' ? 'queryparams' : 'header') // map Postman `in` to Bruno placement; defaults to header
       };
       break;
     case AUTH_TYPES.DIGEST:

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -267,7 +267,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
       requestObject.auth.apikey = {
         key: ensureString(authValues.key),
         value: ensureString(authValues.value),
-        placement: ensureString(authValues.in === 'query' ? 'queryparams' : 'header') // map Postman `in` to Bruno placement; defaults to header
+        placement: authValues.in === 'query' ? 'queryparams' : 'header' // map Postman `in` to Bruno placement; defaults to header
       };
       break;
     case AUTH_TYPES.DIGEST:

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/request-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/request-auth.spec.js
@@ -580,4 +580,67 @@ describe('Request Authentication', () => {
       basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
     });
   });
+
+  describe('API Key Auth placement', () => {
+    const buildApiKeyCollection = (apikey) => ({
+      info: {
+        name: 'API Key Collection',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'API Key Request',
+          request: {
+            method: 'GET',
+            url: 'https://api.example.com/test',
+            auth: { type: 'apikey', apikey }
+          }
+        }
+      ]
+    });
+
+    it('should map Postman in=query to Bruno placement=queryparams', async () => {
+      const postmanCollection = buildApiKeyCollection([
+        { key: 'key', value: 'X-API-Key' },
+        { key: 'value', value: 'secret-token' },
+        { key: 'in', value: 'query' }
+      ]);
+
+      const result = await postmanToBruno(postmanCollection);
+
+      expect(result.items[0].request.auth.mode).toBe('apikey');
+      expect(result.items[0].request.auth.apikey).toEqual({
+        key: 'X-API-Key',
+        value: 'secret-token',
+        placement: 'queryparams'
+      });
+    });
+
+    it('should map Postman in=header to Bruno placement=header', async () => {
+      const postmanCollection = buildApiKeyCollection([
+        { key: 'key', value: 'X-API-Key' },
+        { key: 'value', value: 'secret-token' },
+        { key: 'in', value: 'header' }
+      ]);
+
+      const result = await postmanToBruno(postmanCollection);
+
+      expect(result.items[0].request.auth.apikey).toEqual({
+        key: 'X-API-Key',
+        value: 'secret-token',
+        placement: 'header'
+      });
+    });
+
+    it('should default placement to header when Postman in is absent', async () => {
+      const postmanCollection = buildApiKeyCollection([
+        { key: 'key', value: 'X-API-Key' },
+        { key: 'value', value: 'secret-token' }
+      ]);
+
+      const result = await postmanToBruno(postmanCollection);
+
+      expect(result.items[0].request.auth.apikey.placement).toBe('header');
+    });
+  });
 });

--- a/tests/import/postman/fixtures/postman-import-apikey-header-collection.json
+++ b/tests/import/postman/fixtures/postman-import-apikey-header-collection.json
@@ -1,0 +1,57 @@
+{
+  "info": {
+    "_postman_id": "6df527f0-77aa-4b67-957f-8a3f0c96a027",
+    "name": "My Collection",
+    "description": "### Welcome to Postman! This is your first collection. \n\nCollections are your starting point for building and testing APIs. You can use this one to:\n\n• Group related requests\n• Test your API in real-world scenarios\n• Document and share your requests\n\nUpdate the name and overview whenever you’re ready to make it yours.\n\n[Learn more about Postman Collections.](https://learning.postman.com/docs/collections/collections-overview/)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "54316404",
+    "_collection_link": "https://go.postman.co/collection/54316404-6df527f0-77aa-4b67-957f-8a3f0c96a027?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Headers with API Key",
+      "request": {
+        "auth": {
+          "type": "apikey",
+          "apikey": [
+            {
+              "key": "in",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "value",
+              "value": "hello",
+              "type": "string"
+            },
+            {
+              "key": "key",
+              "value": "hii",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.com/users?X-API-KEY=12345",
+          "protocol": "https",
+          "host": [
+            "api",
+            "com"
+          ],
+          "path": [
+            "users"
+          ],
+          "query": [
+            {
+              "key": "X-API-KEY",
+              "value": "12345"
+            }
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/tests/import/postman/fixtures/postman-import-apikey-query-collection.json
+++ b/tests/import/postman/fixtures/postman-import-apikey-query-collection.json
@@ -1,0 +1,57 @@
+{
+  "info": {
+    "_postman_id": "6df527f0-77aa-4b67-957f-8a3f0c96a027",
+    "name": "My Collection",
+    "description": "### Welcome to Postman! This is your first collection. \n\nCollections are your starting point for building and testing APIs. You can use this one to:\n\n• Group related requests\n• Test your API in real-world scenarios\n• Document and share your requests\n\nUpdate the name and overview whenever you’re ready to make it yours.\n\n[Learn more about Postman Collections.](https://learning.postman.com/docs/collections/collections-overview/)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "54316404",
+    "_collection_link": "https://go.postman.co/collection/54316404-6df527f0-77aa-4b67-957f-8a3f0c96a027?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Query with API Key",
+      "request": {
+        "auth": {
+          "type": "apikey",
+          "apikey": [
+            {
+              "key": "in",
+              "value": "query",
+              "type": "string"
+            },
+            {
+              "key": "value",
+              "value": "hello",
+              "type": "string"
+            },
+            {
+              "key": "key",
+              "value": "hii",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.com/users?X-API-KEY=12345",
+          "protocol": "https",
+          "host": [
+            "api",
+            "com"
+          ],
+          "path": [
+            "users"
+          ],
+          "query": [
+            {
+              "key": "X-API-KEY",
+              "value": "12345"
+            }
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/tests/import/postman/import-apikey-header-collection.spec.ts
+++ b/tests/import/postman/import-apikey-header-collection.spec.ts
@@ -73,23 +73,11 @@ test.describe('Import Postman Collection with API Key in Header', () => {
       await locationModal.waitFor({ state: 'hidden' });
     });
 
-    await test.step('Open collection', async () => {
+    await test.step('Open collection and verify request is displayed', async () => {
       await openCollection(page, 'My Collection');
-    });
-
-    await test.step('Verify collection name appears in sidebar', async () => {
       await expect(locators.sidebar.collection('My Collection')).toBeVisible();
-    });
-
-    await test.step('Verify request exists in the collection', async () => {
       await expect(locators.sidebar.request('Headers with API Key')).toBeVisible();
-    });
-
-    await test.step('Click on the request to view details', async () => {
       await locators.sidebar.request('Headers with API Key').click();
-    });
-
-    await test.step('Verify request details are displayed', async () => {
       await expect(locators.request.pane()).toBeVisible();
     });
 

--- a/tests/import/postman/import-apikey-header-collection.spec.ts
+++ b/tests/import/postman/import-apikey-header-collection.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+import { closeAllCollections, openCollection, selectRequestPaneTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe('Import Postman Collection with API Key in Header', () => {
+  let originalShowOpenDialog;
+
+  test.beforeAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      originalShowOpenDialog = dialog.showOpenDialog;
+    });
+  });
+
+  test.afterAll(async ({ electronApp, page }) => {
+    await closeAllCollections(page);
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = originalShowOpenDialog;
+    });
+  });
+
+  test('should import Postman collection with API Key in Header successfully', async ({ page, electronApp, createTmpDir }) => {
+    const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-import-apikey-header-collection.json');
+    const locators = buildCommonLocators(page);
+
+    const importDir = await createTmpDir('imported-collection');
+
+    await electronApp.evaluate(({ dialog }, { importDir }) => {
+      dialog.showOpenDialog = async () => ({
+        canceled: false,
+        filePaths: [importDir]
+      });
+    }, { importDir });
+
+    await test.step('Open import collection modal', async () => {
+      await locators.plusMenu.button().click();
+      await locators.plusMenu.importCollection().click();
+    });
+
+    await test.step('Wait for import modal and verify title', async () => {
+      const importModal = page.getByRole('dialog');
+      await importModal.waitFor({ state: 'visible' });
+      await expect(locators.modal.title('Import Collection')).toBeVisible();
+    });
+
+    await test.step('Upload Postman collection file using hidden file input', async () => {
+      await locators.import.fileInput().setInputFiles(postmanFile);
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
+    });
+
+    await test.step('Verify no parsing errors occurred', async () => {
+      const hasError = await locators.import.parsingError().isVisible().catch(() => false);
+      if (hasError) {
+        throw new Error('Collection import failed with parsing error');
+      }
+    });
+
+    await test.step('Verify location selection modal appears', async () => {
+      await expect(locators.modal.title('Import Collection')).toBeVisible();
+    });
+
+    await test.step('Verify collection name appears in location modal', async () => {
+      await expect(locators.import.locationModal().getByText('My Collection')).toBeVisible();
+    });
+
+    await test.step('Click Browse link to select collection folder', async () => {
+      await locators.import.browseLink(locators.import.locationModal()).click();
+    });
+
+    await test.step('Complete import by clicking import button', async () => {
+      const locationModal = locators.import.locationModal();
+      await locators.import.importButton(locationModal).click();
+      await locationModal.waitFor({ state: 'hidden' });
+    });
+
+    await test.step('Open collection', async () => {
+      await openCollection(page, 'My Collection');
+    });
+
+    await test.step('Verify collection name appears in sidebar', async () => {
+      await expect(locators.sidebar.collection('My Collection')).toBeVisible();
+    });
+
+    await test.step('Verify request exists in the collection', async () => {
+      await expect(locators.sidebar.request('Headers with API Key')).toBeVisible();
+    });
+
+    await test.step('Click on the request to view details', async () => {
+      await locators.sidebar.request('Headers with API Key').click();
+    });
+
+    await test.step('Verify request details are displayed', async () => {
+      await expect(locators.request.pane()).toBeVisible();
+    });
+
+    await test.step('Select Auth tab and verify API key details', async () => {
+      await selectRequestPaneTab(page, 'Auth');
+    });
+
+    await test.step('Verify API key placement dropdown is set to Header', async () => {
+      await expect(locators.auth.apiKey.placementSelector()).toBeVisible();
+      await expect(locators.auth.apiKey.placementLabel()).toHaveText(/Header/);
+    });
+  });
+});

--- a/tests/import/postman/import-apikey-header-collection.spec.ts
+++ b/tests/import/postman/import-apikey-header-collection.spec.ts
@@ -93,13 +93,10 @@ test.describe('Import Postman Collection with API Key in Header', () => {
       await expect(locators.request.pane()).toBeVisible();
     });
 
-    await test.step('Select Auth tab and verify API key details', async () => {
+    await test.step('Verify API key is set to Header within Auth section', async () => {
       await selectRequestPaneTab(page, 'Auth');
-    });
-
-    await test.step('Verify API key placement dropdown is set to Header', async () => {
       await expect(locators.auth.apiKey.placementSelector()).toBeVisible();
-      await expect(locators.auth.apiKey.placementLabel()).toHaveText(/Header/);
+      await expect(locators.auth.apiKey.placementLabel()).toHaveText('Header');
     });
   });
 });

--- a/tests/import/postman/import-apikey-query-collection.spec.ts
+++ b/tests/import/postman/import-apikey-query-collection.spec.ts
@@ -73,23 +73,11 @@ test.describe('Import Postman Collection with API Key in Query Params', () => {
       await locationModal.waitFor({ state: 'hidden' });
     });
 
-    await test.step('Open collection', async () => {
+    await test.step('Open collection and verify request is displayed', async () => {
       await openCollection(page, 'My Collection');
-    });
-
-    await test.step('Verify collection name appears in sidebar', async () => {
       await expect(locators.sidebar.collection('My Collection')).toBeVisible();
-    });
-
-    await test.step('Verify request exists in the collection', async () => {
       await expect(locators.sidebar.request('Query with API Key')).toBeVisible();
-    });
-
-    await test.step('Click on the request to view details', async () => {
       await locators.sidebar.request('Query with API Key').click();
-    });
-
-    await test.step('Verify request details are displayed', async () => {
       await expect(locators.request.pane()).toBeVisible();
     });
 

--- a/tests/import/postman/import-apikey-query-collection.spec.ts
+++ b/tests/import/postman/import-apikey-query-collection.spec.ts
@@ -93,13 +93,10 @@ test.describe('Import Postman Collection with API Key in Query Params', () => {
       await expect(locators.request.pane()).toBeVisible();
     });
 
-    await test.step('Select Auth tab and verify API key details', async () => {
+    await test.step('Verify API key is set to Query Params within Auth section', async () => {
       await selectRequestPaneTab(page, 'Auth');
-    });
-
-    await test.step('Verify API key placement dropdown is set to Query Params', async () => {
       await expect(locators.auth.apiKey.placementSelector()).toBeVisible();
-      await expect(locators.auth.apiKey.placementLabel()).toHaveText(/Query Params/);
+      await expect(locators.auth.apiKey.placementLabel()).toHaveText('Query Params');
     });
   });
 });

--- a/tests/import/postman/import-apikey-query-collection.spec.ts
+++ b/tests/import/postman/import-apikey-query-collection.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+import { closeAllCollections, openCollection, selectRequestPaneTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe('Import Postman Collection with API Key in Query Params', () => {
+  let originalShowOpenDialog;
+
+  test.beforeAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      originalShowOpenDialog = dialog.showOpenDialog;
+    });
+  });
+
+  test.afterAll(async ({ electronApp, page }) => {
+    await closeAllCollections(page);
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = originalShowOpenDialog;
+    });
+  });
+
+  test('should import Postman collection with API Key in Query Params successfully', async ({ page, electronApp, createTmpDir }) => {
+    const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-import-apikey-query-collection.json');
+    const locators = buildCommonLocators(page);
+
+    const importDir = await createTmpDir('imported-collection');
+
+    await electronApp.evaluate(({ dialog }, { importDir }) => {
+      dialog.showOpenDialog = async () => ({
+        canceled: false,
+        filePaths: [importDir]
+      });
+    }, { importDir });
+
+    await test.step('Open import collection modal', async () => {
+      await locators.plusMenu.button().click();
+      await locators.plusMenu.importCollection().click();
+    });
+
+    await test.step('Wait for import modal and verify title', async () => {
+      const importModal = page.getByRole('dialog');
+      await importModal.waitFor({ state: 'visible' });
+      await expect(locators.modal.title('Import Collection')).toBeVisible();
+    });
+
+    await test.step('Upload Postman collection file using hidden file input', async () => {
+      await locators.import.fileInput().setInputFiles(postmanFile);
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
+    });
+
+    await test.step('Verify no parsing errors occurred', async () => {
+      const hasError = await locators.import.parsingError().isVisible().catch(() => false);
+      if (hasError) {
+        throw new Error('Collection import failed with parsing error');
+      }
+    });
+
+    await test.step('Verify location selection modal appears', async () => {
+      await expect(locators.modal.title('Import Collection')).toBeVisible();
+    });
+
+    await test.step('Verify collection name appears in location modal', async () => {
+      await expect(locators.import.locationModal().getByText('My Collection')).toBeVisible();
+    });
+
+    await test.step('Click Browse link to select collection folder', async () => {
+      await locators.import.browseLink(locators.import.locationModal()).click();
+    });
+
+    await test.step('Complete import by clicking import button', async () => {
+      const locationModal = locators.import.locationModal();
+      await locators.import.importButton(locationModal).click();
+      await locationModal.waitFor({ state: 'hidden' });
+    });
+
+    await test.step('Open collection', async () => {
+      await openCollection(page, 'My Collection');
+    });
+
+    await test.step('Verify collection name appears in sidebar', async () => {
+      await expect(locators.sidebar.collection('My Collection')).toBeVisible();
+    });
+
+    await test.step('Verify request exists in the collection', async () => {
+      await expect(locators.sidebar.request('Query with API Key')).toBeVisible();
+    });
+
+    await test.step('Click on the request to view details', async () => {
+      await locators.sidebar.request('Query with API Key').click();
+    });
+
+    await test.step('Verify request details are displayed', async () => {
+      await expect(locators.request.pane()).toBeVisible();
+    });
+
+    await test.step('Select Auth tab and verify API key details', async () => {
+      await selectRequestPaneTab(page, 'Auth');
+    });
+
+    await test.step('Verify API key placement dropdown is set to Query Params', async () => {
+      await expect(locators.auth.apiKey.placementSelector()).toBeVisible();
+      await expect(locators.auth.apiKey.placementLabel()).toHaveText(/Query Params/);
+    });
+  });
+});

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -91,8 +91,8 @@ export const buildCommonLocators = (page: Page) => ({
   },
   auth: {
     apiKey: {
-      placementSelector: () => page.locator('.auth-placement-selector'),
-      placementLabel: () => page.locator('.auth-placement-selector .auth-type-label')
+      placementSelector: () => page.getByTestId('auth-placement-selector'),
+      placementLabel: () => page.getByTestId('auth-placement-label')
     }
   },
   tags: {
@@ -126,7 +126,7 @@ export const buildCommonLocators = (page: Page) => ({
     locationInput: () => page.locator('#collection-location'),
     fileInput: () => page.locator('input[type="file"]'),
     envOption: (name: string) => page.locator('.dropdown-item').getByText(name, { exact: true }),
-    parsingError: () => page.getByText('Failed to parse the file'),
+    parsingError: () => page.getByTestId('import-error-message'),
     browseLink: (root?: Locator) => (root ?? page).getByText('Browse'),
     importButton: (root?: Locator) => (root ?? page).getByRole('button', { name: 'Import' })
   },

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -128,7 +128,7 @@ export const buildCommonLocators = (page: Page) => ({
     envOption: (name: string) => page.locator('.dropdown-item').getByText(name, { exact: true }),
     parsingError: () => page.getByTestId('import-error-message'),
     browseLink: (root?: Locator) => (root ?? page).getByTestId('import-collection-browse-link'),
-    importButton: (root?: Locator) => (root ?? page).getByTestId('import-collection-submit-button')
+    importButton: (root?: Locator) => (root ?? page).getByTestId('import-collection-location-modal-submit-btn')
   },
   /**
    * Build generic table locators for any table with a testId

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -86,7 +86,14 @@ export const buildCommonLocators = (page: Page) => ({
     requestTestId: () => page.getByTestId('request-name'),
     generateCodeButton: () => page.locator('#request-actions .infotip').first(),
     bodyModeSelector: () => page.getByTestId('request-body-mode-selector'),
-    bodyEditor: () => page.getByTestId('request-body-editor')
+    bodyEditor: () => page.getByTestId('request-body-editor'),
+    pane: () => page.getByTestId('request-pane')
+  },
+  auth: {
+    apiKey: {
+      placementSelector: () => page.locator('.auth-placement-selector'),
+      placementLabel: () => page.locator('.auth-placement-selector .auth-type-label')
+    }
   },
   tags: {
     input: () => page.getByTestId('tag-input').getByRole('textbox'),
@@ -118,7 +125,10 @@ export const buildCommonLocators = (page: Page) => ({
     locationModal: () => page.locator('[data-testid="import-collection-location-modal"]'),
     locationInput: () => page.locator('#collection-location'),
     fileInput: () => page.locator('input[type="file"]'),
-    envOption: (name: string) => page.locator('.dropdown-item').getByText(name, { exact: true })
+    envOption: (name: string) => page.locator('.dropdown-item').getByText(name, { exact: true }),
+    parsingError: () => page.getByText('Failed to parse the file'),
+    browseLink: (root?: Locator) => (root ?? page).getByText('Browse'),
+    importButton: (root?: Locator) => (root ?? page).getByRole('button', { name: 'Import' })
   },
   /**
    * Build generic table locators for any table with a testId

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -127,8 +127,8 @@ export const buildCommonLocators = (page: Page) => ({
     fileInput: () => page.locator('input[type="file"]'),
     envOption: (name: string) => page.locator('.dropdown-item').getByText(name, { exact: true }),
     parsingError: () => page.getByTestId('import-error-message'),
-    browseLink: (root?: Locator) => (root ?? page).getByText('Browse'),
-    importButton: (root?: Locator) => (root ?? page).getByRole('button', { name: 'Import' })
+    browseLink: (root?: Locator) => (root ?? page).getByTestId('import-collection-browse-link'),
+    importButton: (root?: Locator) => (root ?? page).getByTestId('import-collection-submit-button')
   },
   /**
    * Build generic table locators for any table with a testId


### PR DESCRIPTION
### Description



Postman import ignores API Key "in" placement setting and defaults to header
Jira link - https://usebruno.atlassian.net/browse/BRU-3014

Postman's API Key auth supports two placements via the `in` field (`"header"` or `"query"`), but Bruno's Postman importer was ignoring that field entirely and hard-coding the placement to `"header"`. As a result, any Postman collection that authenticated by sending the API key as a query parameter would import incorrectly — the key/value were preserved, but the placement silently flipped to header, breaking the request. The fix is in `packages/bruno-converters/src/postman/postman-to-bruno.js`: when processing `APIKEY` auth, the converter now reads `authValues.in` and maps `"query"` to Bruno's `"queryparams"` placement, falling back to `"header"` for `"header"`, missing, or unknown values (which preserves the previous default for collections that don't specify `in`). Two Playwright tests were added under `tests/import/postman/` covering both placements end-to-end — importing a fixture collection, opening the imported request, and asserting that the Auth tab's placement dropdown reflects the original Postman setting.


Before:
<img width="2356" height="1586" alt="image" src="https://github.com/user-attachments/assets/159ca161-6859-4490-a067-f2035dc95681" />


After:
<img width="3004" height="1516" alt="image" src="https://github.com/user-attachments/assets/6463f800-d0b1-4bc3-8aa9-aead377d54a5" />



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Postman collection import now preserves API key placement — imports API keys as query params or headers according to the source collection (no longer always headers).

* **Tests**
  * Added end-to-end and unit tests validating Postman API key import and that the Auth UI shows correct placement after import.

* **Chores**
  * Added test-friendly attributes and updated locators for import flows, modals, and API key placement UI to improve UI test reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7968)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->