### PR TITLE
feat: support NDJSON/JSON-Lines streaming responses (#6146)

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -36,9 +36,12 @@ const { cookiesStore } = require('../../store/cookies');
 const registerGrpcEventHandlers = require('./grpc-event-handlers');
 const { registerWsEventHandlers } = require('./ws-event-handlers');
 const { getCertsAndProxyConfig, buildCertsAndProxyConfig } = require('./cert-utils');
+const { getStreamType, createNdjsonSplitter } = require('./streaming');
 const { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType } = require('@usebruno/common').utils;
 
 const ERROR_OCCURRED_WHILE_EXECUTING_REQUEST = 'Error occurred while executing the request!';
+// Hoisted to avoid allocating a fresh Buffer per NDJSON record on hot streams.
+const NDJSON_NEWLINE = Buffer.from('\n');
 
 const saveCookies = (url, headers) => {
   if (preferencesUtil.shouldStoreCookies()) {
@@ -65,11 +68,6 @@ const getJsSandboxRuntime = (collection) => {
 
   // default runtime is `quickjs`
   return 'quickjs';
-};
-
-const hasStreamHeaders = (headers) => {
-  const headerSplit = (headers.get('content-type') ?? '').split(';').map((d) => d.trim());
-  return headerSplit.indexOf('text/event-stream') > -1;
 };
 
 const promisifyStream = async (stream, abortController, closeOnFirst) => {
@@ -901,7 +899,7 @@ const registerNetworkIpc = (mainWindow) => {
       try {
         /** @type {import('axios').AxiosResponse} */
         response = await axiosInstance(request);
-        isResponseStream = hasStreamHeaders(response.headers);
+        isResponseStream = getStreamType(response.headers) !== null;
 
         if (!isResponseStream) {
           response.data = await promisifyStream(response.data);
@@ -930,7 +928,7 @@ const registerNetworkIpc = (mainWindow) => {
           // Prevents the duration on leaking to the actual result
           responseTime = response.headers.get('request-duration');
           response.headers.delete('request-duration');
-          isResponseStream = hasStreamHeaders(response.headers);
+          isResponseStream = getStreamType(response.headers) !== null;
           if (!isResponseStream) {
             response.data = await promisifyStream(response.data);
           }
@@ -1209,23 +1207,35 @@ const registerNetworkIpc = (mainWindow) => {
     const response = await runRequest({ item, collection, envVars, processEnvVars, runtimeVariables, runInBackground: false });
     if (response.stream) {
       const stream = response.stream;
+      const streamType = getStreamType(response.headers);
       response.stream = { running: response.status >= 200 && response.status < 300 };
 
-      stream.on('data', (newData) => {
+      // Emits one IPC chunk to the renderer. We don't reuse parseDataFromResponse
+      // here: per-record JSON.parse and BOM stripping are both wrong. The
+      // renderer's streamDataReceived reducer expects data.data as a string.
+      const sendChunk = (chunkData) => {
         seq += 1;
-
-        const parsed = parseDataFromResponse({ data: newData, headers: {} });
-
+        const dataBuffer = Buffer.from(chunkData);
         mainWindow.webContents.send('main:http-stream-new-data', {
           collectionUid,
           itemUid: item.uid,
           seq,
           timestamp: Date.now(),
-          data: parsed
+          data: { data: dataBuffer.toString('utf-8'), dataBuffer }
         });
-      });
+      };
 
-      stream.on('close', () => {
+      // Re-append the terminator the splitter stripped so the renderer's
+      // concatenated item.response.dataBuffer is well-formed NDJSON on download.
+      // (Canonicalizes CRLF→LF and synthesizes a terminator for an unterminated
+      // last record — the saved buffer is normalized NDJSON, not byte-faithful.)
+      const splitter = streamType === 'ndjson'
+        ? createNdjsonSplitter((record) => sendChunk(Buffer.concat([record, NDJSON_NEWLINE])))
+        : null;
+
+      const finish = () => {
+        // Idempotent: a second call (e.g. 'close' after 'error') no-ops once the
+        // cancel token has been deleted.
         if (!cancelTokens[response.cancelTokenUid]) return;
 
         mainWindow.webContents.send('main:http-stream-end', {
@@ -1236,6 +1246,30 @@ const registerNetworkIpc = (mainWindow) => {
         });
 
         deleteCancelToken(response.cancelTokenUid);
+      };
+
+      stream.on('data', (newData) => {
+        if (splitter) {
+          splitter.push(newData);
+        } else {
+          sendChunk(newData);
+        }
+      });
+
+      stream.on('close', () => {
+        // Skip flush after cancellation — the renderer is no longer listening.
+        if (splitter && cancelTokens[response.cancelTokenUid]) {
+          splitter.flush();
+        }
+        finish();
+      });
+
+      // Without an 'error' listener a mid-stream socket error would crash the
+      // Electron main process via an uncaughtException. Treat as end-of-stream
+      // and drop any buffered partial record (likely truncated JSON).
+      stream.on('error', (err) => {
+        console.error('Error during streaming response:', err);
+        finish();
       });
     }
     return response;

--- a/packages/bruno-electron/src/ipc/network/streaming.js
+++ b/packages/bruno-electron/src/ipc/network/streaming.js
@@ -1,0 +1,99 @@
+// Streaming-response support: content-type detection + a line splitter for
+// NDJSON (newline-delimited JSON) responses.
+//
+// This module is intentionally dependency-free so it can be unit-tested
+// without loading the rest of the IPC layer.
+
+// Map of streaming-response content-types to their kind. NDJSON variants are
+// limited to those actually emitted by real-world servers we know about
+// (x-ndjson by Ollama and a number of LLM streaming endpoints; jsonl is the
+// more common spelling in Python tooling).
+const STREAM_TYPES_BY_MIME = new Map([
+  ['text/event-stream', 'sse'],
+  ['application/x-ndjson', 'ndjson'],
+  ['application/jsonl', 'ndjson']
+]);
+
+/**
+ * Inspect the response headers and return which streaming protocol (if any)
+ * applies. Returns one of: `'sse'`, `'ndjson'`, or `null`.
+ *
+ * @param {{ get: (name: string) => string | null | undefined }} headers
+ * @returns {'sse' | 'ndjson' | null}
+ */
+const getStreamType = (headers) => {
+  // The first `;` always terminates the `type/subtype` token (per RFC 9110
+  // §8.3.1, `type` and `subtype` are `token`s which cannot contain `;`), so
+  // splitting on the first `;` always isolates the media type.
+  const mime = (headers.get('content-type') ?? '').split(';', 1)[0].trim();
+  return STREAM_TYPES_BY_MIME.get(mime) ?? null;
+};
+
+/**
+ * Creates a stateful line splitter for NDJSON streams.
+ *
+ * Accepts arbitrary Buffer chunks (which may split a single record across
+ * chunks) and invokes `onRecord(record)` once per complete line. The trailing
+ * `\n` (or `\r\n`) is stripped. Empty and whitespace-only lines are silently
+ * dropped, so blank-line separators are legal.
+ *
+ * Note: `record` is a `Buffer.subarray` view into the snapshot of `pending`
+ * that produced it. The bytes stay valid as long as the caller retains the
+ * view — `push()` allocates a fresh buffer via `Buffer.concat` rather than
+ * mutating in place — but the view keeps that entire snapshot alive. Callers
+ * that need to retain only the record bytes should copy with
+ * `Buffer.from(record)` to allow the rest to be GC'd.
+ *
+ * Any trailing partial record is held in an internal buffer until the next
+ * chunk arrives. `flush()` should be called when the underlying stream ends to
+ * emit a final partial record, if any.
+ *
+ * @param {(record: Buffer) => void} onRecord
+ * @returns {{ push: (chunk: Buffer | Uint8Array | null | undefined) => void, flush: () => void }}
+ */
+const createNdjsonSplitter = (onRecord) => {
+  let pending = Buffer.alloc(0);
+
+  // Drop empty / whitespace-only records: blank line separators are legal
+  // between NDJSON entries and should not surface as records to the consumer.
+  const emit = (record) => {
+    if (record.toString('utf-8').trim().length === 0) return;
+    onRecord(record);
+  };
+
+  return {
+    push(chunk) {
+      if (!chunk || chunk.length === 0) return;
+      pending = pending.length === 0 ? Buffer.from(chunk) : Buffer.concat([pending, Buffer.from(chunk)]);
+
+      // Split on \n. Records may also end with \r\n; trim a trailing \r.
+      let newlineIdx;
+      while ((newlineIdx = pending.indexOf(0x0a)) !== -1) {
+        let line = pending.subarray(0, newlineIdx);
+        if (line.length > 0 && line[line.length - 1] === 0x0d) {
+          line = line.subarray(0, line.length - 1);
+        }
+        emit(line);
+        pending = pending.subarray(newlineIdx + 1);
+      }
+    },
+
+    flush() {
+      if (pending.length === 0) return;
+      let tail = pending;
+      pending = Buffer.alloc(0);
+      // Strip a possible trailing \r so an unterminated CRLF line still emits
+      // the same bytes as a properly-terminated one. (Empty / whitespace-only
+      // tails are dropped by `emit`.)
+      if (tail[tail.length - 1] === 0x0d) {
+        tail = tail.subarray(0, tail.length - 1);
+      }
+      emit(tail);
+    }
+  };
+};
+
+module.exports = {
+  getStreamType,
+  createNdjsonSplitter
+};

--- a/packages/bruno-electron/tests/network/streaming.spec.js
+++ b/packages/bruno-electron/tests/network/streaming.spec.js
@@ -1,0 +1,130 @@
+const {
+  getStreamType,
+  createNdjsonSplitter
+} = require('../../src/ipc/network/streaming');
+
+// Test helper: mimic the axios `headers` object that exposes `.get(name)`.
+const makeHeaders = (contentType) => ({
+  get: (name) => (name.toLowerCase() === 'content-type' ? contentType : undefined)
+});
+
+describe('streaming: getStreamType', () => {
+  it('detects text/event-stream as sse', () => {
+    expect(getStreamType(makeHeaders('text/event-stream'))).toBe('sse');
+  });
+
+  it('detects text/event-stream with charset suffix as sse', () => {
+    expect(getStreamType(makeHeaders('text/event-stream; charset=utf-8'))).toBe('sse');
+  });
+
+  it.each([
+    'application/x-ndjson',
+    'application/jsonl'
+  ])('detects %s (with or without charset suffix) as ndjson', (mime) => {
+    expect(getStreamType(makeHeaders(mime))).toBe('ndjson');
+    expect(getStreamType(makeHeaders(`${mime}; charset=utf-8`))).toBe('ndjson');
+  });
+
+  it('returns null for non-streaming content types', () => {
+    expect(getStreamType(makeHeaders('application/json'))).toBeNull();
+    expect(getStreamType(makeHeaders('text/plain'))).toBeNull();
+    expect(getStreamType(makeHeaders(''))).toBeNull();
+  });
+
+  it('returns null for a missing content-type header', () => {
+    expect(getStreamType({ get: () => undefined })).toBeNull();
+  });
+});
+
+describe('streaming: createNdjsonSplitter', () => {
+  it('emits one record per complete line', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    splitter.push(Buffer.from('{"a":1}\n{"a":2}\n{"a":3}\n', 'utf-8'));
+
+    expect(records).toEqual(['{"a":1}', '{"a":2}', '{"a":3}']);
+  });
+
+  it('buffers across chunk boundaries', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    splitter.push(Buffer.from('{"a":', 'utf-8'));
+    expect(records).toEqual([]);
+    splitter.push(Buffer.from('1}\n{"b":', 'utf-8'));
+    expect(records).toEqual(['{"a":1}']);
+    splitter.push(Buffer.from('2}\n', 'utf-8'));
+    expect(records).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it('strips trailing CR (handles CRLF line endings)', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    splitter.push(Buffer.from('{"a":1}\r\n{"a":2}\r\n', 'utf-8'));
+
+    expect(records).toEqual(['{"a":1}', '{"a":2}']);
+  });
+
+  it('skips blank lines between records', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    splitter.push(Buffer.from('{"a":1}\n\n{"a":2}\n\n\n{"a":3}\n', 'utf-8'));
+
+    expect(records).toEqual(['{"a":1}', '{"a":2}', '{"a":3}']);
+  });
+
+  it('skips whitespace-only lines between records', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    splitter.push(Buffer.from('{"a":1}\n   \n\t \n{"a":2}\n', 'utf-8'));
+
+    expect(records).toEqual(['{"a":1}', '{"a":2}']);
+  });
+
+  it('emits trailing partial record on flush()', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    splitter.push(Buffer.from('{"a":1}\n{"a":2}', 'utf-8'));
+    expect(records).toEqual(['{"a":1}']);
+    splitter.flush();
+    expect(records).toEqual(['{"a":1}', '{"a":2}']);
+  });
+
+  it('flush() drops a whitespace-only tail', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    // Trailing whitespace-only line after the last terminator: nothing to flush.
+    splitter.push(Buffer.from('{"a":1}\n   ', 'utf-8'));
+    splitter.flush();
+
+    expect(records).toEqual(['{"a":1}']);
+  });
+
+  it('ignores empty chunks', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    splitter.push(Buffer.alloc(0));
+    splitter.push(null);
+    splitter.push(undefined);
+    splitter.push(Buffer.from('{"a":1}\n', 'utf-8'));
+
+    expect(records).toEqual(['{"a":1}']);
+  });
+
+  it('handles CRLF split across chunk boundary', () => {
+    const records = [];
+    const splitter = createNdjsonSplitter((b) => records.push(b.toString('utf-8')));
+
+    splitter.push(Buffer.from('{"a":1}\r', 'utf-8'));
+    splitter.push(Buffer.from('\n{"a":2}\r\n', 'utf-8'));
+
+    expect(records).toEqual(['{"a":1}', '{"a":2}']);
+  });
+});

--- a/packages/bruno-tests/src/index.js
+++ b/packages/bruno-tests/src/index.js
@@ -11,6 +11,7 @@ const mixRouter = require('./mix');
 const wsRouter = require('./ws');
 const setupGraphQL = require('./graphql');
 const sseRouter = require('./sse');
+const ndjsonRouter = require('./ndjson');
 const fileBinaryRouter = require('./file-binary');
 
 const app = new express();
@@ -57,6 +58,7 @@ app.use('/api/multipart', multipartRouter);
 app.use('/api/redirect', redirectRouter);
 app.use('/api/mix', mixRouter);
 app.use('/api/sse', sseRouter);
+app.use('/api/ndjson', ndjsonRouter);
 
 app.get('/ping', function (req, res) {
   return res.send('pong');

--- a/packages/bruno-tests/src/ndjson/index.js
+++ b/packages/bruno-tests/src/ndjson/index.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const router = express.Router();
+
+// Track active NDJSON connections
+let activeConnections = new Set();
+let connectionIdCounter = 0;
+
+// Helper to start an NDJSON streaming response and emit records on an interval
+// until the client disconnects.
+const startStream = (req, res, contentType) => {
+  const connectionId = ++connectionIdCounter;
+  activeConnections.add(connectionId);
+
+  console.log(`[NDJSON] Connection ${connectionId} opened. Active: ${activeConnections.size}`);
+
+  res.writeHead(200, {
+    'Content-Type': contentType,
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive'
+  });
+
+  // Send initial connection message
+  res.write(`${JSON.stringify({ message: 'Connected', connectionId, activeConnections: activeConnections.size })}\n`);
+
+  // Send data every 500ms
+  const interval = setInterval(() => {
+    const data = {
+      connectionId,
+      timestamp: new Date().toISOString(),
+      activeConnections: activeConnections.size,
+      seq: Date.now()
+    };
+    res.write(`${JSON.stringify(data)}\n`);
+  }, 500);
+
+  // Handle client disconnect
+  req.on('close', () => {
+    clearInterval(interval);
+    activeConnections.delete(connectionId);
+    console.log(`[NDJSON] Connection ${connectionId} closed. Active: ${activeConnections.size}`);
+  });
+};
+
+// GET /api/ndjson/stream - application/x-ndjson, one JSON object per line.
+router.get('/stream', (req, res) => startStream(req, res, 'application/x-ndjson'));
+
+// GET /api/ndjson/jsonl - application/jsonl alias.
+router.get('/jsonl', (req, res) => startStream(req, res, 'application/jsonl'));
+
+module.exports = router;


### PR DESCRIPTION
### Description

Adds NDJSON/JSON-Lines streaming response support, addressing issue #6146.

The implementation deliberately reuses the SSE streaming infrastructure from #6074: a content-type-aware splitter inside the existing `send-http-request` IPC handler feeds each complete JSON record through the same `main:http-stream-new-data` channel SSE uses, so the renderer-side display (`WSMessagesList`), stop button, stopwatch, status badge, and download/bookmark gating all work for NDJSON without renderer-side changes.

**Detection:** content-types `application/x-ndjson` (Ollama, Elasticsearch bulk APIs) and `application/jsonl` (common in Python tooling).

**Implementation highlights:**
- New `packages/bruno-electron/src/ipc/network/streaming.js` (dependency-free, ~99 LOC) — exports `getStreamType` and `createNdjsonSplitter`. The splitter handles arbitrary chunk boundaries (including CRLF split across chunks), blank/whitespace-only line tolerance, and a trailing partial record flushed on stream end.
- IPC handler wraps the splitter so each completed record reaches the renderer as a `{ data: string, dataBuffer: Buffer }` payload, with the splitter-stripped `\n` re-appended so `item.response.dataBuffer` is well-formed NDJSON when the user downloads or copies the raw response body. (Note: this canonicalizes CRLF→LF and synthesizes a terminator for an unterminated last record — the saved buffer is normalized NDJSON, not byte-faithful.)
- Adds a `stream.on('error')` listener on the streaming path. Without it, a mid-stream socket error (TLS error, RST, axios decompression failure) would crash the Electron main process via an `uncaughtException`. This also hardens the existing SSE path for free.

**Tests:**
- New Jest unit tests covering `getStreamType` (text/event-stream, both NDJSON variants with/without charset, non-streaming types, missing header) and `createNdjsonSplitter` (chunk boundaries, CRLF, CRLF split across chunks, blank lines, whitespace-only lines, partial record + flush, empty/null chunks).
- New `bruno-tests` fixture endpoints at `/api/ndjson/stream` (application/x-ndjson) and `/api/ndjson/jsonl` (application/jsonl), modeled exactly on `/api/sse/stream`.

**Manual testing:** start the test bench (`npm run dev --workspace=packages/bruno-tests`) and send a `GET http://localhost:8081/api/ndjson/stream` from Bruno — each record appears in real time, the stopwatch runs, the stop button cancels, and exporting the response yields valid NDJSON.

**Out of scope** (raised in the issue but explicitly deferred):
- `text/plain` with NDJSON content / manual selection of streaming — matches SSE's precedent of shipping without manual override; can be a follow-up if users hit it.
- `application/json-seq` (RFC 7464) — almost never emitted in the wild; was prototyped and removed to keep the surface tight.
- DoS hardening (unbounded splitter buffer, quadratic `Buffer.concat`) — the same pattern applies across all of Bruno's response handling and is better addressed as a broader, separate change.

Resolves #6146.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
