### PR TITLE
fix: handle send shortcut in GraphQL editor

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
@@ -53,6 +53,14 @@ export default class QueryEditor extends React.Component {
   }
 
   componentDidMount() {
+    const runShortcut = () => {
+      if (this.props.onRun) {
+        this.props.onRun();
+        return;
+      }
+      return CodeMirror.Pass;
+    };
+
     const editor = (this.editor = CodeMirror(this._node, {
       value: this.props.value || '',
       lineNumbers: true,
@@ -124,6 +132,8 @@ export default class QueryEditor extends React.Component {
             this.props.onMergeQuery();
           }
         },
+        'Cmd-Enter': runShortcut,
+        'Ctrl-Enter': runShortcut,
         'Cmd-F': 'findPersistent',
         'Ctrl-F': 'findPersistent'
       }

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.spec.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.spec.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import QueryEditor from './index';
+
+jest.mock('codemirror', () => {
+  const codemirror = require('test-utils/mocks/codemirror');
+  return codemirror;
+});
+
+jest.mock('utils/codemirror/linkAware', () => ({
+  setupLinkAware: jest.fn()
+}));
+
+const CodeMirror = require('codemirror');
+
+const MOCK_THEME = {
+  codemirror: {
+    bg: '#fff',
+    border: '#ddd',
+    tokens: {
+      definition: '#000',
+      property: '#000',
+      string: '#000',
+      number: '#000',
+      atom: '#000',
+      variable: '#000',
+      keyword: '#000',
+      comment: '#000',
+      operator: '#000',
+      tag: '#000',
+      tagBracket: '#000'
+    },
+    variable: {
+      valid: '#000',
+      invalid: '#000'
+    }
+  },
+  status: {
+    success: {
+      background: '#e6ffed'
+    },
+    danger: {
+      background: '#ffeef0'
+    }
+  },
+  colors: {
+    text: {
+      danger: '#d73a49'
+    }
+  }
+};
+
+const renderQueryEditor = (props = {}) => {
+  return render(
+    <ThemeProvider theme={MOCK_THEME}>
+      <QueryEditor {...props} />
+    </ThemeProvider>
+  );
+};
+
+describe('QueryEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('binds send-request shortcuts when onRun is provided', () => {
+    const onRun = jest.fn();
+
+    renderQueryEditor({ onRun });
+
+    const options = CodeMirror.mock.calls[0][1];
+    const cmdEnter = options.extraKeys['Cmd-Enter'];
+    const ctrlEnter = options.extraKeys['Ctrl-Enter'];
+
+    expect(cmdEnter).toEqual(expect.any(Function));
+    expect(ctrlEnter).toEqual(expect.any(Function));
+
+    cmdEnter();
+    ctrlEnter();
+
+    expect(onRun).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/bruno-app/src/test-utils/mocks/codemirror.js
+++ b/packages/bruno-app/src/test-utils/mocks/codemirror.js
@@ -1,4 +1,11 @@
 const CodeMirror = jest.fn((node, options) => {
+  const wrapperElement = {
+    parentNode: {
+      removeChild: jest.fn()
+    },
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  };
   const editor = {
     options,
     _currentValue: '',
@@ -14,6 +21,12 @@ const CodeMirror = jest.fn((node, options) => {
     refresh: jest.fn(),
     off: jest.fn(),
     showHint: jest.fn(),
+    getWrapperElement: jest.fn(() => wrapperElement),
+    getInputField: jest.fn(() => ({
+      classList: {
+        add: jest.fn()
+      }
+    })),
     on: jest.fn(function (event, handler) {
       if (event === 'keyup') {
         if (handler && handler.name === '_onKeyUpMockDataHints') {


### PR DESCRIPTION
## Summary
- route Cmd/Ctrl+Enter through the GraphQL query editor onRun handler
- add focused QueryEditor coverage for the send-request shortcuts
- extend the shared CodeMirror mock for QueryEditor mount/unmount behavior

## Root cause
QueryEditor uses CodeMirror with the sublime keymap, but unlike the shared CodeEditor it did not override Cmd/Ctrl+Enter. That left the editor keymap free to handle the shortcut as a line insertion while the request send shortcut also ran.

Fixes #7961

## Tests
- npm test --workspace=packages/bruno-app -- src/components/RequestPane/QueryEditor/index.spec.js src/components/CodeEditor/index.spec.js
- npx eslint packages/bruno-app/src/components/RequestPane/QueryEditor/index.js packages/bruno-app/src/components/RequestPane/QueryEditor/index.spec.js packages/bruno-app/src/test-utils/mocks/codemirror.js
- git diff --check HEAD
- npm run build:bruno-converters
- npm run build:graphql-docs
- npm run build:web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard shortcut handling in the query editor to provide consistent execution support for both Cmd-Enter (macOS) and Ctrl-Enter (Windows/Linux) shortcuts, with proper fallback to default CodeMirror behavior when execution handlers are unavailable
* **Tests**
  * Added test suite validating query editor keyboard shortcut functionality with CodeMirror integration and DOM event mocking

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7972)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->