### PR TITLE
fix: preserve shared objects in runtime variable serialization

### DIFF
--- a/packages/bruno-js/src/utils.js
+++ b/packages/bruno-js/src/utils.js
@@ -161,14 +161,18 @@ const cleanJson = (data) => {
   ].filter(Boolean);
   const binaryNames = typedArrays.map((d) => d.name);
 
-  const seen = new WeakSet();
+  const ancestors = [];
 
-  const replacer = (key, value) => {
+  const replacer = function (key, value) {
     if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) {
+      while (ancestors.length && ancestors[ancestors.length - 1] !== this) {
+        ancestors.pop();
+      }
+
+      if (ancestors.includes(value)) {
         return '[Circular Reference]';
       }
-      seen.add(value);
+      ancestors.push(value);
 
       // instanceof + [[Class]] cover same-realm; duck-type fallback for cross-realm/cross-context Error-like objects
       if (value instanceof Error || Object.prototype.toString.call(value) === '[object Error]' || (typeof value.message === 'string' && typeof value.stack === 'string')) {
@@ -217,20 +221,24 @@ const cleanJson = (data) => {
 const cleanCircularJson = (data) => {
   try {
     // Handle circular references by keeping track of seen objects
-    const seen = new WeakSet();
+    const ancestors = [];
 
-    const replacer = (key, value) => {
+    const replacer = function (key, value) {
       // Skip non-objects and null
       if (typeof value !== 'object' || value === null) {
         return value;
       }
 
       // Detect circular reference
-      if (seen.has(value)) {
+      while (ancestors.length && ancestors[ancestors.length - 1] !== this) {
+        ancestors.pop();
+      }
+
+      if (ancestors.includes(value)) {
         return '[Circular Reference]';
       }
 
-      seen.add(value);
+      ancestors.push(value);
       return value;
     };
 

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -259,6 +259,23 @@ describe('runtime', () => {
 
       expect(result.runtimeVariables.title).toBe('{{$randomFirstName}}');
     });
+
+    it('should preserve shared object references as duplicated values', async () => {
+      const script = `
+        const objectArray = [{ id: 'abc' }, { id: 'def' }];
+        const filteredArray = objectArray.filter((obj) => obj.id === 'abc');
+
+        bru.setVar('objectArray', objectArray);
+        bru.setVar('filteredArray', filteredArray);
+      `;
+
+      const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+
+      const result = await runtime.runRequestScript(script, {}, {}, {}, '.', null, process.env);
+
+      expect(result.runtimeVariables.objectArray).toEqual([{ id: 'abc' }, { id: 'def' }]);
+      expect(result.runtimeVariables.filteredArray).toEqual([{ id: 'abc' }]);
+    });
   });
 
   describe('assert-runtime', () => {

--- a/packages/bruno-js/tests/utils.spec.js
+++ b/packages/bruno-js/tests/utils.spec.js
@@ -226,6 +226,19 @@ describe('utils', () => {
       expect(cleanJson(obj)).toEqual({ a: 1, self: '[Circular Reference]' });
     });
 
+    it('duplicates shared object references instead of treating them as circular', () => {
+      const shared = { id: 'abc' };
+      const input = {
+        objectArray: [shared, { id: 'def' }],
+        filteredArray: [shared]
+      };
+
+      expect(cleanJson(input)).toEqual({
+        objectArray: [{ id: 'abc' }, { id: 'def' }],
+        filteredArray: [{ id: 'abc' }]
+      });
+    });
+
     it('serializes Error instances with all own properties', () => {
       const err = new Error('oops');
       const out = cleanJson(err);
@@ -295,6 +308,19 @@ describe('utils', () => {
       const obj = { a: 1 };
       obj.self = obj;
       expect(cleanCircularJson(obj)).toEqual({ a: 1, self: '[Circular Reference]' });
+    });
+
+    it('duplicates shared object references instead of treating them as circular', () => {
+      const shared = { id: 'abc' };
+      const input = {
+        objectArray: [shared, { id: 'def' }],
+        filteredArray: [shared]
+      };
+
+      expect(cleanCircularJson(input)).toEqual({
+        objectArray: [{ id: 'abc' }, { id: 'def' }],
+        filteredArray: [{ id: 'abc' }]
+      });
     });
 
     it('handles deeply nested circular ref', () => {


### PR DESCRIPTION
## Summary
- update runtime JSON cleaning to treat only ancestor references as circular
- preserve shared object values set through bru.setVar by duplicating them in serialized output
- add serializer and bru.setVar regression coverage

Fixes #8005

## Testing
- npm run build --workspace=packages/bruno-query
- npm run build --workspace=packages/bruno-common
- npm run build --workspace=packages/bruno-requests
- npm run sandbox:bundle-libraries --workspace=packages/bruno-js
- npm test --workspace=packages/bruno-js -- --runTestsByPath tests/utils.spec.js
- npm test --workspace=packages/bruno-js -- --runTestsByPath tests/runtime.spec.js
- npm test --workspace=packages/bruno-js -- --runTestsByPath tests/utils.spec.js tests/runtime.spec.js
- npm run lint -- packages/bruno-js/src/utils.js packages/bruno-js/tests/utils.spec.js packages/bruno-js/tests/runtime.spec.js
- git diff --check

Note: the bruno-requests build completed with existing dependency/Rollup warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved JSON serialization to more accurately detect and handle circular references while correctly preserving shared non-circular object references.

* **Tests**
  * Added test coverage for shared object reference handling in JSON serialization and runtime variable operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->