### PR TITLE
fix(workspace): openWorkspaceDialog gives success toast on cancel click

### DIFF
--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -153,7 +153,6 @@ const AppTitleBar = () => {
   const handleOpenWorkspace = async () => {
     try {
       await dispatch(openWorkspaceDialog());
-      // toast.success('Workspace opened successfully');
     } catch (error) {
       toast.error(error.message || 'Failed to open workspace');
     }

--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -153,7 +153,7 @@ const AppTitleBar = () => {
   const handleOpenWorkspace = async () => {
     try {
       await dispatch(openWorkspaceDialog());
-      toast.success('Workspace opened successfully');
+      // toast.success('Workspace opened successfully');
     } catch (error) {
       toast.error(error.message || 'Failed to open workspace');
     }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -248,8 +248,10 @@ export const openWorkspaceDialog = () => {
         }));
 
         await dispatch(switchWorkspace(workspaceUid));
-
+        toast.success('Workspace opened successfully');
         return result;
+      } else {
+        return null;
       }
     } catch (error) {
       throw error;

--- a/tests/workspace/open-workspace/open-workspace.spec.ts
+++ b/tests/workspace/open-workspace/open-workspace.spec.ts
@@ -1,0 +1,101 @@
+import path from 'path';
+import fs from 'fs';
+import type { ElectronApplication } from '@playwright/test';
+import { test, expect, closeElectronApp } from '../../../playwright';
+import { buildCommonLocators, openWorkspaceFromDialog, waitForReadyPage } from '../../utils/page';
+
+const buildWorkspaceYml = (workspaceName: string) => [
+  'opencollection: 1.0.0',
+  'info:',
+  `  name: ${workspaceName}`,
+  '  type: workspace',
+  'collections:',
+  'specs: []',
+  'docs: \'\'',
+  ''
+].join('\n');
+
+test.describe('Open Workspace', () => {
+  test.describe('canceling the open workspace dialog should not show a success toast', () => {
+    test('click on cancel button, should just close the dialog', async ({
+      launchElectronApp,
+      createTmpDir
+    }) => {
+      const userDataPath = await createTmpDir('open-workspace-cancel');
+
+      let app: ElectronApplication | undefined;
+      try {
+        app = await launchElectronApp({ userDataPath });
+        const page = await waitForReadyPage(app);
+        const locators = buildCommonLocators(page);
+
+        const initialWorkspaceName = await page
+          .getByTestId('workspace-name')
+          .textContent();
+
+        await app!.evaluate(({ dialog }) => {
+          (
+            dialog as { showOpenDialog: typeof dialog.showOpenDialog }
+          ).showOpenDialog = () =>
+            Promise.resolve({ canceled: true, filePaths: [] });
+        });
+
+        await test.step('Open the workspace menu and click "Open workspace"', async () => {
+          await page.getByTestId('workspace-menu').click();
+          await locators.dropdown.item('Open workspace').click();
+        });
+
+        await test.step('No success toast appears within 5s, workspace unchanged', async () => {
+          const toast = page.getByText('Workspace opened successfully');
+          const deadline = Date.now() + 5000;
+          while (Date.now() < deadline) {
+            await expect(toast).toBeHidden({ timeout: 100 });
+            await page.waitForTimeout(100);
+          }
+          await expect(page.getByTestId('workspace-name')).toHaveText(initialWorkspaceName ?? '');
+        });
+      } finally {
+        if (app) await closeElectronApp(app);
+      }
+    });
+  });
+
+  test.describe('successfully opening a workspace should show a success toast', () => {
+    test('selecting a valid workspace path shows the success toast', async ({
+      launchElectronApp,
+      createTmpDir
+    }) => {
+      const userDataPath = await createTmpDir('open-workspace-success');
+      const workspacePath = await createTmpDir('demo-workspace');
+
+      fs.writeFileSync(path.join(workspacePath, 'workspace.yml'), buildWorkspaceYml('Demo Workspace'));
+
+      let app: ElectronApplication | undefined;
+      try {
+        app = await launchElectronApp({ userDataPath });
+        const page = await waitForReadyPage(app);
+
+        await test.step('Open the demo workspace via the dialog', async () => {
+          await openWorkspaceFromDialog(app, page, workspacePath);
+        });
+
+        await test.step('Success toast appears within 5s and workspace switches', async () => {
+          const toast = page.getByText('Workspace opened successfully');
+          const deadline = Date.now() + 5000;
+          let toastSeen = false;
+          while (Date.now() < deadline) {
+            if (await toast.isVisible()) {
+              toastSeen = true;
+              break;
+            }
+            await page.waitForTimeout(100);
+          }
+          expect(toastSeen).toBe(true);
+          await expect(page.getByTestId('workspace-name')).toHaveText('Demo Workspace', { timeout: 10000 });
+        });
+      } finally {
+        if (app) await closeElectronApp(app);
+      }
+    });
+  });
+});

--- a/tests/workspace/open-workspace/open-workspace.spec.ts
+++ b/tests/workspace/open-workspace/open-workspace.spec.ts
@@ -1,56 +1,36 @@
-import path from 'path';
-import fs from 'fs';
 import type { ElectronApplication } from '@playwright/test';
-import { test, expect, closeElectronApp } from '../../../playwright';
-import { buildCommonLocators, openWorkspaceFromDialog, waitForReadyPage } from '../../utils/page';
-
-const buildWorkspaceYml = (workspaceName: string) => [
-  'opencollection: 1.0.0',
-  'info:',
-  `  name: ${workspaceName}`,
-  '  type: workspace',
-  'collections:',
-  'specs: []',
-  'docs: \'\'',
-  ''
-].join('\n');
+import { expect, test } from '../../../playwright';
+import { buildCommonLocators, waitForReadyPage } from '../../utils/page';
 
 test.describe('Open Workspace', () => {
-  test.describe('canceling the open workspace dialog should not show a success toast', () => {
-    test('click on cancel button, should just close the dialog', async ({
-      launchElectronApp,
-      createTmpDir
-    }) => {
-      const userDataPath = await createTmpDir('open-workspace-cancel');
+  test('click on cancel button, should just close the dialog', async ({
+    launchElectronApp,
+    createTmpDir
+  }) => {
+    const userDataPath = await createTmpDir('open-workspace-cancel');
+    let app: ElectronApplication | undefined;
+    app = await launchElectronApp({ userDataPath });
+    const page = await waitForReadyPage(app);
+    const locators = buildCommonLocators(page);
 
-      let app: ElectronApplication | undefined;
-      try {
-        app = await launchElectronApp({ userDataPath });
-        const page = await waitForReadyPage(app);
-        const locators = buildCommonLocators(page);
+    const initialWorkspaceName = await page
+      .getByTestId('workspace-name')
+      .textContent();
 
-        const initialWorkspaceName = await page
-          .getByTestId('workspace-name')
-          .textContent();
+    await app!.evaluate(({ dialog }) => {
+      (
+        dialog as { showOpenDialog: typeof dialog.showOpenDialog }
+      ).showOpenDialog = () =>
+        Promise.resolve({ canceled: true, filePaths: [] });
+    });
 
-        await app!.evaluate(({ dialog }) => {
-          (
-            dialog as { showOpenDialog: typeof dialog.showOpenDialog }
-          ).showOpenDialog = () =>
-            Promise.resolve({ canceled: true, filePaths: [] });
-        });
+    await test.step('Open the workspace menu and click "Open workspace"', async () => {
+      await page.getByTestId('workspace-menu').click();
+      await locators.dropdown.item('Open workspace').click();
+    });
 
-        await test.step('Open the workspace menu and click "Open workspace"', async () => {
-          await page.getByTestId('workspace-menu').click();
-          await locators.dropdown.item('Open workspace').click();
-        });
-
-        await test.step('Workspace unchanged after canceling the dialog', async () => {
-          await expect(page.getByTestId('workspace-name')).toHaveText(initialWorkspaceName ?? '');
-        });
-      } finally {
-        if (app) await closeElectronApp(app);
-      }
+    await test.step('Workspace unchanged after canceling the dialog', async () => {
+      await expect(page.getByTestId('workspace-name')).toHaveText(initialWorkspaceName ?? '');
     });
   });
 });

--- a/tests/workspace/open-workspace/open-workspace.spec.ts
+++ b/tests/workspace/open-workspace/open-workspace.spec.ts
@@ -45,53 +45,8 @@ test.describe('Open Workspace', () => {
           await locators.dropdown.item('Open workspace').click();
         });
 
-        await test.step('No success toast appears within 5s, workspace unchanged', async () => {
-          const toast = page.getByText('Workspace opened successfully');
-          const deadline = Date.now() + 5000;
-          while (Date.now() < deadline) {
-            await expect(toast).toBeHidden({ timeout: 100 });
-            await page.waitForTimeout(100);
-          }
+        await test.step('Workspace unchanged after canceling the dialog', async () => {
           await expect(page.getByTestId('workspace-name')).toHaveText(initialWorkspaceName ?? '');
-        });
-      } finally {
-        if (app) await closeElectronApp(app);
-      }
-    });
-  });
-
-  test.describe('successfully opening a workspace should show a success toast', () => {
-    test('selecting a valid workspace path shows the success toast', async ({
-      launchElectronApp,
-      createTmpDir
-    }) => {
-      const userDataPath = await createTmpDir('open-workspace-success');
-      const workspacePath = await createTmpDir('demo-workspace');
-
-      fs.writeFileSync(path.join(workspacePath, 'workspace.yml'), buildWorkspaceYml('Demo Workspace'));
-
-      let app: ElectronApplication | undefined;
-      try {
-        app = await launchElectronApp({ userDataPath });
-        const page = await waitForReadyPage(app);
-
-        await test.step('Open the demo workspace via the dialog', async () => {
-          await openWorkspaceFromDialog(app, page, workspacePath);
-        });
-
-        await test.step('Success toast appears within 5s and workspace switches', async () => {
-          const toast = page.getByText('Workspace opened successfully');
-          const deadline = Date.now() + 5000;
-          let toastSeen = false;
-          while (Date.now() < deadline) {
-            if (await toast.isVisible()) {
-              toastSeen = true;
-              break;
-            }
-            await page.waitForTimeout(100);
-          }
-          expect(toastSeen).toBe(true);
-          await expect(page.getByTestId('workspace-name')).toHaveText('Demo Workspace', { timeout: 10000 });
         });
       } finally {
         if (app) await closeElectronApp(app);


### PR DESCRIPTION
JIRA Link - https://usebruno.atlassian.net/browse/BRU-3488

### Description

workspace --> open workspace --> click cancel on dialog box --> gives success toast
fixed this to give success toast only on successful selection of the workspace 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace-open notifications: removed unconditional success toast from the UI handler and ensured success toasts are shown only when the open-workspace flow truly succeeds; cancelling the dialog no longer triggers success feedback.
* **Tests**
  * Added an end-to-end test that simulates a canceled open dialog and verifies the workspace name and notification behavior remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->