### PR TITLE
fix(app): tag input on yml-format collections accepts any non-empty string

### DIFF
--- a/packages/bruno-app/src/components/TagList/index.js
+++ b/packages/bruno-app/src/components/TagList/index.js
@@ -4,10 +4,25 @@ import StyledWrapper from './StyledWrapper';
 import SingleLineEditor from 'components/SingleLineEditor/index';
 import { useTheme } from 'providers/Theme/index';
 
+// BRU file grammar restricts list items to `(alnum | "_" | "-")+`, so tag input
+// must enforce that for `.bru`-format collections to keep generated files
+// parseable. OpenCollection (yml) has no such restriction — its `Tag` schema is
+// just `string`, so any non-empty trimmed value is valid.
+//
+// Returns `null` on valid input, or an error message string to display.
+export const validateTagName = (text, collectionFormat) => {
+  if (!text || !text.trim()) return null; // empty handled by caller
+  if (collectionFormat === 'bru') {
+    return /^[\p{L}\p{N}_-]+$/u.test(text)
+      ? null
+      : 'Tags in BRU format must only contain letters, numbers, "-", "_".';
+  }
+  // yml / opencollection / unknown: allow any non-empty string
+  return null;
+};
+
 const TagList = ({ tagsHintList = [], handleAddTag, tags, handleRemoveTag, onSave, handleValidation, collectionFormat }) => {
   const { displayedTheme } = useTheme();
-  const isBruFormat = collectionFormat === 'bru';
-  const tagNameRegex = isBruFormat ? /^[\p{L}\p{N}_-]+$/u : /^[\p{L}\p{N}_-](?:[\p{L}\p{N}_\s-]*[\p{L}\p{N}_-])?$/u;
   const [text, setText] = useState('');
   const [error, setError] = useState('');
 
@@ -20,11 +35,9 @@ const TagList = ({ tagsHintList = [], handleAddTag, tags, handleRemoveTag, onSav
     if (!text.trim()) {
       return;
     }
-    if (!tagNameRegex.test(text)) {
-      setError(isBruFormat
-        ? 'Tags in BRU format must only contain letters, numbers, "-", "_".'
-        : 'Tags must only contain letters, numbers, spaces, "-", "_"'
-      );
+    const validationError = validateTagName(text, collectionFormat);
+    if (validationError) {
+      setError(validationError);
       return;
     }
     if (tags.includes(text)) {

--- a/packages/bruno-app/src/components/TagList/index.spec.js
+++ b/packages/bruno-app/src/components/TagList/index.spec.js
@@ -1,0 +1,58 @@
+import { validateTagName } from './index';
+
+describe('validateTagName', () => {
+  describe('bru-format collections', () => {
+    it('accepts alphanumeric, underscore, hyphen tags', () => {
+      expect(validateTagName('smoke', 'bru')).toBeNull();
+      expect(validateTagName('regression_1', 'bru')).toBeNull();
+      expect(validateTagName('api-v1', 'bru')).toBeNull();
+      expect(validateTagName('Äiti123', 'bru')).toBeNull();
+    });
+
+    it('rejects ampersand, spaces, and other special characters', () => {
+      expect(validateTagName('Pets & Dogs', 'bru')).toMatch(/BRU format/);
+      expect(validateTagName('R&D', 'bru')).toMatch(/BRU format/);
+      expect(validateTagName('&', 'bru')).toMatch(/BRU format/);
+      expect(validateTagName('api.v1', 'bru')).toMatch(/BRU format/);
+      expect(validateTagName('API (v1)', 'bru')).toMatch(/BRU format/);
+      expect(validateTagName('tag@name', 'bru')).toMatch(/BRU format/);
+    });
+
+    it('error message names BRU format so user understands the restriction', () => {
+      expect(validateTagName('&', 'bru')).toContain('BRU format');
+    });
+  });
+
+  describe('yml / opencollection collections (BRU-3175 follow-up)', () => {
+    it('accepts ampersand, spaces, and other special characters', () => {
+      expect(validateTagName('Pets & Dogs', 'yml')).toBeNull();
+      expect(validateTagName('R&D', 'yml')).toBeNull();
+      expect(validateTagName('&', 'yml')).toBeNull();
+      expect(validateTagName('api.v1', 'yml')).toBeNull();
+      expect(validateTagName('API (v1)', 'yml')).toBeNull();
+      expect(validateTagName('tag@name', 'yml')).toBeNull();
+    });
+
+    it('accepts unicode + emoji', () => {
+      expect(validateTagName('Café', 'yml')).toBeNull();
+      expect(validateTagName('模型管理', 'yml')).toBeNull();
+      expect(validateTagName('🔥tag', 'yml')).toBeNull();
+    });
+
+    it('falls back to permissive behavior for unknown collectionFormat (defensive)', () => {
+      expect(validateTagName('Pets & Dogs', undefined)).toBeNull();
+      expect(validateTagName('Pets & Dogs', null)).toBeNull();
+      expect(validateTagName('Pets & Dogs', 'unknown')).toBeNull();
+    });
+  });
+
+  describe('empty / whitespace input', () => {
+    it('returns null for empty / whitespace-only input (caller handles)', () => {
+      expect(validateTagName('', 'bru')).toBeNull();
+      expect(validateTagName('   ', 'bru')).toBeNull();
+      expect(validateTagName('', 'yml')).toBeNull();
+      expect(validateTagName(null, 'yml')).toBeNull();
+      expect(validateTagName(undefined, 'bru')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
### Description

The Request Settings → Tags input enforces the BRU file grammar (`alnum | "_" | "-"` + spaces in the middle) for **all** collection formats, including opencollection (yml). The OpenCollection spec's `Tag` schema is just `string` with no character restriction, so users on yml collections see an inconsistent UX:

| Action | Today | Expected |
| --- | --- | --- |
| Import OpenAPI spec with tag `R&D` into a yml collection | Preserved verbatim (per #8123) | Preserved verbatim ✓ |
| Type `R&D` as a new tag in Request Settings on the same collection | **Rejected** — "Tags must only contain letters, numbers, spaces, '-', '_'" | Accepted |

Same BRU-grammar leak that BRU-3175 ([#8123](https://github.com/usebruno/bruno/pull/8123)) fixed on the import path, just at the manual tag-entry surface this time.

### Changes

`packages/bruno-app/src/components/TagList/index.js`:
- Extracted a small `validateTagName(text, collectionFormat)` helper. Pure, no React state.
- `'bru'` branch — keeps the strict `/^[\p{L}\p{N}_-]+$/u` check + the "BRU format" error message. Backwards compatible — `.bru` files must continue to obey their grammar at write time.
- Anything else (`'yml'`, `null`, `undefined`, unknown) — permissive, accepts any non-empty trimmed string. Matches the OpenCollection spec.

`packages/bruno-app/src/components/TagList/index.spec.js` (new) — 7 jest cases:
- Bru-format accepts alnum/`_`/`-`/CJK
- Bru-format rejects `&`, spaces, `.`, `()`, `@`
- Yml-format accepts `&`, `R&D`, spaces, dots, parens, `@`, unicode, emoji
- Empty / whitespace / `null` / `undefined` handled correctly
- Unknown `collectionFormat` defaults to permissive (defensive)

### Test plan

- \`npm test --workspace=packages/bruno-app -- TagList\` — 7/7 pass
- Manual:
  - Open a yml-format collection → Request → Settings → Tags → type \`R&D\` → press Enter → tag added, no error
  - Open a bru-format collection (e.g. \`packages/bruno-tests/keycloak-authorization_code\`) → same action → tag rejected with "BRU format" error (no regression)

### Why a separate PR from BRU-3175

[#8123 (BRU-3175)](https://github.com/usebruno/bruno/pull/8123) is scoped to the OpenAPI import path per the Jira ticket's acceptance criteria. This UI-side fix is a related-but-distinct surface — keeping it as its own PR makes both reviewable independently and lets each land on its own merit.

### Contribution Checklist

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized tag validation logic to enforce format-specific rules, ensuring proper validation across different collection types.

* **Tests**
  * Added comprehensive test coverage for tag validation, including tests for various collection formats and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usebruno/bruno/pull/8147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->