### PR TITLE
fix(cli): preserve invalid JSON body strings

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -31,6 +31,24 @@ const getCACertHostRegex = (domain) => {
   return '^https:\\/\\/' + domain.replaceAll('.', '\\.').replaceAll('*', '.*');
 };
 
+const getContentType = (headers = {}) => {
+  let contentType = '';
+  forOwn(headers, (value, key) => {
+    if (key && key.toLowerCase() === 'content-type') {
+      contentType = value;
+    }
+  });
+
+  return typeof contentType === 'string' ? contentType : '';
+};
+
+const preserveRawJsonStringBody = (request) => {
+  const contentType = getContentType(request.headers).toLowerCase();
+  if (!request.transformRequest && typeof request.data === 'string' && contentType.includes('json')) {
+    request.transformRequest = [(data) => data];
+  }
+};
+
 /**
  * Extract prompt variables from a request
  * Tries to respect the hierarchy of the variables and avoid unnecessary prompts as much as possible
@@ -663,6 +681,8 @@ const runSingleRequest = async function (
         addDigestInterceptor(axiosInstance, request);
         delete request.digestConfig;
       }
+
+      preserveRawJsonStringBody(request);
 
       /** @type {import('axios').AxiosResponse} */
       response = await axiosInstance(request);

--- a/packages/bruno-cli/tests/runner/response-fields.spec.js
+++ b/packages/bruno-cli/tests/runner/response-fields.spec.js
@@ -195,3 +195,70 @@ describe('runSingleRequest: duration and size fields (issue #7352)', () => {
     expect(result.response.responseTime).toBe(0);
   });
 });
+
+describe('runSingleRequest: JSON string request bodies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should preserve raw string bodies for JSON requests', async () => {
+    const rawBody = '{"authorizationResult": ano }';
+    const headers = {
+      get: (key) => key === 'request-duration' ? '0' : null,
+      delete: jest.fn()
+    };
+
+    prepareRequest.mockResolvedValue({
+      method: 'POST',
+      url: 'http://example.com/api',
+      headers: { 'Content-Type': 'application/json' },
+      data: rawBody,
+      settings: {}
+    });
+
+    const mockAxios = jest.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers,
+      data: 'ok',
+      request: { protocol: 'http:', host: 'example.com', path: '/api' }
+    });
+    makeAxiosInstance.mockReturnValue(mockAxios);
+
+    await runSingleRequest(...baseArgs);
+
+    const sentRequest = mockAxios.mock.calls[0][0];
+    expect(sentRequest.data).toBe(rawBody);
+    expect(sentRequest.transformRequest).toHaveLength(1);
+    expect(sentRequest.transformRequest[0](rawBody)).toBe(rawBody);
+  });
+
+  it('should not override axios transforms for JSON object bodies', async () => {
+    const headers = {
+      get: (key) => key === 'request-duration' ? '0' : null,
+      delete: jest.fn()
+    };
+
+    prepareRequest.mockResolvedValue({
+      method: 'POST',
+      url: 'http://example.com/api',
+      headers: { 'content-type': 'application/json' },
+      data: { ok: true },
+      settings: {}
+    });
+
+    const mockAxios = jest.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers,
+      data: 'ok',
+      request: { protocol: 'http:', host: 'example.com', path: '/api' }
+    });
+    makeAxiosInstance.mockReturnValue(mockAxios);
+
+    await runSingleRequest(...baseArgs);
+
+    const sentRequest = mockAxios.mock.calls[0][0];
+    expect(sentRequest.transformRequest).toBeUndefined();
+  });
+});

--- a/packages/bruno-cli/tests/runner/response-fields.spec.js
+++ b/packages/bruno-cli/tests/runner/response-fields.spec.js
@@ -233,6 +233,39 @@ describe('runSingleRequest: JSON string request bodies', () => {
     expect(sentRequest.transformRequest[0](rawBody)).toBe(rawBody);
   });
 
+  it('should not override existing transforms for JSON string bodies', async () => {
+    const rawBody = '{"authorizationResult": ano }';
+    const transformRequest = jest.fn((data) => data);
+    const headers = {
+      get: (key) => key === 'request-duration' ? '0' : null,
+      delete: jest.fn()
+    };
+
+    prepareRequest.mockResolvedValue({
+      method: 'POST',
+      url: 'http://example.com/api',
+      headers: { 'Content-Type': 'application/json' },
+      data: rawBody,
+      transformRequest,
+      settings: {}
+    });
+
+    const mockAxios = jest.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers,
+      data: 'ok',
+      request: { protocol: 'http:', host: 'example.com', path: '/api' }
+    });
+    makeAxiosInstance.mockReturnValue(mockAxios);
+
+    await runSingleRequest(...baseArgs);
+
+    const sentRequest = mockAxios.mock.calls[0][0];
+    expect(sentRequest.data).toBe(rawBody);
+    expect(sentRequest.transformRequest).toBe(transformRequest);
+  });
+
   it('should not override axios transforms for JSON object bodies', async () => {
     const headers = {
       get: (key) => key === 'request-duration' ? '0' : null,


### PR DESCRIPTION
### Description

Fixes #8055

- Keeps CLI JSON string bodies raw at send time, so malformed JSON is sent exactly as entered instead of serialized as a JSON string.
- Leaves JSON object bodies on Axios default transform path.

#### Contribution Checklist:

- [x] I have used AI significantly to create this pull request
- [x] The pull request only addresses one issue or adds one feature.
- [x] The pull request does not introduce any breaking changes
- [x] I have added screenshots or gifs to help explain the change if applicable. (Not applicable; CLI behavior only)
- [x] I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).
- [x] Create an issue and link to the pull request.

#### Tests

- `npx eslint packages/bruno-cli/src/runner/run-single-request.js packages/bruno-cli/tests/runner/response-fields.spec.js`
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js packages/bruno-cli/tests/runner --runInBand`
- Local HTTP server smoke check confirmed the received body stays `{"authorizationResult": ano }`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve raw JSON string bodies in CLI requests and avoid overwriting existing request transformers so JSON payloads are sent unchanged.
* **Tests**
  * Added test coverage verifying raw JSON string preservation, non-replacement of provided transformers, and unchanged behavior for JSON object bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->