### PR TITLE
 fix: (RFC 7230) HTTP methods are case-sensitive but usually defined in uppercase.

### DIFF
--- a/packages/bruno-app/src/utils/codegenerator/har.js
+++ b/packages/bruno-app/src/utils/codegenerator/har.js
@@ -139,7 +139,7 @@ export const buildHarRequest = ({ request, headers }) => {
   }
 
   return {
-    method: request.method,
+    method: request.method.toUpperCase(),
     url: request.url,
     httpVersion: 'HTTP/1.1',
     cookies: [],


### PR DESCRIPTION
fix #8043

### Description
This bug occurs with CDNs like Cloudflare (400 response). Most servers ignore case for HTTP methods, but some enforce uppercase-only case-sensitive validation.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP method normalization to ensure request methods are consistently formatted in uppercase when processing archived request data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->