### PR TITLE
fix: Folder-level No Auth inheritance is ignored; requests still use Collection Auth

### DIFF
--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -786,13 +786,13 @@ const mergeAuth = (collection, request, requestTreePath) => {
   let effectiveAuth = collectionAuth;
   let lastFolderWithAuth = null;
 
-  // Traverse through the path to find the closest auth configuration
+  // Innermost folder with a non-inherit mode wins. 'none' is a valid stop;
+  // only 'inherit' (or missing mode) means keep walking up.
   for (let i of requestTreePath) {
     if (i.type === 'folder') {
       const folderRoot = i?.draft || i?.root;
       const folderAuth = get(folderRoot, 'request.auth');
-      // Only consider folders that have a valid auth mode
-      if (folderAuth && folderAuth.mode && folderAuth.mode !== 'none' && folderAuth.mode !== 'inherit') {
+      if (folderAuth && folderAuth.mode && folderAuth.mode !== 'inherit') {
         effectiveAuth = folderAuth;
         lastFolderWithAuth = i;
       }

--- a/packages/bruno-filestore/src/formats/yml/parseFolder.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseFolder.ts
@@ -19,15 +19,9 @@ const parseFolder = (ymlString: string): FolderRoot => {
         name: ensureString(info?.name, 'Untitled Folder'),
         seq: info?.seq || 1
       },
-      request: null,
-      docs: null
-    };
-
-    // request defaults
-    if (ocFolder.request) {
-      folderRoot.request = {
+      request: {
         headers: [],
-        auth: null,
+        auth: toBrunoAuth(ocFolder.request?.auth),
         script: {
           req: null,
           res: null
@@ -37,40 +31,39 @@ const parseFolder = (ymlString: string): FolderRoot => {
           res: []
         },
         tests: null
-      };
+      },
+      docs: null
+    };
+
+    if (ocFolder.request) {
+      const folderRequest = folderRoot.request!;
 
       // headers
       const headers = toBrunoHttpHeaders(ocFolder.request.headers);
       if (headers) {
-        folderRoot.request.headers = headers;
-      }
-
-      // auth
-      const auth = toBrunoAuth(ocFolder.request.auth);
-      if (auth) {
-        folderRoot.request.auth = auth;
+        folderRequest.headers = headers;
       }
 
       // variables
       const variables = toBrunoVariables(ocFolder.request.variables);
       const postResponseVars = toBrunoPostResponseVariables((ocFolder.request as any).actions);
-      folderRoot.request.vars = {
+      folderRequest.vars = {
         req: variables.req,
         res: postResponseVars
       };
 
       // scripts
       const scripts = toBrunoScripts(ocFolder.request.scripts);
-      if (scripts?.script && folderRoot.request.script) {
+      if (scripts?.script && folderRequest.script) {
         if (scripts.script.req) {
-          folderRoot.request.script.req = scripts.script.req;
+          folderRequest.script.req = scripts.script.req;
         }
         if (scripts.script.res) {
-          folderRoot.request.script.res = scripts.script.res;
+          folderRequest.script.res = scripts.script.res;
         }
       }
       if (scripts?.tests) {
-        folderRoot.request.tests = scripts.tests;
+        folderRequest.tests = scripts.tests;
       }
     }
 

--- a/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
+++ b/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '../../../playwright';
+import {
+  AUTH_MODE_LABELS,
+  closeAllCollections,
+  createCollection,
+  createFolder,
+  createRequest,
+  openRequest,
+  saveRequest,
+  selectAuthMode,
+  selectRequestPaneTab,
+  selectResponsePaneTab,
+  sendRequest,
+  typeIntoField
+} from '../../utils/page';
+
+test.afterEach(async ({ page }) => {
+  await closeAllCollections(page);
+});
+
+test('Request inherits No Auth from the folder — collection Bearer Token is overridden', async ({ page, createTmpDir }) => {
+  const collectionName = 'folder-no-auth-inheritance';
+  await test.step('Create a collection', async () => {
+    await createCollection(page, collectionName, await createTmpDir());
+  });
+
+  await test.step('Set auth type for the collection as Bearer Token', async () => {
+    await page.getByTestId('collection-settings-tab-auth').click();
+    await selectAuthMode(page, AUTH_MODE_LABELS.BEARER);
+    await typeIntoField(page, 'Token', 'your_secret_token');
+    await page.getByRole('button', { name: 'Save' }).click();
+  });
+
+  await test.step('Create folder-1 inside the collection and set auth type for folder-1 as No Auth', async () => {
+    await createFolder(page, 'folder-1', collectionName, true);
+    await page.locator('.collection-item-name').filter({ hasText: 'folder-1' }).dblclick();
+    await page.getByTestId('folder-settings-tab-auth').click();
+    await selectAuthMode(page, AUTH_MODE_LABELS.NONE);
+    await page.getByRole('button', { name: 'Save' }).click();
+  });
+
+  await test.step('Create an HTTP request inside folder-1 and set auth type for the request as Inherit', async () => {
+    const requestName = 'http-request-1';
+    await createRequest(page, requestName, 'folder-1', {
+      inFolder: true,
+      requestType: 'HTTP',
+      method: 'GET',
+      url: 'https://testbench-sanity.usebruno.com/api/auth/bearer/protected'
+    });
+    await openRequest(page, collectionName, requestName);
+    await selectRequestPaneTab(page, 'Auth');
+    await selectAuthMode(page, AUTH_MODE_LABELS.INHERIT);
+    await saveRequest(page);
+  });
+
+  await test.step('Send the request and open the Timeline tab', async () => {
+    await sendRequest(page);
+    await selectResponsePaneTab(page, 'Timeline');
+  });
+
+  await test.step('Verify the response status code is 401 Unauthorized', async () => {
+    await expect(page.getByTestId('response-status-code')).toContainText('401');
+  });
+});

--- a/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
+++ b/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../playwright';
 import {
   AUTH_MODE_LABELS,
+  buildCommonLocators,
   closeAllCollections,
   createCollection,
   createFolder,
@@ -20,12 +21,14 @@ test.afterEach(async ({ page }) => {
 
 test('Request inherits No Auth from the folder — collection Bearer Token is overridden', async ({ page, createTmpDir }) => {
   const collectionName = 'folder-no-auth-inheritance';
+  const locators = buildCommonLocators(page);
+
   await test.step('Create a collection', async () => {
     await createCollection(page, collectionName, await createTmpDir());
   });
 
   await test.step('Set auth type for the collection as Bearer Token', async () => {
-    await page.getByTestId('collection-settings-tab-auth').click();
+    await locators.paneTabs.collectionSettingsTab('auth').click();
     await selectAuthMode(page, AUTH_MODE_LABELS.BEARER);
     await typeIntoField(page, 'Token', 'your_secret_token');
     await page.getByRole('button', { name: 'Save' }).click();
@@ -33,8 +36,8 @@ test('Request inherits No Auth from the folder — collection Bearer Token is ov
 
   await test.step('Create folder-1 inside the collection and set auth type for folder-1 as No Auth', async () => {
     await createFolder(page, 'folder-1', collectionName, true);
-    await page.locator('.collection-item-name').filter({ hasText: 'folder-1' }).dblclick();
-    await page.getByTestId('folder-settings-tab-auth').click();
+    await locators.sidebar.folder('folder-1').dblclick();
+    await locators.paneTabs.folderSettingsTab('auth').click();
     await selectAuthMode(page, AUTH_MODE_LABELS.NONE);
     await page.getByRole('button', { name: 'Save' }).click();
   });
@@ -59,6 +62,6 @@ test('Request inherits No Auth from the folder — collection Bearer Token is ov
   });
 
   await test.step('Verify the response status code is 401 Unauthorized', async () => {
-    await expect(page.getByTestId('response-status-code')).toContainText('401');
+    await expect(locators.response.statusCode()).toContainText('401');
   });
 });


### PR DESCRIPTION
**Jira link: https://usebruno.atlassian.net/browse/BRU-3296**

### Description

Fixes folder-level "No Auth" being ignored — requests inside a folder set to **No Auth** were still picking up the collection's auth (e.g. Bearer Token), both in the UI display and at runtime when the request was sent.

**Root cause**

The folder parser (`parseFolder.ts`) returned `auth: null` when a folder's YAML had no `auth:` block. Downstream:
- The UI inheritance walk treated `null` as "keep walking up" and fell through to the collection.
- The runtime resolver (`mergeAuth` in electron) did the same.
- A save+reparse cycle oscillated state between `null` and `{ mode: 'none', ... }`.

**Fix**

- `parseFolder.ts`: always populate `folder.root.request.auth` via `toBrunoAuth(...)` — matches what request parsers do and gives a consistent `{ mode: 'none', ... }` shape when YAML has no auth block.
- `mergeAuth` (electron): folders with `mode: 'none'` are now valid stops on the inheritance walk; only `'inherit'` means "keep walking".
- `getEffectiveAuthSource` / `resolveInheritedAuth` (bruno-app): same stop semantics for the UI.

**Test**

- `tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts` — end-to-end Playwright test: collection Bearer + folder No Auth + request Inherit → asserts the response is `401 Unauthorized` (proving the bearer header wasn't sent).


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed folder authentication inheritance so a folder set to "No Auth" correctly prevents child requests from inheriting parent credentials.

* **Improvements**
  * Request entries now initialize with default request fields (headers, auth, scripts, vars, tests) so requests behave more consistently when folder-level request data is missing.

* **Tests**
  * Added an end-to-end test verifying the "No Auth" folder override.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->