### PR TITLE
fix: preserve raw multipart/mixed body when body mode is text (#7995)

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -1,6 +1,6 @@
 const { interpolate } = require('@usebruno/common');
 const { each, forOwn, cloneDeep, find } = require('lodash');
-const { isFormData } = require('@usebruno/common').utils;
+const { shouldUseMultipartFormData } = require('@usebruno/common').utils;
 
 const isBinaryRequestBody = (data) => Buffer.isBuffer(data) || typeof data?.pipe === 'function';
 
@@ -102,7 +102,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         }));
       }
     } else if (contentType.startsWith('multipart/')) {
-      if (Array.isArray(request?.data) && !isFormData(request.data)) {
+      if (shouldUseMultipartFormData(request?.data)) {
         try {
           request.data = request?.data?.map((d) => ({
             ...d,

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -21,7 +21,7 @@ const { addDigestInterceptor, getHttpHttpsAgents, makeAxiosInstance: makeAxiosIn
 const { getCACertificates, transformProxyConfig } = require('@usebruno/requests');
 const { getOAuth2Token, getFormattedOauth2Credentials } = require('../utils/oauth2');
 const tokenStore = require('../store/tokenStore');
-const { encodeUrl, buildFormUrlEncodedPayload, extractPromptVariables, isFormData, extractBoundaryFromContentType, hasExplicitScheme } = require('@usebruno/common').utils;
+const { encodeUrl, buildFormUrlEncodedPayload, extractPromptVariables, extractBoundaryFromContentType, hasExplicitScheme, shouldUseMultipartFormData } = require('@usebruno/common').utils;
 
 const onConsoleLog = (type, args) => {
   console[type](...args);
@@ -487,7 +487,7 @@ const runSingleRequest = async function (
 
     const contentType = contentTypeHeader ? request.headers[contentTypeHeader] : '';
     if (typeof contentType === 'string' && contentType.startsWith('multipart/')) {
-      if (!isFormData(request?.data)) {
+      if (shouldUseMultipartFormData(request?.data)) {
         request._originalMultipartData = request.data;
         request.collectionPath = collectionPath;
         let form = createFormData(request.data, collectionPath);

--- a/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
+++ b/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
@@ -18,6 +18,51 @@ describe('interpolate-vars: interpolateVars', () => {
     const result = interpolateVars(request, { shouldNotApply: 'value' }, null, null);
     expect(result.data).toBe(streamPayload);
   });
+
+  // Regression coverage for https://github.com/usebruno/bruno/issues/7995
+  it('preserves raw string body when Content-Type is multipart/mixed (manually constructed multipart)', () => {
+    const rawMultipartBody = [
+      '--TestBoundary123',
+      'Content-Type: application/json',
+      '',
+      '{"test": true}',
+      '--TestBoundary123--',
+      ''
+    ].join('\r\n');
+
+    const request = {
+      method: 'POST',
+      url: 'https://httpbin.dev/post',
+      headers: { 'content-type': 'multipart/mixed; boundary=TestBoundary123' },
+      data: rawMultipartBody
+    };
+
+    const result = interpolateVars(request, {}, null, null);
+
+    expect(result.data).toBe(rawMultipartBody);
+    expect(result.data).toContain('--TestBoundary123');
+    expect(result.data).toContain('{"test": true}');
+    expect(result.data).toContain('--TestBoundary123--');
+  });
+
+  it('still interpolates per-field values when Content-Type is multipart/mixed with array data (multipartForm body mode)', () => {
+    const request = {
+      method: 'POST',
+      url: 'https://example.com/upload',
+      headers: { 'content-type': 'multipart/mixed; boundary=----mixed' },
+      data: [
+        { name: 'part1', value: '{{envVar}}', type: 'text' },
+        { name: 'part2', value: '{{another}}', type: 'text' }
+      ]
+    };
+
+    const result = interpolateVars(request, { envVar: 'first', another: 'second' }, null, null);
+
+    expect(result.data).toEqual([
+      { name: 'part1', value: 'first', type: 'text' },
+      { name: 'part2', value: 'second', type: 'text' }
+    ]);
+  });
 });
 
 describe('interpolate-vars: api key header name sidecar', () => {

--- a/packages/bruno-common/src/utils/form-data.spec.ts
+++ b/packages/bruno-common/src/utils/form-data.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType } from './form-data';
+import { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType, shouldUseMultipartFormData } from './form-data';
 import FormData from 'form-data';
 
 describe('buildFormUrlEncodedPayload', () => {
@@ -207,5 +207,72 @@ describe('extractBoundaryFromContentType', () => {
 
   it('should extract quoted boundary when other params exist', () => {
     expect(extractBoundaryFromContentType('multipart/mixed; charset=utf-8; boundary="my-boundary"')).toBe('my-boundary');
+  });
+});
+
+describe('shouldUseMultipartFormData', () => {
+  // Regression coverage for https://github.com/usebruno/bruno/issues/7995
+  // Bruno v3.2.0+ silently dropped raw multipart/mixed bodies because the multipart
+  // wrap path was entered even when request.data was already a serialized string.
+  // This predicate is the gate that prevents that.
+
+  it('returns true for an array of form fields (multipartForm body mode)', () => {
+    const data = [
+      { name: 'description', value: 'value1', type: 'text' },
+      { name: 'attachment', value: ['file.pdf'], type: 'file' }
+    ];
+    expect(shouldUseMultipartFormData(data)).toBe(true);
+  });
+
+  it('returns true for an empty array (empty multipart form is still a form)', () => {
+    expect(shouldUseMultipartFormData([])).toBe(true);
+  });
+
+  it('returns false for a raw multipart/mixed body string (text body mode)', () => {
+    const rawMultipartBody = [
+      '--TestBoundary123',
+      'Content-Type: application/json',
+      '',
+      '{"test": true}',
+      '--TestBoundary123--',
+      ''
+    ].join('\r\n');
+    expect(shouldUseMultipartFormData(rawMultipartBody)).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(shouldUseMultipartFormData('')).toBe(false);
+  });
+
+  it('returns false for a JSON-serialized string (json body mode)', () => {
+    expect(shouldUseMultipartFormData('{"a":1}')).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(shouldUseMultipartFormData(null)).toBe(false);
+    expect(shouldUseMultipartFormData(undefined)).toBe(false);
+  });
+
+  it('returns false for a plain object', () => {
+    expect(shouldUseMultipartFormData({})).toBe(false);
+    expect(shouldUseMultipartFormData({ name: 'x', value: 'y' })).toBe(false);
+  });
+
+  it('returns false for primitive numbers and booleans', () => {
+    expect(shouldUseMultipartFormData(0)).toBe(false);
+    expect(shouldUseMultipartFormData(42)).toBe(false);
+    expect(shouldUseMultipartFormData(true)).toBe(false);
+    expect(shouldUseMultipartFormData(false)).toBe(false);
+  });
+
+  it('returns false for an already-wrapped FormData instance', () => {
+    const formData = new FormData();
+    formData.append('key', 'value');
+    expect(shouldUseMultipartFormData(formData)).toBe(false);
+  });
+
+  it('returns false for a Buffer (binary body mode)', () => {
+    const buffer = Buffer.from('binary content');
+    expect(shouldUseMultipartFormData(buffer)).toBe(false);
   });
 });

--- a/packages/bruno-common/src/utils/form-data.ts
+++ b/packages/bruno-common/src/utils/form-data.ts
@@ -56,3 +56,20 @@ export const extractBoundaryFromContentType = (contentType: unknown): string | n
   const match = contentType.match(/boundary="([^"]+)"|boundary=([^;\s]+)/i);
   return match ? (match[1] || match[2]) : null;
 };
+
+/**
+ * Determines whether request data should be wrapped into a FormData instance for a
+ * multipart/* request.
+ *
+ * Wrapping is only safe when data is an array of form fields ({ name, value, ... }).
+ * For text/json/xml body modes the body is already serialized as a string; wrapping
+ * such a string would silently produce an empty FormData (lodash forEach iterates the
+ * string character-by-character, finds no matching fields, and returns an empty form),
+ * dropping the request body entirely. See https://github.com/usebruno/bruno/issues/7995.
+ *
+ * @param data The request data to inspect.
+ * @returns True if data should be wrapped in FormData, false otherwise.
+ */
+export const shouldUseMultipartFormData = (data: unknown): boolean => {
+  return Array.isArray(data) && !isFormData(data);
+};

--- a/packages/bruno-common/src/utils/index.ts
+++ b/packages/bruno-common/src/utils/index.ts
@@ -9,7 +9,8 @@ export {
 export {
   buildFormUrlEncodedPayload,
   isFormData,
-  extractBoundaryFromContentType
+  extractBoundaryFromContentType,
+  shouldUseMultipartFormData
 } from './form-data';
 
 export {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -36,7 +36,7 @@ const { cookiesStore } = require('../../store/cookies');
 const registerGrpcEventHandlers = require('./grpc-event-handlers');
 const { registerWsEventHandlers } = require('./ws-event-handlers');
 const { getCertsAndProxyConfig, buildCertsAndProxyConfig } = require('./cert-utils');
-const { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType } = require('@usebruno/common').utils;
+const { buildFormUrlEncodedPayload, extractBoundaryFromContentType, shouldUseMultipartFormData } = require('@usebruno/common').utils;
 
 const ERROR_OCCURRED_WHILE_EXECUTING_REQUEST = 'Error occurred while executing the request!';
 
@@ -607,7 +607,7 @@ const registerNetworkIpc = (mainWindow) => {
 
     const contentType = contentTypeHeader ? request.headers[contentTypeHeader] : '';
     if (typeof contentType === 'string' && contentType.startsWith('multipart/')) {
-      if (!isFormData(request.data)) {
+      if (shouldUseMultipartFormData(request.data)) {
         request._originalMultipartData = request.data;
         request.collectionPath = collectionPath;
         let form = createFormData(request.data, collectionPath);

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -1,6 +1,6 @@
 const { interpolate } = require('@usebruno/common');
 const { each, forOwn, cloneDeep } = require('lodash');
-const { isFormData } = require('@usebruno/common').utils;
+const { shouldUseMultipartFormData } = require('@usebruno/common').utils;
 
 const isBinaryRequestBody = (data) => Buffer.isBuffer(data) || typeof data?.pipe === 'function';
 
@@ -140,7 +140,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         }));
       }
     } else if (contentType.startsWith('multipart/')) {
-      if (Array.isArray(request?.data) && !isFormData(request.data)) {
+      if (shouldUseMultipartFormData(request?.data)) {
         try {
           request.data = request?.data?.map((d) => ({
             ...d,


### PR DESCRIPTION
The multipart/* content-type branch in network/index.js (Electron) and runner/run-single-request.js (CLI) was wrapping request.data into a FormData instance whenever Content-Type started with 'multipart/', regardless of body mode. When the body mode is 'text' (raw multipart payload), request.data is a string, so createFormData(string) returned an empty FormData via lodash forEach iterating over the string. That silently replaced the user's raw body with an empty form and auto-generated boundary.

Extract the multipart wrap predicate into a single helper shouldUseMultipartFormData(data) in @usebruno/common, used by both the Electron and CLI request paths and by interpolate-vars in both packages. The helper returns true only when data is an array of form fields and not already a FormData instance, matching the original intent of the guard.

Adds unit tests covering the new helper (raw string body, json string, empty string, null/undefined, plain object, primitives, Buffer, empty array, FormData instance, array of fields) and a regression test in the CLI interpolate-vars spec mirroring the existing Electron one.

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart form data handling to more accurately determine when to convert array-based request bodies into FormData format, preventing unintended serialization issues in both CLI and desktop environments.

* **Tests**
  * Added comprehensive regression test coverage for multipart form data interpolation, including scenarios with raw string bodies and structured array-based request data with per-field value interpolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->