### PR TITLE
feat: Improve JSON error visibility for non-technical users

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -16,6 +16,7 @@ import stripJsonComments from 'strip-json-comments';
 import { getAllVariables } from 'utils/collections';
 import { setupLinkAware } from 'utils/codemirror/linkAware';
 import { setupLintErrorTooltip } from 'utils/codemirror/lint-errors';
+import { improveJsonErrorMessage } from 'utils/codemirror/json-lint-utils';
 import { setupCodeMirrorResizeRefresh } from 'utils/codemirror/resize';
 import CodeMirrorSearch from 'components/CodeMirrorSearch/index';
 import {
@@ -191,10 +192,11 @@ class CodeEditor extends React.Component {
         const line = location?.start?.line;
         const column = location?.start?.column;
         if (line && column) {
+          const improvedMessage = improveJsonErrorMessage(message, text, line, column);
           found.push({
             from: CodeMirror.Pos(line - 1, column),
             to: CodeMirror.Pos(line - 1, column),
-            message
+            message: improvedMessage || message
           });
         }
       }

--- a/packages/bruno-app/src/utils/codemirror/json-lint-utils.js
+++ b/packages/bruno-app/src/utils/codemirror/json-lint-utils.js
@@ -34,7 +34,10 @@ const improveJsonErrorMessage = (message, text, line, column) => {
     if (leadingZeroMatch) {
       const wrongValue = leadingZeroMatch[0];
       const fixedValue = parseInt(wrongValue, 10);
-      return `Invalid number "${wrongValue}": JSON does not allow leading zeros in numbers. Use ${fixedValue} instead.`;
+      return [
+        `Invalid number "${wrongValue}": JSON does not allow leading zeros. Use ${fixedValue} instead.`,
+        `Ungültige Zahl "${wrongValue}": JSON erlaubt keine führenden Nullen. Verwende ${fixedValue} statt ${wrongValue}.`
+      ].join('\n');
     }
   }
 
@@ -46,7 +49,10 @@ const improveJsonErrorMessage = (message, text, line, column) => {
   ) {
     const trimmed = errorLine.trim();
     if (trimmed.endsWith(',')) {
-      return 'Trailing comma: The last item in a JSON object or array must not have a comma after it. Remove the extra comma.';
+      return [
+        'Trailing comma: The last item in a JSON object or array must not have a comma after it.',
+        'Überflüssiges Komma: Das letzte Element in einem JSON-Objekt oder Array darf kein Komma am Ende haben.'
+      ].join('\n');
     }
   }
 
@@ -59,25 +65,34 @@ const improveJsonErrorMessage = (message, text, line, column) => {
     const keyMatch = errorLine.match(/^\s*(\w+)\s*:/);
     if (keyMatch && !errorLine.includes(`"${keyMatch[1]}"`)) {
       const key = keyMatch[1];
-      return `Unquoted key "${key}": JSON requires property names to be in double quotes. Use "${key}": instead.`;
+      return [
+        `Unquoted key "${key}": JSON requires property names in double quotes. Use "${key}": instead.`,
+        `Fehlende Anführungszeichen bei "${key}": JSON verlangt doppelte Anführungszeichen für Eigenschaftsnamen. Schreibe "${key}": statt ${key}:.`
+      ].join('\n');
     }
   }
 
   // 4. Single quotes (JSON only allows double quotes)
   if (message.includes('Unexpected token') || message.includes('Bad string')) {
     if (errorLine.includes("'")) {
-      return 'Wrong quote style: JSON uses double quotes ("), not single quotes (\'). Replace the single quotes with double quotes.';
+      return [
+        'Wrong quote style: JSON uses double quotes ("), not single quotes (\').',
+        'Falsche Anführungszeichen: JSON verwendet doppelte ("), nicht einfache Anführungszeichen (\').'
+      ].join('\n');
     }
   }
 
   // 5. Comments in JSON (JSON does not support comments)
   if (message.includes('Unexpected token')) {
     if (errorLine.includes('//') || errorLine.includes('/*')) {
-      return 'Comments not allowed: JSON does not support comments. Remove any // or /* */ comments from the body.';
+      return [
+        'Comments not allowed: JSON does not support // or /* */ comments.',
+        'Kommentare nicht erlaubt: JSON unterstützt keine // oder /* */ Kommentare.'
+      ].join('\n');
     }
   }
 
-  // Fallback: return the original message if we couldn't improve it
+  // Fallback: return the original message with German translation appended
   // Use jsonlint's message which is usually better than JSON.parse's
   return message;
 };

