### PR TITLE
fix: expand middle-click tab close hit area

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/ExampleTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/ExampleTab/index.js
@@ -84,6 +84,20 @@ const ExampleTab = ({ tab, collection }) => {
     }
   };
 
+  const handleExampleTabMouseUp = (e) => {
+    if (e.button !== 1) {
+      return;
+    }
+
+    if (!hasChanges) {
+      return handleMouseUp(e);
+    }
+
+    e.stopPropagation();
+    e.preventDefault();
+    setShowConfirmClose(true);
+  };
+
   if (!item || !example) {
     const displayName = tab.exampleName || tab.name;
     const showLoading = displayName && isItemsLoading;
@@ -110,7 +124,11 @@ const ExampleTab = ({ tab, collection }) => {
   }
 
   return (
-    <StyledWrapper className="flex items-center justify-between tab-container px-2">
+    <StyledWrapper
+      className="flex items-center justify-between tab-container px-2"
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleExampleTabMouseUp}
+    >
       {showConfirmClose && (
         <ConfirmRequestClose
           item={item}
@@ -141,16 +159,6 @@ const ExampleTab = ({ tab, collection }) => {
         className={`flex items-center tab-label ${tab.preview ? 'italic' : ''}`}
         onContextMenu={handleRightClick}
         onDoubleClick={() => dispatch(makeTabPermanent({ uid: tab.uid }))}
-        onMouseDown={handleMouseDown}
-        onMouseUp={(e) => {
-          if (!hasChanges) return handleMouseUp(e);
-
-          if (e.button === 1) {
-            e.stopPropagation();
-            e.preventDefault();
-            setShowConfirmClose(true);
-          }
-        }}
       >
         <ExampleIcon size={14} color="currentColor" className="example-icon flex-shrink-0" />
         <span className="tab-name ml-1" title={example.name}>

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -147,6 +147,21 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
     }
   };
 
+  const handleRequestTabMouseUp = (e) => {
+    if (e.button !== 1) {
+      return;
+    }
+
+    if (!hasChanges) {
+      isWS && closeWsConnection(item.uid);
+      return handleMouseUp(e);
+    }
+
+    e.stopPropagation();
+    e.preventDefault();
+    setShowConfirmClose(true);
+  };
+
   const getMethodColor = (method = '') => {
     const colorMap = {
       ...theme.request.methods,
@@ -518,7 +533,11 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   }
 
   return (
-    <StyledWrapper className="flex items-center justify-between tab-container px-2">
+    <StyledWrapper
+      className="flex items-center justify-between tab-container px-2"
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleRequestTabMouseUp}
+    >
       {showConfirmClose && (
         <ConfirmRequestClose
           item={item}
@@ -559,16 +578,6 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
         className={`flex items-baseline tab-label ${tab.preview ? 'italic' : ''}`}
         onContextMenu={handleRightClick}
         onDoubleClick={() => dispatch(makeTabPermanent({ uid: tab.uid }))}
-        onMouseDown={handleMouseDown}
-        onMouseUp={(e) => {
-          if (!hasChanges) return handleMouseUp(e);
-
-          if (e.button === 1) {
-            e.stopPropagation();
-            e.preventDefault();
-            setShowConfirmClose(true);
-          }
-        }}
       >
         <span className="tab-method uppercase" style={{ color: getMethodColor(method) }}>
           {method}

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.spec.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.spec.js
@@ -1,0 +1,219 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { ThemeProvider } from 'styled-components';
+import RequestTab from './index';
+
+const mockCloseTabs = jest.fn((payload) => ({ type: 'collections/closeTabs', payload }));
+const mockSaveRequest = jest.fn(() => ({ type: 'collections/saveRequest' }));
+const mockFindItemInCollection = jest.fn();
+const mockFindItemInCollectionByPathname = jest.fn();
+const mockHasRequestChanges = jest.fn();
+const mockHasExampleChanges = jest.fn();
+
+const mockTheme = {
+  bg: '#ffffff',
+  border: { radius: { base: '4px' } },
+  request: {
+    methods: {
+      get: '#22c55e'
+    }
+  },
+  requestTabs: {
+    bg: '#f8fafc',
+    icon: {
+      color: '#64748b',
+      hoverBg: '#e2e8f0',
+      hoverColor: '#0f172a'
+    },
+    example: {
+      iconColor: '#64748b'
+    }
+  }
+};
+
+jest.mock('hooks/useKeybinding', () => jest.fn());
+
+jest.mock('providers/Theme', () => ({
+  useTheme: () => ({ theme: mockTheme })
+}));
+
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  closeTabs: (payload) => mockCloseTabs(payload),
+  saveRequest: (...args) => mockSaveRequest(...args),
+  saveCollectionRoot: jest.fn(),
+  saveFolderRoot: jest.fn(),
+  saveEnvironment: jest.fn(),
+  saveCollectionSettings: jest.fn()
+}));
+
+jest.mock('providers/ReduxStore/slices/tabs', () => ({
+  makeTabPermanent: (payload) => ({ type: 'tabs/makeTabPermanent', payload }),
+  syncTabUid: (payload) => ({ type: 'tabs/syncTabUid', payload })
+}));
+
+jest.mock('providers/ReduxStore/slices/collections', () => ({
+  deleteRequestDraft: (payload) => ({ type: 'collections/deleteRequestDraft', payload }),
+  deleteCollectionDraft: jest.fn(),
+  deleteFolderDraft: jest.fn(),
+  clearEnvironmentsDraft: jest.fn()
+}));
+
+jest.mock('providers/ReduxStore/slices/global-environments', () => ({
+  clearGlobalEnvironmentDraft: jest.fn(),
+  saveGlobalEnvironment: jest.fn()
+}));
+
+jest.mock('utils/collections', () => ({
+  findItemInCollection: (...args) => mockFindItemInCollection(...args),
+  findItemInCollectionByPathname: (...args) => mockFindItemInCollectionByPathname(...args),
+  hasRequestChanges: (...args) => mockHasRequestChanges(...args),
+  hasExampleChanges: (...args) => mockHasExampleChanges(...args),
+  areItemsLoading: jest.fn(() => false)
+}));
+
+jest.mock('utils/collections/index', () => ({
+  findItemInCollection: (...args) => mockFindItemInCollection(...args),
+  findItemInCollectionByPathname: (...args) => mockFindItemInCollectionByPathname(...args),
+  hasRequestChanges: (...args) => mockHasRequestChanges(...args),
+  hasExampleChanges: (...args) => mockHasExampleChanges(...args),
+  areItemsLoading: jest.fn(() => false),
+  flattenItems: jest.fn(() => [])
+}));
+
+jest.mock('utils/network/index', () => ({
+  closeWsConnection: jest.fn()
+}));
+
+jest.mock('./GradientCloseButton', () => ({ onClick, hasChanges }) => (
+  <button data-testid="request-tab-close-icon" data-has-changes={hasChanges} onClick={onClick} />
+));
+
+jest.mock('ui/MenuDropdown', () => {
+  const React = require('react');
+  return React.forwardRef(({ children }, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      show: jest.fn(),
+      hide: jest.fn(),
+      state: { isShown: false }
+    }));
+
+    return <>{children}</>;
+  });
+});
+
+const createStore = () => configureStore({
+  reducer: {
+    tabs: (state = { activeTabUid: 'request-1' }) => state,
+    globalEnvironments: (state = { globalEnvironmentDraft: null }) => state
+  }
+});
+
+const renderRequestTab = () => {
+  const item = {
+    uid: 'request-1',
+    type: 'http-request',
+    name: 'Users',
+    request: {
+      method: 'GET'
+    }
+  };
+  const collection = {
+    uid: 'collection-1',
+    items: [item]
+  };
+  const tab = {
+    uid: 'request-1',
+    type: 'http-request',
+    collectionUid: 'collection-1'
+  };
+
+  mockFindItemInCollection.mockReturnValue(item);
+  mockFindItemInCollectionByPathname.mockReturnValue(null);
+  mockHasRequestChanges.mockReturnValue(false);
+
+  return render(
+    <Provider store={createStore()}>
+      <ThemeProvider theme={mockTheme}>
+        <RequestTab
+          tab={tab}
+          collection={collection}
+          tabIndex={0}
+          collectionRequestTabs={[tab]}
+        />
+      </ThemeProvider>
+    </Provider>
+  );
+};
+
+const renderResponseExampleTab = () => {
+  const example = {
+    uid: 'example-1',
+    name: 'Success'
+  };
+  const item = {
+    uid: 'request-1',
+    type: 'http-request',
+    name: 'Users',
+    request: {
+      method: 'GET'
+    },
+    examples: [example]
+  };
+  const collection = {
+    uid: 'collection-1',
+    items: [item]
+  };
+  const tab = {
+    uid: 'example-1',
+    itemUid: 'request-1',
+    type: 'response-example',
+    collectionUid: 'collection-1'
+  };
+
+  mockFindItemInCollection.mockReturnValue(item);
+  mockFindItemInCollectionByPathname.mockReturnValue(null);
+  mockHasRequestChanges.mockReturnValue(false);
+  mockHasExampleChanges.mockReturnValue(false);
+
+  return render(
+    <Provider store={createStore()}>
+      <ThemeProvider theme={mockTheme}>
+        <RequestTab
+          tab={tab}
+          collection={collection}
+          tabIndex={0}
+          collectionRequestTabs={[tab]}
+        />
+      </ThemeProvider>
+    </Provider>
+  );
+};
+
+describe('RequestTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('closes a request tab when middle-clicking anywhere on the tab container', () => {
+    const { container } = renderRequestTab();
+    const tabContainer = container.querySelector('.tab-container');
+
+    fireEvent.mouseDown(tabContainer, { button: 1 });
+    fireEvent.mouseUp(tabContainer, { button: 1 });
+
+    expect(mockCloseTabs).toHaveBeenCalledWith({ tabUids: ['request-1'] });
+  });
+
+  it('closes a response example tab when middle-clicking anywhere on the tab container', () => {
+    const { container } = renderResponseExampleTab();
+    const tabContainer = container.querySelector('.tab-container');
+
+    fireEvent.mouseDown(tabContainer, { button: 1 });
+    fireEvent.mouseUp(tabContainer, { button: 1 });
+
+    expect(mockCloseTabs).toHaveBeenCalledWith({ tabUids: ['example-1'] });
+  });
+});


### PR DESCRIPTION
## Summary
- handle middle mouse tab closing on the full request tab container instead of only the inner label
- apply the same container-level behavior to response example tabs
- add regression coverage for middle-clicking request and response example tab containers

## Root cause
The middle-button handlers for regular request and response example tabs were attached to the inner `.tab-label`. Areas above, below, or beside the tab text were still part of the visible tab but did not receive the close behavior. Special tabs already handled middle-clicks at the outer tab container level.

Fixes #7950

## Tests
- `npm test --workspace=packages/bruno-app -- src/components/RequestTabs/RequestTab/index.spec.js`
- `npx eslint packages/bruno-app/src/components/RequestTabs/RequestTab/index.js packages/bruno-app/src/components/RequestTabs/ExampleTab/index.js packages/bruno-app/src/components/RequestTabs/RequestTab/index.spec.js`
- `git diff --check`
- `npm run build:web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Middle-click to close request and example tabs now displays a confirmation modal when there are unsaved changes, protecting against accidental data loss. Tabs without pending changes continue to close immediately.

* **Tests**
  * Added comprehensive test coverage for middle-click tab-close behavior across different tab types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7977)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->