### PR TITLE
fix: import url-encoded / multipart form body when importing curl command

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -10,7 +10,9 @@ import {
   updateRequestGraphqlQuery,
   updateRequestGraphqlVariables,
   updateRequestAuthMode,
-  updateAuth
+  updateAuth,
+  setFormUrlEncodedParams,
+  setMultipartFormParams
 } from 'providers/ReduxStore/slices/collections';
 import { saveRequest, cancelRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { getRequestFromCurlCommand } from 'utils/curl';
@@ -295,13 +297,21 @@ const QueryUrl = ({ item, collection, handleRun }) => {
             );
           }
         } else if (bodyMode === 'formUrlEncoded' && request.body.formUrlEncoded) {
-          // For formUrlEncoded, we need to set each param individually
-          // This is a limitation - we'd need to clear existing params first
-          // For now, we'll set the body mode and the user can manually adjust
-          // TODO: Implement proper formUrlEncoded param setting
+          dispatch(
+            setFormUrlEncodedParams({
+              itemUid: item.uid,
+              collectionUid: collection.uid,
+              params: request.body.formUrlEncoded
+            })
+          );
         } else if (bodyMode === 'multipartForm' && request.body.multipartForm) {
-          // For multipartForm, similar limitation
-          // TODO: Implement proper multipartForm param setting
+          dispatch(
+            setMultipartFormParams({
+              itemUid: item.uid,
+              collectionUid: collection.uid,
+              params: request.body.multipartForm
+            })
+          );
         }
       }
 

--- a/tests/request/curl-import/curl-import.spec.ts
+++ b/tests/request/curl-import/curl-import.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '../../../playwright';
+import {
+  closeAllCollections,
+  createCollection,
+  createRequest,
+  openCollection,
+  openRequest,
+  selectRequestPaneTab
+} from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const pasteShortcut = process.platform === 'darwin' ? 'Meta+v' : 'Control+v';
+
+// Copy text to the system clipboard by creating a temporary textarea, selecting
+// its value, and calling document.execCommand('copy'). Avoids clipboard permissions.
+const setClipboard = async (page, text: string) => {
+  await page.evaluate((val: string) => {
+    const ta = document.createElement('textarea');
+    ta.value = val;
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand('copy');
+    document.body.removeChild(ta);
+  }, text);
+};
+
+// Paste a cURL command into the URL bar and wait for the success toast.
+const pasteCurl = async (page, locators, curl: string) => {
+  await setClipboard(page, curl);
+  await locators.request.urlInput().click();
+  await page.keyboard.press(pasteShortcut);
+  await expect(page.getByText('cURL command imported successfully').last()).toBeVisible({ timeout: 5000 });
+  await page.waitForTimeout(500);
+};
+
+// Switch to the Body tab, verify the body mode selector matches expectedMode,
+// then assert the editable table contains the given key/value rows.
+const verifyEditableTable = async (page, locators, expectedMode: string, expectedKeys: string[], expectedValues: string[]) => {
+  await selectRequestPaneTab(page, 'Body');
+  await expect(locators.request.bodyModeSelector()).toContainText(expectedMode);
+
+  const wrapper = page.locator('[data-testid="editable-table"]');
+  const nameInputs = wrapper.locator('[data-testid="column-name"] input');
+  await expect(nameInputs).toHaveCount(expectedKeys.length + 1); // +1 for empty add-row
+
+  for (let i = 0; i < expectedKeys.length; i++) {
+    await expect(nameInputs.nth(i)).toHaveValue(expectedKeys[i]);
+    await expect(wrapper.locator('[data-testid="column-value"]').nth(i)).toContainText(expectedValues[i]);
+  }
+};
+
+test.describe.serial('cURL command import via URL bar paste', () => {
+  const collectionName = 'curl-paste-test';
+  const requestName = 'curl-target';
+
+  test.beforeAll(async ({ page, createTmpDir }) => {
+    await createCollection(page, collectionName, await createTmpDir('curl-paste-collection'));
+    await createRequest(page, requestName, collectionName, {
+      url: 'https://initial.example.com',
+      method: 'GET'
+    });
+    await openCollection(page, collectionName);
+    await openRequest(page, collectionName, requestName, { persist: true });
+  });
+
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('should import form-urlencoded body from curl -d', async ({ page }) => {
+    const locators = buildCommonLocators(page);
+    await pasteCurl(page, locators, `curl -X POST -d "a=b" https://example.com/api`);
+
+    await expect(locators.request.urlLine()).toContainText('https://example.com/api');
+    await expect(page.getByTestId('method-selector')).toContainText('POST');
+    await verifyEditableTable(page, locators, 'Form URL Encoded', ['a'], ['b']);
+  });
+
+  test('should import multipart form body from curl -F and clear form-urlencoded', async ({ page }) => {
+    const locators = buildCommonLocators(page);
+    await pasteCurl(page, locators, `curl -X POST -F "c=d" https://example.com/api`);
+    await verifyEditableTable(page, locators, 'Multipart Form', ['c'], ['d']);
+  });
+
+  test('should re-import form-urlencoded and clear multipart form', async ({ page }) => {
+    const locators = buildCommonLocators(page);
+    await pasteCurl(page, locators, `curl -X POST -d "e=f&g=h" https://example.com/api`);
+    await verifyEditableTable(page, locators, 'Form URL Encoded', ['e', 'g'], ['f', 'h']);
+  });
+
+  test('should import JSON body when Content-Type header is present', async ({ page }) => {
+    const locators = buildCommonLocators(page);
+    await pasteCurl(page, locators, `curl -X POST -H "Content-Type: application/json" -d '{"name":"test"}' https://example.com/api`);
+
+    await selectRequestPaneTab(page, 'Body');
+    await expect(locators.request.bodyModeSelector()).toContainText('JSON');
+
+    const text = await locators.request.bodyEditor().locator('.CodeMirror').textContent();
+    expect(text).toContain('"name"');
+    expect(text).toContain('"test"');
+  });
+});


### PR DESCRIPTION
### Description

This PR allows importing multipart/url-encoded forms from curls command into Bruno (e.g. `curl -X POST "https://example.com" -H "Content-Type: application/x-www-form-urlencoded" --data "field1=value1&field2=value2"`)

Before:
[Kooha-2026-05-18-14-24-57.webm](https://github.com/user-attachments/assets/34cf72f7-3538-4c0f-9147-54f8ab4e7a93)

After:
[Kooha-2026-05-18-14-17-53.webm](https://github.com/user-attachments/assets/600bf618-a881-48be-a4aa-6f6e758bcc3c)

Note that although the fix works, it is quite simple so I'm not sure if I understood completely the problem (existing parameters seem to be cleared when pasting already ?)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** # 8029

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * cURL import now correctly parses and populates both form URL-encoded and multipart form bodies when pasting cURL commands, preventing incomplete imports and preserving form parameters.

* **Tests**
  * Added end-to-end tests validating paste/cURL import behavior: form-urlencoded, multipart form imports, re-import clearing, and JSON Content-Type handling with editor switching and content verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->