### PR TITLE
feat: add JWT Bearer auth type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23463,6 +23463,46 @@
         "node": "*"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -23507,6 +23547,27 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -34385,6 +34446,7 @@
         "https-proxy-agent": "^7.0.2",
         "iconv-lite": "^0.6.3",
         "js-yaml": "^4.1.1",
+        "jsonwebtoken": "^9.0.3",
         "lodash": "^4.17.21",
         "qs": "^6.14.1",
         "socks-proxy-agent": "^8.0.2",
@@ -35049,6 +35111,7 @@
         "iconv-lite": "^0.6.3",
         "is-valid-path": "^0.1.1",
         "js-yaml": "^4.1.1",
+        "jsonwebtoken": "^9.0.3",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.35",
         "nanoid": "3.3.8",
@@ -35872,55 +35935,6 @@
         "@jitl/quickjs-ffi-types": "0.32.0"
       }
     },
-    "packages/bruno-js/node_modules/jsonwebtoken": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^4.0.1",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "packages/bruno-js/node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "packages/bruno-js/node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "packages/bruno-js/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "packages/bruno-js/node_modules/quickjs-emscripten": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.32.0.tgz",
@@ -35944,18 +35958,6 @@
       "license": "MIT",
       "dependencies": {
         "@jitl/quickjs-ffi-types": "0.32.0"
-      }
-    },
-    "packages/bruno-js/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/bruno-js/node_modules/yaml": {
@@ -36344,55 +36346,6 @@
         "node": ">=0.10.0"
       }
     },
-    "packages/bruno-tests/node_modules/jsonwebtoken": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^4.0.1",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "packages/bruno-tests/node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "packages/bruno-tests/node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "packages/bruno-tests/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "packages/bruno-tests/node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -36427,18 +36380,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "packages/bruno-tests/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/bruno-tests/node_modules/strnum": {

