### PR TITLE
fix: handle bracketed query snippets

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -32,6 +32,10 @@ const addCurlAuthFlags = (curlCommand, auth) => {
   return curlCommand;
 };
 
+const encodeHarUrl = (url) => {
+  return encodeUrlCommon(url).replace(/\[/g, '%5B').replace(/\]/g, '%5D');
+};
+
 const generateSnippet = ({ language, item, collection, shouldInterpolate = false }) => {
   try {
     // Get HTTPSnippet dynamically so mocks can be applied in tests
@@ -67,9 +71,16 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
       request.params = interpolateParams(request.params, variables);
     }
 
+    const settings = item.draft ? get(item, 'draft.settings') : get(item, 'settings');
+    const rawUrl = item.rawUrl || request.url;
+    const requestForSnippet = {
+      ...request,
+      url: encodeHarUrl(request.url)
+    };
+
     // Build HAR request
     const harRequest = buildHarRequest({
-      request,
+      request: requestForSnippet,
       headers
     });
 
@@ -85,9 +96,7 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
     // Respect encodeUrl setting: when not explicitly true, replace HTTPSnippet's encoded path+query with the raw version.
     // Replacing the path portion works for all targets since it's a substring of the full URL.
     // encodeUrl defaults to false in the UI when undefined/null
-    const settings = item.draft ? get(item, 'draft.settings') : get(item, 'settings');
-    const rawUrl = item.rawUrl || request.url;
-    const parsed = parse(request.url, true, true);
+    const parsed = parse(requestForSnippet.url, true, true);
     const search = stringify(parsed.query, { sort: false });
     const httpSnippetPath = search ? `${parsed.pathname}?${search}` : parsed.pathname;
 
@@ -95,7 +104,7 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
     if (settings?.encodeUrl === true) {
       // Apply the same encodeUrl() transform used by the actual request execution path
       // so the snippet matches what's sent on the wire.
-      const encodedUrl = encodeUrlCommon(rawUrl);
+      const encodedUrl = encodeHarUrl(rawUrl);
       desiredPath = stripOrigin(encodedUrl);
       // Strip fragment per RFC 3986 §3.5
       desiredPath = desiredPath.replace(/#.*$/, '');

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -996,6 +996,29 @@ describe('generateSnippet – encodeUrl setting', () => {
     expect(result).toContain('time=10:30');
   });
 
+  it('should preserve bracketed query values when encodeUrl is false', () => {
+    const rawUrl = 'https://example.com/filter?ids=[1, 2, 3]';
+    const item = makeItem(rawUrl, { encodeUrl: false });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    const { HTTPSnippet } = require('httpsnippet');
+    const harRequest = HTTPSnippet.mock.calls[0][0];
+
+    expect(harRequest.url).toContain('ids=%5B1%2C%202%2C%203%5D');
+    expect(result).toContain('ids=[1, 2, 3]');
+    expect(result).not.toContain('%5B');
+    expect(result).not.toContain('Error generating code snippet');
+  });
+
+  it('should encode bracketed query values when encodeUrl is true', () => {
+    const rawUrl = 'https://example.com/filter?ids=[1, 2, 3]';
+    const item = makeItem(rawUrl, { encodeUrl: true });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toContain('ids=%5B1%2C%202%2C%203%5D');
+    expect(result).not.toContain('Error generating code snippet');
+  });
+
   it('should encode URL when encodeUrl is true', () => {
     const rawUrl = 'https://example.com/api?token=abc123==&type=test';
     const item = makeItem(rawUrl, { encodeUrl: true });


### PR DESCRIPTION
Fixes #7913
Fixes #7653

## What changed
- encode raw square brackets before passing URLs to HTTPSnippet HAR validation
- preserve raw bracketed query values when URL encoding is disabled
- keep encoded bracket values when URL encoding is enabled

## Testing
- npm test -- --env=node --runTestsByPath src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js --runInBand
- npx eslint packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of special characters (brackets, commas) in URL query parameters when generating code snippets
  * Ensured generated code snippets now properly percent-encode brackets to match the encoding used during actual request execution

* **Tests**
  * Added test coverage for bracket and special character encoding in generated code snippets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->