### PR TITLE
fix: preserve escaped quotes in json preview

### DIFF
--- a/packages/bruno-app/src/utils/common/format-response.spec.js
+++ b/packages/bruno-app/src/utils/common/format-response.spec.js
@@ -53,6 +53,15 @@ describe('formatResponse', () => {
       expect(typeof result).toBe('string');
     });
 
+    it('should preserve unicode escaped quotes when formatting JSON responses', () => {
+      const data = '{"foo":"\\u0022bar"}';
+      const dataBuffer = createBase64Buffer(data);
+      const result = formatResponse(data, dataBuffer, 'application/json');
+
+      expect(result).toBe('{\n  "foo": "\\u0022bar"\n}');
+      expect(() => JSON.parse(result)).not.toThrow();
+    });
+
     it('should preserve bigint value after JSON format', () => {
       const data = '{ "data": 1736184243098437392 }';
       const dataBuffer = createBase64Buffer(data);

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -1,7 +1,6 @@
 import { customAlphabet } from 'nanoid';
 import xmlFormat from 'xml-formatter';
 import { JSONPath } from 'jsonpath-plus';
-import fastJsonFormat from 'fast-json-format';
 import { format, applyEdits } from 'jsonc-parser';
 import { patternHasher } from '@usebruno/common/utils';
 import prettierFormat from 'prettier/standalone';
@@ -303,7 +302,7 @@ export const formatResponse = (data, dataBufferString, mode, filter, bufferThres
     }
 
     try {
-      return fastJsonFormat(rawData);
+      return prettifyJsonString(rawData);
     } catch (error) {}
 
     if (typeof data === 'string') {


### PR DESCRIPTION
## Summary
- preserve unicode escaped quotes when formatting JSON preview responses
- switch the JSON formatting path to the existing jsonc-parser based prettifier
- add regression coverage for `\u0022` so the formatted preview remains valid JSON

## Root cause
The JSON preview formatter used `fast-json-format`, which decodes `\u0022` into a raw quote during formatting. That can produce invalid displayed JSON like `""bar"` for an input string value that should keep the escape sequence.

Fixes #7954

## Tests
- `npm test --workspace=packages/bruno-app -- src/utils/common/format-response.spec.js src/utils/common/index.spec.js`
- `npx eslint packages/bruno-app/src/utils/common/index.js packages/bruno-app/src/utils/common/format-response.spec.js`
- `git diff --check HEAD`
- `npm run build:web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test to verify unicode-escaped quotes in JSON responses are preserved and valid.

* **Refactor**
  * Updated JSON response formatting to use an improved prettifying method.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7976)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->