### PR TITLE
fix(bruno-app): use primary accent in OpenAPI Sync settings modal

### DIFF
--- a/packages/bruno-app/src/components/OpenAPISyncTab/StyledWrapper.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/StyledWrapper.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { rgba, darken } from 'polished';
+import { rgba } from 'polished';
 
 const StyledWrapper = styled.div`
 
@@ -687,7 +687,7 @@ const StyledWrapper = styled.div`
       background: ${(props) => props.theme.colors.text.muted};
 
       &.active {
-        background: ${(props) => props.theme.colors.text.green};
+        background: ${(props) => props.theme.button2.color.primary.bg};
       }
 
       .toggle-knob {
@@ -2288,9 +2288,8 @@ const StyledWrapper = styled.div`
     white-space: nowrap;
 
     &.active {
-      background: ${(props) => darken(0.03, props.theme.background.base)};
-      color: ${(props) => props.theme.button2.color.secondary.text};
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+      background: ${(props) => props.theme.button2.color.primary.bg};
+      color: ${(props) => props.theme.button2.color.primary.text};
     }
 
     &:hover:not(.active) {

--- a/packages/bruno-app/src/components/OpenAPISyncTab/StyledWrapper.js
+++ b/packages/bruno-app/src/components/OpenAPISyncTab/StyledWrapper.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { rgba } from 'polished';
+import { rgba, darken } from 'polished';
 
 const StyledWrapper = styled.div`
 
@@ -724,9 +724,9 @@ const StyledWrapper = styled.div`
         transition: all 0.15s;
 
         &.active {
-          border-color: ${(props) => props.theme.button2.color.primary.border};
-          background: ${(props) => props.theme.button2.color.primary.bg};
-          color: ${(props) => props.theme.button2.color.primary.text};
+          border-color: ${(props) => props.theme.accents.primary};
+          background: ${(props) => rgba(props.theme.accents.primary, 0.07)};
+          color: ${(props) => props.theme.accents.primary};
         }
       }
     }
@@ -2288,8 +2288,9 @@ const StyledWrapper = styled.div`
     white-space: nowrap;
 
     &.active {
-      background: ${(props) => props.theme.button2.color.primary.bg};
-      color: ${(props) => props.theme.button2.color.primary.text};
+      background: ${(props) => darken(0.03, props.theme.background.base)};
+      color: ${(props) => props.theme.button2.color.secondary.text};
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
     }
 
     &:hover:not(.active) {


### PR DESCRIPTION
### Description

Aligns the OpenAPI Sync **Connection Settings** modal with Bruno's primary theme accent, fixing the out-of-place bright-green **Auto-check for updates** toggle.

JIRA: [BRU-3409](https://usebruno.atlassian.net/browse/BRU-3409)

Changes (pure CSS, no behavior change):

- **Auto-check toggle** — active state now uses the primary accent (`theme.button2.color.primary.bg`) instead of green, matching the Save button.
- **Check interval pills** (5 / 15 / 30 / 60 min) — active state now uses an inline yellow style (accent border + faint accent tint + accent text via `theme.accents.primary`) instead of a solid primary fill, matching the Appearance theme toggle in Preferences.

Resolves correctly across all built-in themes (light + dark + catppuccin variants) via the per-theme palette.

### Images

Before : 
<img width="526" height="355" alt="Screenshot 2026-06-01 at 2 51 07 PM" src="https://github.com/user-attachments/assets/fdca31da-fa31-4ee4-9cb8-2c4d72b4ad97" />

After : 
<img width="533" height="349" alt="2026-06-02_13-26-14" src="https://github.com/user-attachments/assets/b24d5fe5-0675-4371-8408-a9ea361f3336" />



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.** (attached in PR comments)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [] **Create an issue and link to the pull request.** 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified active-state colors in the connection settings modal and setup form to use the primary accent theme, improving visual consistency for toggle and interval controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->