### PR TITLE
feat(cli): add official Docker images for Bruno CLI (alpine & debian)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,114 @@
+name: Publish Bruno CLI Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Bruno CLI version to publish (e.g. 3.3.0)'
+        required: true
+        type: string
+      tag_as_latest:
+        description: 'Tag this version as latest on Docker Hub and GHCR?'
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build, Test and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate version input
+        run: |
+          if ! echo "${{ github.event.inputs.version }}" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+$"; then
+            echo "Invalid version format. Expected X.Y.Z (e.g. 3.3.0)"
+            exit 1
+          fi
+
+      - name: Set version variables
+        id: version
+        run: |
+          VERSION=${{ github.event.inputs.version }}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f1,2)
+          echo "full=$VERSION" >> $GITHUB_OUTPUT
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU (for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Alpine ────────────────────────────────────────────────────────────
+
+      - name: Build and push alpine image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/bruno-cli/docker/images/alpine
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: BRUNO_VERSION=${{ steps.version.outputs.full }}
+          tags: |
+            usebruno/cli:alpine
+            usebruno/cli:${{ steps.version.outputs.full }}
+            usebruno/cli:${{ steps.version.outputs.full }}-alpine
+            usebruno/cli:${{ steps.version.outputs.minor }}
+            usebruno/cli:${{ steps.version.outputs.minor }}-alpine
+            usebruno/cli:${{ steps.version.outputs.major }}
+            usebruno/cli:${{ steps.version.outputs.major }}-alpine
+            ghcr.io/usebruno/cli:alpine
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.full }}
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.full }}-alpine
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.minor }}
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.minor }}-alpine
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.major }}
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.major }}-alpine
+            ${{ github.event.inputs.tag_as_latest == 'true' && 'usebruno/cli:latest' || '' }}
+            ${{ github.event.inputs.tag_as_latest == 'true' && 'ghcr.io/usebruno/cli:latest' || '' }}
+
+      - name: Smoke test alpine
+        run: ./packages/bruno-cli/docker/smoke-test.sh usebruno/cli:${{ steps.version.outputs.full }}
+
+      # ── Debian ────────────────────────────────────────────────────────────
+
+      - name: Build and push debian image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/bruno-cli/docker/images/debian
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: BRUNO_VERSION=${{ steps.version.outputs.full }}
+          tags: |
+            usebruno/cli:debian
+            usebruno/cli:${{ steps.version.outputs.full }}-debian
+            usebruno/cli:${{ steps.version.outputs.minor }}-debian
+            usebruno/cli:${{ steps.version.outputs.major }}-debian
+            ghcr.io/usebruno/cli:debian
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.full }}-debian
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.minor }}-debian
+            ghcr.io/usebruno/cli:${{ steps.version.outputs.major }}-debian
+
+      - name: Smoke test debian
+        run: ./packages/bruno-cli/docker/smoke-test.sh usebruno/cli:${{ steps.version.outputs.full }}-debian

