### PR TITLE
fix(cli): use path name for classname in JUnit reports instead of request URL

### DIFF
--- a/packages/bruno-cli/src/reporters/junit.js
+++ b/packages/bruno-cli/src/reporters/junit.js
@@ -15,7 +15,7 @@ const makeJUnitOutput = async (results, outputPath) => {
     const testCount = result.testResults ? result.testResults.length : 0;
     const postResponseTestCount = result.postResponseTestResults ? result.postResponseTestResults.length : 0;
     const totalTests = assertionTestCount + preRequestTestCount + testCount + postResponseTestCount;
-    const classname = result.name;
+    const classname = result.path;
 
     const suite = {
       '@name': result.name,

--- a/packages/bruno-cli/src/reporters/junit.js
+++ b/packages/bruno-cli/src/reporters/junit.js
@@ -15,6 +15,7 @@ const makeJUnitOutput = async (results, outputPath) => {
     const testCount = result.testResults ? result.testResults.length : 0;
     const postResponseTestCount = result.postResponseTestResults ? result.postResponseTestResults.length : 0;
     const totalTests = assertionTestCount + preRequestTestCount + testCount + postResponseTestCount;
+    const classname = result.name;
 
     const suite = {
       '@name': result.name,
@@ -34,7 +35,7 @@ const makeJUnitOutput = async (results, outputPath) => {
       const testcase = {
         '@name': `${assertion.lhsExpr} ${assertion.rhsExpr}`,
         '@status': assertion.status,
-        '@classname': result.request.url,
+        '@classname': classname,
         '@time': (result.runDuration / totalTests).toFixed(3)
       };
 
@@ -52,7 +53,7 @@ const makeJUnitOutput = async (results, outputPath) => {
       const testcase = {
         '@name': test.description,
         '@status': test.status,
-        '@classname': result.request.url,
+        '@classname': classname,
         '@time': (result.runDuration / totalTests).toFixed(3)
       };
 
@@ -70,7 +71,7 @@ const makeJUnitOutput = async (results, outputPath) => {
       const testcase = {
         '@name': test.description,
         '@status': test.status,
-        '@classname': result.request.url,
+        '@classname': classname,
         '@time': (result.runDuration / totalTests).toFixed(3)
       };
 
@@ -88,7 +89,7 @@ const makeJUnitOutput = async (results, outputPath) => {
       const testcase = {
         '@name': test.description,
         '@status': test.status,
-        '@classname': result.request.url,
+        '@classname': classname,
         '@time': (result.runDuration / totalTests).toFixed(3)
       };
 
@@ -110,7 +111,7 @@ const makeJUnitOutput = async (results, outputPath) => {
         {
           '@name': 'Test suite has no errors',
           '@status': 'fail',
-          '@classname': result.request.url,
+          '@classname': classname,
           '@time': result.runDuration.toFixed(3),
           'error': [{ '@type': 'error', '@message': result.error }]
         }

--- a/packages/bruno-cli/src/reporters/junit.js
+++ b/packages/bruno-cli/src/reporters/junit.js
@@ -1,6 +1,7 @@
 const os = require('os');
 const fs = require('fs');
 const xmlbuilder = require('xmlbuilder');
+const { stripExtension } = require('../utils/filesystem');
 
 const makeJUnitOutput = async (results, outputPath) => {
   const output = {
@@ -15,7 +16,7 @@ const makeJUnitOutput = async (results, outputPath) => {
     const testCount = result.testResults ? result.testResults.length : 0;
     const postResponseTestCount = result.postResponseTestResults ? result.postResponseTestResults.length : 0;
     const totalTests = assertionTestCount + preRequestTestCount + testCount + postResponseTestCount;
-    const classname = result.path;
+    const classname = stripExtension(result.path);
 
     const suite = {
       '@name': result.name,

--- a/packages/bruno-cli/tests/reporters/junit.spec.js
+++ b/packages/bruno-cli/tests/reporters/junit.spec.js
@@ -103,6 +103,35 @@ describe('makeJUnitOutput', () => {
     expect(failcase.failure[0]['@type']).toBe('failure');
   });
 
+  it('should use the request name as the testcase classname instead of the request url', () => {
+    const results = [
+      {
+        name: 'Get Users',
+        test: {
+          filename: 'Tests/Get Users.bru'
+        },
+        request: {
+          method: 'GET',
+          url: 'https://ima.test'
+        },
+        testResults: [
+          {
+            description: 'Status is 200',
+            status: 'pass'
+          }
+        ],
+        runDuration: 1.2345678
+      }
+    ];
+
+    makeJUnitOutput(results, '/tmp/testfile.xml');
+
+    const junit = xmlbuilder.create.mock.calls[0][0];
+    const testcase = junit.testsuites.testsuite[0].testcase[0];
+
+    expect(testcase['@classname']).toBe('Get Users');
+  });
+
   it('should handle request errors', () => {
     const results = [
       {

--- a/packages/bruno-cli/tests/reporters/junit.spec.js
+++ b/packages/bruno-cli/tests/reporters/junit.spec.js
@@ -103,12 +103,13 @@ describe('makeJUnitOutput', () => {
     expect(failcase.failure[0]['@type']).toBe('failure');
   });
 
-  it('should use the request name as the testcase classname instead of the request url', () => {
+  it('should use the request path as the testcase classname instead of the request url', () => {
     const results = [
       {
-        name: 'Get Users',
+        name: '1st API',
+        path: 'f1/1st API.bru',
         test: {
-          filename: 'Tests/Get Users.bru'
+          filename: 'f1/1st API.bru'
         },
         request: {
           method: 'GET',
@@ -129,7 +130,7 @@ describe('makeJUnitOutput', () => {
     const junit = xmlbuilder.create.mock.calls[0][0];
     const testcase = junit.testsuites.testsuite[0].testcase[0];
 
-    expect(testcase['@classname']).toBe('Get Users');
+    expect(testcase['@classname']).toBe('f1/1st API');
   });
 
   it('should handle request errors', () => {

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts
@@ -13,8 +13,9 @@ function normalizeJunitReport(xmlContent: string): string {
     .replace(/time="[^"]*"/g, 'time="0.100"')
     // Replace file paths with normalized path
     .replace(/file="[^"]*[\\/][^"]*"/g, 'file="/mock/path/to/file.bru"')
-    // Replace test paths with normalized path
-    .replace(/classname="[^"]*[\\/][^"]*"/g, 'classname="/test/path/collection"');
+    // classname is the request's relative path within the collection (stable across
+    // environments); only normalize the path separator so snapshots match on all platforms
+    .replace(/classname="([^"]*)"/g, (_match, value) => `classname="${value.replace(/\\/g, '/')}"`);
 }
 
 test.describe('Collection Run Report Tests', () => {

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts
@@ -12,10 +12,7 @@ function normalizeJunitReport(xmlContent: string): string {
     // Replace execution times with fixed value
     .replace(/time="[^"]*"/g, 'time="0.100"')
     // Replace file paths with normalized path
-    .replace(/file="[^"]*[\\/][^"]*"/g, 'file="/mock/path/to/file.bru"')
-    // classname is the request's relative path within the collection (stable across
-    // environments); only normalize the path separator so snapshots match on all platforms
-    .replace(/classname="([^"]*)"/g, (_match, value) => `classname="${value.replace(/\\/g, '/')}"`);
+    .replace(/file="[^"]*[\\/][^"]*"/g, 'file="/mock/path/to/file.bru"');
 }
 
 test.describe('Collection Run Report Tests', () => {

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts
@@ -10,9 +10,7 @@ function normalizeJunitReport(xmlContent: string): string {
     // Replace hostnames with fixed value
     .replace(/hostname="[^"]*"/g, 'hostname="test-host"')
     // Replace execution times with fixed value
-    .replace(/time="[^"]*"/g, 'time="0.100"')
-    // Replace file paths with normalized path
-    .replace(/file="[^"]*[\\/][^"]*"/g, 'file="/mock/path/to/file.bru"');
+    .replace(/time="[^"]*"/g, 'time="0.100"');
 }
 
 test.describe('Collection Run Report Tests', () => {

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-darwin.xml
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-darwin.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <testsuites>
   <testsuite name="Get User Info" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response is an object" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has slideshow property" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Slideshow has title" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Response is an object" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Response has slideshow property" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Slideshow has title" status="pass" classname="api/v1/users" time="0.100"/>
   </testsuite>
   <testsuite name="Get UUID" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="This test will fail" status="fail" classname="/test/path/collection" time="0.100">
+    <testcase name="This test will fail" status="fail" classname="api/v1/posts" time="0.100">
       <failure type="failure" message="expected 200 to equal 404"/>
     </testcase>
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response is an object" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has uuid property" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="UUID is a string" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="Response is an object" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="Response has uuid property" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="UUID is a string" status="pass" classname="api/v1/posts" time="0.100"/>
   </testsuite>
   <testsuite name="Login Request" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has json field" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response json has username" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="auth/login" time="0.100"/>
+    <testcase name="Response has json field" status="pass" classname="auth/login" time="0.100"/>
+    <testcase name="Response json has username" status="pass" classname="auth/login" time="0.100"/>
   </testsuite>
   <testsuite name="Logout Request" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="This test will also fail" status="fail" classname="/test/path/collection" time="0.100">
+    <testcase name="This test will also fail" status="fail" classname="auth/logout" time="0.100">
       <failure type="failure" message="expected 200 to equal 500"/>
     </testcase>
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="auth/logout" time="0.100"/>
   </testsuite>
 </testsuites>

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-darwin.xml
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-darwin.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <testsuites>
-  <testsuite name="Get User Info" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Get User Info" file="api/v1/users.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="Status code is 200" status="pass" classname="api/v1/users" time="0.100"/>
     <testcase name="Response is an object" status="pass" classname="api/v1/users" time="0.100"/>
     <testcase name="Response has slideshow property" status="pass" classname="api/v1/users" time="0.100"/>
     <testcase name="Slideshow has title" status="pass" classname="api/v1/users" time="0.100"/>
   </testsuite>
-  <testsuite name="Get UUID" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Get UUID" file="api/v1/posts.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="This test will fail" status="fail" classname="api/v1/posts" time="0.100">
       <failure type="failure" message="expected 200 to equal 404"/>
     </testcase>
@@ -15,12 +15,12 @@
     <testcase name="Response has uuid property" status="pass" classname="api/v1/posts" time="0.100"/>
     <testcase name="UUID is a string" status="pass" classname="api/v1/posts" time="0.100"/>
   </testsuite>
-  <testsuite name="Login Request" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Login Request" file="auth/login.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="Status code is 200" status="pass" classname="auth/login" time="0.100"/>
     <testcase name="Response has json field" status="pass" classname="auth/login" time="0.100"/>
     <testcase name="Response json has username" status="pass" classname="auth/login" time="0.100"/>
   </testsuite>
-  <testsuite name="Logout Request" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Logout Request" file="auth/logout.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="This test will also fail" status="fail" classname="auth/logout" time="0.100">
       <failure type="failure" message="expected 200 to equal 500"/>
     </testcase>

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-linux.xml
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-linux.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <testsuites>
   <testsuite name="Get User Info" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response is an object" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has slideshow property" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Slideshow has title" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Response is an object" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Response has slideshow property" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Slideshow has title" status="pass" classname="api/v1/users" time="0.100"/>
   </testsuite>
   <testsuite name="Get UUID" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="This test will fail" status="fail" classname="/test/path/collection" time="0.100">
+    <testcase name="This test will fail" status="fail" classname="api/v1/posts" time="0.100">
       <failure type="failure" message="expected 200 to equal 404"/>
     </testcase>
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response is an object" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has uuid property" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="UUID is a string" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="Response is an object" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="Response has uuid property" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="UUID is a string" status="pass" classname="api/v1/posts" time="0.100"/>
   </testsuite>
   <testsuite name="Login Request" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has json field" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response json has username" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="auth/login" time="0.100"/>
+    <testcase name="Response has json field" status="pass" classname="auth/login" time="0.100"/>
+    <testcase name="Response json has username" status="pass" classname="auth/login" time="0.100"/>
   </testsuite>
   <testsuite name="Logout Request" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="This test will also fail" status="fail" classname="/test/path/collection" time="0.100">
+    <testcase name="This test will also fail" status="fail" classname="auth/logout" time="0.100">
       <failure type="failure" message="expected 200 to equal 500"/>
     </testcase>
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="auth/logout" time="0.100"/>
   </testsuite>
 </testsuites>

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-linux.xml
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-linux.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <testsuites>
-  <testsuite name="Get User Info" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Get User Info" file="api/v1/users.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="Status code is 200" status="pass" classname="api/v1/users" time="0.100"/>
     <testcase name="Response is an object" status="pass" classname="api/v1/users" time="0.100"/>
     <testcase name="Response has slideshow property" status="pass" classname="api/v1/users" time="0.100"/>
     <testcase name="Slideshow has title" status="pass" classname="api/v1/users" time="0.100"/>
   </testsuite>
-  <testsuite name="Get UUID" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Get UUID" file="api/v1/posts.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="This test will fail" status="fail" classname="api/v1/posts" time="0.100">
       <failure type="failure" message="expected 200 to equal 404"/>
     </testcase>
@@ -15,12 +15,12 @@
     <testcase name="Response has uuid property" status="pass" classname="api/v1/posts" time="0.100"/>
     <testcase name="UUID is a string" status="pass" classname="api/v1/posts" time="0.100"/>
   </testsuite>
-  <testsuite name="Login Request" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Login Request" file="auth/login.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="Status code is 200" status="pass" classname="auth/login" time="0.100"/>
     <testcase name="Response has json field" status="pass" classname="auth/login" time="0.100"/>
     <testcase name="Response json has username" status="pass" classname="auth/login" time="0.100"/>
   </testsuite>
-  <testsuite name="Logout Request" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Logout Request" file="auth/logout.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="This test will also fail" status="fail" classname="auth/logout" time="0.100">
       <failure type="failure" message="expected 200 to equal 500"/>
     </testcase>

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-win32.xml
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-win32.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <testsuites>
-  <testsuite name="Get User Info" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Get User Info" file="api\v1\users.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="Status code is 200" status="pass" classname="api\v1\users" time="0.100"/>
     <testcase name="Response is an object" status="pass" classname="api\v1\users" time="0.100"/>
     <testcase name="Response has slideshow property" status="pass" classname="api\v1\users" time="0.100"/>
     <testcase name="Slideshow has title" status="pass" classname="api\v1\users" time="0.100"/>
   </testsuite>
-  <testsuite name="Get UUID" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Get UUID" file="api\v1\posts.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="This test will fail" status="fail" classname="api\v1\posts" time="0.100">
       <failure type="failure" message="expected 200 to equal 404"/>
     </testcase>
@@ -15,12 +15,12 @@
     <testcase name="Response has uuid property" status="pass" classname="api\v1\posts" time="0.100"/>
     <testcase name="UUID is a string" status="pass" classname="api\v1\posts" time="0.100"/>
   </testsuite>
-  <testsuite name="Login Request" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Login Request" file="auth\login.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="Status code is 200" status="pass" classname="auth\login" time="0.100"/>
     <testcase name="Response has json field" status="pass" classname="auth\login" time="0.100"/>
     <testcase name="Response json has username" status="pass" classname="auth\login" time="0.100"/>
   </testsuite>
-  <testsuite name="Logout Request" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
+  <testsuite name="Logout Request" file="auth\logout.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
     <testcase name="This test will also fail" status="fail" classname="auth\logout" time="0.100">
       <failure type="failure" message="expected 200 to equal 500"/>
     </testcase>

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-win32.xml
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-win32.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <testsuites>
   <testsuite name="Get User Info" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="Status code is 200" status="pass" classname="api/v1/users" time="0.100"/>
-    <testcase name="Response is an object" status="pass" classname="api/v1/users" time="0.100"/>
-    <testcase name="Response has slideshow property" status="pass" classname="api/v1/users" time="0.100"/>
-    <testcase name="Slideshow has title" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="api\v1\users" time="0.100"/>
+    <testcase name="Response is an object" status="pass" classname="api\v1\users" time="0.100"/>
+    <testcase name="Response has slideshow property" status="pass" classname="api\v1\users" time="0.100"/>
+    <testcase name="Slideshow has title" status="pass" classname="api\v1\users" time="0.100"/>
   </testsuite>
   <testsuite name="Get UUID" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="This test will fail" status="fail" classname="api/v1/posts" time="0.100">
+    <testcase name="This test will fail" status="fail" classname="api\v1\posts" time="0.100">
       <failure type="failure" message="expected 200 to equal 404"/>
     </testcase>
-    <testcase name="Status code is 200" status="pass" classname="api/v1/posts" time="0.100"/>
-    <testcase name="Response is an object" status="pass" classname="api/v1/posts" time="0.100"/>
-    <testcase name="Response has uuid property" status="pass" classname="api/v1/posts" time="0.100"/>
-    <testcase name="UUID is a string" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="api\v1\posts" time="0.100"/>
+    <testcase name="Response is an object" status="pass" classname="api\v1\posts" time="0.100"/>
+    <testcase name="Response has uuid property" status="pass" classname="api\v1\posts" time="0.100"/>
+    <testcase name="UUID is a string" status="pass" classname="api\v1\posts" time="0.100"/>
   </testsuite>
   <testsuite name="Login Request" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="Status code is 200" status="pass" classname="auth/login" time="0.100"/>
-    <testcase name="Response has json field" status="pass" classname="auth/login" time="0.100"/>
-    <testcase name="Response json has username" status="pass" classname="auth/login" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="auth\login" time="0.100"/>
+    <testcase name="Response has json field" status="pass" classname="auth\login" time="0.100"/>
+    <testcase name="Response json has username" status="pass" classname="auth\login" time="0.100"/>
   </testsuite>
   <testsuite name="Logout Request" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="This test will also fail" status="fail" classname="auth/logout" time="0.100">
+    <testcase name="This test will also fail" status="fail" classname="auth\logout" time="0.100">
       <failure type="failure" message="expected 200 to equal 500"/>
     </testcase>
-    <testcase name="Status code is 200" status="pass" classname="auth/logout" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="auth\logout" time="0.100"/>
   </testsuite>
 </testsuites>

--- a/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-win32.xml
+++ b/tests/runner/collection-run-report/collection-run-report.spec.ts-snapshots/cli-junit-report-default-win32.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <testsuites>
   <testsuite name="Get User Info" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="4" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response is an object" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has slideshow property" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Slideshow has title" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Response is an object" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Response has slideshow property" status="pass" classname="api/v1/users" time="0.100"/>
+    <testcase name="Slideshow has title" status="pass" classname="api/v1/users" time="0.100"/>
   </testsuite>
   <testsuite name="Get UUID" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="5" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="This test will fail" status="fail" classname="/test/path/collection" time="0.100">
+    <testcase name="This test will fail" status="fail" classname="api/v1/posts" time="0.100">
       <failure type="failure" message="expected 200 to equal 404"/>
     </testcase>
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response is an object" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has uuid property" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="UUID is a string" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="Response is an object" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="Response has uuid property" status="pass" classname="api/v1/posts" time="0.100"/>
+    <testcase name="UUID is a string" status="pass" classname="api/v1/posts" time="0.100"/>
   </testsuite>
   <testsuite name="Login Request" file="/mock/path/to/file.bru" errors="0" failures="0" skipped="0" tests="3" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response has json field" status="pass" classname="/test/path/collection" time="0.100"/>
-    <testcase name="Response json has username" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="auth/login" time="0.100"/>
+    <testcase name="Response has json field" status="pass" classname="auth/login" time="0.100"/>
+    <testcase name="Response json has username" status="pass" classname="auth/login" time="0.100"/>
   </testsuite>
   <testsuite name="Logout Request" file="/mock/path/to/file.bru" errors="0" failures="1" skipped="0" tests="2" timestamp="2024-01-01T00:00:00.000" hostname="test-host" time="0.100">
-    <testcase name="This test will also fail" status="fail" classname="/test/path/collection" time="0.100">
+    <testcase name="This test will also fail" status="fail" classname="auth/logout" time="0.100">
       <failure type="failure" message="expected 200 to equal 500"/>
     </testcase>
-    <testcase name="Status code is 200" status="pass" classname="/test/path/collection" time="0.100"/>
+    <testcase name="Status code is 200" status="pass" classname="auth/logout" time="0.100"/>
   </testsuite>
 </testsuites>


### PR DESCRIPTION
**Jira link: https://usebruno.atlassian.net/browse/BRU-3123**

### Description

The CLI's JUnit reporter used the request URL as the classname on each <testcase>. Since URLs change per environment/region, the same test produced duplicate entries in CI tools (Xray, Azure DevOps) that key tests by classname + name.

This changes classname to use the request name (matching Postman), so the same test maps to a single test case across all environments.

packages/bruno-cli/src/reporters/junit.js — classname now uses result.name instead of result.request.url
Added test coverage asserting classname is the request name
#### Contribution Checklist:

After fix:
<img width="1592" height="458" alt="image" src="https://github.com/user-attachments/assets/436c9f16-b112-49b7-a785-bc199a7f1abf" />


- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JUnit test reports now derive each testcase's classname from the test result path (file/path-derived name) instead of the request URL, improving report clarity.

* **Tests**
  * Added a unit test to assert classname derivation and updated JUnit test snapshots across platforms to reflect the new classname values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->