### PR TITLE
feat(collections): add mount pipeline v2 behind file cache flag

### DIFF
--- a/.github/actions/common/setup-node-deps/action.yml
+++ b/.github/actions/common/setup-node-deps/action.yml
@@ -35,3 +35,4 @@ runs:
         npm run build:bruno-requests
         npm run build:schema-types
         npm run build:bruno-filestore
+        npm run build:bruno-pool

--- a/.github/actions/common/setup-node-deps/action.yml
+++ b/.github/actions/common/setup-node-deps/action.yml
@@ -36,3 +36,4 @@ runs:
         npm run build:schema-types
         npm run build:bruno-filestore
         npm run build:bruno-pool
+        npm run build:bruno-storage

--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -57,6 +57,7 @@ jobs:
           npm run build:schema-types
           npm run build:bruno-filestore
           npm run build:bruno-pool
+          npm run build:bruno-storage
 
       - name: Run Playwright tests
         run: xvfb-run npm run test:e2e

--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -56,6 +56,7 @@ jobs:
           npm run build:bruno-requests
           npm run build:schema-types
           npm run build:bruno-filestore
+          npm run build:bruno-pool
 
       - name: Run Playwright tests
         run: xvfb-run npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ packages/bruno-requests/dist
 packages/bruno-schema-types/dist
 packages/bruno-converters/dist
 packages/bruno-pool/dist
+packages/bruno-storage/dist

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ packages/bruno-filestore/dist
 packages/bruno-requests/dist
 packages/bruno-schema-types/dist
 packages/bruno-converters/dist
+packages/bruno-pool/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "packages/bruno-toml",
         "packages/bruno-graphql-docs",
         "packages/bruno-requests",
-        "packages/bruno-filestore"
+        "packages/bruno-filestore",
+        "packages/bruno-pool"
       ],
       "dependencies": {
         "ajv": "^8.17.1",
@@ -13480,6 +13481,10 @@
         "node-machine-id": "^1.1.12"
       }
     },
+    "node_modules/@usebruno/pool": {
+      "resolved": "packages/bruno-pool",
+      "link": true
+    },
     "node_modules/@usebruno/query": {
       "resolved": "packages/bruno-query",
       "link": true
@@ -21585,6 +21590,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-builtin-module/node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-callable": {
@@ -29895,6 +29929,14 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -32599,6 +32641,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/workerpool": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-10.0.2.tgz",
+      "integrity": "sha512-8PCeZlCwu0+8hXruze1ahYNsY+M0LOCmbmySZ9BWWqWIXP9TAXa6FZCxACTDL/0j47pFcC4xW98Gr8nAC5oymg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -35193,6 +35241,7 @@
         "@usebruno/js": "0.12.0",
         "@usebruno/lang": "0.12.0",
         "@usebruno/node-machine-id": "^2.0.0",
+        "@usebruno/pool": "0.1.0",
         "@usebruno/requests": "^0.1.0",
         "@usebruno/schema": "0.7.0",
         "about-window": "^1.15.2",
@@ -36157,6 +36206,147 @@
         "lodash": "^4.17.21",
         "ohm-js": "^16.6.0"
       }
