### PR TITLE
fix/3112 - Postman import: OAuth2 Implicit Grant Type Silently Converted to Client Credentials on Import

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/GrantTypeSelector/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/GrantTypeSelector/index.js
@@ -80,6 +80,7 @@ const GrantTypeSelector = ({ item = {}, request, updateAuth, collection }) => {
             { id: 'implicit', label: 'Implicit', onClick: () => onGrantTypeChange('implicit') },
             { id: 'client_credentials', label: 'Client Credentials', onClick: () => onGrantTypeChange('client_credentials') }
           ]}
+          data-testid="grant-type-dropdown"
           selectedItemId={oAuth?.grantType}
           placement="bottom-end"
         >

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -303,7 +303,8 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
         authorization_code_with_pkce: 'authorization_code',
         authorization_code: 'authorization_code',
         client_credentials: 'client_credentials',
-        password_credentials: 'password'
+        password_credentials: 'password',
+        implicit: 'implicit'
       };
 
       const postmanGrantType = findValueUsingKey('grant_type');
@@ -348,6 +349,13 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
           break;
         case 'client_credentials':
           requestObject.auth.oauth2 = baseOAuth2Config;
+          break;
+        case 'implicit':
+          requestObject.auth.oauth2 = {
+            ...baseOAuth2Config,
+            authorizationUrl: findValueUsingKey('authUrl'),
+            callbackUrl: findValueUsingKey('redirect_uri')
+          };
           break;
         default:
           console.warn('Unexpected OAuth2 grant type after mapping:', targetGrantType);

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
@@ -420,6 +420,41 @@ describe('processAuth', () => {
     });
   });
 