--- a/packages/bruno-app/src/components/CollectionSettings/Auth/AuthMode/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Auth/AuthMode/index.js
@@ -42,6 +42,11 @@ const AuthMode = ({ collection }) => {
       onClick: () => onModeChange('bearer')
     },
     {
+      id: 'jwtBearer',
+      label: 'JWT Bearer',
+      onClick: () => onModeChange('jwtBearer')
+    },
+    {
       id: 'digest',
       label: 'Digest Auth',
       onClick: () => onModeChange('digest')

--- a/packages/bruno-app/src/components/CollectionSettings/Auth/JwtBearerAuth/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Auth/JwtBearerAuth/StyledWrapper.js
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  label {
+    font-size: ${(props) => props.theme.font.size.sm};
+    color: ${(props) => props.theme.colors.text.subtext1};
+  }
+
+  .single-line-editor-wrapper {
+    padding: 0.15rem 0.4rem;
+    border-radius: 3px;
+    border: solid 1px ${(props) => props.theme.input.border};
+    background-color: ${(props) => props.theme.input.bg};
+  }
+
+  select.jwt-algorithm-select,
+  select.jwt-row-type-select {
+    background-color: ${(props) => props.theme.input.bg};
+    border: solid 1px ${(props) => props.theme.input.border};
+    color: ${(props) => props.theme.text};
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+    font-size: ${(props) => props.theme.font.size.sm};
+
+    &:focus {
+      outline: none;
+      box-shadow: none;
+    }
+  }
+
+  select.jwt-row-type-select {
+    width: 100%;
+  }
+
+  .payload-parse-error {
+    color: ${(props) => props.theme.colors?.text?.danger || '#c0392b'};
+  }
+
+  .jwt-payload-json-view {
+    margin: 0;
+    padding: 0.6rem 0.8rem;
+    border-radius: 3px;
+    border: solid 1px ${(props) => props.theme.input.border};
+    background-color: ${(props) => props.theme.input.bg};
+    color: ${(props) => props.theme.text};
+    font-family: ${(props) => props.theme.font.codeFont || 'monospace'};
+    font-size: ${(props) => props.theme.font.size.sm};
+    white-space: pre-wrap;
+    overflow-x: auto;
+  }
+`;
+
+export default Wrapper;

--- a/packages/bruno-app/src/components/CollectionSettings/Auth/JwtBearerAuth/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Auth/JwtBearerAuth/index.js
@@ -1,0 +1,208 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import get from 'lodash/get';
+import { useTheme } from 'providers/Theme';
+import { useDispatch } from 'react-redux';
+import SingleLineEditor from 'components/SingleLineEditor';
+import EditableTable from 'components/EditableTable';
+import SensitiveFieldWarning from 'components/SensitiveFieldWarning';
+import { useDetectSensitiveField } from 'hooks/useDetectSensitiveField';
+import { usePersistedState } from 'hooks/usePersistedState';
+import { updateCollectionAuth } from 'providers/ReduxStore/slices/collections';
+import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
+import {
+  rowsFromPayload,
+  payloadFromRows,
+  JWT_VALUE_TYPES
+} from 'components/RequestPane/Auth/JwtBearerAuth/payloadCodec';
+import StyledWrapper from './StyledWrapper';
+
+const JWT_ALGORITHMS = ['HS256', 'HS384', 'HS512'];
+
+const TYPE_LABELS = {
+  string: 'String',
+  number: 'Number',
+  boolean: 'Boolean',
+  json: 'JSON'
+};
+
+const JwtBearerAuth = ({ collection }) => {
+  const dispatch = useDispatch();
+  const { storedTheme } = useTheme();
+
+  const jwtAuth = collection.draft?.root
+    ? get(collection, 'draft.root.request.auth.jwtBearer', {})
+    : get(collection, 'root.request.auth.jwtBearer', {});
+
+  const algorithm = jwtAuth.algorithm || 'HS256';
+  const secret = jwtAuth.secret || '';
+  const payload = jwtAuth.payload || '';
+
+  const initial = useMemo(() => rowsFromPayload(payload), [payload]);
+  const [rows, setRows] = useState(initial.rows);
+  const [parseError, setParseError] = useState(initial.parseError);
+  const [showJsonView, setShowJsonView] = useState(false);
+  const [columnWidths, setColumnWidths] = usePersistedState({
+    key: 'collection-jwt-bearer-payload-column-widths',
+    default: {}
+  });
+
+  useEffect(() => {
+    const localStr = payloadFromRows(rows);
+    if (localStr !== payload) {
+      const next = rowsFromPayload(payload);
+      setRows(next.rows);
+      setParseError(next.parseError);
+    }
+  }, [payload]);
+
+  const { isSensitive } = useDetectSensitiveField(collection);
+  const { showWarning, warningMessage } = isSensitive(secret);
+
+  const handleSave = useCallback(() => dispatch(saveCollectionSettings(collection.uid)), [dispatch, collection.uid]);
+
+  const dispatchUpdate = useCallback((next) => {
+    dispatch(
+      updateCollectionAuth({
+        mode: 'jwtBearer',
+        collectionUid: collection.uid,
+        content: {
+          algorithm,
+          secret,
+          payload,
+          ...next
+        }
+      })
+    );
+  }, [dispatch, collection.uid, algorithm, secret, payload]);
+
+  const handleRowsChange = useCallback((updated) => {
+    setRows(updated);
+    dispatchUpdate({ payload: payloadFromRows(updated) });
+  }, [dispatchUpdate]);
+
+  const columns = useMemo(() => [
+    {
+      key: 'key',
+      name: 'Key',
+      isKeyField: true,
+      placeholder: 'Key',
+      width: '35%',
+      render: ({ value, onChange }) => (
+        <SingleLineEditor
+          value={value || ''}
+          theme={storedTheme}
+          onSave={handleSave}
+          onChange={(newValue) => onChange(newValue.replace(/[\r\n]/g, ''))}
+          collection={collection}
+          placeholder={!value ? 'Key' : ''}
+        />
+      )
+    },
+    {
+      key: 'value',
+      name: 'Value',
+      placeholder: 'Value',
+      width: '45%',
+      render: ({ value, onChange }) => (
+        <SingleLineEditor
+          value={value || ''}
+          theme={storedTheme}
+          onSave={handleSave}
+          onChange={(newValue) => onChange(newValue.replace(/[\r\n]/g, ''))}
+          collection={collection}
+          placeholder={!value ? 'Value' : ''}
+        />
+      )
+    },
+    {
+      key: 'type',
+      name: 'Type',
+      width: '20%',
+      render: ({ value, onChange }) => (
+        <select
+          className="jwt-row-type-select"
+          value={value || 'string'}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {JWT_VALUE_TYPES.map((t) => (
+            <option key={t} value={t}>{TYPE_LABELS[t]}</option>
+          ))}
+        </select>
+      )
+    }
+  ], [storedTheme, handleSave, collection]);
+
+  const defaultRow = { key: '', value: '', type: 'string' };
+
+  const jsonPreview = useMemo(() => payloadFromRows(rows), [rows]);
+
+  return (
+    <StyledWrapper className="mt-2 w-full">
+      <label className="block mb-1">Algorithm</label>
+      <div className="mb-3">
+        <select
+          className="jwt-algorithm-select"
+          value={algorithm}
+          onChange={(e) => dispatchUpdate({ algorithm: e.target.value })}
+          data-testid="collection-jwt-bearer-algorithm"
+        >
+          {JWT_ALGORITHMS.map((alg) => (
+            <option key={alg} value={alg}>{alg}</option>
+          ))}
+        </select>
+      </div>
+
+      <label className="block mb-1">Secret</label>
+      <div className="single-line-editor-wrapper mb-3 flex items-center">
+        <SingleLineEditor
+          value={secret}
+          theme={storedTheme}
+          onSave={handleSave}
+          onChange={(val) => dispatchUpdate({ secret: val })}
+          collection={collection}
+          isSecret={true}
+          isCompact
+        />
+        {showWarning && <SensitiveFieldWarning fieldName="collection-jwt-bearer-secret" warningMessage={warningMessage} />}
+      </div>
+
+      <div className="flex items-center justify-between mb-1">
+        <label className="block">Payload claims</label>
+        <button
+          type="button"
+          className="btn-action text-link select-none text-xs"
+          onClick={() => setShowJsonView((v) => !v)}
+        >
+          {showJsonView ? 'Edit as table' : 'View as JSON'}
+        </button>
+      </div>
+
+      {parseError && !showJsonView && (
+        <div className="payload-parse-error text-xs mb-2" data-testid="collection-jwt-bearer-parse-error">
+          Payload couldn’t be parsed as a JSON object ({parseError}). Add a new row to start over, or switch to JSON view to inspect.
+        </div>
+      )}
+
+      {showJsonView ? (
+        <pre className="jwt-payload-json-view" data-testid="collection-jwt-bearer-payload-json-view">{jsonPreview}</pre>
+      ) : (
+        <div data-testid="collection-jwt-bearer-payload-table">
+          <EditableTable
+            tableId="collection-jwt-bearer-payload"
+            columns={columns}
+            rows={rows}
+            onChange={handleRowsChange}
+            defaultRow={defaultRow}
+            reorderable={false}
+            showCheckbox={true}
+            checkboxKey="enabled"
+            columnWidths={columnWidths}
+            onColumnWidthsChange={setColumnWidths}
+          />
+        </div>
+      )}
+    </StyledWrapper>
+  );
+};
+
+export default JwtBearerAuth;

--- a/packages/bruno-app/src/components/CollectionSettings/Auth/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Auth/index.js
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import AuthMode from './AuthMode';
 import AwsV4Auth from './AwsV4Auth';
 import BearerAuth from './BearerAuth';
+import JwtBearerAuth from './JwtBearerAuth';
 import BasicAuth from './BasicAuth';
 import DigestAuth from './DigestAuth';
 import WsseAuth from './WsseAuth';
@@ -31,6 +32,9 @@ const Auth = ({ collection }) => {
       }
       case 'bearer': {
         return <BearerAuth collection={collection} />;
+      }
+      case 'jwtBearer': {
+        return <JwtBearerAuth collection={collection} />;
       }
       case 'digest': {
         return <DigestAuth collection={collection} />;

--- a/packages/bruno-app/src/components/FolderSettings/Auth/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Auth/index.js
@@ -12,6 +12,7 @@ import GrantTypeSelector from 'components/RequestPane/Auth/OAuth2/GrantTypeSelec
 import AuthMode from '../AuthMode';
 import BasicAuth from 'components/RequestPane/Auth/BasicAuth';
 import BearerAuth from 'components/RequestPane/Auth/BearerAuth';
+import JwtBearerAuth from 'components/RequestPane/Auth/JwtBearerAuth';
 import DigestAuth from 'components/RequestPane/Auth/DigestAuth';
 import NTLMAuth from 'components/RequestPane/Auth/NTLMAuth';
 import OAuth1 from 'components/RequestPane/Auth/OAuth1';
@@ -114,6 +115,17 @@ const Auth = ({ collection, folder }) => {
       case 'bearer': {
         return (
           <BearerAuth
+            collection={collection}
+            item={folder}
+            updateAuth={updateFolderAuth}
+            request={request}
+            save={() => handleSave()}
+          />
+        );
+      }
+      case 'jwtBearer': {
+        return (
+          <JwtBearerAuth
             collection={collection}
             item={folder}
             updateAuth={updateFolderAuth}

--- a/packages/bruno-app/src/components/FolderSettings/AuthMode/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/AuthMode/index.js
@@ -38,6 +38,11 @@ const AuthMode = ({ collection, folder }) => {
       onClick: () => onModeChange('bearer')
     },
     {
+      id: 'jwtBearer',
+      label: 'JWT Bearer',
+      onClick: () => onModeChange('jwtBearer')
+    },
+    {
       id: 'digest',
       label: 'Digest Auth',
       onClick: () => onModeChange('digest')

--- a/packages/bruno-app/src/components/RequestPane/Auth/AuthMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/AuthMode/index.js
@@ -38,6 +38,11 @@ const AuthMode = ({ item, collection }) => {
       onClick: () => onModeChange('bearer')
     },
     {
+      id: 'jwtBearer',
+      label: 'JWT Bearer',
+      onClick: () => onModeChange('jwtBearer')
+    },
+    {
       id: 'digest',
       label: 'Digest Auth',
       onClick: () => onModeChange('digest')

--- a/packages/bruno-app/src/components/RequestPane/Auth/JwtBearerAuth/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/JwtBearerAuth/StyledWrapper.js
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  label {
+    font-size: ${(props) => props.theme.font.size.sm};
+    color: ${(props) => props.theme.colors.text.subtext1};
+  }
+
+  .single-line-editor-wrapper {
+    max-width: 400px;
+    padding: 0.15rem 0.4rem;
+    border-radius: 3px;
+    border: solid 1px ${(props) => props.theme.input.border};
+    background-color: ${(props) => props.theme.input.bg};
+  }
+
+  select.jwt-algorithm-select,
+  select.jwt-row-type-select {
+    background-color: ${(props) => props.theme.input.bg};
+    border: solid 1px ${(props) => props.theme.input.border};
+    color: ${(props) => props.theme.text};
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+    font-size: ${(props) => props.theme.font.size.sm};
+
+    &:focus {
+      outline: none;
+      box-shadow: none;
+    }
+  }
+
+  select.jwt-row-type-select {
+    width: 100%;
+  }
+
+  .payload-parse-error {
+    color: ${(props) => props.theme.colors?.text?.danger || '#c0392b'};
+  }
+
+  .jwt-payload-json-view {
+    margin: 0;
+    padding: 0.6rem 0.8rem;
+    border-radius: 3px;
+    border: solid 1px ${(props) => props.theme.input.border};
+    background-color: ${(props) => props.theme.input.bg};
+    color: ${(props) => props.theme.text};
+    font-family: ${(props) => props.theme.font.codeFont || 'monospace'};
+    font-size: ${(props) => props.theme.font.size.sm};
+    white-space: pre-wrap;
+    overflow-x: auto;
+  }
+`;
+
+export default Wrapper;

--- a/packages/bruno-app/src/components/RequestPane/Auth/JwtBearerAuth/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/JwtBearerAuth/index.js
@@ -1,0 +1,212 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import get from 'lodash/get';
+import { useTheme } from 'providers/Theme';
+import { useDispatch } from 'react-redux';
+import SingleLineEditor from 'components/SingleLineEditor';
+import EditableTable from 'components/EditableTable';
+import SensitiveFieldWarning from 'components/SensitiveFieldWarning';
+import { useDetectSensitiveField } from 'hooks/useDetectSensitiveField';
+import { usePersistedState } from 'hooks/usePersistedState';
+import { updateAuth } from 'providers/ReduxStore/slices/collections';
+import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { rowsFromPayload, payloadFromRows, JWT_VALUE_TYPES } from './payloadCodec';
+import StyledWrapper from './StyledWrapper';
+
+const JWT_ALGORITHMS = ['HS256', 'HS384', 'HS512'];
+
+const TYPE_LABELS = {
+  string: 'String',
+  number: 'Number',
+  boolean: 'Boolean',
+  json: 'JSON'
+};
+
+const JwtBearerAuth = ({ item, collection, updateAuth, request, save }) => {
+  const dispatch = useDispatch();
+  const { storedTheme } = useTheme();
+
+  const jwtAuth = get(request, 'auth.jwtBearer', {});
+  const algorithm = jwtAuth.algorithm || 'HS256';
+  const secret = jwtAuth.secret || '';
+  const payload = jwtAuth.payload || '';
+
+  const initial = useMemo(() => rowsFromPayload(payload), [payload]);
+  const [rows, setRows] = useState(initial.rows);
+  const [parseError, setParseError] = useState(initial.parseError);
+  const [showJsonView, setShowJsonView] = useState(false);
+  const [columnWidths, setColumnWidths] = usePersistedState({
+    key: 'jwt-bearer-payload-column-widths',
+    default: {}
+  });
+
+  // Reconcile local rows when the external payload changes (e.g. .bru reloaded,
+  // mode toggled away and back). Only when the string actually differs from what
+  // our rows would produce — otherwise we'd loop on every dispatch.
+  useEffect(() => {
+    const localStr = payloadFromRows(rows);
+    if (localStr !== payload) {
+      const next = rowsFromPayload(payload);
+      setRows(next.rows);
+      setParseError(next.parseError);
+    }
+  }, [payload]);
+
+  const { isSensitive } = useDetectSensitiveField(collection);
+  const { showWarning, warningMessage } = isSensitive(secret);
+
+  const handleRun = useCallback(() => dispatch(sendRequest(item, collection.uid)), [dispatch, item, collection.uid]);
+  const handleSave = useCallback(() => save(), [save]);
+
+  const dispatchUpdate = useCallback((next) => {
+    dispatch(
+      updateAuth({
+        mode: 'jwtBearer',
+        collectionUid: collection.uid,
+        itemUid: item.uid,
+        content: {
+          algorithm,
+          secret,
+          payload,
+          ...next
+        }
+      })
+    );
+  }, [dispatch, updateAuth, collection.uid, item.uid, algorithm, secret, payload]);
+
+  const handleRowsChange = useCallback((updated) => {
+    setRows(updated);
+    dispatchUpdate({ payload: payloadFromRows(updated) });
+  }, [dispatchUpdate]);
+
+  const columns = useMemo(() => [
+    {
+      key: 'key',
+      name: 'Key',
+      isKeyField: true,
+      placeholder: 'Key',
+      width: '35%',
+      render: ({ value, onChange }) => (
+        <SingleLineEditor
+          value={value || ''}
+          theme={storedTheme}
+          onSave={handleSave}
+          onChange={(newValue) => onChange(newValue.replace(/[\r\n]/g, ''))}
+          onRun={handleRun}
+          collection={collection}
+          item={item}
+          placeholder={!value ? 'Key' : ''}
+        />
+      )
+    },
+    {
+      key: 'value',
+      name: 'Value',
+      placeholder: 'Value',
+      width: '45%',
+      render: ({ value, onChange }) => (
+        <SingleLineEditor
+          value={value || ''}
+          theme={storedTheme}
+          onSave={handleSave}
+          onChange={(newValue) => onChange(newValue.replace(/[\r\n]/g, ''))}
+          onRun={handleRun}
+          collection={collection}
+          item={item}
+          placeholder={!value ? 'Value' : ''}
+        />
+      )
+    },
+    {
+      key: 'type',
+      name: 'Type',
+      width: '20%',
+      render: ({ value, onChange }) => (
+        <select
+          className="jwt-row-type-select"
+          value={value || 'string'}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {JWT_VALUE_TYPES.map((t) => (
+            <option key={t} value={t}>{TYPE_LABELS[t]}</option>
+          ))}
+        </select>
+      )
+    }
+  ], [storedTheme, handleSave, handleRun, collection, item]);
+
+  const defaultRow = { key: '', value: '', type: 'string' };
+
+  const jsonPreview = useMemo(() => payloadFromRows(rows), [rows]);
+
+  return (
+    <StyledWrapper className="mt-2 w-full">
+      <label className="block mb-1">Algorithm</label>
+      <div className="mb-3">
+        <select
+          className="jwt-algorithm-select"
+          value={algorithm}
+          onChange={(e) => dispatchUpdate({ algorithm: e.target.value })}
+          data-testid="jwt-bearer-algorithm"
+        >
+          {JWT_ALGORITHMS.map((alg) => (
+            <option key={alg} value={alg}>{alg}</option>
+          ))}
+        </select>
+      </div>
+
+      <label className="block mb-1">Secret</label>
+      <div className="single-line-editor-wrapper mb-3 flex items-center">
+        <SingleLineEditor
+          value={secret}
+          theme={storedTheme}
+          onSave={handleSave}
+          onChange={(val) => dispatchUpdate({ secret: val })}
+          onRun={handleRun}
+          collection={collection}
+          item={item}
+          isSecret={true}
+          isCompact
+        />
+        {showWarning && <SensitiveFieldWarning fieldName="jwt-bearer-secret" warningMessage={warningMessage} />}
+      </div>
+
+      <div className="flex items-center justify-between mb-1">
+        <label className="block">Payload claims</label>
+        <button
+          type="button"
+          className="btn-action text-link select-none text-xs"
+          onClick={() => setShowJsonView((v) => !v)}
+        >
+          {showJsonView ? 'Edit as table' : 'View as JSON'}
+        </button>
+      </div>
+
+      {parseError && !showJsonView && (
+        <div className="payload-parse-error text-xs mb-2" data-testid="jwt-bearer-parse-error">
+          Payload couldn’t be parsed as a JSON object ({parseError}). Add a new row to start over, or switch to JSON view to inspect.
+        </div>
+      )}
+
+      {showJsonView ? (
+        <pre className="jwt-payload-json-view" data-testid="jwt-bearer-payload-json-view">{jsonPreview}</pre>
+      ) : (
+        <div data-testid="jwt-bearer-payload-table">
+          <EditableTable
+            tableId="jwt-bearer-payload"
+            columns={columns}
+            rows={rows}
+            onChange={handleRowsChange}
+            defaultRow={defaultRow}
+            reorderable={false}
+            showCheckbox={true}
+            checkboxKey="enabled"
+            columnWidths={columnWidths}
+            onColumnWidthsChange={setColumnWidths}
+          />
+        </div>
+      )}
+    </StyledWrapper>
+  );
+};
+
+export default JwtBearerAuth;

--- a/packages/bruno-app/src/components/RequestPane/Auth/JwtBearerAuth/payloadCodec.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/JwtBearerAuth/payloadCodec.js
@@ -1,0 +1,64 @@
+import { uuid } from 'utils/common';
+
+export const JWT_VALUE_TYPES = ['string', 'number', 'boolean', 'json'];
+
+// payloadStr → { rows, parseError }
+// rows shape: { uid, key, value (string), type, enabled }
+export const rowsFromPayload = (payloadStr) => {
+  if (!payloadStr || !payloadStr.trim()) {
+    return { rows: [], parseError: null };
+  }
+  let obj;
+  try {
+    obj = JSON.parse(payloadStr);
+  } catch (e) {
+    return { rows: [], parseError: e.message };
+  }
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    return { rows: [], parseError: 'Payload must be a JSON object' };
+  }
+  const rows = Object.entries(obj).map(([key, val]) => {
+    if (typeof val === 'number') {
+      return { uid: uuid(), key, value: String(val), type: 'number', enabled: true };
+    }
+    if (typeof val === 'boolean') {
+      return { uid: uuid(), key, value: String(val), type: 'boolean', enabled: true };
+    }
+    if (val && typeof val === 'object') {
+      return { uid: uuid(), key, value: JSON.stringify(val), type: 'json', enabled: true };
+    }
+    return { uid: uuid(), key, value: String(val ?? ''), type: 'string', enabled: true };
+  });
+  return { rows, parseError: null };
+};
+
+const DEFAULTS_BY_TYPE = {
+  number: '0',
+  boolean: 'false',
+  json: '{}'
+};
+
+// rows → payloadStr (formatted JSON object, raw insertion for number/boolean/json
+// so that `{{vars}}` get interpolated to JSON-valid literals before JSON.parse runs at runtime)
+export const payloadFromRows = (rows) => {
+  const active = (rows || []).filter((r) => r && r.enabled !== false && r.key && r.key.trim() !== '');
+  if (!active.length) return '{}';
+  const pairs = active.map((r) => {
+    const k = JSON.stringify(r.key);
+    const isEmpty = r.value == null || (typeof r.value === 'string' && r.value.trim() === '');
+    let v;
+    switch (r.type) {
+      case 'number':
+      case 'boolean':
+      case 'json':
+        // Raw insertion preserves `{{vars}}` so they interpolate to JSON-valid literals at runtime.
+        // For empty values fall back to the type's zero-value to keep the JSON parseable.
+        v = isEmpty ? DEFAULTS_BY_TYPE[r.type] : r.value;
+        break;
+      default:
+        v = JSON.stringify(r.value ?? '');
+    }
+    return `  ${k}: ${v}`;
+  });
+  return `{\n${pairs.join(',\n')}\n}`;
+};

