### PR TITLE
fix: normalize select file labels

### DIFF
--- a/packages/bruno-app/src/components/OpenAPISyncTab/ConnectSpecForm/index.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/ConnectSpecForm/index.js
@@ -96,7 +96,7 @@ const ConnectSpecForm = ({ sourceUrl, setSourceUrl, isLoading, error, setError, 
                 className="url-input file-pick-btn"
                 onClick={() => fileInputRef.current?.click()}
               >
-                {sourceUrl ? sourceUrl.split(/[\\/]/).pop() : 'Choose file...'}
+                {sourceUrl ? sourceUrl.split(/[\\/]/).pop() : 'Select File'}
               </button>
             </>
           )}

--- a/packages/bruno-app/src/components/OpenAPISyncTab/ConnectionSettingsModal/index.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/ConnectionSettingsModal/index.js
@@ -101,7 +101,7 @@ const ConnectionSettingsModal = ({ collection, sourceUrl, onSave, onDisconnect, 
                   className="settings-input file-pick-btn"
                   onClick={() => fileInputRef.current?.click()}
                 >
-                  {filePath ? filePath.split(/[\\/]/).pop() : 'Choose file...'}
+                  {filePath ? filePath.split(/[\\/]/).pop() : 'Select File'}
                 </button>
               </>
             )}

--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -233,7 +233,7 @@ const General = () => {
               disabled={formik.values.customCaCertificate.enabled ? false : true}
               onClick={() => inputFileCaCertificateRef.current.click()}
             >
-              select file
+              Select File
               <input
                 id="caCertFilePath"
                 type="file"

--- a/packages/bruno-app/src/components/Preferences/ProxySettings/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/index.js
@@ -439,7 +439,7 @@ const ProxySettings = ({ close }) => {
                   >
                     {formik.values.pac.source
                       ? decodeURIComponent(formik.values.pac.source.split('/').pop())
-                      : 'Choose file...'}
+                      : 'Select File'}
                   </button>
                 )}
                 {formik.touched.pac?.source && formik.errors.pac?.source ? (

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth1/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth1/index.js
@@ -256,7 +256,7 @@ const OAuth1 = ({ item = {}, collection, request, save, updateAuth }) => {
                 <button
                   className="flex items-center gap-1 oauth1-icon cursor-pointer text-link"
                   onClick={handleBrowse}
-                  title="Select file"
+                  title="Select File"
                   type="button"
                 >
                   <IconUpload size={14} />

--- a/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js
@@ -192,7 +192,7 @@ const MultipartFormParams = ({ item, collection }) => {
             <button
               className="upload-btn ml-1"
               onClick={() => handleBrowseFiles(row, onChange)}
-              title="Select file"
+              title="Select File"
             >
               <IconUpload size={16} />
             </button>

--- a/packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleMultipartFormParams/index.js
+++ b/packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleMultipartFormParams/index.js
@@ -227,7 +227,7 @@ const ResponseExampleMultipartFormParams = ({ item, collection, exampleUid, edit
             <button
               className="upload-btn ml-1"
               onClick={() => handleBrowseFiles(row, onChange)}
-              title="Select file"
+              title="Select File"
             >
               <IconUpload size={16} />
             </button>


### PR DESCRIPTION
## Summary
- normalize visible file picker labels and tooltips to "Select File"
- cover preferences, proxy PAC file picker, OpenAPI sync file pickers, multipart upload, and OAuth1 private key upload

Fixes #2992

## Testing
- npm ci --ignore-scripts
- npm run lint -- packages/bruno-app/src/components/Preferences/General/index.js packages/bruno-app/src/components/Preferences/ProxySettings/index.js packages/bruno-app/src/components/RequestPane/MultipartFormParams/index.js packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleMultipartFormParams/index.js packages/bruno-app/src/components/OpenAPISyncTab/ConnectSpecForm/index.js packages/bruno-app/src/components/OpenAPISyncTab/ConnectionSettingsModal/index.js packages/bruno-app/src/components/RequestPane/Auth/OAuth1/index.js
- git diff --check origin/main...HEAD
- rg -n "select file|Select file|Choose file|Choose File" packages/bruno-app/src -g '!node_modules' -g '!dist' -g '!build'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized file picker and upload button labels across the application. Updated button text and tooltips to consistently display "Select File" instead of varying formats, providing a more cohesive user interface experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->