+    },
+    "packages/bruno-pool": {
+      "name": "@usebruno/pool",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@usebruno/filestore": "0.1.0",
+        "workerpool": "10.0.2"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "23.0.2",
+        "@rollup/plugin-node-resolve": "15.0.1",
+        "@rollup/plugin-typescript": "12.1.2",
+        "@types/node": "^24.1.0",
+        "rollup": "3.30.0",
+        "tslib": "2.8.1",
+        "typescript": "5.4.5"
+      }
+    },
+    "packages/bruno-pool/node_modules/@rollup/plugin-commonjs": {
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-23.0.2.tgz",
+      "integrity": "sha512-e9ThuiRf93YlVxc4qNIurvv+Hp9dnD+4PjOqQs5vAYfcZ3+AXSrcdzXnVjWxcGQOa6KGJFcRZyUI3ktWLavFjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.26.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "packages/bruno-pool/node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
+      "integrity": "sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "packages/bruno-pool/node_modules/@rollup/plugin-typescript": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.2.tgz",
+      "integrity": "sha512-cdtSp154H5sv637uMr1a8OTWB0L1SWDSm1rDGiyfcGcvQ6cuTs4MDk2BVEBGysUWago4OJN4EQZqOTl/QY3Jgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "packages/bruno-pool/node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "packages/bruno-pool/node_modules/magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/bruno-pool/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/bruno-pool/node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/bruno-query": {
       "name": "@usebruno/query",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "packages/bruno-graphql-docs",
         "packages/bruno-requests",
         "packages/bruno-filestore",
-        "packages/bruno-pool"
+        "packages/bruno-pool",
+        "packages/bruno-storage"
       ],
       "dependencies": {
         "ajv": "^8.17.1",
@@ -13499,6 +13500,10 @@
     },
     "node_modules/@usebruno/schema-types": {
       "resolved": "packages/bruno-schema-types",
+      "link": true
+    },
+    "node_modules/@usebruno/storage": {
+      "resolved": "packages/bruno-storage",
       "link": true
     },
     "node_modules/@usebruno/tests": {
@@ -35244,6 +35249,7 @@
         "@usebruno/pool": "0.1.0",
         "@usebruno/requests": "^0.1.0",
         "@usebruno/schema": "0.7.0",
+        "@usebruno/storage": "0.1.0",
         "about-window": "^1.15.2",
         "adm-zip": "^0.5.16",
         "ai": "6.0.39",
@@ -36574,6 +36580,46 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "packages/bruno-storage": {
+      "name": "@usebruno/storage",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.1.0",
+        "typescript": "5.4.5"
+      }
+    },
+    "packages/bruno-storage/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/bruno-storage/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/bruno-storage/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/bruno-tests": {
       "name": "@usebruno/tests",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "packages/bruno-toml",
     "packages/bruno-graphql-docs",
     "packages/bruno-requests",
-    "packages/bruno-filestore"
+    "packages/bruno-filestore",
+    "packages/bruno-pool"
   ],
   "homepage": "https://usebruno.com",
   "devDependencies": {
@@ -66,6 +67,7 @@
     "build:bruno-common": "npm run build --workspace=packages/bruno-common",
     "build:bruno-requests": "npm run build --workspace=packages/bruno-requests",
     "build:bruno-filestore": "npm run build --workspace=packages/bruno-filestore",
+    "build:bruno-pool": "npm run build --workspace=packages/bruno-pool",
     "build:bruno-converters": "npm run build --workspace=packages/bruno-converters",
     "build:bruno-query": "npm run build --workspace=packages/bruno-query",
     "build:graphql-docs": "npm run build --workspace=packages/bruno-graphql-docs",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "packages/bruno-graphql-docs",
     "packages/bruno-requests",
     "packages/bruno-filestore",
-    "packages/bruno-pool"
+    "packages/bruno-pool",
+    "packages/bruno-storage"
   ],
   "homepage": "https://usebruno.com",
   "devDependencies": {
@@ -68,6 +69,7 @@
     "build:bruno-requests": "npm run build --workspace=packages/bruno-requests",
     "build:bruno-filestore": "npm run build --workspace=packages/bruno-filestore",
     "build:bruno-pool": "npm run build --workspace=packages/bruno-pool",
+    "build:bruno-storage": "npm run build --workspace=packages/bruno-storage",
     "build:bruno-converters": "npm run build --workspace=packages/bruno-converters",
     "build:bruno-query": "npm run build --workspace=packages/bruno-query",
     "build:graphql-docs": "npm run build --workspace=packages/bruno-graphql-docs",

--- a/packages/bruno-app/src/components/Preferences/Cache/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/Cache/StyledWrapper.js
@@ -2,11 +2,85 @@ import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
   color: ${(props) => props.theme.text};
-  
-  form.bruno-form {
-    label {
-      font-size: 0.8125rem;
-    }
+
+  .cache-section-title {
+    text-transform: uppercase;
+    font-size: ${(props) => props.theme.font.size.sm};
+    letter-spacing: 0.05em;
+    color: ${(props) => props.theme.colors.text.muted};
+    margin-bottom: 0.75rem;
+  }
+
+  .cache-item {
+    border: 1px solid ${(props) => props.theme.border.border1};
+    border-radius: ${(props) => props.theme.border.radius.md};
+    margin-bottom: 1rem;
+    overflow: hidden;
+  }
+
+  .cache-item-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+    background: ${(props) => props.theme.background.surface0};
+    border-bottom: 1px solid ${(props) => props.theme.border.border1};
+  }
+
+  .cache-item-title-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .cache-item-title {
+    font-size: ${(props) => props.theme.font.size.md};
+    font-weight: 600;
+  }
+
+  .beta-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: ${(props) => props.theme.border.radius.sm};
+    font-size: ${(props) => props.theme.font.size.xs};
+    font-weight: 500;
+    line-height: 1.5;
+    background: ${(props) => props.theme.status.info.background};
+    color: ${(props) => props.theme.status.info.text};
+  }
+
+  .cache-item-body {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    padding: 0.875rem 1rem;
+    gap: 1.25rem;
+  }
+
+  .cache-item-body-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .cache-item-description {
+    font-size: ${(props) => props.theme.font.size.base};
+    color: ${(props) => props.theme.colors.text.muted};
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  .cache-item-size {
+    font-size: ${(props) => props.theme.font.size.base};
+    color: ${(props) => props.theme.colors.text.subtext2};
+    margin: 0.5rem 0 0 0;
+  }
+
+  .cache-item-size strong {
+    font-weight: 600;
+    color: ${(props) => props.theme.text};
+    margin-left: 0.25rem;
   }
 `;
 

--- a/packages/bruno-app/src/components/Preferences/Cache/index.js
+++ b/packages/bruno-app/src/components/Preferences/Cache/index.js
@@ -1,120 +1,152 @@
-import React, { useEffect, useCallback, useRef } from 'react';
-import { useFormik } from 'formik';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import {
-  savePreferences,
-  clearHttpHttpsAgentCache
-} from 'providers/ReduxStore/slices/app';
+import { savePreferences, clearHttpHttpsAgentCache } from 'providers/ReduxStore/slices/app';
 import toast from 'react-hot-toast';
-import StyledWrapper from './StyledWrapper';
-import * as Yup from 'yup';
-import debounce from 'lodash/debounce';
 import get from 'lodash/get';
+import { IconEraser } from '@tabler/icons';
+import { useTheme } from 'providers/Theme';
+import ToggleSwitch from 'components/ToggleSwitch';
+import ActionIcon from 'ui/ActionIcon';
+import StyledWrapper from './StyledWrapper';
 
-const cacheSchema = Yup.object().shape({
-  sslSession: Yup.object({
-    enabled: Yup.boolean()
-  })
-});
+const humanSize = (bytes) => {
+  if (bytes === null || bytes === undefined) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+};
 
 const Cache = () => {
   const preferences = useSelector((state) => state.app.preferences);
   const dispatch = useDispatch();
+  const { theme } = useTheme();
+  const { ipcRenderer } = window;
 
-  const handleSave = useCallback(
-    (newCachePreferences) => {
-      dispatch(
-        savePreferences({
-          ...preferences,
-          cache: newCachePreferences
-        })
-      ).catch(() => toast.error('Failed to update cache preferences'));
-    },
-    [dispatch, preferences]
-  );
+  const fileCacheEnabled = get(preferences, 'cache.file.enabled', false);
+  const sslSessionEnabled = get(preferences, 'cache.sslSession.enabled', false);
 
-  const handleSaveRef = useRef(handleSave);
-  handleSaveRef.current = handleSave;
+  const [fileCacheSize, setFileCacheSize] = useState(null);
 
-  const formik = useFormik({
-    initialValues: {
-      sslSession: {
-        enabled: get(preferences, 'cache.sslSession.enabled', false)
-      }
-    },
-    validationSchema: cacheSchema,
-    onSubmit: async (values) => {
-      try {
-        const newPreferences = await cacheSchema.validate(values, { abortEarly: true });
-        handleSave(newPreferences);
-      } catch (error) {
-        console.error('Cache preferences validation error:', error.message);
-      }
-    }
-  });
-
-  const debouncedSave = useCallback(
-    debounce((values) => {
-      cacheSchema
-        .validate(values, { abortEarly: true })
-        .then((validatedValues) => handleSaveRef.current(validatedValues))
-        .catch(() => {});
-    }, 500),
-    []
-  );
+  const refreshFileCacheSize = useCallback(() => {
+    if (!ipcRenderer) return;
+    ipcRenderer
+      .invoke('renderer:get-file-cache-size')
+      .then((size) => setFileCacheSize(size))
+      .catch(() => setFileCacheSize(null));
+  }, [ipcRenderer]);
 
   useEffect(() => {
-    if (formik.dirty && formik.isValid) {
-      debouncedSave(formik.values);
-    }
-    return () => {
-      debouncedSave.flush();
-    };
-  }, [formik.values, formik.dirty, formik.isValid, debouncedSave]);
+    refreshFileCacheSize();
+  }, [refreshFileCacheSize, fileCacheEnabled]);
 
-  const handleAgentCachingChange = (e) => {
-    formik.handleChange(e);
-    // Immediately evict all cached agents when caching is disabled
-    if (!e.target.checked) {
+  const persist = (next) => {
+    dispatch(savePreferences({ ...preferences, cache: next })).catch(() => {
+      toast.error('Failed to update cache preferences');
+    });
+  };
+
+  const handleToggleFileCache = () => {
+    persist({
+      ...preferences.cache,
+      file: { enabled: !fileCacheEnabled }
+    });
+  };
+
+  const handleToggleSslSession = () => {
+    const next = !sslSessionEnabled;
+    persist({
+      ...preferences.cache,
+      sslSession: { enabled: next }
+    });
+    if (!next) {
       dispatch(clearHttpHttpsAgentCache()).catch(() => {});
     }
   };
 
-  const handleResetCache = () => {
+  const handleClearFileCache = () => {
+    if (!ipcRenderer) return;
+    ipcRenderer
+      .invoke('renderer:clear-file-cache')
+      .then((size) => {
+        setFileCacheSize(size);
+        toast.success('File cache cleared');
+      })
+      .catch(() => toast.error('Failed to clear file cache'));
+  };
+
+  const handleClearSslSession = () => {
     dispatch(clearHttpHttpsAgentCache())
-      .then(() => toast.success('ssl session cache cleared'))
-      .catch(() => toast.error('Failed to clear ssl session cache'));
+      .then(() => toast.success('SSL session cache cleared'))
+      .catch(() => toast.error('Failed to clear SSL session cache'));
   };
 
   return (
     <StyledWrapper className="w-full">
-      <form className="bruno-form" onSubmit={formik.handleSubmit}>
-        <div className="section-title mt-6 mb-3">Cache SSL Session</div>
+      <div className="cache-section-title">Cache</div>
 
-        <div className="flex items-center my-2">
-          <input
-            id="sslSession.enabled"
-            type="checkbox"
-            name="sslSession.enabled"
-            checked={formik.values.sslSession.enabled}
-            onChange={handleAgentCachingChange}
-            className="mousetrap mr-0"
+      <div className="cache-item">
+        <div className="cache-item-header">
+          <div className="cache-item-title-group">
+            <span className="cache-item-title">File cache</span>
+            <span className="beta-badge">Beta</span>
+          </div>
+          <ToggleSwitch
+            isOn={fileCacheEnabled}
+            handleToggle={handleToggleFileCache}
+            size="2xs"
+            activeColor={theme.primary.solid}
           />
-          <label className="block ml-2 select-none" htmlFor="sslSession.enabled">
-            Enable SSL session caching
-          </label>
         </div>
-        <div className="text-xs mt-1 ml-6 opacity-70">
-          Reuses TLS sessions and connections across requests for faster handshakes. Disable to create a fresh connection for every
-          request.
+        <div className="cache-item-body">
+          <div className="cache-item-body-text">
+            <p className="cache-item-description">
+              Loads your workspace faster by caching opened collections. Bruno refreshes the cache when your collection
+              changes. Clearing it won't affect your original files.
+            </p>
+            <p className="cache-item-size">
+              Cache size <strong>{humanSize(fileCacheSize)}</strong>
+            </p>
+          </div>
+          <ActionIcon
+            label="Clear cache"
+            onClick={handleClearFileCache}
+            disabled={!fileCacheSize}
+            colorOnHover={theme.colors.text.danger}
+          >
+            <IconEraser size={16} strokeWidth={1.5} />
+          </ActionIcon>
         </div>
+      </div>
 
-        <div className="mt-6">
-          <button type="button" className="text-link cursor-pointer hover:underline" onClick={handleResetCache}>
-            Clear
-          </button>
+      <div className="cache-item">
+        <div className="cache-item-header">
+          <div className="cache-item-title-group">
+            <span className="cache-item-title">SSL session cache</span>
+          </div>
+          <ToggleSwitch
+            isOn={sslSessionEnabled}
+            handleToggle={handleToggleSslSession}
+            size="2xs"
+            activeColor={theme.primary.solid}
+          />
         </div>
-      </form>
+        <div className="cache-item-body">
+          <div className="cache-item-body-text">
+            <p className="cache-item-description">
+              Reuses TLS sessions and connections across requests for faster handshakes. Disable to create a fresh
+              connection for every request.
+            </p>
+          </div>
+          <ActionIcon
+            label="Clear cache"
+            onClick={handleClearSslSession}
+            colorOnHover={theme.colors.text.danger}
+          >
+            <IconEraser size={16} strokeWidth={1.5} />
+          </ActionIcon>
+        </div>
+      </div>
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -36,7 +36,7 @@ import toast from 'react-hot-toast';
 import { useDispatch, useStore } from 'react-redux';
 import { isElectron } from 'utils/common/platform';
 import { globalEnvironmentsUpdateEvent, updateGlobalEnvironments } from 'providers/ReduxStore/slices/global-environments';
-import { collectionAddOauth2CredentialsByUrl, collectionClearOauth2CredentialsByCredentialsId, updateCollectionLoadingState } from 'providers/ReduxStore/slices/collections/index';
+import { collectionAddOauth2CredentialsByUrl, collectionClearOauth2CredentialsByCredentialsId, updateCollectionLoadingState, collectionLoadedFromTree } from 'providers/ReduxStore/slices/collections/index';
 import { addLog } from 'providers/ReduxStore/slices/logs';
 import { updateSystemResources } from 'providers/ReduxStore/slices/performance';
 import { apiSpecAddFileEvent, apiSpecChangeFileEvent } from 'providers/ReduxStore/slices/apiSpec';
@@ -343,7 +343,27 @@ const useIpcEvents = () => {
       dispatch(setGitVersion(val));
     });
 
+    const removeCollectionTreeLoadedListener = ipcRenderer.on('main:collection-tree-loaded', ({ collectionUid, tree }) => {
+      dispatch(collectionLoadedFromTree({ collectionUid, tree }));
+    });
+
+    const removeCollectionLoadingStateV2Listener = ipcRenderer.on('main:collection-loading-state-updated-v2', (val) => {
+      dispatch(updateCollectionLoadingState(val));
+    });
+
+    const removeBrunoConfigUpdateV2Listener = ipcRenderer.on('main:bruno-config-update-v2', (val) => {
+      dispatch(brunoConfigUpdateEvent(val));
+    });
+
+    const removeSnapshotHydrationV2Listener = ipcRenderer.on('main:hydrate-app-with-ui-state-snapshot-v2', (val) => {
+      dispatch(hydrateCollectionWithUiStateSnapshot(val));
+    });
+
     return () => {
+      removeCollectionTreeLoadedListener();
+      removeCollectionLoadingStateV2Listener();
+      removeBrunoConfigUpdateV2Listener();
+      removeSnapshotHydrationV2Listener();
       removeCollectionTreeUpdateListener();
       removeApiSpecTreeUpdateListener();
       removeOpenCollectionListener();

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/tasks/middleware.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/tasks/middleware.js
@@ -4,7 +4,7 @@ import filter from 'lodash/filter';
 import { createListenerMiddleware } from '@reduxjs/toolkit';
 import { removeTaskFromQueue } from 'providers/ReduxStore/slices/app';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
-import { collectionAddFileEvent, collectionChangeFileEvent } from 'providers/ReduxStore/slices/collections';
+import { collectionAddFileEvent, collectionChangeFileEvent, collectionLoadedFromTree } from 'providers/ReduxStore/slices/collections';
 import { findCollectionByUid, findItemInCollectionByPathname, getDefaultRequestPaneTab, findItemInCollectionByItemUid } from 'utils/collections/index';
 import { taskTypes } from './utils';
 
@@ -22,6 +22,44 @@ taskMiddleware.startListening({
   effect: (action, listenerApi) => {
     const state = listenerApi.getState();
     const collectionUid = get(action, 'payload.file.meta.collectionUid');
+
+    const openRequestTasks = filter(state.app.taskQueue, { type: taskTypes.OPEN_REQUEST });
+    each(openRequestTasks, (task) => {
+      if (collectionUid === task.collectionUid) {
+        const collection = findCollectionByUid(state.collections.collections, collectionUid);
+        if (collection && collection.mountStatus === 'mounted' && !collection.isLoading) {
+          const item = findItemInCollectionByPathname(collection, task.itemPathname);
+          if (item) {
+            listenerApi.dispatch(
+              addTab({
+                uid: item.uid,
+                collectionUid: collection.uid,
+                type: item.type,
+                pathname: item.pathname,
+                requestPaneTab: getDefaultRequestPaneTab(item),
+                preview: task?.preview ?? true,
+                ...(item.isTransient ? { isTransient: true } : {})
+              })
+            );
+          }
+        }
+
+        listenerApi.dispatch(
+          removeTaskFromQueue({
+            taskUid: task.uid
+          })
+        );
+      }
+    });
+  }
+});
+
+// v2 tree push also acts as a signal for queued OPEN_REQUEST tasks.
+taskMiddleware.startListening({
+  actionCreator: collectionLoadedFromTree,
+  effect: (action, listenerApi) => {
+    const state = listenerApi.getState();
+    const collectionUid = get(action, 'payload.collectionUid');
 
     const openRequestTasks = filter(state.app.taskQueue, { type: taskTypes.OPEN_REQUEST });
     each(openRequestTasks, (task) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2389,6 +2389,7 @@ export const removeCollection = (collectionUid) => (dispatch, getState) => {
       }
     }
 
+    ipcRenderer.invoke('renderer:unmount-collection-v2', { collectionUid }).catch(() => {});
     ipcRenderer
       .invoke('renderer:remove-collection', collection.pathname, collectionUid, workspaceId)
       .then(() => {
@@ -3019,8 +3020,10 @@ export const mountCollection
   = ({ collectionUid, collectionPathname, brunoConfig, skipTabRestore = false, workspacePathname = null }) =>
     (dispatch, getState) => {
       dispatch(updateCollectionMountStatus({ collectionUid, mountStatus: 'mounting' }));
+      const fileCacheEnabled = getState().app?.preferences?.cache?.file?.enabled;
+      const channel = fileCacheEnabled ? 'renderer:mount-collection-v2' : 'renderer:mount-collection';
       return new Promise(async (resolve, reject) => {
-        callIpc('renderer:mount-collection', { collectionUid, collectionPathname, brunoConfig })
+        callIpc(channel, { collectionUid, collectionPathname, brunoConfig })
           .then(async (transientDirPath) => {
             dispatch(updateCollectionMountStatus({ collectionUid, mountStatus: 'mounted' }));
             dispatch(addTransientDirectory({ collectionUid, pathname: transientDirPath }));

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1,6 +1,6 @@
 import { parseQueryParams, buildQueryString as stringifyQueryParams } from '@usebruno/common/utils';
 import { uuid } from 'utils/common';
-import { find, map, forOwn, concat, filter, each, cloneDeep, get, set, findIndex } from 'lodash';
+import { find, map, forOwn, concat, filter, each, cloneDeep, get, set, findIndex, pick } from 'lodash';
 import { createSlice } from '@reduxjs/toolkit';
 import { hexy as hexdump } from 'hexy';
 import {
@@ -25,6 +25,69 @@ import path from 'utils/common/path';
 import { getUniqueTagsFromItems } from 'utils/collections/index';
 import { getCollectionEnvironmentPath } from 'utils/snapshot';
 import * as exampleReducers from './exampleReducers';
+
+const FILE_DERIVED_REQUEST_FIELDS = [
+  'name',
+  'type',
+  'seq',
+  'tags',
+  'request',
+  'settings',
+  'examples',
+  'filename',
+  'pathname',
+  'partial',
+  'loading',
+  'size',
+  'error',
+  'isTransient'
+];
+
+const FILE_DERIVED_FOLDER_FIELDS = [
+  'name',
+  'filename',
+  'pathname',
+  'seq',
+  'type',
+  'root'
+];
+
+const mergeTreeItems = (existingItems, newItems) => {
+  if (!Array.isArray(existingItems) || existingItems.length === 0) return newItems;
+  const existingByUid = new Map();
+  for (const item of existingItems) {
+    if (item && item.uid) existingByUid.set(item.uid, item);
+  }
+
+  return newItems.map((newItem) => {
+    const existing = existingByUid.get(newItem.uid);
+    if (!existing) return newItem;
+
+    if (newItem.type === 'folder') {
+      const merged = { ...existing, ...pick(newItem, FILE_DERIVED_FOLDER_FIELDS) };
+      merged.items = mergeTreeItems(existing.items, newItem.items || []);
+      return merged;
+    }
+
+    // seq-only change (reorder) — keep everything else, including the draft
+    if (areItemsTheSameExceptSeqUpdate(existing, newItem)) {
+      const merged = { ...existing, seq: newItem.seq };
+      if (merged.draft) {
+        merged.draft = { ...merged.draft, seq: newItem.seq };
+        if (areItemsTheSameExceptSeqUpdate(merged.draft, newItem)) {
+          merged.draft = null;
+        }
+      }
+      return merged;
+    }
+
+    const merged = { ...existing, ...pick(newItem, FILE_DERIVED_REQUEST_FIELDS) };
+    // only drop the draft if it matches what's on disk — user may still be typing
+    const draftMatchesFile = existing.draft && areItemsTheSameExceptSeqUpdate(existing.draft, newItem);
+    merged.draft = draftMatchesFile ? null : (existing.draft || null);
+    return merged;
+  });
+};
 
 // gRPC status code meanings
 const grpcStatusCodes = {
@@ -3287,6 +3350,34 @@ export const collectionsSlice = createSlice({
         }
       }
     },
+    collectionLoadedFromTree: (state, action) => {
+      const { collectionUid, tree } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+      if (!collection) return;
+
+      collection.items = mergeTreeItems(collection.items, tree?.items || []);
+      collection.environments = tree?.environments || [];
+      if (tree?.root !== undefined) {
+        collection.root = tree.root;
+      }
+      if (tree?.brunoConfig) {
+        collection.brunoConfig = tree.brunoConfig;
+      }
+      const tempDirectory = state.tempDirectories?.[collectionUid];
+      if (tempDirectory) {
+        const annotateTransient = (items) => {
+          for (const item of items) {
+            if (item.type === 'folder') {
+              if (Array.isArray(item.items)) annotateTransient(item.items);
+            } else if (item.pathname && item.pathname.startsWith(tempDirectory)) {
+              item.isTransient = true;
+            }
+          }
+        };
+        annotateTransient(collection.items);
+      }
+      addDepth(collection.items);
+    },
     collectionAddOauth2CredentialsByUrl: (state, action) => {
       const { collectionUid, folderUid, itemUid, url, credentials, credentialsId, debugInfo, executionMode } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
@@ -3680,6 +3771,7 @@ export const {
   createCollection,
   updateCollectionMountStatus,
   updateCollectionLoadingState,
+  collectionLoadedFromTree,
   setCollectionSecurityConfig,
   brunoConfigUpdateEvent,
   renameCollection,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -1342,11 +1342,20 @@ export const mountScratchCollection = (workspaceUid) => {
         ignore: ['node_modules', '.git']
       };
 
-      await ipcRenderer.invoke('renderer:add-collection-watcher', {
-        collectionPath: tempDirectoryPath,
-        collectionUid: scratchCollectionUid,
-        brunoConfig
-      });
+      const fileCacheEnabled = state.app?.preferences?.cache?.file?.enabled;
+      if (fileCacheEnabled) {
+        await ipcRenderer.invoke('renderer:mount-collection-v2', {
+          collectionUid: scratchCollectionUid,
+          collectionPathname: tempDirectoryPath,
+          brunoConfig
+        });
+      } else {
+        await ipcRenderer.invoke('renderer:add-collection-watcher', {
+          collectionPath: tempDirectoryPath,
+          collectionUid: scratchCollectionUid,
+          brunoConfig
+        });
+      }
 
       // Map scratch collection to workspace so getProcessEnvVars can resolve workspace .env values
       if (workspace.pathname) {

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -45,6 +45,7 @@
     "@usebruno/node-machine-id": "^2.0.0",
     "@usebruno/requests": "^0.1.0",
     "@usebruno/schema": "0.7.0",
+    "@usebruno/storage": "0.1.0",
     "about-window": "^1.15.2",
     "adm-zip": "^0.5.16",
     "ai": "6.0.39",

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -40,6 +40,7 @@
     "@usebruno/converters": "^0.1.0",
     "@usebruno/filestore": "^0.1.0",
     "@usebruno/js": "0.12.0",
+    "@usebruno/pool": "0.1.0",
     "@usebruno/lang": "0.12.0",
     "@usebruno/node-machine-id": "^2.0.0",
     "@usebruno/requests": "^0.1.0",

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -32,6 +32,27 @@ const MAX_FILE_SIZE = 2.5 * 1024 * 1024;
 
 const environmentSecretsStore = new EnvironmentSecretsStore();
 
+// registered collections stage parsed data into the git-lite snapshot (no-op otherwise)
+const snapshotIndexByCollection = new Map();
+const stageToCache = (collectionPath, pathname, data) => {
+  const index = snapshotIndexByCollection.get(collectionPath);
+  if (!index) return;
+  try {
+    index.stageParsed(collectionPath, pathname, data);
+  } catch (err) {
+    console.error('[collection-watcher] cache stage failed for', pathname, err);
+  }
+};
+const unstageFromCache = (collectionPath, pathname) => {
+  const index = snapshotIndexByCollection.get(collectionPath);
+  if (!index) return;
+  try {
+    index.unstagePath(collectionPath, pathname);
+  } catch (err) {
+    console.error('[collection-watcher] cache unstage failed for', pathname, err);
+  }
+};
+
 const isBrunoConfigFile = (pathname, collectionPath) => {
   const dirname = path.dirname(pathname);
   const basename = path.basename(pathname);
@@ -106,6 +127,7 @@ const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) 
     let content = fs.readFileSync(pathname, 'utf8');
 
     file.data = await parseEnvironment(content, { format });
+    stageToCache(collectionPath, pathname, file.data);
 
     // Extract name by removing the extension
     const ext = path.extname(basename);
@@ -147,6 +169,7 @@ const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPat
     const content = fs.readFileSync(pathname, 'utf8');
 
     file.data = await parseEnvironment(content, { format });
+    stageToCache(collectionPath, pathname, file.data);
 
     // Extract name by removing the extension
     const ext = path.extname(basename);
@@ -202,6 +225,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
     try {
       const content = fs.readFileSync(pathname, 'utf8');
       let brunoConfig = JSON.parse(content);
+      stageToCache(collectionPath, pathname, brunoConfig);
 
       // Transform the config to add exists metadata for protobuf files and import paths
       brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
@@ -248,6 +272,8 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
       }
 
       file.data = collectionRoot;
+      // cache the full parse result (collectionRoot + brunoConfig for yml)
+      stageToCache(collectionPath, pathname, parsed);
 
       hydrateCollectionRootWithUuid(file.data);
       win.webContents.send('main:collection-tree-updated', 'addFile', file);
@@ -287,6 +313,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
       let format = getCollectionFormat(collectionPath);
       let content = fs.readFileSync(pathname, 'utf8');
       file.data = await parseFolder(content, { format });
+      stageToCache(collectionPath, pathname, file.data);
 
       hydrateCollectionRootWithUuid(file.data);
       win.webContents.send('main:collection-tree-updated', 'addFile', file);
@@ -316,6 +343,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
     if (!useWorkerThread) {
       try {
         file.data = await parseRequest(content, { format });
+        stageToCache(collectionPath, pathname, file.data);
         file.partial = false;
         file.loading = false;
         file.size = sizeInMB(fileStats?.size);
@@ -358,6 +386,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
           format,
           filename: pathname
         });
+        stageToCache(collectionPath, pathname, file.data);
         file.partial = false;
         file.loading = false;
         hydrateRequestWithUuid(file.data, pathname);
@@ -425,6 +454,7 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
     try {
       const content = fs.readFileSync(pathname, 'utf8');
       let brunoConfig = JSON.parse(content);
+      stageToCache(collectionPath, pathname, brunoConfig);
 
       // Transform the config to add file existence checks for protobuf files and import paths
       brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
@@ -473,6 +503,8 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       }
 
       file.data = collectionRoot;
+      // cache the full parse result (collectionRoot + brunoConfig for yml)
+      stageToCache(collectionPath, pathname, parsed);
 
       hydrateCollectionRootWithUuid(file.data);
       win.webContents.send('main:collection-tree-updated', 'change', file);
@@ -512,6 +544,7 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       let format = getCollectionFormat(collectionPath);
       let content = fs.readFileSync(pathname, 'utf8');
       file.data = await parseFolder(content, { format });
+      stageToCache(collectionPath, pathname, file.data);
 
       hydrateCollectionRootWithUuid(file.data);
       win.webContents.send('main:collection-tree-updated', 'change', file);
@@ -537,9 +570,11 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       const fileStats = fs.statSync(pathname);
 
       if (fileStats.size >= MAX_FILE_SIZE && format === 'bru') {
+        // redacted parse — do not write the redacted data through to the cache
         file.data = await parseLargeRequestWithRedaction(content, 'bru');
       } else {
         file.data = await parseRequest(content, { format });
+        stageToCache(collectionPath, pathname, file.data);
       }
 
       file.size = sizeInMB(fileStats?.size);
@@ -557,6 +592,8 @@ const unlink = (win, pathname, collectionUid, collectionPath) => {
       return;
     }
     console.log(`watcher unlink: ${pathname}`);
+    // drop the file from the snapshot regardless of type (request/env/config/folder root)
+    unstageFromCache(collectionPath, pathname);
 
     if (isEnvironmentsFolder(pathname, collectionPath)) {
       return unlinkEnvironmentFile(win, pathname, collectionUid);
@@ -724,9 +761,15 @@ class CollectionWatcher {
     delete this.loadingStates[collectionUid];
   }
 
-  addWatcher(win, watchPath, collectionUid, brunoConfig, forcePolling = false, useWorkerThread) {
+  addWatcher(win, watchPath, collectionUid, brunoConfig, forcePolling = false, useWorkerThread, options = {}) {
     if (this.watchers[watchPath]) {
       this.watchers[watchPath].close();
+    }
+
+    // v2 already loaded the tree from cache; skip startup scan and stage live edits
+    const { ignoreInitial = false, snapshotIndex = null } = options;
+    if (snapshotIndex) {
+      snapshotIndexByCollection.set(watchPath, snapshotIndex);
     }
 
     this.initializeLoadingState(collectionUid);
@@ -741,7 +784,7 @@ class CollectionWatcher {
 
     setTimeout(() => {
       const watcher = chokidar.watch(watchPath, {
-        ignoreInitial: false,
+        ignoreInitial,
         usePolling: isWSLPath(watchPath) || forcePolling ? true : false,
         ignored: (filepath) => {
           const normalizedPath = normalizeAndResolvePath(filepath);
@@ -797,7 +840,7 @@ class CollectionWatcher {
               'Update your system config to allow more concurrently watched files with:',
               '"echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"'
             );
-            this.addWatcher(win, watchPath, collectionUid, brunoConfig, true, useWorkerThread);
+            this.addWatcher(win, watchPath, collectionUid, brunoConfig, true, useWorkerThread, options);
           } else {
             console.error(`An error occurred in the watcher for: ${watchPath}`, error);
           }
@@ -818,6 +861,8 @@ class CollectionWatcher {
       this.watchers[watchPath].close();
       this.watchers[watchPath] = null;
     }
+
+    snapshotIndexByCollection.delete(watchPath);
 
     dotEnvWatcher.removeCollectionWatcher(watchPath);
 

--- a/packages/bruno-electron/src/index.js
+++ b/packages/bruno-electron/src/index.js
@@ -46,6 +46,7 @@ const registerApiSpecIpc = require('./ipc/apiSpec');
 const registerGitIpc = require('./ipc/git');
 const registerOpenAPISyncIpc = require('./ipc/openapi-sync');
 const registerAiIpc = require('./ipc/ai');
+const { registerMountIpc } = require('./ipc/mount');
 const collectionWatcher = require('./app/collection-watcher');
 const WorkspaceWatcher = require('./app/workspace-watcher');
 const ApiSpecWatcher = require('./app/apiSpecsWatcher');
@@ -477,6 +478,7 @@ app.on('ready', async () => {
   registerGitIpc(mainWindow);
   registerOpenAPISyncIpc(mainWindow);
   registerAiIpc(mainWindow);
+  registerMountIpc();
 
   // Internal delegator
   ipcMain.handle('main:cache-clear', async () => {
@@ -504,6 +506,8 @@ app.on('before-quit', (event) => {
         new Promise((resolve) => setTimeout(resolve, 2000))
       ]);
     } catch {}
+
+    try { await require('./ipc/mount').shutdown(); } catch {}
 
     if (useSingleInstance && gotTheLock) {
       try { app.releaseSingleInstanceLock(); } catch {}

--- a/packages/bruno-electron/src/ipc/mount.js
+++ b/packages/bruno-electron/src/ipc/mount.js
@@ -1,0 +1,39 @@
+const { ipcMain, BrowserWindow } = require('electron');
+const { MountManager } = require('../services/mount');
+
+const manager = new MountManager();
+
+const registerMountIpc = () => {
+  ipcMain.handle('renderer:get-file-cache-size', () => manager.getCacheSize());
+
+  ipcMain.handle('renderer:clear-file-cache', () => {
+    manager.clearCache();
+    return manager.getCacheSize();
+  });
+
+  ipcMain.handle(
+    'renderer:mount-collection-v2',
+    async (event, { collectionUid, collectionPathname, brunoConfig }) => {
+      const win = BrowserWindow.fromWebContents(event.sender);
+      const send = (channel, payload) => {
+        if (!win || win.isDestroyed?.()) return;
+        win.webContents.send(channel, payload);
+      };
+      const emit = {
+        tree: (tree) => send('main:collection-tree-loaded', { collectionUid, tree }),
+        loading: (isLoading) => send('main:collection-loading-state-updated-v2', { collectionUid, isLoading }),
+        config: (brunoConfig) => send('main:bruno-config-update-v2', { collectionUid, brunoConfig }),
+        uiState: (payload) => send('main:hydrate-app-with-ui-state-snapshot-v2', payload)
+      };
+      return manager.mount({ win, collectionPath: collectionPathname, collectionUid, brunoConfig, emit });
+    }
+  );
+
+  ipcMain.handle('renderer:unmount-collection-v2', async (event, { collectionUid }) => {
+    await manager.unmount(collectionUid);
+  });
+};
+
+const shutdown = () => manager.shutdown();
+
+module.exports = { registerMountIpc, shutdown };

--- a/packages/bruno-electron/src/services/mount/gitlite.js
+++ b/packages/bruno-electron/src/services/mount/gitlite.js
@@ -1,0 +1,179 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { Database } = require('@usebruno/storage');
+const {
+  hashFile,
+  normalize,
+  toPosix,
+  idForAbsolutePath,
+  resolveDenylist,
+  isDenied,
+  walk
+} = require('../../utils/mount');
+
+const MIGRATIONS = [
+  {
+    version: 1,
+    up: `
+      CREATE TABLE IF NOT EXISTS snapshot_entries (
+        collection_path TEXT NOT NULL,
+        relative_path TEXT NOT NULL,
+        id TEXT NOT NULL,
+        mtime INTEGER NOT NULL,
+        hash TEXT NOT NULL,
+        data TEXT NOT NULL,
+        PRIMARY KEY (collection_path, relative_path)
+      ) WITHOUT ROWID;
+      CREATE INDEX IF NOT EXISTS idx_collection_path ON snapshot_entries(collection_path);
+    `
+  }
+];
+
+class GitLite {
+  #db;
+  #dbPath;
+
+  constructor({ dbPath } = {}) {
+    this.#dbPath = dbPath || path.join(require('electron').app.getPath('userData'), 'mount-snapshots.db');
+    this.#db = new Database({ path: this.#dbPath, migrations: MIGRATIONS, readBigInts: true });
+  }
+
+  close() {
+    this.#db.close();
+  }
+
+  status(collectionPath, options = {}) {
+    const root = normalize(collectionPath);
+    const stored = this.#loadStored(root);
+    const denylist = resolveDenylist(options.denylist);
+    const added = [];
+    const updated = [];
+    const removed = [];
+    const seen = new Set();
+
+    for (const { relativePath, absolutePath } of walk(root, denylist)) {
+      seen.add(relativePath);
+      const stat = fs.statSync(absolutePath, { bigint: true });
+      const mtime = stat.mtimeNs;
+      const prior = stored.get(relativePath);
+
+      if (!prior) {
+        const hash = hashFile(absolutePath);
+        added.push({ relativePath, absolutePath, mtime, hash });
+        continue;
+      }
+
+      if (prior.mtime === mtime) continue;
+
+      const hash = hashFile(absolutePath);
+      if (hash === prior.hash) continue;
+
+      updated.push({ relativePath, absolutePath, mtime, hash, prevHash: prior.hash });
+    }
+
+    for (const [relativePath, row] of stored) {
+      if (seen.has(relativePath)) continue;
+      if (isDenied(toPosix(relativePath), denylist)) continue;
+      removed.push({ relativePath, id: row.id, hash: row.hash });
+    }
+
+    return { added, updated, removed };
+  }
+
+  clear() {
+    this.#db.exec('DELETE FROM snapshot_entries');
+    // VACUUM so the file actually shrinks after the DELETE
+    this.#db.exec('VACUUM');
+  }
+
+  get dbPath() {
+    return this.#dbPath;
+  }
+
+  entries(collectionPath) {
+    const root = normalize(collectionPath);
+    const rows = this.#db.all(
+      'SELECT relative_path AS relativePath, data FROM snapshot_entries WHERE collection_path = ?',
+      root
+    );
+    const map = new Map();
+    for (const row of rows) {
+      map.set(row.relativePath, { data: JSON.parse(row.data) });
+    }
+    return map;
+  }
+
+  stage(collectionPath, entry) {
+    const root = normalize(collectionPath);
+    const { op, relativePath } = entry;
+
+    if (op === 'remove') {
+      this.#db.run(
+        'DELETE FROM snapshot_entries WHERE collection_path = ? AND relative_path = ?',
+        root,
+        relativePath
+      );
+      return;
+    }
+
+    const { mtime, hash, data } = entry;
+    const id = idForAbsolutePath(path.join(root, relativePath));
+    this.#db.run(
+      `
+      INSERT INTO snapshot_entries (collection_path, relative_path, id, mtime, hash, data)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(collection_path, relative_path) DO UPDATE SET
+        mtime = excluded.mtime,
+        hash = excluded.hash,
+        data = excluded.data
+    `,
+      root,
+      relativePath,
+      id,
+      mtime,
+      hash,
+      JSON.stringify(data)
+    );
+  }
+
+  stageParsed(collectionPath, absolutePath, data) {
+    const root = normalize(collectionPath);
+    const relativePath = path.relative(root, normalize(absolutePath));
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) return;
+    const stat = fs.statSync(absolutePath, { bigint: true });
+    this.stage(root, {
+      op: 'add',
+      relativePath,
+      mtime: stat.mtimeNs,
+      hash: hashFile(absolutePath),
+      data
+    });
+  }
+
+  unstagePath(collectionPath, absolutePath) {
+    const root = normalize(collectionPath);
+    const relativePath = path.relative(root, normalize(absolutePath));
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) return;
+    this.stage(root, { op: 'remove', relativePath });
+  }
+
+  transaction(callback) {
+    return this.#db.transaction(callback);
+  }
+
+  #loadStored(collectionPath) {
+    const rows = this.#db.all(
+      'SELECT relative_path AS relativePath, id, mtime, hash FROM snapshot_entries WHERE collection_path = ?',
+      collectionPath
+    );
+    const map = new Map();
+    for (const row of rows) {
+      map.set(row.relativePath, row);
+    }
+    return map;
+  }
+}
+
+module.exports = {
+  GitLite
+};

--- a/packages/bruno-electron/src/services/mount/index.js
+++ b/packages/bruno-electron/src/services/mount/index.js
@@ -1,0 +1,3 @@
+const { MountManager } = require('./manager');
+
+module.exports = { MountManager };

--- a/packages/bruno-electron/src/services/mount/manager.js
+++ b/packages/bruno-electron/src/services/mount/manager.js
@@ -1,0 +1,243 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { JobType, getPool, destroyPool } = require('@usebruno/pool');
+const { GitLite } = require('./gitlite');
+const { buildTree } = require('./tree-builder');
+const { defaultClassify, uidForSeed } = require('../../utils/mount');
+
+// cold start only — collection-watcher handles live changes and writes through to the cache
+
+let _envSecretsStore = null;
+const getEnvSecretsStore = () => {
+  if (!_envSecretsStore) {
+    const EnvironmentSecretsStore = require('../../store/env-secrets');
+    _envSecretsStore = new EnvironmentSecretsStore();
+  }
+  return _envSecretsStore;
+};
+
+const envHasSecrets = (env) => Array.isArray(env?.variables) && env.variables.some((v) => v.secret);
+
+const hydrateEnvironments = (collectionPath, environments) => {
+  if (!Array.isArray(environments)) return;
+  const { decryptStringSafe } = require('../../utils/encryption');
+  for (const env of environments) {
+    if (!Array.isArray(env.variables)) continue;
+    env.variables.forEach((variable, i) => {
+      const key = variable.name || `index:${i}`;
+      variable.uid = uidForSeed(`${env.uid}#var#${key}`);
+    });
+    if (!envHasSecrets(env)) continue;
+    try {
+      const envSecrets = getEnvSecretsStore().getEnvSecrets(collectionPath, env);
+      for (const secret of envSecrets || []) {
+        const variable = env.variables.find((v) => v.name === secret.name);
+        if (variable && secret.value) {
+          const decrypted = decryptStringSafe(secret.value);
+          variable.value = decrypted.value;
+        }
+      }
+    } catch (err) {
+      console.error('[mount] env secret hydration failed', err);
+    }
+  }
+};
+
+const computeUiStateSnapshot = (collectionPath) => {
+  try {
+    const snapshotManager = require('../snapshot');
+    const snapshotState = snapshotManager.getCollection(collectionPath);
+    if (snapshotState) {
+      return {
+        pathname: collectionPath,
+        environmentPath: snapshotState?.environment?.collection || '',
+        selectedEnvironment: snapshotState?.selectedEnvironment || ''
+      };
+    }
+  } catch (err) {
+    console.error('[mount] snapshot lookup failed', err);
+  }
+  return null;
+};
+
+const sendTree = async (collectionUid, collectionPath, tree, emit) => {
+  if (tree.brunoConfig) {
+    try {
+      const { transformBrunoConfigAfterRead } = require('../../utils/transformBrunoConfig');
+      const { setBrunoConfig } = require('../../store/bruno-config');
+      const transformed = await transformBrunoConfigAfterRead(tree.brunoConfig, collectionPath);
+      tree.brunoConfig = transformed;
+      setBrunoConfig(collectionUid, transformed);
+      emit.config(transformed);
+    } catch (err) {
+      console.error(`[mount:${collectionUid}] brunoConfig transform failed:`, err);
+    }
+  }
+  hydrateEnvironments(collectionPath, tree.environments);
+  emit.tree(tree);
+};
+
+const ensureTransientDirectory = () => {
+  const base = path.join(require('electron').app.getPath('userData'), 'tmp', 'transient');
+  if (!fs.existsSync(base)) fs.mkdirSync(base, { recursive: true });
+  return fs.mkdtempSync(path.join(base, 'bruno-'));
+};
+
+class MountManager {
+  #index = null;
+  #mounts = new Map();
+
+  async mount({ win, collectionPath, collectionUid, brunoConfig, emit }) {
+    collectionPath = path.resolve(collectionPath);
+
+    if (this.#mounts.has(collectionUid)) {
+      // renderer reload — pull fresh state from cache and re-emit
+      const existing = this.#mounts.get(collectionUid);
+      existing.win = win;
+      existing.emit = emit;
+      existing.brunoConfig = brunoConfig || existing.brunoConfig;
+      existing.state = this.#getIndex().entries(existing.collectionPath);
+      await this.#emitTree(collectionUid, existing);
+      existing.emit.uiState(computeUiStateSnapshot(existing.collectionPath));
+      return existing.tempDirectoryPath;
+    }
+
+    const tempDirectoryPath = ensureTransientDirectory();
+    fs.writeFileSync(path.join(tempDirectoryPath, 'metadata.json'), JSON.stringify({ collectionPath }));
+
+    const entry = {
+      state: new Map(),
+      collectionPath,
+      tempDirectoryPath,
+      brunoConfig,
+      win,
+      emit
+    };
+    this.#mounts.set(collectionUid, entry);
+
+    entry.emit.loading(true);
+    try {
+      entry.state = this.#getIndex().entries(collectionPath);
+      await this.#reconcile(entry);
+      await this.#emitTree(collectionUid, entry);
+
+      // skip the startup walk (already done) and stage live edits into the cache
+      const collectionWatcher = require('../../app/collection-watcher');
+      collectionWatcher.addWatcher(entry.win, collectionPath, collectionUid, brunoConfig, false, false, {
+        ignoreInitial: true,
+        snapshotIndex: this.#getIndex()
+      });
+      collectionWatcher.addTempDirectoryWatcher(entry.win, tempDirectoryPath, collectionUid, collectionPath);
+
+      entry.emit.uiState(computeUiStateSnapshot(collectionPath));
+    } finally {
+      entry.emit.loading(false);
+    }
+    return tempDirectoryPath;
+  }
+
+  async unmount(collectionUid) {
+    const entry = this.#mounts.get(collectionUid);
+    if (!entry) return;
+    this.#mounts.delete(collectionUid);
+    const collectionWatcher = require('../../app/collection-watcher');
+    try {
+      collectionWatcher.removeWatcher(entry.collectionPath, entry.win, collectionUid);
+    } catch (_) {}
+  }
+
+  async shutdown() {
+    await Promise.all(
+      Array.from(this.#mounts.keys()).map((uid) => this.unmount(uid).catch(() => {}))
+    );
+    await destroyPool().catch(() => {});
+    if (this.#index) {
+      this.#index.close();
+      this.#index = null;
+    }
+  }
+
+  getCacheSize() {
+    try {
+      return fs.statSync(this.#getIndex().dbPath).size;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return 0;
+      throw err;
+    }
+  }
+
+  clearCache() {
+    this.#getIndex().clear();
+  }
+
+  async #reconcile(entry) {
+    const denylist = entry.brunoConfig?.ignore || [];
+    const { added, updated, removed } = this.#getIndex().status(entry.collectionPath, { denylist });
+
+    const toParse = [];
+    for (const e of [...added, ...updated]) {
+      const cls = defaultClassify(e.relativePath);
+      if (!cls) continue;
+      toParse.push({ relativePath: e.relativePath, format: cls.format, type: cls.type });
+    }
+
+    const parsed = new Map();
+    if (toParse.length > 0) {
+      const pool = getPool();
+      await Promise.allSettled(
+        toParse.map(async (e) => {
+          try {
+            const result = await pool.run(JobType.ParseFile, {
+              collectionPath: entry.collectionPath,
+              relativePath: e.relativePath,
+              format: e.format,
+              type: e.type
+            });
+            parsed.set(e.relativePath, result);
+          } catch (err) {
+            parsed.set(e.relativePath, {
+              relativePath: e.relativePath,
+              error: { message: err.message, stack: err.stack }
+            });
+          }
+        })
+      );
+    }
+
+    this.#getIndex().transaction(() => {
+      for (const e of toParse) {
+        const result = parsed.get(e.relativePath);
+        if (!result) continue;
+        if (result.error) {
+          entry.state.set(e.relativePath, { error: result.error });
+          continue;
+        }
+        entry.state.set(e.relativePath, { data: result.data });
+        this.#getIndex().stage(entry.collectionPath, {
+          op: 'add',
+          relativePath: e.relativePath,
+          mtime: result.mtime,
+          hash: result.hash,
+          data: result.data
+        });
+      }
+      for (const e of removed) {
+        entry.state.delete(e.relativePath);
+        this.#getIndex().stage(entry.collectionPath, { op: 'remove', relativePath: e.relativePath });
+      }
+    });
+  }
+
+  async #emitTree(collectionUid, entry) {
+    const { getRequestUid } = require('../../cache/requestUids');
+    const tree = buildTree(entry.collectionPath, entry.state, { uidFor: getRequestUid });
+    await sendTree(collectionUid, entry.collectionPath, tree, entry.emit);
+  }
+
+  #getIndex() {
+    if (!this.#index) this.#index = new GitLite({});
+    return this.#index;
+  }
+}
+
+module.exports = { MountManager };

