### PR TITLE
fix/import - Postman Import: Binary Body Type Silently Lost

### DIFF
--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -473,37 +473,38 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
 
         const url = constructUrl(i.request.url);
 
-        const brunoRequestItem = {
-          uid: uuid(),
-          name: requestName,
-          type: 'http-request',
-          seq: index + 1,
-          request: {
-            url: url,
-            method: method,
-            auth: {
-              mode: 'inherit',
-              basic: null,
-              bearer: null,
-              awsv4: null,
-              apikey: null,
-              oauth1: null,
-              oauth2: null,
-              digest: null
-            },
-            headers: [],
-            params: [],
-            body: {
-              mode: 'none',
-              json: null,
-              text: null,
-              xml: null,
-              formUrlEncoded: [],
-              multipartForm: []
-            },
-            docs: transformDescription(i.request.description)
-          }
-        };
+      const brunoRequestItem = {
+        uid: uuid(),
+        name: requestName,
+        type: 'http-request',
+        seq: index + 1,
+        request: {
+          url: url,
+          method: method,
+          auth: {
+            mode: 'inherit',
+            basic: null,
+            bearer: null,
+            awsv4: null,
+            apikey: null,
+            oauth1: null,
+            oauth2: null,
+            digest: null
+          },
+          headers: [],
+          params: [],
+          body: {
+            mode: 'none',
+            json: null,
+            text: null,
+            xml: null,
+            formUrlEncoded: [],
+            multipartForm: [],
+            file: []
+          },
+          docs: transformDescription(i.request.description)
+        }
+      };
 
         const settings = {
           encodeUrl: i.protocolProfileBehavior?.disableUrlEncoding !== true
@@ -611,11 +612,22 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
           }
         }
 
-        if (bodyMode === 'graphql') {
-          brunoRequestItem.type = 'graphql-request';
-          brunoRequestItem.request.body.mode = 'graphql';
-          brunoRequestItem.request.body.graphql = parseGraphQLRequest(i.request.body.graphql);
-        }
+      if (bodyMode === 'graphql') {
+        brunoRequestItem.type = 'graphql-request';
+        brunoRequestItem.request.body.mode = 'graphql';
+        brunoRequestItem.request.body.graphql = parseGraphQLRequest(i.request.body.graphql);
+      }
+
+      if (bodyMode === 'file') {
+        brunoRequestItem.request.body.mode = 'file';
+        brunoRequestItem.request.body.file.push({
+          uid: uuid(),
+          selected: true,
+          filePath: ensureString(i.request.body.file?.src),
+          contentType: 'application/octet-stream'
+        });
+        // brunoRequestItem.request.body.file = ensureString(i.request.body.file);
+      }
 
         each(normalizeHeaders(i.request.header), (header) => {
           if (header.key == null && header.value == null) return;
@@ -674,36 +686,37 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
             const exampleUrl = constructUrl(originalRequest.url);
             const exampleMethod = originalRequest.method?.toUpperCase() || method;
 
-            const example = {
-              uid: uuid(),
-              itemUid: brunoRequestItem.uid,
-              name: exampleName,
-              description: '',
-              type: 'http-request',
-              request: {
-                url: exampleUrl,
-                method: exampleMethod,
-                headers: [],
-                params: [],
-                body: {
-                  mode: 'none',
-                  json: null,
-                  text: null,
-                  xml: null,
-                  formUrlEncoded: [],
-                  multipartForm: []
-                }
-              },
-              response: {
-                status: response.code || null,
-                statusText: response.status || '',
-                headers: [],
-                body: {
-                  type: getBodyTypeFromContentTypeHeader(response.header),
-                  content: response.body || ''
-                }
+          const example = {
+            uid: uuid(),
+            itemUid: brunoRequestItem.uid,
+            name: exampleName,
+            description: '',
+            type: 'http-request',
+            request: {
+              url: exampleUrl,
+              method: exampleMethod,
+              headers: [],
+              params: [],
+              body: {
+                mode: 'none',
+                json: null,
+                text: null,
+                xml: null,
+                formUrlEncoded: [],
+                multipartForm: [],
+                file: []
               }
-            };
+            },
+            response: {
+              status: response.code || null,
+              statusText: response.status || '',
+              headers: [],
+              body: {
+                type: getBodyTypeFromContentTypeHeader(response.header),
+                content: response.body || ''
+              }
+            }
+          };
 
             // Convert original request headers
             if (originalRequest.header) {
@@ -804,7 +817,16 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
                   example.request.body.text = originalRequest.body.raw;
                 }
               }
-            }
+            } else if (bodyMode === 'file') {
+            example.request.body.mode = 'file';
+            example.request.body.file.push({
+              uid: uuid(),
+              selected: true,
+              filePath: ensureString(i.request.body.file?.src),
+              contentType: 'application/octet-stream'
+            });
+            // brunoRequestItem.request.body.file = ensureString(i.request.body.file);
+          }
 
             // Convert response headers
             if (response.header) {

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -820,7 +820,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
                 example.request.body.file.push({
                   uid: uuid(),
                   selected: true,
-                  filePath: ensureString(originalRequest.request.body.file?.src),
+                  filePath: ensureString(originalRequest.body.file?.src),
                   contentType: 'application/octet-stream'
                 });
               }

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -473,38 +473,38 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
 
         const url = constructUrl(i.request.url);
 
