### PR TITLE
fix(cli): save cookies from successful responses

### DIFF
--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -137,6 +137,10 @@ function makeAxiosInstance({
       response.headers['request-duration'] = end - start;
       redirectCount = 0;
 
+      if (!disableCookies) {
+        saveCookies(response.config.url, response.headers);
+      }
+
       return response;
     },
     async (error) => {

--- a/packages/bruno-cli/tests/utils/axios-instance.spec.js
+++ b/packages/bruno-cli/tests/utils/axios-instance.spec.js
@@ -25,6 +25,40 @@ function createStubAdapter(responseHeaders = {}) {
   return adapter;
 }
 
+function createRedirectStubAdapter(finalHeaders = {}) {
+  let callCount = 0;
+  let capturedConfig = null;
+
+  const adapter = (config) => {
+    capturedConfig = config;
+    callCount += 1;
+
+    if (callCount === 1) {
+      return Promise.reject({
+        config,
+        response: {
+          status: 302,
+          statusText: 'Found',
+          headers: { location: 'https://api.example.com/final' },
+          config
+        }
+      });
+    }
+
+    return Promise.resolve({
+      data: {},
+      status: 200,
+      statusText: 'OK',
+      headers: finalHeaders,
+      config
+    });
+  };
+
+  adapter.getConfig = () => capturedConfig;
+
+  return adapter;
+}
+
 describe('makeAxiosInstance', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -61,6 +95,20 @@ describe('makeAxiosInstance', () => {
     expect(addCookieToJar).toHaveBeenCalledWith(
       'session=abc123; Path=/; HttpOnly',
       'https://api.example.com/login'
+    );
+  });
+
+  it('saves Set-Cookie headers against the final URL after a redirect', async () => {
+    const stubAdapter = createRedirectStubAdapter({
+      'set-cookie': ['session=final; Path=/; HttpOnly']
+    });
+    const instance = makeAxiosInstance();
+
+    await instance({ url: 'https://api.example.com/login', method: 'get', adapter: stubAdapter });
+
+    expect(addCookieToJar).toHaveBeenCalledWith(
+      'session=final; Path=/; HttpOnly',
+      'https://api.example.com/final'
     );
   });
 

--- a/packages/bruno-cli/tests/utils/axios-instance.spec.js
+++ b/packages/bruno-cli/tests/utils/axios-instance.spec.js
@@ -1,12 +1,23 @@
-const { describe, it, expect } = require('@jest/globals');
-const { makeAxiosInstance } = require('../../src/utils/axios-instance');
+const { describe, it, expect, beforeEach } = require('@jest/globals');
 
-function createStubAdapter() {
+jest.mock('../../src/utils/cookies', () => ({
+  addCookieToJar: jest.fn(),
+  getCookieStringForUrl: jest.fn(() => '')
+}));
+
+jest.mock('../../src/utils/proxy-util', () => ({
+  setupProxyAgents: jest.fn()
+}));
+
+const { makeAxiosInstance } = require('../../src/utils/axios-instance');
+const { addCookieToJar } = require('../../src/utils/cookies');
+
+function createStubAdapter(responseHeaders = {}) {
   let capturedConfig = null;
 
   const adapter = (config) => {
     capturedConfig = config;
-    return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: {}, config });
+    return Promise.resolve({ data: {}, status: 200, statusText: 'OK', headers: responseHeaders, config });
   };
 
   adapter.getConfig = () => capturedConfig;
@@ -15,6 +26,10 @@ function createStubAdapter() {
 }
 
 describe('makeAxiosInstance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('setting User-Agent does not clobber the axios default Accept header', async () => {
     const stubAdapter = createStubAdapter();
     const instance = makeAxiosInstance();
@@ -33,5 +48,30 @@ describe('makeAxiosInstance', () => {
     await instance({ url: 'https://api.example.com/test', method: 'get', adapter: stubAdapter });
 
     expect(stubAdapter.getConfig().headers['User-Agent']).toMatch(/^bruno-runtime\//);
+  });
+
+  it('saves Set-Cookie headers from successful responses', async () => {
+    const stubAdapter = createStubAdapter({
+      'set-cookie': ['session=abc123; Path=/; HttpOnly']
+    });
+    const instance = makeAxiosInstance();
+
+    await instance({ url: 'https://api.example.com/login', method: 'get', adapter: stubAdapter });
+
+    expect(addCookieToJar).toHaveBeenCalledWith(
+      'session=abc123; Path=/; HttpOnly',
+      'https://api.example.com/login'
+    );
+  });
+
+  it('does not save successful response cookies when cookies are disabled', async () => {
+    const stubAdapter = createStubAdapter({
+      'set-cookie': ['session=abc123; Path=/; HttpOnly']
+    });
+    const instance = makeAxiosInstance({ disableCookies: true });
+
+    await instance({ url: 'https://api.example.com/login', method: 'get', adapter: stubAdapter });
+
+    expect(addCookieToJar).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Description

Fixes #8090

- Save `Set-Cookie` headers from successful CLI axios responses into the cookie jar.
- Add focused coverage for saving 2xx cookies and respecting `disableCookies`.

#### Tests

- `node --experimental-vm-modules ../../node_modules/jest/bin/jest.js tests/utils/axios-instance.spec.js --runInBand`
- `npm run lint -- packages/bruno-cli/src/utils/axios-instance.js packages/bruno-cli/tests/utils/axios-instance.spec.js`

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cookie persistence now saves cookies from successful HTTP responses as well as during redirects; respecting the disable-cookies setting.
* **Tests**
  * Added and improved tests to verify cookie saving behavior, redirect handling, and that cookie persistence is disabled when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->