### PR TITLE
fix: 3093 - Fix pm.setNextRequest(null) not translating to bru.runner.stopExecution()

### DIFF
--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -15,12 +15,9 @@ const replacements = {
   // 'pm\\.collectionVariables\\.unset\\(': 'bru.deleteCollectionVar(',
   // 'pm\\.collectionVariables\\.clear\\(': 'bru.deleteAllCollectionVars(',
   // 'pm\\.collectionVariables\\.toObject\\(': 'bru.getAllCollectionVars(',
-  // More specific patterns must come before the general pm.setNextRequest( rule.
-  // Passing null/'null' to Postman's setNextRequest stops the runner; Bruno's
-  // bru.setNextRequest(null) does not — only bru.runner.stopExecution() does.
   'pm\\.setNextRequest\\(null\\)': 'bru.runner.stopExecution()',
   'pm\\.setNextRequest\\([\'\"]null[\'\"]\\)': 'bru.runner.stopExecution()',
-  'pm\\.setNextRequest\\(': 'bru.setNextRequest(',
+  'pm\\.setNextRequest\\(': 'bru.runner.setNextRequest(',
   'pm\\.test\\(': 'test(',
   'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
   'pm\\.response\\.to\\.have\\.status\\(': 'expect(res.getStatus()).to.equal(',

--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -15,6 +15,11 @@ const replacements = {
   // 'pm\\.collectionVariables\\.unset\\(': 'bru.deleteCollectionVar(',
   // 'pm\\.collectionVariables\\.clear\\(': 'bru.deleteAllCollectionVars(',
   // 'pm\\.collectionVariables\\.toObject\\(': 'bru.getAllCollectionVars(',
+  // More specific patterns must come before the general pm.setNextRequest( rule.
+  // Passing null/'null' to Postman's setNextRequest stops the runner; Bruno's
+  // bru.setNextRequest(null) does not — only bru.runner.stopExecution() does.
+  'pm\\.setNextRequest\\(null\\)': 'bru.runner.stopExecution()',
+  'pm\\.setNextRequest\\([\'\"]null[\'\"]\\)': 'bru.runner.stopExecution()',
   'pm\\.setNextRequest\\(': 'bru.setNextRequest(',
   'pm\\.test\\(': 'test(',
   'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -41,9 +41,6 @@ const simpleTranslations = {
   // 'pm.collectionVariables.clear': 'bru.deleteAllCollectionVars',
   // 'pm.collectionVariables.toObject': 'bru.getAllCollectionVars',
 
-  // Request flow control
-  'pm.setNextRequest': 'bru.setNextRequest',
-
   // Testing
   'pm.test': 'test',
   'pm.expect': 'expect',
@@ -266,6 +263,29 @@ const complexTransformations = [
       );
     }
   })),
+
+  // Handle pm.setNextRequest(null) / pm.setNextRequest('null') — stop the runner
+  {
+    pattern: 'pm.setNextRequest',
+    transform: (path, j) => {
+      const callExpr = path.parent.value;
+      const args = callExpr.arguments;
+
+      if (
+        args[0] && args[0].type === 'Literal' && (args[0].value === null || args[0].value === 'null')
+      ) {
+        return j.callExpression(
+          j.identifier('bru.runner.stopExecution'),
+          []
+        );
+      }
+
+      return j.callExpression(
+        j.identifier('bru.setNextRequest'),
+        args
+      );
+    }
+  },
 
   // Handle pm.execution.setNextRequest(null)
   {

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -281,7 +281,7 @@ const complexTransformations = [
       }
 
       return j.callExpression(
-        j.identifier('bru.setNextRequest'),
+        j.identifier('bru.runner.setNextRequest'),
         args
       );
     }