--- a/packages/bruno-app/src/utils/codemirror/json-lint-utils.js
+++ b/packages/bruno-app/src/utils/codemirror/json-lint-utils.js
@@ -83,8 +83,9 @@ const improveJsonErrorMessage = (message, text, line, column) => {
   }
 
   // 5. Comments in JSON (JSON does not support comments)
+  // Use position-aware check to avoid false positives on URLs in strings
   if (message.includes('Unexpected token')) {
-    if (errorLine.includes('//') || errorLine.includes('/*')) {
+    if (errorLine.match(/^\s*(\/\/|\/\*)/) || (!errorLine.includes('"') && (errorLine.includes('//') || errorLine.includes('/*')))) {
       return [
         'Comments not allowed: JSON does not support // or /* */ comments.',
         'Kommentare nicht erlaubt: JSON unterstützt keine // oder /* */ Kommentare.'

--- a/packages/bruno-app/src/utils/codemirror/json-lint-utils.js
+++ b/packages/bruno-app/src/utils/codemirror/json-lint-utils.js
@@ -1,0 +1,85 @@
+/**
+ * Improves JSON lint error messages to be more human-readable.
+ * Handles common mistakes that non-technical users make.
+ *
+ * The built-in jsonlint/JSON.parse error messages are often cryptic
+ * (e.g. "Unexpected number in JSON at position 11"). This function
+ * detects common JSON mistakes and provides clear, actionable messages
+ * that help users understand and fix the error.
+ */
+
+/**
+ * @param {string} message - Original error message from jsonlint
+ * @param {string} text - Full text of the JSON body
+ * @param {number} line - 1-indexed line number of the error
+ * @param {number} column - Column number of the error
+ * @returns {string} Improved error message
+ */
+const improveJsonErrorMessage = (message, text, line, column) => {
+  if (!text || !message) {
+    return message;
+  }
+
+  const lines = text.split('\n');
+  const errorLine = lines[line - 1] || '';
+
+  // 1. Leading zeros in numbers (e.g., 0000, 00123)
+  // JSON spec does not allow leading zeros in numbers
+  if (
+    message.includes('Unexpected number') ||
+    message.includes('Invalid number') ||
+    message.includes('Expected')
+  ) {
+    const leadingZeroMatch = errorLine.match(/\b0\d+\b/);
+    if (leadingZeroMatch) {
+      const wrongValue = leadingZeroMatch[0];
+      const fixedValue = parseInt(wrongValue, 10);
+      return `Invalid number "${wrongValue}": JSON does not allow leading zeros in numbers. Use ${fixedValue} instead.`;
+    }
+  }
+
+  // 2. Trailing commas (e.g., {"a": 1,})
+  if (
+    message.includes('Unexpected token') ||
+    message.includes('Expected') ||
+    message.includes('Unexpected end')
+  ) {
+    const trimmed = errorLine.trim();
+    if (trimmed.endsWith(',')) {
+      return 'Trailing comma: The last item in a JSON object or array must not have a comma after it. Remove the extra comma.';
+    }
+  }
+
+  // 3. Unquoted property keys (e.g., {name: "test"} instead of {"name": "test"})
+  if (
+    message.includes('Unexpected string') ||
+    message.includes('Expected string') ||
+    message.includes('Expected')
+  ) {
+    const keyMatch = errorLine.match(/^\s*(\w+)\s*:/);
+    if (keyMatch && !errorLine.includes(`"${keyMatch[1]}"`)) {
+      const key = keyMatch[1];
+      return `Unquoted key "${key}": JSON requires property names to be in double quotes. Use "${key}": instead.`;
+    }
+  }
+
+  // 4. Single quotes (JSON only allows double quotes)
+  if (message.includes('Unexpected token') || message.includes('Bad string')) {
+    if (errorLine.includes("'")) {
+      return 'Wrong quote style: JSON uses double quotes ("), not single quotes (\'). Replace the single quotes with double quotes.';
+    }
+  }
+
+  // 5. Comments in JSON (JSON does not support comments)
+  if (message.includes('Unexpected token')) {
+    if (errorLine.includes('//') || errorLine.includes('/*')) {
+      return 'Comments not allowed: JSON does not support comments. Remove any // or /* */ comments from the body.';
+    }
+  }
+
+  // Fallback: return the original message if we couldn't improve it
+  // Use jsonlint's message which is usually better than JSON.parse's
+  return message;
+};
+
+module.exports = { improveJsonErrorMessage };

--- a/packages/bruno-app/src/utils/codemirror/json-lint-utils.js
+++ b/packages/bruno-app/src/utils/codemirror/json-lint-utils.js
@@ -24,77 +24,56 @@ const improveJsonErrorMessage = (message, text, line, column) => {
   const errorLine = lines[line - 1] || '';
 
   // 1. Leading zeros in numbers (e.g., 0000, 00123)
-  // JSON spec does not allow leading zeros in numbers
-  if (
-    message.includes('Unexpected number') ||
-    message.includes('Invalid number') ||
-    message.includes('Expected')
-  ) {
-    const leadingZeroMatch = errorLine.match(/\b0\d+\b/);
-    if (leadingZeroMatch) {
-      const wrongValue = leadingZeroMatch[0];
-      const fixedValue = parseInt(wrongValue, 10);
-      return [
-        `Invalid number "${wrongValue}": JSON does not allow leading zeros. Use ${fixedValue} instead.`,
-        `Ungültige Zahl "${wrongValue}": JSON erlaubt keine führenden Nullen. Verwende ${fixedValue} statt ${wrongValue}.`
-      ].join('\n');
-    }
+  // Must come first and use pattern matching on the error line, since
+  // jsonlint may produce various messages (Unexpected number, Expected, etc.)
+  const leadingZeroMatch = errorLine.match(/\b0\d+\b/);
+  if (leadingZeroMatch) {
+    const wrongValue = leadingZeroMatch[0];
+    const fixedValue = parseInt(wrongValue, 10);
+    return [
+      `Invalid number "${wrongValue}": JSON does not allow leading zeros. Use ${fixedValue} instead.`,
+      `Ungültige Zahl "${wrongValue}": JSON erlaubt keine führenden Nullen. Verwende ${fixedValue} statt ${wrongValue}.`
+    ].join('\n');
   }
 
   // 2. Trailing commas (e.g., {"a": 1,})
-  if (
-    message.includes('Unexpected token') ||
-    message.includes('Expected') ||
-    message.includes('Unexpected end')
-  ) {
-    const trimmed = errorLine.trim();
-    if (trimmed.endsWith(',')) {
-      return [
-        'Trailing comma: The last item in a JSON object or array must not have a comma after it.',
-        'Überflüssiges Komma: Das letzte Element in einem JSON-Objekt oder Array darf kein Komma am Ende haben.'
-      ].join('\n');
-    }
+  if (errorLine.trim().endsWith(',')) {
+    return [
+      'Trailing comma: The last item in a JSON object or array must not have a comma after it.',
+      'Überflüssiges Komma: Das letzte Element in einem JSON-Objekt oder Array darf kein Komma am Ende haben.'
+    ].join('\n');
   }
 
   // 3. Unquoted property keys (e.g., {name: "test"} instead of {"name": "test"})
-  if (
-    message.includes('Unexpected string') ||
-    message.includes('Expected string') ||
-    message.includes('Expected')
-  ) {
-    const keyMatch = errorLine.match(/^\s*(\w+)\s*:/);
-    if (keyMatch && !errorLine.includes(`"${keyMatch[1]}"`)) {
-      const key = keyMatch[1];
-      return [
-        `Unquoted key "${key}": JSON requires property names in double quotes. Use "${key}": instead.`,
-        `Fehlende Anführungszeichen bei "${key}": JSON verlangt doppelte Anführungszeichen für Eigenschaftsnamen. Schreibe "${key}": statt ${key}:.`
-      ].join('\n');
-    }
+  const keyMatch = errorLine.match(/^\s*(\w+)\s*:/);
+  if (keyMatch && !errorLine.includes(`"${keyMatch[1]}"`) && !errorLine.includes("'")) {
+    const key = keyMatch[1];
+    return [
+      `Unquoted key "${key}": JSON requires property names in double quotes. Use "${key}": instead.`,
+      `Fehlende Anführungszeichen bei "${key}": JSON verlangt doppelte Anführungszeichen für Eigenschaftsnamen. Schreibe "${key}": statt ${key}:.`
+    ].join('\n');
   }
 
   // 4. Single quotes (JSON only allows double quotes)
-  if (message.includes('Unexpected token') || message.includes('Bad string')) {
-    if (errorLine.includes("'")) {
-      return [
-        'Wrong quote style: JSON uses double quotes ("), not single quotes (\').',
-        'Falsche Anführungszeichen: JSON verwendet doppelte ("), nicht einfache Anführungszeichen (\').'
-      ].join('\n');
-    }
+  if (errorLine.includes("'")) {
+    return [
+      'Wrong quote style: JSON uses double quotes ("), not single quotes (\').',
+      'Falsche Anführungszeichen: JSON verwendet doppelte ("), nicht einfache Anführungszeichen (\').'
+    ].join('\n');
   }
 
   // 5. Comments in JSON (JSON does not support comments)
-  // Use position-aware check to avoid false positives on URLs in strings
-  if (message.includes('Unexpected token')) {
-    if (errorLine.match(/^\s*(\/\/|\/\*)/) || (!errorLine.includes('"') && (errorLine.includes('//') || errorLine.includes('/*')))) {
-      return [
-        'Comments not allowed: JSON does not support // or /* */ comments.',
-        'Kommentare nicht erlaubt: JSON unterstützt keine // oder /* */ Kommentare.'
-      ].join('\n');
-    }
+  if (
+    errorLine.match(/^\s*(\/\/|\/\*)/) ||
+    (!errorLine.includes('"') && (errorLine.includes('//') || errorLine.includes('/*')))
+  ) {
+    return [
+      'Comments not allowed: JSON does not support // or /* */ comments.',
+      'Kommentare nicht erlaubt: JSON unterstützt keine // oder /* */ Kommentare.'
+    ].join('\n');
   }
 
-  // Fallback: return the original message with German translation appended
-  // Use jsonlint's message which is usually better than JSON.parse's
+  // Fallback: return the original message
   return message;
 };
 

--- a/packages/bruno-app/src/utils/codemirror/lint-errors.js
+++ b/packages/bruno-app/src/utils/codemirror/lint-errors.js
@@ -144,26 +144,21 @@ export function setupLintErrorTooltip(editor) {
   // Get the StyledWrapper container (parent of CodeMirror wrapper)
   const container = wrapper.closest('.graphiql-container') || wrapper.parentElement;
 
-  // Auto-show first lint error when user stops typing (debounced)
+  // Auto-show first lint error when user stops typing (debounced on change event)
   let lintAutoShowTimer;
-  const originalPerformLint = editor.performLint;
-  if (!originalPerformLint || typeof originalPerformLint !== 'function') {
-    console.warn('CodeMirror performLint not available, lint auto-show disabled');
-    return () => {
-      wrapper.removeEventListener('mouseover', handleMouseOver);
-      wrapper.removeEventListener('mouseout', handleMouseOut);
-      editor.off('scroll', handleScroll);
-      hideLintTooltip();
-    };
-  }
-  editor.performLint = function() {
-    const result = originalPerformLint.apply(this, arguments);
+  editor.on('change', () => {
     clearTimeout(lintAutoShowTimer);
     lintAutoShowTimer = setTimeout(() => {
-      autoShowFirstVisibleError(editor, container);
+      // Force lint refresh, then show first error
+      if (editor.performLint) {
+        editor.performLint();
+      }
+      // Small delay to let lint markers populate
+      setTimeout(() => {
+        autoShowFirstVisibleError(editor, container);
+      }, 200);
     }, 1200);
-    return result;
-  };
+  });
 
   const handleMouseOver = (e) => {
     const target = e.target;

--- a/packages/bruno-app/src/utils/codemirror/lint-errors.js
+++ b/packages/bruno-app/src/utils/codemirror/lint-errors.js
@@ -147,6 +147,15 @@ export function setupLintErrorTooltip(editor) {
   // Auto-show first lint error when user stops typing (debounced)
   let lintAutoShowTimer;
   const originalPerformLint = editor.performLint;
+  if (!originalPerformLint || typeof originalPerformLint !== 'function') {
+    console.warn('CodeMirror performLint not available, lint auto-show disabled');
+    return () => {
+      wrapper.removeEventListener('mouseover', handleMouseOver);
+      wrapper.removeEventListener('mouseout', handleMouseOut);
+      editor.off('scroll', handleScroll);
+      hideLintTooltip();
+    };
+  }
   editor.performLint = function() {
     const result = originalPerformLint.apply(this, arguments);
     clearTimeout(lintAutoShowTimer);

--- a/packages/bruno-app/src/utils/codemirror/lint-errors.js
+++ b/packages/bruno-app/src/utils/codemirror/lint-errors.js
@@ -76,8 +76,65 @@ function hideLintTooltip() {
 }
 
 /**
+ * Auto-show the first lint error tooltip on the currently visible area
+ * Called after every lint update to help users notice errors immediately
+ */
+const autoShowFirstVisibleError = (editor, container) => {
+  const lintState = editor.state.lint;
+  if (!lintState || !lintState.marked || lintState.marked.length === 0) {
+    return;
+  }
+
+  // Get the first lint error that is in the visible viewport
+  const scrollInfo = editor.getScrollInfo();
+  const firstVisibleLine = editor.lineAtHeight(scrollInfo.top, 'local');
+  const lastVisibleLine = editor.lineAtHeight(scrollInfo.top + scrollInfo.clientHeight, 'local');
+
+  let firstErrorInView = null;
+  for (const mark of lintState.marked) {
+    if (mark.__annotation) {
+      const line = mark.__annotation.from?.line;
+      if (line >= firstVisibleLine && line <= lastVisibleLine) {
+        firstErrorInView = mark.__annotation;
+        break;
+      }
+    }
+  }
+
+  // If no error in view, use the first error overall
+  if (!firstErrorInView) {
+    for (const mark of lintState.marked) {
+      if (mark.__annotation) {
+        firstErrorInView = mark.__annotation;
+        break;
+      }
+    }
+    if (firstErrorInView) {
+      // Scroll to the first error
+      editor.scrollIntoView({ line: firstErrorInView.from.line, ch: 0 }, 100);
+    }
+  }
+
+  if (firstErrorInView) {
+    // Find the line number element to position the tooltip
+    const lineNumberElements = editor.getWrapperElement().querySelectorAll('.CodeMirror-linenumber');
+    for (const el of lineNumberElements) {
+      const lineNum = parseInt(el.textContent, 10) - 1;
+      if (lineNum === firstErrorInView.from.line) {
+        showLintTooltip([firstErrorInView], el, container);
+        // Auto-hide after 8 seconds
+        clearTimeout(window.__brunoLintAutoHide);
+        window.__brunoLintAutoHide = setTimeout(() => hideLintTooltip(), 8000);
+        break;
+      }
+    }
+  }
+};
+
+/**
  * Setup lint error tooltip functionality for a CodeMirror editor
  * Shows lint errors when hovering over line numbers
+ * Also auto-shows the first error briefly when lint errors are detected
  *
  * @param {CodeMirror} editor - The CodeMirror editor instance
  * @returns {Function} Cleanup function to remove event listeners
@@ -86,6 +143,18 @@ export function setupLintErrorTooltip(editor) {
   const wrapper = editor.getWrapperElement();
   // Get the StyledWrapper container (parent of CodeMirror wrapper)
   const container = wrapper.closest('.graphiql-container') || wrapper.parentElement;
+
+  // Auto-show first lint error when user stops typing (debounced)
+  let lintAutoShowTimer;
+  const originalPerformLint = editor.performLint;
+  editor.performLint = function() {
+    const result = originalPerformLint.apply(this, arguments);
+    clearTimeout(lintAutoShowTimer);
+    lintAutoShowTimer = setTimeout(() => {
+      autoShowFirstVisibleError(editor, container);
+    }, 1200);
+    return result;
+  };
 
   const handleMouseOver = (e) => {
     const target = e.target;
@@ -133,6 +202,7 @@ export function setupLintErrorTooltip(editor) {
 
   // Return cleanup function
   return () => {
+    clearTimeout(lintAutoShowTimer);
     wrapper.removeEventListener('mouseover', handleMouseOver);
     wrapper.removeEventListener('mouseout', handleMouseOut);
     editor.off('scroll', handleScroll);

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,10 @@
 <br />
 <img src="assets/images/logo-transparent.png" width="80"/>
 
+> ⚠️ **Fork Notice:** This is a fork of [usebruno/bruno](https://github.com/usebruno/bruno) with AI-generated improvements.
+> All credit goes to the original authors. See the upstream repo for the official version, releases, and documentation.
+> Changes in this fork: improved JSON error messages (EN/DE), auto-show lint tooltips — created with AI assistance.
+
 ### Bruno - Opensource IDE for exploring and testing APIs.
 
 [![GitHub version](https://badge.fury.io/gh/usebruno%2Fbruno.svg)](https://badge.fury.io/gh/usebruno%2Fbruno)


### PR DESCRIPTION
## Problem

Non-technical users often struggle to notice and understand JSON syntax errors in the request body editor. Common mistakes like leading zeros in numbers (`"customerNumber": 0000`) produce cryptic error messages ("Unexpected number in JSON") that are only visible as subtle red squiggly underlines.

## Changes

### 1. Improved error messages (json-lint-utils.js)
New utility that detects common JSON mistakes and provides clear, actionable messages:

| Mistake | Before | After |
|---|---|---|
| Leading zeros `0000` | "Unexpected number in JSON at position 11" | "Invalid number "0000": JSON does not allow leading zeros in numbers. Use 0 instead." |
| Trailing commas `{"a": 1,}` | "Unexpected token" | "Trailing comma: The last item must not have a comma after it." |
| Unquoted keys `{name: "x"}` | "Unexpected string" | "Unquoted key "name": JSON requires property names in double quotes." |
| Single quotes `{'key': 1}` | "Unexpected token" | "Wrong quote style: JSON uses double quotes, not single quotes." |

### 2. Auto-show tooltip (lint-errors.js)
- When the user stops typing (1.2s debounce), the first visible lint error tooltip is shown automatically
- No need to hover over line numbers to discover errors
- Tooltip auto-hides after 8 seconds
- If no error is in view, editor scrolls to the first error

## Files changed
- `packages/bruno-app/src/utils/codemirror/json-lint-utils.js` (new)
- `packages/bruno-app/src/components/CodeEditor/index.js`
- `packages/bruno-app/src/utils/codemirror/lint-errors.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON validation now shows clearer, context-aware messages with guidance for trailing commas, unquoted keys, leading-zero numbers, single quotes, and comments; tooltips prefer the improved message and fall back to the original.
  * Editor auto-displays the first visible lint error tooltip after typing pauses; the tooltip auto-hides after 8 seconds.

* **Documentation**
  * README updated with a fork notice and summary of notable changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->