### PR TITLE
fix(import): preserve special chars in OpenAPI tag/folder names for yml collections

### DIFF
--- a/packages/bruno-converters/src/common/index.js
+++ b/packages/bruno-converters/src/common/index.js
@@ -60,11 +60,18 @@ export const sanitizeTag = (tag, options = {}) => {
 
   let usableTagString = typeof tag == 'string' ? tag : 'name' in tag ? tag.name : '';
 
-  let sanitized = usableTagString.trim();
+  let trimmed = usableTagString.trim();
+
+  // OpenCollection (yml) schema imposes no character restriction on tags.
+  // Preserve the source value verbatim so folder names round-trip (BRU-3175).
+  if (options.collectionFormat === 'yml') {
+    return trimmed || null;
+  }
 
   // BRU format only supports alphanumeric, hyphens, and underscores in tags
   // The BRU grammar defines listitem as: (alnum | "_" | "-")+
   // Spaces are NOT allowed, so we replace them with underscores
+  let sanitized = trimmed;
 
   // Replace spaces with underscores first
   sanitized = sanitized.replace(/\s+/g, '_');

--- a/packages/bruno-converters/src/openapi/openapi-common.js
+++ b/packages/bruno-converters/src/openapi/openapi-common.js
@@ -499,15 +499,16 @@ export const createBrunoExample = ({ brunoRequestItem, exampleValue, exampleName
 /**
  * Groups requests by their first tag
  * @param {Array} requests - Array of parsed request objects
+ * @param {Object} options - Sanitization options (forwarded to sanitizeTag)
  * @returns {Array} Tuple of [tagGroups, ungroupedRequests]
  */
-export const groupRequestsByTags = (requests) => {
+export const groupRequestsByTags = (requests, options = {}) => {
   let _groups = {};
   let ungrouped = [];
   each(requests, (request) => {
     let tags = request.operationObject.tags || [];
     if (tags.length > 0) {
-      let tag = sanitizeTag(tags[0].trim()); // take first tag, trim whitespace, and sanitize
+      let tag = sanitizeTag(tags[0].trim(), options); // take first tag, trim whitespace, and sanitize
 
       if (tag) {
         if (!_groups[tag]) {

--- a/packages/bruno-converters/tests/common/sanitizeTag.spec.js
+++ b/packages/bruno-converters/tests/common/sanitizeTag.spec.js
@@ -125,14 +125,50 @@ describe('sanitizeTag', () => {
     });
   });
 
-  describe('options handling', () => {
-    it('should ignore collectionFormat option and always sanitize', () => {
-      // The collectionFormat option is no longer used - always sanitize
-      // Spaces are replaced with underscores for BRU format compatibility
-      expect(sanitizeTag('User Management', { collectionFormat: 'yml' })).toBe('User_Management');
-      expect(sanitizeTag('api.v1', { collectionFormat: 'yml' })).toBe('api_v1');
-      // 'API (v1)' becomes 'API_v1' (space and parentheses become underscores)
-      expect(sanitizeTag('API (v1)', { collectionFormat: 'yml' })).toBe('API_v1');
+  describe('options.collectionFormat handling (BRU-3175)', () => {
+    describe('yml (OpenCollection) — preserves tag verbatim', () => {
+      it('preserves ampersand and spaces', () => {
+        expect(sanitizeTag('Pets & Dogs', { collectionFormat: 'yml' })).toBe('Pets & Dogs');
+        expect(sanitizeTag('R&D', { collectionFormat: 'yml' })).toBe('R&D');
+      });
+
+      it('preserves a single special character', () => {
+        expect(sanitizeTag('&', { collectionFormat: 'yml' })).toBe('&');
+      });
+
+      it('preserves dots, parentheses and other punctuation', () => {
+        expect(sanitizeTag('api.v1', { collectionFormat: 'yml' })).toBe('api.v1');
+        expect(sanitizeTag('API (v1)', { collectionFormat: 'yml' })).toBe('API (v1)');
+      });
+
+      it('trims surrounding whitespace but keeps inner whitespace verbatim', () => {
+        expect(sanitizeTag('  Pets & Dogs  ', { collectionFormat: 'yml' })).toBe('Pets & Dogs');
+      });
+
+      it('returns null for whitespace-only input', () => {
+        expect(sanitizeTag('   ', { collectionFormat: 'yml' })).toBeNull();
+      });
+
+      it('reads .name from tag-object input', () => {
+        expect(sanitizeTag({ name: 'R&D' }, { collectionFormat: 'yml' })).toBe('R&D');
+      });
+    });
+
+    describe('bru (legacy) — keeps existing strict sanitization', () => {
+      it('rewrites ampersand and spaces to underscores', () => {
+        expect(sanitizeTag('Pets & Dogs', { collectionFormat: 'bru' })).toBe('Pets_Dogs');
+        expect(sanitizeTag('R&D', { collectionFormat: 'bru' })).toBe('R_D');
+      });
+
+      it('drops a tag of only special characters', () => {
+        expect(sanitizeTag('&', { collectionFormat: 'bru' })).toBeNull();
+      });
+
+      it('matches default behavior when collectionFormat is omitted', () => {
+        expect(sanitizeTag('Pets & Dogs')).toBe('Pets_Dogs');
+        expect(sanitizeTag('R&D')).toBe('R_D');
+        expect(sanitizeTag('&')).toBeNull();
+      });
     });
   });
 });

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-tags.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-tags.spec.js
@@ -393,3 +393,46 @@ describe('OpenAPI Import - Tag Sanitization', () => {
     expect(folder).toBeDefined();
   });
 });
+
+describe('OpenAPI Import - yml (opencollection) tag preservation (BRU-3175)', () => {
+  const buildSpec = (tag) => ({
+    openapi: '3.0.0',
+    info: { title: 'Test API', version: '1.0.0' },
+    paths: {
+      '/x': {
+        get: {
+          operationId: 'getX',
+          summary: 'Get X',
+          tags: [tag],
+          responses: { 200: { description: 'OK' } }
+        }
+      }
+    }
+  });
+
+  it.each([
+    ['Pets & Dogs', 'Pets & Dogs'],
+    ['R&D', 'R&D'],
+    ['&', '&'],
+    ['API (v1)', 'API (v1)'],
+    ['api.v1', 'api.v1']
+  ])('preserves tag %p verbatim on request and folder for yml format', (sourceTag, expected) => {
+    const result = openApiToBruno(JSON.stringify(buildSpec(sourceTag)), { collectionFormat: 'yml' });
+
+    const request = findRequestByName(result.items, 'Get X');
+    expect(request).toBeDefined();
+    expect(request.tags).toEqual([expected]);
+
+    const folder = findFolderByName(result.items, expected);
+    expect(folder).toBeDefined();
+  });
+
+  it('keeps bru-format sanitization unchanged when collectionFormat is omitted', () => {
+    const result = openApiToBruno(JSON.stringify(buildSpec('Pets & Dogs')));
+    const request = findRequestByName(result.items, 'Get X');
+    expect(request.tags).toEqual(['Pets_Dogs']);
+
+    const folder = findFolderByName(result.items, 'Pets_Dogs');
+    expect(folder).toBeDefined();
+  });
+});

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -621,7 +621,7 @@ const itemSchema = Yup.object({
   type: Yup.string().oneOf(['http-request', 'graphql-request', 'folder', 'js', 'grpc-request', 'ws-request']).required('type is required'),
   seq: Yup.number().min(1),
   name: Yup.string().min(1, 'name must be at least 1 character').required('name is required'),
-  tags: Yup.array().of(Yup.string().matches(/^[\p{L}\p{N}_-](?:[\p{L}\p{N}_\s-]*[\p{L}\p{N}_-])?$/u, 'tag must contain only letters, numbers, spaces, hyphens, or underscores')),
+  tags: Yup.array().of(Yup.string().min(1, 'tag must not be empty')),
   request: Yup.mixed().when('type', {
     is: (type) => type === 'grpc-request',
     then: grpcRequestSchema.required('request is required when item-type is grpc-request'),

--- a/packages/bruno-schema/src/collections/itemSchema.spec.js
+++ b/packages/bruno-schema/src/collections/itemSchema.spec.js
@@ -15,38 +15,25 @@ describe('Item Schema Validation', () => {
     expect(isValid).toBeTruthy();
   });
 
-  it('item schema must validate tag regex rules', async () => {
+  it('item schema accepts arbitrary non-empty tag strings (opencollection allows any chars)', async () => {
     const validItem = {
       uid: uuid(),
       name: 'A Folder',
       type: 'folder',
-      tags: ['tag_1', 'Äiti-123 test']
+      tags: ['tag_1', 'Äiti-123 test', 'Pets & Dogs', 'R&D', '&', 'tag🔥name']
     };
 
     const isValid = await itemSchema.validate(validItem);
     expect(isValid).toBeTruthy();
 
-    let invalidItem = {
+    const invalidItem = {
       uid: uuid(),
       name: 'A Folder',
       type: 'folder',
-      tags: [' invalid-tag']
+      tags: ['']
     };
 
-    await expect(itemSchema.validate(invalidItem)).rejects.toThrow(
-      'tag must contain only letters, numbers, spaces, hyphens, or underscores'
-    );
-
-    invalidItem = {
-      uid: uuid(),
-      name: 'A Folder',
-      type: 'folder',
-      tags: ['tag🔥name']
-    };
-
-    await expect(itemSchema.validate(invalidItem)).rejects.toThrow(
-      'tag must contain only letters, numbers, spaces, hyphens, or underscores'
-    );
+    await expect(itemSchema.validate(invalidItem)).rejects.toThrow('tag must not be empty');
   });
 
   it('item schema must throw an error if name is missing', async () => {


### PR DESCRIPTION
### Description

When importing an OpenAPI spec into an opencollection (yml) collection, the importer rewrites every non-alphanumeric character in tag names to `_` and collapses/trims the result. Because tag names also drive folder names, users lose their authored tag values:

| OpenAPI tag | Current | Expected |
| --- | --- | --- |
| `Pets & Dogs` | `Pets_Dogs` | `Pets & Dogs` |
| `R&D` | `R_D` | `R&D` |
| `&` | dropped | `&` |

The OpenCollection (yml) `Tag` schema is just `string` — no character restriction. The unconditional sanitization is a BRU-grammar leak (the `.bru` `listitem` grammar is `(alnum | "_" | "-")+`, so its current rewrite must be preserved).

**Jira:** [BRU-3175](https://usebruno.atlassian.net/browse/BRU-3175). Related GitHub issue: #7529.

### Changes

Three layers needed touching for tags to round-trip end-to-end:

1. **`packages/bruno-converters/src/common/index.js`** — `sanitizeTag` now branches on `options.collectionFormat`:
   - `'yml'` → trim only, preserve verbatim
   - `'bru'` (or default) → keep existing BRU-grammar sanitization

2. **`packages/bruno-converters/src/openapi/openapi-common.js`** — `groupRequestsByTags` now accepts + threads `options` to `sanitizeTag`, so the folder-grouping path also respects the target format.

3. **`packages/bruno-schema/src/collections/index.js`** — `itemSchema.tags` regex relaxed to `Yup.string().min(1)`. The previous regex enforced BRU grammar on the in-memory collection shape and rejected our newly-preserved yml tags downstream. Matches the OpenCollection `Tag = string` spec.

### Cross-platform safety

The on-disk folder name is a separate concern from the semantic tag value:

- **Semantic tag value** is stored in `folder.yml` `info.name` and request `.yml` `tags[]` (verbatim, what we preserve here)
- **On-disk folder name** is sanitized by Bruno's existing `sanitizeName` in `packages/bruno-electron/src/utils/filesystem.js` — replaces `<>:"/\|?*` and control chars with `-`, strips trailing dots/spaces

The UI sidebar reads `info.name` from `folder.yml`, so the user sees their authored tag while disk paths stay portable. Verified identical behavior on macOS / Linux / Windows for the AC examples and common inputs.

**Out of scope:** Windows-reserved tag names (`CON`, `PRN`, `NUL`, `AUX`, `COM1-9`, `LPT1-9`) — pre-existing gap in `sanitizeName`, unrelated to BRU-3175. Filesystem-inherent issues (case-sensitivity differences between Linux and macOS/Windows, length limits) are not solvable in code.

### Test plan

- `npm run test --workspace=packages/bruno-converters -- sanitizeTag\|openapi-tags` — 56/56 pass
- `npm run test --workspace=packages/bruno-schema` — 22/22 pass
- Full `bruno-converters` suite — 1022/1044 pass (22 pre-existing skipped, 0 regressions)
- Manual UI repro with `Desktop/bru-3175-test.yaml` (spec containing `Pets & Dogs`, `R&D`, `&` tags) imported via Bruno's Import Collection dialog in **OpenCollection (YAML)** format — folders + sidebar labels now show tag values verbatim. Same spec imported as **BRU Format** still produces sanitized names (`Pets_Dogs/`, `R_D/`, ampersand dropped) — confirming legacy grammar is preserved.

### Contribution Checklist

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes** (yml-import behavior changes per ticket AC; bru-import behavior unchanged)
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (linked: #7529)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI tags now preserve special characters (spaces, ampersands, punctuation) when importing into YAML-format collections.

* **Improvements**
  * Enhanced tag handling with format-specific behavior; BRU collections maintain existing sanitization rules.
  * Relaxed tag validation to support a broader range of characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->