--- a/packages/bruno-app/src/components/RequestPane/Auth/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import get from 'lodash/get';
 import AwsV4Auth from './AwsV4Auth';
 import BearerAuth from './BearerAuth';
+import JwtBearerAuth from './JwtBearerAuth';
 import BasicAuth from './BasicAuth';
 import DigestAuth from './DigestAuth';
 import WsseAuth from './WsseAuth';
@@ -84,6 +85,9 @@ const Auth = ({ item, collection }) => {
       }
       case 'bearer': {
         return <BearerAuth collection={collection} item={item} request={request} save={save} updateAuth={updateAuth} />;
+      }
+      case 'jwtBearer': {
+        return <JwtBearerAuth collection={collection} item={item} request={request} save={save} updateAuth={updateAuth} />;
       }
       case 'digest': {
         return <DigestAuth collection={collection} item={item} request={request} save={save} updateAuth={updateAuth} />;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -26,6 +26,12 @@ import { getUniqueTagsFromItems } from 'utils/collections/index';
 import { getCollectionEnvironmentPath } from 'utils/snapshot';
 import * as exampleReducers from './exampleReducers';
 
+const DEFAULT_JWT_PAYLOAD = `{
+  "iss": "",
+  "aud": "",
+  "exp": 0
+}`;
+
 // gRPC status code meanings
 const grpcStatusCodes = {
   0: 'OK',
@@ -1020,6 +1026,10 @@ export const collectionsSlice = createSlice({
               item.draft.request.auth.mode = 'bearer';
               item.draft.request.auth.bearer = action.payload.content;
               break;
+            case 'jwtBearer':
+              item.draft.request.auth.mode = 'jwtBearer';
+              item.draft.request.auth.jwtBearer = action.payload.content;
+              break;
             case 'basic':
               item.draft.request.auth.mode = 'basic';
               item.draft.request.auth.basic = action.payload.content;
@@ -1690,6 +1700,13 @@ export const collectionsSlice = createSlice({
             item.draft.request.auth = cloneDeep(savedAuth);
           } else {
             item.draft.request.auth = { mode: newMode };
+            if (newMode === 'jwtBearer') {
+              item.draft.request.auth.jwtBearer = {
+                algorithm: 'HS256',
+                secret: '',
+                payload: DEFAULT_JWT_PAYLOAD
+              };
+            }
           }
         }
       }
@@ -2125,7 +2142,15 @@ export const collectionsSlice = createSlice({
         if (newMode === savedMode) {
           set(collection, 'draft.root.request.auth', cloneDeep(savedAuth));
         } else {
-          set(collection, 'draft.root.request.auth', { mode: newMode });
+          const nextAuth = { mode: newMode };
+          if (newMode === 'jwtBearer') {
+            nextAuth.jwtBearer = {
+              algorithm: 'HS256',
+              secret: '',
+              payload: DEFAULT_JWT_PAYLOAD
+            };
+          }
+          set(collection, 'draft.root.request.auth', nextAuth);
         }
       }
     },
@@ -2146,6 +2171,9 @@ export const collectionsSlice = createSlice({
             break;
           case 'bearer':
             set(collection, 'draft.root.request.auth.bearer', action.payload.content);
+            break;
+          case 'jwtBearer':
+            set(collection, 'draft.root.request.auth.jwtBearer', action.payload.content);
             break;
           case 'basic':
             set(collection, 'draft.root.request.auth.basic', action.payload.content);
@@ -2485,6 +2513,9 @@ export const collectionsSlice = createSlice({
             break;
           case 'bearer':
             set(folder, 'draft.request.auth.bearer', action.payload.content);
+            break;
+          case 'jwtBearer':
+            set(folder, 'draft.request.auth.jwtBearer', action.payload.content);
             break;
           case 'digest':
             set(folder, 'draft.request.auth.digest', action.payload.content);
@@ -3340,7 +3371,15 @@ export const collectionsSlice = createSlice({
         if (newMode === savedMode) {
           set(folder, 'draft.request.auth', cloneDeep(savedAuth));
         } else {
-          set(folder, 'draft.request.auth', { mode: newMode });
+          const nextAuth = { mode: newMode };
+          if (newMode === 'jwtBearer') {
+            nextAuth.jwtBearer = {
+              algorithm: 'HS256',
+              secret: '',
+              payload: DEFAULT_JWT_PAYLOAD
+            };
+          }
+          set(folder, 'draft.request.auth', nextAuth);
         }
       }
     },

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -373,6 +373,13 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
               token: get(si.request, 'auth.bearer.token', '')
             };
             break;
+          case 'jwtBearer':
+            di.request.auth.jwtBearer = {
+              algorithm: get(si.request, 'auth.jwtBearer.algorithm', 'HS256'),
+              secret: get(si.request, 'auth.jwtBearer.secret', ''),
+              payload: get(si.request, 'auth.jwtBearer.payload', '')
+            };
+            break;
           case 'digest':
             di.request.auth.digest = {
               username: get(si.request, 'auth.digest.username', ''),
@@ -940,6 +947,10 @@ export const humanizeRequestAuthMode = (mode) => {
     }
     case 'bearer': {
       label = 'Bearer Token';
+      break;
+    }
+    case 'jwtBearer': {
+      label = 'JWT Bearer';
       break;
     }
     case 'digest': {

--- a/packages/bruno-cli/package.json
+++ b/packages/bruno-cli/package.json
@@ -66,6 +66,7 @@
     "https-proxy-agent": "^7.0.2",
     "iconv-lite": "^0.6.3",
     "js-yaml": "^4.1.1",
+    "jsonwebtoken": "^9.0.3",
     "lodash": "^4.17.21",
     "qs": "^6.14.1",
     "socks-proxy-agent": "^8.0.2",

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -1,5 +1,6 @@
 const { interpolate } = require('@usebruno/common');
 const { each, forOwn, cloneDeep, find } = require('lodash');
+const jwt = require('jsonwebtoken');
 const { isFormData } = require('@usebruno/common').utils;
 
 const isBinaryRequestBody = (data) => Buffer.isBuffer(data) || typeof data?.pipe === 'function';
@@ -280,6 +281,29 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
     request.ntlmConfig.username = _interpolate(request.ntlmConfig.username) || '';
     request.ntlmConfig.password = _interpolate(request.ntlmConfig.password) || '';
     request.ntlmConfig.domain = _interpolate(request.ntlmConfig.domain) || '';
+  }
+
+  // interpolate vars for jwt bearer auth and sign the token
+  if (request.jwtBearerConfig) {
+    const algorithm = request.jwtBearerConfig.algorithm || 'HS256';
+    const secret = _interpolate(request.jwtBearerConfig.secret) || '';
+    const payloadStr = _interpolate(request.jwtBearerConfig.payload) || '';
+
+    let payloadObj;
+    try {
+      payloadObj = payloadStr ? JSON.parse(payloadStr) : {};
+    } catch (e) {
+      throw new Error(`JWT Bearer auth: payload is not valid JSON (${e.message})`);
+    }
+
+    try {
+      const token = jwt.sign(payloadObj, secret, { algorithm });
+      request.headers['Authorization'] = `Bearer ${token}`;
+    } catch (e) {
+      throw new Error(`JWT Bearer auth: failed to sign token (${e.message})`);
+    }
+
+    delete request.jwtBearerConfig;
   }
 
   // interpolate vars for oauth1config auth

--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -68,6 +68,14 @@ const prepareRequest = async (item = {}, collection = {}) => {
       axiosRequest.headers['Authorization'] = `Bearer ${get(collectionAuth, 'bearer.token', '')}`;
     }
 
+    if (collectionAuth.mode === 'jwtBearer') {
+      axiosRequest.jwtBearerConfig = {
+        algorithm: get(collectionAuth, 'jwtBearer.algorithm') || 'HS256',
+        secret: get(collectionAuth, 'jwtBearer.secret') || '',
+        payload: get(collectionAuth, 'jwtBearer.payload') || ''
+      };
+    }
+
     if (collectionAuth.mode === 'apikey') {
       if (collectionAuth.apikey?.placement === 'header') {
         axiosRequest.headers[collectionAuth.apikey?.key] = collectionAuth.apikey?.value;
@@ -242,6 +250,14 @@ const prepareRequest = async (item = {}, collection = {}) => {
 
     if (request.auth.mode === 'bearer') {
       axiosRequest.headers['Authorization'] = `Bearer ${get(request, 'auth.bearer.token', '')}`;
+    }
+
+    if (request.auth.mode === 'jwtBearer') {
+      axiosRequest.jwtBearerConfig = {
+        algorithm: get(request, 'auth.jwtBearer.algorithm') || 'HS256',
+        secret: get(request, 'auth.jwtBearer.secret') || '',
+        payload: get(request, 'auth.jwtBearer.payload') || ''
+      };
     }
 
     if (request.auth.mode === 'wsse') {

--- a/packages/bruno-converters/src/opencollection/common/auth.ts
+++ b/packages/bruno-converters/src/opencollection/common/auth.ts
@@ -49,6 +49,7 @@ const fromOpenCollectionOAuth2 = (auth: AuthOAuth2): BrunoAuth => {
       awsv4: null,
       basic: null,
       bearer: null,
+      jwtBearer: null,
       digest: null,
       ntlm: null,
       oauth1: null,
@@ -158,6 +159,7 @@ const fromOpenCollectionOAuth2 = (auth: AuthOAuth2): BrunoAuth => {
         awsv4: null,
         basic: null,
         bearer: null,
+        jwtBearer: null,
         digest: null,
         ntlm: null,
         oauth1: null,
@@ -174,6 +176,7 @@ export const fromOpenCollectionAuth = (auth: Auth | undefined): BrunoAuth => {
     awsv4: null,
     basic: null,
     bearer: null,
+    jwtBearer: null,
     digest: null,
     ntlm: null,
     oauth1: null,
@@ -516,6 +519,11 @@ export const toOpenCollectionAuth = (auth: BrunoAuth | null | undefined): Auth |
 
     case 'oauth2':
       return toOpenCollectionOAuth2(auth.oauth2);
+
+    case 'jwtBearer':
+      // OpenCollection has no native equivalent; jwtBearer is Bruno-only.
+      // The native .bru representation preserves it for end-to-end Bruno use.
+      return undefined;
 
     default:
       return undefined;

--- a/packages/bruno-converters/src/opencollection/types.ts
+++ b/packages/bruno-converters/src/opencollection/types.ts
@@ -137,6 +137,7 @@ export type {
   AuthAwsV4 as BrunoAuthAwsV4,
   AuthBasic as BrunoAuthBasic,
   AuthBearer as BrunoAuthBearer,
+  AuthJwtBearer as BrunoAuthJwtBearer,
   AuthDigest as BrunoAuthDigest,
   AuthNTLM as BrunoAuthNTLM,
   AuthWsse as BrunoAuthWsse,

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -68,6 +68,7 @@
     "iconv-lite": "^0.6.3",
     "is-valid-path": "^0.1.1",
     "js-yaml": "^4.1.1",
+    "jsonwebtoken": "^9.0.3",
     "lodash": "^4.17.21",
     "mime-types": "^2.1.35",
     "nanoid": "3.3.8",

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -1,5 +1,6 @@
 const { interpolate } = require('@usebruno/common');
 const { each, forOwn, cloneDeep } = require('lodash');
+const jwt = require('jsonwebtoken');
 const { isFormData } = require('@usebruno/common').utils;
 
 const isBinaryRequestBody = (data) => Buffer.isBuffer(data) || typeof data?.pipe === 'function';
@@ -365,6 +366,29 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
     request.ntlmConfig.username = _interpolate(request.ntlmConfig.username) || '';
     request.ntlmConfig.password = _interpolate(request.ntlmConfig.password) || '';
     request.ntlmConfig.domain = _interpolate(request.ntlmConfig.domain) || '';
+  }
+
+  // interpolate vars for jwt bearer auth and sign the token
+  if (request.jwtBearerConfig) {
+    const algorithm = request.jwtBearerConfig.algorithm || 'HS256';
+    const secret = _interpolate(request.jwtBearerConfig.secret) || '';
+    const payloadStr = _interpolate(request.jwtBearerConfig.payload) || '';
+
+    let payloadObj;
+    try {
+      payloadObj = payloadStr ? JSON.parse(payloadStr) : {};
+    } catch (e) {
+      throw new Error(`JWT Bearer auth: payload is not valid JSON (${e.message})`);
+    }
+
+    try {
+      const token = jwt.sign(payloadObj, secret, { algorithm });
+      request.headers['Authorization'] = `Bearer ${token}`;
+    } catch (e) {
+      throw new Error(`JWT Bearer auth: failed to sign token (${e.message})`);
+    }
+
+    delete request.jwtBearerConfig;
   }
 
   // interpolate vars for oauth1config auth

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -31,6 +31,13 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
       case 'bearer':
         axiosRequest.headers['Authorization'] = `Bearer ${get(collectionAuth, 'bearer.token', '')}`;
         break;
+      case 'jwtBearer':
+        axiosRequest.jwtBearerConfig = {
+          algorithm: get(collectionAuth, 'jwtBearer.algorithm') || 'HS256',
+          secret: get(collectionAuth, 'jwtBearer.secret') || '',
+          payload: get(collectionAuth, 'jwtBearer.payload') || ''
+        };
+        break;
       case 'digest':
         axiosRequest.digestConfig = {
           username: get(collectionAuth, 'digest.username'),
@@ -199,6 +206,13 @@ const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
         break;
       case 'bearer':
         axiosRequest.headers['Authorization'] = `Bearer ${get(request, 'auth.bearer.token', '')}`;
+        break;
+      case 'jwtBearer':
+        axiosRequest.jwtBearerConfig = {
+          algorithm: get(request, 'auth.jwtBearer.algorithm') || 'HS256',
+          secret: get(request, 'auth.jwtBearer.secret') || '',
+          payload: get(request, 'auth.jwtBearer.payload') || ''
+        };
         break;
       case 'digest':
         axiosRequest.digestConfig = {

--- a/packages/bruno-electron/tests/network/interpolate-vars.spec.js
+++ b/packages/bruno-electron/tests/network/interpolate-vars.spec.js
@@ -427,6 +427,68 @@ describe('interpolate-vars: interpolateVars', () => {
     });
   });
 
+  describe('JWT Bearer auth', () => {
+    const jwt = require('jsonwebtoken');
+
+    it('signs the JWT with the configured secret and sets the Authorization header', () => {
+      const request = {
+        method: 'GET',
+        url: 'http://api.example/x',
+        headers: {},
+        jwtBearerConfig: {
+          algorithm: 'HS256',
+          secret: 'bruno',
+          payload: '{"iss":"issuer","sub":"42"}'
+        }
+      };
+
+      const result = interpolateVars(request, {}, null, null);
+
+      expect(result.headers['Authorization']).toMatch(/^Bearer [A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+      expect(result.jwtBearerConfig).toBeUndefined();
+
+      const token = result.headers['Authorization'].replace(/^Bearer /, '');
+      const decoded = jwt.verify(token, 'bruno', { algorithms: ['HS256'] });
+      expect(decoded.iss).toBe('issuer');
+      expect(decoded.sub).toBe('42');
+    });
+
+    it('interpolates variables in secret and payload before signing', () => {
+      const request = {
+        method: 'GET',
+        url: 'http://api.example/x',
+        headers: {},
+        jwtBearerConfig: {
+          algorithm: 'HS512',
+          secret: '{{SECRET}}',
+          payload: '{"iss":"{{ISS}}","aud":"configurations"}'
+        }
+      };
+
+      const result = interpolateVars(request, { SECRET: 'realSecret', ISS: 'realIssuer' }, null, null);
+
+      const token = result.headers['Authorization'].replace(/^Bearer /, '');
+      const decoded = jwt.verify(token, 'realSecret', { algorithms: ['HS512'] });
+      expect(decoded.iss).toBe('realIssuer');
+      expect(decoded.aud).toBe('configurations');
+    });
+
+    it('throws a descriptive error when payload is not valid JSON', () => {
+      const request = {
+        method: 'GET',
+        url: 'http://api.example/x',
+        headers: {},
+        jwtBearerConfig: {
+          algorithm: 'HS256',
+          secret: 's',
+          payload: '{not-json'
+        }
+      };
+
+      expect(() => interpolateVars(request, {}, null, null)).toThrow(/JWT Bearer auth: payload is not valid JSON/);
+    });
+  });
+
   describe('File body streaming', () => {
     it('keeps stream-backed JSON request bodies intact', () => {
       const streamPayload = {

--- a/packages/bruno-filestore/src/formats/yml/common/auth.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/auth.ts
@@ -173,6 +173,9 @@ export const toOpenCollectionAuth = (auth?: BrunoAuth | null): Auth | undefined 
       return buildOAuth1Auth(auth.oauth1);
     case 'oauth2':
       return toOpenCollectionOAuth2(auth.oauth2);
+    case 'jwtBearer':
+      // jwtBearer is Bruno-only; OpenCollection has no equivalent type
+      return undefined;
     default:
       console.warn(`toOpenCollectionAuth failed: Unsupported auth mode "${auth.mode}".`);
       return undefined;
@@ -185,6 +188,7 @@ export const toBrunoAuth = (auth: Auth | null | undefined): BrunoAuth | null => 
     awsv4: null,
     basic: null,
     bearer: null,
+    jwtBearer: null,
     digest: null,
     ntlm: null,
     oauth2: null,

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -35,7 +35,7 @@ const ANNOTATIONS_KEY = Symbol('annotations');
  */
 const grammar = ohm.grammar(`Bru {
   BruFile = (meta | http | grpc | ws | query | params | headers | metadata | auths | bodies | varsandassert | script | tests | settings | docs | example)*
-  auths = authawsv4 | authbasic | authbearer | authdigest | authNTLM | authOAuth1 | authOAuth2 | authwsse | authapikey | authOauth2Configs
+  auths = authawsv4 | authbasic | authbearer | authjwtbearer | authdigest | authNTLM | authOAuth1 | authOAuth2 | authwsse | authapikey | authOauth2Configs
   bodies = bodyjson | bodytext | bodyxml | bodysparql | bodygraphql | bodygraphqlvars | bodyforms | body | bodygrpc | bodyws
   bodyforms = bodyformurlencoded | bodymultipart | bodyfile
   params = paramspath | paramsquery
@@ -140,6 +140,7 @@ const grammar = ohm.grammar(`Bru {
   authawsv4 = "auth:awsv4" dictionary
   authbasic = "auth:basic" dictionary
   authbearer = "auth:bearer" dictionary
+  authjwtbearer = "auth:jwtbearer" dictionary
   authdigest = "auth:digest" dictionary
   authNTLM = "auth:ntlm" dictionary
   authOAuth1 = "auth:oauth1" dictionary
@@ -741,6 +742,24 @@ const sem = grammar.createSemantics().addAttribute('ast', {
       auth: {
         bearer: {
           token
+        }
+      }
+    };
+  },
+  authjwtbearer(_1, dictionary) {
+    const auth = mapPairListToKeyValPairs(dictionary.ast, false);
+    const algorithmKey = _.find(auth, { name: 'algorithm' });
+    const secretKey = _.find(auth, { name: 'secret' });
+    const payloadKey = _.find(auth, { name: 'payload' });
+    const algorithm = algorithmKey ? algorithmKey.value : 'HS256';
+    const secret = secretKey ? secretKey.value : '';
+    const payload = payloadKey ? payloadKey.value : '';
+    return {
+      auth: {
+        jwtBearer: {
+          algorithm,
+          secret,
+          payload
         }
       }
     };

--- a/packages/bruno-lang/v2/src/collectionBruToJson.js
+++ b/packages/bruno-lang/v2/src/collectionBruToJson.js
@@ -8,7 +8,7 @@ const ANNOTATIONS_KEY = Symbol('annotations');
 
 const grammar = ohm.grammar(`Bru {
   BruFile = (meta | query | headers | auth | auths | vars | script | tests | docs)*
-  auths = authawsv4 | authbasic | authbearer | authdigest | authNTLM | authOAuth1 | authOAuth2 | authwsse | authapikey | authOauth2Configs
+  auths = authawsv4 | authbasic | authbearer | authjwtbearer | authdigest | authNTLM | authOAuth1 | authOAuth2 | authwsse | authapikey | authOauth2Configs
 
   // Oauth2 additional parameters
   authOauth2Configs = oauth2AuthReqConfig | oauth2AccessTokenReqConfig | oauth2RefreshTokenReqConfig
@@ -87,6 +87,7 @@ const grammar = ohm.grammar(`Bru {
   authawsv4 = "auth:awsv4" dictionary
   authbasic = "auth:basic" dictionary
   authbearer = "auth:bearer" dictionary
+  authjwtbearer = "auth:jwtbearer" dictionary
   authdigest = "auth:digest" dictionary
   authNTLM = "auth:ntlm" dictionary
   authOAuth1 = "auth:oauth1" dictionary
@@ -353,6 +354,24 @@ const sem = grammar.createSemantics().addAttribute('ast', {
       auth: {
         bearer: {
           token
+        }
+      }
+    };
+  },
+  authjwtbearer(_1, dictionary) {
+    const auth = mapPairListToKeyValPairs(dictionary.ast, false);
+    const algorithmKey = _.find(auth, { name: 'algorithm' });
+    const secretKey = _.find(auth, { name: 'secret' });
+    const payloadKey = _.find(auth, { name: 'payload' });
+    const algorithm = algorithmKey ? algorithmKey.value : 'HS256';
+    const secret = secretKey ? secretKey.value : '';
+    const payload = payloadKey ? payloadKey.value : '';
+    return {
+      auth: {
+        jwtBearer: {
+          algorithm,
+          secret,
+          payload
         }
       }
     };

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -234,6 +234,16 @@ ${indentString(`token: ${auth?.bearer?.token || ''}`)}
 `;
   }
 
+  if (auth && auth.jwtBearer) {
+    bru += `auth:jwtbearer {
+${indentString(`algorithm: ${auth?.jwtBearer?.algorithm || 'HS256'}`)}
+${indentString(`secret: ${auth?.jwtBearer?.secret || ''}`)}
+${indentString(`payload: ${getValueString(auth?.jwtBearer?.payload || '')}`)}
+}
+
+`;
+  }
+
   if (auth && auth.digest) {
     bru += `auth:digest {
 ${indentString(`username: ${auth?.digest?.username || ''}`)}

--- a/packages/bruno-lang/v2/src/jsonToCollectionBru.js
+++ b/packages/bruno-lang/v2/src/jsonToCollectionBru.js
@@ -114,6 +114,16 @@ ${indentString(`token: ${auth.bearer.token}`)}
 `;
   }
 
+  if (auth && auth.jwtBearer) {
+    bru += `auth:jwtbearer {
+${indentString(`algorithm: ${auth?.jwtBearer?.algorithm || 'HS256'}`)}
+${indentString(`secret: ${auth?.jwtBearer?.secret || ''}`)}
+${indentString(`payload: ${getValueString(auth?.jwtBearer?.payload || '')}`)}
+}
+
+`;
+  }
+
   if (auth && auth.digest) {
     bru += `auth:digest {
 ${indentString(`username: ${auth.digest.username}`)}

--- a/packages/bruno-lang/v2/tests/jwtBearer.spec.js
+++ b/packages/bruno-lang/v2/tests/jwtBearer.spec.js
@@ -1,0 +1,115 @@
+const parser = require('../src/bruToJson');
+const stringify = require('../src/jsonToBru');
+
+describe('auth:jwtbearer', () => {
+  describe('bruToJson', () => {
+    it('parses algorithm, secret and inline payload', () => {
+      const input = `
+auth:jwtbearer {
+  algorithm: HS256
+  secret: bruno
+  payload: {"iss":"issuer"}
+}
+`;
+
+      const expected = {
+        auth: {
+          jwtBearer: {
+            algorithm: 'HS256',
+            secret: 'bruno',
+            payload: '{"iss":"issuer"}'
+          }
+        }
+      };
+
+      expect(parser(input)).toEqual(expected);
+    });
+
+    it('parses multiline payload wrapped in triple quotes', () => {
+      const input = `
+auth:jwtbearer {
+  algorithm: HS512
+  secret: {{SECRET}}
+  payload: '''
+    {
+      "iss": "{{ISS}}",
+      "aud": "configurations"
+    }
+  '''
+}
+`;
+
+      const output = parser(input);
+
+      expect(output.auth.jwtBearer.algorithm).toBe('HS512');
+      expect(output.auth.jwtBearer.secret).toBe('{{SECRET}}');
+      // Multiline triple-quoted values keep their indentation as-is between the delimiters
+      expect(output.auth.jwtBearer.payload).toContain('"iss": "{{ISS}}"');
+      expect(output.auth.jwtBearer.payload).toContain('"aud": "configurations"');
+    });
+
+    it('defaults algorithm to HS256 when omitted', () => {
+      const input = `
+auth:jwtbearer {
+  secret: s
+  payload: {}
+}
+`;
+      expect(parser(input).auth.jwtBearer.algorithm).toBe('HS256');
+    });
+  });
+
+  describe('jsonToBru', () => {
+    it('serializes a jwtBearer auth block with inline payload', () => {
+      const input = {
+        auth: {
+          jwtBearer: {
+            algorithm: 'HS256',
+            secret: 'bruno',
+            payload: '{"iss":"issuer"}'
+          }
+        }
+      };
+
+      const output = stringify(input);
+      expect(output).toContain('auth:jwtbearer {');
+      expect(output).toContain('algorithm: HS256');
+      expect(output).toContain('secret: bruno');
+      expect(output).toContain('payload: {"iss":"issuer"}');
+    });
+
+    it('wraps multiline payload with triple quotes', () => {
+      const input = {
+        auth: {
+          jwtBearer: {
+            algorithm: 'HS256',
+            secret: 's',
+            payload: '{\n  "iss": "x"\n}'
+          }
+        }
+      };
+
+      const output = stringify(input);
+      expect(output).toContain('payload: \'\'\'');
+      expect(output).toContain('"iss": "x"');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves jwtBearer through serialize → parse', () => {
+      const original = {
+        auth: {
+          jwtBearer: {
+            algorithm: 'HS384',
+            secret: '{{SECRET}}',
+            payload: '{"iss":"i","aud":"a"}'
+          }
+        }
+      };
+
+      const bru = stringify(original);
+      const reparsed = parser(bru);
+      expect(reparsed.auth.jwtBearer).toEqual(original.auth.jwtBearer);
+    });
+  });
+});

--- a/packages/bruno-schema-types/src/common/auth.ts
+++ b/packages/bruno-schema-types/src/common/auth.ts
@@ -21,6 +21,14 @@ export interface AuthBearer {
   token?: string | null;
 }
 
+export type JwtBearerAlgorithm = 'HS256' | 'HS384' | 'HS512';
+
+export interface AuthJwtBearer {
+  algorithm?: JwtBearerAlgorithm | null;
+  secret?: string | null;
+  payload?: string | null;
+}
+
 export interface AuthDigest {
   username?: string | null;
   password?: string | null;
@@ -105,6 +113,7 @@ export type AuthMode
     | 'awsv4'
     | 'basic'
     | 'bearer'
+    | 'jwtBearer'
     | 'digest'
     | 'ntlm'
     | 'oauth1'
@@ -117,6 +126,7 @@ export interface Auth {
   awsv4?: AuthAwsV4 | null;
   basic?: AuthBasic | null;
   bearer?: AuthBearer | null;
+  jwtBearer?: AuthJwtBearer | null;
   digest?: AuthDigest | null;
   ntlm?: AuthNTLM | null;
   oauth1?: AuthOauth1 | null;

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -217,6 +217,14 @@ const authBearerSchema = Yup.object({
   .noUnknown(true)
   .strict();
 
+const authJwtBearerSchema = Yup.object({
+  algorithm: Yup.string().oneOf(['HS256', 'HS384', 'HS512']).nullable(),
+  secret: Yup.string().nullable(),
+  payload: Yup.string().nullable()
+})
+  .noUnknown(true)
+  .strict();
+
 const authDigestSchema = Yup.object({
   username: Yup.string().nullable(),
   password: Yup.string().nullable()
@@ -401,11 +409,12 @@ const oauth2Schema = Yup.object({
 
 const authSchema = Yup.object({
   mode: Yup.string()
-    .oneOf(['inherit', 'none', 'awsv4', 'basic', 'bearer', 'digest', 'ntlm', 'oauth1', 'oauth2', 'wsse', 'apikey'])
+    .oneOf(['inherit', 'none', 'awsv4', 'basic', 'bearer', 'jwtBearer', 'digest', 'ntlm', 'oauth1', 'oauth2', 'wsse', 'apikey'])
     .required('mode is required'),
   awsv4: authAwsV4Schema.nullable(),
   basic: authBasicSchema.nullable(),
   bearer: authBearerSchema.nullable(),
+  jwtBearer: authJwtBearerSchema.nullable(),
   ntlm: authNTLMSchema.nullable(),
   digest: authDigestSchema.nullable(),
   oauth1: authOAuth1Schema.nullable(),


### PR DESCRIPTION
Add automatic jwt bearer

Issue: https://github.com/usebruno/bruno/issues/8093
Related: https://github.com/usebruno/bruno/issues/810

### Description

<img width="1124" height="770" alt="immagine" src="https://github.com/user-attachments/assets/f58252f2-a86a-4f4e-938e-4a9504c5b8bc" />

## Summary
- New auth type `JWT Bearer` with HS256/HS384/HS512 algorithms
- Editable key/value/type table for payload claims with `{{vars}}` interpolation
- View-as-JSON toggle for inspection
- Backend signing happens in interpolate-vars (electron + CLI)

## Test plan
- [x] Select JWT Bearer auth, fill iss/aud/exp, run request → JWT signed correctly
- [x] `{{vars}}` interpolate in secret/payload before signing
- [x] Roundtrip via .bru file
- [x] CLI parity (`bru run`)
- [x] Existing tests green (lang, schema, converters, electron)

#### Contribution Checklist:

- [X] **I've used AI significantly to create this pull request**
- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JWT Bearer authentication is now available as an authentication mode for collections, folders, and individual requests
  * Configure JWT signing algorithm, secret, and custom payload claims
  * Automatic JWT token generation and Authorization header injection in CLI and desktop environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8094?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->