-      const brunoRequestItem = {
-        uid: uuid(),
-        name: requestName,
-        type: 'http-request',
-        seq: index + 1,
-        request: {
-          url: url,
-          method: method,
-          auth: {
-            mode: 'inherit',
-            basic: null,
-            bearer: null,
-            awsv4: null,
-            apikey: null,
-            oauth1: null,
-            oauth2: null,
-            digest: null
-          },
-          headers: [],
-          params: [],
-          body: {
-            mode: 'none',
-            json: null,
-            text: null,
-            xml: null,
-            formUrlEncoded: [],
-            multipartForm: [],
-            file: []
-          },
-          docs: transformDescription(i.request.description)
-        }
-      };
+        const brunoRequestItem = {
+          uid: uuid(),
+          name: requestName,
+          type: 'http-request',
+          seq: index + 1,
+          request: {
+            url: url,
+            method: method,
+            auth: {
+              mode: 'inherit',
+              basic: null,
+              bearer: null,
+              awsv4: null,
+              apikey: null,
+              oauth1: null,
+              oauth2: null,
+              digest: null
+            },
+            headers: [],
+            params: [],
+            body: {
+              mode: 'none',
+              json: null,
+              text: null,
+              xml: null,
+              formUrlEncoded: [],
+              multipartForm: [],
+              file: []
+            },
+            docs: transformDescription(i.request.description)
+          }
+        };
 
         const settings = {
           encodeUrl: i.protocolProfileBehavior?.disableUrlEncoding !== true
@@ -612,22 +612,21 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
           }
         }
 
-      if (bodyMode === 'graphql') {
-        brunoRequestItem.type = 'graphql-request';
-        brunoRequestItem.request.body.mode = 'graphql';
-        brunoRequestItem.request.body.graphql = parseGraphQLRequest(i.request.body.graphql);
-      }
+        if (bodyMode === 'graphql') {
+          brunoRequestItem.type = 'graphql-request';
+          brunoRequestItem.request.body.mode = 'graphql';
+          brunoRequestItem.request.body.graphql = parseGraphQLRequest(i.request.body.graphql);
+        }
 
