### PR TITLE
fix: open panes at default size on expand from collapsed state

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -392,7 +392,7 @@ export const tabsSlice = createSlice({
       const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
       if (tab) {
         tab.requestPaneCollapsed = false;
-        // Drag-to-collapse leaves requestPaneWidth/Height clamped to min/max; reset so the panes return to their default share of the space on expand.
+        // reset so the panes return to their default size on expand
         tab.requestPaneWidth = null;
         tab.requestPaneHeight = null;
       }
@@ -401,7 +401,7 @@ export const tabsSlice = createSlice({
       const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
       if (tab) {
         tab.responsePaneCollapsed = false;
-        // Drag-to-collapse leaves requestPaneWidth/Height clamped to min/max; reset so the panes return to their default share of the space on expand.
+        // reset so the panes return to their default size on expand
         tab.requestPaneWidth = null;
         tab.requestPaneHeight = null;
       }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -104,8 +104,6 @@ export const tabsSlice = createSlice({
           requestPaneHeight: null,
           requestPaneCollapsed: false,
           responsePaneCollapsed: false,
-          requestPaneWidthBeforeCollapse: null,
-          requestPaneHeightBeforeCollapse: null,
           requestPaneTab: requestPaneTab || defaultRequestPaneTab,
           responsePaneTab: 'response',
           responseFormat: null,
@@ -135,8 +133,6 @@ export const tabsSlice = createSlice({
         requestPaneHeight: null,
         requestPaneCollapsed: false,
         responsePaneCollapsed: false,
-        requestPaneWidthBeforeCollapse: null,
-        requestPaneHeightBeforeCollapse: null,
         requestPaneTab: requestPaneTab || defaultRequestPaneTab,
         responsePaneTab: 'response',
         responseFormat: null,
@@ -383,8 +379,6 @@ export const tabsSlice = createSlice({
       if (tab) {
         tab.requestPaneCollapsed = true;
         tab.responsePaneCollapsed = false;
-        tab.requestPaneWidthBeforeCollapse = tab.requestPaneWidth;
-        tab.requestPaneHeightBeforeCollapse = tab.requestPaneHeight;
       }
     },
     collapseResponsePane: (state, action) => {
@@ -398,20 +392,18 @@ export const tabsSlice = createSlice({
       const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
       if (tab) {
         tab.requestPaneCollapsed = false;
-        if (tab.requestPaneWidthBeforeCollapse != null) {
-          tab.requestPaneWidth = tab.requestPaneWidthBeforeCollapse;
-        }
-        if (tab.requestPaneHeightBeforeCollapse != null) {
-          tab.requestPaneHeight = tab.requestPaneHeightBeforeCollapse;
-        }
-        tab.requestPaneWidthBeforeCollapse = null;
-        tab.requestPaneHeightBeforeCollapse = null;
+        // Drag-to-collapse leaves requestPaneWidth/Height clamped to min/max; reset so the panes return to their default share of the space on expand.
+        tab.requestPaneWidth = null;
+        tab.requestPaneHeight = null;
       }
     },
     expandResponsePane: (state, action) => {
       const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
       if (tab) {
         tab.responsePaneCollapsed = false;
+        // Drag-to-collapse leaves requestPaneWidth/Height clamped to min/max; reset so the panes return to their default share of the space on expand.
+        tab.requestPaneWidth = null;
+        tab.requestPaneHeight = null;
       }
     },
     reorderTabs: (state, action) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
@@ -43,6 +43,7 @@ describe('tabs slice - collapse/expand reducers', () => {
     const next = reducer(makeState({ requestPaneCollapsed: true }), expandRequestPane({ uid: 'tab-1' }));
 
     expect(next.tabs[0].requestPaneCollapsed).toBe(false);
+    expect(next.tabs[0].responsePaneCollapsed).toBe(false);
     expect(next.tabs[0].requestPaneWidth).toBeNull();
     expect(next.tabs[0].requestPaneHeight).toBeNull();
   });
@@ -51,6 +52,7 @@ describe('tabs slice - collapse/expand reducers', () => {
     const next = reducer(makeState({ responsePaneCollapsed: true }), expandResponsePane({ uid: 'tab-1' }));
 
     expect(next.tabs[0].responsePaneCollapsed).toBe(false);
+    expect(next.tabs[0].requestPaneCollapsed).toBe(false);
     expect(next.tabs[0].requestPaneWidth).toBeNull();
     expect(next.tabs[0].requestPaneHeight).toBeNull();
   });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.spec.js
@@ -1,0 +1,57 @@
+import reducer, {
+  collapseRequestPane,
+  collapseResponsePane,
+  expandRequestPane,
+  expandResponsePane
+} from './tabs';
+
+const makeState = (overrides = {}) => ({
+  tabs: [{
+    uid: 'tab-1',
+    collectionUid: 'col-1',
+    type: 'http-request',
+    requestPaneWidth: 500,
+    requestPaneHeight: 400,
+    requestPaneCollapsed: false,
+    responsePaneCollapsed: false,
+    ...overrides
+  }],
+  activeTabUid: 'tab-1',
+  recentlyClosedTabs: []
+});
+
+describe('tabs slice - collapse/expand reducers', () => {
+  it('collapseRequestPane flips flags and preserves stored dimensions', () => {
+    const next = reducer(makeState({ responsePaneCollapsed: true }), collapseRequestPane({ uid: 'tab-1' }));
+
+    expect(next.tabs[0].requestPaneCollapsed).toBe(true);
+    expect(next.tabs[0].responsePaneCollapsed).toBe(false);
+    expect(next.tabs[0].requestPaneWidth).toBe(500);
+    expect(next.tabs[0].requestPaneHeight).toBe(400);
+  });
+
+  it('collapseResponsePane flips flags and preserves stored dimensions', () => {
+    const next = reducer(makeState({ requestPaneCollapsed: true }), collapseResponsePane({ uid: 'tab-1' }));
+
+    expect(next.tabs[0].requestPaneCollapsed).toBe(false);
+    expect(next.tabs[0].responsePaneCollapsed).toBe(true);
+    expect(next.tabs[0].requestPaneWidth).toBe(500);
+    expect(next.tabs[0].requestPaneHeight).toBe(400);
+  });
+
+  it('expandRequestPane flips flag and resets stored dimensions to default', () => {
+    const next = reducer(makeState({ requestPaneCollapsed: true }), expandRequestPane({ uid: 'tab-1' }));
+
+    expect(next.tabs[0].requestPaneCollapsed).toBe(false);
+    expect(next.tabs[0].requestPaneWidth).toBeNull();
+    expect(next.tabs[0].requestPaneHeight).toBeNull();
+  });
+
+  it('expandResponsePane flips flag and resets stored dimensions to default', () => {
+    const next = reducer(makeState({ responsePaneCollapsed: true }), expandResponsePane({ uid: 'tab-1' }));
+
+    expect(next.tabs[0].responsePaneCollapsed).toBe(false);
+    expect(next.tabs[0].requestPaneWidth).toBeNull();
+    expect(next.tabs[0].requestPaneHeight).toBeNull();
+  });
+});


### PR DESCRIPTION
### Description

Fixed an issue where the Response Pane did not restore to its default width after being reopened from a collapsed state. This caused the pane content to render in a squished layout, with icons and content partially clipped.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3352)

### Demo
https://github.com/user-attachments/assets/2e776dce-807e-42fa-908c-ba9153ca7632


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed legacy "before collapse" size tracking and simplified pane expand/collapse behavior.
  * Expanding a pane now resets its stored width/height to avoid restoring stale dimensions.
  * Collapsing no longer snapshots pane dimensions, improving layout predictability when toggling panes.

* **Tests**
  * Added unit tests verifying collapse/expand behavior and that stored dimensions are reset on expand.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->