### PR TITLE
fix: show yml extension when renaming requests

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js
@@ -15,6 +15,7 @@ import Portal from 'components/Portal';
 import Dropdown from 'components/Dropdown';
 import StyledWrapper from './StyledWrapper';
 import Button from 'ui/Button';
+import { getRequestFileExtension } from './utils';
 
 const RenameCollectionItem = ({ collectionUid, item, onClose }) => {
   const dispatch = useDispatch();
@@ -25,6 +26,7 @@ const RenameCollectionItem = ({ collectionUid, item, onClose }) => {
   const itemName = item?.name;
   const itemType = item?.type;
   const itemFilename = item?.filename ? path.parse(item?.filename).name : '';
+  const requestFileExtension = getRequestFileExtension(item?.filename, collection?.format);
   const [showFilesystemName, toggleShowFilesystemName] = useState(false);
 
   const dropdownTippyRef = useRef();
@@ -188,7 +190,7 @@ const RenameCollectionItem = ({ collectionUid, item, onClose }) => {
                       onChange={formik.handleChange}
                       value={formik.values.filename || ''}
                     />
-                    {itemType !== 'folder' && <span className="absolute right-2 top-4 flex justify-center items-center file-extension">.{collection?.format || 'bru'}</span>}
+                    {itemType !== 'folder' && <span className="absolute right-2 top-4 flex justify-center items-center file-extension">.{requestFileExtension}</span>}
                   </div>
                 ) : (
                   <div className="relative flex flex-row gap-1 items-center justify-between">

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/utils.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/utils.js
@@ -1,0 +1,9 @@
+export const getRequestFileExtension = (itemFilename, collectionFormat) => {
+  const filenameExtension = itemFilename?.match(/\.([^.\\/]+)$/)?.[1];
+
+  if (filenameExtension) {
+    return filenameExtension.toLowerCase();
+  }
+
+  return collectionFormat || 'bru';
+};

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/utils.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/utils.spec.js
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import { getRequestFileExtension } from './utils';
+
+describe('getRequestFileExtension', () => {
+  it('uses the current request filename extension when available', () => {
+    expect(getRequestFileExtension('request.yml', 'bru')).toBe('yml');
+  });
+
+  it('falls back to the collection format when the item has no filename extension', () => {
+    expect(getRequestFileExtension('request', 'bru')).toBe('bru');
+  });
+});


### PR DESCRIPTION
## Summary\n- derive the rename modal file extension from the current request filename before falling back to the collection format\n- keep OpenCollection requests displaying .yml in the filesystem name field\n- add focused coverage for extension selection\n\nFixes #7233\n\n## Testing\n- NODE_PATH=/Users/mehmet.turac/Documents/bruno/node_modules PATH=/Users/mehmet.turac/Documents/bruno/node_modules/.bin:$PATH npm test --workspace=packages/bruno-app -- RenameCollectionItem/utils.spec.js --runInBand\n- ./node_modules/.bin/eslint packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/index.js packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/utils.js packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RenameCollectionItem/utils.spec.js\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accuracy of file extensions displayed when renaming collection items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->