-      if (bodyMode === 'file') {
-        brunoRequestItem.request.body.mode = 'file';
-        brunoRequestItem.request.body.file.push({
-          uid: uuid(),
-          selected: true,
-          filePath: ensureString(i.request.body.file?.src),
-          contentType: 'application/octet-stream'
-        });
-        // brunoRequestItem.request.body.file = ensureString(i.request.body.file);
-      }
+        if (bodyMode === 'file') {
+          brunoRequestItem.request.body.mode = 'file';
+          brunoRequestItem.request.body.file.push({
+            uid: uuid(),
+            selected: true,
+            filePath: ensureString(i.request.body.file?.src),
+            contentType: 'application/octet-stream'
+          });
+        }
 
         each(normalizeHeaders(i.request.header), (header) => {
           if (header.key == null && header.value == null) return;
@@ -686,37 +685,37 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
             const exampleUrl = constructUrl(originalRequest.url);
             const exampleMethod = originalRequest.method?.toUpperCase() || method;
 
-          const example = {
-            uid: uuid(),
-            itemUid: brunoRequestItem.uid,
-            name: exampleName,
-            description: '',
-            type: 'http-request',
-            request: {
-              url: exampleUrl,
-              method: exampleMethod,
-              headers: [],
-              params: [],
-              body: {
-                mode: 'none',
-                json: null,
-                text: null,
-                xml: null,
-                formUrlEncoded: [],
-                multipartForm: [],
-                file: []
+            const example = {
+              uid: uuid(),
+              itemUid: brunoRequestItem.uid,
+              name: exampleName,
+              description: '',
+              type: 'http-request',
+              request: {
+                url: exampleUrl,
+                method: exampleMethod,
+                headers: [],
+                params: [],
+                body: {
+                  mode: 'none',
+                  json: null,
+                  text: null,
+                  xml: null,
+                  formUrlEncoded: [],
+                  multipartForm: [],
+                  file: []
+                }
+              },
+              response: {
+                status: response.code || null,
+                statusText: response.status || '',
+                headers: [],
+                body: {
+                  type: getBodyTypeFromContentTypeHeader(response.header),
+                  content: response.body || ''
+                }
               }
-            },
-            response: {
-              status: response.code || null,
-              statusText: response.status || '',
-              headers: [],
-              body: {
-                type: getBodyTypeFromContentTypeHeader(response.header),
-                content: response.body || ''
-              }
-            }
-          };
+            };
 
             // Convert original request headers
             if (originalRequest.header) {
@@ -818,15 +817,14 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
                 }
               }
             } else if (bodyMode === 'file') {
-            example.request.body.mode = 'file';
-            example.request.body.file.push({
-              uid: uuid(),
-              selected: true,
-              filePath: ensureString(i.request.body.file?.src),
-              contentType: 'application/octet-stream'
-            });
-            // brunoRequestItem.request.body.file = ensureString(i.request.body.file);
-          }
+              example.request.body.mode = 'file';
+              example.request.body.file.push({
+                uid: uuid(),
+                selected: true,
+                filePath: ensureString(i.request.body.file?.src),
+                contentType: 'application/octet-stream'
+              });
+            }
 
             // Convert response headers
             if (response.header) {

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -815,15 +815,15 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
                   example.request.body.mode = 'text';
                   example.request.body.text = originalRequest.body.raw;
                 }
+              } else if (bodyMode === 'file') {
+                example.request.body.mode = 'file';
+                example.request.body.file.push({
+                  uid: uuid(),
+                  selected: true,
+                  filePath: ensureString(originalRequest.request.body.file?.src),
+                  contentType: 'application/octet-stream'
+                });
               }
-            } else if (bodyMode === 'file') {
-              example.request.body.mode = 'file';
-              example.request.body.file.push({
-                uid: uuid(),
-                selected: true,
-                filePath: ensureString(i.request.body.file?.src),
-                contentType: 'application/octet-stream'
-              });
             }
 
             // Convert response headers

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -610,22 +610,22 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
               brunoRequestItem.request.body.text = i.request.body.raw;
             }
           }
+
+          if (bodyMode === 'file') {
+            brunoRequestItem.request.body.mode = 'file';
+            brunoRequestItem.request.body.file.push({
+              uid: uuid(),
+              selected: true,
+              filePath: ensureString(i.request.body.file?.src),
+              contentType: 'application/octet-stream'
+            });
+          }
         }
 
         if (bodyMode === 'graphql') {
           brunoRequestItem.type = 'graphql-request';
           brunoRequestItem.request.body.mode = 'graphql';
           brunoRequestItem.request.body.graphql = parseGraphQLRequest(i.request.body.graphql);
-        }
-
-        if (bodyMode === 'file') {
-          brunoRequestItem.request.body.mode = 'file';
-          brunoRequestItem.request.body.file.push({
-            uid: uuid(),
-            selected: true,
-            filePath: ensureString(i.request.body.file?.src),
-            contentType: 'application/octet-stream'
-          });
         }
 
         each(normalizeHeaders(i.request.header), (header) => {

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -514,6 +514,62 @@ describe('Send Request Translation', () => {
     });
   });
 
