### PR TITLE
fix: stop collection runs from test scripts

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1818,6 +1818,10 @@ const registerNetworkIpc = (mainWindow) => {
                 nextRequestName = testResults.nextRequestName;
               }
 
+              if (testResults?.stopExecution) {
+                stopRunnerExecution = true;
+              }
+
               mainWindow.webContents.send('main:run-folder-event', {
                 type: 'test-results',
                 testResults: testResults.results,

--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -131,7 +131,8 @@ class TestRuntime {
       persistentEnvVariables: cleanJson(bru.persistentEnvVariables),
       oauth2CredentialsToReset: bru.oauth2CredentialsToReset,
       results: cleanJson(__brunoTestResults.getResults()),
-      nextRequestName: bru.nextRequest
+      nextRequestName: bru.nextRequest,
+      stopExecution: bru.stopExecution
     };
 
     if (scriptError) {

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -90,6 +90,50 @@ describe('runtime', () => {
         { description: 'format valid', status: 'pass' }
       ]);
     });
+
+    it('should return stopExecution when tests request runner stop', async () => {
+      const testFile = `
+                bru.runner.stopExecution();
+            `;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env
+      );
+      expect(result.stopExecution).toBe(true);
+    });
+
+    it('should preserve stopExecution when a test script throws', async () => {
+      const testFile = `
+                bru.runner.stopExecution();
+                throw new Error('boom');
+            `;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      await expect(
+        runtime.runTests(
+          testFile,
+          { ...baseRequest },
+          { ...baseResponse },
+          {},
+          {},
+          '.',
+          null,
+          process.env
+        )
+      ).rejects.toMatchObject({
+        partialResults: expect.objectContaining({
+          stopExecution: true
+        })
+      });
+    });
   });
 
   describe('script-runtime', () => {


### PR DESCRIPTION
Fixes #7928

## What changed
- return stopExecution from test script runtime results
- preserve stopExecution in partial results when a test script throws
- make the GUI collection runner stop after tests request it

## Testing
- npm test -- --runTestsByPath tests/runtime.spec.js --runInBand
- npx eslint packages/bruno-js/src/runtime/test-runtime.js packages/bruno-js/tests/runtime.spec.js packages/bruno-electron/src/ipc/network/index.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test scripts can now halt execution of subsequent requests during collection and folder runs, enabling more granular control over your test workflows and request execution flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8020?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->