### PR TITLE
feat: middle mouse click on a request opens a permanent tab now

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -484,6 +484,38 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     dispatch(makeTabPermanent({ uid: tabUidForItem || item.uid }));
   };
 
+  const handleMiddleMouseDown = (e) => {
+    if (e.button === 1) e.preventDefault();
+  };
+  const handleMiddleMouseUp = (e) => {
+    if (e.button !== 1) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const uid = tabUidForItem || item.uid;
+    if (isTabForItemPresent) {
+      dispatch(makeTabPermanent({ uid }));
+      return;
+    }
+    if (isItemARequest(item)) {
+      dispatch(addTab({
+        uid: item.uid,
+        collectionUid,
+        requestPaneTab: getDefaultRequestPaneTab(item),
+        type: item.type,
+        pathname: item.pathname,
+        preview: false
+      }));
+    } else {
+      dispatch(addTab({
+        uid: item.uid,
+        collectionUid,
+        type: 'folder-settings',
+        pathname: item.pathname,
+        preview: false
+      }));
+    }
+  };
+
   // Sort items by their "seq" property.
   const sortItemsBySequence = (items = []) => {
     return items.sort((a, b) => a.seq - b.seq);
@@ -659,6 +691,8 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
                 <div
                   onClick={handleClick}
                   onDoubleClick={handleDoubleClick}
+                  onMouseDown={handleMiddleMouseDown}
+                  onMouseUp={handleMiddleMouseUp}
                   className="indent-block"
                   key={i}
                   style={{ width: 16, minWidth: 16, height: '100%' }}
@@ -672,6 +706,8 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
             style={{ paddingLeft: 8 }}
             onClick={handleClick}
             onDoubleClick={handleDoubleClick}
+            onMouseDown={handleMiddleMouseDown}
+            onMouseUp={handleMiddleMouseUp}
           >
 
             {isFolder ? (


### PR DESCRIPTION
### Description

Middle clicking a collection item in the sidebar now opens it as a permanent tab (same behavior as double-click)

**Before:** Single click opens a preview tab, Double click pins the tab

**After:** Middle click on a request or folder row opens/pins the tab in one action:
- If the tab is not open -> `addTab` with `preview: false`
- If the tab is already open (ie as a preview) -> `makeTabPermanent`

Implementation is limited to `CollectionItem` (sidebar rows). `preventDefault` on middle `mousedown` prevents the browser autoscroll behavior, scroll wheel scrolling in the sidebar is unchanged

Closes #7951

### Test plan

- [x] Open a collection with multiple requests
- [x] Single click request A -> tab is italic (preview)
- [x] Single click request B -> preview moves to B (A replaced if still preview)
- [x] Middle click request C -> tab is **not** italic (permanent)
- [x] Single click request D -> C stays open, D opens as preview
- [x] Middle click an already open preview tab -> tab becomes permanent (not italic)
- [x] Scroll wheel still scrolls the collections sidebar with many requests
- [x] Middle click does not trigger on folder minimize (collapse still works)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection items can now be opened in new tabs by middle-clicking, allowing faster navigation between multiple items without replacing the current tab.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->