### PR TITLE
fix: persist non-string global env values

### DIFF
--- a/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.spec.js
+++ b/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.spec.js
@@ -1,0 +1,39 @@
+const { parseEnvironment, stringifyEnvironment } = require('../../index');
+
+describe('stringifyEnvironment', () => {
+  it('preserves non-string variable values by serializing them as strings', () => {
+    const yml = stringifyEnvironment(
+      {
+        name: 'Global',
+        variables: [
+          {
+            uid: 'var-1',
+            name: 'TestA',
+            value: '123',
+            type: 'text',
+            enabled: true,
+            secret: false
+          },
+          {
+            uid: 'var-2',
+            name: 'TestB',
+            value: 456,
+            type: 'text',
+            enabled: true,
+            secret: false
+          }
+        ]
+      },
+      { format: 'yml' }
+    );
+
+    const parsed = parseEnvironment(yml, { format: 'yml' });
+
+    expect(parsed.variables).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'TestA', value: '123' }),
+        expect.objectContaining({ name: 'TestB', value: '456' })
+      ])
+    );
+  });
+});

--- a/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.ts
@@ -2,6 +2,7 @@ import type { Environment as BrunoEnvironment, EnvironmentVariable as BrunoEnvir
 import type { Environment } from '@opencollection/types/config/environments';
 import type { Variable, SecretVariable } from '@opencollection/types/common/variables';
 import { stringifyYml } from './utils';
+import { ensureString } from '../../utils';
 
 const toOpenCollectionEnvironmentVariables = (variables: BrunoEnvironmentVariable[]): (Variable | SecretVariable)[] | undefined => {
   if (!variables?.length) {
@@ -9,11 +10,6 @@ const toOpenCollectionEnvironmentVariables = (variables: BrunoEnvironmentVariabl
   }
 
   const ocVariables: (Variable | SecretVariable)[] = variables
-    .filter((v: BrunoEnvironmentVariable) => {
-      // todo: currently neither bru lang nor bruno app supports non-string values
-      // update this when bruno app supports non-string values
-      return typeof v.value === 'string';
-    })
     .map((v: BrunoEnvironmentVariable): Variable | SecretVariable => {
       if (v.secret === true) {
         const secretVar: SecretVariable = {
@@ -28,7 +24,7 @@ const toOpenCollectionEnvironmentVariables = (variables: BrunoEnvironmentVariabl
 
       const variable: Variable = {
         name: v.name || '',
-        value: v.value as string
+        value: ensureString(v.value)
       };
 
       if (v.enabled === false) {


### PR DESCRIPTION
## Summary
- preserve global environment variables written from scripts even when their values are not strings
- serialize non-string environment values with the existing `ensureString` helper instead of dropping them from the yml output
- add a regression test covering a numeric global environment variable round-tripping through yml serialization

Fixes #7958.

## Verification
- `npm test --workspace=packages/bruno-filestore -- src/formats/yml/stringifyEnvironment.spec.js`
- `npx eslint packages/bruno-filestore/src/formats/yml/stringifyEnvironment.ts packages/bruno-filestore/src/formats/yml/stringifyEnvironment.spec.js`
- `git diff --check HEAD`
- `npm run build:bruno-filestore` attempted; it still fails on existing workspace type-resolution errors such as missing `@usebruno/schema-types/common/variables`, `@usebruno/schema-types/collection/environment`, and related schema-types modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of non-string values in environment variables to ensure proper serialization during import/export.

* **Tests**
  * Added test coverage for environment variable type conversion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7981)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->