+  describe('Binary/File Body Mode', () => {
+    it('should show the correct translation for file/binary body mode', () => {
+      const code = `
+        pm.sendRequest({
+            url: 'https://echo.usebruno.com',
+            method: 'POST',
+            header: {
+                'Content-Type': 'application/octet-stream',
+            },
+            body: {
+                mode: 'file',
+                file: {
+                    src: '/path/to/file.bin'
+                }
+            }
+        }, function (error, response) {
+            if (error) {
+                const errorCode = error.code;
+                console.log(errorCode);
+            }
+            if (response) {
+                const response_body = response.json();
+                const response_headers = response.headers;
+                console.log(response_body, response_headers);
+            }
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({
+            url: 'https://echo.usebruno.com',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/octet-stream',
+            },
+            body: {
+                mode: 'file',
+                file: {
+                    src: '/path/to/file.bin'
+                }
+            }
+        }, async function(error, response) {
+            if (error) {
+                const errorCode = error.code;
+                console.log(errorCode);
+            }
+            if (response) {
+                const response_body = response.data;
+                const response_headers = response.headers;
+                console.log(response_body, response_headers);
+            }
+        });
+      `);
+    });
+  });
+
   describe('Headers and Content-Type Handling', () => {
     it('should rename header property to headers', () => {
       const code = `

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -514,62 +514,6 @@ describe('Send Request Translation', () => {
     });
   });
 
-  describe('Binary/File Body Mode', () => {
-    it('should show the correct translation for file/binary body mode', () => {
-      const code = `
-        pm.sendRequest({
-            url: 'https://echo.usebruno.com',
-            method: 'POST',
-            header: {
-                'Content-Type': 'application/octet-stream',
-            },
-            body: {
-                mode: 'file',
-                file: {
-                    src: '/path/to/file.bin'
-                }
-            }
-        }, function (error, response) {
-            if (error) {
-                const errorCode = error.code;
-                console.log(errorCode);
-            }
-            if (response) {
-                const response_body = response.json();
-                const response_headers = response.headers;
-                console.log(response_body, response_headers);
-            }
-        });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({
-            url: 'https://echo.usebruno.com',
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/octet-stream',
-            },
-            body: {
-                mode: 'file',
-                file: {
-                    src: '/path/to/file.bin'
-                }
-            }
-        }, async function(error, response) {
-            if (error) {
-                const errorCode = error.code;
-                console.log(errorCode);
-            }
-            if (response) {
-                const response_body = response.data;
-                const response_headers = response.headers;
-                console.log(response_body, response_headers);
-            }
-        });
-      `);
-    });
-  });
-
   describe('Headers and Content-Type Handling', () => {
     it('should rename header property to headers', () => {
       const code = `

--- a/tests/import/postman/fixtures/postman-import-binary-body-mode.json
+++ b/tests/import/postman/fixtures/postman-import-binary-body-mode.json
@@ -1,0 +1,46 @@
+{
+  "info": {
+    "_postman_id": "b7368879-4f3f-46e1-a187-0b0821517151",
+    "name": "My Collection",
+    "description": "### Welcome to Postman! This is your first collection. \n\nCollections are your starting point for building and testing APIs. You can use this one to:\n\n• Group related requests\n• Test your API in real-world scenarios\n• Document and share your requests\n\nUpdate the name and overview whenever you’re ready to make it yours.\n\n[Learn more about Postman Collections.](https://learning.postman.com/docs/collections/collections-overview/)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "55235588",
+    "_collection_link": "https://go.postman.co/collection/55235588-b7368879-4f3f-46e1-a187-0b0821517151?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Binary body mode",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "file",
+          "file": {
+            "src": "/tmp/binary-payload.bin"
+          }
+        },
+        "url": {
+          "raw": "https://api.com/users?X-API-KEY=12345",
+          "protocol": "https",
+          "host": [
+            "api",
+            "com"
+          ],
+          "path": [
+            "users"
+          ],
+          "query": [
+            {
+              "key": "X-API-KEY",
+              "value": "12345"
+            }
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/tests/import/postman/fixtures/postman-import-binary-body-mode.json
+++ b/tests/import/postman/fixtures/postman-import-binary-body-mode.json
@@ -19,7 +19,7 @@
         "body": {
           "mode": "file",
           "file": {
-            "src": "/tmp/binary-payload.bin"
+            "src": "./binary-payload.bin"
           }
         },
         "url": {

--- a/tests/import/postman/fixtures/postman-import-binary-body-mode.json
+++ b/tests/import/postman/fixtures/postman-import-binary-body-mode.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "_postman_id": "b7368879-4f3f-46e1-a187-0b0821517151",
-    "name": "My Collection",
+    "name": "Binary body type",
     "description": "### Welcome to Postman! This is your first collection. \n\nCollections are your starting point for building and testing APIs. You can use this one to:\n\n• Group related requests\n• Test your API in real-world scenarios\n• Document and share your requests\n\nUpdate the name and overview whenever you’re ready to make it yours.\n\n[Learn more about Postman Collections.](https://learning.postman.com/docs/collections/collections-overview/)",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "55235588",
@@ -40,7 +40,49 @@
           ]
         }
       },
-      "response": []
+      "response": [
+        {
+          "name": "Binary upload example",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "file",
+              "file": {
+                "src": "./binary-payload.bin"
+              }
+            },
+            "url": {
+              "raw": "https://api.com/users?X-API-KEY=12345",
+              "protocol": "https",
+              "host": [
+                "api",
+                "com"
+              ],
+              "path": [
+                "users"
+              ],
+              "query": [
+                {
+                  "key": "X-API-KEY",
+                  "value": "12345"
+                }
+              ]
+            }
+          },
+          "status": "Created",
+          "code": 201,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "cookie": [],
+          "body": ""
+        }
+      ]
     }
   ]
 }

