### PR TITLE
fix: standardize select file label casing

### DIFF
--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -233,7 +233,7 @@ const General = () => {
               disabled={formik.values.customCaCertificate.enabled ? false : true}
               onClick={() => inputFileCaCertificateRef.current.click()}
             >
-              select file
+              Select File
               <input
                 id="caCertFilePath"
                 type="file"

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth1/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth1/index.js
@@ -256,7 +256,7 @@ const OAuth1 = ({ item = {}, collection, request, save, updateAuth }) => {
                 <button
                   className="flex items-center gap-1 oauth1-icon cursor-pointer text-link"
                   onClick={handleBrowse}
-                  title="Select file"
+                  title="Select File"
                   type="button"
                 >
                   <IconUpload size={14} />

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -192,7 +192,7 @@ const MultipartFormParams = ({ item, collection }) => {
             <button
               className="upload-btn ml-1"
               onClick={() => handleBrowseFiles(row, onChange)}
-              title="Select file"
+              title="Select File"
             >
               <IconUpload size={16} />
             </button>

--- a/packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleMultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleMultipartFormParams/index.js
@@ -227,7 +227,7 @@ const ResponseExampleMultipartFormParams = ({ item, collection, exampleUid, edit
             <button
               className="upload-btn ml-1"
               onClick={() => handleBrowseFiles(row, onChange)}
-              title="Select file"
+              title="Select File"
             >
               <IconUpload size={16} />
             </button>


### PR DESCRIPTION
## Description

Standardizes the file picker label casing used in the app to `Select File`.

This fixes the inconsistent `select file` / `Select file` / `Select File` wording reported in #2992.

## Changes

- Updates the custom CA certificate file button label.
- Updates file picker tooltip titles in OAuth1 and multipart form file upload buttons.

## Validation

- `npx eslint packages/bruno-app/src/components/Preferences/General/index.js packages/bruno-app/src/components/RequestPane/Auth/OAuth1/index.js packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleMultipartFormParams/index.js`
- `git diff --check`
- `rg -n "select file|Select file" packages/bruno-app/src/components` returned no matches.

Fixes #2992


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized capitalization in file selection button labels across the application for improved visual consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7969)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->