### PR TITLE
fix(bruno-app): use primary accent in OpenAPI Sync settings modal

### DIFF
--- a/packages/bruno-app/src/components/OpenAPISyncTab/StyledWrapper.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/StyledWrapper.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { rgba, darken } from 'polished';
+import { rgba } from 'polished';
 
 const StyledWrapper = styled.div`
 
@@ -687,7 +687,7 @@ const StyledWrapper = styled.div`
       background: ${(props) => props.theme.colors.text.muted};
 
       &.active {
-        background: ${(props) => props.theme.colors.text.green};
+        background: ${(props) => props.theme.button2.color.primary.bg};
       }
 
       .toggle-knob {
@@ -2288,9 +2288,8 @@ const StyledWrapper = styled.div`
     white-space: nowrap;
 
     &.active {
-      background: ${(props) => darken(0.03, props.theme.background.base)};
-      color: ${(props) => props.theme.button2.color.secondary.text};
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+      background: ${(props) => props.theme.button2.color.primary.bg};
+      color: ${(props) => props.theme.button2.color.primary.text};
     }
 
     &:hover:not(.active) {


### PR DESCRIPTION
### Description

Aligns the **Auto-check for updates** toggle and the **URL/File** mode buttons in the OpenAPI Sync **Connection Settings** modal with Bruno's primary theme accent. Previously the toggle's active state was bright green and the URL/File active state was a near-black gray, which both clashed with the modal's Save button and the active **Check interval** pill (both already use the primary accent).

Refs: [BRU-3409](https://usebruno.atlassian.net/browse/BRU-3409)

Pure CSS swap — uses the existing `theme.button2.color.primary.bg` / `theme.button2.color.primary.text` tokens (same tokens used by the Save button and active interval pill). No behavior change. Resolves correctly across all 14 themes (light + dark + catppuccin variants) via the per-theme palette.

Also drops the now-unused `darken` import from `polished` in the same file.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.** (attached in PR comments)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (Jira BRU-3409)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated theme color usage for toggle switches and setup buttons: active states now use primary background and text colors from the design system to ensure consistent visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->