### PR TITLE
Fix/pm.set next request(null) not translating

### DIFF
--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -15,12 +15,9 @@ const replacements = {
   // 'pm\\.collectionVariables\\.unset\\(': 'bru.deleteCollectionVar(',
   // 'pm\\.collectionVariables\\.clear\\(': 'bru.deleteAllCollectionVars(',
   // 'pm\\.collectionVariables\\.toObject\\(': 'bru.getAllCollectionVars(',
-  // More specific patterns must come before the general pm.setNextRequest( rule.
-  // Passing null/'null' to Postman's setNextRequest stops the runner; Bruno's
-  // bru.setNextRequest(null) does not — only bru.runner.stopExecution() does.
   'pm\\.setNextRequest\\(null\\)': 'bru.runner.stopExecution()',
   'pm\\.setNextRequest\\([\'\"]null[\'\"]\\)': 'bru.runner.stopExecution()',
-  'pm\\.setNextRequest\\(': 'bru.setNextRequest(',
+  'pm\\.setNextRequest\\(': 'bru.runner.setNextRequest(',
   'pm\\.test\\(': 'test(',
   'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
   'pm\\.response\\.to\\.have\\.status\\(': 'expect(res.getStatus()).to.equal(',

--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -15,6 +15,11 @@ const replacements = {
   // 'pm\\.collectionVariables\\.unset\\(': 'bru.deleteCollectionVar(',
   // 'pm\\.collectionVariables\\.clear\\(': 'bru.deleteAllCollectionVars(',
   // 'pm\\.collectionVariables\\.toObject\\(': 'bru.getAllCollectionVars(',
+  // More specific patterns must come before the general pm.setNextRequest( rule.
+  // Passing null/'null' to Postman's setNextRequest stops the runner; Bruno's
+  // bru.setNextRequest(null) does not — only bru.runner.stopExecution() does.
+  'pm\\.setNextRequest\\(null\\)': 'bru.runner.stopExecution()',
+  'pm\\.setNextRequest\\([\'\"]null[\'\"]\\)': 'bru.runner.stopExecution()',
   'pm\\.setNextRequest\\(': 'bru.setNextRequest(',
   'pm\\.test\\(': 'test(',
   'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',

--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -15,8 +15,9 @@ const replacements = {
   // 'pm\\.collectionVariables\\.unset\\(': 'bru.deleteCollectionVar(',
   // 'pm\\.collectionVariables\\.clear\\(': 'bru.deleteAllCollectionVars(',
   // 'pm\\.collectionVariables\\.toObject\\(': 'bru.getAllCollectionVars(',
+  // Only the actual null literal stops the runner; the string 'null' is a valid
+  // request name and falls through to setNextRequest.
   'pm\\.setNextRequest\\(null\\)': 'bru.runner.stopExecution()',
-  'pm\\.setNextRequest\\([\'\"]null[\'\"]\\)': 'bru.runner.stopExecution()',
   'pm\\.setNextRequest\\(': 'bru.runner.setNextRequest(',
   'pm\\.test\\(': 'test(',
   'pm.response.to.have\\.status\\(': 'expect(res.getStatus()).to.equal(',
@@ -128,8 +129,9 @@ const replacements = {
   'postman\\.clearEnvironmentVariable\\(': 'bru.deleteEnvVar(',
   'pm\\.execution\\.skipRequest\\(\\)': 'bru.runner.skipRequest()',
   'pm\\.execution\\.skipRequest': 'bru.runner.skipRequest',
+  // Only the actual null literal stops the runner; the string 'null' falls through to setNextRequest.
   'pm\\.execution\\.setNextRequest\\(null\\)': 'bru.runner.stopExecution()',
-  'pm\\.execution\\.setNextRequest\\(\'null\'\\)': 'bru.runner.stopExecution()',
+  'pm\\.execution\\.setNextRequest\\(': 'bru.runner.setNextRequest(',
   // Cookie jar translations — order matters:
   // 1. Specific jar method patterns must come before the general jar() pattern,
   //    otherwise jar() consumes the prefix and the method patterns never match.

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -41,9 +41,6 @@ const simpleTranslations = {
   // 'pm.collectionVariables.clear': 'bru.deleteAllCollectionVars',
   // 'pm.collectionVariables.toObject': 'bru.getAllCollectionVars',
 
-  // Request flow control
-  'pm.setNextRequest': 'bru.setNextRequest',
-
   // Testing
   'pm.test': 'test',
   'pm.expect': 'expect',
@@ -266,6 +263,29 @@ const complexTransformations = [
       );
     }
   })),
+
+  // Handle pm.setNextRequest(null) / pm.setNextRequest('null') — stop the runner
+  {
+    pattern: 'pm.setNextRequest',
+    transform: (path, j) => {
+      const callExpr = path.parent.value;
+      const args = callExpr.arguments;
+
+      if (
+        args[0] && args[0].type === 'Literal' && (args[0].value === null || args[0].value === 'null')
+      ) {
+        return j.callExpression(
+          j.identifier('bru.runner.stopExecution'),
+          []
+        );
+      }
+
+      return j.callExpression(
+        j.identifier('bru.setNextRequest'),
+        args
+      );
+    }
+  },
 
   // Handle pm.execution.setNextRequest(null)
   {

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -264,16 +264,16 @@ const complexTransformations = [
     }
   })),
 
