### PR TITLE
fix: honor stopExecution from test scripts

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1818,6 +1818,10 @@ const registerNetworkIpc = (mainWindow) => {
                 nextRequestName = testResults.nextRequestName;
               }
 
+              if (testResults?.stopExecution) {
+                stopRunnerExecution = true;
+              }
+
               mainWindow.webContents.send('main:run-folder-event', {
                 type: 'test-results',
                 testResults: testResults.results,

--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -131,7 +131,8 @@ class TestRuntime {
       persistentEnvVariables: cleanJson(bru.persistentEnvVariables),
       oauth2CredentialsToReset: bru.oauth2CredentialsToReset,
       results: cleanJson(__brunoTestResults.getResults()),
-      nextRequestName: bru.nextRequest
+      nextRequestName: bru.nextRequest,
+      stopExecution: bru.stopExecution
     };
 
     if (scriptError) {

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -90,6 +90,32 @@ describe('runtime', () => {
         { description: 'format valid', status: 'pass' }
       ]);
     });
+
+    it('should return stopExecution when test scripts stop the runner', async () => {
+      const testFile = `
+                test('non-200 response', () => {
+                    expect.fail('response is not 200');
+                });
+                bru.runner.stopExecution();
+            `;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env
+      );
+
+      expect(result.results.map((el) => ({ description: el.description, status: el.status }))).toEqual([
+        { description: 'non-200 response', status: 'fail' }
+      ]);
+      expect(result.stopExecution).toBe(true);
+    });
   });
 
   describe('script-runtime', () => {


### PR DESCRIPTION
## Summary
- include `stopExecution` in `TestRuntime.runTests()` results when test scripts call `bru.runner.stopExecution()`
- make the Electron collection runner stop when request test scripts return `stopExecution`
- add a regression test covering a failing test script that stops the runner

Fixes #7928.

## Verification
- RED: `npm test --workspace=packages/bruno-js -- --runTestsByPath tests/runtime.spec.js --runInBand` failed with `Expected: true, Received: undefined`
- GREEN: `npm test --workspace=packages/bruno-js -- --runTestsByPath tests/runtime.spec.js --runInBand`
- `npx eslint packages/bruno-js/src/runtime/test-runtime.js packages/bruno-js/tests/runtime.spec.js packages/bruno-electron/src/ipc/network/index.js`
- `git diff --check HEAD`

Note: the local workspace needed `npm run build:bruno-query` and `npm run sandbox:bundle-libraries --workspace=packages/bruno-js` before the targeted runtime test could load existing local workspace dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test scripts can now stop collection execution, allowing you to halt a collection run based on test conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7982)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->