### PR TITLE
feat: add bru docs generate command for HTML documentation

### DIFF
--- a/packages/bruno-cli/.gitignore
+++ b/packages/bruno-cli/.gitignore
@@ -2,6 +2,8 @@ node_modules
 web
 out
 
+output.html
+
 pnpm-lock.yaml
 package-lock.json
 yarn.lock

--- a/packages/bruno-cli/src/commands/docs.js
+++ b/packages/bruno-cli/src/commands/docs.js
@@ -1,0 +1,20 @@
+'use strict';
+/**
+ * packages/bruno-cli/src/commands/docs.js
+ *
+ * Registers the `bru docs` sub-command group using yargs' commandDir pattern.
+ * Yargs auto-discovers sub-commands from the ./docs/ directory.
+ *
+ * Usage:
+ *   bru docs generate <collection-path> [options]
+ */
+
+exports.command = 'docs <subcommand>';
+exports.describe = 'Generate documentation from a Bruno collection';
+
+exports.builder = (yargs) => {
+  return yargs.commandDir('docs').demandCommand(1, 'Please specify a docs subcommand (e.g. generate)');
+};
+
+// The handler is never called directly — yargs routes to the sub-command.
+exports.handler = () => {};

--- a/packages/bruno-cli/src/commands/docs/generate.js
+++ b/packages/bruno-cli/src/commands/docs/generate.js
@@ -136,6 +136,12 @@ exports.handler = async (argv) => {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+/**
+ * Recursively count requests and folders in the items tree.
+ * @param {Array} items
+ * @param {{ requests: number, folders: number }} acc
+ * @returns {{ requests: number, folders: number }}
+ */
 function countItems(items, acc = { requests: 0, folders: 0 }) {
   for (const item of items) {
     if (item.type === 'folder') {

--- a/packages/bruno-cli/src/commands/docs/generate.js
+++ b/packages/bruno-cli/src/commands/docs/generate.js
@@ -1,0 +1,169 @@
+'use strict';
+/**
+ * packages/bruno-cli/src/commands/docs/generate.js
+ *
+ * Implements `bru docs generate <collection-path>`.
+ *
+ * Pipeline:
+ *   1. Validate the collection path
+ *   2. Load & parse the collection (OpenCollection YAML or .bru)
+ *   3. Build a single OpenCollection YAML string
+ *   4. Render the HTML file embedding that YAML + CDN viewer
+ *   5. Write output and print summary
+ */
+
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+const { loadCollection } = require('../../docs/load-collection');
+const { buildYaml, validateYaml } = require('../../docs/build-yaml');
+const { renderHtml } = require('../../docs/render-html');
+const { resolveOutput, assertCollectionRoot, ensureDir } = require('../../docs/fs-helpers');
+const { EXIT_STATUS } = require('../../constants');
+
+// ── Command definition (yargs API) ────────────────────────────────────────────
+
+exports.command = 'generate <collection>';
+exports.describe = 'Generate an HTML documentation file from a Bruno collection';
+
+exports.builder = (yargs) => {
+  return yargs
+    .positional('collection', {
+      describe: 'Path to the Bruno collection folder',
+      type: 'string'
+    })
+    .option('output', {
+      alias: 'o',
+      describe: 'Path for the generated HTML file',
+      type: 'string',
+      default: 'docs/index.html'
+    })
+    .option('title', {
+      alias: 't',
+      describe: 'Override the collection name shown in the docs',
+      type: 'string'
+    })
+    .option('theme', {
+      describe: 'Viewer theme',
+      type: 'string',
+      choices: ['light', 'dark'],
+      default: 'light'
+    })
+    .option('git-url', {
+      describe: 'URL of the Git repository (shown in the viewer)',
+      type: 'string'
+    })
+    .example(
+      '$0 docs generate ./my-api --output docs/index.html --theme dark',
+      'Generate dark-themed docs for ./my-api'
+    )
+    .example(
+      '$0 docs generate ./my-api --title "My API" --git-url https://github.com/org/repo',
+      'Generate docs with a custom title and Git link'
+    );
+};
+
+exports.handler = async (argv) => {
+  const collectionDir = path.resolve(argv.collection);
+  const outputPath = resolveOutput(argv.output);
+
+  const theme = argv.theme;
+  const gitUrl = argv['git-url'] || '';
+  const titleOverride = argv.title || null;
+
+  // ── Step 1: validate collection path ──────────────────────────────────────
+  try {
+    assertCollectionRoot(collectionDir);
+  } catch (err) {
+    console.error(chalk.red(`\n  ${err.message}\n`));
+    process.exit(EXIT_STATUS.ERROR_FILE_NOT_FOUND);
+  }
+
+  console.log(chalk.dim(`\n  Reading collection: ${collectionDir}`));
+
+  // ── Step 2: load & parse collection ───────────────────────────────────────
+  let collection;
+  try {
+    collection = loadCollection(collectionDir, { titleOverride });
+  } catch (err) {
+    console.error(chalk.red(`\n  Failed to parse collection: ${err.message}\n`));
+    if (process.env.DEBUG) console.error(err.stack);
+    process.exit(EXIT_STATUS.ERROR_INVALID_FILE);
+  }
+
+  const { requests, folders } = countItems(collection.items);
+  console.log(
+    chalk.green(`  ${collection.info.name}`)
+    + chalk.dim(` — ${requests} requests, ${folders} folders, ${collection.environments.length} environments`)
+  );
+
+  // ── Step 3: build OpenCollection YAML ─────────────────────────────────────
+  let yamlString;
+  try {
+    yamlString = buildYaml(collection);
+  } catch (err) {
+    console.error(chalk.red(`\n  Failed to build YAML: ${err.message}\n`));
+    process.exit(EXIT_STATUS.ERROR_INVALID_FILE);
+  }
+
+  const { valid, error: yamlError } = validateYaml(yamlString);
+  if (!valid) {
+    console.error(chalk.yellow(`\n  Warning: generated YAML failed validation: ${yamlError}`));
+    console.error(chalk.yellow('  The output HTML may not render correctly.\n'));
+  }
+
+  // ── Step 4: render HTML ────────────────────────────────────────────────────
+  const html = renderHtml({
+    title: collection.info.name,
+    yamlString,
+    theme,
+    gitUrl
+  });
+
+  // ── Step 5: write output ───────────────────────────────────────────────────
+  try {
+    ensureDir(path.dirname(outputPath));
+    fs.writeFileSync(outputPath, html, 'utf8');
+  } catch (err) {
+    console.error(chalk.red(`\n  Failed to write output file: ${err.message}\n`));
+    process.exit(EXIT_STATUS.ERROR_GENERIC);
+  }
+
+  const sizeKb = (Buffer.byteLength(html, 'utf8') / 1024).toFixed(1);
+  console.log(chalk.green(`\n  Documentation generated: ${outputPath}`));
+  console.log(chalk.dim(`  Size: ${sizeKb} KB  •  YAML: ${(Buffer.byteLength(yamlString, 'utf8') / 1024).toFixed(1)} KB\n`));
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function countItems(items, acc = { requests: 0, folders: 0 }) {
+  for (const item of items) {
+    if (item.type === 'folder') {
+      acc.folders++;
+      countItems(item.items || [], acc);
+    } else {
+      acc.requests++;
+    }
+  }
+  return acc;
+}
+
+if (require.main === module) {
+  const argv = require('yargs/yargs')(process.argv.slice(2))
+    .option('output', { type: 'string', default: 'docs/index.html' })
+    .option('title', { type: 'string' })
+    .option('theme', { type: 'string', default: 'light' })
+    .option('git-url', { type: 'string' })
+    .parse();
+
+  exports.handler({
+    'collection': argv._[0],
+    'output': argv.output,
+    'title': argv.title,
+    'theme': argv.theme,
+    'git-url': argv['git-url']
+  }).catch((err) => {
+    console.error(chalk.red(err.message));
+    process.exit(EXIT_STATUS.ERROR_GENERIC);
+  });
+}

--- a/packages/bruno-cli/src/docs/build-yaml.js
+++ b/packages/bruno-cli/src/docs/build-yaml.js
@@ -1,0 +1,224 @@
+'use strict';
+/**
+ * packages/bruno-cli/src/docs/build-yaml.js
+ *
+ * Converts the normalized collection object (from load-collection.js) into a
+ * single OpenCollection YAML string suitable for embedding in the HTML viewer.
+ *
+ * Key serialization choices:
+ *  - lineWidth: -1    → URLs and long values are never broken across lines
+ *  - noRefs: true     → no YAML anchors/aliases; the viewer may not support them
+ *  - sortKeys: false  → preserve semantic order (info before http before docs, etc.)
+ *  - Multiline strings (body.data, script code) serialize as YAML block literals
+ *    automatically when they contain newlines — js-yaml handles this.
+ */
+
+const yaml = require('js-yaml');
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * @param {CollectionModel} collection
+ * @returns {string}  Valid YAML string
+ */
+function buildYaml(collection) {
+  const doc = assembleDocument(collection);
+
+  return yaml.dump(doc, {
+    lineWidth: -1,
+    noRefs: true,
+    quotingType: '\'',
+    forceQuotes: false,
+    condenseFlow: false,
+    sortKeys: false
+  });
+}
+
+/**
+ * Validates that the produced YAML can be round-tripped.
+ * @param {string} yamlStr
+ * @returns {{ valid: boolean, error?: string }}
+ */
+function validateYaml(yamlStr) {
+  try {
+    const parsed = yaml.load(yamlStr);
+    if (!parsed || typeof parsed !== 'object') {
+      return { valid: false, error: 'YAML parsed to a non-object value' };
+    }
+    return { valid: true };
+  } catch (err) {
+    return { valid: false, error: err.message };
+  }
+}
+
+// ── Document assembly ─────────────────────────────────────────────────────────
+
+function assembleDocument(col) {
+  const doc = { opencollection: col.opencollection || '1.0.0' };
+
+  doc.info = compact({ ...col.info });
+
+  if (col.config && Object.keys(col.config).length > 0) {
+    doc.config = col.config;
+  }
+
+  if (col.environments && col.environments.length > 0) {
+    doc.environments = col.environments.map(serializeEnvironment);
+  }
+
+  if (col.items && col.items.length > 0) {
+    doc.items = col.items.map(serializeItem);
+  }
+
+  return doc;
+}
+
+// ── Environments ──────────────────────────────────────────────────────────────
+
+function serializeEnvironment(env) {
+  return {
+    name: env.name,
+    variables: (env.variables || []).map((v) => compact({
+      name: v.name,
+      value: v.value ?? '',
+      enabled: v.enabled !== false ? undefined : false, // omit if true (default)
+      secret: v.secret || undefined
+    }))
+  };
+}
+
+// ── Items (folders and requests) ──────────────────────────────────────────────
+
+function serializeItem(item) {
+  return item.type === 'folder' ? serializeFolder(item) : serializeRequest(item);
+}
+
+function serializeFolder(folder) {
+  const out = {
+    type: 'folder',
+    name: folder.name
+  };
+
+  if (Number.isFinite(folder.seq)) out.seq = folder.seq;
+  if (folder.description) out.description = folder.description;
+  if (folder.auth) out.auth = folder.auth;
+  if (folder.config && Object.keys(folder.config).length > 0) out.config = folder.config;
+
+  if (folder.items && folder.items.length > 0) {
+    out.items = folder.items.map(serializeItem);
+  }
+
+  return out;
+}
+
+function serializeRequest(req) {
+  // Determine protocol key: http | graphql | grpc | websocket
+  const protocolKey = ['http', 'graphql', 'grpc', 'websocket'].find((k) => req[k]);
+
+  const out = {};
+
+  // info block always first
+  out.info = serializeRequestInfo(req.info);
+
+  // protocol block
+  if (protocolKey && req[protocolKey]) {
+    out[protocolKey] = serializeProtocolBlock(req[protocolKey]);
+  }
+
+  // optional blocks — only if present
+  if (req.runtime) {
+    const r = serializeRuntime(req.runtime);
+    if (r) out.runtime = r;
+  }
+
+  if (req.docs) out.docs = req.docs;
+  if (req.examples && req.examples.length > 0) out.examples = req.examples;
+  if (req.settings && Object.keys(req.settings).length > 0) out.settings = req.settings;
+
+  return out;
+}
+
+function serializeRequestInfo(info) {
+  return compact({
+    name: info.name,
+    type: info.type || 'http',
+    seq: Number.isFinite(info.seq) ? info.seq : undefined,
+    description: info.description || undefined
+  });
+}
+
+function serializeProtocolBlock(block) {
+  if (!block || typeof block !== 'object') return {};
+
+  const out = {};
+
+  if (block.method) out.method = block.method;
+  if (block.url) out.url = block.url;
+  if (block.path) out.path = block.path;
+
+  if (Array.isArray(block.headers) && block.headers.length > 0) {
+    out.headers = block.headers;
+  }
+
+  if (Array.isArray(block.params) && block.params.length > 0) {
+    out.params = block.params;
+  }
+
+  if (block.body) {
+    const body = serializeBody(block.body);
+    if (body) out.body = body;
+  }
+
+  if (block.auth !== undefined && block.auth !== null) {
+    out.auth = block.auth;
+  }
+
+  return out;
+}
+
+function serializeBody(body) {
+  if (!body || !body.type || body.type === 'none') return null;
+
+  const out = { type: body.type };
+
+  if (body.data !== undefined && body.data !== null && body.data !== '') {
+    // Force to string. If it contains newlines, js-yaml will use block literal (|).
+    out.data = String(body.data);
+  }
+
+  if (Array.isArray(body.fields) && body.fields.length > 0) {
+    out.fields = body.fields;
+  }
+
+  return out;
+}
+
+function serializeRuntime(runtime) {
+  if (!runtime) return null;
+  const out = {};
+
+  if (Array.isArray(runtime.scripts) && runtime.scripts.length > 0) {
+    out.scripts = runtime.scripts.map((s) => ({
+      type: s.type || 'pre-request',
+      code: String(s.code || '') // multiline → block literal automatically
+    }));
+  }
+
+  if (runtime.auth) out.auth = runtime.auth;
+  if (runtime.vars) out.vars = runtime.vars;
+
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+/** Remove keys whose value is undefined (not null — null is a valid YAML value). */
+function compact(obj) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+module.exports = { buildYaml, validateYaml };

--- a/packages/bruno-cli/src/docs/build-yaml.js
+++ b/packages/bruno-cli/src/docs/build-yaml.js
@@ -53,6 +53,11 @@ function validateYaml(yamlStr) {
 
 // ── Document assembly ─────────────────────────────────────────────────────────
 
+/**
+ * Assemble the full OpenCollection document object from the normalised collection model.
+ * @param {object} col
+ * @returns {object}
+ */
 function assembleDocument(col) {
   const doc = { opencollection: col.opencollection || '1.0.0' };
 
@@ -75,6 +80,11 @@ function assembleDocument(col) {
 
 // ── Environments ──────────────────────────────────────────────────────────────
 
+/**
+ * Serialise a single environment to OpenCollection format.
+ * @param {object} env
+ * @returns {object}
+ */
 function serializeEnvironment(env) {
   return {
     name: env.name,
@@ -89,10 +99,20 @@ function serializeEnvironment(env) {
 
 // ── Items (folders and requests) ──────────────────────────────────────────────
 
+/**
+ * Serialise a single item (folder or request).
+ * @param {object} item
+ * @returns {object}
+ */
 function serializeItem(item) {
   return item.type === 'folder' ? serializeFolder(item) : serializeRequest(item);
 }
 
+/**
+ * Serialise a folder item, including its child items.
+ * @param {object} folder
+ * @returns {object}
+ */
 function serializeFolder(folder) {
   const out = {
     type: 'folder',
@@ -111,6 +131,11 @@ function serializeFolder(folder) {
   return out;
 }
 
+/**
+ * Serialise a request item with its info, protocol block, runtime, docs, etc.
+ * @param {object} req
+ * @returns {object}
+ */
 function serializeRequest(req) {
   // Determine protocol key: http | graphql | grpc | websocket
   const protocolKey = ['http', 'graphql', 'grpc', 'websocket'].find((k) => req[k]);
@@ -138,6 +163,11 @@ function serializeRequest(req) {
   return out;
 }
 
+/**
+ * Serialise the request info block, removing undefined values.
+ * @param {object} info
+ * @returns {object}
+ */
 function serializeRequestInfo(info) {
   return compact({
     name: info.name,
@@ -147,6 +177,11 @@ function serializeRequestInfo(info) {
   });
 }
 
+/**
+ * Serialise a protocol block (method, url, headers, params, body, auth).
+ * @param {object} block
+ * @returns {object}
+ */
 function serializeProtocolBlock(block) {
   if (!block || typeof block !== 'object') return {};
 
@@ -176,6 +211,12 @@ function serializeProtocolBlock(block) {
   return out;
 }
 
+/**
+ * Serialise a body block to { type, data?, fields? }.
+ * Returns null for empty or 'none' type bodies.
+ * @param {object} body
+ * @returns {object|null}
+ */
 function serializeBody(body) {
   if (!body || !body.type || body.type === 'none') return null;
 
@@ -193,6 +234,12 @@ function serializeBody(body) {
   return out;
 }
 
+/**
+ * Serialise runtime scripts, auth, and vars.
+ * Returns null if runtime is empty.
+ * @param {object} runtime
+ * @returns {object|null}
+ */
 function serializeRuntime(runtime) {
   if (!runtime) return null;
   const out = {};
@@ -212,7 +259,9 @@ function serializeRuntime(runtime) {
 
 // ── Utilities ─────────────────────────────────────────────────────────────────
 
-/** Remove keys whose value is undefined (not null — null is a valid YAML value). */
+/**
+ * Remove keys whose value is undefined (not null — null is a valid YAML value).
+ */
 function compact(obj) {
   const out = {};
   for (const [k, v] of Object.entries(obj)) {

--- a/packages/bruno-cli/src/docs/fs-helpers.js
+++ b/packages/bruno-cli/src/docs/fs-helpers.js
@@ -1,0 +1,65 @@
+'use strict';
+/**
+ * packages/bruno-cli/src/docs/fs-helpers.js
+ *
+ * Thin filesystem helpers for the docs command.
+ * Kept separate so they can be unit-tested in isolation.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Throws a descriptive Error if `dir` is not a valid Bruno collection root.
+ * A valid root contains either opencollection.yml (v3+) or bruno.json (.bru).
+ *
+ * @param {string} dir  Absolute path
+ * @throws {Error}
+ */
+function assertCollectionRoot(dir) {
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Collection path does not exist: ${dir}`);
+  }
+
+  const stat = fs.lstatSync(dir);
+  if (!stat.isDirectory()) {
+    throw new Error(`Collection path is not a directory: ${dir}`);
+  }
+
+  const hasOpenCollection = fs.existsSync(path.join(dir, 'opencollection.yml'));
+  const hasBruJson = fs.existsSync(path.join(dir, 'bruno.json'));
+
+  if (!hasOpenCollection && !hasBruJson) {
+    throw new Error(
+      `Not a Bruno collection: ${dir}\n`
+      + `  Expected to find "opencollection.yml" (OpenCollection format) `
+      + `or "bruno.json" (.bru format).`
+    );
+  }
+}
+
+/**
+ * Resolves the output path.
+ * If the value is relative it is resolved against process.cwd().
+ *
+ * @param {string} outputArg  Value of --output (may be relative or absolute)
+ * @returns {string}          Absolute path
+ */
+function resolveOutput(outputArg) {
+  return path.resolve(outputArg);
+}
+
+/**
+ * Creates `dir` (and any parent directories) if it does not exist.
+ * No-op if it already exists.
+ *
+ * @param {string} dir
+ * @throws {Error} If creation fails
+ */
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+module.exports = { assertCollectionRoot, resolveOutput, ensureDir };

--- a/packages/bruno-cli/src/docs/load-collection.js
+++ b/packages/bruno-cli/src/docs/load-collection.js
@@ -27,6 +27,7 @@ const yaml = require('js-yaml');
 // Re-use @usebruno/lang for .bru files, exactly as run.js does.
 // We lazy-require so the module only fails if someone actually has a .bru collection.
 let _bruUtils = null;
+/** Lazy-load and cache the @usebruno/lang bridge utility. */
 function getBruUtils() {
   if (!_bruUtils) {
     try {
@@ -79,6 +80,13 @@ function loadCollection(collectionDir, { titleOverride = null } = {}) {
 
 // ── Root metadata ─────────────────────────────────────────────────────────────
 
+/**
+ * Read collection-level metadata (name, version, description, config)
+ * from either opencollection.yml or bruno.json.
+ * @param {string} collectionDir
+ * @param {boolean} isOpenCollection
+ * @returns {{ name: string|null, version: string|null, description: string|null, config: object }}
+ */
 function readRootMeta(collectionDir, isOpenCollection) {
   if (isOpenCollection) {
     const raw = loadYamlFile(path.join(collectionDir, 'opencollection.yml')) || {};
@@ -105,6 +113,13 @@ function readRootMeta(collectionDir, isOpenCollection) {
 
 // ── Environments ──────────────────────────────────────────────────────────────
 
+/**
+ * Read all environment files from the environments/ sub-directory.
+ * Supports .yml (OpenCollection) and .bru (classic) formats.
+ * @param {string} collectionDir
+ * @param {boolean} isOpenCollection
+ * @returns {Array<{ name: string, variables: Array }>}
+ */
 function readEnvironments(collectionDir, isOpenCollection) {
   const envDir = path.join(collectionDir, 'environments');
   if (!fs.existsSync(envDir)) return [];
@@ -138,6 +153,11 @@ function readEnvironments(collectionDir, isOpenCollection) {
   return results;
 }
 
+/**
+ * Normalise environment variables to a consistent { name, value, enabled, secret? } shape.
+ * @param {Array} vars
+ * @returns {Array}
+ */
 function normalizeEnvVars(vars) {
   if (!Array.isArray(vars)) return [];
   return vars
@@ -152,6 +172,13 @@ function normalizeEnvVars(vars) {
 
 // ── OpenCollection YAML items ─────────────────────────────────────────────────
 
+/**
+ * Recursively scan a directory for OpenCollection YAML items.
+ * Directories become folders, .yml files become requests.
+ * @param {string} dir
+ * @param {string} rootDir
+ * @returns {Array}
+ */
 function readOpenCollectionItems(dir, rootDir) {
   const items = [];
 
@@ -169,6 +196,12 @@ function readOpenCollectionItems(dir, rootDir) {
   return items;
 }
 
+/**
+ * Read a folder.yml and recursively collect its child items.
+ * @param {string} folderPath
+ * @param {string} rootDir
+ * @returns {object|null}
+ */
 function readOpenCollectionFolder(folderPath, rootDir) {
   const metaFile = path.join(folderPath, 'folder.yml');
   const raw = fs.existsSync(metaFile) ? (loadYamlFile(metaFile) || {}) : {};
@@ -188,6 +221,12 @@ function readOpenCollectionFolder(folderPath, rootDir) {
   };
 }
 
+/**
+ * Parse a single OpenCollection YAML request file.
+ * Detects the protocol (http/graphql/grpc/websocket) and normalises the block.
+ * @param {string} filePath
+ * @returns {object|null}
+ */
 function readOpenCollectionRequest(filePath) {
   const raw = loadYamlFile(filePath);
   if (!raw || typeof raw !== 'object') return null;
@@ -220,6 +259,12 @@ function readOpenCollectionRequest(filePath) {
 
 // ── .bru items ────────────────────────────────────────────────────────────────
 
+/**
+ * Recursively scan a directory for .bru items.
+ * @param {string} dir
+ * @param {string} rootDir
+ * @returns {Array}
+ */
 function readBruItems(dir, rootDir) {
   const items = [];
   const { bruToJson } = getBruUtils();
@@ -241,6 +286,12 @@ function readBruItems(dir, rootDir) {
   return items;
 }
 
+/**
+ * Read a folder.bru for metadata, then recursively collect child items.
+ * @param {string} folderPath
+ * @param {string} rootDir
+ * @returns {object|null}
+ */
 function readBruFolder(folderPath, rootDir) {
   const { collectionBruToJson } = getBruUtils();
   let name = formatDirName(path.basename(folderPath));
@@ -289,6 +340,11 @@ function normalizeBruRequest(bruJson) {
   };
 }
 
+/**
+ * Normalise a .bru body object to { type, data }.
+ * @param {object} body
+ * @returns {object|null}
+ */
 function normalizeBruBody(body) {
   if (!body || body.mode === 'none') return null;
 
@@ -304,11 +360,18 @@ function normalizeBruBody(body) {
 
 // ── Normalization helpers ─────────────────────────────────────────────────────
 
+/**
+ * Normalise a protocol block (http/graphql/grpc/websocket) to a consistent shape.
+ * Coerces method to uppercase string.  Returns empty object if input is falsy.
+ * @param {object} proto
+ * @param {object} rawRequest  The full raw request (fallback for auth)
+ * @returns {object}
+ */
 function normalizeProtocolBlock(proto, rawRequest) {
   if (!proto || typeof proto !== 'object') return {};
 
   const out = {};
-  if (proto.method) out.method = proto.method.toUpperCase();
+  if (proto.method) out.method = String(proto.method).toUpperCase();
   if (proto.url) out.url = proto.url;
   if (proto.path) out.path = proto.path; // grpc
 
@@ -346,6 +409,12 @@ function normalizeProtocolBlock(proto, rawRequest) {
   return out;
 }
 
+/**
+ * Normalise an array of { name, key, value, ... } objects to { name, value, enabled?, description? }.
+ * Filters out entries without a name or key.
+ * @param {Array} arr
+ * @returns {Array}
+ */
 function normalizeKvArray(arr) {
   return arr
     .filter((i) => i && (i.name || i.key))
@@ -357,6 +426,12 @@ function normalizeKvArray(arr) {
     }));
 }
 
+/**
+ * Normalise runtime scripts from both OpenCollection (runtime.scripts) and legacy .bru (script.req/res) formats.
+ * @param {object} runtime
+ * @param {object} [legacyScript]
+ * @returns {object|undefined}
+ */
 function normalizeRuntime(runtime, legacyScript) {
   const scripts = [];
 
@@ -382,6 +457,11 @@ function normalizeRuntime(runtime, legacyScript) {
 
 // ── Detection helpers ─────────────────────────────────────────────────────────
 
+/**
+ * Detect the request protocol from the top-level keys of a raw OpenCollection request.
+ * @param {object} raw
+ * @returns {string|null}
+ */
 function detectProtocol(raw) {
   if (raw.http) return 'http';
   if (raw.graphql) return 'graphql';
@@ -397,6 +477,10 @@ function hasDocContent(docs) {
 
 // ── Sorting ───────────────────────────────────────────────────────────────────
 
+/**
+ * Sort items in-place by seq, then by name (case-insensitive).
+ * @param {Array} items
+ */
 function sortItems(items) {
   items.sort((a, b) => {
     const sa = toSeq(a.seq ?? (a.info && a.info.seq));
@@ -410,6 +494,7 @@ function sortItems(items) {
 
 // ── Low-level utils ───────────────────────────────────────────────────────────
 
+/** Read and parse a YAML file, returning null on any failure. */
 function loadYamlFile(fp) {
   try {
     return yaml.load(fs.readFileSync(fp, 'utf8'));
@@ -418,19 +503,23 @@ function loadYamlFile(fp) {
   }
 }
 
+/** Safe directory listing that returns empty array on error. */
 function safeReaddir(dir) {
   try { return fs.readdirSync(dir); } catch { return []; }
 }
 
+/** Safe directory listing with file-type metadata. */
 function safeReaddirWithTypes(dir) {
   try { return fs.readdirSync(dir, { withFileTypes: true }); } catch { return []; }
 }
 
+/** Convert a value to a numeric sequence number, defaulting to Infinity. */
 function toSeq(val) {
   const n = Number(val);
   return Number.isFinite(n) ? n : Infinity;
 }
 
+/** Convert a directory name (kebab-case, snake_case) to Title Case. */
 function formatDirName(name) {
   return name.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/packages/bruno-cli/src/docs/load-collection.js
+++ b/packages/bruno-cli/src/docs/load-collection.js
@@ -1,0 +1,438 @@
+'use strict';
+/**
+ * packages/bruno-cli/src/docs/load-collection.js
+ *
+ * Reads a Bruno collection from disk and returns a normalized JS object.
+ * Supports both:
+ *   - OpenCollection YAML format (Bruno v3+, files: opencollection.yml + *.yml)
+ *   - Classic .bru format (uses @usebruno/lang, same as the run command)
+ *
+ * The returned shape is:
+ * {
+ *   opencollection: '1.0.0',
+ *   info: { name, version?, description? },
+ *   config: {},
+ *   environments: [{ name, variables: [{name, value, enabled, secret?}] }],
+ *   items: [ FolderItem | RequestItem ]
+ * }
+ *
+ * FolderItem:  { type:'folder', name, seq, description?, items: [...] }
+ * RequestItem: { type:'request', info:{name,type,seq}, http:{...}, docs?, examples?, runtime?, settings? }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// Re-use @usebruno/lang for .bru files, exactly as run.js does.
+// We lazy-require so the module only fails if someone actually has a .bru collection.
+let _bruUtils = null;
+function getBruUtils() {
+  if (!_bruUtils) {
+    try {
+      _bruUtils = require('../utils/bru'); // the existing bru.js util in the CLI
+    } catch {
+      throw new Error(
+        'Could not load @usebruno/lang. Make sure you are running inside the bruno-cli package.'
+      );
+    }
+  }
+  return _bruUtils;
+}
+
+// Directories that are never collection items
+const SKIP_DIRS = new Set(['environments', 'node_modules', '.git', '.bruno']);
+
+// Files at the root of a directory that are metadata, not requests
+const META_FILES = new Set(['opencollection.yml', 'folder.yml', 'collection.yml', 'bruno.json']);
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * @param {string} collectionDir  Absolute path to the collection root
+ * @param {{ titleOverride?: string }} options
+ * @returns {CollectionModel}
+ */
+function loadCollection(collectionDir, { titleOverride = null } = {}) {
+  const isOpenCollection = fs.existsSync(path.join(collectionDir, 'opencollection.yml'));
+
+  const rootMeta = readRootMeta(collectionDir, isOpenCollection);
+  const environments = readEnvironments(collectionDir, isOpenCollection);
+  const items = isOpenCollection
+    ? readOpenCollectionItems(collectionDir, collectionDir)
+    : readBruItems(collectionDir, collectionDir);
+
+  sortItems(items);
+
+  return {
+    opencollection: '1.0.0',
+    info: {
+      name: titleOverride || rootMeta.name || path.basename(collectionDir),
+      ...(rootMeta.version ? { version: rootMeta.version } : {}),
+      ...(rootMeta.description ? { description: rootMeta.description } : {})
+    },
+    config: rootMeta.config || {},
+    environments,
+    items
+  };
+}
+
+// ── Root metadata ─────────────────────────────────────────────────────────────
+
+function readRootMeta(collectionDir, isOpenCollection) {
+  if (isOpenCollection) {
+    const raw = loadYamlFile(path.join(collectionDir, 'opencollection.yml')) || {};
+    const info = raw.info || raw;
+    return {
+      name: info.name || null,
+      version: info.version || null,
+      description: info.description || null,
+      config: raw.config || {}
+    };
+  }
+
+  // .bru format — read bruno.json
+  const bruJson = path.join(collectionDir, 'bruno.json');
+  if (fs.existsSync(bruJson)) {
+    try {
+      const d = JSON.parse(fs.readFileSync(bruJson, 'utf8'));
+      return { name: d.name || null, version: d.version || null, description: null, config: {} };
+    } catch { /* fall through */ }
+  }
+
+  return { name: null, version: null, description: null, config: {} };
+}
+
+// ── Environments ──────────────────────────────────────────────────────────────
+
+function readEnvironments(collectionDir, isOpenCollection) {
+  const envDir = path.join(collectionDir, 'environments');
+  if (!fs.existsSync(envDir)) return [];
+
+  const results = [];
+  for (const file of safeReaddir(envDir)) {
+    const fp = path.join(envDir, file);
+
+    if (isOpenCollection && file.endsWith('.yml')) {
+      const raw = loadYamlFile(fp);
+      if (!raw) continue;
+      results.push({
+        name: raw.name || path.basename(file, '.yml'),
+        variables: normalizeEnvVars(raw.variables || raw.vars || [])
+      });
+      continue;
+    }
+
+    if (!isOpenCollection && file.endsWith('.bru')) {
+      try {
+        const { bruToEnvJson } = getBruUtils();
+        const bru = fs.readFileSync(fp, 'utf8');
+        const env = bruToEnvJson(bru);
+        results.push({
+          name: env.name || path.basename(file, '.bru'),
+          variables: normalizeEnvVars(env.variables || [])
+        });
+      } catch { /* skip malformed env */ }
+    }
+  }
+  return results;
+}
+
+function normalizeEnvVars(vars) {
+  if (!Array.isArray(vars)) return [];
+  return vars
+    .filter((v) => v && (v.name || v.key))
+    .map((v) => ({
+      name: v.name || v.key,
+      value: v.value ?? '',
+      enabled: v.enabled !== false,
+      ...(v.secret ? { secret: true } : {})
+    }));
+}
+
+// ── OpenCollection YAML items ─────────────────────────────────────────────────
+
+function readOpenCollectionItems(dir, rootDir) {
+  const items = [];
+
+  for (const entry of safeReaddirWithTypes(dir)) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const folder = readOpenCollectionFolder(path.join(dir, entry.name), rootDir);
+      if (folder) items.push(folder);
+    } else if (entry.isFile() && entry.name.endsWith('.yml')) {
+      if (META_FILES.has(entry.name)) continue;
+      const req = readOpenCollectionRequest(path.join(dir, entry.name));
+      if (req) items.push(req);
+    }
+  }
+  return items;
+}
+
+function readOpenCollectionFolder(folderPath, rootDir) {
+  const metaFile = path.join(folderPath, 'folder.yml');
+  const raw = fs.existsSync(metaFile) ? (loadYamlFile(metaFile) || {}) : {};
+  const m = raw.meta || raw;
+
+  const children = readOpenCollectionItems(folderPath, rootDir);
+  sortItems(children);
+
+  return {
+    type: 'folder',
+    name: m.name || formatDirName(path.basename(folderPath)),
+    seq: toSeq(m.seq),
+    ...(m.description ? { description: m.description } : {}),
+    ...(raw.auth ? { auth: raw.auth } : {}),
+    ...(raw.config && Object.keys(raw.config).length ? { config: raw.config } : {}),
+    items: children
+  };
+}
+
+function readOpenCollectionRequest(filePath) {
+  const raw = loadYamlFile(filePath);
+  if (!raw || typeof raw !== 'object') return null;
+
+  const type = (raw.info && raw.info.type) || detectProtocol(raw);
+  if (!type) return null;
+
+  const protocolKey = type; // 'http' | 'graphql' | 'grpc' | 'websocket'
+  const proto = raw[protocolKey] || (type === 'http' ? raw.http : null) || {};
+
+  const req = {
+    type: 'request',
+    info: {
+      name: (raw.info && raw.info.name) || path.basename(filePath, '.yml'),
+      type,
+      seq: toSeq(raw.info && raw.info.seq)
+    },
+    [protocolKey]: normalizeProtocolBlock(proto, raw)
+  };
+
+  if (raw.runtime) req.runtime = normalizeRuntime(raw.runtime, raw.script);
+  else if (raw.script && (raw.script.req || raw.script.res)) req.runtime = normalizeRuntime({}, raw.script);
+
+  if (raw.docs && hasDocContent(raw.docs)) req.docs = raw.docs;
+  if (Array.isArray(raw.examples) && raw.examples.length > 0) req.examples = raw.examples;
+  if (raw.settings && Object.keys(raw.settings).length > 0) req.settings = raw.settings;
+
+  return req;
+}
+
+// ── .bru items ────────────────────────────────────────────────────────────────
+
+function readBruItems(dir, rootDir) {
+  const items = [];
+  const { bruToJson } = getBruUtils();
+
+  for (const entry of safeReaddirWithTypes(dir)) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const folder = readBruFolder(path.join(dir, entry.name), rootDir);
+      if (folder) items.push(folder);
+    } else if (entry.isFile() && entry.name.endsWith('.bru')) {
+      if (entry.name === 'collection.bru' || entry.name === 'folder.bru') continue;
+      try {
+        const raw = bruToJson(fs.readFileSync(path.join(dir, entry.name), 'utf8'));
+        const req = normalizeBruRequest(raw);
+        if (req) items.push(req);
+      } catch { /* skip malformed request */ }
+    }
+  }
+  return items;
+}
+
+function readBruFolder(folderPath, rootDir) {
+  const { collectionBruToJson } = getBruUtils();
+  let name = formatDirName(path.basename(folderPath));
+  let seq = Infinity;
+
+  const folderBru = path.join(folderPath, 'folder.bru');
+  if (fs.existsSync(folderBru)) {
+    try {
+      const raw = collectionBruToJson(fs.readFileSync(folderBru, 'utf8'));
+      name = raw.name || name;
+      seq = toSeq(raw.seq);
+    } catch { /* use defaults */ }
+  }
+
+  const children = readBruItems(folderPath, rootDir);
+  sortItems(children);
+
+  return { type: 'folder', name, seq, items: children };
+}
+
+/**
+ * Converts the shape returned by bruToJson (run.js format) to our canonical shape.
+ */
+function normalizeBruRequest(bruJson) {
+  if (!bruJson || !bruJson.name) return null;
+
+  const method = (bruJson.request && bruJson.request.method) || 'GET';
+  const url = (bruJson.request && bruJson.request.url) || '';
+
+  return {
+    type: 'request',
+    info: {
+      name: bruJson.name,
+      type: bruJson.type === 'graphql-request' ? 'graphql' : 'http',
+      seq: toSeq(bruJson.seq)
+    },
+    http: {
+      method,
+      url,
+      ...(bruJson.request.headers && bruJson.request.headers.length ? { headers: bruJson.request.headers } : {}),
+      ...(bruJson.request.params && bruJson.request.params.length ? { params: bruJson.request.params } : {}),
+      ...(bruJson.request.body && bruJson.request.body.mode !== 'none' ? { body: normalizeBruBody(bruJson.request.body) } : {}),
+      ...(bruJson.request.auth ? { auth: bruJson.request.auth } : {})
+    },
+    ...(bruJson.request.script ? { runtime: normalizeRuntime({}, bruJson.request.script) } : {})
+  };
+}
+
+function normalizeBruBody(body) {
+  if (!body || body.mode === 'none') return null;
+
+  const data = body[body.mode];
+
+  return {
+    type: body.mode || 'text',
+    data: typeof data === 'object'
+      ? JSON.stringify(data, null, 2)
+      : data || ''
+  };
+}
+
+// ── Normalization helpers ─────────────────────────────────────────────────────
+
+function normalizeProtocolBlock(proto, rawRequest) {
+  if (!proto || typeof proto !== 'object') return {};
+
+  const out = {};
+  if (proto.method) out.method = proto.method.toUpperCase();
+  if (proto.url) out.url = proto.url;
+  if (proto.path) out.path = proto.path; // grpc
+
+  if (Array.isArray(proto.headers) && proto.headers.length)
+    out.headers = normalizeKvArray(proto.headers);
+
+  if (Array.isArray(proto.params) && proto.params.length)
+    out.params = normalizeKvArray(proto.params);
+  else if (Array.isArray(proto.query) && proto.query.length)
+    out.params = normalizeKvArray(proto.query);
+
+  if (proto.body && proto.body.type && proto.body.type !== 'none') {
+    const type = proto.body.type;
+
+    out.body = { type };
+
+    if (type === 'form-urlencoded' || type === 'multipart-form') {
+      if (Array.isArray(proto.body.fields) && proto.body.fields.length) {
+        out.body.fields = normalizeKvArray(proto.body.fields);
+      }
+      return out;
+    }
+
+    if (proto.body.data !== undefined && proto.body.data !== null && proto.body.data !== '') {
+      if (typeof proto.body.data === 'object') {
+        out.body.data = JSON.stringify(proto.body.data, null, 2);
+      } else {
+        out.body.data = String(proto.body.data);
+      }
+    }
+  }
+  const auth = proto.auth || rawRequest.auth;
+  if (auth) out.auth = typeof auth === 'string' ? auth : { ...auth };
+
+  return out;
+}
+
+function normalizeKvArray(arr) {
+  return arr
+    .filter((i) => i && (i.name || i.key))
+    .map((i) => ({
+      name: i.name || i.key,
+      value: i.value ?? '',
+      ...(i.enabled === false ? { enabled: false } : {}),
+      ...(i.description ? { description: i.description } : {})
+    }));
+}
+
+function normalizeRuntime(runtime, legacyScript) {
+  const scripts = [];
+
+  if (Array.isArray(runtime.scripts)) {
+    for (const s of runtime.scripts) {
+      if (s && s.code) scripts.push({ type: s.type || 'pre-request', code: String(s.code) });
+    }
+  }
+
+  // Legacy .bru script block: { req, res }
+  if (legacyScript) {
+    if (legacyScript.req) scripts.push({ type: 'pre-request', code: String(legacyScript.req) });
+    if (legacyScript.res) scripts.push({ type: 'post-response', code: String(legacyScript.res) });
+  }
+
+  const out = {};
+  if (scripts.length) out.scripts = scripts;
+  if (runtime.auth) out.auth = runtime.auth;
+  if (runtime.vars) out.vars = runtime.vars;
+
+  return Object.keys(out).length ? out : undefined;
+}
+
+// ── Detection helpers ─────────────────────────────────────────────────────────
+
+function detectProtocol(raw) {
+  if (raw.http) return 'http';
+  if (raw.graphql) return 'graphql';
+  if (raw.grpc) return 'grpc';
+  if (raw.websocket) return 'websocket';
+  if (raw.info && raw.info.name) return 'http'; // fallback
+  return null;
+}
+
+function hasDocContent(docs) {
+  return !!(docs && (docs.description || docs.content || docs.body || docs.markdown));
+}
+
+// ── Sorting ───────────────────────────────────────────────────────────────────
+
+function sortItems(items) {
+  items.sort((a, b) => {
+    const sa = toSeq(a.seq ?? (a.info && a.info.seq));
+    const sb = toSeq(b.seq ?? (b.info && b.info.seq));
+    if (sa !== sb) return sa - sb;
+    const na = a.name || (a.info && a.info.name) || '';
+    const nb = b.name || (b.info && b.info.name) || '';
+    return na.localeCompare(nb);
+  });
+}
+
+// ── Low-level utils ───────────────────────────────────────────────────────────
+
+function loadYamlFile(fp) {
+  try {
+    return yaml.load(fs.readFileSync(fp, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function safeReaddir(dir) {
+  try { return fs.readdirSync(dir); } catch { return []; }
+}
+
+function safeReaddirWithTypes(dir) {
+  try { return fs.readdirSync(dir, { withFileTypes: true }); } catch { return []; }
+}
+
+function toSeq(val) {
+  const n = Number(val);
+  return Number.isFinite(n) ? n : Infinity;
+}
+
+function formatDirName(name) {
+  return name.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+module.exports = { loadCollection };

--- a/packages/bruno-cli/src/docs/render-html.js
+++ b/packages/bruno-cli/src/docs/render-html.js
@@ -73,14 +73,14 @@ function render(currentTheme) {
       target         : target,
       opencollection : collectionYaml,
       theme          : currentTheme,
-      ...(gitCollectionUrl ? { gitCollectionUrl: gitCollectionUrl } : {}),
+      ...(gitCollectionUrl ? { gitCollectionUrl: gitCollectionUrl } : {})
     });
 
   } else if (Component && typeof Component.mount === 'function') {
     Component.mount(target, {
       opencollection : collectionYaml,
       theme          : currentTheme,
-      ...(gitCollectionUrl ? { gitCollectionUrl: gitCollectionUrl } : {}),
+      ...(gitCollectionUrl ? { gitCollectionUrl: gitCollectionUrl } : {})
     });
 
   } else {
@@ -114,6 +114,11 @@ render(theme);
 </html>`;
 }
 
+/**
+ * Escape HTML special characters for safe embedding in HTML content.
+ * @param {string} str
+ * @returns {string}
+ */
 function escapeHtml(str) {
   return String(str || '')
     .replace(/&/g, '&amp;')

--- a/packages/bruno-cli/src/docs/render-html.js
+++ b/packages/bruno-cli/src/docs/render-html.js
@@ -1,0 +1,125 @@
+'use strict';
+/**
+ * packages/bruno-cli/src/docs/render-html.js
+ *
+ * Renders the final single-file HTML documentation.
+ * Embeds the OpenCollection YAML string and initializes the official
+ * OpenCollection viewer from cdn.opencollection.com.
+ *
+ * Embedding strategy:
+ *   JSON.stringify(yamlString) is used to produce a JS string literal.
+ *   This correctly escapes every character that would break a JS string:
+ *   backslashes, quotes, newlines, null bytes, Unicode surrogates — everything.
+ *   It is more robust than template literals or manual escaping.
+ */
+
+/**
+ * @param {{ title: string, yamlString: string, theme: 'light'|'dark', gitUrl: string }} opts
+ * @returns {string}  Complete HTML document
+ */
+function renderHtml({ title, yamlString, theme, gitUrl }) {
+  // JSON.stringify produces a valid JS string literal including the outer quotes.
+  const yamlLiteral = JSON.stringify(yamlString);
+  const gitUrlLiteral = JSON.stringify(gitUrl || '');
+  const themeLiteral = JSON.stringify(theme === 'dark' ? 'dark' : 'light');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${escapeHtml(title)} - API Documentation</title>
+  <link rel="stylesheet" href="https://cdn.opencollection.com/docs.css" />
+  <style>
+    body { margin: 0; padding: 0; }
+    #app { width: 100vw; height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+
+  <script src="https://cdn.opencollection.com/docs.js"></script>
+  <script>
+    (function () {
+      var collectionYaml  = ${yamlLiteral};
+      var gitCollectionUrl = ${gitUrlLiteral};
+      var theme           = ${themeLiteral};
+
+      // The bundle exports window.OpenCollectionPlayground (current name as of Bruno v3).
+      // Fallback chain covers possible future renames.
+      var Component =
+        window.OpenCollection ||
+        window.OpenCollectionPlayground           ||
+        window.OpenCollectionDocs;
+
+      if (!Component) {
+        document.getElementById('app').innerHTML =
+          '<div style="font-family:sans-serif;padding:48px;max-width:640px">' +
+            '<h2 style="color:#c00">OpenCollection viewer failed to load</h2>' +
+            '<p>The CDN asset <code>cdn.opencollection.com/docs.js</code> did not export a component.</p>' +
+            '<p>Check your internet connection and that the CDN is reachable.</p>' +
+          '</div>';
+        return;
+      }
+
+      try {
+var target = document.getElementById('app');
+
+function render(currentTheme) {
+  target.innerHTML = '';
+
+  if (typeof Component === 'function') {
+    new Component({
+      target         : target,
+      opencollection : collectionYaml,
+      theme          : currentTheme,
+      ...(gitCollectionUrl ? { gitCollectionUrl: gitCollectionUrl } : {}),
+    });
+
+  } else if (Component && typeof Component.mount === 'function') {
+    Component.mount(target, {
+      opencollection : collectionYaml,
+      theme          : currentTheme,
+      ...(gitCollectionUrl ? { gitCollectionUrl: gitCollectionUrl } : {}),
+    });
+
+  } else {
+    throw new Error('OpenCollection component has unsupported format');
+  }
+}
+
+render(theme);
+
+} catch (err) {
+        console.error('[bruno-docs] Failed to initialise OpenCollection component:', err);
+        document.getElementById('app').innerHTML =
+          '<div style="font-family:sans-serif;padding:48px;max-width:640px">' +
+            '<h2 style="color:#c00">Render error</h2>' +
+            '<pre style="background:#f4f4f4;padding:16px;border-radius:6px;overflow:auto">' +
+              escapeHtmlRuntime(err.message) +
+            '</pre>' +
+            '<p>Open the browser DevTools console for the full stack trace.</p>' +
+          '</div>';
+      }
+
+      function escapeHtmlRuntime(str) {
+        return String(str)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+      }
+    })();
+  </script>
+</body>
+</html>`;
+}
+
+function escapeHtml(str) {
+  return String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+module.exports = { renderHtml };

--- a/packages/bruno-cli/src/index.js
+++ b/packages/bruno-cli/src/index.js
@@ -1,7 +1,5 @@
 const yargs = require('yargs');
 const chalk = require('chalk');
-const { initializeShellEnv } = require('@usebruno/requests');
-
 const { CLI_EPILOGUE, CLI_VERSION } = require('./constants');
 
 const printBanner = () => {
@@ -10,7 +8,12 @@ const printBanner = () => {
 
 const run = async () => {
   // Fetch shell environment (useful when CLI is run as subprocess from GUI app or cron)
-  await initializeShellEnv();
+  try {
+    const { initializeShellEnv } = require('@usebruno/requests');
+    if (typeof initializeShellEnv === 'function') {
+      await initializeShellEnv();
+    }
+  } catch { /* shell-env is optional */ }
 
   const argLength = process.argv.length;
   const commandsToPrintBanner = ['--help', '-h'];

--- a/packages/bruno-cli/tests/commands/docs/generate.spec.js
+++ b/packages/bruno-cli/tests/commands/docs/generate.spec.js
@@ -1,0 +1,279 @@
+'use strict';
+/**
+ * packages/bruno-cli/tests/commands/docs/generate.spec.js
+ *
+ * Tests for the docs/generate command pipeline.
+ * Mirrors the test style used in the existing CLI (Jest + in-memory fixtures).
+ *
+ * Run with:
+ *   cd packages/bruno-cli
+ *   npx jest tests/commands/docs
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// ── Module under test ─────────────────────────────────────────────────────────
+const { loadCollection } = require('../../../src/docs/load-collection');
+const { buildYaml, validateYaml } = require('../../../src/docs/build-yaml');
+const { renderHtml } = require('../../../src/docs/render-html');
+const { assertCollectionRoot, resolveOutput, ensureDir } = require('../../../src/docs/fs-helpers');
+
+// ── Fixture helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Creates a minimal OpenCollection YAML collection in a temp directory.
+ * Returns the temp dir path.
+ */
+function createOcFixture(overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-docs-test-'));
+
+  fs.writeFileSync(
+    path.join(dir, 'opencollection.yml'),
+    `info:\n  name: ${overrides.name || 'Test API'}\n  version: '1.0.0'\n`
+  );
+
+  fs.mkdirSync(path.join(dir, 'environments'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'environments', 'DEV.yml'),
+    `name: DEV\nvariables:\n  - name: base_url\n    value: https://api.dev.example.com\n    enabled: true\n`
+  );
+
+  fs.mkdirSync(path.join(dir, 'users'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'users', 'folder.yml'),
+    `meta:\n  name: Users\n  seq: 1\n`
+  );
+  fs.writeFileSync(
+    path.join(dir, 'users', 'list-users.yml'),
+    `info:\n  name: List users\n  type: http\n  seq: 1\nhttp:\n  method: GET\n  url: "{{base_url}}/users"\n  headers:\n    - name: Authorization\n      value: "Bearer {{token}}"\ndocs:\n  description: Returns all users.\nexamples:\n  - name: Success\n    response:\n      status: 200\n      body:\n        users: []\n`
+  );
+  fs.writeFileSync(
+    path.join(dir, 'users', 'create-user.yml'),
+    `info:\n  name: Create user\n  type: http\n  seq: 2\nhttp:\n  method: POST\n  url: "{{base_url}}/users"\n  headers:\n    - name: Content-Type\n      value: application/json\n  body:\n    type: json\n    data: |-\n      {"name":"Alice","email":"alice@example.com"}\nruntime:\n  scripts:\n    - type: post-response\n      code: |-\n        bru.setEnvVar("userId", res.body.id);\n`
+  );
+
+  return dir;
+}
+
+afterEach(() => {
+  // Cleanup is optional in unit tests; tmp dirs are removed on OS restart.
+});
+
+// ── fs-helpers ────────────────────────────────────────────────────────────────
+
+describe('fs-helpers', () => {
+  describe('assertCollectionRoot', () => {
+    it('accepts a valid OpenCollection directory', () => {
+      const dir = createOcFixture();
+      expect(() => assertCollectionRoot(dir)).not.toThrow();
+    });
+
+    it('throws when the path does not exist', () => {
+      expect(() => assertCollectionRoot('/tmp/does-not-exist-bruno-test')).toThrow(
+        /does not exist/i
+      );
+    });
+
+    it('throws when the path is a file, not a directory', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-file-test-'));
+      const file = path.join(tmp, 'file.txt');
+      fs.writeFileSync(file, '');
+      expect(() => assertCollectionRoot(file)).toThrow(/not a directory/i);
+    });
+
+    it('throws when neither opencollection.yml nor bruno.json is present', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-empty-'));
+      expect(() => assertCollectionRoot(tmp)).toThrow(/not a Bruno collection/i);
+    });
+  });
+
+  describe('resolveOutput', () => {
+    it('resolves relative paths against cwd', () => {
+      const result = resolveOutput('docs/index.html');
+      expect(result).toBe(path.resolve('docs/index.html'));
+    });
+
+    it('passes through absolute paths unchanged', () => {
+      const abs = path.join(os.tmpdir(), 'my-docs.html');
+      expect(resolveOutput(abs)).toBe(abs);
+    });
+  });
+
+  describe('ensureDir', () => {
+    it('creates nested directories that do not exist', () => {
+      const target = path.join(os.tmpdir(), `bruno-ensureDir-${Date.now()}`, 'a', 'b', 'c');
+      ensureDir(target);
+      expect(fs.existsSync(target)).toBe(true);
+    });
+
+    it('does not throw when directory already exists', () => {
+      const existing = os.tmpdir();
+      expect(() => ensureDir(existing)).not.toThrow();
+    });
+  });
+});
+
+// ── load-collection ───────────────────────────────────────────────────────────
+
+describe('load-collection', () => {
+  it('returns a collection with correct info', () => {
+    const dir = createOcFixture({ name: 'My API' });
+    const col = loadCollection(dir);
+    expect(col.info.name).toBe('My API');
+    expect(col.opencollection).toBe('1.0.0');
+  });
+
+  it('respects titleOverride', () => {
+    const dir = createOcFixture({ name: 'My API' });
+    const col = loadCollection(dir, { titleOverride: 'Overridden Title' });
+    expect(col.info.name).toBe('Overridden Title');
+  });
+
+  it('loads environments', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    expect(col.environments).toHaveLength(1);
+    expect(col.environments[0].name).toBe('DEV');
+    expect(col.environments[0].variables[0].name).toBe('base_url');
+  });
+
+  it('loads folders and requests recursively', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    expect(col.items).toHaveLength(1); // 1 folder: users
+    expect(col.items[0].type).toBe('folder');
+    expect(col.items[0].name).toBe('Users');
+    expect(col.items[0].items).toHaveLength(2); // 2 requests
+  });
+
+  it('parses request fields: method, url, headers, body, runtime', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    const folder = col.items[0];
+    const create = folder.items.find((r) => r.info.name === 'Create user');
+
+    expect(create.http.method).toBe('POST');
+    expect(create.http.url).toMatch(/{{base_url}}\/users/);
+    expect(create.http.body.type).toBe('json');
+    expect(create.runtime.scripts).toHaveLength(1);
+    expect(create.runtime.scripts[0].type).toBe('post-response');
+  });
+
+  it('preserves {{variable}} placeholders in values', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    const list = col.items[0].items.find((r) => r.info.name === 'List users');
+    const authH = list.http.headers.find((h) => h.name === 'Authorization');
+    expect(authH.value).toBe('Bearer {{token}}');
+  });
+
+  it('maintains seq ordering within folders', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    const reqs = col.items[0].items;
+    expect(reqs[0].info.seq).toBeLessThanOrEqual(reqs[1].info.seq);
+  });
+});
+
+// ── build-yaml ────────────────────────────────────────────────────────────────
+
+describe('build-yaml', () => {
+  it('produces valid YAML', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    const str = buildYaml(col);
+    expect(validateYaml(str)).toEqual({ valid: true });
+  });
+
+  it('round-trips: parsed YAML contains expected fields', () => {
+    const yaml = require('js-yaml');
+    const dir = createOcFixture({ name: 'Round-trip API' });
+    const col = loadCollection(dir);
+    const str = buildYaml(col);
+    const parsed = yaml.load(str);
+
+    expect(parsed.opencollection).toBe('1.0.0');
+    expect(parsed.info.name).toBe('Round-trip API');
+    expect(parsed.environments[0].name).toBe('DEV');
+    expect(parsed.items[0].type).toBe('folder');
+  });
+
+  it('preserves multiline body data in the YAML output', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    const str = buildYaml(col);
+    // The body data field should appear in the YAML output
+    expect(str).toContain('data:');
+    expect(str).toContain('alice@example.com');
+  });
+
+  it('preserves {{variable}} placeholders in the YAML', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    const str = buildYaml(col);
+    expect(str).toContain('{{base_url}}');
+    expect(str).toContain('{{token}}');
+  });
+
+  it('serializes post-response scripts', () => {
+    const dir = createOcFixture();
+    const col = loadCollection(dir);
+    const str = buildYaml(col);
+    expect(str).toContain('post-response');
+    expect(str).toContain('bru.setEnvVar');
+  });
+});
+
+// ── render-html ───────────────────────────────────────────────────────────────
+
+describe('render-html', () => {
+  it('produces valid HTML with expected CDN links', () => {
+    const html = renderHtml({
+      title: 'Test API',
+      yamlString: 'opencollection: "1.0.0"\n',
+      theme: 'dark',
+      gitUrl: ''
+    });
+
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('cdn.opencollection.com/docs.css');
+    expect(html).toContain('cdn.opencollection.com/docs.js');
+  });
+
+  it('embeds title in <title> tag', () => {
+    const html = renderHtml({ title: 'My <API>', yamlString: '', theme: 'light', gitUrl: '' });
+    expect(html).toContain('<title>My &lt;API&gt; - API Documentation</title>');
+  });
+
+  it('embeds YAML as JSON-escaped JS string', () => {
+    const yaml = 'key: "hello\\nworld"';
+    const html = renderHtml({ title: 'X', yamlString: yaml, theme: 'light', gitUrl: '' });
+    expect(html).toContain(JSON.stringify(yaml));
+  });
+
+  it('includes gitCollectionUrl when provided', () => {
+    const html = renderHtml({
+      title: 'X',
+      yamlString: '',
+      theme: 'light',
+      gitUrl: 'https://github.com/org/repo'
+    });
+    expect(html).toContain('https://github.com/org/repo');
+  });
+
+  it('does not include gitCollectionUrl when empty', () => {
+    const html = renderHtml({ title: 'X', yamlString: '', theme: 'light', gitUrl: '' });
+    // The guard var is "" (empty), so the conditional spread produces {}
+    expect(html).toContain('gitCollectionUrl = "";');
+    expect(html).toContain('gitCollectionUrl ?');
+  });
+
+  it('passes the correct theme to the component', () => {
+    const dark = renderHtml({ title: 'X', yamlString: '', theme: 'dark', gitUrl: '' });
+    const light = renderHtml({ title: 'X', yamlString: '', theme: 'light', gitUrl: '' });
+    expect(dark).toContain('"dark"');
+    expect(light).toContain('"light"');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/usebruno/bruno/issues/7188
[JIRA](https://usebruno.atlassian.net/browse/BRU-2546)

### Description

Adds a new CLI command `bru docs generate` to generate HTML documentation from Bruno collections. This feature mirrors the "Generate Documentation" functionality available in the Bruno desktop app, making it accessible from the CLI for CI/CD pipelines and automation.
**Usage:**
bru docs generate <collection-path> -o output.html --theme light
bru docs generate <collection-path> -o output-dark.html --theme dark
**How it works:**
1. Loads a collection from the filesystem (supports `.bru` files and `opencollection.yml`)
2. Builds an OpenCollection YAML with all requests, folders, environments, and metadata
3. Renders a standalone HTML page that embeds the CDN-based documentation viewer (`cdn.usebruno.com/docs.js`)
**Generated HTML features:**
- Standalone, portable file (no local dependencies)
- Interactive request navigation with folder tree
- Environment variable display
- Theme support via `--theme` parameter (light/dark)
- Git repository link embedding via `--git-url`
**Files changed:**
- `packages/bruno-cli/src/commands/docs.js` — command group definition (`docs <subcommand>`)
- `packages/bruno-cli/src/commands/docs/generate.js` — command handler with full pipeline (validate → load → build YAML → render → write)
- `packages/bruno-cli/src/docs/load-collection.js` — recursive collection loader from filesystem
- `packages/bruno-cli/src/docs/build-yaml.js` — serializes collection to OpenCollection YAML format
- `packages/bruno-cli/src/docs/render-html.js` — generates HTML with CDN viewer embedding
- `packages/bruno-cli/src/docs/fs-helpers.js` — filesystem validation helpers (path checks, directory creation)
- `packages/bruno-cli/src/index.js` — registers `docs` subcommand
- `packages/bruno-cli/.gitignore` — adds `output.html` to ignored files
- `packages/bruno-cli/tests/commands/docs/generate.spec.js` — 26 unit tests covering all modules
**Testing:**
- 26 unit tests pass: validation, loading, YAML serialization, HTML rendering, theme support, variable preservation
- Successfully tested against real collection (238 requests, 51 folders, 3 environments)
- Verified output with both `--theme light` and `--theme dark`
- Lint checks pass (nano-staged pre-commit hook)
#### Contribution Checklist:
- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "docs" CLI group and a generate command to produce single-file HTML documentation from a Bruno collection, with options for output path, title, theme, and repository URL; supports both modern and legacy collection formats.

* **Tests**
  * Added end-to-end tests for the docs generation pipeline, including collection loading, YAML serialization, HTML rendering, and filesystem helpers.

* **Chores**
  * Updated .gitignore to ignore generated HTML output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->