### PR TITLE
fix(proxy): proxy config export from v2 to import in v3 

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1228,8 +1228,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             };
           }
           brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
-          console.log('Transformed Bruno Config:', brunoConfig);
-
           return brunoConfig;
         };
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -28,6 +28,7 @@ const { cookiesStore } = require('../store/cookies');
 const { parseLargeRequestWithRedaction } = require('../utils/parse');
 const { wsClient } = require('../ipc/network/ws-event-handlers');
 const { hasSubDirectories } = require('../utils/filesystem');
+const { transformProxyConfig } = require('@usebruno/requests');
 
 const {
   DEFAULT_GITIGNORE,
@@ -1226,6 +1227,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               ignore: ['node_modules', '.git']
             };
           }
+          brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
+          console.log('Transformed Bruno Config:', brunoConfig);
 
           return brunoConfig;
         };

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1227,7 +1227,9 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               ignore: ['node_modules', '.git']
             };
           }
-          brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
+          if (brunoConfig.proxy) {
+            brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
+          }
           return brunoConfig;
         };
 
@@ -2422,7 +2424,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
         await fsExtra.move(collectionDir, finalCollectionPath);
         if (tempDir !== collectionDir) {
-          await fsExtra.remove(tempDir).catch(() => {});
+          await fsExtra.remove(tempDir).catch(() => { });
         }
 
         const uid = generateUidBasedOnHash(finalCollectionPath);
@@ -2435,7 +2437,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
         return finalCollectionPath;
       } catch (error) {
-        await fsExtra.remove(tempDir).catch(() => {});
+        await fsExtra.remove(tempDir).catch(() => { });
         throw error;
       }
     } catch (error) {

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -4,6 +4,7 @@ const { ipcMain } = require('electron');
 const { sanitizeName, createDirectory, writeFile, safeWriteFileSync, getCollectionStats } = require('./filesystem');
 const { generateUidBasedOnHash, stringifyJson } = require('./common');
 const { stringifyRequestViaWorker, stringifyCollection, stringifyEnvironment, stringifyFolder, DEFAULT_COLLECTION_FORMAT } = require('@usebruno/filestore');
+const { transformProxyConfig } = require('@usebruno/requests/dist/cjs');
 
 /**
  * Recursively find a unique folder name by appending incremental numbers
@@ -92,6 +93,8 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
         ignore: ['node_modules', '.git']
       };
     }
+
+    brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
 
     return brunoConfig;
   };

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -94,7 +94,9 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
       };
     }
 
-    brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
+    if (brunoConfig.proxy) {
+      brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
+    }
 
     return brunoConfig;
   };

--- a/tests/import/bruno/fixtures/bruno-v2-json-collection-with-proxy.json
+++ b/tests/import/bruno/fixtures/bruno-v2-json-collection-with-proxy.json
@@ -1,0 +1,87 @@
+{
+  "name": "proxy-collection-v2",
+  "version": "1",
+  "items": [
+    {
+      "type": "http",
+      "name": "proxy-get",
+      "filename": "proxy-get.bru",
+      "seq": 1,
+      "settings": {
+        "encodeUrl": true,
+        "timeout": 0
+      },
+      "tags": [],
+      "request": {
+        "url": "https://httpbin.org/get?paramName=paramValue",
+        "method": "GET",
+        "headers": [
+          {
+            "name": "headerKey",
+            "value": "headerValue",
+            "enabled": true
+          }
+        ],
+        "params": [
+          {
+            "name": "paramName",
+            "value": "paramValue",
+            "type": "query",
+            "enabled": true
+          }
+        ],
+        "body": {
+          "mode": "none",
+          "formUrlEncoded": [],
+          "multipartForm": [],
+          "file": []
+        },
+        "script": {},
+        "vars": {},
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": {
+          "mode": "inherit"
+        }
+      }
+    }
+  ],
+  "environments": [],
+  "root": {
+    "request": {
+      "headers": [
+        {
+          "name": "collectionHeader",
+          "value": "collectionHeaderValue",
+          "enabled": true,
+          "uid": "ZPXDKmXFtuYkq1KLjYIlz"
+        }
+      ]
+    },
+    "docs": "This is collection Doc"
+  },
+  "brunoConfig": {
+    "version": "1",
+    "name": "proxy-collection-v2",
+    "type": "collection",
+    "ignore": [
+      "node_modules",
+      ".git"
+    ],
+    "size": 0.0001430511474609375,
+    "filesCount": 1,
+    "proxy": {
+      "enabled": true,
+      "protocol": "http",
+      "hostname": "127.0.0.1",
+      "port": 8080,
+      "auth": {
+        "enabled": false,
+        "username": "",
+        "password": ""
+      },
+      "bypassProxy": ""
+    }
+  }
+}

--- a/tests/import/bruno/import-bruno-JSON-v2.spec.ts
+++ b/tests/import/bruno/import-bruno-JSON-v2.spec.ts
@@ -4,7 +4,7 @@ import { importCollection, closeAllCollections } from '../../utils/page';
 import { buildCommonLocators } from '../../utils/page/locators';
 
 test.describe('Import Bruno v2 JSON collection', () => {
-  test.afterAll(async ({ page }) => {
+  test.afterEach(async ({ page }) => {
     await closeAllCollections(page);
   });
 

--- a/tests/import/bruno/import-bruno-JSON-v2.spec.ts
+++ b/tests/import/bruno/import-bruno-JSON-v2.spec.ts
@@ -1,0 +1,37 @@
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import { importCollection, closeAllCollections } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe('Import Bruno v2 JSON collection', () => {
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('proxy settings are preserved after importing a v2 JSON collection', async ({ page, createTmpDir }) => {
+    const collectionName = 'proxy-collection-v2';
+    const collectionFile = path.join(__dirname, 'fixtures', 'bruno-v2-json-collection-with-proxy.json');
+    const locators = buildCommonLocators(page);
+
+    await test.step('Import v2 JSON collection', async () => {
+      await importCollection(page, collectionFile, await createTmpDir('v2-json-proxy-import'), {
+        expectedCollectionName: collectionName
+      });
+    });
+
+    await test.step('Open collection settings → Proxy tab', async () => {
+      await locators.sidebar.collection(collectionName).hover();
+      await locators.actions.collectionActions(collectionName).click();
+      await locators.dropdown.item('Settings').click();
+      await locators.paneTabs.collectionSettingsTab('proxy').click();
+    });
+
+    await test.step('Verify proxy settings match the imported file', async () => {
+      await expect(page.locator('input[name="enabled"][value="true"]')).toBeChecked();
+      await expect(page.locator('input[name="protocol"][value="http"]')).toBeChecked();
+      await expect(page.locator('#hostname')).toHaveValue('127.0.0.1');
+      await expect(page.locator('#port')).toHaveValue('8080');
+      await expect(page.locator('input[name="auth.disabled"]')).not.toBeChecked();
+    });
+  });
+});


### PR DESCRIPTION
JIRA link -  https://usebruno.atlassian.net/browse/BRU-3216
### Description

Proxy settings were not being imported properly  from JSON export file created with v2 and imported into v3. 
Currently yaml import method works but the bru method still fails to import a collection. 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection import now preserves and displays proxy settings in Collection Settings → Proxy; imported collections show the original proxy configuration and normalize proxy fields for consistent display.
* **Tests**
  * Added an end-to-end test that verifies imported proxy settings are correctly shown in the UI.
* **Chores**
  * Added a collection fixture with proxy configuration to improve import test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->