### PR TITLE
fix: generate python file uploads as open calls

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -32,6 +32,14 @@ const addCurlAuthFlags = (curlCommand, auth) => {
   return curlCommand;
 };
 
+const normalizePythonRequestsFileUploads = (snippet) => {
+  if (!snippet) {
+    return snippet;
+  }
+
+  return snippet.replace(/"open\('([^']*)', 'rb'\)"/g, (_, filePath) => `open('${filePath}', 'rb')`);
+};
+
 const generateSnippet = ({ language, item, collection, shouldInterpolate = false }) => {
   try {
     // Get HTTPSnippet dynamically so mocks can be applied in tests
@@ -82,6 +90,10 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
       result = addCurlAuthFlags(result, effectiveAuth);
     }
 
+    if (language.target === 'python' && language.client === 'requests') {
+      result = normalizePythonRequestsFileUploads(result);
+    }
+
     // Respect encodeUrl setting: when not explicitly true, replace HTTPSnippet's encoded path+query with the raw version.
     // Replacing the path portion works for all targets since it's a substring of the full URL.
     // encodeUrl defaults to false in the UI when undefined/null
@@ -121,6 +133,4 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
   }
 };
 
-export {
-  generateSnippet
-};
+export { generateSnippet, normalizePythonRequestsFileUploads };

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -66,7 +66,20 @@ jest.mock('utils/collections/index', () => {
   };
 });
 
-import { generateSnippet } from './snippet-generator';
+import {
+  generateSnippet,
+  normalizePythonRequestsFileUploads
+} from './snippet-generator';
+
+describe('normalizePythonRequestsFileUploads', () => {
+  it('unwraps file upload open calls generated as strings', () => {
+    const snippet = `files = { "file": "open('tasks_service/upload_file/invalid.svg', 'rb')" }`;
+
+    expect(normalizePythonRequestsFileUploads(snippet)).toBe(
+      `files = { "file": open('tasks_service/upload_file/invalid.svg', 'rb') }`
+    );
+  });
+});
 
 describe('Snippet Generator - Simple Tests', () => {
   // Simple test request - easy to understand
@@ -175,6 +188,25 @@ describe('Snippet Generator - Simple Tests', () => {
     });
 
     expect(result).toBe('curl -X GET https://api.example.com/{{endpoint}}');
+  });
+
+  it('should generate Python requests multipart file uploads as open calls', () => {
+    require('httpsnippet').HTTPSnippet = jest.fn().mockImplementation(() => ({
+      convert: jest.fn(
+        () => `files = { "file": "open('tasks_service/upload_file/invalid.svg', 'rb')" }`
+      )
+    }));
+
+    const result = generateSnippet({
+      language: { target: 'python', client: 'requests' },
+      item: testRequest,
+      collection: testCollection,
+      shouldInterpolate: false
+    });
+
+    expect(result).toBe(
+      `files = { "file": open('tasks_service/upload_file/invalid.svg', 'rb') }`
+    );
   });
 
   it('should handle requests with different headers', () => {


### PR DESCRIPTION
### Description

Fixes #5860.

Python `requests` snippets generated for multipart file uploads currently wrap the generated `open(..., 'rb')` call in quotes, which passes a string instead of a file object. This PR normalizes only the Python/requests generated snippet so file uploads are emitted as executable `open(...)` calls.

#### Testing

- `npm test --workspace=packages/bruno-app -- snippet-generator.spec.js --runInBand --env=node`
- `npm run lint -- packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js`
- `git diff --check`

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced code snippet generation for Python API requests to properly handle file upload operations, ensuring correct file access syntax formatting and improving code usability.

* **Tests**
  * Added unit tests for Python file upload code snippet generation to validate syntax handling and proper code normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->