### PR TITLE
fix: refresh response search results on content change

### DIFF
--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -171,6 +171,23 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     doSearch(0);
   }, [debouncedSearchText, doSearch]);
 
+  useEffect(() => {
+    if (!editor || !visible || !debouncedSearchText) {
+      return;
+    }
+
+    const handleEditorChange = () => {
+      searchCacheKey.current = '';
+      doSearch(0);
+    };
+
+    editor.on('change', handleEditorChange);
+
+    return () => {
+      editor.off('change', handleEditorChange);
+    };
+  }, [debouncedSearchText, doSearch, editor, visible]);
+
   const handleSearchBarClose = useCallback(() => {
     searchMarks.current.forEach((mark) => mark.clear());
     searchMarks.current = [];


### PR DESCRIPTION
## Description
Refreshes the response search state when the underlying CodeMirror editor content changes, so the visible match count is recalculated after a new response is rendered.

Fixes #7891.

## Testing
- npx eslint packages/bruno-app/src/components/CodeMirrorSearch/index.js
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced search functionality to dynamically refresh results whenever code content is modified in the editor while the search bar is active.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->