### PR TITLE
fix: parse digest auth headers with quoted commas

### DIFF
--- a/packages/bruno-requests/src/auth/digestauth-helper.js
+++ b/packages/bruno-requests/src/auth/digestauth-helper.js
@@ -16,6 +16,45 @@ function splitAuthHeaderKeyValue(str) {
   return [key, value];
 }
 
+function splitAuthHeaderParams(authHeader) {
+  const params = [];
+  let current = '';
+  let insideQuotes = false;
+  let escaped = false;
+
+  for (const char of authHeader) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\' && insideQuotes) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      insideQuotes = !insideQuotes;
+    }
+
+    if (char === ',' && !insideQuotes) {
+      params.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) {
+    params.push(current);
+  }
+
+  return params;
+}
+
 function containsDigestHeader(response) {
   const authHeader = response?.headers?.['www-authenticate'];
   return authHeader ? authHeader.trim().toLowerCase().startsWith('digest') : false;
@@ -60,8 +99,7 @@ export function addDigestInterceptor(axiosInstance, request) {
         console.debug('Processing Digest Authentication Challenge');
         console.debug(error.response.headers['www-authenticate']);
 
-        const authDetails = error.response.headers['www-authenticate']
-          .split(',')
+        const authDetails = splitAuthHeaderParams(error.response.headers['www-authenticate'])
           .map((pair) => splitAuthHeaderKeyValue(pair).map((item) => item.trim()).map(stripQuotes))
           .reduce((acc, [key, value]) => {
             const normalizedKey = key.toLowerCase().replace('digest ', '');

--- a/packages/bruno-requests/src/auth/digestauth-helper.js
+++ b/packages/bruno-requests/src/auth/digestauth-helper.js
@@ -16,6 +16,10 @@ function splitAuthHeaderKeyValue(str) {
   return [key, value];
 }
 
+/**
+ * Split a digest auth challenge on commas that separate parameters, while
+ * preserving commas that appear inside quoted values.
+ */
 function splitAuthHeaderParams(authHeader) {
   const params = [];
   let current = '';

--- a/packages/bruno-requests/src/auth/digestauth-helper.spec.js
+++ b/packages/bruno-requests/src/auth/digestauth-helper.spec.js
@@ -55,4 +55,51 @@ describe('Digest Auth with query params', () => {
     // Expected to include both pathname and query
     expect(uri).toBe('/resource?foo=bar&baz=qux');
   });
+
+  test('parses quoted digest header values containing commas', async () => {
+    const axiosInstance = axios.create();
+
+    let callCount = 0;
+    let capturedAuthorization;
+
+    axiosInstance.defaults.adapter = async (config) => {
+      callCount += 1;
+      if (callCount === 1) {
+        const error = new Error('Unauthorized');
+        error.config = config;
+        error.response = {
+          status: 401,
+          headers: {
+            'www-authenticate': 'Digest realm="api, v1", nonce="abc", qop="auth,auth-int", opaque="token,123"'
+          }
+        };
+        throw error;
+      }
+
+      capturedAuthorization = config.headers && (config.headers.Authorization || config.headers.authorization);
+      return {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+        data: { ok: true }
+      };
+    };
+
+    const request = {
+      method: 'GET',
+      url: 'http://example.com/resource',
+      headers: {},
+      digestConfig: { username: 'user', password: 'pass' }
+    };
+
+    addDigestInterceptor(axiosInstance, request);
+
+    const res = await axiosInstance(request);
+    expect(res.status).toEqual(200);
+
+    expect(capturedAuthorization).toContain('realm="api, v1"');
+    expect(capturedAuthorization).toContain('qop="auth"');
+    expect(capturedAuthorization).toContain('opaque="token,123"');
+  });
 });


### PR DESCRIPTION
### Description

Fixes #5509.

Digest authentication challenges can include commas inside quoted parameter values, for example `realm="api, v1"` or `qop="auth,auth-int"`. The previous parser split the `WWW-Authenticate` header on every comma, which corrupted those values before building the Authorization header.

This change splits digest auth parameters only on commas outside quoted strings and adds a regression test covering quoted commas in `realm`, `qop`, and `opaque`.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Testing:

- `npm test --workspace=packages/bruno-requests -- digestauth-helper.spec.js --runInBand`
- `npm run lint -- packages/bruno-requests/src/auth/digestauth-helper.js packages/bruno-requests/src/auth/digestauth-helper.spec.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved digest authentication header parsing to correctly handle quoted parameter values that include commas and escaped characters, increasing compatibility with varied authentication servers.

* **Tests**
  * Added tests validating digest-auth parsing for complex quoted directive values to ensure stable, accurate Authorization header generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->