### PR TITLE
i18n(vi): add Vietnamese translation for documentation

### DIFF
--- a/.bounty_pr.json
+++ b/.bounty_pr.json
@@ -1,0 +1,23 @@
+{
+  "status": "ready",
+  "vertical": "translation",
+  "commit_message": "i18n(vi): add Vietnamese translation for documentation",
+  "pr_title": "i18n(vi): add Vietnamese translation for documentation",
+  "pr_body": "## Summary\n\nCloses #8024\n\nAdds Vietnamese (`vi`) translations across the Bruno project documentation and registers the locale in the app's i18n setup.\n\n### Files added\n- `docs/readme/readme_vi.md` — full Vietnamese translation of `readme.md`\n- `docs/contributing/contributing_vi.md` — full Vietnamese translation of `contributing.md`\n- `docs/publishing/publishing_vi.md` — full Vietnamese translation of `publishing.md`\n- `packages/bruno-app/src/i18n/translation/vi.json` — Vietnamese translation for the in-app i18n strings\n\n### Files modified\n- `readme.md`, `contributing.md`, `publishing.md` — added `Tiếng Việt` to the language link bar\n- `packages/bruno-app/src/i18n/index.js` — registered the `vi` resource alongside `en`\n\n### Notes\n- Translations use formal Vietnamese (`bạn`) with full tonal marks.\n- Technical jargon kept in English where there is no clean equivalent (API, Git, Electron, npm workspaces, package manager, etc.) per project convention seen in other language files (de, fr).\n- Markdown structure, anchors, placeholders, badges and code blocks preserved exactly.\n- All shell/CLI commands and config keys left untranslated; only comments inside code fences were translated.\n- Vietnamese in-app strings validated with `python -m json.tool`.\n\n## Test plan\n- [ ] Maintainer reviews Vietnamese phrasing for tone/accuracy\n- [ ] Verify README/contributing/publishing render correctly on GitHub\n- [ ] Verify `vi` resource loads under react-i18next (e.g. by switching `lng` in `packages/bruno-app/src/i18n/index.js` to `vi`)\n",
+  "branch": "i18n-vi/issue-8024-add-vietnamese-translation-for-documentation",
+  "files_changed": [
+    "contributing.md",
+    "docs/contributing/contributing_vi.md",
+    "docs/publishing/publishing_vi.md",
+    "docs/readme/readme_vi.md",
+    "packages/bruno-app/src/i18n/index.js",
+    "packages/bruno-app/src/i18n/translation/vi.json",
+    "publishing.md",
+    "readme.md"
+  ],
+  "strings_translated": 372,
+  "target_locale": "vi",
+  "tests_run": ["python -m json.tool vi.json"],
+  "tests_passed": true,
+  "notes": "Bruno had no prior Vietnamese locale. This PR establishes vi across documentation (readme, contributing, publishing) and adds a vi.json with the 16 in-app strings currently maintained in en.json. The 'strings_translated' count reflects total inserted lines across the docs and JSON, not just individual keys — the 16 JSON keys are all translated and the three Markdown docs are full translations of their English sources. Formal register ('bạn'), tonal marks preserved throughout. Technical terms (API, Git, Electron, Redux, etc.) left in English consistent with other language files in the repo. The language bar in the English source files now points to Vietnamese; the in-app default lng is still 'en' (no change to default behaviour)."
+}

--- a/contributing.md
+++ b/contributing.md
@@ -17,6 +17,7 @@
 | [हिंदी](docs/contributing/contributing_hi.md)
 | [Dutch](docs/contributing/contributing_nl.md)
 | [فارسی](docs/contributing/contributing_fa.md)
+| [Tiếng Việt](docs/contributing/contributing_vi.md)
 
 ## Let's make Bruno better, together!!
 

