### PR TITLE
fix: show "+ Add request" CTA in empty .bru collection sidebar

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -744,6 +744,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
               ))}
               <div style={{ paddingLeft: 8 }}>
                 <MenuDropdown
+                  data-testid="add-request-cta-folder"
                   items={emptyFolderMenuItems}
                   placement="bottom-start"
                   appendTo={dropdownContainerRef?.current || document.body}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -75,8 +75,9 @@ const Collection = ({ collection, searchText }) => {
   const dispatch = useDispatch();
   const isLoading = collection.isLoading;
   const collectionRef = useRef(null);
-  // Only count persisted items; transients don't affect empty state
-  const itemCount = collection.items?.filter((i) => !i.isTransient).length || 0;
+  // Only count persisted requests and folders; transients and file items
+  // (bruno.json, .js scripts) don't affect empty state
+  const itemCount = collection.items?.filter((i) => !i.isTransient && (isItemARequest(i) || isItemAFolder(i))).length || 0;
 
   const isCollectionFocused = useSelector(isTabForItemActive({ itemUid: collection.uid }));
   const { hasCopiedItems } = useSelector((state) => state.app.clipboard);
@@ -533,6 +534,7 @@ const Collection = ({ collection, searchText }) => {
                 </div>
                 <div style={{ paddingLeft: 8 }}>
                   <MenuDropdown
+                    data-testid="add-request-cta"
                     items={emptyStateMenuItems}
                     placement="bottom-start"
                     appendTo={dropdownContainerRef?.current || document.body}

--- a/tests/sidebar/empty-state-cta/empty-state-cta.spec.ts
+++ b/tests/sidebar/empty-state-cta/empty-state-cta.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, Page } from '../../../playwright';
+import { buildCommonLocators, closeAllCollections } from '../../utils/page';
+
+test.describe.serial('Sidebar empty-state "+ Add request" CTA', () => {
+  let locators: ReturnType<typeof buildCommonLocators>;
+
+  test.beforeAll(async ({ pageWithUserData: page }) => {
+    locators = buildCommonLocators(page);
+  });
+
+  test.afterAll(async ({ pageWithUserData: page }) => {
+    await closeAllCollections(page);
+  });
+
+  // Scope an assertion to a single collection — pageWithUserData reuses one app
+  // across the describe block, and multiple expanded collections would otherwise
+  // make `getByTestId('add-request-cta')` match more than one element.
+  const collectionScope = (page: Page, name: string) => page.locator(`#collection-${name}`);
+
+  const expandCollection = async (name: string) => {
+    const collection = locators.sidebar.collection(name);
+    await collection.waitFor({ state: 'visible' });
+    await collection.click();
+  };
+
+  // Empty collection — CTA should appear
+
+  test('should show CTA for an empty .bru collection', async ({ pageWithUserData: page }) => {
+    await test.step('Expand empty-bru collection', async () => {
+      await expandCollection('empty-bru');
+    });
+
+    await test.step('Verify CTA is visible at collection root', async () => {
+      await expect(collectionScope(page, 'empty-bru').getByTestId('add-request-cta')).toBeVisible();
+    });
+  });
+
+  test('should show CTA for an empty .yml collection', async ({ pageWithUserData: page }) => {
+    await test.step('Expand empty-yml collection', async () => {
+      await expandCollection('empty-yml');
+    });
+
+    await test.step('Verify CTA is visible at collection root', async () => {
+      await expect(collectionScope(page, 'empty-yml').getByTestId('add-request-cta')).toBeVisible();
+    });
+  });
+
+  // Collection containing only a .js script — CTA should still appear
+
+  test('should show CTA for a .bru collection containing only a .js script', async ({ pageWithUserData: page }) => {
+    await test.step('Expand bru-with-js collection', async () => {
+      await expandCollection('bru-with-js');
+    });
+
+    await test.step('Verify CTA is visible at collection root', async () => {
+      await expect(collectionScope(page, 'bru-with-js').getByTestId('add-request-cta')).toBeVisible();
+    });
+  });
+
+  test('should show CTA for a .yml collection containing only a .js script', async ({ pageWithUserData: page }) => {
+    await test.step('Expand yml-with-js collection', async () => {
+      await expandCollection('yml-with-js');
+    });
+
+    await test.step('Verify CTA is visible at collection root', async () => {
+      await expect(collectionScope(page, 'yml-with-js').getByTestId('add-request-cta')).toBeVisible();
+    });
+  });
+
+  // Collection has user content — root CTA should be hidden
+
+  test('should hide CTA when .yml collection contains a request', async ({ pageWithUserData: page }) => {
+    await test.step('Expand yml-with-request collection', async () => {
+      await expandCollection('yml-with-request');
+      await expect(locators.sidebar.request('yml-echo')).toBeVisible();
+    });
+
+    await test.step('Verify CTA is not rendered at collection root', async () => {
+      await expect(collectionScope(page, 'yml-with-request').getByTestId('add-request-cta')).toHaveCount(0);
+    });
+  });
+
+  test('should hide root CTA when .yml collection contains a folder', async ({ pageWithUserData: page }) => {
+    await test.step('Expand yml-with-folder collection', async () => {
+      await expandCollection('yml-with-folder');
+      await expect(locators.sidebar.folder('yml-scripts')).toBeVisible();
+    });
+
+    await test.step('Verify CTA is not rendered at collection root', async () => {
+      await expect(collectionScope(page, 'yml-with-folder').getByTestId('add-request-cta')).toHaveCount(0);
+    });
+  });
+
+  // Folder containing only a .js script — folder CTA should appear
+
+  test('should show folder CTA when a .yml folder contains only a .js script', async ({ pageWithUserData: page }) => {
+    await test.step('Expand yml-with-folder collection and the yml-scripts folder', async () => {
+      await expandCollection('yml-with-folder');
+      const folder = locators.sidebar.folder('yml-scripts');
+      await folder.waitFor({ state: 'visible' });
+      await folder.click();
+    });
+
+    await test.step('Verify folder-level CTA is visible', async () => {
+      await expect(collectionScope(page, 'yml-with-folder').getByTestId('add-request-cta-folder')).toBeVisible();
+    });
+  });
+});

--- a/tests/sidebar/empty-state-cta/empty-state-cta.spec.ts
+++ b/tests/sidebar/empty-state-cta/empty-state-cta.spec.ts
@@ -69,6 +69,17 @@ test.describe.serial('Sidebar empty-state "+ Add request" CTA', () => {
 
   // Collection has user content — root CTA should be hidden
 
+  test('should hide CTA when .bru collection contains a request', async ({ pageWithUserData: page }) => {
+    await test.step('Expand bru-with-request collection', async () => {
+      await expandCollection('bru-with-request');
+      await expect(locators.sidebar.request('bru-echo')).toBeVisible();
+    });
+
+    await test.step('Verify CTA is not rendered at collection root', async () => {
+      await expect(collectionScope(page, 'bru-with-request').getByTestId('add-request-cta')).toHaveCount(0);
+    });
+  });
+
   test('should hide CTA when .yml collection contains a request', async ({ pageWithUserData: page }) => {
     await test.step('Expand yml-with-request collection', async () => {
       await expandCollection('yml-with-request');
@@ -77,6 +88,17 @@ test.describe.serial('Sidebar empty-state "+ Add request" CTA', () => {
 
     await test.step('Verify CTA is not rendered at collection root', async () => {
       await expect(collectionScope(page, 'yml-with-request').getByTestId('add-request-cta')).toHaveCount(0);
+    });
+  });
+
+  test('should hide root CTA when .bru collection contains a folder', async ({ pageWithUserData: page }) => {
+    await test.step('Expand bru-folder-with-js collection', async () => {
+      await expandCollection('bru-folder-with-js');
+      await expect(locators.sidebar.folder('bru-scripts')).toBeVisible();
+    });
+
+    await test.step('Verify CTA is not rendered at collection root', async () => {
+      await expect(collectionScope(page, 'bru-folder-with-js').getByTestId('add-request-cta')).toHaveCount(0);
     });
   });
 
@@ -92,6 +114,19 @@ test.describe.serial('Sidebar empty-state "+ Add request" CTA', () => {
   });
 
   // Folder containing only a .js script — folder CTA should appear
+
+  test('should show folder CTA when a .bru folder contains only a .js script', async ({ pageWithUserData: page }) => {
+    await test.step('Expand bru-folder-with-js collection and the bru-scripts folder', async () => {
+      await expandCollection('bru-folder-with-js');
+      const folder = locators.sidebar.folder('bru-scripts');
+      await folder.waitFor({ state: 'visible' });
+      await folder.click();
+    });
+
+    await test.step('Verify folder-level CTA is visible', async () => {
+      await expect(collectionScope(page, 'bru-folder-with-js').getByTestId('add-request-cta-folder')).toBeVisible();
+    });
+  });
 
   test('should show folder CTA when a .yml folder contains only a .js script', async ({ pageWithUserData: page }) => {
     await test.step('Expand yml-with-folder collection and the yml-scripts folder', async () => {

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-folder-with-js/bruno.json
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-folder-with-js/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "bru-folder-with-js",
+  "type": "collection"
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-folder-with-js/collection.bru
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-folder-with-js/collection.bru
@@ -1,0 +1,3 @@
+meta {
+  name: bru-folder-with-js
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-folder-with-js/scripts/folder.bru
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-folder-with-js/scripts/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: bru-scripts
+  seq: 1
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-folder-with-js/scripts/helper.js
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-folder-with-js/scripts/helper.js
@@ -1,0 +1,1 @@
+// placeholder for the empty-state CTA test

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-js/bruno.json
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-js/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "bru-with-js",
+  "type": "collection"
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-js/collection.bru
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-js/collection.bru
@@ -1,0 +1,3 @@
+meta {
+  name: bru-with-js
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-js/helper.js
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-js/helper.js
@@ -1,0 +1,1 @@
+// placeholder for the empty-state CTA test

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-request/bruno.json
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-request/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "bru-with-request",
+  "type": "collection"
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-request/collection.bru
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-request/collection.bru
@@ -1,0 +1,3 @@
+meta {
+  name: bru-with-request
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-request/echo.bru
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/bru-with-request/echo.bru
@@ -1,0 +1,9 @@
+meta {
+  name: bru-echo
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://echo.usebruno.com
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/empty-bru/bruno.json
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/empty-bru/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "empty-bru",
+  "type": "collection"
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/empty-bru/collection.bru
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/empty-bru/collection.bru
@@ -1,0 +1,3 @@
+meta {
+  name: empty-bru
+}

--- a/tests/sidebar/empty-state-cta/fixtures/collections/empty-yml/opencollection.yml
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/empty-yml/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: empty-yml

--- a/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-folder/opencollection.yml
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-folder/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: yml-with-folder

--- a/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-folder/scripts/folder.yml
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-folder/scripts/folder.yml
@@ -1,0 +1,3 @@
+info:
+  name: yml-scripts
+  seq: 1

--- a/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-folder/scripts/helper.js
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-folder/scripts/helper.js
@@ -1,0 +1,1 @@
+// placeholder for the empty-state CTA test

--- a/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-js/helper.js
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-js/helper.js
@@ -1,0 +1,1 @@
+// placeholder for the empty-state CTA test

--- a/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-js/opencollection.yml
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-js/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: yml-with-js

--- a/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-request/echo.yml
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-request/echo.yml
@@ -1,0 +1,8 @@
+info:
+  name: yml-echo
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: https://echo.usebruno.com

--- a/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-request/opencollection.yml
+++ b/tests/sidebar/empty-state-cta/fixtures/collections/yml-with-request/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: yml-with-request

--- a/tests/sidebar/empty-state-cta/init-user-data/preferences.json
+++ b/tests/sidebar/empty-state-cta/init-user-data/preferences.json
@@ -1,0 +1,16 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/empty-bru",
+    "{{collectionPath}}/empty-yml",
+    "{{collectionPath}}/bru-with-js",
+    "{{collectionPath}}/yml-with-js",
+    "{{collectionPath}}/yml-with-request",
+    "{{collectionPath}}/yml-with-folder"
+  ],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/sidebar/empty-state-cta/init-user-data/preferences.json
+++ b/tests/sidebar/empty-state-cta/init-user-data/preferences.json
@@ -4,7 +4,9 @@
     "{{collectionPath}}/empty-yml",
     "{{collectionPath}}/bru-with-js",
     "{{collectionPath}}/yml-with-js",
+    "{{collectionPath}}/bru-with-request",
     "{{collectionPath}}/yml-with-request",
+    "{{collectionPath}}/bru-folder-with-js",
     "{{collectionPath}}/yml-with-folder"
   ],
   "preferences": {


### PR DESCRIPTION
### Description

- Empty .bru collections in the sidebar did not show the "+ Add request" CTA, because bruno.json (auto-created in every .bru collection) and other non-request items were counted toward itemCount, suppressing the empty state.
- This change aligns the collection-level empty check with how folders already behave: only requests and folders count toward "has content."

Tracked in: [JIRA](https://usebruno.atlassian.net/browse/BRU-3375)

### Screen Recording

https://github.com/user-attachments/assets/51271a5a-dac8-4854-a4e1-9bb412b908b3






#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-state detection in collections to properly identify when the "+ Add request" button should display, now excluding non-request items such as script files from consideration.

* **Tests**
  * Added comprehensive test coverage for the "+ Add request" call-to-action behavior across empty and populated collections in both `.bru` and `.yml` formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8000)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->