+  it('should handle oauth2 auth with implicit grant type', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'implicit',
+        authUrl: 'https://auth.example.com',
+        redirect_uri: 'https://callback.example.com',
+        accessTokenUrl: 'https://token.example.com',
+        refreshTokenUrl: 'https://refresh.example.com',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        scope: 'test-scope',
+        state: 'test-state',
+        addTokenTo: 'header',
+        client_authentication: 'body'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('oauth2');
+    expect(requestObject.auth.oauth2).toEqual({
+      grantType: 'implicit',
+      authorizationUrl: 'https://auth.example.com',
+      callbackUrl: 'https://callback.example.com',
+      accessTokenUrl: 'https://token.example.com',
+      refreshTokenUrl: 'https://refresh.example.com',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      scope: 'test-scope',
+      state: 'test-state',
+      pkce: true,
+      tokenPlacement: 'header',
+      credentialsPlacement: 'body'
+    });
+  });
+
   it('should handle auth object with undefined type', () => {
     const auth = {};
     processAuth(auth, requestObject);

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
@@ -449,7 +449,6 @@ describe('processAuth', () => {
       clientSecret: 'test-client-secret',
       scope: 'test-scope',
       state: 'test-state',
-      pkce: true,
       tokenPlacement: 'header',
       credentialsPlacement: 'body'
     });

--- a/tests/import/postman/fixtures/postman-import-oauth2-implicit-grant-type.json
+++ b/tests/import/postman/fixtures/postman-import-oauth2-implicit-grant-type.json
@@ -1,0 +1,52 @@
+{
+  "info": {
+    "_postman_id": "fdc5dd4a-4ea5-4c6b-932c-c766e05029d1",
+    "name": "My Collection",
+    "description": "### Welcome to Postman! This is your first collection. \n\nCollections are your starting point for building and testing APIs. You can use this one to:\n\n• Group related requests\n• Test your API in real-world scenarios\n• Document and share your requests\n\nUpdate the name and overview whenever you’re ready to make it yours.\n\n[Learn more about Postman Collections.](https://learning.postman.com/docs/collections/collections-overview/)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "55235588",
+    "_collection_link": "https://go.postman.co/collection/55235588-fdc5dd4a-4ea5-4c6b-932c-c766e05029d1?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "OAuth2 Implicit Grant Type",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "grant_type",
+              "value": "implicit",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "Bearer",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.com/users?X-API-KEY=12345",
+          "protocol": "https",
+          "host": [
+            "api",
+            "com"
+          ],
+          "path": [
+            "users"
+          ],
+          "query": [
+            {
+              "key": "X-API-KEY",
+              "value": "12345"
+            }
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/tests/import/postman/import-oauth2-implicit-grant-type.spec.ts
+++ b/tests/import/postman/import-oauth2-implicit-grant-type.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+import { closeAllCollections, openCollection, selectRequestPaneTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe('Import Postman Collection with OAuth2.0 Implicit Grant Type', () => {
+  let originalShowOpenDialog;
+
+  test.beforeAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      originalShowOpenDialog = dialog.showOpenDialog;
+    });
+  });
+
+  test.afterAll(async ({ electronApp, page }) => {
+    await closeAllCollections(page);
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = originalShowOpenDialog;
+    });
+  });
+
+  test('should import Postman collection with OAuth2.0 Implicit Grant Type successfully', async ({ page, electronApp, createTmpDir }) => {
+    const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-import-oauth2-implicit-grant-type.json');
+    const locators = buildCommonLocators(page);
+    console.log('locators:', locators);
+    const importDir = await createTmpDir('imported-collection');
+
+    await electronApp.evaluate(({ dialog }, { importDir }) => {
+      dialog.showOpenDialog = async () => ({
+        canceled: false,
+        filePaths: [importDir]
+      });
+    }, { importDir });
+
+    await test.step('Open import collection modal', async () => {
+      await locators.plusMenu.button().click();
+      await locators.plusMenu.importCollection().click();
+    });
+
+    await test.step('Wait for import modal and verify title', async () => {
+      const importModal = page.getByRole('dialog');
+      await importModal.waitFor({ state: 'visible' });
+      await expect(locators.modal.title('Import Collection')).toBeVisible();
+    });
+
+    await test.step('Upload Postman collection file using hidden file input', async () => {
+      await locators.import.fileInput().setInputFiles(postmanFile);
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
+    });
+
+    await test.step('Verify no parsing errors occurred', async () => {
+      const hasError = await locators.import.parsingError().isVisible().catch(() => false);
+      if (hasError) {
+        throw new Error('Collection import failed with parsing error');
+      }
+    });
+
+    await test.step('Verify location selection modal appears', async () => {
+      await expect(locators.modal.title('Import Collection')).toBeVisible();
+    });
+
+    await test.step('Verify collection name appears in location modal', async () => {
+      await expect(locators.import.locationModal().getByText('My Collection')).toBeVisible();
+    });
+
+    await test.step('Click Browse link to select collection folder', async () => {
+      await locators.import.browseLink(locators.import.locationModal()).click();
+    });
+
+    await test.step('Complete import by clicking import button', async () => {
+      const locationModal = locators.import.locationModal();
+      await locators.import.importButton(locationModal).click();
+      await locationModal.waitFor({ state: 'hidden' });
+    });
+
+    await test.step('Open collection and verify request is displayed', async () => {
+      await openCollection(page, 'My Collection');
+      await expect(locators.sidebar.collection('My Collection')).toBeVisible();
+      await expect(locators.sidebar.request('OAuth2 Implicit Grant Type')).toBeVisible();
+      await locators.sidebar.request('OAuth2 Implicit Grant Type').click();
+      await expect(locators.request.pane()).toBeVisible();
+    });
+
+    await test.step('Verify OAuth2.0 Implicit Grant Type is set correctly', async () => {
+      await selectRequestPaneTab(page, 'Auth');
+      await expect(locators.auth.oauth2.grantTypeLabel()).toContainText('Implicit');
+    });
+  });
+});

