### PR TITLE
fix(cli): multipart form body not sent due to mode name mismatch

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -409,7 +409,9 @@ const prepareRequest = async (item = {}, collection = {}) => {
   }
 
   if (request.body.mode === 'multipartForm' || request.body.mode === 'multipart-form') {
-    axiosRequest.headers['content-type'] = 'multipart/form-data';
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'multipart/form-data';
+    }
     const enabledParams = filter(request.body.multipartForm, (p) => p.enabled);
     axiosRequest.data = enabledParams;
   }

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -408,7 +408,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
     axiosRequest.data = enabledParams;
   }
 
-  if (request.body.mode === 'multipartForm') {
+  if (request.body.mode === 'multipartForm' || request.body.mode === 'multipart-form') {
     axiosRequest.headers['content-type'] = 'multipart/form-data';
     const enabledParams = filter(request.body.multipartForm, (p) => p.enabled);
     axiosRequest.data = enabledParams;

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -478,7 +478,7 @@ const prepareRequest = async (item, collection = {}, abortController) => {
     axiosRequest.data = enabledParams;
   }
 
-  if (request.body.mode === 'multipartForm') {
+  if (request.body.mode === 'multipartForm' || request.body.mode === 'multipart-form') {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'multipart/form-data';
     }


### PR DESCRIPTION
## Problem

When running a `.bru` file with `body:multipart-form` via the CLI runner (`bru run`), the request is sent without a `Content-Type: multipart/form-data` header and without a body. The server receives an empty POST request, causing a parse failure (typically 422).

## Root Cause

There is a naming convention mismatch between the `.bru` v2 parser and `prepare-request.js`:

- The parser (`@usebruno/filestore`) sets `request.body.mode = "multipart-form"` (kebab-case)
- `prepare-request.js` checks for `request.body.mode === "multipartForm"` (camelCase)
- Because no branch matches, neither the `Content-Type` header nor the form data are set

## Fix

Accept both naming conventions in `prepare-request.js` for both `bruno-cli` and `bruno-electron` packages:

```js
if (request.body.mode === 'multipartForm' || request.body.mode === 'multipart-form') {
```

## Affected Files

- `packages/bruno-cli/src/runner/prepare-request.js`
- `packages/bruno-electron/src/ipc/network/prepare-request.js`

Closes: https://github.com/usebruno/bruno/issues/7552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart form submissions now accept both common naming variants for form-mode configuration.
  * Automatically sets the multipart content-type header when missing.
  * Builds multipart payloads only from enabled form parameters so only active fields are submitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8082?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->