### PR TITLE
fix(ui): add internal scrolling to context menu to prevent clipping on small screens (#8117)

### DIFF
--- a/packages/bruno-app/src/components/Dropdown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Dropdown/StyledWrapper.js
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
     props.theme.dropdown.border && props.theme.dropdown.border !== 'none'
       ? `border: 1px solid ${props.theme.dropdown.border};`
       : ''}
-  max-height: 90vh;
+  max-height: 50vh;
   overflow-y: auto;
   max-width: unset !important;
   padding: 0.25rem;

--- a/packages/bruno-app/src/ui/MenuDropdown/index.js
+++ b/packages/bruno-app/src/ui/MenuDropdown/index.js
@@ -492,7 +492,7 @@ const MenuDropdown = forwardRef(({
             <div className="dropdown-divider"></div>
           </div>
         )}
-        <div role="menu" tabIndex={-1} onKeyDown={handleMenuKeyDown}>
+        <div role="menu" tabIndex={-1} onKeyDown={handleMenuKeyDown} style={{ overflowY: 'auto', maxHeight: 'calc(50vh - 40px)' }}>
           {renderMenuContent()}
         </div>
         {footer && (


### PR DESCRIPTION
### Description

* ADDED overflow-y: auto and max-height: calc(50vh - 40px) to the menu container
  - Prevents context menu from being clipped on small screens
  - Menu content scrolls internally when items exceed available space
  - 40px offset accounts for header/footer padding

Closes #8117.

Screenshots of the scrollbar on the smaller screen in Bruno app:

1. Context menu opening above the parent collection for which it is opened:

<img width="903" height="523" alt="image" src="https://github.com/user-attachments/assets/0868bc28-13e8-44b9-99df-4c179d9c4152" />

<img width="910" height="524" alt="image" src="https://github.com/user-attachments/assets/e21cfb7c-91dc-4658-abe4-ccade879b8fa" />


2. Context menu opening below the parent collection for which it is opened:

<img width="912" height="526" alt="image" src="https://github.com/user-attachments/assets/463555ae-07ed-47e2-b86f-58cb7c173bf6" />

<img width="908" height="521" alt="image" src="https://github.com/user-attachments/assets/3df3ef3d-4cad-483c-b61f-31b7c8ccfb49" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved scrolling behavior for dropdown and menu components with refined size constraints, enabling better handling of large item lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->