-  // Handle pm.setNextRequest(null) / pm.setNextRequest('null') — stop the runner
+  // Handle pm.setNextRequest(null) — stop the runner.
+  // Note: the string 'null' is a valid request name in Postman, so only the
+  // actual null literal triggers stopExecution(); 'null' falls through to setNextRequest.
   {
     pattern: 'pm.setNextRequest',
     transform: (path, j) => {
       const callExpr = path.parent.value;
       const args = callExpr.arguments;
 
-      if (
-        args[0] && args[0].type === 'Literal' && (args[0].value === null || args[0].value === 'null')
-      ) {
+      if (args[0] && args[0].type === 'Literal' && args[0].value === null) {
         return j.callExpression(
           j.identifier('bru.runner.stopExecution'),
           []
@@ -287,7 +287,7 @@ const complexTransformations = [
     }
   },
 
-  // Handle pm.execution.setNextRequest(null)
+  // Handle pm.execution.setNextRequest(null) — same null-vs-'null' rule as above.
   {
     pattern: 'pm.execution.setNextRequest',
     transform: (path, j) => {
@@ -295,10 +295,9 @@ const complexTransformations = [
 
       const args = callExpr.arguments;
 
-      // If argument is null or 'null', transform to bru.runner.stopExecution()
-      if (
-        args[0].type === 'Literal' && (args[0].value === null || args[0].value === 'null')
-      ) {
+      // Only the actual null literal triggers stopExecution(); the string 'null'
+      // is a valid request name and falls through to setNextRequest.
+      if (args[0] && args[0].type === 'Literal' && args[0].value === null) {
         return j.callExpression(
           j.identifier('bru.runner.stopExecution'),
           []

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -281,7 +281,7 @@ const complexTransformations = [
       }
 
       return j.callExpression(
-        j.identifier('bru.setNextRequest'),
+        j.identifier('bru.runner.setNextRequest'),
         args
       );
     }

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -288,29 +288,6 @@ const complexTransformations = [
     }
   },
 
-  // Handle pm.execution.setNextRequest(null) — same null-vs-'null' rule as above.
-  {
-    pattern: 'pm.setNextRequest',
-    transform: (path, j) => {
-      const callExpr = path.parent.value;
-      const args = callExpr.arguments;
-
-      // Only the actual null literal triggers stopExecution(); the string 'null'
-      // is a valid request name and falls through to setNextRequest.
-      if (args[0] && args[0].type === 'Literal' && args[0].value === null) {
-        return j.callExpression(
-          j.identifier('bru.runner.stopExecution'),
-          []
-        );
-      }
-
-      return j.callExpression(
-        j.identifier('bru.runner.setNextRequest'),
-        args
-      );
-    }
-  },
-
   // Handle pm.execution.setNextRequest(null)
   {
     pattern: 'pm.execution.setNextRequest',
@@ -321,7 +298,7 @@ const complexTransformations = [
 
       // If argument is null or 'null', transform to bru.runner.stopExecution()
       if (
-        args[0].type === 'Literal' && (args[0].value === null || args[0].value === 'null')
+        args[0] && args[0].type === 'Literal' && (args[0].value === null)
       ) {
         return j.callExpression(
           j.identifier('bru.runner.stopExecution'),

--- a/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/execution.test.js
+++ b/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/execution.test.js
@@ -14,6 +14,12 @@ describe('Bruno to Postman Execution Control Translation', () => {
     expect(translatedCode).toBe('pm.execution.setNextRequest("Create Order");');
   });
 
+  it('should preserve the string "null" as a request name when translating bru.runner.setNextRequest("null")', () => {
+    const code = 'bru.runner.setNextRequest("null");';
+    const translatedCode = translateBruToPostman(code);
+    expect(translatedCode).toBe('pm.execution.setNextRequest("null");');
+  });
+
   // skipRequest translation
   it('should translate bru.runner.skipRequest', () => {
     const code = 'bru.runner.skipRequest();';

--- a/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/execution.test.js
+++ b/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/execution.test.js
@@ -79,7 +79,7 @@ const status = res.getStatus();
 const data = res.getBody();
 
 if (status === 200 && data.hasMore) {
-    bru.setNextRequest("Fetch Next Page");
+    bru.runner.setNextRequest("Fetch Next Page");
 } else if (status === 429) {
     console.log("Rate limited, skipping");
     bru.runner.skipRequest();

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
@@ -5,7 +5,7 @@ describe('Execution Flow Translation', () => {
   it('should translate pm.setNextRequest', () => {
     const code = 'pm.setNextRequest("Get User Details");';
     const translatedCode = translateCode(code);
-    expect(translatedCode).toBe('bru.setNextRequest("Get User Details");');
+    expect(translatedCode).toBe('bru.runner.setNextRequest("Get User Details");');
   });
 
   it('should translate pm.setNextRequest(null) to bru.runner.stopExecution()', () => {
@@ -18,6 +18,12 @@ describe('Execution Flow Translation', () => {
     const code = 'pm.setNextRequest("null");';
     const translatedCode = translateCode(code);
     expect(translatedCode).toBe('bru.runner.stopExecution();');
+  });
+
+  it('should keep pm.setNextRequest(<request name>) as bru.setNextRequest(<request name>) for non-null arguments', () => {
+    const code = 'pm.setNextRequest("Get User Details");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.runner.setNextRequest("Get User Details");');
   });
 
   it('should translate pm.execution.skipRequest', () => {
@@ -71,6 +77,6 @@ describe('Execution Flow Translation', () => {
     expect(translatedCode).toContain('} else if (res.getStatus() === 500) {');
     expect(translatedCode).toContain('bru.runner.stopExecution();');
     expect(translatedCode).toContain('} else {');
-    expect(translatedCode).toContain('bru.setNextRequest("Get User Details");');
+    expect(translatedCode).toContain('bru.runner.setNextRequest("Get User Details");');
   });
 });

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
@@ -14,10 +14,10 @@ describe('Execution Flow Translation', () => {
     expect(translatedCode).toBe('bru.runner.stopExecution();');
   });
 
-  it('should translate pm.setNextRequest("null") to bru.runner.stopExecution()', () => {
+  it('should translate pm.setNextRequest("null") to bru.runner.setNextRequest("null") (string is a valid request name)', () => {
     const code = 'pm.setNextRequest("null");';
     const translatedCode = translateCode(code);
-    expect(translatedCode).toBe('bru.runner.stopExecution();');
+    expect(translatedCode).toBe('bru.runner.setNextRequest("null");');
   });
 
   it('should keep pm.setNextRequest(<request name>) as bru.setNextRequest(<request name>) for non-null arguments', () => {
@@ -38,10 +38,10 @@ describe('Execution Flow Translation', () => {
     expect(translatedCode).toBe('bru.runner.stopExecution();');
   });
 
-  it('should translate pm.execution.setNextRequest("null")', () => {
+  it('should translate pm.execution.setNextRequest("null") to bru.runner.setNextRequest("null") (string is a valid request name)', () => {
     const code = 'pm.execution.setNextRequest("null");';
     const translatedCode = translateCode(code);
-    expect(translatedCode).toBe('bru.runner.stopExecution();');
+    expect(translatedCode).toBe('bru.runner.setNextRequest("null");');
   });
 
   it('should handle pm.execution.setNextRequest with non-null parameters', () => {

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
@@ -44,6 +44,18 @@ describe('Execution Flow Translation', () => {
     expect(translatedCode).toBe('bru.runner.setNextRequest("null");');
   });
 
+  it('should translate pm.execution.setNextRequest("req1") to bru.runner.setNextRequest("req1")', () => {
+    const code = 'pm.execution.setNextRequest("req1");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.runner.setNextRequest("req1");');
+  });
+
+  it('should translate pm.execution.setNextRequest() with no arguments to bru.runner.setNextRequest()', () => {
+    const code = 'pm.execution.setNextRequest();';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.runner.setNextRequest();');
+  });
+
   it('should handle pm.execution.setNextRequest with non-null parameters', () => {
     const code = `
         // Continue normal flow

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/exec-flow.test.js
@@ -8,6 +8,18 @@ describe('Execution Flow Translation', () => {
     expect(translatedCode).toBe('bru.setNextRequest("Get User Details");');
   });
 
+  it('should translate pm.setNextRequest(null) to bru.runner.stopExecution()', () => {
+    const code = 'pm.setNextRequest(null);';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.runner.stopExecution();');
+  });
+
+  it('should translate pm.setNextRequest("null") to bru.runner.stopExecution()', () => {
+    const code = 'pm.setNextRequest("null");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.runner.stopExecution();');
+  });
+
   it('should translate pm.execution.skipRequest', () => {
     const code = 'if (condition) pm.execution.skipRequest();';
     const translatedCode = translateCode(code);

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/postman-references.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/postman-references.test.js
@@ -71,9 +71,9 @@ describe('Postman to PM References Conversion', () => {
     const translatedCode = translateCode(code);
     expect(translatedCode).toContain('if (bru.getEnvVar("isProduction") === "true") {');
     expect(translatedCode).toContain('const apiUrl = bru.getEnvVar("prodUrl");');
-    expect(translatedCode).toContain('bru.setNextRequest("Production Flow");');
+    expect(translatedCode).toContain('bru.runner.setNextRequest("Production Flow");');
     expect(translatedCode).toContain('const apiUrl = bru.getEnvVar("devUrl");');
-    expect(translatedCode).toContain('bru.setNextRequest("Development Flow");');
+    expect(translatedCode).toContain('bru.runner.setNextRequest("Development Flow");');
   });
 
   // Legacy response handling


### PR DESCRIPTION
**Jira link: https://usebruno.atlassian.net/browse/BRU-3093**
### Description

Fixes a bug where the Postman → Bruno translator treated the string `"null"` the same as the `null` literal when converting `pm.setNextRequest` / `pm.execution.setNextRequest`. Since `"null"` is a valid Postman request name, code like `pm.setNextRequest("null")` should be translated to `bru.runner.setNextRequest("null")`, not `bru.runner.stopExecution()` — only the actual `null` literal stops the runner.

**Changes**

- `packages/bruno-converters/src/utils/postman-to-bruno-translator.js` — tightened the null check in both `pm.setNextRequest` and `pm.execution.setNextRequest` AST transforms so only the actual `null` literal triggers `bru.runner.stopExecution()`. Also added a guard for empty argument lists.
- `packages/bruno-converters/src/postman/postman-translations.js` — removed the obsolete regex mappings that incorrectly matched the string `"null"`, and added a fallthrough regex for `pm.execution.setNextRequest(` so other arguments still translate via the regex path.

**Tests**

- Updated two stale assertions in `exec-flow.test.js` that expected the old (incorrect) behavior.
- Added a Bruno → Postman test confirming `bru.runner.setNextRequest("null")` round-trips correctly.

| Input | Before | After |
|---|---|---|
| `pm.setNextRequest(null)` | `bru.runner.stopExecution()` | unchanged |
| `pm.setNextRequest("null")` | `bru.runner.stopExecution()` ❌ | `bru.runner.setNextRequest("null")` ✓ |
| `pm.execution.setNextRequest(null)` | `bru.runner.stopExecution()` | unchanged |
| `pm.execution.setNextRequest("null")` | `bru.runner.stopExecution()` ❌ | `bru.runner.setNextRequest("null")` ✓ |


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix conversion logic so only a literal null stops execution; the string "null" is preserved as a request name and forwarded for normal chaining.

* **Tests**
  * Added and updated tests to validate correct handling of null vs. string "null" in execution flow translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->