### PR TITLE
fix(websockets): show Add Message button when body.ws is empty array

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.js
@@ -38,7 +38,7 @@ const WSBody = ({ item, collection, handleRun }) => {
     }));
   };
 
-  if (!body?.ws || !Array.isArray(body.ws)) {
+  if (!body?.ws || !Array.isArray(body.ws) || body.ws.length === 0) {
     return (
       <StyledWrapper>
         <div className="empty-state">

--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.spec.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.spec.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+// Mock heavy sub-components so jsdom doesn't have to load CodeMirror/themes
+jest.mock('./SingleWSMessage/index', () => ({
+  SingleWSMessage: ({ message }) => <div data-testid="ws-message">{message.content}</div>
+}));
+jest.mock('./StyledWrapper', () => ({ children }) => <div>{children}</div>);
+jest.mock('ui/Button', () => ({ children, onClick }) => (
+  <button onClick={onClick}>{children}</button>
+));
+jest.mock('@tabler/icons', () => ({ IconPlus: () => null }));
+
+import WSBody from './index';
+
+const makeStore = () =>
+  configureStore({
+    reducer: { collections: (s = {}) => s }
+  });
+
+const makeItem = (ws) => ({
+  uid: 'item-1',
+  draft: null,
+  request: {
+    methodType: 'GET',
+    body: { mode: 'ws', ws }
+  }
+});
+
+const collection = { uid: 'col-1' };
+
+const renderWSBody = (ws) =>
+  render(
+    <Provider store={makeStore()}>
+      <WSBody item={makeItem(ws)} collection={collection} handleRun={() => {}} />
+    </Provider>
+  );
+
+describe('WSBody', () => {
+  describe('when body.ws is an empty array', () => {
+    it('shows the Add Message button instead of a blank screen', () => {
+      renderWSBody([]);
+      expect(screen.getByText('Add Message')).toBeInTheDocument();
+    });
+
+    it('does NOT render any message editor', () => {
+      renderWSBody([]);
+      expect(screen.queryByTestId('ws-message')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when body.ws is undefined', () => {
+    it('shows the Add Message button', () => {
+      renderWSBody(undefined);
+      expect(screen.getByText('Add Message')).toBeInTheDocument();
+    });
+  });
+
+  describe('when body.ws has one message', () => {
+    it('renders the message editor', () => {
+      renderWSBody([{ name: 'message 1', content: '{}', type: 'json' }]);
+      expect(screen.getByTestId('ws-message')).toBeInTheDocument();
+    });
+
+    it('does NOT show the Add Message button', () => {
+      renderWSBody([{ name: 'message 1', content: '{}', type: 'json' }]);
+      expect(screen.queryByText('Add Message')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/bruno-filestore/src/formats/yml/items/parseWebsocketRequest.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseWebsocketRequest.spec.ts
@@ -1,0 +1,63 @@
+import parseWebsocketRequest from './parseWebsocketRequest';
+
+describe('parseWebsocketRequest', () => {
+  describe('body.ws initialization', () => {
+    it('should initialize with one default message when no message data is present', () => {
+      const result = parseWebsocketRequest({
+        info: { name: 'test', seq: 1 },
+        websocket: { url: 'ws://localhost:8082/ws' }
+      } as any);
+
+      expect(result.request.body.ws).toHaveLength(1);
+      expect(result.request.body.ws[0].content).toBe('{}');
+      expect(result.request.body.ws[0].name).toBe('message 1');
+    });
+
+    it('should NOT initialize with an empty array when no message data is present', () => {
+      const result = parseWebsocketRequest({
+        info: { name: 'test', seq: 1 },
+        websocket: { url: 'ws://localhost:8082/ws' }
+      } as any);
+
+      // regression guard: ws: [] caused a blank Message tab in the UI
+      expect(result.request.body.ws).not.toHaveLength(0);
+    });
+
+    it('should use message data from the YAML when present', () => {
+      const result = parseWebsocketRequest({
+        info: { name: 'test', seq: 1 },
+        websocket: {
+          url: 'ws://localhost:8082/ws',
+          message: { data: '{"hello":"world"}', type: 'json' }
+        }
+      } as any);
+
+      expect(result.request.body.ws).toHaveLength(1);
+      expect(result.request.body.ws[0].content).toBe('{"hello":"world"}');
+      expect(result.request.body.ws[0].type).toBe('json');
+    });
+
+    it('should fall back to default message when message data is whitespace-only', () => {
+      const result = parseWebsocketRequest({
+        info: { name: 'test', seq: 1 },
+        websocket: {
+          url: 'ws://localhost:8082/ws',
+          message: { data: '   ', type: 'text' }
+        }
+      } as any);
+
+      // whitespace-only data should not count as a real message
+      expect(result.request.body.ws).toHaveLength(1);
+      expect(result.request.body.ws[0].content).toBe('{}');
+    });
+
+    it('should set body mode to ws', () => {
+      const result = parseWebsocketRequest({
+        info: { name: 'test', seq: 1 },
+        websocket: { url: 'ws://localhost:8082/ws' }
+      } as any);
+
+      expect(result.request.body.mode).toBe('ws');
+    });
+  });
+});

--- a/packages/bruno-filestore/src/formats/yml/items/parseWebsocketRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseWebsocketRequest.ts
@@ -18,7 +18,7 @@ const parseWebsocketRequest = (ocRequest: WebSocketRequest): BrunoItem => {
     auth: toBrunoAuth(websocket?.auth),
     body: {
       mode: 'ws',
-      ws: []
+      ws: [{ name: 'message 1', type: 'text', content: '{}' }]
     },
     script: {
       req: null,

--- a/tests/websockets/fixtures/collection/ws-empty-message.bru
+++ b/tests/websockets/fixtures/collection/ws-empty-message.bru
@@ -1,0 +1,10 @@
+meta {
+  name: ws-empty-message
+  type: ws
+  seq: 3
+}
+
+ws {
+  url: ws://localhost:8082/ws
+  auth: inherit
+}


### PR DESCRIPTION
Fixes #8152 — WebSocket message input not present.

When a WebSocket request had body.ws = [] (an empty array), the Message tab rendered completely blank — no editor and no "Add Message" button. This made it impossible to compose or send any outbound WebSocket message, even though the connection itself worked fine.

This occurs specifically when importing a WebSocket request from OpenCollection YAML format where no message data is present. The YAML parser initialized body.ws = [] by default, and the WsBody component's guard condition did not treat an empty array as an empty state (since [] is truthy in JavaScript), causing the UI to silently render nothing.

Changes:
1. packages/bruno-app/src/components/RequestPane/WsBody/index.js — Extended the empty-state guard to also handle body.ws = [], so the "Add Message" button is shown instead of a blank screen.
2. packages/bruno-filestore/src/formats/yml/items/parseWebsocketRequest.ts — Changed the YAML parser to initialize WS requests with one default message ({}) instead of an empty array, consistent with how .bru format and new request creation already behave.
3. Added unit tests for both changes to prevent regression.

Before: Message tab is completely blank when body.ws = [].

<img width="904" height="957" alt="image" src="https://github.com/user-attachments/assets/8d7ba97b-e153-453e-bb20-deb6d6637d2c" />

After: "Add Message" button is shown, allowing the user to compose and send messages normally.

<img width="1916" height="482" alt="image" src="https://github.com/user-attachments/assets/7d81b4f0-7f78-4438-a5d9-d7563baa28cc" />



- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed WebSocket request display to properly show empty state when no messages are configured.
  * Improved WebSocket request initialization to include a default placeholder message template.

* **Tests**
  * Added test coverage for WebSocket message component rendering and state handling.
  * Added test coverage for WebSocket request parsing and message initialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->