--- a/tests/import/postman/import-oauth2-implicit-grant-type.spec.ts
+++ b/tests/import/postman/import-oauth2-implicit-grant-type.spec.ts
@@ -34,39 +34,18 @@ test.describe('Import Postman Collection with OAuth2.0 Implicit Grant Type', () 
     await test.step('Open import collection modal', async () => {
       await locators.plusMenu.button().click();
       await locators.plusMenu.importCollection().click();
-    });
-
-    await test.step('Wait for import modal and verify title', async () => {
       const importModal = page.getByRole('dialog');
       await importModal.waitFor({ state: 'visible' });
       await expect(locators.modal.title('Import Collection')).toBeVisible();
-    });
-
-    await test.step('Upload Postman collection file using hidden file input', async () => {
       await locators.import.fileInput().setInputFiles(postmanFile);
       await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
-    });
-
-    await test.step('Verify no parsing errors occurred', async () => {
       const hasError = await locators.import.parsingError().isVisible().catch(() => false);
       if (hasError) {
         throw new Error('Collection import failed with parsing error');
       }
-    });
-
-    await test.step('Verify location selection modal appears', async () => {
       await expect(locators.modal.title('Import Collection')).toBeVisible();
-    });
-
-    await test.step('Verify collection name appears in location modal', async () => {
       await expect(locators.import.locationModal().getByText('My Collection')).toBeVisible();
-    });
-
-    await test.step('Click Browse link to select collection folder', async () => {
       await locators.import.browseLink(locators.import.locationModal()).click();
-    });
-
-    await test.step('Complete import by clicking import button', async () => {
       const locationModal = locators.import.locationModal();
       await locators.import.importButton(locationModal).click();
       await locationModal.waitFor({ state: 'hidden' });
@@ -82,7 +61,7 @@ test.describe('Import Postman Collection with OAuth2.0 Implicit Grant Type', () 
 
     await test.step('Verify OAuth2.0 Implicit Grant Type is set correctly', async () => {
       await selectRequestPaneTab(page, 'Auth');
-      await expect(locators.auth.oauth2.grantTypeLabel()).toContainText('Implicit');
+      await expect(locators.auth.oauth2.grantTypeDropdown()).toContainText('Implicit');
     });
   });
 });

--- a/tests/import/postman/import-oauth2-implicit-grant-type.spec.ts
+++ b/tests/import/postman/import-oauth2-implicit-grant-type.spec.ts
@@ -22,7 +22,6 @@ test.describe('Import Postman Collection with OAuth2.0 Implicit Grant Type', () 
   test('should import Postman collection with OAuth2.0 Implicit Grant Type successfully', async ({ page, electronApp, createTmpDir }) => {
     const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-import-oauth2-implicit-grant-type.json');
     const locators = buildCommonLocators(page);
-    console.log('locators:', locators);
     const importDir = await createTmpDir('imported-collection');
 
     await electronApp.evaluate(({ dialog }, { importDir }) => {

--- a/tests/import/postman/import-oauth2-implicit-grant-type.spec.ts
+++ b/tests/import/postman/import-oauth2-implicit-grant-type.spec.ts
@@ -34,19 +34,15 @@ test.describe('Import Postman Collection with OAuth2.0 Implicit Grant Type', () 
     await test.step('Open import collection modal', async () => {
       await locators.plusMenu.button().click();
       await locators.plusMenu.importCollection().click();
-      const importModal = page.getByRole('dialog');
+      const importModal = locators.import.modal();
       await importModal.waitFor({ state: 'visible' });
       await expect(locators.modal.title('Import Collection')).toBeVisible();
       await locators.import.fileInput().setInputFiles(postmanFile);
-      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
-      const hasError = await locators.import.parsingError().isVisible().catch(() => false);
-      if (hasError) {
-        throw new Error('Collection import failed with parsing error');
-      }
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 5000 });
       await expect(locators.modal.title('Import Collection')).toBeVisible();
       await expect(locators.import.locationModal().getByText('My Collection')).toBeVisible();
-      await locators.import.browseLink(locators.import.locationModal()).click();
       const locationModal = locators.import.locationModal();
+      await locators.import.browseLink(locationModal).click();
       await locators.import.importButton(locationModal).click();
       await locationModal.waitFor({ state: 'hidden' });
     });

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -94,6 +94,9 @@ export const buildCommonLocators = (page: Page) => ({
     apiKey: {
       placementSelector: () => page.getByTestId('auth-placement-selector'),
       placementLabel: () => page.getByTestId('auth-placement-label')
+    },
+    oauth2: {
+      grantTypeLabel: () => page.locator('.grant-type-label')
     }
   },
   tags: {

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -96,7 +96,7 @@ export const buildCommonLocators = (page: Page) => ({
       placementLabel: () => page.getByTestId('auth-placement-label')
     },
     oauth2: {
-      grantTypeLabel: () => page.locator('.grant-type-label')
+      grantTypeDropdown: () => page.getByTestId('grant-type-dropdown')
     }
   },
   tags: {


### PR DESCRIPTION
Jira link: https://usebruno.atlassian.net/browse/BRU-3112

### Description

 Added Grant type implicit in postman-to-bruno.js and handled the case for same.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for OAuth2 "Implicit" grant when importing Postman collections, preserving authorization and callback URLs.

* **Tests**
  * Added unit, fixture, and end-to-end tests to verify implicit grant import and that the Auth tab displays "Implicit".

* **Chores**
  * Added a test identifier and locator to enable reliable UI verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->