### PR TITLE
fix: skip cookie API key imports

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -42,12 +42,12 @@ const isSupportedSecurityScheme = (scheme) => {
 
 const getFirstSupportedSecurityScheme = (securityRequirements = [], securitySchemes = {}) => {
   for (const requirement of securityRequirements) {
-    for (const schemeName of Object.keys(requirement)) {
-      const scheme = securitySchemes[schemeName];
-      if (isSupportedSecurityScheme(scheme)) {
-        return scheme;
-      }
+    const schemes = Object.keys(requirement).map((schemeName) => securitySchemes[schemeName]);
+    if (schemes.some((scheme) => !isSupportedSecurityScheme(scheme))) {
+      continue;
     }
+
+    return schemes[0] || null;
   }
 
   return null;
@@ -359,6 +359,9 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
   let auth = null;
   if (_operationObject.security && _operationObject.security.length > 0) {
     auth = request.global.security.getFirstSupportedScheme(_operationObject.security);
+    if (!auth) {
+      brunoRequestItem.request.auth.mode = 'none';
+    }
   }
 
   if (auth) {
@@ -795,8 +798,8 @@ const getSecurity = (apiSpec) => {
   return {
     supported: hasSchemes
       ? defaultSchemes
-          .flatMap((scheme) => Object.keys(scheme).map((schemeName) => securitySchemes[schemeName]))
-          .filter(isSupportedSecurityScheme)
+          .map((scheme) => getFirstSupportedSecurityScheme([scheme], securitySchemes))
+          .filter(Boolean)
       : [],
     schemes: securitySchemes,
     getScheme: (schemeName) => {

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -28,6 +28,31 @@ const getSchemaPropertyExampleValue = (prop, propName, parentExample = {}) => {
   return '';
 };
 
+const isSupportedSecurityScheme = (scheme) => {
+  if (!scheme) {
+    return false;
+  }
+
+  if (scheme.type === 'apiKey') {
+    return scheme.in === 'header' || scheme.in === 'query';
+  }
+
+  return true;
+};
+
+const getFirstSupportedSecurityScheme = (securityRequirements = [], securitySchemes = {}) => {
+  for (const requirement of securityRequirements) {
+    for (const schemeName of Object.keys(requirement)) {
+      const scheme = securitySchemes[schemeName];
+      if (isSupportedSecurityScheme(scheme)) {
+        return scheme;
+      }
+    }
+  }
+
+  return null;
+};
+
 /**
  * Extracts parameter entries based on OpenAPI parameter schema
  * For enum parameters, creates multiple entries (one per enum value)
@@ -333,8 +358,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
 
   let auth = null;
   if (_operationObject.security && _operationObject.security.length > 0) {
-    const schemeName = Object.keys(_operationObject.security[0])[0];
-    auth = request.global.security.getScheme(schemeName);
+    auth = request.global.security.getFirstSupportedScheme(_operationObject.security);
   }
 
   if (auth) {
@@ -771,11 +795,16 @@ const getSecurity = (apiSpec) => {
   return {
     supported: hasSchemes
       ? defaultSchemes
-          .map((scheme) => securitySchemes[Object.keys(scheme)[0]])
-          .filter(Boolean)
+          .flatMap((scheme) => Object.keys(scheme).map((schemeName) => securitySchemes[schemeName]))
+          .filter(isSupportedSecurityScheme)
       : [],
     schemes: securitySchemes,
-    getScheme: (schemeName) => securitySchemes[schemeName]
+    getScheme: (schemeName) => {
+      const scheme = securitySchemes[schemeName];
+      return isSupportedSecurityScheme(scheme) ? scheme : null;
+    },
+    getFirstSupportedScheme: (securityRequirements) =>
+      getFirstSupportedSecurityScheme(securityRequirements, securitySchemes)
   };
 };
 

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-auth.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-auth.spec.js
@@ -63,7 +63,7 @@ servers:
     expect(hasQueryParam).toBe(true);
   });
 
-  it('maps apiKey in cookie and treats it as a header', () => {
+  it('ignores apiKey in cookie instead of importing it as a header', () => {
     const spec = `
 openapi: 3.0.3
 info:
@@ -86,11 +86,45 @@ servers:
   - url: https://example.com
 `;
     const { items: [req] } = openApiToBruno(spec);
-    expect(req.request.auth.mode).toBe('apikey');
-    expect(req.request.auth.apikey.placement).toBe('header');
+    expect(req.request.auth.mode).toBe('inherit');
     const apiKeyHeader = req.request.headers.find((h) => h.name === 'DEMO_API_KEY');
-    expect(apiKeyHeader).toBeDefined();
-    expect(apiKeyHeader.value).toBe('{{apiKey}}');
+    expect(apiKeyHeader).toBeUndefined();
+  });
+
+  it('skips cookie apiKey global security and uses the next supported scheme', () => {
+    const spec = `
+openapi: 3.0.3
+info:
+  title: Cookie and Header API-Key
+  version: '1.0'
+components:
+  securitySchemes:
+    SessionCookie:
+      type: apiKey
+      in: cookie
+      name: SessionCookie
+    ApiKeyHeader:
+      type: apiKey
+      in: header
+      name: X-API-Key
+security:
+  - SessionCookie: []
+  - ApiKeyHeader: []
+paths:
+  /whoami:
+    get:
+      responses:
+        '200': { description: OK }
+servers:
+  - url: https://example.com
+`;
+    const collection = openApiToBruno(spec);
+
+    expect(collection.root.request.auth.mode).toBe('apikey');
+    expect(collection.root.request.auth.apikey).toMatchObject({
+      key: 'X-API-Key',
+      placement: 'header'
+    });
   });
 
   it('maps OAuth2 authorizationCode flow to oauth2 grantType authorization_code', () => {

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-auth.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-auth.spec.js
@@ -86,7 +86,7 @@ servers:
   - url: https://example.com
 `;
     const { items: [req] } = openApiToBruno(spec);
-    expect(req.request.auth.mode).toBe('inherit');
+    expect(req.request.auth.mode).toBe('none');
     const apiKeyHeader = req.request.headers.find((h) => h.name === 'DEMO_API_KEY');
     expect(apiKeyHeader).toBeUndefined();
   });
@@ -125,6 +125,78 @@ servers:
       key: 'X-API-Key',
       placement: 'header'
     });
+  });
+
+  it('skips a security requirement when any required scheme is unsupported', () => {
+    const spec = `
+openapi: 3.0.3
+info:
+  title: Combined Security API
+  version: '1.0'
+components:
+  securitySchemes:
+    SessionCookie:
+      type: apiKey
+      in: cookie
+      name: SessionCookie
+    FirstHeader:
+      type: apiKey
+      in: header
+      name: X-First-Key
+    FallbackHeader:
+      type: apiKey
+      in: header
+      name: X-Fallback-Key
+security:
+  - SessionCookie: []
+    FirstHeader: []
+  - FallbackHeader: []
+paths:
+  /whoami:
+    get:
+      responses:
+        '200': { description: OK }
+servers:
+  - url: https://example.com
+`;
+    const collection = openApiToBruno(spec);
+
+    expect(collection.root.request.auth.mode).toBe('apikey');
+    expect(collection.root.request.auth.apikey.key).toBe('X-Fallback-Key');
+  });
+
+  it('disables inheritance when operation security only has unsupported schemes', () => {
+    const spec = `
+openapi: 3.0.3
+info:
+  title: Operation Cookie API-Key
+  version: '1.0'
+components:
+  securitySchemes:
+    ApiKeyHeader:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    SessionCookie:
+      type: apiKey
+      in: cookie
+      name: SessionCookie
+security:
+  - ApiKeyHeader: []
+paths:
+  /whoami:
+    get:
+      security:
+        - SessionCookie: []
+      responses:
+        '200': { description: OK }
+servers:
+  - url: https://example.com
+`;
+    const { items: [req] } = openApiToBruno(spec);
+
+    expect(req.request.auth.mode).toBe('none');
+    expect(req.request.headers.find((h) => h.name === 'SessionCookie')).toBeUndefined();
   });
 
   it('maps OAuth2 authorizationCode flow to oauth2 grantType authorization_code', () => {


### PR DESCRIPTION
## Summary
- stop importing OpenAPI `apiKey` security schemes with `in: cookie` as header auth
- select the next supported security alternative when a global or operation security list starts with an unsupported cookie API key scheme
- update OpenAPI converter coverage for cookie API key imports and supported fallback auth

## Root cause
The OpenAPI converter treated every non-query `apiKey` security scheme as header auth. That made `in: cookie` schemes import as API Key / Header even though Bruno's API key auth currently only supports header and query param placement, causing cookie-backed auth schemes to be sent as custom headers.

Fixes #7953

## Tests
- `npm test --workspace=packages/bruno-converters -- tests/openapi/openapi-to-bruno/openapi-auth.spec.js tests/openapi/openapi-to-bruno/openapi-to-bruno.spec.js tests/openapi/openapi-to-bruno/openapi-path-parameters.spec.js`
- `npx eslint packages/bruno-converters/src/openapi/openapi-to-bruno.js packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-auth.spec.js`
- `git diff --check HEAD`
- `npm run build:bruno-converters` (passes with existing TypeScript warnings in `src/opencollection/*`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI-to-Bruno now reliably picks the first supported authentication scheme for operations and global security, and defaults to no auth when none apply.
  * API key-in-cookie schemes are no longer treated as headers and are skipped when alternative auth methods exist.

* **Tests**
  * Expanded tests covering security-scheme selection and cookie-based authentication handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7975)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->