### PR TITLE
feat: add bru.hasGlobalEnvVar method and update translations

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/autocomplete.js
+++ b/packages/bruno-app/src/utils/codemirror/autocomplete.js
@@ -136,6 +136,7 @@ const STATIC_API_HINTS = {
     'bru.getCollectionName()',
     'bru.isSafeMode()',
     'bru.getOauth2CredentialVar(key)',
+    'bru.hasGlobalEnvVar(key)',
     'bru.getGlobalEnvVar(key)',
     'bru.setGlobalEnvVar(key, value)',
     // 'bru.deleteGlobalEnvVar(key)',

--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -28,6 +28,7 @@ const replacements = {
   'pm\\.response\\.responseTime': 'res.getResponseTime()',
   'pm\\.globals\\.set\\(': 'bru.setGlobalEnvVar(',
   'pm\\.globals\\.get\\(': 'bru.getGlobalEnvVar(',
+  'pm\\.globals\\.has\\(': 'bru.hasGlobalEnvVar(',
   // 'pm\\.globals\\.unset\\(': 'bru.deleteGlobalEnvVar(',
   'pm\\.globals\\.toObject\\(': 'bru.getAllGlobalEnvVars(',
   // 'pm\\.globals\\.clear\\(': 'bru.deleteAllGlobalEnvVars(',

--- a/packages/bruno-converters/src/utils/bruno-to-postman-translator.js
+++ b/packages/bruno-converters/src/utils/bruno-to-postman-translator.js
@@ -20,6 +20,7 @@ const simpleTranslations = {
   // Global variables
   'bru.getGlobalEnvVar': 'pm.globals.get',
   'bru.setGlobalEnvVar': 'pm.globals.set',
+  'bru.hasGlobalEnvVar': 'pm.globals.has',
   // 'bru.deleteGlobalEnvVar': 'pm.globals.unset',
   'bru.getAllGlobalEnvVars': 'pm.globals.toObject',
   // 'bru.deleteAllGlobalEnvVars': 'pm.globals.clear',

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -12,6 +12,7 @@ const simpleTranslations = {
   // Global Variables
   'pm.globals.get': 'bru.getGlobalEnvVar',
   'pm.globals.set': 'bru.setGlobalEnvVar',
+  'pm.globals.has': 'bru.hasGlobalEnvVar',
   'pm.globals.replaceIn': 'bru.interpolate',
   // 'pm.globals.unset': 'bru.deleteGlobalEnvVar',
   'pm.globals.toObject': 'bru.getAllGlobalEnvVars',
@@ -289,30 +290,6 @@ const complexTransformations = [
       return j.callExpression(
         j.identifier('bru.runner.setNextRequest'),
         args
-      );
-    }
-  },
-
-  // pm.globals.has requires special handling
-  {
-    pattern: 'pm.globals.has',
-    transform: (path, j) => {
-      const callExpr = path.parent.value;
-      const args = callExpr.arguments;
-
-      // Create: bru.getGlobalEnvVar(arg) !== undefined && bru.getGlobalEnvVar(arg) !== null
-      return j.logicalExpression(
-        '&&',
-        j.binaryExpression(
-          '!==',
-          j.callExpression(j.identifier('bru.getGlobalEnvVar'), args),
-          j.identifier('undefined')
-        ),
-        j.binaryExpression(
-          '!==',
-          j.callExpression(j.identifier('bru.getGlobalEnvVar'), args),
-          j.identifier('null')
-        )
       );
     }
   },

--- a/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/variables.test.js
+++ b/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/variables.test.js
@@ -51,6 +51,12 @@ describe('Bruno to Postman Variables Translation', () => {
     expect(translatedCode).toBe('pm.globals.set("test", "value");');
   });
 
+  it('should translate bru.hasGlobalEnvVar', () => {
+    const code = 'bru.hasGlobalEnvVar("token");';
+    const translatedCode = translateBruToPostman(code);
+    expect(translatedCode).toBe('pm.globals.has("token");');
+  });
+
   // Collection variables tests
   it('should translate bru.getCollectionVar', () => {
     const code = 'bru.getCollectionVar("baseUrl");';

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/variables.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/variables.test.js
@@ -244,23 +244,20 @@ describe('Variables Translation', () => {
     const code = 'pm.globals.has("token");';
     const translatedCode = translateCode(code);
 
-    expect(translatedCode).toContain('bru.getGlobalEnvVar("token") !== undefined');
-    expect(translatedCode).toContain('bru.getGlobalEnvVar("token") !== null');
+    expect(translatedCode).toBe('bru.hasGlobalEnvVar("token");');
   });
 
   it('should translate pm.globals.has in conditional', () => {
     const code = 'if (pm.globals.has("authToken")) { console.log("Token exists"); }';
     const translatedCode = translateCode(code);
 
-    expect(translatedCode).toContain('bru.getGlobalEnvVar("authToken") !== undefined');
-    expect(translatedCode).toContain('bru.getGlobalEnvVar("authToken") !== null');
-    expect(translatedCode).toContain('console.log("Token exists");');
+    expect(translatedCode).toBe('if (bru.hasGlobalEnvVar("authToken")) { console.log("Token exists"); }');
   });
 
   it('should translate pm.globals.has with variable assignment', () => {
     const code = 'const hasGlobal = pm.globals.has("config");';
     const translatedCode = translateCode(code);
 
-    expect(translatedCode).toContain('const hasGlobal = bru.getGlobalEnvVar("config") !== undefined && bru.getGlobalEnvVar("config") !== null');
+    expect(translatedCode).toBe('const hasGlobal = bru.hasGlobalEnvVar("config");');
   });
 });

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -222,6 +222,10 @@ class Bru {
     }
   }
 
+  hasGlobalEnvVar(key) {
+    return Object.hasOwn(this.globalEnvironmentVariables, key);
+  }
+
   getGlobalEnvVar(key) {
     return this.interpolate(this.globalEnvironmentVariables[key]);
   }

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bru.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bru.js
@@ -116,6 +116,12 @@ const addBruShimToContext = (vm, bru) => {
   vm.setProp(bruObject, 'getAllGlobalEnvVars', getAllGlobalEnvVars);
   getAllGlobalEnvVars.dispose();
 
+  let hasGlobalEnvVar = vm.newFunction('hasGlobalEnvVar', function (key) {
+    return marshallToVm(bru.hasGlobalEnvVar(vm.dump(key)), vm);
+  });
+  vm.setProp(bruObject, 'hasGlobalEnvVar', hasGlobalEnvVar);
+  hasGlobalEnvVar.dispose();
+
   // TODO: deleteAllGlobalEnvVars works in the request lifecycle but does not update the UI.
   // Re-enable once the UI sync issue is resolved.
   // let deleteAllGlobalEnvVars = vm.newFunction('deleteAllGlobalEnvVars', function () {


### PR DESCRIPTION
[JIRA](https://usebruno.atlassian.net/browse/BRU-3089)
### Description

- Introduced the `bru.hasGlobalEnvVar(key)` method to check for the existence of global environment variables.
- Updated translation mappings in Postman converters to include `pm.globals.has` for `bru.hasGlobalEnvVar`.
- Enhanced test cases to validate the new method and its translation in both directions between Bruno and Postman.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bru.hasGlobalEnvVar() to check existence of global environment variables.
  * Autocomplete now suggests the new environment-variable check.
  * Postman import/export translations updated to map Postman global-existence checks to the new helper.

* **Tests**
  * Added and updated tests covering the new helper and its Postman translation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->