### PR TITLE
docs(cli): fix Docker Hub overview rendering — absolute README links + restructure Step 3 blockquotes

### DIFF
--- a/packages/bruno-cli/docker/README.md
+++ b/packages/bruno-cli/docker/README.md
@@ -31,8 +31,8 @@ docker pull ghcr.io/usebruno/cli:latest
 
 | Variant | Base image | Details |
 |---------|-----------|---------|
-| **Alpine** (default) | `node:22-alpine` | [→ Alpine README](./images/alpine/README.md) |
-| **Debian** | `node:22-slim` | [→ Debian README](./images/debian/README.md) |
+| **Alpine** (default) | `node:22-alpine` | [→ Alpine README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/alpine/README.md) |
+| **Debian** | `node:22-slim` | [→ Debian README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/debian/README.md) |
 
 ### Quick choice
 
@@ -105,10 +105,9 @@ docker run --rm usebruno/cli --version
 ### Step 3 — Run your collection
 
 > These examples assume you are running `docker` from your Bruno collection directory. Mount that directory to `/bruno` and pass `bru` arguments directly after the image name. If your collection lives elsewhere on disk, see the path-based examples further down.
-> **Cross-platform note:** the examples below use `$(pwd)` which works in Bash / Zsh / Git Bash / WSL.
-> On Windows native shells, substitute `$(pwd)` with:
-> - PowerShell: `${PWD}`
-> - CMD: `%cd%`
+
+> **Cross-platform note:** the examples below use `$(pwd)` which works in Bash / Zsh / Git Bash / WSL. On Windows native shells, substitute `$(pwd)` with `${PWD}` (PowerShell) or `%cd%` (CMD).
+
 > **Adding `bru` options:** The examples below show docker-specific flags. For all `bru run` options — recurse (`-r`), environments, variables, reporters, bail, and more — see the [Bruno CLI docs](https://docs.usebruno.com/bru-cli/overview).
 
 ```bash
@@ -197,14 +196,14 @@ docker run -v $(pwd):/bruno usebruno/cli:3.3.0-debian run
 
 ### Alpine variant
 
-See [Alpine README](./images/alpine/README.md) for:
+See [Alpine README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/alpine/README.md) for:
 - Building the Alpine image
 - When to use Alpine
 - Variant-specific options
 
 ### Debian variant
 
-See [Debian README](./images/debian/README.md) for:
+See [Debian README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/debian/README.md) for:
 - Building the Debian image
 - When to use Debian
 - Compatibility notes
@@ -284,7 +283,7 @@ The `/path/to/reports:/reports` mount catches the JSON, JUnit XML, and HTML repo
 
 ### Try it from this repo
 
-A ready-to-run `docker-compose.yml` lives in this repo at [`packages/bruno-tests/docker-compose.yml`](../../bruno-tests/docker-compose.yml). It mounts the sibling `collection/` directory into the container, runs the `echo` folder against the `Prod` environment, and writes JSON, JUnit XML, and HTML reports into `packages/bruno-tests/reports/`:
+A ready-to-run `docker-compose.yml` lives in this repo at [`packages/bruno-tests/docker-compose.yml`](https://github.com/usebruno/bruno/blob/main/packages/bruno-tests/docker-compose.yml). It mounts the sibling `collection/` directory into the container, runs the `echo` folder against the `Prod` environment, and writes JSON, JUnit XML, and HTML reports into `packages/bruno-tests/reports/`:
 
 ```bash
 cd packages/bruno-tests


### PR DESCRIPTION
## Summary

Two rendering bugs in the Docker Hub overview (the README at `packages/bruno-cli/docker/README.md` that gets synced via `peter-evans/dockerhub-description`). Both render correctly on GitHub but break on Docker Hub due to differences in the Markdown renderer.

### Issue 1 — Broken relative README links

The Variants table and "Usage by variant" section linked to `./images/alpine/README.md` etc. GitHub resolves the relative path against the file's location in the repo. Docker Hub has no concept of the repo tree, so the links 404.

**Fix:** switched to absolute `https://github.com/usebruno/bruno/blob/main/...` URLs for all four affected links (Alpine README × 2, Debian README × 2, and the `packages/bruno-tests/docker-compose.yml` link in the Docker Compose section). Absolute URLs resolve correctly in both contexts.

### Issue 2 — Step 3 blockquote bullets merged with the next paragraph

The Step 3 intro was a single multi-line blockquote containing a paragraph, a sub-list (`PowerShell` / `CMD` options), and another paragraph (the "Adding `bru` options" note). GitHub's CommonMark closes the list at the next paragraph; Docker Hub's renderer keeps the list open and absorbed the "Adding `bru` options" note into the last `- CMD:` bullet.

**Fix:** split the single blockquote into three discrete blockquotes (separated by blank lines) and inlined the PowerShell/CMD options into prose to dodge the fragile list-in-blockquote rendering. Both renderers handle the new structure identically.

Tracks: BRU-1220 (follow-up polish to merged PR #8036)

## Test plan

- [ ] After merge + next Docker image release, verify Docker Hub overview shows the Alpine/Debian README links as working hyperlinks
- [ ] After merge + next release, verify Step 3 in the Docker Hub overview shows three discrete note panels (no list-bleed)
- [ ] Confirm GitHub render of `packages/bruno-cli/docker/README.md` still looks correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Docker setup documentation with updated internal variant links now pointing to GitHub-hosted resources for improved reliability and accessibility across all image types
  * Expanded cross-platform compatibility guidance with explicit Windows shell substitution examples to clarify directory path variable handling on Windows systems
  * Improved docker-compose example references with updated GitHub-hosted links for consistent resource access

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->