### PR TITLE
ci: better concurrency setup for the e2e jobs to avoid filling up gh runner pool

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -53,10 +53,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-e2e
       cancel-in-progress: true
-    strategy:
-      matrix:
-        runner: ${{ github.repository == 'usebruno/bruno' && fromJson('["self-hosted", "macOS"]') || fromJson('["macos-latest"]') }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -50,7 +50,10 @@ jobs:
   e2e-test:
     name: Playwright E2E Tests (macOS)
     timeout-minutes: 150
-    runs-on: [self-hosted, macOS]
+    runs-on: 
+      - self-hosted
+      - macos
+      - e2e
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -50,9 +50,7 @@ jobs:
   e2e-test:
     name: Playwright E2E Tests (macOS)
     timeout-minutes: 150
-    runs-on: 
-      - self-hosted
-      - macOS
+    runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -53,10 +53,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-e2e
       cancel-in-progress: true
-    runs-on: 
-      - self-hosted
-      - macOS
-      - e2e
+    strategy:
+      matrix:
+        runner: ${{ github.repository == 'usebruno/bruno' && fromJson('["self-hosted", "macOS"]') || fromJson('["macos-latest"]') }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -51,8 +51,7 @@ jobs:
     name: Playwright E2E Tests (macOS)
     timeout-minutes: 150
     runs-on: 
-      - self-hosted
-      - macos
+      - macos-latest
       - e2e
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -50,7 +50,9 @@ jobs:
   e2e-test:
     name: Playwright E2E Tests (macOS)
     timeout-minutes: 150
-    runs-on: macos-latest
+    runs-on: 
+      - self-hosted
+      - macOS
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -50,8 +50,12 @@ jobs:
   e2e-test:
     name: Playwright E2E Tests (macOS)
     timeout-minutes: 150
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-e2e
+      cancel-in-progress: true
     runs-on: 
-      - macos-latest
+      - self-hosted
+      - macOS
       - e2e
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to run macOS end-to-end jobs on a labeled self-hosted macOS runner instead of the previous hosted runner.
  * Added concurrency grouping for those CI runs with in-progress cancellations enabled.
  * No changes to public interfaces or exported entities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->