### PR TITLE
fix: varinfo drag-select dismiss

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -942,9 +942,9 @@ if (!SERVER_RENDERED) {
       CodeMirror.off(popup, 'mouseout', onMouseOut);
       CodeMirror.off(popup, 'click', onPopupClick);
       CodeMirror.off(cm.getWrapperElement(), 'mouseout', onMouseOut);
-      document.removeEventListener('mousedown', onDocumentMouseDown, true);
       CodeMirror.off(document, 'click', onDocumentClick);
       CodeMirror.off(cm, 'change', onEditorChange);
+      document.removeEventListener('mousedown', onDocumentMouseDown, true);
 
       // Cleanup CodeMirror and MaskedEditor instances
       const valueContainer = popup.querySelector('.var-value-container');

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -890,6 +890,7 @@ if (!SERVER_RENDERED) {
     let popupTimeout;
     let isPinned = false;
     let isHidden = false;
+    let mouseDownInsidePopup = false;
 
     const onMouseOverPopup = function () {
       clearTimeout(popupTimeout);
@@ -911,7 +912,18 @@ if (!SERVER_RENDERED) {
       clearTimeout(popupTimeout);
     };
 
+    const onDocumentMouseDown = function (e) {
+      mouseDownInsidePopup = popup.contains(e.target);
+    };
+
     const onDocumentClick = function (e) {
+      if (mouseDownInsidePopup) {
+        mouseDownInsidePopup = false;
+        return;
+      }
+      if (popup.contains(document.activeElement)) {
+        return;
+      }
       if (!popup.contains(e.target)) {
         isPinned = false;
         hidePopup();
@@ -930,6 +942,7 @@ if (!SERVER_RENDERED) {
       CodeMirror.off(popup, 'mouseout', onMouseOut);
       CodeMirror.off(popup, 'click', onPopupClick);
       CodeMirror.off(cm.getWrapperElement(), 'mouseout', onMouseOut);
+      document.removeEventListener('mousedown', onDocumentMouseDown, true);
       CodeMirror.off(document, 'click', onDocumentClick);
       CodeMirror.off(cm, 'change', onEditorChange);
 
@@ -993,6 +1006,7 @@ if (!SERVER_RENDERED) {
     CodeMirror.on(popup, 'mouseout', onMouseOut);
     CodeMirror.on(popup, 'click', onPopupClick);
     CodeMirror.on(cm.getWrapperElement(), 'mouseout', onMouseOut);
+    // document.addEventListener('mousedown', onDocumentMouseDown, true);
     CodeMirror.on(document, 'click', onDocumentClick);
     CodeMirror.on(cm, 'change', onEditorChange);
   }

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -915,6 +915,7 @@ if (!SERVER_RENDERED) {
       if (popup.contains(document.activeElement)) {
         return;
       }
+
       if (!popup.contains(e.target)) {
         isPinned = false;
         hidePopup();

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -890,7 +890,6 @@ if (!SERVER_RENDERED) {
     let popupTimeout;
     let isPinned = false;
     let isHidden = false;
-    let mouseDownInsidePopup = false;
 
     const onMouseOverPopup = function () {
       clearTimeout(popupTimeout);
@@ -912,15 +911,7 @@ if (!SERVER_RENDERED) {
       clearTimeout(popupTimeout);
     };
 
-    const onDocumentMouseDown = function (e) {
-      mouseDownInsidePopup = popup.contains(e.target);
-    };
-
     const onDocumentClick = function (e) {
-      if (mouseDownInsidePopup) {
-        mouseDownInsidePopup = false;
-        return;
-      }
       if (popup.contains(document.activeElement)) {
         return;
       }
@@ -944,7 +935,6 @@ if (!SERVER_RENDERED) {
       CodeMirror.off(cm.getWrapperElement(), 'mouseout', onMouseOut);
       CodeMirror.off(document, 'click', onDocumentClick);
       CodeMirror.off(cm, 'change', onEditorChange);
-      document.removeEventListener('mousedown', onDocumentMouseDown, true);
 
       // Cleanup CodeMirror and MaskedEditor instances
       const valueContainer = popup.querySelector('.var-value-container');
@@ -1006,7 +996,6 @@ if (!SERVER_RENDERED) {
     CodeMirror.on(popup, 'mouseout', onMouseOut);
     CodeMirror.on(popup, 'click', onPopupClick);
     CodeMirror.on(cm.getWrapperElement(), 'mouseout', onMouseOut);
-    // document.addEventListener('mousedown', onDocumentMouseDown, true);
     CodeMirror.on(document, 'click', onDocumentClick);
     CodeMirror.on(cm, 'change', onEditorChange);
   }


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3484)

Fixes - select the entire value and drag the mouse outside the input field. The popup closes even though the input remains focused.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable-info popup in the code editor from closing when clicking inside the popup area.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8070?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->