--- a/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/execution.test.js
+++ b/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/execution.test.js
@@ -79,7 +79,7 @@ const status = res.getStatus();
 const data = res.getBody();
 
 if (status === 200 && data.hasMore) {
-    bru.setNextRequest("Fetch Next Page");
+    bru.runner.setNextRequest("Fetch Next Page");
 } else if (status === 429) {
     console.log("Rate limited, skipping");
     bru.runner.skipRequest();

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
@@ -5,7 +5,7 @@ describe('Execution Flow Translation', () => {
   it('should translate pm.setNextRequest', () => {
     const code = 'pm.setNextRequest("Get User Details");';
     const translatedCode = translateCode(code);
-    expect(translatedCode).toBe('bru.setNextRequest("Get User Details");');
+    expect(translatedCode).toBe('bru.runner.setNextRequest("Get User Details");');
   });
 
   it('should translate pm.setNextRequest(null) to bru.runner.stopExecution()', () => {
@@ -18,6 +18,12 @@ describe('Execution Flow Translation', () => {
     const code = 'pm.setNextRequest("null");';
     const translatedCode = translateCode(code);
     expect(translatedCode).toBe('bru.runner.stopExecution();');
+  });
+
+  it('should keep pm.setNextRequest(<request name>) as bru.setNextRequest(<request name>) for non-null arguments', () => {
+    const code = 'pm.setNextRequest("Get User Details");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.runner.setNextRequest("Get User Details");');
   });
 
   it('should translate pm.execution.skipRequest', () => {
@@ -71,6 +77,6 @@ describe('Execution Flow Translation', () => {
     expect(translatedCode).toContain('} else if (res.getStatus() === 500) {');
     expect(translatedCode).toContain('bru.runner.stopExecution();');
     expect(translatedCode).toContain('} else {');
-    expect(translatedCode).toContain('bru.setNextRequest("Get User Details");');
+    expect(translatedCode).toContain('bru.runner.setNextRequest("Get User Details");');
   });
 });

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
@@ -8,6 +8,18 @@ describe('Execution Flow Translation', () => {
     expect(translatedCode).toBe('bru.setNextRequest("Get User Details");');
   });
 
+  it('should translate pm.setNextRequest(null) to bru.runner.stopExecution()', () => {
+    const code = 'pm.setNextRequest(null);';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.runner.stopExecution();');
+  });
+
+  it('should translate pm.setNextRequest("null") to bru.runner.stopExecution()', () => {
+    const code = 'pm.setNextRequest("null");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.runner.stopExecution();');
+  });
+
   it('should translate pm.execution.skipRequest', () => {
     const code = 'if (condition) pm.execution.skipRequest();';
     const translatedCode = translateCode(code);

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/postman-references.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/postman-references.test.js
@@ -71,9 +71,9 @@ describe('Postman to PM References Conversion', () => {
     const translatedCode = translateCode(code);
     expect(translatedCode).toContain('if (bru.getEnvVar("isProduction") === "true") {');
     expect(translatedCode).toContain('const apiUrl = bru.getEnvVar("prodUrl");');
-    expect(translatedCode).toContain('bru.setNextRequest("Production Flow");');
+    expect(translatedCode).toContain('bru.runner.setNextRequest("Production Flow");');
     expect(translatedCode).toContain('const apiUrl = bru.getEnvVar("devUrl");');
-    expect(translatedCode).toContain('bru.setNextRequest("Development Flow");');
+    expect(translatedCode).toContain('bru.runner.setNextRequest("Development Flow");');
   });
 
   // Legacy response handling


### PR DESCRIPTION
**Jira link: https://usebruno.atlassian.net/browse/BRU-3093**

### Description

Fix pm.setNextRequest(null) / pm.setNextRequest('null') translating to a no-op
bru.setNextRequest(null) instead of bru.runner.stopExecution().

In Postman, passing null stops the collection runner. Bruno's setNextRequest
only nulls the next-request pointer; only bru.runner.stopExecution() actually
stops the runner — so imported scripts were silently broken.

- AST translator: replaced the 1:1 pm.setNextRequest mapping with a complex
  transform that emits bru.runner.stopExecution() for null / 'null' literals,
  otherwise bru.setNextRequest(arg).
- Regex fallback: added null / 'null' specific patterns before the general
  pm.setNextRequest( rule.
- Added unit tests for both null variants.

Mirrors the existing pm.execution.setNextRequest(null) handling.
Fixes BRU-1367 / BRU-3093.

Before:
<img width="672" height="475" alt="image" src="https://github.com/user-attachments/assets/d3c40a2b-bd65-4807-bd71-49b2ba71573b" />


After:
<img width="560" height="306" alt="image" src="https://github.com/user-attachments/assets/47ffaf8a-5207-409c-8cff-aad712975592" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Packages changed:
- packages/bruno-converters

What changed
- Fixes translation of pm.setNextRequest(null) and pm.setNextRequest("null") so they map to bru.runner.stopExecution() instead of producing a no-op bru.setNextRequest(null).
- Replaced the previous simple 1:1 pm.setNextRequest translation with an AST transformation that:
  - Emits bru.runner.stopExecution() for null or string-'null' literal arguments.
  - Emits bru.runner.setNextRequest(...) for other arguments (preserving intended behavior).
- Added a higher-priority regex fallback for null / "null" patterns before the general pm.setNextRequest( rule to cover non-AST fallback paths.
- Aligned behavior with existing pm.execution.setNextRequest(null) handling.
- Adjusted tests and expectations to reflect bru.runner.* usage where appropriate.

Tests
- Added unit tests asserting pm.setNextRequest(null) and pm.setNextRequest("null") translate to bru.runner.stopExecution().
- Updated existing translation tests to expect bru.runner.setNextRequest(...) rather than bru.setNextRequest(...) for non-null cases.
- Updated corresponding Bruno→Postman translation test to use bru.runner.setNextRequest(...) input where applicable.

Issues fixed
- Addresses BRU-1367 / BRU-3093.

Notes on scope/interdependencies
- Changes are confined to the bruno-converters package (translation logic + tests). No exported public API changes outside tests.
- Translation behavior change affects any tooling that relies on bruno-converters for Postman→Bruno transpilation; callers should expect bru.runner.stopExecution() for null cases and bru.runner.setNextRequest(...) otherwise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->