### PR TITLE
Bugfix/workspace open success toast on cancel

### DIFF
--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -152,8 +152,10 @@ const AppTitleBar = () => {
 
   const handleOpenWorkspace = async () => {
     try {
-      await dispatch(openWorkspaceDialog());
-      toast.success('Workspace opened successfully');
+      const result = await dispatch(openWorkspaceDialog());
+      if (result) {
+        toast.success('Workspace opened successfully');
+      }
     } catch (error) {
       toast.error(error.message || 'Failed to open workspace');
     }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -250,6 +250,8 @@ export const openWorkspaceDialog = () => {
         await dispatch(switchWorkspace(workspaceUid));
 
         return result;
+      } else {
+        return null;
       }
     } catch (error) {
       throw error;

--- a/tests/workspace/open-workspace/open-workspace.spec.ts
+++ b/tests/workspace/open-workspace/open-workspace.spec.ts
@@ -1,0 +1,38 @@
+import type { ElectronApplication } from '@playwright/test';
+import { expect, test } from '../../../playwright';
+import { buildCommonLocators, waitForReadyPage } from '../../utils/page';
+
+test.describe('Open Workspace', () => {
+  test('click on cancel button, should just close the dialog', async ({
+    launchElectronApp,
+    createTmpDir
+  }) => {
+    const userDataPath = await createTmpDir('open-workspace-cancel');
+
+    let app: ElectronApplication = await launchElectronApp({ userDataPath });
+    const page = await waitForReadyPage(app);
+    const locators = buildCommonLocators(page);
+
+    const initialWorkspaceName = await page
+      .getByTestId('workspace-name')
+      .textContent();
+
+    await app.evaluate(({ dialog }) => {
+      (
+        dialog as { showOpenDialog: typeof dialog.showOpenDialog }
+      ).showOpenDialog = () =>
+        Promise.resolve({ canceled: true, filePaths: [] });
+    });
+
+    await test.step('Open the workspace menu and click "Open workspace"', async () => {
+      await page.getByTestId('workspace-menu').click();
+      await locators.dropdown.item('Open workspace').click();
+    });
+
+    await test.step('Workspace unchanged after canceling the dialog', async () => {
+      expect(initialWorkspaceName).not.toBeNull();
+      const workspaceName = initialWorkspaceName as string;
+      await expect(page.getByTestId('workspace-name')).toHaveText(workspaceName);
+    });
+  });
+});


### PR DESCRIPTION
JIRA Link - https://usebruno.atlassian.net/browse/BRU-3488

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed workspace opening confirmation to display success message only when the operation completes successfully, rather than unconditionally.

* **Tests**
  * Added integration test suite for workspace opening functionality to validate correct behavior in various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->