### PR TITLE
fix: use OS resolver for .local hostnames to fix mDNS resolution

### DIFF
--- a/packages/bruno-requests/src/network/fast-lookup.spec.ts
+++ b/packages/bruno-requests/src/network/fast-lookup.spec.ts
@@ -57,6 +57,32 @@ describe('fastLookup', () => {
     });
   });
 
+  it('should use dns.lookup directly for localhost (RFC 6761)', (done) => {
+    mockResolve('resolve4', ['93.184.216.34']); // hijacked result
+    mockLookup('127.0.0.1', 4);
+
+    fastLookup('localhost', {}, (err, address, family) => {
+      expect(err).toBeNull();
+      expect(address).toBe('127.0.0.1');
+      expect(family).toBe(4);
+      expect(dns.resolve4).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should use dns.lookup for .localhost subdomains', (done) => {
+    mockResolve('resolve4', ['93.184.216.34']);
+    mockLookup('127.0.0.1', 4);
+
+    fastLookup('api.localhost', {}, (err, address, family) => {
+      expect(err).toBeNull();
+      expect(address).toBe('127.0.0.1');
+      expect(family).toBe(4);
+      expect(dns.resolve4).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
   it('should fall back to dns.lookup when both resolvers fail', (done) => {
     mockResolve('resolve4', [], new Error('ENOTFOUND'));
     mockResolve('resolve6', [], new Error('ENOTFOUND'));

--- a/packages/bruno-requests/src/network/fast-lookup.spec.ts
+++ b/packages/bruno-requests/src/network/fast-lookup.spec.ts
@@ -44,6 +44,19 @@ describe('fastLookup', () => {
     });
   });
 
+  it('should use dns.lookup for mixed-case .LOCAL hostnames', (done) => {
+    mockResolve('resolve4', ['192.0.78.134']);
+    mockLookup('192.168.33.254', 4);
+
+    fastLookup('FHIR.LOCAL', {}, (err, address, family) => {
+      expect(err).toBeNull();
+      expect(address).toBe('192.168.33.254');
+      expect(family).toBe(4);
+      expect(dns.resolve4).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
   it('should fall back to dns.lookup when both resolvers fail', (done) => {
     mockResolve('resolve4', [], new Error('ENOTFOUND'));
     mockResolve('resolve6', [], new Error('ENOTFOUND'));

--- a/packages/bruno-requests/src/network/fast-lookup.spec.ts
+++ b/packages/bruno-requests/src/network/fast-lookup.spec.ts
@@ -31,6 +31,19 @@ describe('fastLookup', () => {
     });
   });
 
+  it('should use dns.lookup directly for .local hostnames (mDNS)', (done) => {
+    mockResolve('resolve4', ['192.0.78.134']); // bogus public-DNS result
+    mockLookup('192.168.33.254', 4); // correct mDNS result
+
+    fastLookup('fhir.local', {}, (err, address, family) => {
+      expect(err).toBeNull();
+      expect(address).toBe('192.168.33.254');
+      expect(family).toBe(4);
+      expect(dns.resolve4).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
   it('should fall back to dns.lookup when both resolvers fail', (done) => {
     mockResolve('resolve4', [], new Error('ENOTFOUND'));
     mockResolve('resolve6', [], new Error('ENOTFOUND'));

--- a/packages/bruno-requests/src/network/fast-lookup.ts
+++ b/packages/bruno-requests/src/network/fast-lookup.ts
@@ -23,7 +23,10 @@ export function fastLookup(
   // .local domains use mDNS (RFC 6762 — https://datatracker.ietf.org/doc/html/rfc6762)
   // which only the OS resolver understands. c-ares queries public DNS and may
   // return wrong results.
-  if (hostname.toLowerCase().endsWith('.local')) {
+  // localhost is reserved (RFC 6761 — https://datatracker.ietf.org/doc/html/rfc6761)
+  // and must always resolve via the OS — c-ares could return hijacked results.
+  const lower = hostname.toLowerCase();
+  if (lower.endsWith('.local') || lower === 'localhost' || lower.endsWith('.localhost')) {
     return dns.lookup(hostname, options ?? {}, (err, address, family) => {
       callback(err, address, family);
     });

--- a/packages/bruno-requests/src/network/fast-lookup.ts
+++ b/packages/bruno-requests/src/network/fast-lookup.ts
@@ -23,7 +23,7 @@ export function fastLookup(
   // .local domains use mDNS (RFC 6762 — https://datatracker.ietf.org/doc/html/rfc6762)
   // which only the OS resolver understands. c-ares queries public DNS and may
   // return wrong results.
-  if (hostname.endsWith('.local')) {
+  if (hostname.toLowerCase().endsWith('.local')) {
     return dns.lookup(hostname, options ?? {}, (err, address, family) => {
       callback(err, address, family);
     });

--- a/packages/bruno-requests/src/network/fast-lookup.ts
+++ b/packages/bruno-requests/src/network/fast-lookup.ts
@@ -6,6 +6,10 @@ import dns from 'node:dns';
  * Tries dns.resolve4 then dns.resolve6 (async, c-ares based),
  * falls back to dns.lookup for /etc/hosts and mDNS hostnames.
  *
+ * .local hostnames are reserved for mDNS (RFC 6762) and must always use the
+ * OS resolver (dns.lookup / getaddrinfo) — c-ares doesn't speak mDNS, so
+ * dns.resolve4 can return bogus public-DNS results for .local names.
+ *
  * NOTE: `options.family` is not currently respected — the function always
  * tries IPv4 first regardless of the caller's preference. This is safe today
  * because Bruno's HTTP agents use the default family (0), but should be
@@ -16,6 +20,15 @@ export function fastLookup(
   options: dns.LookupOptions | undefined,
   callback: (err: Error | null, address: string | dns.LookupAddress[], family?: number) => void
 ): void {
+  // .local domains use mDNS (RFC 6762 — https://datatracker.ietf.org/doc/html/rfc6762)
+  // which only the OS resolver understands. c-ares queries public DNS and may
+  // return wrong results.
+  if (hostname.endsWith('.local')) {
+    return dns.lookup(hostname, options ?? {}, (err, address, family) => {
+      callback(err, address, family);
+    });
+  }
+
   dns.resolve4(hostname, (err4, addresses4) => {
     if (!err4 && addresses4?.length) {
       return options?.all


### PR DESCRIPTION
[Jira](https://usebruno.atlassian.net/browse/BRU-3476)
Fixes https://github.com/usebruno/bruno/issues/8067
## Summary

- `.local` hostnames (RFC 6762) are reserved for mDNS (Bonjour/Avahi), which only the OS resolver (`getaddrinfo`) understands
- Since v3.4.0 (#7664), `fastLookup` tries `dns.resolve4` (c-ares) first — c-ares doesn't speak mDNS and queries upstream DNS servers instead
- On networks where upstream DNS performs NXDOMAIN hijacking, `dns.resolve4` returns bogus public IPs (e.g. WordPress.com `192.0.78.134`) for `.local` queries, and the fallback to `dns.lookup` never triggers
- cURL is unaffected because it always uses `getaddrinfo`

## Fix

Skip `dns.resolve4` for `.local` hostnames and go directly to `dns.lookup` (OS resolver). Case-insensitive check to handle `FHIR.LOCAL`, `Fhir.Local`, etc. No performance impact — mDNS resolves locally in microseconds, so the libuv thread pool bottleneck that motivated the original optimization doesn't apply.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostname resolution for local network access by enhancing support for `.local`, `localhost`, and `.localhost` domains to use OS-level resolution methods
  * Enhanced reliability for accessing services on local networks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->