### PR TITLE
fix: preserve duplicate urlencoded curl fields

### DIFF
--- a/packages/bruno-app/src/utils/curl/index.js
+++ b/packages/bruno-app/src/utils/curl/index.js
@@ -7,7 +7,10 @@ export const getRequestFromCurlCommand = (curlCommand, requestType = 'http-reque
   const parseFormData = (parsedBody) => {
     const formData = [];
     forOwn(parsedBody, (value, key) => {
-      formData.push({ name: key, value, enabled: true });
+      const values = Array.isArray(value) ? value : [value];
+      values.forEach((item) => {
+        formData.push({ name: key, value: item, enabled: true });
+      });
     });
 
     return formData;

--- a/packages/bruno-app/src/utils/curl/index.spec.js
+++ b/packages/bruno-app/src/utils/curl/index.spec.js
@@ -1,0 +1,22 @@
+const { describe, it, expect } = require('@jest/globals');
+
+import { getRequestFromCurlCommand } from '.';
+
+describe('getRequestFromCurlCommand', () => {
+  it('preserves duplicate form-url-encoded fields from curl imports', () => {
+    const curlCommand = `curl --request GET \\
+      --url https://postman-echo.com/get \\
+      --header 'content-type: application/x-www-form-urlencoded' \\
+      --data tag=value \\
+      --data name=ishowspeed \\
+      --data tag=brook`;
+
+    const result = getRequestFromCurlCommand(curlCommand);
+
+    expect(result.body.formUrlEncoded).toEqual([
+      { name: 'tag', value: 'value', enabled: true },
+      { name: 'tag', value: 'brook', enabled: true },
+      { name: 'name', value: 'ishowspeed', enabled: true }
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #4967

## Summary
- expand duplicate urlencoded form values into separate imported rows
- add a regression test for repeated curl --data fields

## Verification
- npm test -- --env=node --runTestsByPath src/utils/curl/index.spec.js --runInBand
- npx eslint packages/bruno-app/src/utils/curl/index.js packages/bruno-app/src/utils/curl/index.spec.js
- git diff --check

Note: running the same Jest target with the default jsdom environment failed before tests because the local canvas native binding is unavailable; the parser test was run with node env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate form fields when importing curl commands to ensure all repeated fields are properly preserved during the import process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->