### PR TITLE
fix: allow users to clear the cache, adds environment tests and re-serialization addition

### DIFF
--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -82,10 +82,13 @@ class ErrorBoundary extends React.Component {
                 className="text-sm text-red-400 border border-red-400 hover:text-red-600 px-4 py-2 rounded transition cursor-pointer"
                 onClick={async (e) => {
                   e.preventDefault();
-                  if (this.state.clearCaches) {
-                    await this.clearCache();
+                  try {
+                    if (this.state.clearCaches) {
+                      await this.clearCache();
+                    }
+                  } finally {
+                    this.forceQuit();
                   }
-                  this.forceQuit();
                 }}
               >
                 Force Quit

--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -6,7 +6,7 @@ class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { hasError: false };
+    this.state = { hasError: false, clearCaches: false };
   }
 
   componentDidMount() {
@@ -21,12 +21,8 @@ class ErrorBoundary extends React.Component {
     this.setState({ hasError: true, error, errorInfo });
   }
 
-  async clearCachesAndReturnToApp() {
-    const { ipcRenderer } = window;
-    await ipcRenderer.invoke('main:cache-clear');
-    this.returnToApp();
-
-    this.setState({ hasError: false, error: null, errorInfo: null });
+  async clearCache() {
+    await window.ipcRenderer.invoke('main:cache-clear');
   }
 
   returnToApp() {
@@ -71,18 +67,30 @@ class ErrorBoundary extends React.Component {
               Return to App
             </button>
 
-            <div className="text-red-500 mt-3">
-              <a href="" className="hover:underline cursor-pointer" onClick={this.forceQuit}>
+            <div className="mt-5 pt-4 border-t border-gray-100 flex flex-col items-center gap-2">
+              <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none hover:text-gray-800 transition">
+                <input
+                  type="checkbox"
+                  checked={this.state.clearCaches}
+                  onChange={(e) => this.setState({ clearCaches: e.target.checked })}
+                  className="cursor-pointer"
+                />
+                Clear caches on quit
+              </label>
+              <a
+                href=""
+                className="text-sm text-red-400 border border-red-400 hover:text-red-600 px-4 py-2 rounded transition cursor-pointer"
+                onClick={async (e) => {
+                  e.preventDefault();
+                  if (this.state.clearCaches) {
+                    return await this.clearCache();
+                  }
+                  this.forceQuit();
+                }}
+              >
                 Force Quit
               </a>
             </div>
-
-            <button
-              className="text-red-500 mt-3 px-4 py-2 mt-4 rounded transition"
-              onClick={() => this.clearCachesAndReturnToApp()}
-            >
-              Clear Caches and Return to App
-            </button>
           </div>
         </div>
       );

--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -40,7 +40,7 @@ class ErrorBoundary extends React.Component {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex text-center justify-center p-20 h-full">
+        <div className="flex text-center justify-center p-10 h-full">
           <div className="bg-white rounded-lg p-10 w-full">
             <div className="m-auto" style={{ width: '256px' }}>
               <Bruno width={256} />

--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -21,6 +21,14 @@ class ErrorBoundary extends React.Component {
     this.setState({ hasError: true, error, errorInfo });
   }
 
+  async clearCachesAndReturnToApp() {
+    const { ipcRenderer } = window;
+    await ipcRenderer.invoke('main:cache-clear');
+    this.returnToApp();
+
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  }
+
   returnToApp() {
     const { ipcRenderer } = window;
     ipcRenderer.invoke('open-file');
@@ -68,6 +76,13 @@ class ErrorBoundary extends React.Component {
                 Force Quit
               </a>
             </div>
+
+            <button
+              className="text-red-500 mt-3 px-4 py-2 mt-4 rounded transition"
+              onClick={() => this.clearCachesAndReturnToApp()}
+            >
+              Clear Caches and Return to App
+            </button>
           </div>
         </div>
       );

--- a/packages/bruno-app/src/pages/ErrorBoundary/index.js
+++ b/packages/bruno-app/src/pages/ErrorBoundary/index.js
@@ -83,7 +83,7 @@ class ErrorBoundary extends React.Component {
                 onClick={async (e) => {
                   e.preventDefault();
                   if (this.state.clearCaches) {
-                    return await this.clearCache();
+                    await this.clearCache();
                   }
                   this.forceQuit();
                 }}

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/middleware.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/middleware.js
@@ -157,6 +157,9 @@ const serializeSnapshot = async (state) => {
 
     const workspacePathname = activeWorkspace?.pathname || '';
     const collectionSnapshotKey = getWorkspaceCollectionSnapshotKey(workspacePathname, collection.pathname);
+    const existingCollection = (collectionSnapshotKey && existingSnapshotLookups.collectionsByWorkspaceAndPath?.[collectionSnapshotKey])
+      || existingSnapshotLookups.collectionsByPath?.[normalizedPath]
+      || null;
     if (collectionSnapshotKey) {
       serializedCollectionKeys.add(collectionSnapshotKey);
     }
@@ -174,7 +177,17 @@ const serializeSnapshot = async (state) => {
     );
 
     const selectedEnvironment = (collection.environments || []).find((env) => env.uid === collection.activeEnvironmentUid);
-    const environmentPath = getCollectionEnvironmentPath(collection, selectedEnvironment, '');
+    const environmentPathFromRedux = getCollectionEnvironmentPath(collection, selectedEnvironment, '');
+    const selectedEnvironmentFromRedux = selectedEnvironment?.name || '';
+    const existingEnvironmentPath = existingCollection?.environment?.collection || existingCollection?.environmentPath || '';
+    const existingSelectedEnvironment = existingCollection?.selectedEnvironment || '';
+    const shouldPreserveExistingEnvironment = collection.mountStatus !== 'mounted'
+      && !environmentPathFromRedux
+      && !selectedEnvironmentFromRedux;
+    const environmentPath = shouldPreserveExistingEnvironment ? existingEnvironmentPath : environmentPathFromRedux;
+    const selectedEnvironmentName = shouldPreserveExistingEnvironment
+      ? existingSelectedEnvironment
+      : selectedEnvironmentFromRedux;
 
     snapshot.collections.push({
       pathname: collection.pathname,
@@ -184,7 +197,7 @@ const serializeSnapshot = async (state) => {
         global: globalEnvironments.activeGlobalEnvironmentUid || ''
       },
       environmentPath,
-      selectedEnvironment: selectedEnvironment?.name || '',
+      selectedEnvironment: selectedEnvironmentName,
       isOpen: !collection.collapsed,
       isMounted: collection.mountStatus === 'mounted',
       activeTab: serializeActiveTab(activeTabInCollection, collection),

--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -23,7 +23,8 @@ const postmanToBruno = (collection) => {
 };
 
 const isPostmanCollection = (data) => {
-  const info = data.info;
+  // Newer Postman exports wrap the collection in a { collection: { ... } } envelope
+  const info = data.info || data?.collection?.info;
   if (!info || typeof info !== 'object') {
     return false;
   }

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -950,7 +950,10 @@ const importPostmanV2Collection = async (collection, { useWorkers = false }) => 
 
 const parsePostmanCollection = async (collection, { useWorkers = false }) => {
   try {
-    let schema = get(collection, 'info.schema');
+    // Newer Postman exports wrap the collection in a { collection: { ... } } envelope
+    const parsedCollection = collection.collection?.info ? collection.collection : collection;
+
+    let schema = get(parsedCollection, 'info.schema');
 
     let v2Schemas = [
       'https://schema.getpostman.com/json/collection/v2.0.0/collection.json',
@@ -960,7 +963,7 @@ const parsePostmanCollection = async (collection, { useWorkers = false }) => {
     ];
 
     if (v2Schemas.includes(schema)) {
-      return await importPostmanV2Collection(collection, { useWorkers });
+      return await importPostmanV2Collection(parsedCollection, { useWorkers });
     }
 
     throw new Error('Unsupported Postman schema version. Only Postman Collection v2.0 and v2.1 are supported.');

--- a/packages/bruno-converters/src/utils/postman-status-assertions.js
+++ b/packages/bruno-converters/src/utils/postman-status-assertions.js
@@ -1,0 +1,51 @@
+const j = require('jscodeshift');
+
+/**
+ * Generates data-driven status assertion entries for pm.response.to.be.*
+ * Each assertion gets positive, to.not.be, and to.be.not variants.
+ */
+export const buildStatusAssertionEntries = () => {
+  const buildStatusTransform = (chain, litArgs) => (path) => {
+    return j.callExpression(
+      j.memberExpression(
+        j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getStatus'), [])]),
+        j.identifier(chain)
+      ),
+      litArgs.map((v) => j.literal(v))
+    );
+  };
+
+  // Only replaces the first 'to.' — safe because all chains start with 'to.' and contain no other 'to.'
+  const negateChain = (chain) => chain.replace('to.', 'to.not.');
+
+  const statusAssertions = [
+    // Range-based assertions
+    { name: 'ok', chain: 'to.be.within', args: [200, 299] },
+    { name: 'success', chain: 'to.be.within', args: [200, 299] },
+    { name: 'info', chain: 'to.be.within', args: [100, 199] },
+    { name: 'redirection', chain: 'to.be.within', args: [300, 399] },
+    { name: 'clientError', chain: 'to.be.within', args: [400, 499] },
+    { name: 'serverError', chain: 'to.be.within', args: [500, 599] },
+    { name: 'error', chain: 'to.be.at.least', args: [400] },
+    // Specific status code assertions
+    { name: 'accepted', chain: 'to.equal', args: [202] },
+    { name: 'badRequest', chain: 'to.equal', args: [400] },
+    { name: 'unauthorized', chain: 'to.equal', args: [401] },
+    { name: 'forbidden', chain: 'to.equal', args: [403] },
+    { name: 'notFound', chain: 'to.equal', args: [404] },
+    { name: 'rateLimited', chain: 'to.equal', args: [429] }
+  ];
+
+  const entries = [];
+
+  // Generate positive + negated entries for each status assertion
+  statusAssertions.forEach(({ name, chain, args }) => {
+    entries.push(
+      { pattern: `pm.response.to.be.${name}`, transform: buildStatusTransform(chain, args) },
+      { pattern: `pm.response.to.not.be.${name}`, transform: buildStatusTransform(negateChain(chain), args) },
+      { pattern: `pm.response.to.be.not.${name}`, transform: buildStatusTransform(negateChain(chain), args) }
+    );
+  });
+
+  return entries;
+};

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -2,6 +2,7 @@ import sendRequestTransformer from './send-request-transformer';
 import { getMemberExpressionString } from './ast-utils';
 const j = require('jscodeshift');
 const cloneDeep = require('lodash/cloneDeep');
+import { buildStatusAssertionEntries } from './postman-status-assertions';
 
 // Simple 1:1 translations for straightforward replacements
 // TODO: Restore the commented-out translations once the UI update fixes are live.
@@ -211,87 +212,60 @@ const complexTransformations = [
       return j.callExpression(j.identifier('res.getHeader'), path.parent.value.arguments);
     }
   },
-  // Handle pm.response.to.have.status
-  {
-    pattern: 'pm.response.to.have.status',
+  // pm.response.to[.not].have.status -> expect(res.getStatus()).to[.not].equal(arg)
+  ...['to.have.status', 'to.not.have.status', 'to.have.not.status'].map((pattern) => ({
+    pattern: `pm.response.${pattern}`,
     transform: (path, j) => {
-      const callExpr = path.parent.value;
-
-      const args = callExpr.arguments;
-
-      // Create: expect(res.getStatus()).to.equal(arg)
+      const negated = pattern.includes('.not.');
       return j.callExpression(
         j.memberExpression(
-          j.callExpression(
-            j.identifier('expect'),
-            [
-              j.callExpression(
-                j.identifier('res.getStatus'),
-                []
-              )
-            ]
-          ),
-          j.identifier('to.equal')
+          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getStatus'), [])]),
+          j.identifier(negated ? 'to.not.equal' : 'to.equal')
         ),
-        args
+        path.parent.value.arguments
       );
     }
-  },
+  })),
 
-  // handle 'pm.response.to.have.header' to expect(res.getHeaders()).to.have.property(args)
-  {
-    pattern: 'pm.response.to.have.header',
+  // pm.response.to[.not].have.header -> expect(res.getHeaders()).to[.not].have.property(args)
+  // Header names are lowercased because axios normalizes response headers to lowercase
+  ...['to.have.header', 'to.not.have.header', 'to.have.not.header'].map((pattern) => ({
+    pattern: `pm.response.${pattern}`,
     transform: (path, j) => {
-      const callExpr = path.parent.value;
-
-      const args = callExpr.arguments;
+      const args = path.parent.value.arguments;
+      const negated = pattern.includes('.not.');
 
       if (args.length > 0) {
-        // Apply toLowerCase() to the first argument
         args[0] = j.callExpression(
-          j.memberExpression(
-            args[0],
-            j.identifier('toLowerCase')
-          ),
+          j.memberExpression(args[0], j.identifier('toLowerCase')),
           []
         );
       }
 
-      // Create: expect(res.getHeaders()).to.have.property(args)
       return j.callExpression(
         j.memberExpression(
-          j.callExpression(
-            j.identifier('expect'),
-            [
-              j.callExpression(
-                j.identifier('res.getHeaders'),
-                []
-              )
-            ]
-          ),
-          j.identifier('to.have.property')
+          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getHeaders'), [])]),
+          j.identifier(negated ? 'to.not.have.property' : 'to.have.property')
         ),
         args
       );
     }
-  },
-  // handle pm.response.to.have.body to expect(res.getBody()).to.equal(arg)
-  {
-    pattern: 'pm.response.to.have.body',
+  })),
+
+  // pm.response.to[.not].have.body -> expect(res.getBody()).to[.not].equal(arg)
+  ...['to.have.body', 'to.not.have.body', 'to.have.not.body'].map((pattern) => ({
+    pattern: `pm.response.${pattern}`,
     transform: (path, j) => {
-      const callExpr = path.parent.value;
-
-      const args = callExpr.arguments;
-
+      const negated = pattern.includes('.not.');
       return j.callExpression(
         j.memberExpression(
-          j.callExpression(j.identifier('expect'), [j.identifier('res.getBody()')]),
-          j.identifier('to.equal')
+          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getBody'), [])]),
+          j.identifier(negated ? 'to.not.equal' : 'to.equal')
         ),
-        args
+        path.parent.value.arguments
       );
     }
-  },
+  })),
 
   // Handle pm.execution.setNextRequest(null)
   {
@@ -439,90 +413,6 @@ const complexTransformations = [
     }
   },
 
-  // pm.response.to.be.ok -> expect(res.getStatus()).to.be.within(200, 299)
-  {
-    pattern: 'pm.response.to.be.ok',
-    transform: (path, j) => {
-      return j.callExpression(
-        j.memberExpression(
-          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getStatus'), [])]),
-          j.identifier('to.be.within')
-        ),
-        [j.literal(200), j.literal(299)]
-      );
-    }
-  },
-
-  // pm.response.to.be.success -> expect(res.getStatus()).to.be.within(200, 299)
-  {
-    pattern: 'pm.response.to.be.success',
-    transform: (path, j) => {
-      return j.callExpression(
-        j.memberExpression(
-          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getStatus'), [])]),
-          j.identifier('to.be.within')
-        ),
-        [j.literal(200), j.literal(299)]
-      );
-    }
-  },
-
-  // pm.response.to.be.redirection -> expect(res.getStatus()).to.be.within(300, 399)
-  {
-    pattern: 'pm.response.to.be.redirection',
-    transform: (path, j) => {
-      return j.callExpression(
-        j.memberExpression(
-          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getStatus'), [])]),
-          j.identifier('to.be.within')
-        ),
-        [j.literal(300), j.literal(399)]
-      );
-    }
-  },
-
-  // pm.response.to.be.clientError -> expect(res.getStatus()).to.be.within(400, 499)
-  {
-    pattern: 'pm.response.to.be.clientError',
-    transform: (path, j) => {
-      return j.callExpression(
-        j.memberExpression(
-          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getStatus'), [])]),
-          j.identifier('to.be.within')
-        ),
-        [j.literal(400), j.literal(499)]
-      );
-    }
-  },
-
-  // pm.response.to.be.serverError -> expect(res.getStatus()).to.be.within(500, 599)
-  {
-    pattern: 'pm.response.to.be.serverError',
-    transform: (path, j) => {
-      return j.callExpression(
-        j.memberExpression(
-          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getStatus'), [])]),
-          j.identifier('to.be.within')
-        ),
-        [j.literal(500), j.literal(599)]
-      );
-    }
-  },
-
-  // pm.response.to.be.error -> expect(res.getStatus()).to.be.at.least(400)
-  {
-    pattern: 'pm.response.to.be.error',
-    transform: (path, j) => {
-      return j.callExpression(
-        j.memberExpression(
-          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getStatus'), [])]),
-          j.identifier('to.be.at.least')
-        ),
-        [j.literal(400)]
-      );
-    }
-  },
-
   // pm.response.to.have.jsonBody(...) -> expect(res.getBody()).to.have.jsonBody(...)
   {
     pattern: 'pm.response.to.have.jsonBody',
@@ -655,7 +545,49 @@ const complexTransformations = [
       const args = callExpr.arguments;
       return j.callExpression(j.identifier('res.getHeader'), args);
     }
-  }
+  },
+
+  // pm.response.to.be.withBody -> expect(res.getBody()).to.not.equal(undefined)
+  // Uses undefined check instead of truthiness (.to.be.ok) so falsy bodies (false, 0, null) pass correctly
+  {
+    pattern: 'pm.response.to.be.withBody',
+    transform: (path, j) => {
+      return j.callExpression(
+        j.memberExpression(
+          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getBody'), [])]),
+          j.identifier('to.not.equal')
+        ),
+        [j.identifier('undefined')]
+      );
+    }
+  },
+  {
+    pattern: 'pm.response.to.not.be.withBody',
+    transform: (path, j) => {
+      return j.callExpression(
+        j.memberExpression(
+          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getBody'), [])]),
+          j.identifier('to.equal')
+        ),
+        [j.identifier('undefined')]
+      );
+    }
+  },
+  {
+    pattern: 'pm.response.to.be.not.withBody',
+    transform: (path, j) => {
+      return j.callExpression(
+        j.memberExpression(
+          j.callExpression(j.identifier('expect'), [j.callExpression(j.identifier('res.getBody'), [])]),
+          j.identifier('to.equal')
+        ),
+        [j.identifier('undefined')]
+      );
+    }
+  },
+
+  // --- Data-driven status assertions (pm.response.to.be.*) ---
+  ...buildStatusAssertionEntries()
 ];
 
 // Create a map for complex transformations to enable O(1) lookups

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
@@ -1120,6 +1120,15 @@ describe('postman-collection', () => {
     expect(headers[1].value).toBe('example.com');
   });
 
+  it('should unwrap and import a Postman collection with { collection: { ... } } envelope', async () => {
+    const wrappedCollection = {
+      collection: { ...postmanCollection }
+    };
+
+    const brunoCollection = await postmanToBruno(wrappedCollection);
+    expect(brunoCollection).toMatchObject(expectedOutput);
+  });
+
   it('should handle string headers with no value', async () => {
     const collectionWithNoValueHeader = {
       info: {

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/response.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/response.test.js
@@ -906,4 +906,299 @@ describe('Response Translation', () => {
     const translatedCode = translateCode(code);
     expect(translatedCode).toBe('const json = res.headerList.toJSON();');
   });
+
+  // --- New status assertions ---
+
+  it('should translate pm.response.to.be.info', () => {
+    const code = 'pm.response.to.be.info;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.be.within(100, 199)');
+  });
+
+  it('should translate pm.response.to.be.accepted', () => {
+    const code = 'pm.response.to.be.accepted;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(202)');
+  });
+
+  it('should translate pm.response.to.be.badRequest', () => {
+    const code = 'pm.response.to.be.badRequest;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(400)');
+  });
+
+  it('should translate pm.response.to.be.unauthorized', () => {
+    const code = 'pm.response.to.be.unauthorized;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(401)');
+  });
+
+  it('should translate pm.response.to.be.forbidden', () => {
+    const code = 'pm.response.to.be.forbidden;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(403)');
+  });
+
+  it('should translate pm.response.to.be.notFound', () => {
+    const code = 'pm.response.to.be.notFound;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(404)');
+  });
+
+  it('should translate pm.response.to.be.rateLimited', () => {
+    const code = 'pm.response.to.be.rateLimited;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(429)');
+  });
+
+  it('should translate pm.response.to.be.withBody', () => {
+    const code = 'pm.response.to.be.withBody;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getBody()).to.not.equal(undefined);');
+  });
+
+  it('should translate withBody using undefined check (not truthiness) so falsy bodies work', () => {
+    const code = 'pm.response.to.be.withBody;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('to.not.equal(undefined)');
+  });
+
+  it('should handle new status assertions inside test blocks', () => {
+    const code = `
+        pm.test("Status checks", function() {
+            pm.response.to.be.info;
+            pm.response.to.be.accepted;
+            pm.response.to.be.badRequest;
+            pm.response.to.be.unauthorized;
+            pm.response.to.be.forbidden;
+            pm.response.to.be.notFound;
+            pm.response.to.be.rateLimited;
+        });
+        `;
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('test("Status checks", function() {');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.be.within(100, 199)');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(202)');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(400)');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(401)');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(403)');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(404)');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.equal(429)');
+  });
+
+  // --- .not negation for to.be.* assertions ---
+
+  it('should translate pm.response.to.not.be.ok', () => {
+    const code = 'pm.response.to.not.be.ok;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(200, 299)');
+  });
+
+  it('should translate pm.response.to.be.not.ok (alternate position)', () => {
+    const code = 'pm.response.to.be.not.ok;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(200, 299)');
+  });
+
+  it('should translate pm.response.to.be.not.forbidden (alternate position)', () => {
+    const code = 'pm.response.to.be.not.forbidden;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.equal(403)');
+  });
+
+  it('should translate pm.response.to.be.not.serverError (alternate position)', () => {
+    const code = 'pm.response.to.be.not.serverError;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(500, 599)');
+  });
+
+  it('should translate pm.response.to.be.not.withBody (alternate position)', () => {
+    const code = 'pm.response.to.be.not.withBody;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getBody()).to.equal(undefined);');
+  });
+
+  it('should translate pm.response.to.not.be.success', () => {
+    const code = 'pm.response.to.not.be.success;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(200, 299)');
+  });
+
+  it('should translate pm.response.to.not.be.serverError', () => {
+    const code = 'pm.response.to.not.be.serverError;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(500, 599)');
+  });
+
+  it('should translate pm.response.to.not.be.clientError', () => {
+    const code = 'pm.response.to.not.be.clientError;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(400, 499)');
+  });
+
+  it('should translate pm.response.to.not.be.redirection', () => {
+    const code = 'pm.response.to.not.be.redirection;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(300, 399)');
+  });
+
+  it('should translate pm.response.to.not.be.error', () => {
+    const code = 'pm.response.to.not.be.error;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.at.least(400)');
+  });
+
+  it('should translate pm.response.to.not.be.info', () => {
+    const code = 'pm.response.to.not.be.info;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(100, 199)');
+  });
+
+  it('should translate pm.response.to.not.be.accepted', () => {
+    const code = 'pm.response.to.not.be.accepted;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.equal(202)');
+  });
+
+  it('should translate pm.response.to.not.be.badRequest', () => {
+    const code = 'pm.response.to.not.be.badRequest;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.equal(400)');
+  });
+
+  it('should translate pm.response.to.not.be.unauthorized', () => {
+    const code = 'pm.response.to.not.be.unauthorized;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.equal(401)');
+  });
+
+  it('should translate pm.response.to.not.be.forbidden', () => {
+    const code = 'pm.response.to.not.be.forbidden;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.equal(403)');
+  });
+
+  it('should translate pm.response.to.not.be.notFound', () => {
+    const code = 'pm.response.to.not.be.notFound;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.equal(404)');
+  });
+
+  it('should translate pm.response.to.not.be.rateLimited', () => {
+    const code = 'pm.response.to.not.be.rateLimited;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.equal(429)');
+  });
+
+  it('should translate pm.response.to.not.be.withBody', () => {
+    const code = 'pm.response.to.not.be.withBody;';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getBody()).to.equal(undefined);');
+  });
+
+  it('should handle negated assertions inside test blocks', () => {
+    const code = `
+        pm.test("Response is not a server error", function() {
+            pm.response.to.not.be.serverError;
+            pm.response.to.not.be.clientError;
+        });
+        `;
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('test("Response is not a server error", function() {');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(500, 599)');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(400, 499)');
+  });
+
+  it('should handle mixed positive and negated assertions', () => {
+    const code = `
+        pm.test("Mixed assertions", function() {
+            pm.response.to.be.success;
+            pm.response.to.not.be.serverError;
+        });
+        `;
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.be.within(200, 299)');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(500, 599)');
+  });
+
+  it('should handle negated assertions with aliases', () => {
+    const code = `
+        const resp = pm.response;
+        resp.to.not.be.serverError;
+        `;
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.be.within(500, 599)');
+  });
+
+  // --- .not negation for to.have.* assertions ---
+
+  it('should translate pm.response.to.not.have.status', () => {
+    const code = 'pm.response.to.not.have.status(404);';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getStatus()).to.not.equal(404);');
+  });
+
+  it('should translate pm.response.to.not.have.header', () => {
+    const code = 'pm.response.to.not.have.header("X-Error");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getHeaders()).to.not.have.property("X-Error".toLowerCase());');
+  });
+
+  it('should translate pm.response.to.not.have.header with value', () => {
+    const code = 'pm.response.to.not.have.header("Content-Type", "text/plain");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getHeaders()).to.not.have.property("Content-Type".toLowerCase(), "text/plain");');
+  });
+
+  it('should translate pm.response.to.not.have.body', () => {
+    const code = 'pm.response.to.not.have.body("error");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getBody()).to.not.equal("error");');
+  });
+
+  // --- to.have.not.* (alternate .not position) ---
+
+  it('should translate pm.response.to.have.not.status (alternate position)', () => {
+    const code = 'pm.response.to.have.not.status(404);';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getStatus()).to.not.equal(404);');
+  });
+
+  it('should translate pm.response.to.have.not.header (alternate position)', () => {
+    const code = 'pm.response.to.have.not.header("X-Error");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getHeaders()).to.not.have.property("X-Error".toLowerCase());');
+  });
+
+  it('should translate pm.response.to.have.not.body (alternate position)', () => {
+    const code = 'pm.response.to.have.not.body("error");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('expect(res.getBody()).to.not.equal("error");');
+  });
+
+  it('should handle negated to.have.* assertions inside test blocks', () => {
+    const code = `
+        pm.test("Negative assertions", function() {
+            pm.response.to.not.have.status(500);
+            pm.response.to.not.have.header("X-Error");
+            pm.response.to.not.have.body("error");
+        });
+        `;
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toContain('test("Negative assertions", function() {');
+    expect(translatedCode).toContain('expect(res.getStatus()).to.not.equal(500)');
+    expect(translatedCode).toContain('expect(res.getHeaders()).to.not.have.property("X-Error".toLowerCase())');
+    expect(translatedCode).toContain('expect(res.getBody()).to.not.equal("error")');
+  });
+
+  it('should handle negated to.have.status with alias', () => {
+    const code = `
+        const resp = pm.response;
+        resp.to.not.have.status(404);
+        `;
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe(`
+        expect(res.getStatus()).to.not.equal(404);
+        `);
+  });
 });

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -475,6 +475,11 @@ app.on('ready', async () => {
   registerSystemMonitorIpc(mainWindow, systemMonitor);
   registerGitIpc(mainWindow);
   registerOpenAPISyncIpc(mainWindow);
+
+  // Internal delegator
+  ipcMain.handle('main:cache-clear', async () => {
+    ipcMain.emit('internal:snapshot:reset');
+  });
 });
 
 // Quit the app once all windows are closed.