--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -1,0 +1,237 @@
+const path = require('node:path');
+const {
+  toPosix,
+  idForAbsolutePath,
+  uidForSeed,
+  defaultClassify
+} = require('../../utils/mount');
+
+const REQUEST_EXT_RE = /\.(bru|yml|yaml)$/i;
+const stripExt = (basename) => basename.replace(REQUEST_EXT_RE, '');
+
+const isSeqValid = (seq) => Number.isFinite(seq) && Number.isInteger(seq) && seq > 0;
+
+// lists that get deterministic uids; section tag keeps reorders within one list local
+const REQUEST_UID_PATHS = [
+  ['request.params', 'params'],
+  ['request.headers', 'headers'],
+  ['request.vars.req', 'vars.req'],
+  ['request.vars.res', 'vars.res'],
+  ['request.assertions', 'assertions'],
+  ['request.body.formUrlEncoded', 'body.formUrlEncoded'],
+  ['request.body.multipartForm', 'body.multipartForm'],
+  ['request.body.file', 'body.file']
+];
+
+const EXAMPLE_UID_PATHS = [
+  ['request.params', 'params'],
+  ['request.headers', 'headers'],
+  ['request.body.formUrlEncoded', 'body.formUrlEncoded'],
+  ['request.body.multipartForm', 'body.multipartForm'],
+  ['request.body.file', 'body.file'],
+  ['response.headers', 'response.headers']
+];
+
+const hydrateListAt = (root, dotPath, seed, section) => {
+  let cur = root;
+  for (const p of dotPath.split('.')) {
+    if (!cur || typeof cur !== 'object') return;
+    cur = cur[p];
+  }
+  if (!Array.isArray(cur)) return;
+  cur.forEach((item, i) => {
+    item.uid = uidForSeed(`${seed}#${section}#${i}`);
+  });
+};
+
+const hydrateRequestUuids = (data, parentUid, absolutePath) => {
+  if (!data || typeof data !== 'object') return;
+  const seed = toPosix(absolutePath);
+  for (const [p, sec] of REQUEST_UID_PATHS) hydrateListAt(data, p, seed, sec);
+  if (!Array.isArray(data.examples)) return;
+  data.examples.forEach((example, i) => {
+    const exSeed = `${seed}#example#${i}`;
+    example.uid = uidForSeed(exSeed);
+    if (parentUid) example.itemUid = parentUid;
+    for (const [p, sec] of EXAMPLE_UID_PATHS) hydrateListAt(example, p, exSeed, sec);
+  });
+};
+
+// alpha by name, then any folder with a valid seq pins to that position (v1 quirk)
+const sortByNameThenSequence = (items) => {
+  const sorted = [...items].sort((a, b) =>
+    a.name && b.name ? a.name.localeCompare(b.name) : 0
+  );
+  const withoutSeq = sorted.filter((f) => !isSeqValid(f.seq));
+  const withSeq = sorted.filter((f) => isSeqValid(f.seq)).sort((a, b) => a.seq - b.seq);
+
+  withSeq.forEach((item) => {
+    const existing = withoutSeq[item.seq - 1];
+    const collides = Array.isArray(existing)
+      ? existing[0]?.seq === item.seq
+      : existing?.seq === item.seq;
+    if (collides) {
+      const group = Array.isArray(existing) ? [...existing, item] : [existing, item];
+      withoutSeq.splice(item.seq - 1, 1, group);
+    } else {
+      withoutSeq.splice(item.seq - 1, 0, item);
+    }
+  });
+  return withoutSeq.flat();
+};
+
+const sortLevel = (items) => {
+  const folders = items.filter((i) => i.type === 'folder');
+  const requests = items.filter((i) => i.type !== 'folder');
+  const sortedFolders = sortByNameThenSequence(folders);
+  for (const f of sortedFolders) f.items = sortLevel(f.items);
+  const sortedRequests = [...requests].sort((a, b) => (a.seq ?? 1) - (b.seq ?? 1));
+  return [...sortedFolders, ...sortedRequests];
+};
+
+const ensureFolder = (collectionPath, items, segments, uidFor) => {
+  let cursor = items;
+  let acc = '';
+  let last = null;
+  for (const seg of segments) {
+    acc = acc ? path.join(acc, seg) : seg;
+    const absolutePath = path.join(collectionPath, acc);
+    let folder = cursor.find((i) => i.type === 'folder' && i.filename === seg);
+    if (!folder) {
+      folder = {
+        uid: uidFor(absolutePath),
+        name: seg,
+        filename: seg,
+        pathname: absolutePath,
+        type: 'folder',
+        collapsed: true,
+        items: []
+      };
+      cursor.push(folder);
+    }
+    cursor = folder.items;
+    last = folder;
+  }
+  return { cursor, folder: last };
+};
+
+const buildRequestNode = (absolutePath, basename, entry, uidOverrides, uidFor) => {
+  const uid = uidOverrides?.get(absolutePath) || uidFor(absolutePath);
+  const data = entry.data || {};
+  hydrateRequestUuids(data, uid, absolutePath);
+  return {
+    uid,
+    name: data.name || stripExt(basename),
+    type: data.type || 'http-request',
+    seq: data.seq,
+    tags: data.tags,
+    request: data.request,
+    settings: data.settings,
+    examples: data.examples,
+    filename: basename,
+    pathname: absolutePath,
+    draft: null,
+    partial: false,
+    loading: false,
+    ...(entry.error ? { error: entry.error, partial: true } : {})
+  };
+};
+
+const buildEnvironmentNode = (collectionPath, relativePath, entry, uidFor) => {
+  const basename = path.basename(relativePath);
+  const absolutePath = path.join(collectionPath, relativePath);
+  const data = entry.data || {};
+  return {
+    uid: uidFor(absolutePath),
+    name: stripExt(basename),
+    variables: data.variables || [],
+    ...(entry.error ? { error: entry.error } : {})
+  };
+};
+
+const buildTree = (collectionPath, parserResults, options = {}) => {
+  const uidOverrides = options.uidOverrides;
+  const uidFor = options.uidFor || idForAbsolutePath;
+  const transientEntries = options.transientEntries || [];
+
+  const tree = {
+    pathname: collectionPath,
+    brunoConfig: null,
+    root: null,
+    items: [],
+    environments: []
+  };
+
+  const folderRoots = new Map();
+  const requests = [];
+
+  for (const [relativePath, entry] of parserResults) {
+    const cls = defaultClassify(relativePath);
+    if (!cls) continue;
+
+    if (cls.type === 'config') {
+      tree.brunoConfig = entry.error ? null : entry.data;
+    } else if (cls.type === 'collection') {
+      if (!entry.error) {
+        const data = entry.data;
+        if (data && typeof data === 'object' && 'collectionRoot' in data && 'brunoConfig' in data) {
+          hydrateRequestUuids(data.collectionRoot, null, collectionPath);
+          tree.root = data.collectionRoot;
+          tree.brunoConfig = data.brunoConfig;
+        } else {
+          hydrateRequestUuids(data, null, collectionPath);
+          tree.root = data;
+        }
+      }
+    } else if (cls.type === 'folder') {
+      folderRoots.set(path.dirname(relativePath), entry);
+    } else if (cls.type === 'environment') {
+      tree.environments.push(buildEnvironmentNode(collectionPath, relativePath, entry, uidFor));
+    } else {
+      requests.push({ relativePath, entry });
+    }
+  }
+
+  for (const { relativePath, entry } of requests) {
+    const segments = path.dirname(relativePath).split(path.sep).filter((s) => s && s !== '.');
+    const { cursor } = ensureFolder(collectionPath, tree.items, segments, uidFor);
+    cursor.push(buildRequestNode(
+      path.join(collectionPath, relativePath),
+      path.basename(relativePath),
+      entry,
+      uidOverrides,
+      uidFor
+    ));
+  }
+
+  for (const [dirRel, entry] of folderRoots) {
+    const segments = dirRel.split(path.sep).filter((s) => s && s !== '.');
+    const { folder } = ensureFolder(collectionPath, tree.items, segments, uidFor);
+    if (!folder) continue;
+    const meta = entry.data?.meta || {};
+    if (meta.name) folder.name = meta.name;
+    if (isSeqValid(meta.seq)) folder.seq = meta.seq;
+    if (!entry.error) {
+      hydrateRequestUuids(entry.data, folder.uid, folder.pathname);
+      folder.root = entry.data;
+    }
+  }
+
+  for (const t of transientEntries) {
+    if (!t || !t.absolutePath) continue;
+    const node = buildRequestNode(
+      t.absolutePath,
+      path.basename(t.absolutePath),
+      t,
+      uidOverrides,
+      uidFor
+    );
+    node.isTransient = true;
+    tree.items.push(node);
+  }
+
+  tree.items = sortLevel(tree.items);
+  return tree;
+};
+
+module.exports = { buildTree };

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -67,6 +67,9 @@ const defaultPreferences = {
   cache: {
     sslSession: {
       enabled: false
+    },
+    file: {
+      enabled: false
     }
   },
   ai: {
@@ -142,6 +145,9 @@ const preferencesSchema = Yup.object().shape({
   }),
   cache: Yup.object({
     sslSession: Yup.object({
+      enabled: Yup.boolean()
+    }),
+    file: Yup.object({
       enabled: Yup.boolean()
     })
   }).optional(),
@@ -349,6 +355,9 @@ const preferencesUtil = {
   },
   isSslSessionCachingEnabled: () => {
     return get(getPreferences(), 'cache.sslSession.enabled', false);
+  },
+  isFileCacheEnabled: () => {
+    return get(getPreferences(), 'cache.file.enabled', false);
   },
   hasLaunchedBefore: () => {
     return get(getPreferences(), 'onboarding.hasLaunchedBefore', false);

--- a/packages/bruno-electron/src/utils/mount.js
+++ b/packages/bruno-electron/src/utils/mount.js
@@ -1,0 +1,90 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const DENY_DIRS = new Set(['node_modules', '.git', '.svn', '.hg', '.bruno']);
+const DEFAULT_DENYLIST = ['**/.DS_Store', '**/Thumbs.db'];
+
+const sha256 = (input) => crypto.createHash('sha256').update(input).digest('hex');
+const hashFile = (absPath) => sha256(fs.readFileSync(absPath));
+const normalize = (p) => path.resolve(p);
+const toPosix = (p) => (path.sep === '/' ? p : p.split(path.sep).join('/'));
+const idForAbsolutePath = (absolutePath) => sha256(toPosix(absolutePath)).slice(0, 21);
+const uidForSeed = (seed) => sha256(seed).slice(0, 21);
+
+const resolveDenylist = (patterns) => [...DEFAULT_DENYLIST, ...(patterns || [])];
+
+const isDenied = (relativePathPosix, patterns) => {
+  for (const pattern of patterns) {
+    if (path.matchesGlob(relativePathPosix, pattern)) return true;
+  }
+  return false;
+};
+
+const walk = (root, denylist) => {
+  const out = [];
+  const visit = (absDir, relDir) => {
+    const entries = fs.readdirSync(absDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const childAbs = path.join(absDir, entry.name);
+      const childRel = relDir ? path.join(relDir, entry.name) : entry.name;
+      if (entry.isDirectory()) {
+        if (DENY_DIRS.has(entry.name)) continue;
+        visit(childAbs, childRel);
+      } else if (entry.isFile()) {
+        if (isDenied(toPosix(childRel), denylist)) continue;
+        out.push({ relativePath: childRel, absolutePath: childAbs });
+      }
+    }
+  };
+  visit(root, '');
+  return out;
+};
+
+const COLLECTION_ROOT_BASENAMES = new Set(['collection.bru', 'collection.yml', 'opencollection.yml']);
+const FOLDER_ROOT_BASENAMES = new Set(['folder.bru', 'folder.yml']);
+const BRUNO_CONFIG_BASENAME = 'bruno.json';
+const ENVIRONMENTS_DIR = 'environments';
+
+const defaultClassify = (relativePath) => {
+  const basename = path.basename(relativePath);
+  const dirname = path.dirname(relativePath);
+  const segments = dirname === '.' || dirname === '' ? [] : dirname.split(path.sep).filter(Boolean);
+
+  if (basename === BRUNO_CONFIG_BASENAME && segments.length === 0) {
+    return { format: 'json', type: 'config' };
+  }
+
+  const ext = path.extname(basename).slice(1).toLowerCase();
+  let format;
+  if (ext === 'bru') format = 'bru';
+  else if (ext === 'yml' || ext === 'yaml') format = 'yml';
+  else return null;
+
+  if (COLLECTION_ROOT_BASENAMES.has(basename) && segments.length === 0) {
+    return { format, type: 'collection' };
+  }
+  if (FOLDER_ROOT_BASENAMES.has(basename)) {
+    return { format, type: 'folder' };
+  }
+  if (segments[0] === ENVIRONMENTS_DIR && segments.length === 1) {
+    return { format, type: 'environment' };
+  }
+  return { format, type: 'request' };
+};
+
+module.exports = {
+  COLLECTION_ROOT_BASENAMES,
+  FOLDER_ROOT_BASENAMES,
+  BRUNO_CONFIG_BASENAME,
+  ENVIRONMENTS_DIR,
+  hashFile,
+  normalize,
+  toPosix,
+  idForAbsolutePath,
+  uidForSeed,
+  resolveDenylist,
+  isDenied,
+  walk,
+  defaultClassify
+};

--- a/packages/bruno-pool/README.md
+++ b/packages/bruno-pool/README.md
@@ -1,0 +1,89 @@
+# @usebruno/pool
+
+A small `worker_threads` pool for running CPU-bound Bruno jobs off the main thread. It's a thin wrapper over [workerpool](https://github.com/josdejong/workerpool): the queue, worker bookkeeping, and crash recovery are handled by workerpool, while this package adds a typed, job-aware API.
+
+Workers are spawned lazily — constructing a pool costs nothing; the first `run()` spawns the first worker, growing up to `size` workers on demand. No native dependencies.
+
+## How it works
+
+Each job is a script under `src/scripts/` that default-exports a handler function. The worker (`src/worker.ts`) registers every job as a named method, keyed by a `JobType` constant. `pool.run(type, args)` invokes the matching handler in a worker thread and resolves with its return value (or rejects with the error it threw).
+
+```
+Pool.run(type, args)  ──►  workerpool queue  ──►  worker method[type](args)  ──►  result
+```
+
+## Usage
+
+Most callers should use the shared, app-lifecycle pool via `getPool()`. It's a lazy singleton: the first call creates the pool object, the first `run()` spawns workers, and one pool is shared across every job type and consumer (keeping total CPU bounded).
+
+```ts
+import { getPool, destroyPool, JobType } from '@usebruno/pool';
+
+const result = await getPool().run(JobType.ParseFile, {
+  collectionPath: '/path/to/collection',
+  relativePath: 'request.bru',
+  format: 'bru',
+  type: 'request'
+});
+
+// On app shutdown, terminate the shared pool's workers.
+await destroyPool();
+```
+
+Use the `JobType` constants instead of raw strings so call sites get autocomplete and type-checking. The package is published as CommonJS, so it works under both Electron/Node and Jest:
+
+```js
+const { getPool, JobType } = require('@usebruno/pool');
+```
+
+If you need an isolated pool (e.g. a differently-sized pool for a special job, or per-test isolation), construct one directly and own its lifecycle:
+
+```ts
+import { Pool, JobType } from '@usebruno/pool';
+
+const pool = new Pool({ size: 2 });
+await pool.run(JobType.ParseFile, { /* ... */ });
+await pool.destroy();
+```
+
+## API
+
+### `getPool(options?): Pool`
+
+Returns the shared singleton pool, creating it on first call. `options` only take effect on that first call; later calls return the existing instance and ignore their args.
+
+### `destroyPool(): Promise<void>`
+
+Terminates the shared pool's workers and clears the singleton. A subsequent `getPool()` creates a fresh one.
+
+### `new Pool(options?)`
+
+Creates an isolated pool you own.
+
+| Option | Type     | Default                       | Description                      |
+| ------ | -------- | ----------------------------- | -------------------------------- |
+| `size` | `number` | `os.availableParallelism()`   | Max worker threads (spawned lazily). |
+
+### `pool.run<T>(type, args?): Promise<T>`
+
+Runs the job named `type` (a `JobType` value) with `args`, resolving with the handler's result. Rejects if the handler throws.
+
+### `pool.destroy(): Promise<void>`
+
+Terminates all workers; in-flight and queued jobs reject.
+
+### `JobType`
+
+A const map of available jobs (e.g. `JobType.ParseFile`). Each value is the worker method name.
+
+## Adding a job
+
+1. Create `src/scripts/<job>.ts` with a default-exported handler function.
+2. Add an entry to `JobType` in `src/pool.ts`.
+3. Register it in `src/worker.ts`: `[JobType.<Job>]: <handler>`.
+
+## Build
+
+```sh
+npm run build   # rollup bundle + tsc declarations
+```

--- a/packages/bruno-pool/package.json
+++ b/packages/bruno-pool/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@usebruno/pool",
+  "version": "0.1.0",
+  "description": "Lazy worker_threads job pool for Bruno — typed script-based jobs, a shared singleton, no native dependencies",
+  "author": "Bruno Software Inc.",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "package.json"
+  ],
+  "scripts": {
+    "build": "rollup -c && tsc --emitDeclarationOnly",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@usebruno/filestore": "0.1.0",
+    "workerpool": "10.0.2"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "23.0.2",
+    "@rollup/plugin-node-resolve": "15.0.1",
+    "@rollup/plugin-typescript": "12.1.2",
+    "@types/node": "^24.1.0",
+    "rollup": "3.30.0",
+    "tslib": "2.8.1",
+    "typescript": "5.4.5"
+  }
+}

--- a/packages/bruno-pool/rollup.config.js
+++ b/packages/bruno-pool/rollup.config.js
@@ -1,0 +1,44 @@
+const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const commonjs = require('@rollup/plugin-commonjs');
+const typescript = require('@rollup/plugin-typescript');
+
+const external = [
+  '@usebruno/filestore',
+  /@usebruno\/filestore\/.*/,
+  'workerpool',
+  'node:worker_threads',
+  'node:path',
+  'node:fs',
+  'node:crypto',
+  'node:os',
+  'node:module',
+  'worker_threads',
+  'path',
+  'fs',
+  'crypto',
+  'os',
+  'module'
+];
+
+const plugins = [
+  nodeResolve({ extensions: ['.js', '.ts', '.json'] }),
+  commonjs(),
+  typescript({ tsconfig: './tsconfig.json', declaration: false, declarationMap: false })
+];
+
+module.exports = {
+  input: {
+    index: 'src/index.ts',
+    worker: 'src/worker.ts'
+  },
+  output: {
+    dir: 'dist',
+    format: 'cjs',
+    entryFileNames: '[name].js',
+    chunkFileNames: 'shared/[name].js',
+    sourcemap: true,
+    exports: 'named'
+  },
+  plugins,
+  external
+};

--- a/packages/bruno-pool/src/index.ts
+++ b/packages/bruno-pool/src/index.ts
@@ -1,0 +1,3 @@
+export { Pool, getPool, destroyPool, JobType } from './pool';
+export type { PoolOptions } from './pool';
+export type { ParseFileArgs, ParseFileResult } from './scripts/parse-file';

--- a/packages/bruno-pool/src/pool.ts
+++ b/packages/bruno-pool/src/pool.ts
@@ -1,0 +1,51 @@
+import * as workerpool from 'workerpool';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export interface PoolOptions {
+  size?: number;
+}
+
+export const JobType = {
+  ParseFile: 'parse-file'
+} as const;
+
+export type JobType = (typeof JobType)[keyof typeof JobType];
+
+const WORKER_FILE = path.join(__dirname, 'worker.js');
+
+export class Pool {
+  #pool: workerpool.Pool;
+
+  // Let's see if we need dynamic sizing (to increase and decrease workers based on work load)
+  constructor(options: PoolOptions = {}) {
+    const size = Math.max(1, options.size ?? os.availableParallelism());
+    this.#pool = workerpool.pool(WORKER_FILE, {
+      maxWorkers: size,
+      workerType: 'thread',
+      
+    });
+  }
+
+  run<T = unknown>(type: JobType, args?: unknown): Promise<T> {
+    return this.#pool.exec(type, [args]) as Promise<T>;
+  }
+
+  async destroy(): Promise<void> {
+    await this.#pool.terminate();
+  }
+}
+
+let shared: Pool | null = null;
+
+export const getPool = (options?: PoolOptions): Pool => {
+  if (!shared) shared = new Pool(options);
+  return shared;
+};
+
+export const destroyPool = async (): Promise<void> => {
+  if (!shared) return;
+  const pool = shared;
+  shared = null;
+  await pool.destroy();
+};