--- a/packages/bruno-cli/docker/README.md
+++ b/packages/bruno-cli/docker/README.md
@@ -1,0 +1,266 @@
+# Bruno CLI Docker Images
+
+Official Docker images for [Bruno CLI](https://www.usebruno.com), enabling container-native API collection runs in CI/CD pipelines and local environments without requiring Node.js or npm on the host.
+
+## Image structure
+
+```
+docker/
+  ├── README.md           ← you are here
+  └── images/
+      ├── alpine/
+      │   ├── Dockerfile  ← Alpine Linux variant (smallest, ~141MB)
+      │   └── README.md
+      └── debian/
+          ├── Dockerfile  ← Debian slim variant (~200MB+, glibc support)
+          └── README.md
+```
+
+---
+
+## Registries
+
+```bash
+docker pull usebruno/cli:latest
+docker pull ghcr.io/usebruno/cli:latest
+```
+
+---
+
+## Variants
+
+| Variant | Base image | Details |
+|---------|-----------|---------|
+| **Alpine** (default) | `node:22-alpine` | [→ Alpine README](./images/alpine/README.md) |
+| **Debian** | `node:22-slim` | [→ Debian README](./images/debian/README.md) |
+
+### Quick choice
+
+- **Use Alpine** unless you have a specific reason not to (90% of users)
+- **Use Debian** if you hit SSL/glibc compatibility issues
+
+---
+
+## Tags
+
+| Tag | Example | Variant |
+|-----|---------|---------|
+| `latest` | `usebruno/cli:latest` | alpine |
+| `<version>` | `usebruno/cli:3.3.0` | alpine |
+| `<major.minor>` | `usebruno/cli:3.3` | alpine |
+| `<major>` | `usebruno/cli:3` | alpine |
+| `<version>-alpine` | `usebruno/cli:3.3.0-alpine` | alpine |
+| `<version>-debian` | `usebruno/cli:3.3.0-debian` | debian |
+| `debian` | `usebruno/cli:debian` | debian |
+
+---
+
+## Step-by-step guide
+
+### Step 1 — Pull the image
+
+```bash
+# latest (alpine by default — smallest, fastest to pull)
+docker pull usebruno/cli:latest
+
+# specific version (recommended for production CI)
+docker pull usebruno/cli:3.3.0
+
+# major.minor — gets patch updates automatically
+docker pull usebruno/cli:3.3
+
+# debian variant
+docker pull usebruno/cli:debian
+docker pull usebruno/cli:3.3.0-debian
+```
+
+---
+
+### Step 2 — Check it works
+
+```bash
+docker run --rm usebruno/cli --version
+```
+
+---
+
+### Step 3 — Run your collection
+
+> Mount your collection directory to `/bruno` and pass `bru` arguments directly after the image name.
+
+```bash
+# collection at your current directory
+docker run --rm -v $(pwd):/bruno usebruno/cli run --env staging
+
+# collection in a subfolder
+docker run --rm -v $(pwd):/bruno usebruno/cli run ./api-tests --env staging
+
+# single request file
+docker run --rm -v $(pwd):/bruno usebruno/cli run ./api-tests/login.bru --env staging
+```
+
+---
+
+### Step 4 — Choose your environment
+
+```bash
+docker run --rm -v $(pwd):/bruno usebruno/cli run --env local
+docker run --rm -v $(pwd):/bruno usebruno/cli run --env staging
+docker run --rm -v $(pwd):/bruno usebruno/cli run --env production
+```
+
+---
+
+### Step 5 — Pass variables at runtime
+
+```bash
+# override a single variable
+docker run --rm \
+  -v $(pwd):/bruno \
+  usebruno/cli run --env staging --env-var API_KEY=your_key
+
+# override multiple variables
+docker run --rm \
+  -v $(pwd):/bruno \
+  usebruno/cli run --env staging \
+  --env-var BASE_URL=https://api.example.com \
+  --env-var API_KEY=secret123
+
+# load variables from a file
+docker run --rm \
+  -v $(pwd):/bruno \
+  --env-file .env \
+  usebruno/cli run --env staging
+```
+
+---
+
+### Step 6 — Save test results
+
+```bash
+# JSON report
+docker run --rm \
+  -v $(pwd):/bruno \
+  usebruno/cli run --env staging --output results.json --format json
+
+# JUnit XML report (for CI test reporters)
+docker run --rm \
+  -v $(pwd):/bruno \
+  usebruno/cli run --env staging --output results.xml --format junit
+```
+
+---
+
+### Step 7 — Stop on first failure
+
+```bash
+docker run --rm -v $(pwd):/bruno usebruno/cli run --env staging --bail
+```
+
+---
+
+### Step 8 — Pin the right version
+
+```bash
+# exact version — safest for production, no surprise updates
+docker run --rm -v $(pwd):/bruno usebruno/cli:3.3.0 run --env staging
+
+# major.minor — gets patch fixes automatically
+docker run --rm -v $(pwd):/bruno usebruno/cli:3.3 run --env staging
+
+# latest — always newest, not recommended for production CI
+docker run --rm -v $(pwd):/bruno usebruno/cli:latest run --env staging
+```
+
+---
+
+### Step 9 — Choose alpine or debian
+
+```bash
+# alpine (default) — use this for most cases
+docker run --rm -v $(pwd):/bruno usebruno/cli:3.3.0 run --env staging
+
+# debian — use if you hit SSL, glibc, or native module issues
+docker run --rm -v $(pwd):/bruno usebruno/cli:3.3.0-debian run --env staging
+```
+
+---
+
+## Usage by variant
+
+### Alpine variant
+
+See [Alpine README](./images/alpine/README.md) for:
+- Building the Alpine image
+- When to use Alpine
+- Variant-specific options
+
+### Debian variant
+
+See [Debian README](./images/debian/README.md) for:
+- Building the Debian image
+- When to use Debian
+- Compatibility notes
+
+---
+
+## CI/CD integration
+
+### GitHub Actions
+
+```yaml
+jobs:
+  api-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Bruno collection
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/bruno \
+            usebruno/cli:3.3 run --env staging --output results.xml --format junit
+
+      - name: Publish Test Report
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: Bruno Test Results
+          path: results.xml
+          reporter: java-junit
+```
+
+### GitLab CI
+
+```yaml
+api-tests:
+  image: usebruno/cli:3.3
+  script:
+    - bru run --env staging --output results.xml --format junit
+  artifacts:
+    reports:
+      junit: results.xml
+```
+
+---
+
+## Image details
+
+All variants include:
+
+- **Entrypoint:** `bru`
+- **Working directory:** `/bruno`
+- **User:** `node` (UID 1000, non-root)
+- **Architectures:** `linux/amd64`, `linux/arm64`
+
+---
+
+## All version × variant combinations
+
+| | Alpine | Debian |
+|---|---|---|
+| `latest` | `usebruno/cli:latest` | `usebruno/cli:debian` |
+| `3` | `usebruno/cli:3` | `usebruno/cli:3-debian` |
+| `3.3` | `usebruno/cli:3.3` | `usebruno/cli:3.3-debian` |
+| `3.3.0` | `usebruno/cli:3.3.0` | `usebruno/cli:3.3.0-debian` |
+| `3.2.0` | `usebruno/cli:3.2.0` | `usebruno/cli:3.2.0-debian` |

--- a/packages/bruno-cli/docker/images/alpine/Dockerfile
+++ b/packages/bruno-cli/docker/images/alpine/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22-alpine
+
+LABEL maintainer="Bruno <engineering@usebruno.com>"
+
+ARG BRUNO_VERSION
+ENV BRUNO_VERSION=${BRUNO_VERSION}
+
+ENV LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8"
+
+# If BRUNO_VERSION is provided, validate it is a valid semver before installing
+RUN if [ -n "$BRUNO_VERSION" ]; then \
+        if [ ! $(echo $BRUNO_VERSION | grep -oE "^[0-9]+\.[0-9]+\.[0-9]+$") ]; then \
+            echo "\033[0;31mA valid semver Bruno version is required in the BRUNO_VERSION build-arg (e.g. 1.16.0)\033[0m"; \
+            exit 1; \
+        fi; \
+    fi && \
+    npm install -g @usebruno/cli${BRUNO_VERSION:+@${BRUNO_VERSION}}
+
+WORKDIR /bruno
+
+USER node
+
+ENTRYPOINT ["bru"]
+CMD []

--- a/packages/bruno-cli/docker/images/alpine/README.md
+++ b/packages/bruno-cli/docker/images/alpine/README.md
@@ -1,0 +1,27 @@
+# Bruno CLI — Alpine
+
+Alpine Linux variant of the Bruno CLI Docker image.
+
+**Base image:** `node:22-alpine`
+
+## Building
+
+```bash
+docker build -t usebruno/cli:alpine ./images/alpine
+
+# with specific Bruno CLI version
+docker build \
+  --build-arg BRUNO_VERSION=3.3.0 \
+  -t usebruno/cli:3.3.0-alpine \
+  ./images/alpine
+```
+
+## Usage
+
+```bash
+# Run a collection
+docker run --rm -v $(pwd):/bruno usebruno/cli:alpine run --env staging
+
+# with pinned version
+docker run --rm -v $(pwd):/bruno usebruno/cli:3.3.0-alpine run --env staging
+```

--- a/packages/bruno-cli/docker/images/debian/Dockerfile
+++ b/packages/bruno-cli/docker/images/debian/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22-slim
+
+LABEL maintainer="Bruno <engineering@usebruno.com>"
+
+ARG BRUNO_VERSION
+ENV BRUNO_VERSION=${BRUNO_VERSION}
+
+ENV LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8"
+
+# If BRUNO_VERSION is provided, validate it is a valid semver before installing
+RUN if [ -n "$BRUNO_VERSION" ]; then \
+        if [ ! $(echo $BRUNO_VERSION | grep -oE "^[0-9]+\.[0-9]+\.[0-9]+$") ]; then \
+            echo "\033[0;31mA valid semver Bruno version is required in the BRUNO_VERSION build-arg (e.g. 1.16.0)\033[0m"; \
+            exit 1; \
+        fi; \
+    fi && \
+    npm install -g @usebruno/cli${BRUNO_VERSION:+@${BRUNO_VERSION}}
+
+WORKDIR /bruno
+
+USER node
+
+ENTRYPOINT ["bru"]
+CMD []

--- a/packages/bruno-cli/docker/images/debian/README.md
+++ b/packages/bruno-cli/docker/images/debian/README.md
@@ -1,0 +1,27 @@
+# Bruno CLI — Debian
+
+Debian slim variant of the Bruno CLI Docker image.
+
+**Base image:** `node:22-slim`
+
+## Building
+
+```bash
+docker build -t usebruno/cli:debian ./images/debian
+
+# with specific Bruno CLI version
+docker build \
+  --build-arg BRUNO_VERSION=3.3.0 \
+  -t usebruno/cli:3.3.0-debian \
+  ./images/debian
+```
+
+## Usage
+
+```bash
+# Run a collection
+docker run --rm -v $(pwd):/bruno usebruno/cli:debian run --env staging
+
+# with pinned version
+docker run --rm -v $(pwd):/bruno usebruno/cli:3.3.0-debian run --env staging
+```

--- a/packages/bruno-cli/docker/smoke-test.sh
+++ b/packages/bruno-cli/docker/smoke-test.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Smoke tests for Bruno CLI Docker image
+# Usage: ./smoke-test.sh <image>
+# Example: ./smoke-test.sh usebruno/cli:alpine
+
+set -e
+
+IMAGE=$1
+
+if [ -z "$IMAGE" ]; then
+  echo "Usage: $0 <image>"
+  exit 1
+fi
+
+echo "Running smoke tests for image: $IMAGE"
+echo "---"
+
+# Test 1 - bru is installed and returns a version
+echo "Test 1: bru --version"
+VERSION=$(docker run --rm "$IMAGE" --version)
+echo "  → $VERSION"
+if [ -z "$VERSION" ]; then
+  echo "  FAIL: no version output"
+  exit 1
+fi
+echo "  PASS"
+
+# Test 2 - container runs as non-root user "node"
+echo "Test 2: non-root user"
+USER=$(docker run --rm --entrypoint whoami "$IMAGE")
+echo "  → $USER"
+if [ "$USER" != "node" ]; then
+  echo "  FAIL: expected 'node', got '$USER'"
+  exit 1
+fi
+echo "  PASS"
+
+# Test 3 - working directory is /bruno
+echo "Test 3: working directory"
+DIR=$(docker run --rm --entrypoint pwd "$IMAGE")
+echo "  → $DIR"
+if [ "$DIR" != "/bruno" ]; then
+  echo "  FAIL: expected '/bruno', got '$DIR'"
+  exit 1
+fi
+echo "  PASS"
+
+# Test 4 - bru help works
+echo "Test 4: bru --help"
+docker run --rm "$IMAGE" --help > /dev/null
+echo "  PASS"
+
+echo "---"
+echo "All smoke tests passed for $IMAGE"


### PR DESCRIPTION
## Summary

- Adds two official Docker image variants for Bruno CLI: Alpine (default, smallest) and Debian (glibc compatibility)
- Multi-arch builds supporting `linux/amd64` and `linux/arm64`
- Runs as non-root `node` user (UID 1000), `WORKDIR /bruno`, `ENTRYPOINT ["bru"]`
- Published to Docker Hub (`usebruno/cli`) and GHCR (`ghcr.io/usebruno/cli`)

## Files added

```
packages/bruno-cli/docker/
  ├── README.md                    ← full user guide (pull, run, CI/CD examples)
  ├── smoke-test.sh                ← 4 post-push checks (version, user, workdir, help)
  └── images/
      ├── alpine/
      │   ├── Dockerfile           ← node:22-alpine base
      │   └── README.md
      └── debian/
          ├── Dockerfile           ← node:22-slim base
          └── README.md

.github/workflows/docker-publish.yml   ← manual workflow_dispatch publish workflow
```

## Workflow

Manual trigger (`workflow_dispatch`) with two inputs:
- **version** (required) — Bruno CLI version to publish e.g. `3.3.0`
- **tag_as_latest** (boolean, default `false`) — explicitly move the `latest` tag

Build flow: build alpine → push → smoke test → build debian → push → smoke test

## Test plan

- [x] Built and tested both images locally (`docker build` + `docker run`)
- [x] Verified non-root user, correct WORKDIR, `bru --version`, collection runs
- [x] Tested with env files, subfolder collections, `--output` reports
- [x] Pushed to Docker Hub (`sundrambruno/cli`) and confirmed pull works
- [x] GitHub Actions workflow appears in fork Actions UI with correct input fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Docker image publishing workflow with manual trigger support, multi-architecture builds, and Alpine/Debian variants.

* **Documentation**
  * Added comprehensive Docker guide covering image usage, registry options, version management, and CI/CD integration examples.
  * Added variant-specific documentation for Alpine and Debian images.

* **Tests**
  * Added smoke-test validation script for Docker image verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7986)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->