--- a/packages/bruno-electron/src/ipc/snapshot.js
+++ b/packages/bruno-electron/src/ipc/snapshot.js
@@ -11,7 +11,11 @@ const registerSnapshotIpc = () => {
   });
 
   ipcMain.on('internal:snapshot:reset', () => {
-    snapshotManager.resetSnapshot();
+    try {
+      snapshotManager.resetSnapshot();
+    } catch (err) {
+      // digest error if reset fails
+    }
   });
 
   ipcMain.handle('renderer:snapshot:save', async (event, data) => {

--- a/packages/bruno-electron/src/ipc/snapshot.js
+++ b/packages/bruno-electron/src/ipc/snapshot.js
@@ -10,6 +10,10 @@ const registerSnapshotIpc = () => {
     return snapshotManager.getTabs(collectionPathname, workspacePathname);
   });
 
+  ipcMain.on('internal:snapshot:reset', () => {
+    snapshotManager.resetSnapshot();
+  });
+
   ipcMain.handle('renderer:snapshot:save', async (event, data) => {
     return snapshotManager.saveSnapshot(data);
   });

--- a/packages/bruno-electron/src/services/snapshot/index.js
+++ b/packages/bruno-electron/src/services/snapshot/index.js
@@ -187,6 +187,18 @@ class SnapshotManager {
     }
   }
 
