### PR TITLE
feat: include deprecated GraphQL input values

### DIFF
--- a/packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js
@@ -10,7 +10,7 @@ const prepareGqlIntrospectionRequest = (endpoint, resolvedVars, request, collect
   }
 
   const queryParams = {
-    query: getIntrospectionQuery()
+    query: getIntrospectionQuery({ inputValueDeprecation: true })
   };
 
   let axiosRequest = {

--- a/packages/bruno-electron/tests/network/prepare-gql-introspection-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-gql-introspection-request.spec.js
@@ -100,6 +100,15 @@ describe('prepareGqlIntrospectionRequest', () => {
     expect(result.headers['Content-Type']).toBe('application/json');
   });
 
+  it('should request deprecated GraphQL input values during introspection', () => {
+    const setup = createBasicSetup();
+    const result = prepareGqlIntrospectionRequest(setup.endpoint, {}, setup.request, setup.collectionRoot);
+    const { query } = JSON.parse(result.data);
+
+    expect(query).toContain('inputFields(includeDeprecated: true)');
+    expect(query).toContain('args(includeDeprecated: true)');
+  });
+
   it('should handle process.env variables in endpoint URL', () => {
     const setup = createBasicSetup();
     setup.endpoint = 'https://{{process.env.API_HOST}}/graphql';


### PR DESCRIPTION
## Summary
- enable GraphQL introspection to request deprecated input values
- add regression coverage for `inputFields(includeDeprecated: true)` and deprecated argument metadata

## Root cause
Bruno used `getIntrospectionQuery()` with default GraphQL options. That includes deprecated object fields and enum values, but it does not include deprecated input fields or deprecated arguments unless `inputValueDeprecation` is enabled.

Fixes #7830

## Tests
- `npm test --workspace=packages/bruno-electron -- tests/network/prepare-gql-introspection-request.spec.js`
- `npx eslint packages/bruno-electron/src/ipc/network/prepare-gql-introspection-request.js packages/bruno-electron/tests/network/prepare-gql-introspection-request.spec.js`
- `git diff --check`

## Note
- `npm run build:bruno-filestore` was attempted as a local prerequisite for the electron test, but exits 2 on existing schema-types resolution errors unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GraphQL schema introspection now includes detailed information about deprecated input values and arguments, enabling developers to better understand deprecation patterns and API evolution when exploring GraphQL services.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7978)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->