### PR TITLE
fix: accept LF-only response headers

### DIFF
--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -88,6 +88,7 @@ function makeAxiosInstance({
   /** @type {axios.AxiosInstance} */
   const instance = axios.create({
     proxy: false,
+    insecureHTTPParser: true,
     maxRedirects: 0,
     headers: {}
   });

--- a/packages/bruno-cli/tests/utils/axios-instance.spec.js
+++ b/packages/bruno-cli/tests/utils/axios-instance.spec.js
@@ -1,4 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
+const net = require('net');
 const { makeAxiosInstance } = require('../../src/utils/axios-instance');
 
 function createStubAdapter() {
@@ -12,6 +13,24 @@ function createStubAdapter() {
   adapter.getConfig = () => capturedConfig;
 
   return adapter;
+}
+
+function createLfOnlyHeaderServer() {
+  const server = net.createServer((socket) => {
+    socket.once('data', () => {
+      socket.write('HTTP/1.1 200 OK\r\nContent-Type: text/plain\nContent-Length: 2\n\nOK');
+      socket.end();
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        server,
+        url: `http://127.0.0.1:${server.address().port}`
+      });
+    });
+  });
 }
 
 describe('makeAxiosInstance', () => {
@@ -33,5 +52,19 @@ describe('makeAxiosInstance', () => {
     await instance({ url: 'https://api.example.com/test', method: 'get', adapter: stubAdapter });
 
     expect(stubAdapter.getConfig().headers['User-Agent']).toMatch(/^bruno-runtime\//);
+  });
+
+  it('accepts LF-only response header terminators', async () => {
+    const { server, url } = await createLfOnlyHeaderServer();
+    const instance = makeAxiosInstance();
+
+    try {
+      const response = await instance({ url, method: 'get' });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toBe('OK');
+    } finally {
+      server.close();
+    }
   });
 });

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -95,6 +95,7 @@ function makeAxiosInstance({
       return data;
     },
     proxy: false,
+    insecureHTTPParser: true,
     maxRedirects: 0,
     headers: {}
   });

--- a/packages/bruno-electron/tests/network/axios-instance.spec.js
+++ b/packages/bruno-electron/tests/network/axios-instance.spec.js
@@ -1,4 +1,6 @@
 // Mock electron before requiring axios-instance
+const net = require('net');
+
 jest.mock('electron', () => ({
   app: {
     getVersion: () => '1.0.0'
@@ -51,6 +53,24 @@ function createStubAdapter() {
   return adapter;
 }
 
+function createLfOnlyHeaderServer() {
+  const server = net.createServer((socket) => {
+    socket.once('data', () => {
+      socket.write('HTTP/1.1 200 OK\r\nContent-Type: text/plain\nContent-Length: 2\n\nOK');
+      socket.end();
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        server,
+        url: `http://127.0.0.1:${server.address().port}`
+      });
+    });
+  });
+}
+
 describe('axios-instance: default headers', () => {
   test('setting User-Agent does not clobber the axios default Accept header', async () => {
     const stubAdapter = createStubAdapter();
@@ -70,6 +90,22 @@ describe('axios-instance: default headers', () => {
     await instance({ url: 'https://api.example.com/test', method: 'get', adapter: stubAdapter });
 
     expect(stubAdapter.getConfig().headers['User-Agent']).toMatch(/^bruno-runtime\//);
+  });
+});
+
+describe('axios-instance: HTTP parser tolerance', () => {
+  test('accepts LF-only response header terminators', async () => {
+    const { server, url } = await createLfOnlyHeaderServer();
+    const instance = makeAxiosInstance();
+
+    try {
+      const response = await instance({ url, method: 'get' });
+
+      expect(response.status).toBe(200);
+      expect(response.data.toString()).toBe('OK');
+    } finally {
+      server.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- enable the Node HTTP insecure parser for Bruno runtime axios instances
- allow CLI and Electron requests to accept response headers terminated with LF
- add raw socket regression tests for LF-only response header terminators

Fixes #326

## Tests
- npm run build:bruno-common
- npm run build:bruno-requests
- npm test --workspace=packages/bruno-cli -- tests/utils/axios-instance.spec.js
- npm test --workspace=packages/bruno-electron -- tests/network/axios-instance.spec.js
- npx eslint packages/bruno-electron/src/ipc/network/axios-instance.js packages/bruno-cli/src/utils/axios-instance.js packages/bruno-electron/tests/network/axios-instance.spec.js packages/bruno-cli/tests/utils/axios-instance.spec.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced HTTP parser configuration to handle HTTP responses with non-standard header line terminators
  
* **Tests**
  * Added test coverage validating HTTP parser tolerance for alternative header terminator formats

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7970)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->