### PR TITLE
fix: 8107 sanitize unsafe URLs for code generation

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -8,6 +8,22 @@ import { encodeUrl as encodeUrlCommon, stripOrigin } from '@usebruno/common/util
 import { parse } from 'url';
 import { stringify } from 'query-string';
 
+const HAR_UNSAFE_URL_CHARS = /[\[\]\\^`{|}]/g;
+const HAR_UNSAFE_URL_CHAR_ENCODING = {
+  '[': '%5B',
+  '\\': '%5C',
+  ']': '%5D',
+  '^': '%5E',
+  '`': '%60',
+  '{': '%7B',
+  '|': '%7C',
+  '}': '%7D'
+};
+
+const sanitizeUrlForHarValidation = (url) => {
+  return url?.replace(HAR_UNSAFE_URL_CHARS, (char) => HAR_UNSAFE_URL_CHAR_ENCODING[char]);
+};
+
 const addCurlAuthFlags = (curlCommand, auth) => {
   if (!auth || !curlCommand) return curlCommand;
 
@@ -68,8 +84,13 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
     }
 
     // Build HAR request
+    const requestForSnippet = {
+      ...request,
+      url: sanitizeUrlForHarValidation(request.url)
+    };
+
     const harRequest = buildHarRequest({
-      request,
+      request: requestForSnippet,
       headers
     });
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -996,6 +996,55 @@ describe('generateSnippet – encodeUrl setting', () => {
     expect(result).toContain('time=10:30');
   });
 
+  it('should preserve raw pipe when encodeUrl is false while passing HAR-safe URL to httpsnippet', () => {
+    const rawUrl = 'https://example.com/Patient?identifier=urn:foo:bar|';
+    const item = makeItem(rawUrl, { encodeUrl: false });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    const harUtils = require('utils/codegenerator/har');
+    const harCall = harUtils.buildHarRequest.mock.calls[0][0];
+
+    expect(harCall.request.url).toContain('identifier=urn:foo:bar%7C');
+    expect(result).toContain('identifier=urn:foo:bar|');
+    expect(result).not.toBe('Error generating code snippet');
+  });
+
+  it('should encode raw pipe when encodeUrl is true', () => {
+    const rawUrl = 'https://example.com/Patient?identifier=urn:foo:bar|';
+    const item = makeItem(rawUrl, { encodeUrl: true });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+
+    expect(result).toContain('identifier=urn%3Afoo%3Abar%7C');
+    expect(result).not.toContain('identifier=urn:foo:bar|');
+  });
+
+  it('should pass HAR-safe URLs for strict URI unsafe characters', () => {
+    const rawUrl = 'https://example.com/Patient?identifier=[]\\^`{|}';
+    const item = makeItem(rawUrl, { encodeUrl: false });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    const harUtils = require('utils/codegenerator/har');
+    const harCall = harUtils.buildHarRequest.mock.calls[0][0];
+
+    expect(harCall.request.url).toContain('identifier=%5B%5D%5C%5E%60%7B%7C%7D');
+    expect(result).toContain('identifier=[]\\^`{|}');
+    expect(result).not.toBe('Error generating code snippet');
+  });
+
+  it('should not double-encode existing encoded pipe before HAR validation', () => {
+    const rawUrl = 'https://example.com/Patient?identifier=urn:foo:bar%7C';
+    const item = makeItem(rawUrl, { encodeUrl: false });
+
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    const harUtils = require('utils/codegenerator/har');
+    const harCall = harUtils.buildHarRequest.mock.calls[0][0];
+
+    expect(harCall.request.url).toContain('identifier=urn:foo:bar%7C');
+    expect(harCall.request.url).not.toContain('%257C');
+    expect(result).toContain('identifier=urn:foo:bar%7C');
+  });
+
   it('should encode URL when encodeUrl is true', () => {
     const rawUrl = 'https://example.com/api?token=abc123==&type=test';
     const item = makeItem(rawUrl, { encodeUrl: true });


### PR DESCRIPTION
### Description

Fixes #8107.

This PR fixes code snippet generation for request URLs containing raw strict-URI-unsafe characters such as `|`, `[`, `]`, `\`, `^`, `` ` ``, `{`, and `}`.

Previously, `httpsnippet` rejected the generated HAR request URL and Bruno showed:

`Error generating code snippet`

The fix sanitizes these unsafe characters only in the temporary URL passed to `httpsnippet` for HAR validation. Bruno's existing output behavior is preserved:

- `encodeUrl: false` keeps the user-entered raw URL in the generated snippet
- `encodeUrl: true` keeps generating encoded URLs
- Existing encoded values like `%7C` are not double-encoded

Added regression tests for raw pipe, other unsafe characters, and pre-encoded `%7C`.

After the changes:
 
<img width="762" height="587" alt="image" src="https://github.com/user-attachments/assets/5e6d8c27-871a-4e1a-9683-af8e63ddacc1" />

<img width="858" height="667" alt="image" src="https://github.com/user-attachments/assets/d607eb19-9d9f-460c-a6c3-862cc65524bd" />


Tested with:

```bash
npm test --workspace=packages/bruno-app -- snippet-generator.spec.js
````

Result: 54 tests passed.

Contribution Checklist:
I've used AI significantly to create this pull request
The pull request only addresses one issue or adds one feature.
The pull request does not introduce any breaking changes
I have added screenshots or gifs to help explain the change if applicable.
I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).
Create an issue and link to the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL sanitization in code snippet generation. Request URLs containing special characters such as brackets, backslashes, carets, and pipes are now automatically converted to their HAR-safe percent-encoded equivalents before generating code snippets, improving compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->