### PR TITLE
fix: resolve inherited auth in generated docs

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -15,6 +15,7 @@ import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsL
 import { brunoToOpenCollection } from '@usebruno/converters';
 import { sanitizeName } from 'utils/common/regex';
 import { escapeHtml } from 'utils/response';
+import { resolveInheritedAuthForDocumentation } from './utils';
 
 const CDN_BASE_URL = 'https://cdn.opencollection.com';
 
@@ -75,6 +76,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
   const handleGenerate = useCallback(() => {
     try {
       const collectionCopy = cloneDeep(collection);
+      resolveInheritedAuthForDocumentation(collectionCopy);
       const transformedCollection = transformCollectionToSaveToExportAsFile(collectionCopy);
       const openCollection = brunoToOpenCollection(transformedCollection);
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/utils.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/utils.js
@@ -1,0 +1,20 @@
+import { resolveInheritedAuth } from 'utils/auth';
+
+const resolveItemAuthForDocumentation = (item, collection) => {
+  if (item?.type === 'http-request' && item?.request?.auth?.mode === 'inherit') {
+    item.request.auth = resolveInheritedAuth(item, collection).auth;
+  }
+
+  if (Array.isArray(item?.items)) {
+    item.items.forEach((child) => resolveItemAuthForDocumentation(child, collection));
+  }
+};
+
+export const resolveInheritedAuthForDocumentation = (collection) => {
+  if (!collection?.items?.length) {
+    return collection;
+  }
+
+  collection.items.forEach((item) => resolveItemAuthForDocumentation(item, collection));
+  return collection;
+};

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/utils.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/utils.spec.js
@@ -1,0 +1,70 @@
+import { resolveInheritedAuthForDocumentation } from './utils';
+
+describe('resolveInheritedAuthForDocumentation', () => {
+  it('resolves request auth inherited from a parent folder', () => {
+    const collection = {
+      root: {
+        request: {
+          auth: { mode: 'none' }
+        }
+      },
+      items: [
+        {
+          uid: 'folder-1',
+          type: 'folder',
+          root: {
+            request: {
+              auth: {
+                mode: 'bearer',
+                bearer: { token: '{{token}}' }
+              }
+            }
+          },
+          items: [
+            {
+              uid: 'request-1',
+              type: 'http-request',
+              request: {
+                auth: { mode: 'inherit' }
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    resolveInheritedAuthForDocumentation(collection);
+
+    expect(collection.items[0].items[0].request.auth).toEqual({
+      mode: 'bearer',
+      bearer: { token: '{{token}}' }
+    });
+  });
+
+  it('leaves explicit request auth unchanged', () => {
+    const requestAuth = {
+      mode: 'apikey',
+      apikey: { key: 'x-api-key', value: '{{key}}', placement: 'header' }
+    };
+    const collection = {
+      root: {
+        request: {
+          auth: { mode: 'bearer', bearer: { token: '{{token}}' } }
+        }
+      },
+      items: [
+        {
+          uid: 'request-1',
+          type: 'http-request',
+          request: {
+            auth: requestAuth
+          }
+        }
+      ]
+    };
+
+    resolveInheritedAuthForDocumentation(collection);
+
+    expect(collection.items[0].request.auth).toBe(requestAuth);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve request-level inherited auth before converting generated documentation to OpenCollection
- add coverage for folder-inherited auth and explicit auth preservation

Fixes #7990

## Test plan
- node --check packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/utils.js
- node --check packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/utils.spec.js
- git diff --check

Note: the focused Jest test could not be run locally because this environment cannot read the existing Bruno node_modules path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation generation now correctly resolves and reflects inherited authentication settings for requests within collections, ensuring accurate auth information is included in generated documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->