### PR TITLE
fix(app): make SwaggerUI "Try it out" work cross-origin in API Spec viewer (BRU-3300)

### DIFF
--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
@@ -2,8 +2,6 @@ import { memo } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import StyledWrapper from './StyledWrapper';
 
-const { ipcRenderer } = window.require('electron');
-
 const serializeHeaders = (headers) => {
   if (!headers) return {};
   if (typeof headers.entries === 'function') {
@@ -18,13 +16,12 @@ const serializeBody = (body) => {
   if (body == null) return undefined;
   if (typeof body === 'string') return body;
   if (body instanceof URLSearchParams) return body.toString();
-  if (body instanceof ArrayBuffer) return Buffer.from(body).toString('binary');
-  // FormData / file uploads are not yet supported by the IPC bridge.
+  // FormData / Blob / ArrayBuffer not yet supported by the IPC bridge.
   return body;
 };
 
 const proxiedFetch = async (url, options = {}) => {
-  const result = await ipcRenderer.invoke('renderer:swagger-fetch', {
+  const result = await window.ipcRenderer.invoke('renderer:swagger-fetch', {
     url,
     method: options.method || 'GET',
     headers: serializeHeaders(options.headers),
@@ -35,7 +32,9 @@ const proxiedFetch = async (url, options = {}) => {
     throw new TypeError(`${result.code}: ${result.message}`);
   }
 
-  const bodyBytes = result.bodyBase64
+  // The Response constructor throws if a null-body status carries a body.
+  const nullBodyStatus = [101, 204, 205, 304].includes(result.status);
+  const bodyBytes = !nullBodyStatus && result.bodyBase64
     ? Uint8Array.from(atob(result.bodyBase64), (c) => c.charCodeAt(0))
     : null;
 

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
@@ -2,11 +2,64 @@ import { memo } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import StyledWrapper from './StyledWrapper';
 
+const { ipcRenderer } = window.require('electron');
+
+const serializeHeaders = (headers) => {
+  if (!headers) return {};
+  if (typeof headers.entries === 'function') {
+    const out = {};
+    for (const [k, v] of headers.entries()) out[k] = v;
+    return out;
+  }
+  return { ...headers };
+};
+
+const serializeBody = (body) => {
+  if (body == null) return undefined;
+  if (typeof body === 'string') return body;
+  if (body instanceof URLSearchParams) return body.toString();
+  if (body instanceof ArrayBuffer) return Buffer.from(body).toString('binary');
+  // FormData / file uploads are not yet supported by the IPC bridge.
+  return body;
+};
+
+const proxiedFetch = async (url, options = {}) => {
+  const result = await ipcRenderer.invoke('renderer:swagger-fetch', {
+    url,
+    method: options.method || 'GET',
+    headers: serializeHeaders(options.headers),
+    body: serializeBody(options.body)
+  });
+
+  if (result.error) {
+    throw new TypeError(`${result.code}: ${result.message}`);
+  }
+
+  const bodyBytes = result.bodyBase64
+    ? Uint8Array.from(atob(result.bodyBase64), (c) => c.charCodeAt(0))
+    : null;
+
+  return new Response(bodyBytes, {
+    status: result.status,
+    statusText: result.statusText,
+    headers: new Headers(result.headers || {})
+  });
+};
+
+const requestInterceptor = (req) => {
+  req.userFetch = proxiedFetch;
+  return req;
+};
+
 const Swagger = ({ spec, onComplete }) => {
   return (
     <StyledWrapper>
       <div className="swagger-root w-full">
-        <SwaggerUI spec={spec} onComplete={onComplete} />
+        <SwaggerUI
+          spec={spec}
+          onComplete={onComplete}
+          requestInterceptor={requestInterceptor}
+        />
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import StyledWrapper from './StyledWrapper';
+import { serializeBody } from './serializeBody';
 
 const serializeHeaders = (headers) => {
   if (!headers) return {};
@@ -10,14 +11,6 @@ const serializeHeaders = (headers) => {
     return out;
   }
   return { ...headers };
-};
-
-const serializeBody = (body) => {
-  if (body == null) return undefined;
-  if (typeof body === 'string') return body;
-  if (body instanceof URLSearchParams) return body.toString();
-  // FormData / Blob / ArrayBuffer not yet supported by the IPC bridge.
-  return body;
 };
 
 const proxiedFetch = async (url, options = {}) => {

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
@@ -29,7 +29,9 @@ const proxiedFetch = async (url, options = {}) => {
   });
 
   if (result.error) {
-    throw new TypeError(`${result.code}: ${result.message}`);
+    const err = new TypeError(result.message);
+    err.code = result.code;
+    throw err;
   }
 
   // The Response constructor throws if a null-body status carries a body.
@@ -38,10 +40,23 @@ const proxiedFetch = async (url, options = {}) => {
     ? Uint8Array.from(atob(result.bodyBase64), (c) => c.charCodeAt(0))
     : null;
 
+  // Build Headers manually so multi-value response headers (e.g. Set-Cookie,
+  // which axios returns as string[]) end up as repeated entries rather than
+  // joined via toString(). new Headers({ 'set-cookie': ['a','b'] }) coerces
+  // the array to "a,b", which is invalid Set-Cookie syntax.
+  const responseHeaders = new Headers();
+  for (const [name, value] of Object.entries(result.headers || {})) {
+    if (Array.isArray(value)) {
+      value.forEach((v) => responseHeaders.append(name, String(v)));
+    } else if (value != null) {
+      responseHeaders.append(name, String(value));
+    }
+  }
+
   return new Response(bodyBytes, {
     status: result.status,
     statusText: result.statusText,
-    headers: new Headers(result.headers || {})
+    headers: responseHeaders
   });
 };
 

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js
@@ -20,14 +20,32 @@ const detectBodyType = (body) => {
 
 export const UNSUPPORTED_BODY_TYPE_CODE = 'UNSUPPORTED_BODY_TYPE';
 
+// Map the Web API class name to a user-friendly subject that reads naturally in
+// the error message. SwaggerUI itself supports these body types fine; the
+// limitation is Bruno's renderer↔main IPC bridge, not Swagger.
+const friendlyBodySubject = (typeName) => {
+  switch (typeName) {
+    case 'File': return 'File upload';
+    case 'Blob': return 'Binary file upload';
+    case 'FormData': return 'Multipart form data';
+    case 'ArrayBuffer': return 'Binary data';
+    case 'ReadableStream': return 'Streaming upload';
+    default:
+      // TypedArrays (Uint8Array etc.) and anything else unknown.
+      if (typeof typeName === 'string' && typeName.endsWith('Array')) return 'Binary data';
+      return 'This request body type';
+  }
+};
+
 export const UNSUPPORTED_BODY_MESSAGE = (typeName) =>
-  `Request body type "${typeName}" isn't supported in Swagger Try-it-out yet. `
-  + `Supported types: JSON, URL-encoded forms, plain text. `
-  + `Use a Bruno request for file uploads / binary bodies.`;
+  `${friendlyBodySubject(typeName)} via the Swagger Try-it-out panel isn't supported in Bruno yet. `
+  + `Supported body types: JSON, URL-encoded forms, plain text. `
+  + `Create a Bruno request to test this endpoint.`;
 
 // Build a TypeError that carries the detected type as a property so downstream
 // catchers can branch on `err.code` / `err.bodyType` instead of regex-parsing
-// the message. Mirrors the IPC-error preservation pattern used in index.js.
+// the message. `err.bodyType` keeps the raw Web API class name for diagnostics;
+// the user-visible message uses the friendly subject above.
 const unsupportedBodyError = (typeName) => {
   const err = new TypeError(UNSUPPORTED_BODY_MESSAGE(typeName));
   err.code = UNSUPPORTED_BODY_TYPE_CODE;

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js
@@ -18,10 +18,22 @@ const detectBodyType = (body) => {
   return typeof body;
 };
 
+export const UNSUPPORTED_BODY_TYPE_CODE = 'UNSUPPORTED_BODY_TYPE';
+
 export const UNSUPPORTED_BODY_MESSAGE = (typeName) =>
   `Request body type "${typeName}" isn't supported in Swagger Try-it-out yet. `
   + `Supported types: JSON, URL-encoded forms, plain text. `
   + `Use a Bruno request for file uploads / binary bodies.`;
+
+// Build a TypeError that carries the detected type as a property so downstream
+// catchers can branch on `err.code` / `err.bodyType` instead of regex-parsing
+// the message. Mirrors the IPC-error preservation pattern used in index.js.
+const unsupportedBodyError = (typeName) => {
+  const err = new TypeError(UNSUPPORTED_BODY_MESSAGE(typeName));
+  err.code = UNSUPPORTED_BODY_TYPE_CODE;
+  err.bodyType = typeName;
+  return err;
+};
 
 export const serializeBody = (body) => {
   const typeName = detectBodyType(body);
@@ -38,11 +50,11 @@ export const serializeBody = (body) => {
     case 'Blob':
     case 'ArrayBuffer':
     case 'ReadableStream':
-      throw new TypeError(UNSUPPORTED_BODY_MESSAGE(typeName));
+      throw unsupportedBodyError(typeName);
     default:
       // TypedArrays land here (Uint8Array, etc.) — also unsupported by the bridge.
       if (ArrayBuffer.isView && ArrayBuffer.isView(body)) {
-        throw new TypeError(UNSUPPORTED_BODY_MESSAGE(typeName));
+        throw unsupportedBodyError(typeName);
       }
       // Plain objects, numbers, booleans — pass through. SwaggerUI rarely sends
       // these as body directly (it stringifies JSON before fetch), but keep the

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js
@@ -20,25 +20,26 @@ const detectBodyType = (body) => {
 
 export const UNSUPPORTED_BODY_TYPE_CODE = 'UNSUPPORTED_BODY_TYPE';
 
-// Map the Web API class name to a user-friendly subject that reads naturally in
-// the error message. SwaggerUI itself supports these body types fine; the
-// limitation is Bruno's renderer↔main IPC bridge, not Swagger.
-const friendlyBodySubject = (typeName) => {
-  switch (typeName) {
-    case 'File': return 'File upload';
-    case 'Blob': return 'Binary file upload';
-    case 'FormData': return 'Multipart form data';
-    case 'ArrayBuffer': return 'Binary data';
-    case 'ReadableStream': return 'Streaming upload';
-    default:
-      // TypedArrays (Uint8Array etc.) and anything else unknown.
-      if (typeof typeName === 'string' && typeName.endsWith('Array')) return 'Binary data';
-      return 'This request body type';
-  }
+// Mapping from Web API class name (the raw detected type) to the user-facing
+// subject used in the error message. SwaggerUI itself supports these body
+// types fine; the limitation is Bruno's renderer↔main IPC bridge, not Swagger.
+const BODY_TYPE_LABEL_MAP = {
+  File: 'File upload',
+  Blob: 'Binary file upload',
+  FormData: 'Multipart form data',
+  ArrayBuffer: 'Binary data',
+  ReadableStream: 'Streaming upload'
+};
+
+const mapBodyTypeToLabel = (typeName) => {
+  if (BODY_TYPE_LABEL_MAP[typeName]) return BODY_TYPE_LABEL_MAP[typeName];
+  // TypedArrays (Uint8Array, Float32Array, etc.) share a label.
+  if (typeof typeName === 'string' && typeName.endsWith('Array')) return 'Binary data';
+  return 'This request body type';
 };
 
 export const UNSUPPORTED_BODY_MESSAGE = (typeName) =>
-  `${friendlyBodySubject(typeName)} via the Swagger Try-it-out panel isn't supported in Bruno yet. `
+  `${mapBodyTypeToLabel(typeName)} via the Swagger Try-it-out panel isn't supported in Bruno yet. `
   + `Supported body types: JSON, URL-encoded forms, plain text. `
   + `Create a Bruno request to test this endpoint.`;
 

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js
@@ -1,0 +1,52 @@
+// Serializes a SwaggerUI fetch body for transport across the renderer ↔ main
+// IPC bridge in `renderer:swagger-fetch`. Only types that survive Electron's
+// structured-clone serialization (and that our axios bridge knows how to send
+// as an HTTP body) are supported. Multipart / binary types throw so the user
+// gets a clear message in the SwaggerUI response panel instead of a silent
+// failure.
+
+const detectBodyType = (body) => {
+  if (body == null) return 'null';
+  if (typeof body === 'string') return 'string';
+  if (typeof FormData !== 'undefined' && body instanceof FormData) return 'FormData';
+  if (typeof File !== 'undefined' && body instanceof File) return 'File';
+  if (typeof Blob !== 'undefined' && body instanceof Blob) return 'Blob';
+  if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) return 'URLSearchParams';
+  if (typeof ArrayBuffer !== 'undefined' && body instanceof ArrayBuffer) return 'ArrayBuffer';
+  if (ArrayBuffer.isView && ArrayBuffer.isView(body)) return body.constructor?.name || 'TypedArray';
+  if (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream) return 'ReadableStream';
+  return typeof body;
+};
+
+export const UNSUPPORTED_BODY_MESSAGE = (typeName) =>
+  `Request body type "${typeName}" isn't supported in Swagger Try-it-out yet. `
+  + `Supported types: JSON, URL-encoded forms, plain text. `
+  + `Use a Bruno request for file uploads / binary bodies.`;
+
+export const serializeBody = (body) => {
+  const typeName = detectBodyType(body);
+
+  switch (typeName) {
+    case 'null':
+      return undefined;
+    case 'string':
+      return body;
+    case 'URLSearchParams':
+      return body.toString();
+    case 'FormData':
+    case 'File':
+    case 'Blob':
+    case 'ArrayBuffer':
+    case 'ReadableStream':
+      throw new TypeError(UNSUPPORTED_BODY_MESSAGE(typeName));
+    default:
+      // TypedArrays land here (Uint8Array, etc.) — also unsupported by the bridge.
+      if (ArrayBuffer.isView && ArrayBuffer.isView(body)) {
+        throw new TypeError(UNSUPPORTED_BODY_MESSAGE(typeName));
+      }
+      // Plain objects, numbers, booleans — pass through. SwaggerUI rarely sends
+      // these as body directly (it stringifies JSON before fetch), but keep the
+      // path open rather than rejecting unexpectedly.
+      return body;
+  }
+};

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.spec.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.spec.js
@@ -1,4 +1,14 @@
-import { serializeBody, UNSUPPORTED_BODY_MESSAGE } from './serializeBody';
+import { serializeBody, UNSUPPORTED_BODY_MESSAGE, UNSUPPORTED_BODY_TYPE_CODE } from './serializeBody';
+
+// Helper: invoke serializeBody and return the thrown error (or fail).
+const catchSerializeError = (body) => {
+  try {
+    serializeBody(body);
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected serializeBody to throw');
+};
 
 describe('serializeBody', () => {
   describe('supported body types', () => {
@@ -57,6 +67,26 @@ describe('serializeBody', () => {
 
     it('message names the supported alternatives', () => {
       expect(UNSUPPORTED_BODY_MESSAGE('FormData')).toMatch(/JSON, URL-encoded forms, plain text/);
+    });
+  });
+
+  describe('error metadata preservation (Bijin review feedback)', () => {
+    it('attaches err.code = UNSUPPORTED_BODY_TYPE so callers can branch programmatically', () => {
+      const err = catchSerializeError(new FormData());
+      expect(err.code).toBe(UNSUPPORTED_BODY_TYPE_CODE);
+      expect(UNSUPPORTED_BODY_TYPE_CODE).toBe('UNSUPPORTED_BODY_TYPE');
+    });
+
+    it('attaches err.bodyType naming the specific unsupported type', () => {
+      expect(catchSerializeError(new FormData()).bodyType).toBe('FormData');
+      expect(catchSerializeError(new Blob(['x'])).bodyType).toBe('Blob');
+      expect(catchSerializeError(new File(['x'], 'a.txt')).bodyType).toBe('File');
+      expect(catchSerializeError(new ArrayBuffer(4)).bodyType).toBe('ArrayBuffer');
+      expect(catchSerializeError(new Uint8Array([1, 2])).bodyType).toBe('Uint8Array');
+    });
+
+    it('thrown error is still a TypeError instance', () => {
+      expect(catchSerializeError(new FormData())).toBeInstanceOf(TypeError);
     });
   });
 });

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.spec.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.spec.js
@@ -32,40 +32,43 @@ describe('serializeBody', () => {
   });
 
   describe('unsupported body types (BRU-3300)', () => {
-    it('throws TypeError for FormData with type name in message', () => {
+    it('throws TypeError for FormData using "Multipart form data" subject', () => {
       const fd = new FormData();
       fd.append('file', new Blob(['x']));
       expect(() => serializeBody(fd)).toThrow(TypeError);
-      expect(() => serializeBody(fd)).toThrow(/FormData/);
-      expect(() => serializeBody(fd)).toThrow(/Use a Bruno request/);
+      expect(() => serializeBody(fd)).toThrow(/Multipart form data/);
+      expect(() => serializeBody(fd)).toThrow(/Create a Bruno request/);
     });
 
-    it('throws TypeError for Blob with type name in message', () => {
+    it('throws TypeError for Blob using "Binary file upload" subject', () => {
       const blob = new Blob(['payload']);
       expect(() => serializeBody(blob)).toThrow(TypeError);
-      expect(() => serializeBody(blob)).toThrow(/Blob/);
+      expect(() => serializeBody(blob)).toThrow(/Binary file upload/);
     });
 
-    it('throws TypeError for File with type name in message', () => {
+    it('throws TypeError for File using "File upload" subject', () => {
       const file = new File(['payload'], 'test.txt', { type: 'text/plain' });
       expect(() => serializeBody(file)).toThrow(TypeError);
-      // File is a Blob subtype; detector prefers the more specific File label.
-      expect(() => serializeBody(file)).toThrow(/File/);
+      expect(() => serializeBody(file)).toThrow(/File upload/);
     });
 
-    it('throws TypeError for ArrayBuffer', () => {
+    it('throws TypeError for ArrayBuffer using "Binary data" subject', () => {
       const buf = new ArrayBuffer(8);
       expect(() => serializeBody(buf)).toThrow(TypeError);
-      expect(() => serializeBody(buf)).toThrow(/ArrayBuffer/);
+      expect(() => serializeBody(buf)).toThrow(/Binary data/);
     });
 
-    it('throws TypeError for TypedArray with specific constructor name', () => {
+    it('throws TypeError for TypedArray using "Binary data" subject', () => {
       const u8 = new Uint8Array([1, 2, 3]);
       expect(() => serializeBody(u8)).toThrow(TypeError);
-      expect(() => serializeBody(u8)).toThrow(/Uint8Array/);
+      expect(() => serializeBody(u8)).toThrow(/Binary data/);
     });
 
-    it('message names the supported alternatives', () => {
+    it('message attributes the limitation to Bruno, not Swagger', () => {
+      expect(UNSUPPORTED_BODY_MESSAGE('FormData')).toMatch(/isn't supported in Bruno yet/);
+    });
+
+    it('message lists supported alternatives', () => {
       expect(UNSUPPORTED_BODY_MESSAGE('FormData')).toMatch(/JSON, URL-encoded forms, plain text/);
     });
   });

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.spec.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.spec.js
@@ -1,0 +1,62 @@
+import { serializeBody, UNSUPPORTED_BODY_MESSAGE } from './serializeBody';
+
+describe('serializeBody', () => {
+  describe('supported body types', () => {
+    it('returns undefined for null', () => {
+      expect(serializeBody(null)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(serializeBody(undefined)).toBeUndefined();
+    });
+
+    it('returns string bodies as-is', () => {
+      expect(serializeBody('{"name":"doggie"}')).toBe('{"name":"doggie"}');
+      expect(serializeBody('plain text')).toBe('plain text');
+    });
+
+    it('stringifies URLSearchParams', () => {
+      const params = new URLSearchParams({ a: '1', b: '2' });
+      expect(serializeBody(params)).toBe('a=1&b=2');
+    });
+  });
+
+  describe('unsupported body types (BRU-3300)', () => {
+    it('throws TypeError for FormData with type name in message', () => {
+      const fd = new FormData();
+      fd.append('file', new Blob(['x']));
+      expect(() => serializeBody(fd)).toThrow(TypeError);
+      expect(() => serializeBody(fd)).toThrow(/FormData/);
+      expect(() => serializeBody(fd)).toThrow(/Use a Bruno request/);
+    });
+
+    it('throws TypeError for Blob with type name in message', () => {
+      const blob = new Blob(['payload']);
+      expect(() => serializeBody(blob)).toThrow(TypeError);
+      expect(() => serializeBody(blob)).toThrow(/Blob/);
+    });
+
+    it('throws TypeError for File with type name in message', () => {
+      const file = new File(['payload'], 'test.txt', { type: 'text/plain' });
+      expect(() => serializeBody(file)).toThrow(TypeError);
+      // File is a Blob subtype; detector prefers the more specific File label.
+      expect(() => serializeBody(file)).toThrow(/File/);
+    });
+
+    it('throws TypeError for ArrayBuffer', () => {
+      const buf = new ArrayBuffer(8);
+      expect(() => serializeBody(buf)).toThrow(TypeError);
+      expect(() => serializeBody(buf)).toThrow(/ArrayBuffer/);
+    });
+
+    it('throws TypeError for TypedArray with specific constructor name', () => {
+      const u8 = new Uint8Array([1, 2, 3]);
+      expect(() => serializeBody(u8)).toThrow(TypeError);
+      expect(() => serializeBody(u8)).toThrow(/Uint8Array/);
+    });
+
+    it('message names the supported alternatives', () => {
+      expect(UNSUPPORTED_BODY_MESSAGE('FormData')).toMatch(/JSON, URL-encoded forms, plain text/);
+    });
+  });
+});

--- a/packages/bruno-electron/src/ipc/apiSpec.js
+++ b/packages/bruno-electron/src/ipc/apiSpec.js
@@ -5,6 +5,7 @@ const { removeApiSpecUid } = require('../cache/apiSpecUids');
 const { removeApiSpecFromWorkspace } = require('../utils/workspace-config');
 const { getCertsAndProxyConfig } = require('./network/cert-utils');
 const { makeAxiosInstance } = require('./network/axios-instance');
+const { proxySwaggerFetch } = require('./swagger-fetch');
 const path = require('path');
 const fs = require('fs');
 
@@ -86,6 +87,10 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedApiSpecs) 
     } catch (error) {
       return Promise.reject(error);
     }
+  });
+
+  ipcMain.handle('renderer:swagger-fetch', async (event, req) => {
+    return proxySwaggerFetch(req);
   });
 
   ipcMain.handle('renderer:ensure-apispec-folder', async (event, workspacePath) => {

--- a/packages/bruno-electron/src/ipc/swagger-fetch.js
+++ b/packages/bruno-electron/src/ipc/swagger-fetch.js
@@ -1,0 +1,55 @@
+const { getCertsAndProxyConfig } = require('./network/cert-utils');
+const { makeAxiosInstance } = require('./network/axios-instance');
+
+const proxySwaggerFetch = async ({ url, method, headers, body }) => {
+  try {
+    const { proxyMode, proxyConfig, httpsAgentRequestFields, interpolationOptions }
+      = await getCertsAndProxyConfig({
+        collectionUid: null,
+        collection: { promptVariables: {} },
+        request: { url },
+        envVars: {},
+        runtimeVariables: {},
+        processEnvVars: {},
+        collectionPath: '',
+        globalEnvironmentVariables: {}
+      });
+
+    const axiosInstance = makeAxiosInstance({
+      proxyMode,
+      proxyConfig,
+      httpsAgentRequestFields,
+      interpolationOptions
+    });
+
+    const response = await axiosInstance.request({
+      url,
+      method: method || 'GET',
+      headers: headers || {},
+      data: body,
+      responseType: 'arraybuffer',
+      validateStatus: () => true,
+      maxRedirects: 5,
+      timeout: 60000
+    });
+
+    const dataBuf = response.data instanceof Buffer
+      ? response.data
+      : Buffer.from(response.data || '');
+
+    return {
+      status: response.status,
+      statusText: response.statusText || '',
+      headers: response.headers || {},
+      bodyBase64: dataBuf.toString('base64')
+    };
+  } catch (err) {
+    return {
+      error: true,
+      code: err.code || 'UNKNOWN',
+      message: err.message || String(err)
+    };
+  }
+};
+
+module.exports = { proxySwaggerFetch };

--- a/packages/bruno-electron/src/ipc/swagger-fetch.js
+++ b/packages/bruno-electron/src/ipc/swagger-fetch.js
@@ -1,7 +1,17 @@
 const { getCertsAndProxyConfig } = require('./network/cert-utils');
 const { makeAxiosInstance } = require('./network/axios-instance');
 
-const proxySwaggerFetch = async ({ url, method, headers, body }) => {
+const proxySwaggerFetch = async (req = {}) => {
+  const { url, method, headers, body } = req || {};
+
+  if (!url || typeof url !== 'string') {
+    return {
+      error: true,
+      code: 'INVALID_REQUEST',
+      message: 'Missing or invalid url'
+    };
+  }
+
   try {
     const { proxyMode, proxyConfig, httpsAgentRequestFields, interpolationOptions }
       = await getCertsAndProxyConfig({

--- a/packages/bruno-electron/src/ipc/swagger-fetch.js
+++ b/packages/bruno-electron/src/ipc/swagger-fetch.js
@@ -47,10 +47,14 @@ const proxySwaggerFetch = async (req = {}) => {
       ? response.data
       : Buffer.from(response.data || '');
 
+    const headersPlain = typeof response.headers?.toJSON === 'function'
+      ? response.headers.toJSON()
+      : { ...(response.headers || {}) };
+
     return {
       status: response.status,
       statusText: response.statusText || '',
-      headers: response.headers || {},
+      headers: headersPlain,
       bodyBase64: dataBuf.toString('base64')
     };
   } catch (err) {

--- a/packages/bruno-electron/tests/swagger-fetch.test.js
+++ b/packages/bruno-electron/tests/swagger-fetch.test.js
@@ -96,6 +96,22 @@ describe('proxySwaggerFetch', () => {
     expect(result.code).toBe('CERT_HAS_EXPIRED');
   });
 
+  test('returns INVALID_REQUEST when called with no payload', async () => {
+    const result = await proxySwaggerFetch();
+
+    expect(result.error).toBe(true);
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  test('returns INVALID_REQUEST when url is missing', async () => {
+    const result = await proxySwaggerFetch({ method: 'GET' });
+
+    expect(result.error).toBe(true);
+    expect(result.code).toBe('INVALID_REQUEST');
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
   test('forwards method, headers, and body to axios', async () => {
     mockRequest.mockResolvedValueOnce({
       status: 201,

--- a/packages/bruno-electron/tests/swagger-fetch.test.js
+++ b/packages/bruno-electron/tests/swagger-fetch.test.js
@@ -138,4 +138,71 @@ describe('proxySwaggerFetch', () => {
     const call = mockRequest.mock.calls[0][0];
     expect(call.validateStatus(599)).toBe(true);
   });
+
+  test.each(['PUT', 'DELETE', 'PATCH'])('forwards %s method with body to axios', async (method) => {
+    mockRequest.mockResolvedValueOnce({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data: Buffer.from('')
+    });
+
+    await proxySwaggerFetch({
+      url: 'https://example.com/pet/10',
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"id":10}'
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'https://example.com/pet/10',
+      method,
+      data: '{"id":10}'
+    }));
+  });
+
+  test('forwards Authorization header for auth-required endpoints', async () => {
+    mockRequest.mockResolvedValueOnce({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data: Buffer.from('{"authenticated":true}')
+    });
+
+    await proxySwaggerFetch({
+      url: 'https://example.com/secure',
+      method: 'GET',
+      headers: {
+        'Authorization': 'Bearer test-token',
+        'X-Api-Key': 'abc123'
+      }
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+      headers: {
+        'Authorization': 'Bearer test-token',
+        'X-Api-Key': 'abc123'
+      }
+    }));
+  });
+
+  test('accepts plain http:// targets (no scheme restriction)', async () => {
+    mockRequest.mockResolvedValueOnce({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data: Buffer.from('ok')
+    });
+
+    const result = await proxySwaggerFetch({
+      url: 'http://example.com/data',
+      method: 'GET',
+      headers: {}
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'http://example.com/data'
+    }));
+  });
 });

--- a/packages/bruno-electron/tests/swagger-fetch.test.js
+++ b/packages/bruno-electron/tests/swagger-fetch.test.js
@@ -1,0 +1,125 @@
+const mockRequest = jest.fn();
+
+jest.mock('../src/ipc/network/cert-utils', () => ({
+  getCertsAndProxyConfig: jest.fn(async () => ({
+    proxyMode: 'off',
+    proxyConfig: {},
+    httpsAgentRequestFields: {},
+    interpolationOptions: {}
+  }))
+}));
+
+jest.mock('../src/ipc/network/axios-instance', () => ({
+  makeAxiosInstance: jest.fn(() => ({
+    request: mockRequest
+  }))
+}));
+
+const { proxySwaggerFetch } = require('../src/ipc/swagger-fetch');
+
+describe('proxySwaggerFetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns base64-encoded body for 2xx response', async () => {
+    mockRequest.mockResolvedValueOnce({
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+      data: Buffer.from('{"ok":true}')
+    });
+
+    const result = await proxySwaggerFetch({
+      url: 'https://example.com/x',
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      body: undefined
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe('OK');
+    expect(result.headers['content-type']).toBe('application/json');
+    expect(Buffer.from(result.bodyBase64, 'base64').toString()).toBe('{"ok":true}');
+  });
+
+  test('surfaces non-2xx status without throwing', async () => {
+    mockRequest.mockResolvedValueOnce({
+      status: 404,
+      statusText: 'Not Found',
+      headers: {},
+      data: Buffer.from('not here')
+    });
+
+    const result = await proxySwaggerFetch({
+      url: 'https://example.com/x',
+      method: 'GET',
+      headers: {},
+      body: undefined
+    });
+
+    expect(result.status).toBe(404);
+    expect(result.error).toBeUndefined();
+  });
+
+  test('returns error shape with code on network failure', async () => {
+    const err = new Error('getaddrinfo ENOTFOUND nope.invalid');
+    err.code = 'ENOTFOUND';
+    mockRequest.mockRejectedValueOnce(err);
+
+    const result = await proxySwaggerFetch({
+      url: 'https://nope.invalid/',
+      method: 'GET',
+      headers: {},
+      body: undefined
+    });
+
+    expect(result.error).toBe(true);
+    expect(result.code).toBe('ENOTFOUND');
+    expect(result.message).toMatch(/ENOTFOUND/);
+  });
+
+  test('returns error shape on TLS failure', async () => {
+    const err = new Error('certificate has expired');
+    err.code = 'CERT_HAS_EXPIRED';
+    mockRequest.mockRejectedValueOnce(err);
+
+    const result = await proxySwaggerFetch({
+      url: 'https://expired.example.com/',
+      method: 'GET',
+      headers: {},
+      body: undefined
+    });
+
+    expect(result.error).toBe(true);
+    expect(result.code).toBe('CERT_HAS_EXPIRED');
+  });
+
+  test('forwards method, headers, and body to axios', async () => {
+    mockRequest.mockResolvedValueOnce({
+      status: 201,
+      statusText: 'Created',
+      headers: {},
+      data: Buffer.from('')
+    });
+
+    await proxySwaggerFetch({
+      url: 'https://example.com/pet',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"name":"doggie"}'
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'https://example.com/pet',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      data: '{"name":"doggie"}',
+      responseType: 'arraybuffer',
+      validateStatus: expect.any(Function)
+    }));
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.validateStatus(599)).toBe(true);
+  });
+});

--- a/packages/bruno-electron/tests/swagger-fetch.test.js
+++ b/packages/bruno-electron/tests/swagger-fetch.test.js
@@ -186,6 +186,35 @@ describe('proxySwaggerFetch', () => {
     }));
   });
 
+  test('normalizes AxiosHeaders instance to plain object via toJSON', async () => {
+    // Axios v1 returns response.headers as an AxiosHeaders instance.
+    // It must be serialized to a plain object before crossing the IPC boundary.
+    const axiosHeaders = {
+      'content-type': 'application/json',
+      'set-cookie': ['a=1', 'b=2'],
+      toJSON() {
+        return {
+          'content-type': this['content-type'],
+          'set-cookie': this['set-cookie']
+        };
+      }
+    };
+    mockRequest.mockResolvedValueOnce({
+      status: 200,
+      statusText: 'OK',
+      headers: axiosHeaders,
+      data: Buffer.from('')
+    });
+
+    const result = await proxySwaggerFetch({ url: 'https://example.com/x', method: 'GET', headers: {} });
+
+    expect(result.headers).toEqual({
+      'content-type': 'application/json',
+      'set-cookie': ['a=1', 'b=2']
+    });
+    expect(typeof result.headers.toJSON).toBe('undefined');
+  });
+
   test('accepts plain http:// targets (no scheme restriction)', async () => {
     mockRequest.mockResolvedValueOnce({
       status: 200,


### PR DESCRIPTION
### Description

SwaggerUI's **Try it out** in the API Spec viewer failed on every cross-origin request with:

> `Failed to fetch. Possible Reasons: CORS / Network Failure / URL scheme must be "http" or "https" for CORS request.`

JIRA : https://usebruno.atlassian.net/browse/BRU-3300

Two stacked blockers caused it:

- **CSP** — the renderer's `connect-src 'self' https://*.posthog.com` directive refuses fetches to any other origin (visible in dev).
- **`file://` CORS** — packaged builds load the renderer over `file://`; Chromium refuses CORS-preflighted requests from `file://` origins regardless of server headers (visible in production).

`swagger-ui-react` was bumped 5.17 → 5.31 (#7086), after which it sets `Content-Type`/`Accept: application/json` more aggressively, guaranteeing preflight and exposing the latent issue. Downgrading the dependency was investigated and ruled out (existing pin would reintroduce other fixes shipped between 5.17 and 5.31).

**Approach:** route SwaggerUI's request through the Electron main process instead of letting the renderer `fetch()` directly — the same architecture every other Bruno network request already uses (`renderer:fetch-api-spec`, collection requests, GraphQL introspection).

- A SwaggerUI `requestInterceptor` attaches a per-request `userFetch` (honored by `swagger-client`'s `http()`).
- `userFetch` forwards `{url, method, headers, body}` over IPC to a new `renderer:swagger-fetch` handler.
- The handler runs the request via the existing `makeAxiosInstance()` + `getCertsAndProxyConfig()` plumbing (proxy, CA certs, redirects all reused), then returns `{status, statusText, headers, bodyBase64}`.
- The interceptor rebuilds a standard `Response`, which `swagger-client` consumes transparently.

**CSP and `webPreferences.webSecurity` are left untouched** — defense in depth preserved. TLS/network errors surface with their `err.code` (e.g. `CERT_HAS_EXPIRED`, `ENOTFOUND`) instead of a silent failure.

### Supported vs unsupported request body types

The IPC bridge transports only structured-cloneable values that the axios HTTP path can render as a body. Other types throw a typed `TypeError` whose message is displayed in the SwaggerUI response panel — phrased so users know the limitation is Bruno's (not SwaggerUI's), and using a friendly subject derived from the detected type:

> `<Friendly subject> via the Swagger Try-it-out panel isn't supported in Bruno yet. Supported body types: JSON, URL-encoded forms, plain text. Create a Bruno request to test this endpoint.`

| Detected type | Friendly subject |
|---|---|
| `File` | File upload |
| `Blob` | Binary file upload |
| `FormData` | Multipart form data |
| `ArrayBuffer` / `Uint8Array` / other TypedArray | Binary data |
| `ReadableStream` | Streaming upload |

The raw class name is preserved on `err.bodyType` for programmatic handling / diagnostics.

**Supported**

| Body type | Common content type | Status |
|---|---|---|
| `string` (e.g. JSON, XML, plain text) | `application/json`, `application/xml`, `text/*` | ✓ |
| `URLSearchParams` | `application/x-www-form-urlencoded` | ✓ |
| No body (`null` / `undefined`) | — | ✓ |

**Unsupported (clear error surfaced to user)**

| Body type | Example endpoints | Status |
|---|---|---|
| `FormData` | `multipart/form-data` — file uploads, mixed text + file forms (`POST /pet/{petId}/uploadImage`) | ✗ — clear error |
| `File` | Single-file upload endpoints | ✗ — clear error |
| `Blob` | Image / audio / video uploads, `application/octet-stream` | ✗ — clear error |
| `ArrayBuffer` / `TypedArray` (`Uint8Array` etc.) | Raw binary bodies | ✗ — clear error |
| `ReadableStream` | Streaming uploads | ✗ — clear error |

Real multipart/binary bridge support is tracked as a follow-up — needs its own design pass for IPC payload chunking + large-file handling.

**Files changed:**
- `packages/bruno-electron/src/ipc/swagger-fetch.js` *(new)* — `proxySwaggerFetch()` with axios-aware header normalization
- `packages/bruno-electron/src/ipc/apiSpec.js` — register `renderer:swagger-fetch` handler
- `packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js` — `requestInterceptor` + `userFetch` proxy; null-body status guard; multi-value response header support; preload-exposed `window.ipcRenderer`
- `packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/serializeBody.js` *(new)* — body type detection + typed errors for unsupported types
- Plus jest suites for both new files

**Test plan:**
- `proxySwaggerFetch` unit tests (2xx, non-2xx, network error, TLS error, request forwarding, AxiosHeaders normalization, PUT/DELETE/PATCH, Authorization header, plain http://) — 13/13 pass
- `serializeBody` unit tests (supported types + 5 unsupported type rejections) — 10/10 pass
- Full `bruno-electron` suite — 320 pass, 0 regressions
- Manual: POST /pet and GET /pet/10 against Petstore return real responses (status, headers, body rendered); Bruno mirrors `curl` exactly (petstore's own 500 on some endpoints is server-side)
- Manual: spec render path unaffected (interceptor only fires on Execute)

**Known limitations (follow-ups, out of scope):**
- Multipart / file / binary request bodies — see table above; clear error shown; bridge-level support tracked separately
- Requests use Bruno's main-process cookie jar rather than the renderer's `document.cookie`; SwaggerUI auth uses headers, so real-world impact is negligible
- Request timeout is fixed at 60s (does not yet read user preferences)

**Review feedback addressed:**
- Set-Cookie / multi-value response headers expanded via `Headers.append()` (was joined via `toString()` coercion)
- AxiosHeaders class instance normalized to a plain object via `.toJSON()` before crossing IPC
- IPC errors re-thrown with `err.code` preserved as a property (was concatenated into message string)

Closes #7771

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swagger "Try it out" requests now route through the app's network layer (respecting proxy/TLS and app network settings).
  * Request bodies are serialized for bridge transport; unsupported binary/multipart bodies produce a clear error message.

* **Bug Fixes**
  * Improved handling of responses with no body and clearer propagation of upstream HTTP status/errors to the UI.

* **Tests**
  * Expanded coverage for request shaping, response encoding, error paths and multiple HTTP methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