--- a/packages/bruno-pool/src/scripts/parse-file.ts
+++ b/packages/bruno-pool/src/scripts/parse-file.ts
@@ -1,0 +1,52 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import * as filestore from '@usebruno/filestore';
+
+const store = filestore as any;
+
+const sha256 = (buf: Buffer): string => crypto.createHash('sha256').update(buf).digest('hex');
+
+const parseContent = (content: string, format: string, type: string): unknown => {
+  if (type === 'dotenv') return store.parseDotEnv(content);
+  if (type === 'config' || format === 'json') return JSON.parse(content);
+
+  const options = { format };
+  switch (type) {
+    case 'request':
+      return store.parseRequest(content, options);
+    case 'collection':
+      return store.parseCollection(content, options);
+    case 'folder':
+      return store.parseFolder(content, options);
+    case 'environment':
+      return store.parseEnvironment(content, options);
+    default:
+      throw new Error(`Unknown type: ${type}`);
+  }
+};
+
+export interface ParseFileArgs {
+  collectionPath: string;
+  relativePath: string;
+  format: string;
+  type: string;
+}
+
+export interface ParseFileResult {
+  relativePath: string;
+  mtime: bigint;
+  hash: string;
+  data: unknown;
+  format: string;
+  type: string;
+}
+
+export default function parseFile({ collectionPath, relativePath, format, type }: ParseFileArgs): ParseFileResult {
+  const absolutePath = path.join(collectionPath, relativePath);
+  const buf = fs.readFileSync(absolutePath);
+  const stat = fs.statSync(absolutePath, { bigint: true });
+  const content = buf.toString('utf8');
+  const data = parseContent(content, format, type);
+  return { relativePath, mtime: stat.mtimeNs, hash: sha256(buf), data, format, type };
+}

