### PR TITLE
fix(app): null-safe OAuth2 scope in OpenAPI export

### DIFF
--- a/packages/bruno-app/src/utils/exporters/openapi-spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.js
@@ -361,6 +361,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
           case 'oauth2':
             if (!auth?.oauth2?.grantType) break;
             const { authorizationUrl, accessTokenUrl, callbackUrl, scope } = auth?.oauth2;
+            const scopes = scope ? { [scope]: '' } : {};
             switch (auth?.oauth2?.grantType) {
               case 'authorization_code':
                 components.securitySchemes[securitySchemaId] = {
@@ -369,13 +370,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
                     authorizationCode: {
                       authorizationUrl,
                       tokenUrl: accessTokenUrl,
-                      ...(scope.length > 0
-                        ? {
-                            scopes: {
-                              [scope]: ''
-                            }
-                          }
-                        : {})
+                      scopes
                     }
                   }
                 };
@@ -389,13 +384,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
                   flows: {
                     password: {
                       tokenUrl: accessTokenUrl,
-                      ...(scope.length > 0
-                        ? {
-                            scopes: {
-                              [scope]: ''
-                            }
-                          }
-                        : {})
+                      scopes
                     }
                   }
                 };
@@ -409,13 +398,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
                   flows: {
                     password: {
                       tokenUrl: accessTokenUrl,
-                      ...(scope.length > 0
-                        ? {
-                            scopes: {
-                              [scope]: ''
-                            }
-                          }
-                        : {})
+                      scopes
                     }
                   }
                 };

--- a/packages/bruno-app/src/utils/exporters/openapi-spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.js
@@ -358,7 +358,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
               [securitySchemaId]: []
             };
             break;
-          case 'oauth2':
+          case 'oauth2': {
             if (!auth?.oauth2?.grantType) break;
             const { authorizationUrl, accessTokenUrl, callbackUrl, scope } = auth?.oauth2;
             const scopes = scope ? { [scope]: '' } : {};
@@ -408,6 +408,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
                 break;
             }
             break;
+          }
           case 'awsv4':
             components.securitySchemes[securitySchemaId] = {
               'type': 'apiKey',

--- a/packages/bruno-app/src/utils/exporters/openapi-spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.js
@@ -396,7 +396,7 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
                 components.securitySchemes[securitySchemaId] = {
                   type: 'oauth2',
                   flows: {
-                    password: {
+                    clientCredentials: {
                       tokenUrl: accessTokenUrl,
                       scopes
                     }

--- a/packages/bruno-app/src/utils/exporters/openapi-spec.spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.spec.js
@@ -476,3 +476,70 @@ describe('exportApiSpec - multi-environment servers', () => {
     expect(content).toContain('description: Staging');
   });
 });
+
+describe('exportApiSpec - OAuth2 scope handling (BRU-3297)', () => {
+  const makeOauth2Item = (grantType, scope) => ({
+    name: 'Req',
+    type: 'http-request',
+    request: {
+      url: 'https://api.example.com/users',
+      method: 'GET',
+      params: [],
+      headers: [],
+      body: {},
+      auth: {
+        mode: 'oauth2',
+        oauth2: {
+          grantType,
+          authorizationUrl: 'https://auth.example.com/authorize',
+          accessTokenUrl: 'https://auth.example.com/token',
+          callbackUrl: 'https://app.example.com/callback',
+          scope
+        }
+      }
+    }
+  });
+
+  // No-throw checks for all 3 grant types affected by BRU-3297.
+  describe.each([
+    'authorization_code',
+    'password',
+    'client_credentials'
+  ])('grant type %s', (grantType) => {
+    it(`should not throw when scope is null`, () => {
+      const items = [makeOauth2Item(grantType, null)];
+      expect(() => exportApiSpec({ variables: {}, items, name: 'Test' })).not.toThrow();
+    });
+
+    it(`should not throw when scope is undefined`, () => {
+      const items = [makeOauth2Item(grantType, undefined)];
+      expect(() => exportApiSpec({ variables: {}, items, name: 'Test' })).not.toThrow();
+    });
+  });
+
+  // Content assertions limited to grants whose flow key is correct in current code.
+  // `client_credentials` writes flow key `password:` due to a separate bug, not in scope of BRU-3297.
+  describe.each([
+    ['authorization_code', 'authorizationCode'],
+    ['password', 'password']
+  ])('grant type %s emits valid scopes object', (grantType, flowKey) => {
+    it(`should emit empty scopes object when scope is null (OpenAPI 3.0 requires scopes key)`, () => {
+      const items = [makeOauth2Item(grantType, null)];
+      const { content } = exportApiSpec({ variables: {}, items, name: 'Test' });
+      expect(content).toContain(`${flowKey}:`);
+      expect(content).toMatch(new RegExp(`${flowKey}:[\\s\\S]*?scopes:\\s*{}`));
+    });
+
+    it(`should emit empty scopes object when scope is empty string`, () => {
+      const items = [makeOauth2Item(grantType, '')];
+      const { content } = exportApiSpec({ variables: {}, items, name: 'Test' });
+      expect(content).toMatch(new RegExp(`${flowKey}:[\\s\\S]*?scopes:\\s*{}`));
+    });
+
+    it(`should emit scope entry when scope is a non-empty string`, () => {
+      const items = [makeOauth2Item(grantType, 'openid')];
+      const { content } = exportApiSpec({ variables: {}, items, name: 'Test' });
+      expect(content).toContain('openid:');
+    });
+  });
+});

--- a/packages/bruno-app/src/utils/exporters/openapi-spec.spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.spec.js
@@ -517,11 +517,10 @@ describe('exportApiSpec - OAuth2 scope handling (BRU-3297)', () => {
     });
   });
 
