### PR TITLE
fix(portable-autoupdate): stop auto updating for portable version in windows

### DIFF
--- a/packages/bruno-electron/electron-builder-config.js
+++ b/packages/bruno-electron/electron-builder-config.js
@@ -95,6 +95,7 @@ const config = {
     artifactName: '${name}_${version}_${arch}_win.${ext}',
     icon: 'resources/icons/win/icon.ico',
     target: [
+
       {
         target: 'nsis',
         arch: ['x64', 'arm64']

--- a/packages/bruno-electron/electron-builder-config.js
+++ b/packages/bruno-electron/electron-builder-config.js
@@ -95,7 +95,6 @@ const config = {
     artifactName: '${name}_${version}_${arch}_win.${ext}',
     icon: 'resources/icons/win/icon.ico',
     target: [
-
       {
         target: 'nsis',
         arch: ['x64', 'arm64']

--- a/packages/bruno-electron/electron-builder-config.js
+++ b/packages/bruno-electron/electron-builder-config.js
@@ -98,6 +98,10 @@ const config = {
       {
         target: 'nsis',
         arch: ['x64', 'arm64']
+      },
+      {
+        target: 'portable',
+        arch: ['x64', 'arm64']
       }
     ],
     sign: null,
@@ -110,6 +114,9 @@ const config = {
     allowElevation: true,
     createDesktopShortcut: true,
     createStartMenuShortcut: true
+  },
+  portable: {
+    artifactName: '${name}_${version}_${arch}_win-portable.${ext}'
   }
 };
 


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3397)

Fixes:  #3751

### Problem

On Windows, when Bruno is run from a non-default location (portable build, or installer files extracted by hand), the auto-updater still fires. It silently downloads the NSIS installer and runs it on quit, which always installs Bruno into `%LOCALAPPDATA%\Programs\Bruno`. 
Result: A phantom Bruno install and uninstall entry the user never asked for, while their actual portable copy is left stale on the old version.

### Solution

1. Add a portable target to the Windows electron-builder config so a real portable build is produced — it sets `process.env.PORTABLE_EXECUTABLE_DIR` at runtime.
2. In the auto-updater code, bail out early when that env var is set — no version check, no download, no silent install.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