+  resetSnapshot() {
+    this.store.delete('activeWorkspacePath');
+    this.store.set('workspaces', this.store.store.workspaces.map((d) => {
+      d.lastActiveCollectionPathname = undefined;
+      return d;
+    }));
+    this.store.set('collections', this.store.store.collections.map((d) => {
+      d.tabs = [];
+      return d;
+    }));
+  }
+
   setCollection(pathname, data) {
     const normalizedPath = normalizeLookupKey(pathname);
     if (!normalizedPath) {

--- a/packages/bruno-electron/src/services/snapshot/index.js
+++ b/packages/bruno-electron/src/services/snapshot/index.js
@@ -189,12 +189,17 @@ class SnapshotManager {
 
   resetSnapshot() {
     this.store.delete('activeWorkspacePath');
-    this.store.set('workspaces', this.store.store.workspaces.map((d) => {
+    this.store.set('workspaces', (this.store.store?.workspaces ?? []).map((d) => {
       d.lastActiveCollectionPathname = undefined;
       return d;
     }));
-    this.store.set('collections', this.store.store.collections.map((d) => {
-      d.tabs = [];
+    this.store.set('collections', (this.store.store?.collections ?? []).map((d) => {
+      if ('tabs' in d) {
+        d.tabs = [];
+      }
+      if ('activeTab' in d) {
+        d.activeTab = undefined;
+      }
       return d;
     }));
   }

--- a/tests/import/postman/fixtures/postman-v21-wrapped.json
+++ b/tests/import/postman/fixtures/postman-v21-wrapped.json
@@ -1,0 +1,66 @@
+{
+  "collection": {
+    "info": {
+      "name": "Postman v2.1 Wrapped Collection",
+      "description": "Test collection using newer Postman export format with collection envelope",
+      "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+      "_postman_id": "beaf4d12-a72a-47cb-902d-2942a68a59c4"
+    },
+    "item": [
+      {
+        "name": "Get Users",
+        "request": {
+          "method": "GET",
+          "header": [
+            {
+              "key": "Authorization",
+              "value": "Bearer {{token}}",
+              "type": "text"
+            }
+          ],
+          "url": {
+            "raw": "{{baseUrl}}/users",
+            "host": ["{{baseUrl}}"],
+            "path": ["users"],
+            "query": [
+              {
+                "key": "page",
+                "value": "1"
+              }
+            ]
+          }
+        },
+        "response": []
+      },
+      {
+        "name": "Create User",
+        "request": {
+          "method": "POST",
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json",
+              "type": "text"
+            }
+          ],
+          "body": {
+            "mode": "raw",
+            "raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"john@example.com\"\n}"
+          },
+          "url": {
+            "raw": "{{baseUrl}}/users",
+            "host": ["{{baseUrl}}"],
+            "path": ["users"]
+          }
+        },
+        "response": []
+      }
+    ],
+    "variable": [
+      {
+        "key": "baseUrl",
+        "value": "https://api.example.com"
+      }
+    ]
+  }
+}

--- a/tests/import/postman/import-postman-v21-wrapped.spec.ts
+++ b/tests/import/postman/import-postman-v21-wrapped.spec.ts
@@ -1,0 +1,17 @@
+import { test } from '../../../playwright';
+import * as path from 'path';
+import { closeAllCollections, importCollection } from '../../utils/page';
+
+test.describe('Import Postman Collection v2.1 (wrapped format)', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('Import Postman Collection v2.1 with collection envelope successfully', async ({ page, createTmpDir }) => {
+    const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-v21-wrapped.json');
+
+    await importCollection(page, postmanFile, await createTmpDir('postman-v21-wrapped-test'), {
+      expectedCollectionName: 'Postman v2.1 Wrapped Collection'
+    });
+  });
+});

--- a/tests/snapshots/environment.spec.ts
+++ b/tests/snapshots/environment.spec.ts
@@ -1,0 +1,172 @@
+import path from 'path';
+import fs from 'fs';
+import { test, expect, closeElectronApp } from '../../playwright';
+import {
+  createCollection,
+  createEnvironment,
+  openCollection,
+  selectEnvironment,
+  waitForReadyPage
+} from '../utils/page';
+
+const readSnapshot = (userDataPath: string) => {
+  const snapshotPath = path.join(userDataPath, 'ui-state-snapshot.json');
+  if (!fs.existsSync(snapshotPath)) {
+    return null;
+  }
+
+  return JSON.parse(fs.readFileSync(snapshotPath, 'utf-8'));
+};
+
+test.describe('Snapshot: Collection Environment Persistence', () => {
+  test('keeps selected environments for non-active collections across snapshot saves', async ({ launchElectronApp, createTmpDir }) => {
+    const userDataPath = await createTmpDir('snap-env-persistence');
+    const firstCollectionPath = await createTmpDir('snap-col-a');
+    const secondCollectionPath = await createTmpDir('snap-col-b');
+    const firstCollectionRoot = path.join(firstCollectionPath, 'Collection A');
+    const secondCollectionRoot = path.join(secondCollectionPath, 'Collection B');
+
+    const app = await launchElectronApp({ userDataPath });
+    const page = await waitForReadyPage(app);
+
+    await test.step('Create two collections with distinct selected environments', async () => {
+      await createCollection(page, 'Collection A', firstCollectionPath);
+      await openCollection(page, 'Collection A');
+      await createEnvironment(page, 'local-a', 'collection');
+      await selectEnvironment(page, 'local-a', 'collection');
+
+      await createCollection(page, 'Collection B', secondCollectionPath);
+      await openCollection(page, 'Collection B');
+      await createEnvironment(page, 'local-b', 'collection');
+      await selectEnvironment(page, 'local-b', 'collection');
+    });
+
+    await test.step('Switch back to first collection and verify environment did not drift', async () => {
+      await openCollection(page, 'Collection A');
+      await expect(page.locator('.current-environment')).toContainText('local-a');
+      await openCollection(page, 'Collection B');
+      await expect(page.locator('.current-environment')).toContainText('local-b');
+    });
+
+    await test.step('Close app and assert snapshot stores both environments', async () => {
+      await page.waitForTimeout(2000);
+      await closeElectronApp(app);
+
+      const snapshot = readSnapshot(userDataPath);
+      expect(snapshot).not.toBeNull();
+
+      const collections = Array.isArray(snapshot?.collections) ? snapshot.collections : [];
+      const firstEntry = collections.find((collection: any) => collection?.pathname === firstCollectionRoot);
+      const secondEntry = collections.find((collection: any) => collection?.pathname === secondCollectionRoot);
+
+      expect(firstEntry?.selectedEnvironment).toBe('local-a');
+      expect(secondEntry?.selectedEnvironment).toBe('local-b');
+      expect(firstEntry?.environmentPath).toContain(path.join('environments', 'local-a'));
+      expect(secondEntry?.environmentPath).toContain(path.join('environments', 'local-b'));
+    });
+
+    await test.step('Restart app and verify both selections are still restored', async () => {
+      const app2 = await launchElectronApp({ userDataPath });
+      const page2 = await waitForReadyPage(app2);
+
+      await openCollection(page2, 'Collection A');
+      await expect(page2.locator('.current-environment')).toContainText('local-a');
+
+      await openCollection(page2, 'Collection B');
+      await expect(page2.locator('.current-environment')).toContainText('local-b');
+
+      await closeElectronApp(app2);
+    });
+  });
+
+  test('keeps selected environments for three collections across delayed switches and snapshot updates', async ({ launchElectronApp, createTmpDir }) => {
+    const userDataPath = await createTmpDir('snap-env-persistence-three');
+    const firstCollectionPath = await createTmpDir('snap-col-a-three');
+    const secondCollectionPath = await createTmpDir('snap-col-b-three');
+    const thirdCollectionPath = await createTmpDir('snap-col-c-three');
+    const firstCollectionRoot = path.join(firstCollectionPath, 'Collection A');
+    const secondCollectionRoot = path.join(secondCollectionPath, 'Collection B');
+    const thirdCollectionRoot = path.join(thirdCollectionPath, 'Collection C');
+
+    const app = await launchElectronApp({ userDataPath });
+    const page = await waitForReadyPage(app);
+
+    await test.step('Create three collections with distinct selected environments', async () => {
+      await createCollection(page, 'Collection A', firstCollectionPath);
+      await openCollection(page, 'Collection A');
+      await createEnvironment(page, 'local-a', 'collection');
+      await selectEnvironment(page, 'local-a', 'collection');
+
+      await createCollection(page, 'Collection B', secondCollectionPath);
+      await openCollection(page, 'Collection B');
+      await createEnvironment(page, 'local-b', 'collection');
+      await selectEnvironment(page, 'local-b', 'collection');
+
+      await createCollection(page, 'Collection C', thirdCollectionPath);
+      await openCollection(page, 'Collection C');
+      await createEnvironment(page, 'local-c', 'collection');
+      await selectEnvironment(page, 'local-c', 'collection');
+    });
+
+    await test.step('Switch to each collection with delays and verify selected environment stays correct', async () => {
+      await openCollection(page, 'Collection A');
+      await expect(page.locator('.current-environment')).toContainText('local-a');
+
+      await openCollection(page, 'Collection B');
+      await expect(page.locator('.current-environment')).toContainText('local-b');
+
+      await openCollection(page, 'Collection C');
+      await expect(page.locator('.current-environment')).toContainText('local-c');
+    });
+
+    await test.step('Close app and assert snapshot stores all three environments', async () => {
+      await closeElectronApp(app);
+
+      const snapshot = readSnapshot(userDataPath);
+      expect(snapshot).not.toBeNull();
+
+      const collections = Array.isArray(snapshot?.collections) ? snapshot.collections : [];
+      const firstEntry = collections.find((collection: any) => collection?.pathname === firstCollectionRoot);
+      const secondEntry = collections.find((collection: any) => collection?.pathname === secondCollectionRoot);
+      const thirdEntry = collections.find((collection: any) => collection?.pathname === thirdCollectionRoot);
+
+      expect(firstEntry?.selectedEnvironment).toBe('local-a');
+      expect(secondEntry?.selectedEnvironment).toBe('local-b');
+      expect(thirdEntry?.selectedEnvironment).toBe('local-c');
+      expect(firstEntry?.environmentPath).toContain(path.join('environments', 'local-a'));
+      expect(secondEntry?.environmentPath).toContain(path.join('environments', 'local-b'));
+      expect(thirdEntry?.environmentPath).toContain(path.join('environments', 'local-c'));
+    });
+
+    await test.step('Restart app, switch through collections with delays, and verify all selections are restored', async () => {
+      const app2 = await launchElectronApp({ userDataPath });
+      const page2 = await waitForReadyPage(app2);
+
+      await openCollection(page2, 'Collection A');
+      await expect(page2.locator('.current-environment')).toContainText('local-a');
+      await page2.waitForTimeout(2000);
+
+      await openCollection(page2, 'Collection B');
+      await expect(page2.locator('.current-environment')).toContainText('local-b');
+      await page2.waitForTimeout(2000);
+
+      await openCollection(page2, 'Collection C');
+      await expect(page2.locator('.current-environment')).toContainText('local-c');
+      await page2.waitForTimeout(2000);
+
+      await closeElectronApp(app2);
+
+      const updatedSnapshot = readSnapshot(userDataPath);
+      expect(updatedSnapshot).not.toBeNull();
+
+      const updatedCollections = Array.isArray(updatedSnapshot?.collections) ? updatedSnapshot.collections : [];
+      const firstUpdatedEntry = updatedCollections.find((collection: any) => collection?.pathname === firstCollectionRoot);
+      const secondUpdatedEntry = updatedCollections.find((collection: any) => collection?.pathname === secondCollectionRoot);
+      const thirdUpdatedEntry = updatedCollections.find((collection: any) => collection?.pathname === thirdCollectionRoot);
+
+      expect(firstUpdatedEntry?.selectedEnvironment).toBe('local-a');
+      expect(secondUpdatedEntry?.selectedEnvironment).toBe('local-b');
+      expect(thirdUpdatedEntry?.selectedEnvironment).toBe('local-c');
+    });
+  });
+});

--- a/tests/snapshots/environment/environment.spec.ts
+++ b/tests/snapshots/environment/environment.spec.ts
@@ -29,7 +29,7 @@ const migrationCollectionPath = path.join(
 );
 
 test.describe('Snapshot: Collection Environment Persistence', () => {
-  test.only('migrates legacy snapshot format and preserves selected collection environment', async ({ launchElectronApp, createTmpDir }) => {
+  test('migrates legacy snapshot format and preserves selected collection environment', async ({ launchElectronApp, createTmpDir }) => {
     const userDataPath = await createTmpDir('snap-legacy-env-migration');
 
     const app = await launchElectronApp({

--- a/tests/snapshots/environment/environment.spec.ts
+++ b/tests/snapshots/environment/environment.spec.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 import fs from 'fs';
-import { test, expect, closeElectronApp } from '../../playwright';
+import { test, expect, closeElectronApp } from '../../../playwright';
 import {
   createCollection,
   createEnvironment,
   openCollection,
   selectEnvironment,
   waitForReadyPage
-} from '../utils/page';
+} from '../../utils/page';
 
 const readSnapshot = (userDataPath: string) => {
   const snapshotPath = path.join(userDataPath, 'ui-state-snapshot.json');
@@ -18,7 +18,55 @@ const readSnapshot = (userDataPath: string) => {
   return JSON.parse(fs.readFileSync(snapshotPath, 'utf-8'));
 };
 
+const legacyPromptVariablesInitUserDataPath = path.join(
+  __dirname,
+  'init-user-data'
+);
+
+const migrationCollectionPath = path.join(
+  __dirname,
+  'fixtures/collection'
+);
+
 test.describe('Snapshot: Collection Environment Persistence', () => {
+  test.only('migrates legacy snapshot format and preserves selected collection environment', async ({ launchElectronApp, createTmpDir }) => {
+    const userDataPath = await createTmpDir('snap-legacy-env-migration');
+
+    const app = await launchElectronApp({
+      initUserDataPath: legacyPromptVariablesInitUserDataPath,
+      userDataPath
+    });
+    const page = await waitForReadyPage(app);
+
+    await test.step('Verify legacy selected environment is hydrated in UI', async () => {
+      await openCollection(page, 'migration-collection');
+      await expect(page.locator('.current-environment')).toContainText('local');
+    });
+
+    await test.step('Close app and verify snapshot migrated to new shape', async () => {
+      await page.waitForTimeout(2000);
+      await closeElectronApp(app);
+
+      const snapshot = readSnapshot(userDataPath);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot).toHaveProperty('version');
+      expect(snapshot).toHaveProperty('activeWorkspacePath');
+      expect(snapshot).toHaveProperty('extras');
+      expect(snapshot).toHaveProperty('workspaces');
+      expect(snapshot).toHaveProperty('collections');
+      expect(Array.isArray(snapshot?.workspaces)).toBe(true);
+      expect(Array.isArray(snapshot?.collections)).toBe(true);
+
+      const migratedCollectionEntry = snapshot?.collections?.find(
+        (collection: any) => collection?.pathname === migrationCollectionPath
+      );
+      expect(migratedCollectionEntry).toBeTruthy();
+      console.log(JSON.stringify(migratedCollectionEntry));
+
+      expect(migratedCollectionEntry?.selectedEnvironment).toBe('local');
+    });
+  });
+
   test('keeps selected environments for non-active collections across snapshot saves', async ({ launchElectronApp, createTmpDir }) => {
     const userDataPath = await createTmpDir('snap-env-persistence');
     const firstCollectionPath = await createTmpDir('snap-col-a');

--- a/tests/snapshots/environment/fixtures/collection/bruno.json
+++ b/tests/snapshots/environment/fixtures/collection/bruno.json
@@ -1,0 +1,10 @@
+{
+  "version": "1",
+  "name": "migration-collection",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ],
+  "filesCount": 1
+}

--- a/tests/snapshots/environment/fixtures/collection/environments/local.bru
+++ b/tests/snapshots/environment/fixtures/collection/environments/local.bru
@@ -1,0 +1,4 @@
+vars {
+  collectionEnvVar: hello
+  ~collectionEnvVarDisabled: there
+}

--- a/tests/snapshots/environment/fixtures/collection/request.bru
+++ b/tests/snapshots/environment/fixtures/collection/request.bru
@@ -1,0 +1,9 @@
+meta {
+  name: http-request
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:8081/ping
+}

--- a/tests/snapshots/environment/init-user-data/preferences.json
+++ b/tests/snapshots/environment/init-user-data/preferences.json
@@ -1,0 +1,12 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": [
+    "{{projectRoot}}/tests/snapshots/environment/fixtures/collection"
+  ],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/snapshots/environment/init-user-data/ui-state-snapshot.json
+++ b/tests/snapshots/environment/init-user-data/ui-state-snapshot.json
@@ -1,0 +1,8 @@
+{
+  "collections": [
+    {
+      "pathname": "{{projectRoot}}/tests/snapshots/environment/fixtures/collection",
+      "selectedEnvironment": "local"
+    }
+  ]
+}


### PR DESCRIPTION
### Description

- Implements internal events to delegate clear cache handling to snapshots
- re-serialization addition for environment path when restoring non-mounted collections

[JIRA](https://usebruno.atlassian.net/browse/BRU-3444)

[JIRA 2](https://usebruno.atlassian.net/browse/BRU-3448)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Clear caches on quit" checkbox to the error recovery dialog so caches can be cleared when quitting.
  * Environment selections now persist per collection across app restarts.

* **Bug Fixes**
  * Improved environment state preservation when switching between collections.

* **Tests**
  * Added end-to-end snapshot tests validating collection environment persistence and migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->