### PR TITLE
feat(query-params): add Description column to query params table

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -114,13 +114,14 @@ const QueryParams = ({ item, collection }) => {
       key: 'name',
       name: 'Name',
       isKeyField: true,
-      width: '30%',
+      width: '25%',
       readOnly: true
     },
     {
       key: 'value',
       name: 'Value',
       placeholder: 'Value',
+      width: '40%',
       render: ({ row, value, onChange }) => (
         <MultiLineEditor
           value={value || ''}
@@ -130,6 +131,22 @@ const QueryParams = ({ item, collection }) => {
           onRun={handleRun}
           collection={collection}
           item={item}
+        />
+      )
+    },
+    {
+      key: 'description',
+      name: 'Description',
+      placeholder: 'Description',
+      render: ({ row, value }) => (
+        <input
+          type="text"
+          autoComplete="off"
+          spellCheck="false"
+          className="mousetrap"
+          value={value || ''}
+          placeholder="Description"
+          onChange={(e) => handlePathParamChange(row.uid, 'description', e.target.value)}
         />
       )
     }

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -81,12 +81,13 @@ const QueryParams = ({ item, collection }) => {
       name: 'Name',
       isKeyField: true,
       placeholder: 'Name',
-      width: '30%'
+      width: '25%'
     },
     {
       key: 'value',
       name: 'Value',
       placeholder: 'Value',
+      width: '40%',
       render: ({ value, onChange }) => (
         <MultiLineEditor
           value={value || ''}
@@ -100,6 +101,11 @@ const QueryParams = ({ item, collection }) => {
           placeholder={!value ? 'Value' : ''}
         />
       )
+    },
+    {
+      key: 'description',
+      name: 'Description',
+      placeholder: 'Description'
     }
   ];
 

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -140,6 +140,7 @@ const QueryParams = ({ item, collection }) => {
       placeholder: 'Description',
       render: ({ row, value }) => (
         <input
+          data-testid={`path-param-description-${row.uid}`}
           type="text"
           autoComplete="off"
           spellCheck="false"

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -186,11 +186,12 @@ const grammar = ohm.grammar(`Bru {
 // returning the remaining annotations untouched. Allows the GUI to render
 // per-field descriptions in a dedicated column while round-tripping cleanly.
 const extractDescription = (annotations) => {
-  if (!annotations || !annotations.length) return { description: '', remaining: [] };
-  let description = '';
+  if (!annotations || !annotations.length) return { description: undefined, remaining: [] };
+  // Track presence separately so empty string `@description('')` is preserved.
+  let description;
   const remaining = [];
   for (const ann of annotations) {
-    if (ann && ann.name === 'description' && typeof ann.value === 'string' && !description) {
+    if (ann && ann.name === 'description' && typeof ann.value === 'string' && description === undefined) {
       description = ann.value;
     } else {
       remaining.push(ann);
@@ -242,7 +243,7 @@ const mapRequestParams = (pairList = [], type) => {
     }
 
     const result = { name, value, enabled, type };
-    if (description) result.description = description;
+    if (description !== undefined) result.description = description;
     if (remaining.length) result.annotations = remaining;
     return result;
   });

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -182,6 +182,23 @@ const grammar = ohm.grammar(`Bru {
   docs = "docs" st* "{" nl* textblock tagend
 }`);
 
+// Extract @description annotation into a top-level `description` string,
+// returning the remaining annotations untouched. Allows the GUI to render
+// per-field descriptions in a dedicated column while round-tripping cleanly.
+const extractDescription = (annotations) => {
+  if (!annotations || !annotations.length) return { description: '', remaining: [] };
+  let description = '';
+  const remaining = [];
+  for (const ann of annotations) {
+    if (ann && ann.name === 'description' && typeof ann.value === 'string' && !description) {
+      description = ann.value;
+    } else {
+      remaining.push(ann);
+    }
+  }
+  return { description, remaining };
+};
+
 const mapPairListToKeyValPairs = (pairList = [], parseEnabled = true) => {
   if (!pairList.length) {
     return [];
@@ -217,6 +234,7 @@ const mapRequestParams = (pairList = [], type) => {
     let name = _.keys(pair)[0];
     let value = pair[name];
     const rawAnnotations = pair[ANNOTATIONS_KEY];
+    const { description, remaining } = extractDescription(rawAnnotations);
     let enabled = true;
     if (name && name.length && name.charAt(0) === '~') {
       name = name.slice(1);
@@ -224,7 +242,8 @@ const mapRequestParams = (pairList = [], type) => {
     }
 
     const result = { name, value, enabled, type };
-    if (rawAnnotations && rawAnnotations.length) result.annotations = rawAnnotations;
+    if (description) result.description = description;
+    if (remaining.length) result.annotations = remaining;
     return result;
   });
 };

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -10,12 +10,14 @@ const disabled = (items = [], key = 'enabled') => items.filter((item) => !item[k
 // annotation block. If description exists, it's emitted as @description("...").
 // Mirrors the extractDescription logic in bruToJson.
 const serializeItemAnnotations = (item) => {
-  const description = item && typeof item.description === 'string' ? item.description : '';
   const existing = (item && Array.isArray(item.annotations)) ? item.annotations : [];
-  if (!description) return serializeAnnotations(existing);
-  // Avoid duplicating if @description already present
+  // Presence check (not truthiness) so explicit empty-string descriptions
+  // round-trip as @description('') instead of being dropped.
+  const hasDescriptionField
+    = item && Object.prototype.hasOwnProperty.call(item, 'description') && typeof item.description === 'string';
+  if (!hasDescriptionField) return serializeAnnotations(existing);
   const hasDescAnnotation = existing.some((a) => a && a.name === 'description');
-  const merged = hasDescAnnotation ? existing : [{ name: 'description', value: description }, ...existing];
+  const merged = hasDescAnnotation ? existing : [{ name: 'description', value: item.description }, ...existing];
   return serializeAnnotations(merged);
 };
 

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -6,6 +6,19 @@ const jsonToExampleBru = require('./example/jsonToBru');
 const enabled = (items = [], key = 'enabled') => items.filter((item) => item[key]);
 const disabled = (items = [], key = 'enabled') => items.filter((item) => !item[key]);
 
+// Combine item.description (string) + item.annotations into a single serialized
+// annotation block. If description exists, it's emitted as @description("...").
+// Mirrors the extractDescription logic in bruToJson.
+const serializeItemAnnotations = (item) => {
+  const description = item && typeof item.description === 'string' ? item.description : '';
+  const existing = (item && Array.isArray(item.annotations)) ? item.annotations : [];
+  if (!description) return serializeAnnotations(existing);
+  // Avoid duplicating if @description already present
+  const hasDescAnnotation = existing.some((a) => a && a.name === 'description');
+  const merged = hasDescAnnotation ? existing : [{ name: 'description', value: description }, ...existing];
+  return serializeAnnotations(merged);
+};
+
 // remove the last line if two new lines are found
 const stripLastLine = (text) => {
   if (!text || !text.length) return text;
@@ -128,7 +141,7 @@ const jsonToBru = (json) => {
       if (enabled(queryParams).length) {
         bru += `\n${indentString(
           enabled(queryParams)
-            .map((item) => `${serializeAnnotations(item.annotations)}${getKeyString(item.name)}: ${getValueString(item.value)}`)
+            .map((item) => `${serializeItemAnnotations(item)}${getKeyString(item.name)}: ${getValueString(item.value)}`)
             .join('\n')
         )}`;
       }
@@ -136,7 +149,7 @@ const jsonToBru = (json) => {
       if (disabled(queryParams).length) {
         bru += `\n${indentString(
           disabled(queryParams)
-            .map((item) => `${serializeAnnotations(item.annotations)}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
+            .map((item) => `${serializeItemAnnotations(item)}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
             .join('\n')
         )}`;
       }
@@ -147,7 +160,7 @@ const jsonToBru = (json) => {
     if (pathParams.length) {
       bru += 'params:path {';
 
-      bru += `\n${indentString(pathParams.map((item) => `${serializeAnnotations(item.annotations)}${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      bru += `\n${indentString(pathParams.map((item) => `${serializeItemAnnotations(item)}${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
 
       bru += '\n}\n\n';
     }

--- a/packages/bruno-lang/v2/tests/annotations.spec.js
+++ b/packages/bruno-lang/v2/tests/annotations.spec.js
@@ -385,6 +385,32 @@ params:query {
     expect(bru).toContain('q: hello');
   });
 
+  it('@description("") empty string on params:query is preserved', () => {
+    const input = `
+params:query {
+  @description('')
+  q: hello
+}
+`;
+    const output = parser(input);
+    expect(output.params).toEqual([
+      { name: 'q', value: 'hello', enabled: true, type: 'query', description: '' }
+    ]);
+  });
+
+  it('empty-string description round-trip for query/path params', () => {
+    const json = {
+      params: [
+        { name: 'q', value: 'hello', enabled: true, type: 'query', description: '' },
+        { name: 'userId', value: '123', enabled: true, type: 'path', description: '' }
+      ]
+    };
+    const bru = jsonToBru(json);
+    expect(bru).toContain('@description(\'\')');
+    const parsed = parser(bru);
+    expect(parsed.params).toEqual(json.params);
+  });
+
   it('annotation on params:path block', () => {
     const input = `
 params:path {

--- a/packages/bruno-lang/v2/tests/annotations.spec.js
+++ b/packages/bruno-lang/v2/tests/annotations.spec.js
@@ -362,6 +362,29 @@ params:query {
     ]);
   });
 
+  it('@description on params:query is promoted to top-level `description` field', () => {
+    const input = `
+params:query {
+  @description('search keyword')
+  q: hello
+}
+`;
+    const output = parser(input);
+    expect(output.params).toEqual([
+      { name: 'q', value: 'hello', enabled: true, type: 'query', description: 'search keyword' }
+    ]);
+  });
+
+  it('serializeItemAnnotations — query param description round-trip', () => {
+    const json = {
+      params: [{ name: 'q', value: 'hello', enabled: true, type: 'query', description: 'search keyword' }]
+    };
+    const bru = jsonToBru(json);
+    expect(bru).toContain('params:query {');
+    expect(bru).toContain('@description(\'search keyword\')');
+    expect(bru).toContain('q: hello');
+  });
+
   it('annotation on params:path block', () => {
     const input = `
 params:path {
@@ -370,8 +393,10 @@ params:path {
 }
 `;
     const output = parser(input);
+    // @description is promoted to a dedicated `description` field so the UI
+    // can render it as a column. Other annotations stay in `annotations`.
     expect(output.params).toEqual([
-      { name: 'userId', value: '123', enabled: true, type: 'path', annotations: [{ name: 'description', value: 'user id' }] }
+      { name: 'userId', value: '123', enabled: true, type: 'path', description: 'user id' }
     ]);
   });
 


### PR DESCRIPTION
## Summary
Adds a third **Description** column to the Query Params table in the Request Pane, fulfilling the long-requested feature in #4838.

## Wiring
- **Parser** (`bruToJson`): `@description("text")` on `params:query` / `params:path` is promoted to a top-level `description` string on each param. Other annotations stay in the `annotations` array (back-compat for `@string`, `@version`, etc.).
- **Serializer** (`jsonToBru`): new `serializeItemAnnotations()` helper auto-emits `@description("...")` when an item has a `description` field and no equivalent annotation already present. Used for both `params:query` and `params:path` blocks.
- **UI** (`QueryParams/index.js`): adds `description` plain-text column next to Name/Value via the existing `EditableTable` fallback. Column widths: Name 25% / Value 40% / Description rest.

The `description` field is already part of the schema (`bruno-schema/src/collections/index.js` line 424) and the Redux `setQueryParams` reducer already preserves it — this PR just wires the parser/serializer + UI so the round-trip works end-to-end.

## Scope
Limited to `params:query` and `params:path` per the issue title. Headers, body, vars, multipart, etc. continue to use the raw annotations array. Happy to extend in follow-up PRs once this lands.

## Tests
- Updated existing `params:path` annotation test to assert the new promoted-field shape.
- Added 2 new tests verifying round-trip for `params:query` description (parse promotes → serialize emits annotation).
- All `bruno-lang` (264), `bruno-schema` (22), and `bruno-filestore` (11) tests still pass — 297 total.

## Screenshot
_To be added by reviewer or maintainer after `npm run dev:web` in `packages/bruno-app`._

Closes #4838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parameter descriptions for query and path params are now supported end-to-end: editable in the request UI and preserved through parsing and serialization.

* **User Interface**
  * Request parameter table column widths adjusted for readability and a new editable Description column added for query and path params.

* **Tests**
  * Added and updated tests to ensure description values (including empty strings) round-trip correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->