### PR TITLE
fix: render multi-valued response headers (e.g. Set-Cookie) as separate rows

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
@@ -3,8 +3,17 @@ import StyledWrapper from './StyledWrapper';
 import { usePersistedState } from 'hooks/usePersistedState';
 import { useTrackScroll } from 'hooks/useTrackScroll';
 
+const flattenHeaders = (headers) => {
+  if (typeof headers !== 'object' || headers === null) return [];
+  // Multi-valued headers (e.g. Set-Cookie) arrive as arrays from the network layer.
+  // Render each value as its own row so they don't collapse into an unreadable blob.
+  return Object.entries(headers).flatMap(([name, value]) =>
+    Array.isArray(value) ? value.map((v) => [name, v]) : [[name, value]]
+  );
+};
+
 const ResponseHeaders = ({ headers, item }) => {
-  const headersArray = typeof headers === 'object' ? Object.entries(headers) : [];
+  const headersArray = flattenHeaders(headers);
   const wrapperRef = useRef(null);
   const [scroll, setScroll] = usePersistedState({ key: `response-headers-scroll-${item?.uid}`, default: 0 });
   useTrackScroll({ ref: wrapperRef, selector: '.response-tab-content', onChange: setScroll, initialValue: scroll });

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Common/Headers/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Common/Headers/index.js
@@ -36,9 +36,13 @@ const Headers = ({ headers, type }) => {
       </div>
     );
   } else {
+    // Multi-valued headers (e.g. Set-Cookie) arrive as arrays; render one line per value.
+    const flattened = Object.entries(headers).flatMap(([key, value]) =>
+      Array.isArray(value) ? value.map((v) => [key, v]) : [[key, value]]
+    );
     return (
       <div className="mt-1">
-        {Object.entries(headers).map(([key, value], index) => (
+        {flattened.map(([key, value], index) => (
           <pre key={index} className="mb-1 whitespace-pre-wrap">
             {type === 'request' ? '>' : '<'}&nbsp;<span className="opacity-60">{key}:</span>
             <span>{String(value)}</span>

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -114,7 +114,9 @@ const ResponsePane = ({ item, collection }) => {
       return 0;
     }
   }, [response.size, response.dataBuffer]);
-  const responseHeadersCount = typeof response.headers === 'object' ? Object.entries(response.headers).length : 0;
+  const responseHeadersCount = typeof response.headers === 'object' && response.headers !== null
+    ? Object.values(response.headers).reduce((count, value) => count + (Array.isArray(value) ? value.length : 1), 0)
+    : 0;
 
   const hasScriptError = item?.preRequestScriptErrorMessage || item?.postResponseScriptErrorMessage || item?.testScriptErrorMessage;
 

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -255,10 +255,13 @@ function makeAxiosInstance({
       });
 
       Object.entries(response.headers).forEach(([key, value]) => {
-        timeline.push({
-          timestamp: new Date(),
-          type: 'responseHeader',
-          message: `${key}: ${value}`
+        const values = Array.isArray(value) ? value : [value];
+        values.forEach((v) => {
+          timeline.push({
+            timestamp: new Date(),
+            type: 'responseHeader',
+            message: `${key}: ${v}`
+          });
         });
       });
 
@@ -290,10 +293,13 @@ function makeAxiosInstance({
             message: `HTTP/${error.response.httpVersion || '1.1'} ${error.response.status} ${error.response.statusText}`
           });
           Object.entries(error.response.headers).forEach(([key, value]) => {
-            timeline.push({
-              timestamp: new Date(),
-              type: 'responseHeader',
-              message: `${key}: ${value}`
+            const values = Array.isArray(value) ? value : [value];
+            values.forEach((v) => {
+              timeline.push({
+                timestamp: new Date(),
+                type: 'responseHeader',
+                message: `${key}: ${v}`
+              });
             });
           });
           timeline.push({


### PR DESCRIPTION
### Description

Multi-valued response headers (`Set-Cookie` being the canonical case) arrive at the renderer as arrays. The Response Headers tab, the header count badge, and the timeline were all stringifying the array directly, which collapses every value into a single illegible row with no separators.

### Screenshots

**Before:** all `Set-Cookie` values mashed into one row, e.g.
```
checkout.vtex.com=__ofid=…; path=/; secure; samesite=lax; httponlyCheckoutOrderFormOwnership=…; path=/; secure; samesite=strict; httponly
```
<img width="3952" height="2242" alt="image" src="https://github.com/user-attachments/assets/6be87210-25d4-4e6b-8f3e-4a150e38daf0" />


**After:** one row per value in the Headers tab, one line per value in the timeline, and the count badge reflects the true number of header entries.
<img width="3952" height="2242" alt="Screenshot 2026-05-25 at 09 29 36" src="https://github.com/user-attachments/assets/d61786b7-eac1-4ddf-a0b5-2a1126ff17f3" />


### Changes

- `packages/bruno-app/.../ResponsePane/ResponseHeaders/index.js` — flatten array-valued headers into one row per value.
- `packages/bruno-app/.../ResponsePane/index.js` — make the header count include each array element.
- `packages/bruno-app/.../Timeline/TimelineItem/Common/Headers/index.js` — same flatten for the Timeline pane's response view.
- `packages/bruno-electron/.../ipc/network/axios-instance.js` — emit one `responseHeader` timeline entry per array value (success and redirect-error paths).

Closes #4920. Related: #3475 (umbrella issue for multi-header support; this PR addresses only the **response** display, not request-side sending).

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display and counting of multi-valued response headers. Headers with multiple values (such as duplicate Set-Cookie entries) now display each value as a separate row in response views and timeline. Updated header count calculations to accurately reflect total individual header values rather than just counting unique header keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8091?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->