--- a/tests/import/postman/import-binary-body-mode.spec.ts
+++ b/tests/import/postman/import-binary-body-mode.spec.ts
@@ -4,18 +4,17 @@ import { closeAllCollections, openCollection, selectRequestPaneTab } from '../..
 import { buildCommonLocators } from '../../utils/page/locators';
 
 test.describe('Import Postman Collection with binary body mode', () => {
-  let originalShowOpenDialog;
-
   test.beforeAll(async ({ electronApp }) => {
     await electronApp.evaluate(({ dialog }) => {
-      originalShowOpenDialog = dialog.showOpenDialog;
+      (global as any)._originalShowOpenDialog = dialog.showOpenDialog;
     });
   });
 
   test.afterAll(async ({ electronApp, page }) => {
     await closeAllCollections(page);
     await electronApp.evaluate(({ dialog }) => {
-      dialog.showOpenDialog = originalShowOpenDialog;
+      dialog.showOpenDialog = (global as any)._originalShowOpenDialog;
+      delete (global as any)._originalShowOpenDialog;
     });
   });
 

--- a/tests/import/postman/import-binary-body-mode.spec.ts
+++ b/tests/import/postman/import-binary-body-mode.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+import { closeAllCollections, openCollection, selectRequestPaneTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe('Import Postman Collection with binary body mode', () => {
+  let originalShowOpenDialog;
+
+  test.beforeAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      originalShowOpenDialog = dialog.showOpenDialog;
+    });
+  });
+
+  test.afterAll(async ({ electronApp, page }) => {
+    await closeAllCollections(page);
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = originalShowOpenDialog;
+    });
+  });
+
+  test('should import Postman collection with binary body mode successfully', async ({ page, electronApp, createTmpDir }) => {
+    const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-import-binary-body-mode.json');
+    const locators = buildCommonLocators(page);
+
+    const importDir = await createTmpDir('imported-collection');
+
+    await electronApp.evaluate(({ dialog }, { importDir }) => {
+      dialog.showOpenDialog = async () => ({
+        canceled: false,
+        filePaths: [importDir]
+      });
+    }, { importDir });
+
+    await test.step('Open import collection modal', async () => {
+      await locators.plusMenu.button().click();
+      await locators.plusMenu.importCollection().click();
+    });
+
+    await test.step('Wait for import modal and verify title', async () => {
+      const importModal = page.getByRole('dialog');
+      await importModal.waitFor({ state: 'visible' });
+      await expect(locators.modal.title('Import Collection')).toBeVisible();
+    });
+
+    await test.step('Upload Postman collection file using hidden file input', async () => {
+      await locators.import.fileInput().setInputFiles(postmanFile);
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
+    });
+
+    await test.step('Verify no parsing errors occurred', async () => {
+      const hasError = await locators.import.parsingError().isVisible().catch(() => false);
+      if (hasError) {
+        throw new Error('Collection import failed with parsing error');
+      }
+    });
+
+    await test.step('Verify location selection modal appears', async () => {
+      await expect(locators.modal.title('Import Collection')).toBeVisible();
+    });
+
+    await test.step('Verify collection name appears in location modal', async () => {
+      await expect(locators.import.locationModal().getByText('My Collection')).toBeVisible();
+    });
+
+    await test.step('Click Browse link to select collection folder', async () => {
+      await locators.import.browseLink(locators.import.locationModal()).click();
+    });
+
+    await test.step('Complete import by clicking import button', async () => {
+      const locationModal = locators.import.locationModal();
+      await locators.import.importButton(locationModal).click();
+      await locationModal.waitFor({ state: 'hidden' });
+    });
+
+    await test.step('Open collection and verify request is displayed', async () => {
+      await openCollection(page, 'My Collection');
+      await expect(locators.sidebar.collection('My Collection')).toBeVisible();
+      await expect(locators.sidebar.request('Binary body mode')).toBeVisible();
+      await locators.sidebar.request('Binary body mode').click();
+      await expect(locators.request.pane()).toBeVisible();
+    });
+
+    await test.step('Verify body mode is File / Binary and imported file path is preserved', async () => {
+      await selectRequestPaneTab(page, 'Body');
+      await expect(locators.request.bodyModeSelector()).toContainText('File / Binary');
+      await expect(locators.request.pane().getByText('binary-payload.bin')).toBeVisible();
+    });
+  });
+});

