### PR TITLE
fix(codegen): handle null basic auth credentials

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -479,6 +479,23 @@ describe('Snippet Generator - Simple Tests', () => {
       })
     );
   });
+
+  it('should treat a null basic auth username as an empty string', () => {
+    const { getAuthHeaders: actualGetAuthHeaders } = jest.requireActual('utils/codegenerator/auth');
+
+    const headers = actualGetAuthHeaders({
+      mode: 'basic',
+      basic: { username: null, password: 'pwd' }
+    });
+
+    // ":pwd" encoded is "OnB3ZA==" — never "null:pwd" ("bnVsbDpwd2Q=")
+    expect(headers).toContainEqual(
+      expect.objectContaining({
+        name: 'Authorization',
+        value: 'Basic OnB3ZA=='
+      })
+    );
+  });
 });
 
 // Snippet should include inherited headers

--- a/packages/bruno-app/src/utils/codegenerator/auth.js
+++ b/packages/bruno-app/src/utils/codegenerator/auth.js
@@ -11,8 +11,8 @@ export const getAuthHeaders = (requestAuth, collection = null, item = null) => {
 
   switch (requestAuth.mode) {
     case 'basic':
-      const username = get(requestAuth, 'basic.username', '');
-      const password = get(requestAuth, 'basic.password', '');
+      const username = get(requestAuth, 'basic.username') || '';
+      const password = get(requestAuth, 'basic.password') || '';
       const basicToken = Buffer.from(`${username}:${password}`).toString('base64');
 
       return [

--- a/packages/bruno-app/src/utils/codegenerator/auth.js
+++ b/packages/bruno-app/src/utils/codegenerator/auth.js
@@ -11,8 +11,8 @@ export const getAuthHeaders = (requestAuth, collection = null, item = null) => {
 
   switch (requestAuth.mode) {
     case 'basic':
-      const username = get(requestAuth, 'basic.username') || '';
-      const password = get(requestAuth, 'basic.password') || '';
+      const username = get(requestAuth, 'basic.username') ?? '';
+      const password = get(requestAuth, 'basic.password') ?? '';
       const basicToken = Buffer.from(`${username}:${password}`).toString('base64');
 
       return [


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fixes #8111

`lodash.get(obj, path, '')` returns `null` (not `''`) when the path is `null`, which the codegen serialized as the literal "null".
Fallback after `get` so both `undefined` and `null` collapse to `''`.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of null or missing basic-auth credentials so `Authorization: Basic` headers are generated correctly (null username/password are treated as empty strings before encoding).

* **Tests**
  * Added a test to verify the exact `Authorization: Basic` header produced when basic-auth username or password is null.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->