### PR TITLE
fix: prevent success toast when workspace selection is cancelled

### DIFF
--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -152,8 +152,10 @@ const AppTitleBar = () => {
 
   const handleOpenWorkspace = async () => {
     try {
-      await dispatch(openWorkspaceDialog());
-      toast.success('Workspace opened successfully');
+      const result = await dispatch(openWorkspaceDialog());
+      if (result) {
+        toast.success('Workspace opened successfully');
+      }
     } catch (error) {
       toast.error(error.message || 'Failed to open workspace');
     }


### PR DESCRIPTION
### Description

When attempting to open a workspace in Bruno, the application shows a success toast notification even if the workspace selection is canceled.

#### Changes Made
- Updated `handleOpenWorkspace` to verify that a workspace was actually selected before showing the success toast.
- Prevented false-positive success notifications when the folder picker dialog is canceled.

#### Before
- Clicking Open Workspace
- Canceling the folder selection dialog
- Still showed: `"Workspace opened successfully"`

https://github.com/user-attachments/assets/78b908ca-138b-4122-8822-ff514d8b1215

#### After
- Success toast is shown only when a valid workspace is selected and opened successfully.
- Canceling the dialog now closes silently without any misleading notification.


https://github.com/user-attachments/assets/b452e7be-795a-4a78-8739-2c8756156391


Fixes #8079 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed workspace opening to only display the success confirmation message when the workspace actually opens successfully, preventing misleading notifications when the operation fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->