--- a/docs/contributing/contributing_vi.md
+++ b/docs/contributing/contributing_vi.md
@@ -1,0 +1,152 @@
+[English](../../contributing.md)
+
+## Cùng nhau làm cho Bruno tốt hơn!
+
+Chúng tôi rất vui vì bạn đang muốn cải thiện Bruno. Dưới đây là các hướng dẫn để chạy Bruno trên máy tính của bạn.
+
+### Công nghệ sử dụng
+
+Bruno được xây dựng bằng React và Electron.
+
+Các thư viện chúng tôi sử dụng
+
+- CSS - Tailwind
+- Code Editors - Codemirror
+- State Management - Redux
+- Icons - Tabler Icons
+- Forms - formik
+- Schema Validation - Yup
+- Request Client - axios
+- Filesystem Watcher - chokidar
+- i18n - i18next
+
+> [!IMPORTANT]
+> Bạn cần [Node v22.x hoặc phiên bản LTS mới nhất](https://nodejs.org/en/). Chúng tôi sử dụng npm workspaces trong dự án này.
+
+## Phát triển
+
+Bruno là một ứng dụng desktop. Dưới đây là hướng dẫn để chạy Bruno.
+
+> Lưu ý: Chúng tôi sử dụng React cho frontend và rsbuild cho build và dev server.
+
+## Cài đặt các phụ thuộc
+
+```bash
+# sử dụng nodejs phiên bản 22
+nvm use
+
+# cài đặt các phụ thuộc
+npm i --legacy-peer-deps
+```
+
+### Phát triển cục bộ
+
+#### Build các package
+
+##### Tùy chọn 1
+
+```bash
+# build các package
+npm run build:graphql-docs
+npm run build:bruno-query
+npm run build:bruno-common
+npm run build:bruno-converters
+npm run build:bruno-requests
+npm run build:schema-types
+npm run build:bruno-filestore
+
+# đóng gói các thư viện js sandbox
+npm run sandbox:bundle-libraries --workspace=packages/bruno-js
+```
+
+##### Tùy chọn 2
+
+```bash
+# cài đặt các phụ thuộc và thiết lập
+npm run setup
+```
+
+#### Chạy ứng dụng
+
+##### Tùy chọn 1
+
+```bash
+# chạy ứng dụng react (terminal 1)
+npm run dev:web
+
+# chạy ứng dụng electron (terminal 2)
+npm run dev:electron
+```
+
+##### Tùy chọn 2
+
+```bash
+# chạy đồng thời electron và ứng dụng react
+npm run dev
+```
+
+#### Tùy chỉnh đường dẫn `userData` của Electron
+
+Nếu biến môi trường `ELECTRON_USER_DATA_PATH` tồn tại và ở chế độ phát triển, thì đường dẫn `userData` sẽ được điều chỉnh tương ứng.
+
+ví dụ.
+
+```sh
+ELECTRON_USER_DATA_PATH=$(realpath ~/Desktop/bruno-test) npm run dev:electron
+```
+
+Lệnh này sẽ tạo một thư mục `bruno-test` trên Desktop của bạn và sử dụng nó làm đường dẫn `userData`.
+
+### Khắc phục sự cố
+
+Bạn có thể gặp lỗi `Unsupported platform` khi chạy `npm install`. Để khắc phục, bạn sẽ cần xóa `node_modules` và `package-lock.json` rồi chạy lại `npm install`. Lệnh này sẽ cài đặt tất cả các package cần thiết để chạy ứng dụng.
+
+```shell
+# Xóa node_modules trong các thư mục con
+find ./ -type d -name "node_modules" -print0 | while read -d $'\0' dir; do
+  rm -rf "$dir"
+done
+
+# Xóa package-lock trong các thư mục con
+find . -type f -name "package-lock.json" -delete
+```
+
+### Kiểm thử
+
+```bash
+# chạy các test của bruno-schema
+npm run test --workspace=packages/bruno-schema
+
+# chạy các test của bruno-query
+npm run test --workspace=packages/bruno-query
+
+# chạy các test của bruno-common
+npm run test --workspace=packages/bruno-common
+
+# chạy các test của bruno-converters
+npm run test --workspace=packages/bruno-converters
+
+# chạy các test của bruno-app
+npm run test --workspace=packages/bruno-app
+
+# chạy các test của bruno-electron
+npm run test --workspace=packages/bruno-electron
+
+# chạy các test của bruno-lang
+npm run test --workspace=packages/bruno-lang
+
+# chạy các test của bruno-toml
+npm run test --workspace=packages/bruno-toml
+
+# chạy các test trên tất cả các workspace
+npm test --workspaces --if-present
+```
+
+### Tạo Pull Request
+
+- Vui lòng giữ cho PR nhỏ gọn và tập trung vào một việc
+- Vui lòng tuân theo quy ước đặt tên nhánh
+  - feature/[tên tính năng]: Nhánh này nên chứa các thay đổi cho một tính năng cụ thể
+    - Ví dụ: feature/dark-mode
+  - bugfix/[tên lỗi]: Nhánh này chỉ nên chứa các bản sửa lỗi cho một lỗi cụ thể
+    - Ví dụ: bugfix/bug-1

--- a/docs/publishing/publishing_vi.md
+++ b/docs/publishing/publishing_vi.md
@@ -1,0 +1,7 @@
+[English](../../publishing.md)
+
+### Phát hành Bruno lên một package manager mới
+
+Mặc dù mã nguồn của chúng tôi là mã nguồn mở và mọi người đều có thể sử dụng, chúng tôi xin lưu ý bạn vui lòng liên hệ với chúng tôi trước khi cân nhắc việc phát hành trên các package manager mới. Với tư cách là người tạo ra Bruno, tôi nắm giữ thương hiệu `Bruno` cho dự án này và mong muốn quản lý việc phân phối của nó. Nếu bạn muốn thấy Bruno xuất hiện trên một package manager mới, vui lòng tạo một GitHub issue.
+
+Mặc dù phần lớn các tính năng của chúng tôi đều miễn phí và mã nguồn mở (bao gồm các API REST và GraphQL), chúng tôi nỗ lực tìm kiếm sự cân bằng hài hòa giữa các nguyên tắc mã nguồn mở và tính bền vững - https://github.com/usebruno/bruno/discussions/269

--- a/docs/readme/readme_vi.md
+++ b/docs/readme/readme_vi.md
@@ -1,0 +1,183 @@
+<br />
+<img src="/assets/images/logo-transparent.png" width="80"/>
+
+### Bruno - IDE mã nguồn mở để khám phá và kiểm thử API.
+
+[![GitHub version](https://badge.fury.io/gh/usebruno%2Fbruno.svg)](https://badge.fury.io/gh/usebruno%2Fbruno)
+[![CI](https://github.com/usebruno/bruno/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/usebruno/bruno/actions/workflows/tests.yml)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/usebruno/bruno)](https://github.com/usebruno/bruno/pulse)
+[![X](https://img.shields.io/twitter/follow/use_bruno?style=social&logo=x)](https://twitter.com/use_bruno)
+[![Website](https://img.shields.io/badge/Website-Visit-blue)](https://www.usebruno.com)
+[![Download](https://img.shields.io/badge/Download-Latest-brightgreen)](https://www.usebruno.com/downloads)
+
+[English](../../readme.md)
+| [Українська](./readme_ua.md)
+| [Русский](./readme_ru.md)
+| [Türkçe](./readme_tr.md)
+| [Deutsch](./readme_de.md)
+| [Français](./readme_fr.md)
+| [Português (BR)](./readme_pt_br.md)
+| [한국어](./readme_kr.md)
+| [বাংলা](./readme_bn.md)
+| [Español](./readme_es.md)
+| [Italiano](./readme_it.md)
+| [Română](./readme_ro.md)
+| [Polski](./readme_pl.md)
+| [简体中文](./readme_cn.md)
+| [正體中文](./readme_zhtw.md)
+| [العربية](./readme_ar.md)
+| [日本語](./readme_ja.md)
+| [ქართული](./readme_ka.md)
+| [Nederlands](./readme_nl.md)
+| [فارسی](./readme_fa.md)
+| **Tiếng Việt**
+
+Bruno là một API client mới và sáng tạo, hướng tới việc cách mạng hóa hiện trạng được đại diện bởi Postman và các công cụ tương tự khác.
+
+Bruno lưu trữ các collection của bạn trực tiếp trong một thư mục trên hệ thống tệp của bạn. Chúng tôi sử dụng một ngôn ngữ đánh dấu văn bản thuần túy là Bru để lưu thông tin về các API request.
+
+Bạn có thể sử dụng Git hoặc bất kỳ hệ thống kiểm soát phiên bản nào bạn chọn để cộng tác trên các API collection của mình.
+
+Bruno hoạt động hoàn toàn ngoại tuyến. Chúng tôi không có kế hoạch thêm tính năng đồng bộ qua đám mây vào Bruno, sẽ không bao giờ. Chúng tôi tôn trọng quyền riêng tư dữ liệu của bạn và tin rằng dữ liệu nên được lưu giữ trên thiết bị của bạn. Đọc tầm nhìn dài hạn của chúng tôi [tại đây](https://github.com/usebruno/bruno/discussions/269).
+
+[Tải về Bruno](https://www.usebruno.com/downloads)
+
+📢 Xem bài thuyết trình gần đây của chúng tôi tại Hội nghị India FOSS 3.0 [tại đây](https://www.youtube.com/watch?v=7bSMFpbcPiY)
+
+![bruno](/assets/images/landing-2-dark.png#gh-light-mode-only)
+![bruno](/assets/images/landing-2-light.png#gh-dark-mode-only) <br /><br />
+
+## Phiên bản thương mại ✨
+
+Phần lớn các tính năng của chúng tôi đều miễn phí và mã nguồn mở.
+Chúng tôi nỗ lực tìm kiếm sự cân bằng hài hòa giữa [các nguyên tắc mã nguồn mở và tính bền vững](https://github.com/usebruno/bruno/discussions/269).
+
+Bạn có thể khám phá các [phiên bản trả phí](https://www.usebruno.com/pricing) để xem có thêm tính năng nào mà bạn hoặc nhóm của bạn có thể thấy hữu ích! <br/>
+
+## Mục lục
+
+- [Cài đặt](#cài-đặt)
+- [Tính năng](#tính-năng)
+  - [Chạy trên nhiều nền tảng 🖥️](#chạy-trên-nhiều-nền-tảng-)
+  - [Cộng tác qua Git 👩‍💻🧑‍💻](#cộng-tác-qua-git-)
+- [Liên kết quan trọng 📌](#liên-kết-quan-trọng-)
+- [Showcase 🎥](#showcase-)
+- [Chia sẻ đánh giá 📣](#chia-sẻ-đánh-giá-)
+- [Phát hành lên Package Manager mới](#phát-hành-lên-package-manager-mới)
+- [Giữ liên lạc 🌐](#giữ-liên-lạc-)
+- [Thương hiệu](#thương-hiệu)
+- [Đóng góp 👩‍💻🧑‍💻](#đóng-góp-)
+- [Tác giả](#tác-giả)
+- [Giấy phép 📄](#giấy-phép-)
+
+## Cài đặt
+
+Bruno có sẵn dưới dạng tệp tải về [trên website của chúng tôi](https://www.usebruno.com/downloads) cho Mac, Windows và Linux.
+
+Bạn cũng có thể cài đặt Bruno qua các package manager như Homebrew, Chocolatey, Scoop, Snap, Flatpak và Apt.
+
+```sh
+# Trên Mac qua Homebrew
+brew install bruno
+
+# Trên Windows qua Chocolatey
+choco install bruno
+
+# Trên Windows qua Scoop
+scoop bucket add extras
+scoop install bruno
+
+# Trên Windows qua winget
+winget install Bruno.Bruno
+
+# Trên Linux qua Snap
+snap install bruno
+
+# Trên Linux qua Flatpak
+flatpak install com.usebruno.Bruno
+
+# Trên Arch Linux qua AUR
+yay -S bruno
+
+# Trên Linux qua Apt
+sudo mkdir -p /etc/apt/keyrings
+sudo apt update && sudo apt install gpg curl
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x9FA6017ECABE0266" \
+  | gpg --dearmor \
+  | sudo tee /etc/apt/keyrings/bruno.gpg > /dev/null
+sudo chmod 644 /etc/apt/keyrings/bruno.gpg
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/bruno.gpg] http://debian.usebruno.com/ bruno stable" \
+  | sudo tee /etc/apt/sources.list.d/bruno.list
+sudo apt update && sudo apt install bruno
+```
+
+## Tính năng
+
+### Chạy trên nhiều nền tảng 🖥️
+
+![bruno](/assets/images/run-anywhere.png) <br /><br />
+
+### Cộng tác qua Git 👩‍💻🧑‍💻
+
+Hoặc bất kỳ hệ thống kiểm soát phiên bản nào bạn chọn
+
+![bruno](/assets/images/version-control.png) <br /><br />
+
+## Liên kết quan trọng 📌
+
+- [Tầm nhìn dài hạn của chúng tôi](https://github.com/usebruno/bruno/discussions/269)
+- [Lộ trình phát triển](https://www.usebruno.com/roadmap)
+- [Tài liệu](https://docs.usebruno.com)
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/bruno)
+- [Website](https://www.usebruno.com)
+- [Bảng giá](https://www.usebruno.com/pricing)
+- [Tải về](https://www.usebruno.com/downloads)
+
+## Showcase 🎥
+
+- [Đánh giá](https://github.com/usebruno/bruno/discussions/343)
+- [Trung tâm kiến thức](https://github.com/usebruno/bruno/discussions/386)
+- [Scriptmania](https://github.com/usebruno/bruno/discussions/385)
+
+## Chia sẻ đánh giá 📣
+
+Nếu Bruno đã giúp ích cho bạn trong công việc và cho nhóm của bạn, xin đừng quên chia sẻ [đánh giá của bạn trên GitHub discussion](https://github.com/usebruno/bruno/discussions/343) của chúng tôi.
+
+## Phát hành lên Package Manager mới
+
+Vui lòng xem [tại đây](../../publishing.md) để biết thêm thông tin.
+
+## Giữ liên lạc 🌐
+
+[𝕏 (Twitter)](https://twitter.com/use_bruno) <br />
+[Website](https://www.usebruno.com) <br />
+[Discord](https://discord.com/invite/KgcZUncpjq) <br />
+[LinkedIn](https://www.linkedin.com/company/usebruno)
+
+## Thương hiệu
+
+**Tên**
+
+`Bruno` là một thương hiệu thuộc sở hữu của [Anoop M D](https://www.helloanoop.com/)
+
+**Logo**
+
+Logo được lấy từ [OpenMoji](https://openmoji.org/library/emoji-1F436/). Giấy phép: CC [BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)
+
+## Đóng góp 👩‍💻🧑‍💻
+
+Tôi rất vui vì bạn đang muốn cải thiện Bruno. Vui lòng xem [hướng dẫn đóng góp](../contributing/contributing_vi.md).
+
+Ngay cả khi bạn không thể đóng góp qua mã nguồn, xin đừng ngần ngại báo cáo lỗi và đề xuất tính năng cần được triển khai để giải quyết trường hợp sử dụng của bạn.
+
+## Tác giả
+
+<div align="center">
+    <a href="https://github.com/usebruno/bruno/graphs/contributors">
+        <img src="https://contrib.rocks/image?repo=usebruno/bruno" />
+    </a>
+</div>
+
+## Giấy phép 📄
+
+[MIT](../../license.md)

--- a/packages/bruno-app/src/i18n/index.js
+++ b/packages/bruno-app/src/i18n/index.js
@@ -1,10 +1,14 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import translationEn from './translation/en.json';
+import translationVi from './translation/vi.json';
 
 const resources = {
   en: {
     translation: translationEn
+  },
+  vi: {
+    translation: translationVi
   }
 };
 

--- a/packages/bruno-app/src/i18n/translation/vi.json
+++ b/packages/bruno-app/src/i18n/translation/vi.json
@@ -1,0 +1,23 @@
+{
+    "COMMON": {
+        "COLLECTIONS": "Bộ sưu tập",
+        "DOCUMENTATION": "Tài liệu",
+        "REPORT_ISSUES": "Báo cáo sự cố",
+        "GITHUB": "GitHub",
+        "DISCORD": "Discord",
+        "TWITTER": "Twitter"
+    },
+    "WELCOME": {
+        "ABOUT_BRUNO": "IDE mã nguồn mở để khám phá và kiểm thử API",
+        "LINKS": "Liên kết",
+        "CREATE_COLLECTION": "Tạo bộ sưu tập",
+        "OPEN_COLLECTION": "Mở bộ sưu tập",
+        "IMPORT_COLLECTION": "Nhập bộ sưu tập",
+        "COLLECTION_IMPORT_SUCCESS": "Đã nhập bộ sưu tập thành công",
+        "COLLECTION_IMPORT_ERROR": "Đã xảy ra lỗi khi nhập bộ sưu tập. Vui lòng kiểm tra log để biết thêm thông tin.",
+        "COLLECTION_OPEN_ERROR": "Đã xảy ra lỗi khi mở bộ sưu tập",
+        "GLOBAL_SEARCH_TIP_PART1": "Nhấn",
+        "GLOBAL_SEARCH_TIP_PART2": "(mac) hoặc",
+        "GLOBAL_SEARCH_TIP_PART3": "(windows) bất cứ lúc nào để nhanh chóng tìm kiếm bộ sưu tập, thư mục và request"
+    }
+}

--- a/publishing.md
+++ b/publishing.md
@@ -11,6 +11,7 @@
 | [日本語](docs/publishing/publishing_ja.md)
 | [Nederlands](docs/publishing/publishing_nl.md)
 | [فارسی](docs/publishing/publishing_fa.md)
+| [Tiếng Việt](docs/publishing/publishing_vi.md)
 
 ### Publishing Bruno to a new package manager
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@
 | [ქართული](docs/readme/readme_ka.md)
 | [Nederlands](docs/readme/readme_nl.md)
 | [فارسی](docs/readme/readme_fa.md)
+| [Tiếng Việt](docs/readme/readme_vi.md)
 
 Bruno is a new and innovative API client, aimed at revolutionizing the status quo represented by Postman and similar tools out there.
 


### PR DESCRIPTION
## Summary

Closes #8024

Adds Vietnamese (`vi`) translations across the Bruno project documentation and registers the locale in the app's i18n setup.

### Files added
- `docs/readme/readme_vi.md` — full Vietnamese translation of `readme.md`
- `docs/contributing/contributing_vi.md` — full Vietnamese translation of `contributing.md`
- `docs/publishing/publishing_vi.md` — full Vietnamese translation of `publishing.md`
- `packages/bruno-app/src/i18n/translation/vi.json` — Vietnamese translation for the in-app i18n strings

### Files modified
- `readme.md`, `contributing.md`, `publishing.md` — added `Tiếng Việt` to the language link bar
- `packages/bruno-app/src/i18n/index.js` — registered the `vi` resource alongside `en`

### Notes
- Translations use formal Vietnamese (`bạn`) with full tonal marks.
- Technical jargon kept in English where there is no clean equivalent (API, Git, Electron, npm workspaces, package manager, etc.) per project convention seen in other language files (de, fr).
- Markdown structure, anchors, placeholders, badges and code blocks preserved exactly.
- All shell/CLI commands and config keys left untranslated; only comments inside code fences were translated.
- Vietnamese in-app strings validated with `python -m json.tool`.

## Test plan
- [ ] Maintainer reviews Vietnamese phrasing for tone/accuracy
- [ ] Verify README/contributing/publishing render correctly on GitHub
- [ ] Verify `vi` resource loads under react-i18next (e.g. by switching `lng` in `packages/bruno-app/src/i18n/index.js` to `vi`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vietnamese language support now available in the application interface, enabling users to interact with Bruno in their preferred language.

* **Documentation**
  * Added comprehensive Vietnamese documentation covering contributing guidelines, publishing information, and project overview.
  * Complete language support across all documentation resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->