### PR TITLE
fix: openapi spec export crash on websocket request

### DIFF
--- a/packages/bruno-app/src/utils/exporters/openapi-spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.js
@@ -4,7 +4,7 @@ import { isValidUrl } from 'utils/url/index';
 const xml2js = require('xml2js');
 
 export const exportApiSpec = ({ variables, items, name, environments }) => {
-  // Filter out transient items and grpc requests
+  // Filter only include http-request and graphql-request items that aren't transient
   items = items.filter((item) => ['http-request', 'graphql-request'].includes(item.type) && !item.isTransient);
 
   const components = {

--- a/packages/bruno-app/src/utils/exporters/openapi-spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.js
@@ -5,7 +5,7 @@ const xml2js = require('xml2js');
 
 export const exportApiSpec = ({ variables, items, name, environments }) => {
   // Filter out transient items and grpc requests
-  items = items.filter((item) => !['grpc-request'].includes(item.type) && !item.isTransient);
+  items = items.filter((item) => ['http-request', 'graphql-request'].includes(item.type) && !item.isTransient);
 
   const components = {
     schemas: {},

--- a/packages/bruno-app/src/utils/exporters/openapi-spec.spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.spec.js
@@ -881,3 +881,90 @@ describe('exportApiSpec - OAuth2 scope handling (BRU-3297)', () => {
     });
   });
 });
+
+describe('exportApiSpec - non-HTTP request type filtering', () => {
+  it('should keep only http-request and graphql-request items and not crash on others', () => {
+    const items = [
+      {
+        name: 'HTTP Request',
+        type: 'http-request',
+        pathname: 'folder/http',
+        depth: 2,
+        request: {
+          url: 'https://api.example.com/http',
+          method: 'GET',
+          params: [],
+          headers: [],
+          body: {},
+          auth: {}
+        },
+        examples: []
+      },
+      {
+        name: 'GraphQL Request',
+        type: 'graphql-request',
+        pathname: 'folder/graphql',
+        depth: 2,
+        request: {
+          url: 'https://api.example.com/graphql',
+          method: 'POST',
+          params: [],
+          headers: [],
+          body: {},
+          auth: {}
+        },
+        examples: []
+      },
+      {
+        name: 'gRPC Request',
+        type: 'grpc-request',
+        request: { url: 'grpc://example.com/service' }
+      },
+      {
+        name: 'WebSocket Request',
+        type: 'ws-request',
+        request: { url: 'wss://example.com/socket' }
+      },
+      {
+        name: 'Folder',
+        type: 'folder',
+        items: []
+      },
+      {
+        name: 'script.js',
+        type: 'js'
+      },
+      {
+        name: 'Transient',
+        type: 'http-request',
+        isTransient: true,
+        pathname: 'folder/transient',
+        depth: 2,
+        request: {
+          url: 'https://api.example.com/transient',
+          method: 'GET',
+          params: [],
+          headers: [],
+          body: {},
+          auth: {}
+        },
+        examples: []
+      }
+    ];
+
+    let result;
+    expect(() => {
+      result = exportApiSpec({ variables: {}, items, name: 'Test API' });
+    }).not.toThrow();
+
+    const spec = require('js-yaml').load(result.content);
+    const pathKeys = Object.keys(spec.paths);
+
+    expect(pathKeys).toHaveLength(2);
+    expect(spec.paths['/http']).toBeDefined();
+    expect(spec.paths['/http'].get).toBeDefined();
+    expect(spec.paths['/graphql']).toBeDefined();
+    expect(spec.paths['/graphql'].post).toBeDefined();
+    expect(spec.paths['/transient']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description

We we're not handling websocket filtering when exporting via openapi, that caused exporter to crash the app.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3495)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined OpenAPI spec export filtering to include only HTTP and GraphQL requests while properly excluding transient requests and other unsupported request types such as gRPC and WebSocket.

* **Tests**
  * Added comprehensive test suite to verify OpenAPI spec export correctly handles request type filtering and transient request exclusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->