### PR TITLE
fix: surface zip import errors

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import get from 'lodash/get';
+import toast from 'react-hot-toast';
 import path from 'utils/common/path';
 import { IconCaretDown } from '@tabler/icons';
 import { browseDirectory } from 'providers/ReduxStore/slices/collections/actions';
@@ -12,7 +13,8 @@ import { convertOpenapiToBruno } from 'utils/importers/openapi-collection';
 import { processBrunoCollection } from 'utils/importers/bruno-collection';
 import { processOpenCollection } from 'utils/importers/opencollection';
 import { wsdlToBruno } from '@usebruno/converters';
-import { toastError } from 'utils/common/error';
+import { multiLineMsg } from 'utils/common';
+import { formatIpcError, toastError } from 'utils/common/error';
 import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
 import Modal from 'components/Modal';
 import Help from 'components/Help';
@@ -92,6 +94,11 @@ const convertCollection = async (format, rawData, groupingType, collectionFormat
   }
 };
 
+const showImportCollectionError = (error) => {
+  console.error('Failed to import collection', error);
+  toast.error(multiLineMsg('Failed to import collection', formatIpcError(error)));
+};
+
 const groupingOptions = [
   { value: 'tags', label: 'Tags', description: 'Group requests by OpenAPI/Swagger tags', testId: 'grouping-option-tags' },
   { value: 'path', label: 'Paths', description: 'Group requests by URL path structure', testId: 'grouping-option-path' }
@@ -122,6 +129,13 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
     : (activeWorkspace?.pathname ? path.join(activeWorkspace.pathname, 'collections') : '');
 
   const collectionName = getCollectionName(format, rawData);
+  const submitCollectionImport = async (...args) => {
+    try {
+      await handleSubmit(...args);
+    } catch (error) {
+      showImportCollectionError(error);
+    }
+  };
 
   const formik = useFormik({
     enableReinitialize: true,
@@ -163,7 +177,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
         options.rawOpenAPISpec = rawContent || rawData;
       }
 
-      handleSubmit(convertedCollection, values.collectionLocation, options);
+      await submitCollectionImport(convertedCollection, values.collectionLocation, options);
     }
   });
 
@@ -209,7 +223,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
         return;
       }
       const collectionLocation = formik.values.collectionLocation;
-      handleSubmit(rawData, collectionLocation, { format: collectionFormat, isZipImport: true });
+      await submitCollectionImport(rawData, collectionLocation, { format: collectionFormat, isZipImport: true });
     } else {
       formik.handleSubmit();
     }

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.spec.js
@@ -1,0 +1,118 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import toast from 'react-hot-toast';
+import ImportCollectionLocation from './index';
+
+const mockDispatch = jest.fn();
+let consoleErrorSpy;
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector) =>
+    selector({
+      app: {
+        preferences: {
+          general: {
+            defaultLocation: '/tmp/bruno-collections'
+          }
+        }
+      },
+      workspaces: {
+        workspaces: [],
+        activeWorkspaceUid: null
+      }
+    })
+}));
+
+jest.mock('react-hot-toast', () => ({
+  error: jest.fn()
+}));
+
+jest.mock('components/Modal', () => {
+  const React = require('react');
+
+  return function MockModal({ children, confirmText, handleConfirm }) {
+    return (
+      <div>
+        {children}
+        <button type="button" onClick={handleConfirm}>
+          {confirmText}
+        </button>
+      </div>
+    );
+  };
+});
+
+jest.mock('components/Help', () => {
+  const React = require('react');
+
+  return function MockHelp({ children }) {
+    return <span>{children}</span>;
+  };
+});
+
+jest.mock('components/Dropdown', () => {
+  const React = require('react');
+
+  return function MockDropdown({ children }) {
+    return <div>{children}</div>;
+  };
+});
+
+jest.mock('./StyledWrapper', () => {
+  const React = require('react');
+
+  return function MockStyledWrapper({ children }) {
+    return <div>{children}</div>;
+  };
+});
+
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  browseDirectory: jest.fn()
+}));
+
+jest.mock('utils/beta-features', () => ({
+  BETA_FEATURES: {
+    OPENAPI_SYNC: 'openapi-sync'
+  },
+  useBetaFeature: jest.fn(() => false)
+}));
+
+describe('ImportCollectionLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('surfaces zip import errors returned by the Electron process', async () => {
+    const ipcError = new Error(
+      'Error invoking remote method \'renderer:import-collection-zip\': Error: Security error: Symlink "boilerplate.js" points outside extraction directory'
+    );
+    const handleSubmit = jest.fn(() => Promise.reject(ipcError));
+
+    render(
+      <ImportCollectionLocation
+        onClose={jest.fn()}
+        handleSubmit={handleSubmit}
+        format="bruno-zip"
+        rawData={{
+          zipFilePath: '/tmp/collection.zip',
+          collectionName: 'Collection With Symlink'
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Failed to import collection\nSecurity error: Symlink "boilerplate.js" points outside extraction directory'
+      );
+    });
+  });
+});

--- a/packages/bruno-app/src/components/Sidebar/Sections/CollectionsSection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Sections/CollectionsSection/index.js
@@ -114,7 +114,7 @@ const CollectionsSection = () => {
       ? importCollectionFromZip(convertedCollection.zipFilePath, collectionLocation)
       : importCollection(convertedCollection, collectionLocation, options);
 
-    dispatch(importAction)
+    return dispatch(importAction)
       .then(() => {
         setImportCollectionLocationModalOpen(false);
         setImportData(null);

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/index.js
@@ -80,7 +80,7 @@ const WorkspaceOverview = ({ workspace }) => {
       ? importCollectionFromZip(convertedCollection.zipFilePath, collectionLocation)
       : importCollection(convertedCollection, collectionLocation, options);
 
-    dispatch(importAction)
+    return dispatch(importAction)
       .then(() => {
         setImportCollectionLocationModalOpen(false);
         setImportData(null);


### PR DESCRIPTION
## What changed

- Shows a toast when collection import from a Bruno zip fails, including Electron IPC errors such as external symlink validation failures.
- Returns the import dispatch promise from both collection import entry points so the shared location modal can handle failures consistently.
- Adds a regression test for surfacing the symlink-outside-extraction error.

Fixes #7741.

## Validation

- `npm test --workspace=packages/bruno-app -- src/components/Sidebar/ImportCollectionLocation/index.spec.js`
- `npx eslint packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.spec.js packages/bruno-app/src/components/Sidebar/Sections/CollectionsSection/index.js packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/index.js`
- `git diff --check HEAD`
- `npm run build:web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for collection import operations with improved error notifications.
  * Updated import submission to properly capture and display detailed failure messages to users.

* **Tests**
  * Added test coverage for collection import error scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7980)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->