### PR TITLE
fix: align pdf preview shadow with canvas

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/StyledWrapper.js
@@ -22,13 +22,12 @@ const StyledWrapper = styled.div`
     background-color: transparent !important;
   }
   .react-pdf__Page__textContent {
-    border: 1px solid darkgrey;
-    box-shadow: 5px 5px 5px 1px #ccc;
-    border-radius: 0px;
     margin: 0 auto;
   }
   .react-pdf__Page__canvas {
     margin: 0 auto;
+    outline: 1px solid darkgrey;
+    filter: drop-shadow(5px 5px 5px #ccc);
   }
   div[role='tablist'] {
     .active {


### PR DESCRIPTION
## Summary
- move PDF preview border/shadow styling from the text layer to the rendered canvas
- use `outline` plus `drop-shadow` so the visual frame follows rotated/landscape PDF pages without changing canvas layout dimensions

Fixes #7960.

## Verification
- `npx eslint packages/bruno-app/src/components/ResponsePane/QueryResult/StyledWrapper.js`
- `git diff --check HEAD`
- `npm run build:web` passed with the existing Browserslist warning

Note: this is a visual CSS fix for rotated PDF pages; there is no existing focused automated test for react-pdf page rotation/shadow rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual appearance of embedded PDF rendering in the response viewer with improved outline and shadow effects for better clarity of rendered content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7983)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->