-  // Content assertions limited to grants whose flow key is correct in current code.
-  // `client_credentials` writes flow key `password:` due to a separate bug, not in scope of BRU-3297.
   describe.each([
     ['authorization_code', 'authorizationCode'],
-    ['password', 'password']
+    ['password', 'password'],
+    ['client_credentials', 'clientCredentials']
   ])('grant type %s emits valid scopes object', (grantType, flowKey) => {
     it(`should emit empty scopes object when scope is null (OpenAPI 3.0 requires scopes key)`, () => {
       const items = [makeOauth2Item(grantType, null)];


### PR DESCRIPTION
### Description

The OpenAPI exporter (`packages/bruno-app/src/utils/exporters/openapi-spec.js`) calls `.length` on `auth.oauth2.scope` without a null guard. When a user never fills the Scope field for an OAuth2 auth, Bruno stores `scope` as `null`, causing the entire export to crash with:

```
TypeError: Cannot read properties of null (reading 'length')
```

Affected grant types: `authorization_code`, `password`, `client_credentials`. A single offending request aborts the entire export — users with OAuth2-secured APIs can't get an OpenAPI export at all.

**Linked issue:** [#7365](https://github.com/usebruno/bruno/issues/7365). Internal Jira: BRU-3297.

#### Changes

- Replace `scope.length > 0 ? { scopes: { [scope]: '' } } : {}` ternary in all 3 grant cases with a single hoisted `const scopes = scope ? { [scope]: '' } : {}`. Truthy check handles `null`, `undefined`, and `""` uniformly.
- Emit `scopes` unconditionally on each flow. OpenAPI 3.0 requires `scopes` to be present on every OAuth2 flow even when empty.
- Wrap `case 'oauth2'` in a block to scope the new `const` declarations (resolves Biome `noSwitchDeclarations`).
- Fix `client_credentials` grant emitting `flows.password` instead of `flows.clientCredentials` (copy-paste from sibling case; produced an invalid OpenAPI spec that importers/validators reject).
- Add 15 jest tests in `openapi-spec.spec.js` covering all 3 affected grant types.

#### Test plan

- `npm run test --workspace=packages/bruno-app -- openapi-spec` — 32/32 pass (15 new + 17 existing)
- Bug reproduced in installed Bruno 3.1.x via Share → OpenAPI Specification — identical stack trace confirmed (`TypeError: Cannot read properties of null (reading 'length')` at `Array.map`)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (linked: #7365)

#### Screenshot

Production crash on installed Bruno 3.1.x exporting a collection with OAuth2 auth + blank scope:

```
TypeError: Cannot read properties of null (reading 'length')
  at file:///Applications/Bruno.app/Contents/Resources/app.asar/web/static/js/index.a442c869.js:45:21358
  at Array.map (<anonymous>)
  ...
```

Stack `Array.map` corresponds to `items.map(...)` at `openapi-spec.js:133`, inside which the `scope.length` runs in the OAuth2 case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI export now reliably handles OAuth2 scopes across grant types: no errors when scope is missing/empty, empty scopes are emitted as an empty object, and non-empty scopes are preserved.

* **Tests**
  * Added end-to-end tests covering OAuth2 scope scenarios to prevent regressions in OpenAPI exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8083?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->