### PR TITLE
fix: add missing runtime dependencies for pnpm strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35598,6 +35598,7 @@
         "@usebruno/lang": "0.12.0",
         "ajv": "^8.17.1",
         "lodash": "^4.17.21",
+        "nanoid": "3.3.8",
         "yaml": "^2.3.4"
       },
       "devDependencies": {
@@ -35614,7 +35615,6 @@
         "@usebruno/schema-types": "0.0.1",
         "babel-jest": "^29.7.0",
         "jest": "^29.2.0",
-        "nanoid": "3.3.8",
         "rimraf": "^3.0.2",
         "rollup": "3.30.0",
         "rollup-plugin-dts": "^5.0.0",
@@ -35799,6 +35799,7 @@
       "dependencies": {
         "@usebruno/common": "0.1.0",
         "@usebruno/query": "0.1.0",
+        "@usebruno/requests": "^0.1.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "atob": "^2.1.2",
@@ -36016,6 +36017,7 @@
         "https-proxy-agent": "~7.0.6",
         "is-ip": "^5.0.1",
         "pac-resolver": "^7.0.1",
+        "qs": "^6.14.1",
         "quickjs-emscripten": "^0.32.0",
         "shell-env": "^4.0.1",
         "socks-proxy-agent": "~8.0.5",
@@ -36122,6 +36124,21 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "packages/bruno-requests/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "packages/bruno-requests/node_modules/quickjs-emscripten": {
       "version": "0.32.0",

--- a/packages/bruno-filestore/package.json
+++ b/packages/bruno-filestore/package.json
@@ -32,7 +32,6 @@
     "@usebruno/schema-types": "0.0.1",
     "babel-jest": "^29.7.0",
     "jest": "^29.2.0",
-    "nanoid": "3.3.8",
     "rimraf": "^3.0.2",
     "rollup": "3.30.0",
     "rollup-plugin-dts": "^5.0.0",
@@ -46,6 +45,7 @@
   "dependencies": {
     "@types/nanoid": "^2.1.0",
     "@usebruno/lang": "0.12.0",
+    "nanoid": "3.3.8",
     "ajv": "^8.17.1",
     "lodash": "^4.17.21",
     "yaml": "^2.3.4"

--- a/packages/bruno-js/package.json
+++ b/packages/bruno-js/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@usebruno/common": "0.1.0",
     "@usebruno/query": "0.1.0",
-    "@usebruno/requests": "^0.1.0",
+    "@usebruno/requests": "0.1.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "atob": "^2.1.2",

--- a/packages/bruno-js/package.json
+++ b/packages/bruno-js/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@usebruno/common": "0.1.0",
     "@usebruno/query": "0.1.0",
+    "@usebruno/requests": "^0.1.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "atob": "^2.1.2",

--- a/packages/bruno-requests/package.json
+++ b/packages/bruno-requests/package.json
@@ -25,6 +25,7 @@
     "@grpc/proto-loader": "^0.7.15",
     "@types/qs": "^6.9.18",
     "axios": "1.13.6",
+    "qs": "^6.14.1",
     "pac-resolver": "^7.0.1",
     "quickjs-emscripten": "^0.32.0",
     "debug": "^4.4.3",


### PR DESCRIPTION
### Description

Fixes #8077
Internal - BRU-3489

Bruno CLI fails with `Cannot find module 'qs'` when installed globally with pnpm 11. This happens because pnpm uses a strict `node_modules` layout where packages can only access dependencies they explicitly declare. npm/yarn mask this by hoisting everything flat.

Three missing/misplaced dependency declarations were fixed:

**Files Changed:**

- **`packages/bruno-requests/package.json`** : Added `qs` to `dependencies`. It's imported in `oauth2-helper.ts` but only `@types/qs` was declared.
- **`packages/bruno-filestore/package.json`** : Moved `nanoid` from `devDependencies` to `dependencies`. It's required at runtime in `utils/index.ts`.
- **`packages/bruno-js/package.json`** : Added `@usebruno/requests` to `dependencies`. It's required at runtime in `bru.js` but was never declared.
- **`package-lock.json`** : Updated to reflect the above changes.

**After fix:**

<img width="934" height="786" alt="Screenshot 2026-05-26 at 01-31-19" src="https://github.com/user-attachments/assets/5cb44ed6-b87e-4cbc-969f-684133d3a0d5" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package dependency configuration to ensure required runtime functionality is available when using the JavaScript and request-related packages.
  * Improved dependency clarity and runtime availability by promoting a utility to a runtime dependency and declaring required request and query-string support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->