### PR TITLE
fix: add tab error boundary

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/TabPanelErrorBoundary.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/TabPanelErrorBoundary.js
@@ -5,6 +5,7 @@ import find from 'lodash/find';
 import { closeTabs } from 'providers/ReduxStore/slices/collections/actions';
 import { NON_CLOSABLE_TAB_TYPES } from 'providers/ReduxStore/slices/tabs';
 import Button from 'ui/Button';
+import { useTheme } from 'providers/Theme';
 
 class TabPanelErrorBoundaryInner extends React.Component {
   constructor(props) {
@@ -21,13 +22,15 @@ class TabPanelErrorBoundaryInner extends React.Component {
   }
 
   render() {
+    const { theme } = this.props;
+
     if (this.state.hasError) {
       const { isClosable, onClose } = this.props;
       const errorMessage = this.state.error?.message;
 
       return (
         <div className="h-full flex flex-col items-center justify-center gap-3 px-6 text-center">
-          <IconAlertTriangle size={36} strokeWidth={1.5} className="text-yellow-500" />
+          <IconAlertTriangle size={36} strokeWidth={1.5} style={{ color: theme?.status?.warning?.text }} />
           <h2 className="text-lg font-medium">Something went wrong</h2>
           {isClosable ? (
             <p className="text-sm opacity-70 max-w-md">
@@ -60,13 +63,14 @@ const TabPanelErrorBoundary = ({ tabUid, children }) => {
   const tabs = useSelector((state) => state.tabs.tabs);
   const focusedTab = find(tabs, (t) => t.uid === tabUid);
   const isClosable = !focusedTab || !NON_CLOSABLE_TAB_TYPES.includes(focusedTab.type);
+  const { theme } = useTheme();
 
   const handleClose = () => {
     dispatch(closeTabs({ tabUids: [tabUid] }));
   };
 
   return (
-    <TabPanelErrorBoundaryInner isClosable={isClosable} onClose={handleClose}>
+    <TabPanelErrorBoundaryInner isClosable={isClosable} onClose={handleClose} theme={theme}>
       {children}
     </TabPanelErrorBoundaryInner>
   );

--- a/packages/bruno-app/src/components/RequestTabPanel/TabPanelErrorBoundary.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/TabPanelErrorBoundary.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { IconAlertTriangle } from '@tabler/icons';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import find from 'lodash/find';
 import { closeTabs } from 'providers/ReduxStore/slices/collections/actions';
+import { NON_CLOSABLE_TAB_TYPES } from 'providers/ReduxStore/slices/tabs';
 import Button from 'ui/Button';
 
 class TabPanelErrorBoundaryInner extends React.Component {
@@ -20,16 +22,31 @@ class TabPanelErrorBoundaryInner extends React.Component {
 
   render() {
     if (this.state.hasError) {
+      const { isClosable, onClose } = this.props;
+      const errorMessage = this.state.error?.message;
+
       return (
         <div className="h-full flex flex-col items-center justify-center gap-3 px-6 text-center">
           <IconAlertTriangle size={36} strokeWidth={1.5} className="text-yellow-500" />
           <h2 className="text-lg font-medium">Something went wrong</h2>
-          <p className="text-sm opacity-70 max-w-md">
-            This tab encountered an unexpected error. Close the tab and try reopening the request.
-          </p>
-          <Button size="md" data-testid="tab-panel-error-boundary-close-tab" color="primary" onClick={this.props.onClose}>
-            Close Tab
-          </Button>
+          {isClosable ? (
+            <p className="text-sm opacity-70 max-w-md">
+              This tab encountered an unexpected error. Close it and try reopening the request. If the
+              error repeats, the request file may be corrupt.
+            </p>
+          ) : (
+            <p className="text-sm opacity-70 max-w-md">
+              This panel encountered an unexpected error. Restart Bruno to recover.
+            </p>
+          )}
+          {errorMessage && (
+            <p className="text-xs font-mono opacity-50 max-w-md break-all">{errorMessage}</p>
+          )}
+          {isClosable && (
+            <Button size="md" data-testid="tab-panel-error-boundary-close-tab" color="primary" onClick={onClose}>
+              Close Tab
+            </Button>
+          )}
         </div>
       );
     }
@@ -40,13 +57,16 @@ class TabPanelErrorBoundaryInner extends React.Component {
 
 const TabPanelErrorBoundary = ({ tabUid, children }) => {
   const dispatch = useDispatch();
+  const tabs = useSelector((state) => state.tabs.tabs);
+  const focusedTab = find(tabs, (t) => t.uid === tabUid);
+  const isClosable = !focusedTab || !NON_CLOSABLE_TAB_TYPES.includes(focusedTab.type);
 
   const handleClose = () => {
     dispatch(closeTabs({ tabUids: [tabUid] }));
   };
 
   return (
-    <TabPanelErrorBoundaryInner onClose={handleClose}>
+    <TabPanelErrorBoundaryInner isClosable={isClosable} onClose={handleClose}>
       {children}
     </TabPanelErrorBoundaryInner>
   );

--- a/packages/bruno-app/src/components/RequestTabPanel/TabPanelErrorBoundary.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/TabPanelErrorBoundary.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { IconAlertTriangle } from '@tabler/icons';
+import { useDispatch } from 'react-redux';
+import { closeTabs } from 'providers/ReduxStore/slices/collections/actions';
+import Button from 'ui/Button';
+
+class TabPanelErrorBoundaryInner extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('[TabPanelErrorBoundary] Unexpected render error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="h-full flex flex-col items-center justify-center gap-3 px-6 text-center">
+          <IconAlertTriangle size={36} strokeWidth={1.5} className="text-yellow-500" />
+          <h2 className="text-lg font-medium">Something went wrong</h2>
+          <p className="text-sm opacity-70 max-w-md">
+            This tab encountered an unexpected error. Close the tab and try reopening the request.
+          </p>
+          <Button size="md" color="primary" onClick={this.props.onClose}>
+            Close Tab
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const TabPanelErrorBoundary = ({ tabUid, children }) => {
+  const dispatch = useDispatch();
+
+  const handleClose = () => {
+    dispatch(closeTabs({ tabUids: [tabUid] }));
+  };
+
+  return (
+    <TabPanelErrorBoundaryInner onClose={handleClose}>
+      {children}
+    </TabPanelErrorBoundaryInner>
+  );
+};
+
+export default TabPanelErrorBoundary;

--- a/packages/bruno-app/src/components/RequestTabPanel/TabPanelErrorBoundary.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/TabPanelErrorBoundary.js
@@ -27,7 +27,7 @@ class TabPanelErrorBoundaryInner extends React.Component {
           <p className="text-sm opacity-70 max-w-md">
             This tab encountered an unexpected error. Close the tab and try reopening the request.
           </p>
-          <Button size="md" color="primary" onClick={this.props.onClose}>
+          <Button size="md" data-testid="tab-panel-error-boundary-close-tab" color="primary" onClick={this.props.onClose}>
             Close Tab
           </Button>
         </div>

--- a/packages/bruno-app/src/pages/Bruno/index.js
+++ b/packages/bruno-app/src/pages/Bruno/index.js
@@ -7,6 +7,7 @@ import Sidebar from 'components/Sidebar';
 import StatusBar from 'components/StatusBar';
 import AppTitleBar from 'components/AppTitleBar';
 import ApiSpecPanel from 'components/ApiSpecPanel';
+import TabPanelErrorBoundary from 'components/RequestTabPanel/TabPanelErrorBoundary';
 // import ErrorCapture from 'components/ErrorCapture';
 import { useSelector } from 'react-redux';
 import { isElectron } from 'utils/common/platform';
@@ -145,7 +146,9 @@ export default function Main() {
             ) : (
               <>
                 <RequestTabs />
-                <RequestTabPanel key={activeTabUid} />
+                <TabPanelErrorBoundary key={activeTabUid} tabUid={activeTabUid}>
+                  <RequestTabPanel key={activeTabUid} />
+                </TabPanelErrorBoundary>
               </>
             )}
           </section>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -8,6 +8,8 @@ import { isActiveTab as checkIsActiveTab, deserializeTab } from 'utils/snapshot'
 
 const MAX_RECENTLY_CLOSED_TABS = 50;
 
+export const NON_CLOSABLE_TAB_TYPES = ['workspaceOverview', 'workspaceEnvironments'];
+
 const initialState = {
   tabs: [],
   activeTabUid: null,
@@ -304,12 +306,10 @@ export const tabsSlice = createSlice({
       const activeTab = find(state.tabs, (t) => t.uid === state.activeTabUid);
       const tabUids = action.payload.tabUids || [];
 
-      const nonClosableTypes = ['workspaceOverview', 'workspaceEnvironments'];
-
       // Push closed tabs onto the recently closed stack (LIFO)
       // Exclude transient requests — they have no persisted file and can't be reopened
       const closedTabs = state.tabs.filter((t) =>
-        tabUids.includes(t.uid) && !nonClosableTypes.includes(t.type) && !t.isTransient
+        tabUids.includes(t.uid) && !NON_CLOSABLE_TAB_TYPES.includes(t.type) && !t.isTransient
       );
       if (closedTabs.length > 0) {
         state.recentlyClosedTabs.push(...closedTabs);
@@ -320,7 +320,7 @@ export const tabsSlice = createSlice({
       }
 
       state.tabs = filter(state.tabs, (t) =>
-        !tabUids.includes(t.uid) || nonClosableTypes.includes(t.type)
+        !tabUids.includes(t.uid) || NON_CLOSABLE_TAB_TYPES.includes(t.type)
       );
 
       if (activeTab && state.tabs.length) {

--- a/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-bru/bruno.json
+++ b/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-bru/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "invalid-tags-bru",
+  "type": "collection"
+}

--- a/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-bru/collection.bru
+++ b/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-bru/collection.bru
@@ -1,0 +1,3 @@
+meta {
+  name: invalid-tags-bru
+}

--- a/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-bru/invalid-tags-bru-request.bru
+++ b/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-bru/invalid-tags-bru-request.bru
@@ -1,0 +1,12 @@
+meta {
+  name: invalid-tags-bru-request
+  type: http
+  seq: 1
+  tags: smoke
+}
+
+get {
+  url: https://httpbin.org/get
+  body: none
+  auth: none
+}

--- a/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-yml/control-yml-request.yml
+++ b/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-yml/control-yml-request.yml
@@ -1,0 +1,13 @@
+meta:
+  name: control-yml-request
+  type: http
+  seq: 3
+
+info:
+  name: control-yml-request
+  type: http
+  seq: 3
+
+http:
+  method: GET
+  url: https://httpbin.org/get

--- a/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-yml/invalid-tags-yml-request.yml
+++ b/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-yml/invalid-tags-yml-request.yml
@@ -1,0 +1,15 @@
+meta:
+  name: invalid-tags-yml-request
+  type: http
+  seq: 1
+  tags: smoke
+
+info:
+  name: invalid-tags-yml-request
+  type: http
+  seq: 1
+  tags: smoke
+
+http:
+  method: GET
+  url: https://httpbin.org/get

--- a/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-yml/opencollection.yml
+++ b/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-yml/opencollection.yml
@@ -1,0 +1,6 @@
+opencollection: "1.0.0"
+
+info:
+  name: invalid-tags-yml
+
+bundled: false

--- a/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-yml/valid-tags-yml-request.yml
+++ b/tests/request/tab-panel-error-boundary/fixtures/collections/invalid-tags-yml/valid-tags-yml-request.yml
@@ -1,0 +1,19 @@
+meta:
+  name: valid-tags-yml-request
+  type: http
+  seq: 2
+  tags:
+    - smoke
+    - sanity
+
+info:
+  name: valid-tags-yml-request
+  type: http
+  seq: 2
+  tags:
+    - smoke
+    - sanity
+
+http:
+  method: GET
+  url: https://httpbin.org/get

--- a/tests/request/tab-panel-error-boundary/init-user-data/preferences.json
+++ b/tests/request/tab-panel-error-boundary/init-user-data/preferences.json
@@ -1,0 +1,12 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/invalid-tags-bru",
+    "{{collectionPath}}/invalid-tags-yml"
+  ],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/request/tab-panel-error-boundary/tab-panel-error-boundary.spec.ts
+++ b/tests/request/tab-panel-error-boundary/tab-panel-error-boundary.spec.ts
@@ -31,7 +31,11 @@ const assertTabPanelErrorBoundary = async (page: Page, collectionName: string, r
 
   await test.step('Verify fallback UI', async () => {
     await expect(page.getByText('Something went wrong')).toBeVisible();
-    await expect(page.getByText('This tab encountered an unexpected error. Close the tab and try reopening the request.')).toBeVisible();
+    await expect(
+      page.getByText(
+        'This tab encountered an unexpected error. Close it and try reopening the request. If the error repeats, the request file may be corrupt.'
+      )
+    ).toBeVisible();
     await expect(page.getByTestId('tab-panel-error-boundary-close-tab')).toBeVisible();
   });
 

--- a/tests/request/tab-panel-error-boundary/tab-panel-error-boundary.spec.ts
+++ b/tests/request/tab-panel-error-boundary/tab-panel-error-boundary.spec.ts
@@ -1,0 +1,71 @@
+import { expect, Page, test } from '../../../playwright';
+import { openRequest } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+// NOTE: Rewritten instead of `selectRequestPaneTab` from actions.ts because we want to avoid assertion
+// of tab active state
+const openRequestSettingsTab = async (page: Page) => {
+  const requestPane = page.locator('[data-testid="request-pane"] > .px-4');
+  await expect(requestPane).toBeVisible();
+
+  const settingsTab = requestPane.locator('.tabs').getByRole('tab', { name: 'Settings' });
+  if (await settingsTab.isVisible().catch(() => false)) {
+    await settingsTab.click();
+    return;
+  }
+
+  const moreTabs = requestPane.locator('.tabs .more-tabs');
+  await expect(moreTabs).toBeVisible();
+  await moreTabs.click();
+  await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Settings' }).click({ force: true });
+};
+
+const assertTabPanelErrorBoundary = async (page: Page, collectionName: string, requestName: string) => {
+  const commonLocators = buildCommonLocators(page);
+
+  await test.step(`Open ${requestName} and trigger render error`, async () => {
+    await openRequest(page, collectionName, requestName);
+    await expect(commonLocators.tabs.activeRequestTab()).toContainText(requestName);
+    await openRequestSettingsTab(page);
+  });
+
+  await test.step('Verify fallback UI', async () => {
+    await expect(page.getByText('Something went wrong')).toBeVisible();
+    await expect(page.getByText('This tab encountered an unexpected error. Close the tab and try reopening the request.')).toBeVisible();
+    await expect(page.getByTestId('tab-panel-error-boundary-close-tab')).toBeVisible();
+  });
+
+  await test.step('Close errored tab via boundary action', async () => {
+    await page.getByTestId('tab-panel-error-boundary-close-tab').click();
+    await expect(commonLocators.tabs.requestTab(requestName)).not.toBeVisible();
+  });
+};
+
+const assertBoundaryVisible = async (page: Page) => {
+  await expect(page.getByText('Something went wrong')).toBeVisible();
+  await expect(page.getByTestId('tab-panel-error-boundary-close-tab')).toBeVisible();
+};
+
+test.describe.serial('Tab Panel Error Boundary', () => {
+  test('handles invalid tags type in YAML request metadata', async ({ pageWithUserData: page }) => {
+    await assertTabPanelErrorBoundary(page, 'invalid-tags-yml', 'invalid-tags-yml-request');
+  });
+
+  test('shows error only on failed tab and allows switching to valid tab', async ({ pageWithUserData: page }) => {
+    const commonLocators = buildCommonLocators(page);
+
+    await openRequest(page, 'invalid-tags-yml', 'invalid-tags-yml-request', { persist: true });
+    await openRequestSettingsTab(page);
+    await assertBoundaryVisible(page);
+
+    await openRequest(page, 'invalid-tags-yml', 'control-yml-request');
+    await expect(commonLocators.tabs.activeRequestTab()).toContainText('control-yml-request');
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+    await expect(page.getByTestId('tab-panel-error-boundary-close-tab')).toHaveCount(0);
+    await expect(page.locator('[data-testid="request-pane"]')).toBeVisible();
+
+    await commonLocators.tabs.requestTab('invalid-tags-yml-request').click();
+    await expect(commonLocators.tabs.activeRequestTab()).toContainText('invalid-tags-yml-request');
+    await assertBoundaryVisible(page);
+  });
+});


### PR DESCRIPTION
### Description

[JIRA #1](https://usebruno.atlassian.net/browse/BRU-3377)
[JIRA #2](https://usebruno.atlassian.net/browse/BRU-3381)

- Add a boundary for collection and tabs so any mount issues can be handled by the user instead of crashing the entire app



https://github.com/user-attachments/assets/c6d4c09f-5479-4258-b742-e473f61b68cd

 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an error boundary for request tabs with a fallback UI and a conditional “Close Tab” action for closable tabs.
* **Bug Fixes**
  * Prevents a failing request tab from affecting other tabs or the rest of the app.
* **Tests**
  * Adds end-to-end tests and fixtures validating the fallback UI, tab isolation, and recovery via Close Tab.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/7987)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->