--- a/tests/import/postman/import-binary-body-mode.spec.ts
+++ b/tests/import/postman/import-binary-body-mode.spec.ts
@@ -4,18 +4,8 @@ import { closeAllCollections, openCollection, selectRequestPaneTab } from '../..
 import { buildCommonLocators } from '../../utils/page/locators';
 
 test.describe('Import Postman Collection with binary body mode', () => {
-  test.beforeAll(async ({ electronApp }) => {
-    await electronApp.evaluate(({ dialog }) => {
-      (global as any)._originalShowOpenDialog = dialog.showOpenDialog;
-    });
-  });
-
-  test.afterAll(async ({ electronApp, page }) => {
+  test.afterAll(async ({ page }) => {
     await closeAllCollections(page);
-    await electronApp.evaluate(({ dialog }) => {
-      dialog.showOpenDialog = (global as any)._originalShowOpenDialog;
-      delete (global as any)._originalShowOpenDialog;
-    });
   });
 
   test('should import Postman collection with binary body mode successfully', async ({ page, electronApp, createTmpDir }) => {
@@ -25,44 +15,51 @@ test.describe('Import Postman Collection with binary body mode', () => {
     const importDir = await createTmpDir('imported-collection');
 
     await electronApp.evaluate(({ dialog }, { importDir }) => {
-      dialog.showOpenDialog = async () => ({
-        canceled: false,
-        filePaths: [importDir]
-      });
+      const originalShowOpenDialog = dialog.showOpenDialog;
+      dialog.showOpenDialog = async () => {
+        dialog.showOpenDialog = originalShowOpenDialog;
+        return {
+          canceled: false,
+          filePaths: [importDir]
+        };
+      };
     }, { importDir });
 
-    await test.step('Open import collection modal', async () => {
+    await test.step('Import collection', async () => {
       await locators.plusMenu.button().click();
       await locators.plusMenu.importCollection().click();
-      const importModal = page.getByRole('dialog');
+      const importModal = locators.import.modal();
       await importModal.waitFor({ state: 'visible' });
-      await expect(locators.modal.title('Import Collection')).toBeVisible();
       await locators.import.fileInput().setInputFiles(postmanFile);
-      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
-      const hasError = await locators.import.parsingError().isVisible().catch(() => false);
-      if (hasError) {
-        throw new Error('Collection import failed with parsing error');
-      }
-      await expect(locators.modal.title('Import Collection')).toBeVisible();
-      await expect(locators.import.locationModal().getByText('My Collection')).toBeVisible();
-      await locators.import.browseLink(locators.import.locationModal()).click();
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 5000 });
       const locationModal = locators.import.locationModal();
+      await expect(locationModal.getByText('Binary body type')).toBeVisible();
+      await locators.import.browseLink(locationModal).click();
       await locators.import.importButton(locationModal).click();
       await locationModal.waitFor({ state: 'hidden' });
-    });
-
-    await test.step('Open collection and verify request is displayed', async () => {
-      await openCollection(page, 'My Collection');
-      await expect(locators.sidebar.collection('My Collection')).toBeVisible();
-      await expect(locators.sidebar.request('Binary body mode')).toBeVisible();
-      await locators.sidebar.request('Binary body mode').click();
-      await expect(locators.request.pane()).toBeVisible();
+      await openCollection(page, 'Binary body type');
+      await expect(locators.sidebar.collection('Binary body type')).toBeVisible();
     });
 
     await test.step('Verify body mode is File / Binary and imported file path is preserved', async () => {
+      await locators.sidebar.request('Binary body mode').click();
+      await expect(locators.request.pane()).toBeVisible();
       await selectRequestPaneTab(page, 'Body');
       await expect(locators.request.bodyModeSelector()).toContainText('File / Binary');
       await expect(locators.request.pane().getByText('binary-payload.bin')).toBeVisible();
+    });
+
+    await test.step('Verify example is imported and preserves the binary body mode', async () => {
+      const chevronIcon = page.getByTestId('request-item-chevron');
+      await expect(chevronIcon).toBeVisible();
+      await chevronIcon.click();
+      const example = locators.sidebar.request('Binary upload example');
+      await expect(example).toBeVisible();
+      await example.click();
+      const examplePane = locators.request.pane();
+      await expect(examplePane).toBeVisible();
+      await expect(examplePane.locator('.selected-body-mode')).toContainText('File / Binary');
+      await expect(examplePane.getByText('binary-payload.bin')).toBeVisible();
     });
   });
 });

--- a/tests/import/postman/import-binary-body-mode.spec.ts
+++ b/tests/import/postman/import-binary-body-mode.spec.ts
@@ -34,39 +34,18 @@ test.describe('Import Postman Collection with binary body mode', () => {
     await test.step('Open import collection modal', async () => {
       await locators.plusMenu.button().click();
       await locators.plusMenu.importCollection().click();
-    });
-
-    await test.step('Wait for import modal and verify title', async () => {
       const importModal = page.getByRole('dialog');
       await importModal.waitFor({ state: 'visible' });
       await expect(locators.modal.title('Import Collection')).toBeVisible();
-    });
-
-    await test.step('Upload Postman collection file using hidden file input', async () => {
       await locators.import.fileInput().setInputFiles(postmanFile);
       await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
-    });
-
-    await test.step('Verify no parsing errors occurred', async () => {
       const hasError = await locators.import.parsingError().isVisible().catch(() => false);
       if (hasError) {
         throw new Error('Collection import failed with parsing error');
       }
-    });
-
-    await test.step('Verify location selection modal appears', async () => {
       await expect(locators.modal.title('Import Collection')).toBeVisible();
-    });
-
-    await test.step('Verify collection name appears in location modal', async () => {
       await expect(locators.import.locationModal().getByText('My Collection')).toBeVisible();
-    });
-
-    await test.step('Click Browse link to select collection folder', async () => {
       await locators.import.browseLink(locators.import.locationModal()).click();
-    });
-
-    await test.step('Complete import by clicking import button', async () => {
       const locationModal = locators.import.locationModal();
       await locators.import.importButton(locationModal).click();
       await locationModal.waitFor({ state: 'hidden' });


### PR DESCRIPTION
Jira link: https://usebruno.atlassian.net/browse/BRU-3118

### Description

Binary body type was missing in postman-to-bruno.js. Added case for binary body type in postman-to-bruno.js. Binary file is mapped and content type is set to default (application/octet-stream)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Postman import preserves file/binary request and example bodies, including file entries, file paths and content types; imported requests show "File / Binary" for body mode.
* **Tests**
  * Added unit and E2E tests plus a fixture to validate file-body conversion, translator behavior for binary request bodies, the UI import flow, and that the binary file appears in the request pane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->