### PR TITLE
fix: align runner loading spinner

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RunnerResults/StyledWrapper.js
@@ -78,6 +78,11 @@ const Wrapper = styled.div`
     color: ${(props) => props.theme.colors.text.muted};
   }
 
+  .runner-loading-icon {
+    transform: scaleY(-1);
+    animation: rotateCounterClockwise 1s linear infinite;
+  }
+
   .text-muted {
     color: ${(props) => props.theme.colors.text.muted};
   }

--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -411,7 +411,7 @@ export default function RunnerResults({ collection }) {
                         {item.displayName}
                       </span>
                       {item.status !== 'error' && item.status !== 'skipped' && item.status !== 'completed' ? (
-                        <IconRefresh className="animate-spin ml-1" size={18} strokeWidth={1.5} />
+                        <IconRefresh className="runner-loading-icon ml-1" size={18} strokeWidth={1.5} />
                       ) : item.responseReceived?.status ? (
                         <span className="text-xs link cursor-pointer" onClick={() => setSelectedItem(item)}>
                           <span className="mr-1">{item.responseReceived?.status}</span>

--- a/packages/bruno-app/src/components/RunnerResults/index.spec.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.spec.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import RunnerResults from './index';
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => jest.fn()
+}));
+
+jest.mock('utils/collections', () => ({
+  areItemsLoading: jest.fn(() => false),
+  findItemInCollection: jest.fn(() => ({
+    uid: 'request-1',
+    name: 'Request 1',
+    type: 'http-request',
+    pathname: '/collection/request-1.bru',
+    request: {
+      tags: []
+    }
+  })),
+  getTotalRequestCountInCollection: jest.fn(() => 1)
+}));
+
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  cancelRunnerExecution: jest.fn(),
+  mountCollection: jest.fn(),
+  runCollectionFolder: jest.fn(),
+  updateRunnerConfiguration: jest.fn()
+}));
+
+jest.mock('providers/ReduxStore/slices/collections', () => ({
+  resetCollectionRunner: jest.fn()
+}));
+
+jest.mock('./ResponsePane', () => () => <div data-testid="runner-response-pane" />);
+jest.mock('./RunnerTags/index', () => () => <div data-testid="runner-tags" />);
+jest.mock('./RunConfigurationPanel', () => () => <div data-testid="runner-config-panel" />);
+jest.mock('./StyledWrapper', () => ({ children, ...props }) => <div {...props}>{children}</div>);
+jest.mock('ui/Button/index', () => ({ children, ...props }) => {
+  const { color, size, variant, ...buttonProps } = props;
+  return <button {...buttonProps}>{children}</button>;
+});
+
+const collection = {
+  uid: 'collection-1',
+  pathname: '/collection',
+  mountStatus: 'mounted',
+  runnerResult: {
+    info: {
+      status: 'running',
+      cancelTokenUid: 'cancel-token-1'
+    },
+    items: [
+      {
+        uid: 'request-1',
+        status: 'running'
+      }
+    ]
+  }
+};
+
+describe('RunnerResults', () => {
+  beforeEach(() => {
+    Element.prototype.scrollTo = jest.fn();
+  });
+
+  it('uses the runner loading icon class for in-progress requests', () => {
+    const { container } = render(<RunnerResults collection={collection} />);
+
+    const loadingIcon = container.querySelector('svg.runner-loading-icon');
+
+    expect(loadingIcon).toBeInTheDocument();
+    expect(loadingIcon).not.toHaveClass('animate-spin');
+  });
+});


### PR DESCRIPTION
## Summary
- align the Runner in-progress request spinner with the request loading overlay
- replace the generic `animate-spin` class with a runner-specific loading icon class
- add focused `RunnerResults` coverage for the in-progress spinner class

## Root cause
The request loading overlay flips `IconRefresh` and uses the shared `rotateCounterClockwise` animation, while Runner used the raw `IconRefresh` with Tailwind `animate-spin`. That made the arrow orientation and apparent spin direction differ between the two places.

Fixes #7829

## Tests
- `npm test --workspace=packages/bruno-app -- src/components/RunnerResults/index.spec.jsx`
- `npx eslint packages/bruno-app/src/components/RunnerResults/index.jsx packages/bruno-app/src/components/RunnerResults/index.spec.jsx packages/bruno-app/src/components/RunnerResults/StyledWrapper.js`
- `git diff --check`
- `npm run build:web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the loading icon animation for runner operations with a new counter-clockwise rotation effect and vertical flip styling for enhanced visual feedback.

* **Tests**
  * Added test suite for the runner results component to ensure proper loading icon rendering and styling behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7974)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->