### PR TITLE
feat: simplify new request creation flow

### DIFF
--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -393,6 +393,39 @@ const General = () => {
           <div className="text-red-500">{formik.errors.defaultLocation}</div>
         ) : null}
       </form>
+      <div className="section-header mt-2">Request Creation Style (Demo)</div>
+      <p className="text-muted mt-1 text-xs">
+        Switches the behavior of the sidebar <code>+</code> button on collection and folder rows.
+      </p>
+      <div className="flex flex-col mt-3 gap-2 mb-16 pb-12" data-testid="request-creation-style-radio-group">
+        {[
+          { value: 'modal', label: 'Modal — opens the New Request dialog (current default)' },
+          { value: 'inline-rename', label: 'Inline rename — creates request immediately, then inline-renames' },
+          { value: 'inline-create', label: 'Inline create — type chip + name input + cog, deferred create' }
+        ].map((opt) => (
+          <label key={opt.value} className="flex items-center select-none cursor-pointer">
+            <input
+              type="radio"
+              name="requestCreationStyle"
+              value={opt.value}
+              checked={(preferences?.sidebar?.requestCreationStyle || 'modal') === opt.value}
+              onChange={() => {
+                dispatch(
+                  savePreferences({
+                    ...preferences,
+                    sidebar: {
+                      ...(preferences?.sidebar || {}),
+                      requestCreationStyle: opt.value
+                    }
+                  })
+                ).catch(() => toast.error('Failed to update preference'));
+              }}
+              className="mr-2"
+            />
+            <span>{opt.label}</span>
+          </label>
+        ))}
+      </div>
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
@@ -99,6 +99,51 @@ const Wrapper = styled.div`
       overflow: hidden;
     }
 
+    .inline-rename-wrapper {
+      display: flex;
+      align-items: center;
+      flex: 1;
+      min-width: 0;
+      margin-left: -2px;
+      margin-right: 8px;
+      border: 1px solid ${(props) => props.theme.input.border};
+      border-radius: 3px;
+      background: ${(props) => props.theme.input.bg};
+
+      &:focus-within {
+        border-color: ${(props) => props.theme.input.focusBorder};
+      }
+    }
+
+    .inline-rename-input {
+      font-size: 13px;
+      padding: 1px 4px;
+      border: none;
+      background: transparent;
+      color: ${(props) => props.theme.text};
+      outline: none;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .inline-rename-cog {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      width: 20px;
+      height: 100%;
+      border: none;
+      cursor: pointer;
+      background: transparent;
+      color: ${(props) => props.theme.text};
+      opacity: 0.5;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+
     /* Single source of truth for hover/focus states: background and menu icon visibility */
     &:hover,
     &.item-hovered,

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -18,15 +18,17 @@ import {
   IconTrash,
   IconSettings,
   IconInfoCircle,
-  IconTerminal2
+  IconTerminal2,
+  IconPlus
 } from '@tabler/icons';
 import { useSelector, useDispatch } from 'react-redux';
 import { addTab, focusTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
-import { handleCollectionItemDrop, sendRequest, showInFolder, pasteItem, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { handleCollectionItemDrop, sendRequest, showInFolder, pasteItem, saveRequest, renameItem } from 'providers/ReduxStore/slices/collections/actions';
 import { toggleCollectionItem, addResponseExample } from 'providers/ReduxStore/slices/collections';
 import { insertTaskIntoQueue } from 'providers/ReduxStore/slices/app';
 import { uuid } from 'utils/common';
-import { copyRequest, setFocusedSidebarPath } from 'providers/ReduxStore/slices/app';
+import { sanitizeName } from 'utils/common/regex';
+import { copyRequest, setFocusedSidebarPath, setItemBeingRenamed } from 'providers/ReduxStore/slices/app';
 import NewRequest from 'components/Sidebar/NewRequest';
 import NewFolder from 'components/Sidebar/NewFolder';
 import RenameCollectionItem from './RenameCollectionItem';
@@ -102,6 +104,56 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   const hasSearchText = searchText && searchText?.trim()?.length;
   const itemIsCollapsed = hasSearchText ? false : item.collapsed;
   const isFolder = isItemAFolder(item);
+  const isRenaming = useSelector((state) => state.app.itemBeingRenamed === item.pathname);
+  const isRenameInFlightRef = useRef(false);
+  const [advancedNewRequestModalOpen, setAdvancedNewRequestModalOpen] = useState(false);
+
+  const handleInlineRenameCog = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dispatch(setItemBeingRenamed(null));
+    setAdvancedNewRequestModalOpen(true);
+  };
+
+  const performInlineRename = async (newName) => {
+    if (isRenameInFlightRef.current) return;
+    isRenameInFlightRef.current = true;
+    const trimmed = newName?.trim();
+    if (!trimmed || trimmed === item.name) {
+      dispatch(setItemBeingRenamed(null));
+      isRenameInFlightRef.current = false;
+      return;
+    }
+    try {
+      await dispatch(
+        renameItem({
+          itemUid: item.uid,
+          collectionUid,
+          newName: trimmed,
+          newFilename: sanitizeName(trimmed)
+        })
+      );
+    } catch (err) {
+      toast.error(err?.message || 'Failed to rename');
+    } finally {
+      dispatch(setItemBeingRenamed(null));
+      isRenameInFlightRef.current = false;
+    }
+  };
+
+  const handleRenameKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      performInlineRename(e.currentTarget.value);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      dispatch(setItemBeingRenamed(null));
+    }
+  };
+
+  const handleRenameBlur = (e) => {
+    performInlineRename(e.currentTarget.value);
+  };
 
   // Check if request has examples (only for HTTP requests)
   const hasExamples = isItemARequest(item) && item.type === 'http-request' && item.examples && item.examples.length > 0;
@@ -544,7 +596,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   const requestItems = sortItemsBySequence(filter(item.items, (i) => isItemARequest(i) && !i.isTransient));
   const showEmptyFolderMessage = isFolder && !hasSearchText && !folderItems?.length && !requestItems?.length;
 
-  const emptyFolderMenuItems = createEmptyStateMenuItems({ dispatch, collection, itemUid: item.uid });
+  const emptyFolderMenuItems = createEmptyStateMenuItems({ dispatch, collection, itemUid: item.uid, enterRenameMode: true });
 
   const handleGenerateCode = () => {
     if (
@@ -621,6 +673,13 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
       )}
       {newRequestModalOpen && (
         <NewRequest item={item} collectionUid={collectionUid} onClose={() => setNewRequestModalOpen(false)} />
+      )}
+      {advancedNewRequestModalOpen && (
+        <NewRequest
+          item={findParentItemInCollection(collection, item.uid)}
+          collectionUid={collectionUid}
+          onClose={() => setAdvancedNewRequestModalOpen(false)}
+        />
       )}
       {newFolderModalOpen && (
         <NewFolder item={item} collectionUid={collectionUid} onClose={() => setNewFolderModalOpen(false)} />
@@ -702,25 +761,81 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
             <div className="ml-1 flex w-full h-full items-center overflow-hidden">
               <CollectionItemIcon item={item} />
-              <span className="item-name" title={item.name}>
-                {item.name}
-              </span>
+              {isRenaming ? (
+                <div className="inline-rename-wrapper ml-1">
+                  <input
+                    ref={(el) => {
+                      if (el && !el.dataset.focused) {
+                        el.dataset.focused = '1';
+                        el.focus();
+                        el.select();
+                      }
+                    }}
+                    type="text"
+                    className="inline-rename-input"
+                    defaultValue={item.name}
+                    onClick={(e) => e.stopPropagation()}
+                    onDoubleClick={(e) => e.stopPropagation()}
+                    onKeyDown={handleRenameKeyDown}
+                    onFocus={(e) => e.stopPropagation()}
+                    onBlur={(e) => {
+                      e.stopPropagation();
+                      handleRenameBlur(e);
+                    }}
+                    autoComplete="off"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck="false"
+                    aria-label="Rename request"
+                    data-testid="inline-rename-input"
+                  />
+                  <button
+                    type="button"
+                    className="inline-rename-cog"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={handleInlineRenameCog}
+                    title="Advanced options"
+                    data-testid="inline-rename-cog"
+                  >
+                    <IconSettings size={13} strokeWidth={1.5} />
+                  </button>
+                </div>
+              ) : (
+                <span className="item-name" title={item.name}>
+                  {item.name}
+                </span>
+              )}
             </div>
           </div>
-          <div className="pr-2">
-            <MenuDropdown
-              ref={menuDropdownRef}
-              items={buildMenuItems()}
-              placement="bottom-start"
-              data-testid="collection-item-menu"
-              popperOptions={{ strategy: 'fixed' }}
-              appendTo={dropdownContainerRef?.current || document.body}
-            >
-              <ActionIcon className="menu-icon">
-                <IconDots size={18} className="collection-item-menu-icon" />
-              </ActionIcon>
-            </MenuDropdown>
-          </div>
+          {!isRenaming && (
+            <div className="flex items-center pr-2">
+              {isFolder ? (
+                <MenuDropdown
+                  items={emptyFolderMenuItems}
+                  placement="bottom-end"
+                  appendTo={dropdownContainerRef?.current || document.body}
+                  popperOptions={{ strategy: 'fixed' }}
+                  data-testid="folder-new-request"
+                >
+                  <ActionIcon className="menu-icon" aria-label="New Request">
+                    <IconPlus size={18} className="collection-item-menu-icon" />
+                  </ActionIcon>
+                </MenuDropdown>
+              ) : null}
+              <MenuDropdown
+                ref={menuDropdownRef}
+                items={buildMenuItems()}
+                placement="bottom-start"
+                data-testid="collection-item-menu"
+                popperOptions={{ strategy: 'fixed' }}
+                appendTo={dropdownContainerRef?.current || document.body}
+              >
+                <ActionIcon className="menu-icon">
+                  <IconDots size={18} className="collection-item-menu-icon" />
+                </ActionIcon>
+              </MenuDropdown>
+            </div>
+          )}
         </div>
       </div>
       {!itemIsCollapsed ? (

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -54,6 +54,7 @@ import {
 } from 'src/selectors/tab';
 import { isEqual } from 'lodash';
 import { createEmptyStateMenuItems } from 'utils/collections/emptyStateRequest';
+import InlineRequestCreator from 'components/Sidebar/InlineRequestCreator';
 import { calculateDraggedItemNewPathname, getInitialExampleName, findParentItemInCollection } from 'utils/collections/index';
 import { sortByNameThenSequence } from 'utils/common/index';
 import { getRevealInFolderLabel } from 'utils/common/platform';
@@ -107,6 +108,8 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   const isRenaming = useSelector((state) => state.app.itemBeingRenamed === item.pathname);
   const isRenameInFlightRef = useRef(false);
   const [advancedNewRequestModalOpen, setAdvancedNewRequestModalOpen] = useState(false);
+  const [isInlineCreatingRequest, setIsInlineCreatingRequest] = useState(false);
+  const requestCreationStyle = useSelector((state) => state.app.preferences?.sidebar?.requestCreationStyle || 'modal');
 
   const handleInlineRenameCog = (e) => {
     e.preventDefault();
@@ -596,7 +599,12 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   const requestItems = sortItemsBySequence(filter(item.items, (i) => isItemARequest(i) && !i.isTransient));
   const showEmptyFolderMessage = isFolder && !hasSearchText && !folderItems?.length && !requestItems?.length;
 
-  const emptyFolderMenuItems = createEmptyStateMenuItems({ dispatch, collection, itemUid: item.uid, enterRenameMode: true });
+  const emptyFolderMenuItems = createEmptyStateMenuItems({
+    dispatch,
+    collection,
+    itemUid: item.uid,
+    enterRenameMode: requestCreationStyle === 'inline-rename'
+  });
 
   const handleGenerateCode = () => {
     if (
@@ -810,17 +818,46 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
           {!isRenaming && (
             <div className="flex items-center pr-2">
               {isFolder ? (
-                <MenuDropdown
-                  items={emptyFolderMenuItems}
-                  placement="bottom-end"
-                  appendTo={dropdownContainerRef?.current || document.body}
-                  popperOptions={{ strategy: 'fixed' }}
-                  data-testid="folder-new-request"
-                >
-                  <ActionIcon className="menu-icon" aria-label="New Request">
+                requestCreationStyle === 'inline-create' ? (
+                  <ActionIcon
+                    className="menu-icon"
+                    aria-label="New Request"
+                    data-testid="folder-new-request"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (item.collapsed) {
+                        dispatch(toggleCollectionItem({ itemUid: item.uid, collectionUid }));
+                      }
+                      setIsInlineCreatingRequest(true);
+                    }}
+                  >
+                    <IconPlus size={16} className="collection-item-menu-icon" />
+                  </ActionIcon>
+                ) : requestCreationStyle === 'inline-rename' ? (
+                  <MenuDropdown
+                    items={emptyFolderMenuItems}
+                    placement="bottom-end"
+                    appendTo={dropdownContainerRef?.current || document.body}
+                    popperOptions={{ strategy: 'fixed' }}
+                    data-testid="folder-new-request"
+                  >
+                    <ActionIcon className="menu-icon" aria-label="New Request">
+                      <IconPlus size={16} className="collection-item-menu-icon" />
+                    </ActionIcon>
+                  </MenuDropdown>
+                ) : (
+                  <ActionIcon
+                    className="menu-icon"
+                    aria-label="New Request"
+                    data-testid="folder-new-request"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setNewRequestModalOpen(true);
+                    }}
+                  >
                     <IconPlus size={18} className="collection-item-menu-icon" />
                   </ActionIcon>
-                </MenuDropdown>
+                )
               ) : null}
               <MenuDropdown
                 ref={menuDropdownRef}
@@ -850,6 +887,17 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
                 return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} />;
               })
             : null}
+          {isInlineCreatingRequest ? (
+            <InlineRequestCreator
+              collection={collection}
+              parentItemUid={item.uid}
+              depth={item.depth + 1}
+              onDone={({ openAdvanced } = {}) => {
+                setIsInlineCreatingRequest(false);
+                if (openAdvanced) setNewRequestModalOpen(true);
+              }}
+            />
+          ) : null}
           {showEmptyFolderMessage ? (
             <div className="empty-folder-message">
               {range(item.depth + 1).map((i) => (

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -54,6 +54,7 @@ import StatusBadge from 'ui/StatusBadge';
 import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
 import { createEmptyStateMenuItems } from 'utils/collections/emptyStateRequest';
+import InlineRequestCreator from 'components/Sidebar/InlineRequestCreator';
 import useKeybinding from 'hooks/useKeybinding';
 
 // Delay before showing empty collection state (ms)
@@ -73,6 +74,7 @@ const Collection = ({ collection, searchText }) => {
   const [dropType, setDropType] = useState(null);
   const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
   const [showEmptyState, setShowEmptyState] = useState(false);
+  const [isInlineCreatingRequest, setIsInlineCreatingRequest] = useState(false);
   const dispatch = useDispatch();
   const isLoading = collection.isLoading;
   const collectionRef = useRef(null);
@@ -82,6 +84,7 @@ const Collection = ({ collection, searchText }) => {
 
   const isCollectionFocused = useSelector(isTabForItemActive({ itemUid: collection.uid }));
   const { hasCopiedItems } = useSelector((state) => state.app.clipboard);
+  const requestCreationStyle = useSelector((state) => state.app.preferences?.sidebar?.requestCreationStyle || 'modal');
   const menuDropdownRef = useRef(null);
 
   // Open the OpenAPI Sync tab
@@ -327,7 +330,12 @@ const Collection = ({ collection, searchText }) => {
   const folderItems = sortByNameThenSequence(filter(collection.items, (i) => isItemAFolder(i) && !i.isTransient));
   const showEmptyCollectionMessage = showEmptyState && !hasSearchText;
 
-  const emptyStateMenuItems = createEmptyStateMenuItems({ dispatch, collection, itemUid: null, enterRenameMode: true });
+  const emptyStateMenuItems = createEmptyStateMenuItems({
+    dispatch,
+    collection,
+    itemUid: null,
+    enterRenameMode: requestCreationStyle === 'inline-rename'
+  });
 
   const menuItems = [
     {
@@ -504,23 +512,54 @@ const Collection = ({ collection, searchText }) => {
         </div>
         <div className="flex items-center">
           <div>
-            <MenuDropdown
-              items={emptyStateMenuItems.map((it) => ({
-                ...it,
-                onClick: () => {
+            {requestCreationStyle === 'inline-create' ? (
+              <ActionIcon
+                className="collection-actions"
+                aria-label="New Request"
+                data-testid="collection-new-request"
+                onClick={(e) => {
+                  e.stopPropagation();
                   ensureCollectionIsMounted();
-                  it.onClick?.();
-                }
-              }))}
-              placement="bottom-end"
-              appendTo={dropdownContainerRef?.current || document.body}
-              popperOptions={{ strategy: 'fixed' }}
-              data-testid="collection-new-request"
-            >
-              <ActionIcon className="collection-actions" aria-label="New Request">
+                  if (collection.collapsed) {
+                    dispatch(toggleCollection(collection.uid));
+                  }
+                  setIsInlineCreatingRequest(true);
+                }}
+              >
+                <IconPlus size={16} />
+              </ActionIcon>
+            ) : requestCreationStyle === 'inline-rename' ? (
+              <MenuDropdown
+                items={emptyStateMenuItems.map((it) => ({
+                  ...it,
+                  onClick: () => {
+                    ensureCollectionIsMounted();
+                    it.onClick?.();
+                  }
+                }))}
+                placement="bottom-end"
+                appendTo={dropdownContainerRef?.current || document.body}
+                popperOptions={{ strategy: 'fixed' }}
+                data-testid="collection-new-request"
+              >
+                <ActionIcon className="collection-actions" aria-label="New Request">
+                  <IconPlus size={16} />
+                </ActionIcon>
+              </MenuDropdown>
+            ) : (
+              <ActionIcon
+                className="collection-actions"
+                aria-label="New Request"
+                data-testid="collection-new-request"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  ensureCollectionIsMounted();
+                  setShowNewRequestModal(true);
+                }}
+              >
                 <IconPlus size={18} />
               </ActionIcon>
-            </MenuDropdown>
+            )}
           </div>
           <div className="pr-2">
             <MenuDropdown
@@ -547,6 +586,17 @@ const Collection = ({ collection, searchText }) => {
             {requestItems?.map?.((i) => {
               return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} />;
             })}
+            {isInlineCreatingRequest ? (
+              <InlineRequestCreator
+                collection={collection}
+                parentItemUid={null}
+                depth={0}
+                onDone={({ openAdvanced } = {}) => {
+                  setIsInlineCreatingRequest(false);
+                  if (openAdvanced) setShowNewRequestModal(true);
+                }}
+              />
+            ) : null}
             {showEmptyCollectionMessage ? (
               <div className="empty-collection-message">
                 <div className="indent-block" style={{ width: 16, minWidth: 16, height: '100%' }}>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -20,7 +20,8 @@ import {
   IconSettings,
   IconTerminal2,
   IconFolder,
-  IconBook
+  IconBook,
+  IconPlus
 } from '@tabler/icons';
 import OpenAPISyncIcon from 'components/Icons/OpenAPISync';
 import { toggleCollection, collapseFullCollection } from 'providers/ReduxStore/slices/collections';
@@ -326,7 +327,7 @@ const Collection = ({ collection, searchText }) => {
   const folderItems = sortByNameThenSequence(filter(collection.items, (i) => isItemAFolder(i) && !i.isTransient));
   const showEmptyCollectionMessage = showEmptyState && !hasSearchText;
 
-  const emptyStateMenuItems = createEmptyStateMenuItems({ dispatch, collection, itemUid: null });
+  const emptyStateMenuItems = createEmptyStateMenuItems({ dispatch, collection, itemUid: null, enterRenameMode: true });
 
   const menuItems = [
     {
@@ -501,7 +502,26 @@ const Collection = ({ collection, searchText }) => {
           </div>
           {isLoading ? <IconLoader2 className="animate-spin mx-1" size={18} strokeWidth={1.5} /> : null}
         </div>
-        <div>
+        <div className="flex items-center">
+          <div>
+            <MenuDropdown
+              items={emptyStateMenuItems.map((it) => ({
+                ...it,
+                onClick: () => {
+                  ensureCollectionIsMounted();
+                  it.onClick?.();
+                }
+              }))}
+              placement="bottom-end"
+              appendTo={dropdownContainerRef?.current || document.body}
+              popperOptions={{ strategy: 'fixed' }}
+              data-testid="collection-new-request"
+            >
+              <ActionIcon className="collection-actions" aria-label="New Request">
+                <IconPlus size={18} />
+              </ActionIcon>
+            </MenuDropdown>
+          </div>
           <div className="pr-2">
             <MenuDropdown
               ref={menuDropdownRef}

--- a/packages/bruno-app/src/components/Sidebar/InlineRequestCreator/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/InlineRequestCreator/StyledWrapper.js
@@ -1,0 +1,96 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  height: 1.6rem;
+  margin-top: 2px;
+  /* No left padding: indent-blocks render flush like in CollectionItem;
+     the bordered inner wrapper offsets itself with margin-left to align
+     with the icon position (paddingLeft 8 + ml-1 4 = 12) of regular rows. */
+  padding-left: 0;
+  padding-right: 8px;
+
+  .indent-block {
+    border-right: 1px solid ${(props) => props.theme.sidebar.collection.item.indentBorder};
+  }
+
+  .inline-request-creator-wrapper {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+    margin-left: 20px;
+    border: 1px solid ${(props) => props.theme.input.border};
+    border-radius: 3px;
+    background: ${(props) => props.theme.input.bg};
+    transition: border-color 180ms ease, background-color 180ms ease;
+
+    &:focus-within {
+      border-color: ${(props) => props.theme.input.focusBorder};
+    }
+
+    &.is-pending {
+      border-color: transparent;
+      background: transparent;
+
+      .inline-type-chip-trigger {
+        border-right-color: transparent;
+        cursor: default;
+        pointer-events: none;
+
+        &:hover {
+          background: transparent;
+        }
+
+        /* Hide the chevron — chip becomes a passive badge */
+        & > svg:last-child {
+          display: none;
+        }
+      }
+    }
+  }
+
+  .inline-request-creator-pending-name {
+    flex: 1;
+    min-width: 0;
+    padding: 0 6px;
+    font-size: 13px;
+    line-height: 1.6rem;
+    color: ${(props) => props.theme.text};
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  .inline-request-creator-input {
+    font-size: 13px;
+    padding: 1px 6px;
+    border: none;
+    background: transparent;
+    color: ${(props) => props.theme.text};
+    outline: none;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .inline-request-creator-cog {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 20px;
+    height: 100%;
+    border: none;
+    cursor: pointer;
+    background: transparent;
+    color: ${(props) => props.theme.text};
+    opacity: 0.5;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/InlineRequestCreator/index.js
+++ b/packages/bruno-app/src/components/Sidebar/InlineRequestCreator/index.js
@@ -1,0 +1,197 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import range from 'lodash/range';
+import { get } from 'lodash';
+import { useDispatch, useSelector } from 'react-redux';
+import { IconSettings } from '@tabler/icons';
+import toast from 'react-hot-toast';
+import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
+import InlineTypeChip, { TYPE_OPTIONS } from 'components/Sidebar/InlineTypeChip';
+import { createRequest } from 'utils/collections/emptyStateRequest';
+import { generateUniqueRequestName, flattenItems } from 'utils/collections';
+import { formatIpcError } from 'utils/common/error';
+import StyledWrapper from './StyledWrapper';
+
+const DEFAULT_TYPE = TYPE_OPTIONS[0].id;
+
+const InlineRequestCreator = ({ collection, parentItemUid = null, depth = 0, onDone }) => {
+  const inputRef = useRef(null);
+  const containerRef = useRef(null);
+  const dispatch = useDispatch();
+  const { dropdownContainerRef } = useSidebarAccordion();
+  const presetType
+    = get(collection, 'draft.brunoConfig.presets.requestType')
+      || get(collection, 'brunoConfig.presets.requestType');
+  const initialType = TYPE_OPTIONS.some((o) => o.id === presetType) ? presetType : DEFAULT_TYPE;
+  const [requestType, setRequestType] = useState(initialType);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const [pendingPathname, setPendingPathname] = useState(null);
+  const [committedName, setCommittedName] = useState('');
+  const closingRef = useRef(false);
+
+  // After commit, keep the row visible until the new item appears in collection state
+  // (file watcher) to avoid a flicker. Fallback timeout closes the row regardless.
+  const itemAppeared = useSelector((state) => {
+    if (!pendingPathname) return false;
+    const c = state.collections.collections.find((col) => col.uid === collection.uid);
+    if (!c) return false;
+    return flattenItems(c.items).some((i) => i.pathname === pendingPathname);
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    generateUniqueRequestName(collection, 'Untitled', parentItemUid)
+      .then((name) => {
+        if (cancelled || !inputRef.current) return;
+        inputRef.current.value = name;
+        inputRef.current.focus();
+        inputRef.current.select();
+      })
+      .catch(() => {
+        if (cancelled || !inputRef.current) return;
+        inputRef.current.value = 'Untitled';
+        inputRef.current.focus();
+        inputRef.current.select();
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [collection, parentItemUid]);
+
+  const finish = useCallback(
+    (openAdvanced = false) => {
+      if (closingRef.current) return;
+      closingRef.current = true;
+      onDone({ openAdvanced });
+    },
+    [onDone]
+  );
+
+  const commit = useCallback(async () => {
+    if (isCommitting || closingRef.current) return;
+    const name = inputRef.current?.value?.trim();
+    if (!name) {
+      finish();
+      return;
+    }
+    setIsCommitting(true);
+    setCommittedName(name);
+    try {
+      const pathname = await createRequest({
+        dispatch,
+        collection,
+        itemUid: parentItemUid,
+        requestType,
+        requestName: name
+      });
+      if (pathname) {
+        setPendingPathname(pathname);
+      } else {
+        finish();
+      }
+    } catch (err) {
+      toast.error(formatIpcError(err) || 'Failed to create request');
+      setIsCommitting(false);
+      setCommittedName('');
+    }
+  }, [collection, parentItemUid, requestType, isCommitting, dispatch, finish]);
+
+  useEffect(() => {
+    if (pendingPathname && itemAppeared) {
+      finish();
+    }
+  }, [pendingPathname, itemAppeared, finish]);
+
+  useEffect(() => {
+    if (!pendingPathname) return;
+    const t = setTimeout(() => finish(), 3000);
+    return () => clearTimeout(t);
+  }, [pendingPathname, finish]);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (!containerRef.current) return;
+      if (containerRef.current.contains(e.target)) return;
+      // Allow clicks inside MenuDropdown portals (type dropdown menu items)
+      if (e.target.closest('[role="menu"]')) return;
+      commit();
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [commit]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      finish();
+    }
+  };
+
+  const handleCogClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    finish(true);
+  };
+
+  const handleTypeChange = (id) => {
+    setRequestType(id);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <StyledWrapper depth={depth} ref={containerRef}>
+      {range(depth).map((i) => (
+        <div className="indent-block" key={i} style={{ width: 16, minWidth: 16, height: '100%' }}>
+          &nbsp;
+        </div>
+      ))}
+      <div className={`inline-request-creator-wrapper${pendingPathname ? ' is-pending' : ''}`}>
+        <InlineTypeChip
+          value={requestType}
+          onChange={handleTypeChange}
+          appendTo={dropdownContainerRef?.current || document.body}
+        />
+        {pendingPathname ? (
+          <span className="inline-request-creator-pending-name" data-testid="inline-request-creator-pending-name">
+            {committedName}
+          </span>
+        ) : (
+          <>
+            <input
+              ref={inputRef}
+              type="text"
+              className="inline-request-creator-input"
+              defaultValue=""
+              placeholder="Request name"
+              onKeyDown={handleKeyDown}
+              onFocus={(e) => e.stopPropagation()}
+              onBlur={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck="false"
+              readOnly={isCommitting}
+              aria-label="New request name"
+              data-testid="inline-request-creator-input"
+            />
+            <button
+              type="button"
+              className="inline-request-creator-cog"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleCogClick}
+              title="Advanced options"
+              data-testid="inline-request-creator-cog"
+            >
+              <IconSettings size={13} strokeWidth={1.5} />
+            </button>
+          </>
+        )}
+      </div>
+    </StyledWrapper>
+  );
+};
+
+export default InlineRequestCreator;

--- a/packages/bruno-app/src/components/Sidebar/InlineTypeChip/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/InlineTypeChip/StyledWrapper.js
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: inline-flex;
+  align-items: stretch;
+  flex-shrink: 0;
+
+  .inline-type-chip-trigger {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    height: 100%;
+    padding: 0 6px;
+    border: none;
+    border-right: 1px solid ${(props) => props.theme.input.border};
+    background: transparent;
+    cursor: pointer;
+    color: ${(props) => props.theme.text};
+
+    &:hover {
+      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
+    }
+
+    /* Tighten the RequestMethod min-width so the chip stays compact */
+    & > div > div {
+      min-width: 0;
+    }
+  }
+
+  .inline-type-chip-http-badge {
+    display: inline-flex;
+    align-items: center;
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.text};
+    text-transform: uppercase;
+    margin-right: 4px;
+    position: relative;
+    top: 1px;
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/InlineTypeChip/index.js
+++ b/packages/bruno-app/src/components/Sidebar/InlineTypeChip/index.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { IconChevronDown } from '@tabler/icons';
+import MenuDropdown from 'ui/MenuDropdown';
+import RequestMethod from 'components/Sidebar/Collections/Collection/CollectionItem/RequestMethod';
+import StyledWrapper from './StyledWrapper';
+
+export const TYPE_OPTIONS = [
+  { id: 'http', label: 'HTTP', bruType: 'http-request' },
+  { id: 'graphql', label: 'GraphQL', bruType: 'graphql-request' },
+  { id: 'grpc', label: 'gRPC', bruType: 'grpc-request' },
+  { id: 'websocket', label: 'WebSocket', bruType: 'ws-request' }
+];
+
+const TypeBadge = ({ option }) => {
+  if (option.id === 'http') {
+    return <span className="inline-type-chip-http-badge">HTTP</span>;
+  }
+  return <RequestMethod item={{ type: option.bruType, request: { method: '' } }} />;
+};
+
+const InlineTypeChip = ({ value, onChange, appendTo }) => {
+  const current = TYPE_OPTIONS.find((o) => o.id === value) || TYPE_OPTIONS[0];
+
+  const menuItems = TYPE_OPTIONS.map((option) => ({
+    id: option.id,
+    label: option.label,
+    leftSection: <TypeBadge option={option} />,
+    onClick: () => onChange(option.id)
+  }));
+
+  return (
+    <StyledWrapper>
+      <MenuDropdown
+        items={menuItems}
+        placement="bottom-start"
+        appendTo={appendTo}
+        popperOptions={{ strategy: 'fixed' }}
+        data-testid="inline-type-chip-menu"
+      >
+        <button
+          type="button"
+          className="inline-type-chip-trigger"
+          onMouseDown={(e) => e.preventDefault()}
+          title={`Request type: ${current.label}`}
+          aria-label={`Request type: ${current.label}`}
+          data-testid="inline-type-chip-trigger"
+        >
+          <TypeBadge option={current} />
+          <IconChevronDown size={10} strokeWidth={2} />
+        </button>
+      </MenuDropdown>
+    </StyledWrapper>
+  );
+};
+
+export default InlineTypeChip;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -19,6 +19,7 @@ const initialState = {
   sidebarCollapsed: false,
   showSidebarSearch: false,
   focusedSidebarPath: null,
+  itemBeingRenamed: null,
   screenWidth: 500,
   showHomePage: false,
   showApiSpecPage: false,
@@ -196,6 +197,9 @@ export const appSlice = createSlice({
     setFocusedSidebarPath: (state, action) => {
       state.focusedSidebarPath = action.payload;
     },
+    setItemBeingRenamed: (state, action) => {
+      state.itemBeingRenamed = action.payload;
+    },
     updateGitOperationProgress: (state, action) => {
       const { uid, data } = action.payload;
       if (!state.gitOperationProgress[uid]) {
@@ -267,6 +271,7 @@ export const {
   toggleSidebarCollapse,
   toggleSidebarSearch,
   setFocusedSidebarPath,
+  setItemBeingRenamed,
   updateGitOperationProgress,
   removeGitOperationProgress,
   setGitVersion,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -60,6 +60,10 @@ const initialState = {
       sslSession: {
         enabled: false
       }
+    },
+    sidebar: {
+      // Demo toggle: 'modal' | 'inline-rename' | 'inline-create'
+      requestCreationStyle: 'modal'
     }
   },
   generateCode: {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1381,7 +1381,7 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
                 preview: false
               })
             );
-            resolve();
+            resolve(fullName);
           })
           .catch(reject);
       } else {
@@ -1412,7 +1412,7 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
                 itemPathname: fullName
               })
             );
-            resolve();
+            resolve(fullName);
           })
           .catch(reject);
       } else {
@@ -1442,7 +1442,7 @@ export const newHttpRequest = (params) => (dispatch, getState) => {
                   itemPathname: fullName
                 })
               );
-              resolve();
+              resolve(fullName);
             })
             .catch(reject);
         } else {
@@ -1538,7 +1538,7 @@ export const newGrpcRequest = (params) => (dispatch, getState) => {
               preview: false
             })
           );
-          resolve();
+          resolve(fullName);
         })
         .catch(reject);
     } else {
@@ -1574,7 +1574,7 @@ export const newGrpcRequest = (params) => (dispatch, getState) => {
               itemPathname: fullName
             })
           );
-          resolve();
+          resolve(fullName);
         })
         .catch(reject);
     }
@@ -1666,7 +1666,7 @@ export const newWsRequest = (params) => (dispatch, getState) => {
               preview: false
             })
           );
-          resolve();
+          resolve(fullName);
         })
         .catch(reject);
     } else {
@@ -1702,7 +1702,7 @@ export const newWsRequest = (params) => (dispatch, getState) => {
               itemPathname: fullName
             })
           );
-          resolve();
+          resolve(fullName);
         })
         .catch(reject);
     }

--- a/packages/bruno-app/src/utils/collections/emptyStateRequest.js
+++ b/packages/bruno-app/src/utils/collections/emptyStateRequest.js
@@ -1,12 +1,35 @@
 import React from 'react';
 import { IconApi, IconBrandGraphql, IconPlugConnected, IconCode } from '@tabler/icons';
 import { newHttpRequest, newWsRequest, newGrpcRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { setItemBeingRenamed } from 'providers/ReduxStore/slices/app';
 import { generateUniqueRequestName } from 'utils/collections';
 import { sanitizeName } from 'utils/common/regex';
 import { formatIpcError } from 'utils/common/error';
 import toast from 'react-hot-toast';
 
-const createRequest = async ({ dispatch, collection, itemUid, requestType }) => {
+const dispatchByType = (dispatch, requestType, baseParams) => {
+  switch (requestType) {
+    case 'http':
+      return dispatch(newHttpRequest({ ...baseParams, requestType: 'http-request', requestMethod: 'GET' }));
+    case 'graphql':
+      return dispatch(
+        newHttpRequest({
+          ...baseParams,
+          requestType: 'graphql-request',
+          requestMethod: 'POST',
+          body: { mode: 'graphql', graphql: { query: '', variables: '' } }
+        })
+      );
+    case 'websocket':
+      return dispatch(newWsRequest({ ...baseParams, requestMethod: 'ws' }));
+    case 'grpc':
+      return dispatch(newGrpcRequest(baseParams));
+    default:
+      return Promise.resolve();
+  }
+};
+
+export const createRequest = async ({ dispatch, collection, itemUid, requestType, enterRenameMode = false }) => {
   try {
     const uniqueName = await generateUniqueRequestName(collection, 'Untitled', itemUid);
     const filename = sanitizeName(uniqueName);
@@ -19,26 +42,10 @@ const createRequest = async ({ dispatch, collection, itemUid, requestType }) => 
       itemUid
     };
 
-    switch (requestType) {
-      case 'http':
-        await dispatch(newHttpRequest({ ...baseParams, requestType: 'http-request', requestMethod: 'GET' }));
-        break;
-      case 'graphql':
-        await dispatch(
-          newHttpRequest({
-            ...baseParams,
-            requestType: 'graphql-request',
-            requestMethod: 'POST',
-            body: { mode: 'graphql', graphql: { query: '', variables: '' } }
-          })
-        );
-        break;
-      case 'websocket':
-        await dispatch(newWsRequest({ ...baseParams, requestMethod: 'ws' }));
-        break;
-      case 'grpc':
-        await dispatch(newGrpcRequest(baseParams));
-        break;
+    const newItemPathname = await dispatchByType(dispatch, requestType, baseParams);
+
+    if (enterRenameMode && newItemPathname) {
+      dispatch(setItemBeingRenamed(newItemPathname));
     }
   } catch (err) {
     toast.error(formatIpcError(err) || 'An error occurred while adding the request');
@@ -49,9 +56,9 @@ const createRequest = async ({ dispatch, collection, itemUid, requestType }) => 
  * Returns menu items for the empty state "Add request" dropdown.
  * Used by both Collection (empty collection) and CollectionItem (empty folder).
  */
-export const createEmptyStateMenuItems = ({ dispatch, collection, itemUid }) => {
+export const createEmptyStateMenuItems = ({ dispatch, collection, itemUid, enterRenameMode = false }) => {
   const handleCreate = (requestType) => () => {
-    createRequest({ dispatch, collection, itemUid, requestType });
+    createRequest({ dispatch, collection, itemUid, requestType, enterRenameMode });
   };
 
   return [

--- a/packages/bruno-app/src/utils/collections/emptyStateRequest.js
+++ b/packages/bruno-app/src/utils/collections/emptyStateRequest.js
@@ -29,13 +29,13 @@ const dispatchByType = (dispatch, requestType, baseParams) => {
   }
 };
 
-export const createRequest = async ({ dispatch, collection, itemUid, requestType, enterRenameMode = false }) => {
+export const createRequest = async ({ dispatch, collection, itemUid, requestType, requestName, enterRenameMode = false }) => {
   try {
-    const uniqueName = await generateUniqueRequestName(collection, 'Untitled', itemUid);
-    const filename = sanitizeName(uniqueName);
+    const name = requestName?.trim() || (await generateUniqueRequestName(collection, 'Untitled', itemUid));
+    const filename = sanitizeName(name);
 
     const baseParams = {
-      requestName: uniqueName,
+      requestName: name,
       filename,
       requestUrl: '',
       collectionUid: collection.uid,
@@ -47,8 +47,10 @@ export const createRequest = async ({ dispatch, collection, itemUid, requestType
     if (enterRenameMode && newItemPathname) {
       dispatch(setItemBeingRenamed(newItemPathname));
     }
+    return newItemPathname;
   } catch (err) {
     toast.error(formatIpcError(err) || 'An error occurred while adding the request');
+    throw err;
   }
 };
 


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2674)

Bruno's current "New Request" flow opens a modal that takes 3–4× the clicks to create a new request. This PR explores two alternative flows that bring reduces the number of click, both surfaced from the existing sidebar `+` button.

A preference toggle in **Preferences → General → Request Creation Style** is included so reviewers can flip between the two implementations (and the existing modal) without restarting the app.


### Screen Recording
https://github.com/user-attachments/assets/00ac1550-fe08-44a4-b7f8-11ca156fcab4


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
