### PR TITLE
docs(cli): polish Docker Hub README rendering — absolute links, blockquote restructure, streamline steps

### DIFF
--- a/packages/bruno-cli/docker/README.md
+++ b/packages/bruno-cli/docker/README.md
@@ -2,22 +2,6 @@
 
 Official Docker images for [Bruno CLI](https://www.usebruno.com), enabling container-native API collection runs in CI/CD pipelines and local environments without requiring Node.js or npm on the host. See the [Bruno CLI docs](https://docs.usebruno.com/bru-cli/overview) for CLI usage.
 
-## Folder structure
-
-```text
-docker/
-  ├── README.md           ← you are here
-  └── images/
-      ├── alpine/
-      │   ├── Dockerfile  ← Alpine Linux variant
-      │   └── README.md
-      └── debian/
-          ├── Dockerfile  ← Debian slim variant (glibc support)
-          └── README.md
-```
-
----
-
 ## Registries
 
 ```bash

--- a/packages/bruno-cli/docker/README.md
+++ b/packages/bruno-cli/docker/README.md
@@ -9,10 +9,10 @@ docker/
   ├── README.md           ← you are here
   └── images/
       ├── alpine/
-      │   ├── Dockerfile  ← Alpine Linux variant (smallest, ~141MB)
+      │   ├── Dockerfile  ← Alpine Linux variant
       │   └── README.md
       └── debian/
-          ├── Dockerfile  ← Debian slim variant (~162MB, glibc support)
+          ├── Dockerfile  ← Debian slim variant (glibc support)
           └── README.md
 ```
 
@@ -94,7 +94,7 @@ docker pull usebruno/cli:3.3.0-debian
 
 ---
 
-### Step 2 — Check it works
+#### Check it works
 
 ```bash
 docker run --rm usebruno/cli --version
@@ -102,7 +102,7 @@ docker run --rm usebruno/cli --version
 
 ---
 
-### Step 3 — Run your collection
+### Step 2 — Run your collection
 
 > These examples assume you are running `docker` from your Bruno collection directory. Mount that directory to `/bruno` and pass `bru` arguments directly after the image name. If your collection lives elsewhere on disk, see the path-based examples further down.
 
@@ -143,72 +143,13 @@ docker run -v /path/to/your/collection:/bruno usebruno/cli run ./auth/login.bru
 ```
 
 > **Note on `--rm`:** Examples below include `--rm`. Docker keeps stopped containers around after they exit, which lets you `docker logs` or `docker inspect` them later for debugging. If you'd rather have Docker auto-delete the container as soon as `bru` finishes — useful for CI runs or to avoid `docker ps -a` filling up with stale entries — append `--rm` to any `docker run` (or `docker compose run`) command:
->
-> ```bash
-> docker run --rm -v $(pwd):/bruno usebruno/cli run
-> ```
->
+
+```bash
+docker run --rm -v $(pwd):/bruno usebruno/cli run
+```
+
 > It's purely a cleanup convenience; it doesn't affect the image, mounts, stdout output, or exit code.
 
----
-
-### Step 4 — Choose your environment
-
-```bash
-docker run -v $(pwd):/bruno usebruno/cli run --env local
-docker run -v $(pwd):/bruno usebruno/cli run --env staging
-docker run -v $(pwd):/bruno usebruno/cli run --env production
-```
-
----
-
-### Step 5 — Pin the right version
-
-```bash
-# exact version — safest for production, no surprise updates
-docker run -v $(pwd):/bruno usebruno/cli:3.3.0 run
-
-# major.minor — gets patch fixes automatically
-docker run -v $(pwd):/bruno usebruno/cli:3.3 run
-
-# latest — always newest, not recommended for production CI
-docker run -v $(pwd):/bruno usebruno/cli:latest run
-```
-
----
-
-### Step 6 — Choose alpine or debian
-
-```bash
-# alpine (default) — use this for most cases
-docker run -v $(pwd):/bruno usebruno/cli:3.3.0 run
-
-# alpine — explicitly use the alpine-based image variant
-docker run -v $(pwd):/bruno usebruno/cli:3.3.0-alpine run
-
-# debian — use if you hit SSL, glibc, or native module issues
-docker run -v $(pwd):/bruno usebruno/cli:3.3.0-debian run
-```
-
----
-
-## Usage by variant
-
-### Alpine variant
-
-See [Alpine README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/alpine/README.md) for:
-- Building the Alpine image
-- When to use Alpine
-- Variant-specific options
-
-### Debian variant
-
-See [Debian README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/debian/README.md) for:
-- Building the Debian image
-- When to use Debian
-- Compatibility notes
-
----
 
 ## CI/CD integration
 

--- a/packages/bruno-cli/docker/README.md
+++ b/packages/bruno-cli/docker/README.md
@@ -31,8 +31,8 @@ docker pull ghcr.io/usebruno/cli:latest
 
 | Variant | Base image | Details |
 |---------|-----------|---------|
-| **Alpine** (default) | `node:22-alpine` | [→ Alpine README](./images/alpine/README.md) |
-| **Debian** | `node:22-slim` | [→ Debian README](./images/debian/README.md) |
+| **Alpine** (default) | `node:22-alpine` | [→ Alpine README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/alpine/README.md) |
+| **Debian** | `node:22-slim` | [→ Debian README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/debian/README.md) |
 
 ### Quick choice
 
@@ -105,10 +105,9 @@ docker run --rm usebruno/cli --version
 ### Step 3 — Run your collection
 
 > These examples assume you are running `docker` from your Bruno collection directory. Mount that directory to `/bruno` and pass `bru` arguments directly after the image name. If your collection lives elsewhere on disk, see the path-based examples further down.
-> **Cross-platform note:** the examples below use `$(pwd)` which works in Bash / Zsh / Git Bash / WSL.
-> On Windows native shells, substitute `$(pwd)` with:
-> - PowerShell: `${PWD}`
-> - CMD: `%cd%`
+
+> **Cross-platform note:** the examples below use `$(pwd)` which works in Bash / Zsh / Git Bash / WSL. On Windows native shells, substitute `$(pwd)` with `${PWD}` (PowerShell) or `%cd%` (CMD).
+
 > **Adding `bru` options:** The examples below show docker-specific flags. For all `bru run` options — recurse (`-r`), environments, variables, reporters, bail, and more — see the [Bruno CLI docs](https://docs.usebruno.com/bru-cli/overview).
 
 ```bash
@@ -197,14 +196,14 @@ docker run -v $(pwd):/bruno usebruno/cli:3.3.0-debian run
 
 ### Alpine variant
 
-See [Alpine README](./images/alpine/README.md) for:
+See [Alpine README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/alpine/README.md) for:
 - Building the Alpine image
 - When to use Alpine
 - Variant-specific options
 
 ### Debian variant
 
-See [Debian README](./images/debian/README.md) for:
+See [Debian README](https://github.com/usebruno/bruno/blob/main/packages/bruno-cli/docker/images/debian/README.md) for:
 - Building the Debian image
 - When to use Debian
 - Compatibility notes
@@ -284,7 +283,7 @@ The `/path/to/reports:/reports` mount catches the JSON, JUnit XML, and HTML repo
 
 ### Try it from this repo
 
-A ready-to-run `docker-compose.yml` lives in this repo at [`packages/bruno-tests/docker-compose.yml`](../../bruno-tests/docker-compose.yml). It mounts the sibling `collection/` directory into the container, runs the `echo` folder against the `Prod` environment, and writes JSON, JUnit XML, and HTML reports into `packages/bruno-tests/reports/`:
+A ready-to-run `docker-compose.yml` lives in this repo at [`packages/bruno-tests/docker-compose.yml`](https://github.com/usebruno/bruno/blob/main/packages/bruno-tests/docker-compose.yml). It mounts the sibling `collection/` directory into the container, runs the `echo` folder against the `Prod` environment, and writes JSON, JUnit XML, and HTML reports into `packages/bruno-tests/reports/`:
 
 ```bash
 cd packages/bruno-tests


### PR DESCRIPTION
## Summary

Polish pass on `packages/bruno-cli/docker/README.md` (the README synced to Docker Hub via `peter-evans/dockerhub-description`). Three groups of changes, all driven by rendering bugs / clutter visible only on the published Docker Hub overview — GitHub renders the source file correctly already.

### 1. Broken relative README links → absolute GitHub URLs

The Variants table, the "Usage by variant" section, and the "Try it from this repo" docker-compose link all used relative paths like `./images/alpine/README.md` and `../../bruno-tests/docker-compose.yml`. GitHub resolves these against the file's location in the repo. Docker Hub has no concept of the repo tree, so the links 404.

**Fix:** swapped all four relative links to absolute `https://github.com/usebruno/bruno/blob/main/...` URLs. Both renderers resolve absolute URLs correctly.

### 2. Step 3 (now Step 2) — blockquote bullet bleed + `--rm` note panel

The Step 3 intro was one multi-line blockquote containing a paragraph, a sub-list (PowerShell / CMD options), and another paragraph (the "Adding `bru` options" note). GitHub closes the list at the next paragraph; Docker Hub's renderer kept the list open and absorbed "Adding `bru` options" into the last `- CMD:` bullet.

The `--rm` note panel had the same fragility — a fenced code block nested inside a `> `-prefixed blockquote, which Docker Hub re-flowed.

**Fix:**
- Split the Step 2 intro blockquote into three discrete blockquotes (separated by blank lines), and inlined the PowerShell / CMD options as prose to dodge list-in-blockquote rendering entirely.
- Pulled the `--rm` example code block OUT of the `--rm` note blockquote, so the structure is now: blockquote → fenced code block → blockquote. Both renderers handle this cleanly.

### 3. Step-by-step section streamlining

Trimmed the step-by-step guide to focus on docker-specific usage. Removed the bru-flag-only steps (Choose environment, Pin version, Choose alpine or debian) since those are covered by the "Adding `bru` options" pointer to the CLI docs and the Tags / Variants tables higher up. "Check it works" downgraded to a `####` subsection under Step 1 to reflect that it's a sanity probe, not a full numbered step.

Final shape: **Step 1 — Pull the image** → *Check it works* → **Step 2 — Run your collection** → CI/CD → Docker Compose → Image details → Versioning.

Tracks: BRU-1220 (follow-up polish to merged PR #8036)

## Test plan

- [ ] After merge + next Docker image release, verify Docker Hub overview shows the Alpine / Debian README links as working hyperlinks
- [ ] After merge + next release, verify Step 2 in the Docker Hub overview shows three discrete note panels (no list-bleed into "Adding `bru` options")
- [ ] After merge + next release, verify the `--rm` note panel renders cleanly with the example code block inline
- [ ] Confirm GitHub render of `packages/bruno-cli/docker/README.md` still looks correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the Docker step-by-step guide and added a new "Check it works" subsection with a runnable example.
  * Clarified cross-platform instructions using inline Windows shell suggestions.
  * Updated variant references and replaced relative compose links with absolute GitHub URLs for clearer external references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->