### PR TITLE
fix: wrap long request names in delete modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/StyledWrapper.js
@@ -10,6 +10,10 @@ const Wrapper = styled.div`
       border: inherit !important;
     }
   }
+
+  .delete-item-name {
+    overflow-wrap: anywhere;
+  }
 `;
 
 export default Wrapper;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js
@@ -46,7 +46,7 @@ const DeleteCollectionItem = ({ onClose, item, collectionUid }) => {
         handleConfirm={onConfirm}
         handleCancel={onClose}
       >
-        Are you sure you want to delete <span className="font-medium">{item.name}</span> ?
+        Are you sure you want to delete <span className="delete-item-name font-medium">{item.name}</span> ?
       </Modal>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.spec.js
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DeleteCollectionItem from './index';
+
+jest.mock('components/Modal', () => {
+  const React = require('react');
+
+  return function MockModal({ children, title }) {
+    return (
+      <div role="dialog" aria-label={title}>
+        {children}
+      </div>
+    );
+  };
+});
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => jest.fn()
+}));
+
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  deleteItem: jest.fn(),
+  closeTabs: jest.fn()
+}));
+
+jest.mock('utils/collections', () => ({
+  recursivelyGetAllItemUids: jest.fn(() => [])
+}));
+
+describe('DeleteCollectionItem', () => {
+  it('allows long request names to wrap inside the delete confirmation modal', () => {
+    const longRequestName
+      = 'https://apis.data.go/B552584/EvCharger/helloworlld?serviceKey=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff&zcode=11&numOfRows=10&pageNo=1&dataType=JSON';
+
+    render(
+      <DeleteCollectionItem
+        onClose={jest.fn()}
+        collectionUid="collection-1"
+        item={{
+          uid: 'request-1',
+          type: 'http-request',
+          request: {},
+          name: longRequestName
+        }}
+      />
+    );
+
+    const requestName = screen.getByText(longRequestName);
+
+    expect(requestName).toHaveClass('delete-item-name');
+    expect(document.head.textContent.replace(/\s/g, '')).toContain('overflow-wrap:anywhere');
+  });
+});


### PR DESCRIPTION
## What changed

- Adds a dedicated wrapping style to the request name shown in the Delete Request confirmation modal.
- Adds a regression test for long unbroken request names/URLs in that modal.

Fixes #7934.

## Validation

- `npm test --workspace=packages/bruno-app -- src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.spec.js`
- `npx eslint packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/StyledWrapper.js packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.spec.js`
- `git diff --check HEAD`
- `npm run build:web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping behavior in the delete confirmation modal to properly display long item names.

* **Tests**
  * Added test coverage to verify long item names wrap correctly in delete dialogs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7979)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->