### PR TITLE
fix: encode hashes in query values

### DIFF
--- a/packages/bruno-common/src/utils/url/index.spec.ts
+++ b/packages/bruno-common/src/utils/url/index.spec.ts
@@ -76,15 +76,27 @@ describe('encodeUrl', () => {
   });
 
   describe('hash fragment handling', () => {
-    it('should preserve hash fragments with encoded query parameters', () => {
-      const url = 'https://example.com/api?name=john doe#section1';
-      const expected = 'https://example.com/api?name=john%20doe#section1';
+    it('should encode hashes in query parameter values', () => {
+      const url = 'https://example.com/api?hashtagParam=test#abc';
+      const expected = 'https://example.com/api?hashtagParam=test%23abc';
       expect(encodeUrl(url)).toBe(expected);
     });
 
-    it('should preserve hash fragments with pipe operator in query', () => {
+    it('should keep encoding query parameters after a hash character', () => {
+      const url = 'https://example.com/api?test={"key":"|#value|"}&page=$1';
+      const expected = 'https://example.com/api?test=%7B%22key%22%3A%22%7C%23value%7C%22%7D&page=%241';
+      expect(encodeUrl(url)).toBe(expected);
+    });
+
+    it('should encode hash-like query suffixes with encoded query parameters', () => {
+      const url = 'https://example.com/api?name=john doe#section1';
+      const expected = 'https://example.com/api?name=john%20doe%23section1';
+      expect(encodeUrl(url)).toBe(expected);
+    });
+
+    it('should encode hash-like query suffixes with pipe operator in query', () => {
       const url = 'https://example.com/api?filter=status|active#results';
-      const expected = 'https://example.com/api?filter=status%7Cactive#results';
+      const expected = 'https://example.com/api?filter=status%7Cactive%23results';
       expect(encodeUrl(url)).toBe(expected);
     });
   });
@@ -105,7 +117,7 @@ describe('encodeUrl', () => {
 
     it('should handle complex query parameters with multiple special characters', () => {
       const url = 'https://example.com/api?search=hello world!@#$%^&*()&filter=active&sort=name asc';
-      const expected = 'https://example.com/api?search=hello%20world!%40#$%^&*()&filter=active&sort=name asc';
+      const expected = 'https://example.com/api?search=hello%20world!%40%23%24%25%5E&*()&filter=active&sort=name%20asc';
       expect(encodeUrl(url)).toBe(expected);
     });
 

--- a/packages/bruno-common/src/utils/url/index.ts
+++ b/packages/bruno-common/src/utils/url/index.ts
@@ -33,8 +33,7 @@ function parseQueryParams(query: string, { decode = false }: ExtractQueryParamsO
   }
 
   try {
-    const [queryString, ...hashParts] = query.split('#');
-    const pairs = queryString.split('&');
+    const pairs = query.split('&');
 
     const params = pairs.map((pair) => {
       const [name, ...valueParts] = pair.split('=');
@@ -66,8 +65,7 @@ const encodeUrl = (url: string): string => {
     return url;
   }
 
-  const [urlWithoutHash, ...hashFragments] = url.split('#');
-  const [basePath, ...queryString] = urlWithoutHash.split('?');
+  const [basePath, ...queryString] = url.split('?');
 
   // If no query parameters exist, return original URL
   if (!queryString || queryString.length === 0) {
@@ -79,7 +77,7 @@ const encodeUrl = (url: string): string => {
   const encodedQueryString = buildQueryString(queryParams, { encode: true });
 
   // Reconstruct URL with encoded query parameters
-  const encodedUrl = `${basePath}?${encodedQueryString}${hashFragments.length > 0 ? `#${hashFragments.join('#')}` : ''}`;
+  const encodedUrl = `${basePath}?${encodedQueryString}`;
 
   return encodedUrl;
 };


### PR DESCRIPTION
Fixes #5788

## Summary
- treat `#` after `?` as part of the query string when URL encoding is enabled
- encode hashtag query values as `%23` and continue encoding following query params
- add regression coverage for hashtag query values and the reported post-hash encoding case

## Verification
- npm test -- --runTestsByPath src/utils/url/index.spec.ts --runInBand
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL query parameter encoding to properly handle special characters. Hash (`#`) and other special symbols appearing within parameter values are now correctly percent-encoded instead of being interpreted as URL fragment delimiters, improving URL parsing accuracy and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->