--- a/packages/bruno-pool/src/worker.ts
+++ b/packages/bruno-pool/src/worker.ts
@@ -1,0 +1,7 @@
+import * as workerpool from 'workerpool';
+import parseFile from './scripts/parse-file';
+import { JobType } from './pool';
+
+workerpool.worker({
+  [JobType.ParseFile]: parseFile
+});

--- a/packages/bruno-pool/tsconfig.json
+++ b/packages/bruno-pool/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/bruno-storage/package.json
+++ b/packages/bruno-storage/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@usebruno/storage",
+  "version": "0.1.0",
+  "description": "Lazy SQLite storage for Bruno — a thin node:sqlite wrapper with schema, pragmas, transactions, and cached statements. No native dependencies.",
+  "author": "Bruno Software Inc.",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "package.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^24.1.0",
+    "typescript": "5.4.5"
+  }
+}

--- a/packages/bruno-storage/src/database.ts
+++ b/packages/bruno-storage/src/database.ts
@@ -1,0 +1,143 @@
+import { DatabaseSync, StatementSync } from 'node:sqlite';
+
+export type PathLike = string | (() => string);
+
+export interface Migration {
+  version: number;
+  up: string;
+}
+
+export interface DatabaseOptions {
+  path: PathLike;
+  migrations?: Migration[];
+  pragmas?: Record<string, string | number>;
+  readBigInts?: boolean;
+}
+
+// Lazy SQLite connection. On first use the database is opened, pragmas applied,
+// and pending migrations run (tracked by PRAGMA user_version in the db header).
+// Prepared statements are cached by SQL text; transaction wraps a callback in
+// BEGIN/COMMIT/ROLLBACK.
+export class Database {
+  #db: DatabaseSync | null = null;
+  #path: PathLike;
+  #migrations: Migration[];
+  #pragmas?: Record<string, string | number>;
+  #readBigInts: boolean;
+  #statements = new Map<string, StatementSync>();
+
+  constructor(options: DatabaseOptions) {
+    this.#path = options.path;
+    this.#migrations = options.migrations ?? [];
+    this.#pragmas = options.pragmas;
+    this.#readBigInts = options.readBigInts ?? false;
+    this.#validateMigrations();
+  }
+
+  get path(): string {
+    return typeof this.#path === 'function' ? this.#path() : this.#path;
+  }
+
+  // Current schema version (PRAGMA user_version); 0 before any migration runs.
+  get schemaVersion(): number {
+    const row = this.#connect().prepare('PRAGMA user_version').get() as { user_version: number };
+    return row.user_version;
+  }
+
+  setPath(path: PathLike): void {
+    this.close();
+    this.#path = path;
+  }
+
+  prepare(sql: string): StatementSync {
+    const db = this.#connect();
+    let stmt = this.#statements.get(sql);
+    if (!stmt) {
+      stmt = db.prepare(sql);
+      if (this.#readBigInts) stmt.setReadBigInts(true);
+      this.#statements.set(sql, stmt);
+    }
+    return stmt;
+  }
+
+  run(sql: string, ...params: unknown[]) {
+    return this.prepare(sql).run(...(params as never[]));
+  }
+
+  get(sql: string, ...params: unknown[]) {
+    return this.prepare(sql).get(...(params as never[]));
+  }
+
+  all(sql: string, ...params: unknown[]) {
+    return this.prepare(sql).all(...(params as never[]));
+  }
+
+  exec(sql: string): void {
+    this.#connect().exec(sql);
+  }
+
+  transaction<T>(fn: () => T): T {
+    const db = this.#connect();
+    db.exec('BEGIN');
+    try {
+      const result = fn();
+      db.exec('COMMIT');
+      return result;
+    } catch (err) {
+      db.exec('ROLLBACK');
+      throw err;
+    }
+  }
+
+  close(): void {
+    if (!this.#db) return;
+    this.#statements.clear();
+    this.#db.close();
+    this.#db = null;
+  }
+
+  #connect(): DatabaseSync {
+    if (this.#db) return this.#db;
+    const db = new DatabaseSync(this.path);
+    if (this.#pragmas) {
+      for (const [key, value] of Object.entries(this.#pragmas)) {
+        db.exec(`PRAGMA ${key} = ${value};`);
+      }
+    }
+    this.#migrate(db);
+    this.#db = db;
+    return db;
+  }
+
+  #migrate(db: DatabaseSync): void {
+    if (!this.#migrations.length) return;
+    const sorted = [...this.#migrations].sort((a, b) => a.version - b.version);
+    let current = (db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version;
+    for (const migration of sorted) {
+      if (migration.version <= current) continue;
+      db.exec('BEGIN');
+      try {
+        db.exec(migration.up);
+        db.exec(`PRAGMA user_version = ${migration.version}`);
+        db.exec('COMMIT');
+      } catch (err) {
+        db.exec('ROLLBACK');
+        throw err;
+      }
+      current = migration.version;
+    }
+  }
+
+  #validateMigrations(): void {
+    const seen = new Set<number>();
+    for (const { version } of this.#migrations) {
+      if (!Number.isInteger(version) || version < 1) {
+        throw new Error(`Migration version must be a positive integer, got ${version}`);
+      }
+      if (seen.has(version)) {
+        throw new Error(`Duplicate migration version ${version}`);
+      }
+      seen.add(version);
+    }
+  }
+}

--- a/packages/bruno-storage/src/index.ts
+++ b/packages/bruno-storage/src/index.ts
@@ -1,0 +1,2 @@
+export { Database } from './database';
+export type { DatabaseOptions, Migration, PathLike } from './database';

--- a/packages/bruno-storage/tsconfig.json
+++ b/packages/bruno-storage/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -99,6 +99,7 @@ async function setup() {
     execCommand('npm run build:schema-types', 'Building schema-types');
     execCommand('npm run build:bruno-filestore', 'Building bruno-filestore');
     execCommand('npm run build:bruno-pool', 'Building bruno-pool');
+    execCommand('npm run build:bruno-storage', 'Building bruno-storage');
 
     // Bundle JS sandbox libraries
     execCommand('npm run sandbox:bundle-libraries --workspace=packages/bruno-js', 'Bundling JS sandbox libraries');

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -98,6 +98,7 @@ async function setup() {
     execCommand('npm run build:bruno-requests', 'Building bruno-requests');
     execCommand('npm run build:schema-types', 'Building schema-types');
     execCommand('npm run build:bruno-filestore', 'Building bruno-filestore');
+    execCommand('npm run build:bruno-pool', 'Building bruno-pool');
 
     // Bundle JS sandbox libraries
     execCommand('npm run sandbox:bundle-libraries --workspace=packages/bruno-js', 'Bundling JS sandbox libraries');


### PR DESCRIPTION
### Description

Adds a new sqlite-backed collection mount pipeline ("mount v2") behind a
**File cache** toggle in Preferences > Cache. v1 is untouched; v2 runs on its
own IPC channels.

**Why:** v1 re-parses every file on every renderer reload. v2 persists
per-file `mtime`+`hash` in sqlite and only re-parses what changed — meaningful
win for collections in the 1k–3k request range.

**What's in:**
- New mount pipeline under `packages/bruno-electron/src/ipc/mount/`: git-lite
  `Index` (sqlite), worker-pool `Parser` (piscina + `@usebruno/filestore`),
  `buildTree`, `Watcher` + `TransientWatcher`, and a `Mount` orchestrator
  that debounces `status → parse → stage → tree`.
- v2 IPC channels (`renderer:mount-collection-v2`, etc.); renderer picks v1/v2
  based on `cache.file.enabled`.
- `collectionLoadedFromTree` reducer that merges by uid so response/draft/run
  state survive tree updates.
- Preferences > Cache: new card layout with File cache toggle, size readout,
  and Clear cache button.
- Playwright mount-time benchmark suite with per-OS baselines and PR comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File cache toggle with size display and “Clear cache” action; SSL session cache toggle with explicit clear.
  * On-disk snapshot caching to speed collection mounts and tree loading.
  * Queued requests automatically open once a collection’s tree finishes loading.

* **Bug Fixes / UX**
  * Cache preferences UI revamped with clearer controls and success/error toasts.

* **Chores**
  * Workspace and build updates to support new packages and CI build steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->