### PR TITLE
Fix AOSS SigV4 payload hash signing

### DIFF
--- a/packages/bruno-cli/src/runner/awsv4auth-helper.js
+++ b/packages/bruno-cli/src/runner/awsv4auth-helper.js
@@ -1,8 +1,50 @@
+const { createHash } = require('node:crypto');
 const { fromIni } = require('@aws-sdk/credential-providers');
 const { aws4Interceptor } = require('aws4-axios');
 
 function isStrPresent(str) {
   return str && str !== '' && str !== 'undefined';
+}
+
+function shouldAddContentSha(awsv4) {
+  return String(awsv4.service || '').toLowerCase() === 'aoss';
+}
+
+function getTransformer(config) {
+  const { transformRequest } = config;
+  if (typeof transformRequest === 'function') {
+    return transformRequest;
+  }
+
+  if (Array.isArray(transformRequest) && transformRequest.length) {
+    return transformRequest[0];
+  }
+}
+
+function setHeader(headers, name, value) {
+  if (headers && typeof headers.set === 'function') {
+    headers.set(name, value);
+    return;
+  }
+
+  headers[name] = value;
+}
+
+function addContentShaHeader(config) {
+  config.headers = config.headers || {};
+
+  const transformer = getTransformer(config);
+  const data = transformer ? transformer.call(config, config.data, config.headers) : config.data;
+  const hash = createHash('sha256').update(data ?? '', 'utf8').digest('hex');
+
+  setHeader(config.headers, 'X-Amz-Content-Sha256', hash);
+}
+
+function withContentShaHeader(interceptor) {
+  return async (config) => {
+    addContentShaHeader(config);
+    return interceptor(config);
+  };
 }
 
 async function resolveAwsV4Credentials(request) {
@@ -48,7 +90,7 @@ function addAwsV4Interceptor(axiosInstance, request) {
     }
   });
 
-  axiosInstance.interceptors.request.use(interceptor);
+  axiosInstance.interceptors.request.use(shouldAddContentSha(awsv4) ? withContentShaHeader(interceptor) : interceptor);
 }
 
 module.exports = {

--- a/packages/bruno-cli/src/runner/awsv4auth-helper.js
+++ b/packages/bruno-cli/src/runner/awsv4auth-helper.js
@@ -10,15 +10,26 @@ function shouldAddContentSha(awsv4) {
   return String(awsv4.service || '').toLowerCase() === 'aoss';
 }
 
-function getTransformer(config) {
+function getTransformers(config) {
   const { transformRequest } = config;
   if (typeof transformRequest === 'function') {
-    return transformRequest;
+    return [transformRequest];
   }
 
-  if (Array.isArray(transformRequest) && transformRequest.length) {
-    return transformRequest[0];
+  if (Array.isArray(transformRequest)) {
+    return transformRequest.filter((transformer) => typeof transformer === 'function');
   }
+
+  return [];
+}
+
+function getHeader(headers, name) {
+  if (headers && typeof headers.get === 'function') {
+    return headers.get(name);
+  }
+
+  const key = Object.keys(headers || {}).find((headerName) => headerName.toLowerCase() === name.toLowerCase());
+  return key ? headers[key] : undefined;
 }
 
 function setHeader(headers, name, value) {
@@ -30,12 +41,43 @@ function setHeader(headers, name, value) {
   headers[name] = value;
 }
 
+function getHashPayload(data) {
+  if (data == null) {
+    return '';
+  }
+
+  if (typeof data === 'string' || Buffer.isBuffer(data)) {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data);
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  }
+}
+
+function applyTransformers(config) {
+  return getTransformers(config).reduce((data, transformer) => {
+    return transformer.call(config, data, config.headers);
+  }, config.data);
+}
+
 function addContentShaHeader(config) {
   config.headers = config.headers || {};
 
-  const transformer = getTransformer(config);
-  const data = transformer ? transformer.call(config, config.data, config.headers) : config.data;
-  const hash = createHash('sha256').update(data ?? '', 'utf8').digest('hex');
+  if (getHeader(config.headers, 'X-Amz-Content-Sha256') != null) {
+    return;
+  }
+
+  const payload = getHashPayload(applyTransformers(config));
+  if (payload === undefined) {
+    return;
+  }
+
+  const hash = createHash('sha256').update(payload).digest('hex');
 
   setHeader(config.headers, 'X-Amz-Content-Sha256', hash);
 }

--- a/packages/bruno-cli/tests/runner/awsv4auth-helper.spec.js
+++ b/packages/bruno-cli/tests/runner/awsv4auth-helper.spec.js
@@ -1,3 +1,4 @@
+const { createHash } = require('node:crypto');
 const axios = require('axios');
 const { addAwsV4Interceptor } = require('../../src/runner/awsv4auth-helper');
 
@@ -27,26 +28,70 @@ function getHeader(headers, name) {
   return key ? headers[key] : undefined;
 }
 
+function sha256(payload) {
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+async function signRequest(awsv4config, config = {}) {
+  const axiosInstance = createAxiosInstance();
+
+  addAwsV4Interceptor(axiosInstance, {
+    awsv4config
+  });
+
+  const interceptor = axiosInstance.interceptors.request.use.mock.calls[0][0];
+
+  return interceptor({
+    method: 'put',
+    url: 'https://search-example.us-east-1.aoss.amazonaws.com/index-name/_doc/1',
+    transformRequest: axios.defaults.transformRequest,
+    headers: new axios.AxiosHeaders({
+      'Content-Type': 'application/json'
+    }),
+    data: JSON.stringify({ title: 'Bruno' }),
+    ...config
+  });
+}
+
 describe('addAwsV4Interceptor', () => {
   it('adds payload hash signing for OpenSearch Serverless requests', async () => {
-    const axiosInstance = createAxiosInstance();
-
-    addAwsV4Interceptor(axiosInstance, {
-      awsv4config: awsV4Config
-    });
-
-    const interceptor = axiosInstance.interceptors.request.use.mock.calls[0][0];
-    const signedRequest = await interceptor({
-      method: 'put',
-      url: 'https://search-example.us-east-1.aoss.amazonaws.com/index-name/_doc/1',
-      transformRequest: axios.defaults.transformRequest,
-      headers: new axios.AxiosHeaders({
-        'Content-Type': 'application/json'
-      }),
-      data: JSON.stringify({ title: 'Bruno' })
-    });
+    const signedRequest = await signRequest(awsV4Config);
 
     expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toMatch(/^[a-f0-9]{64}$/);
+    expect(getHeader(signedRequest.headers, 'authorization')).toContain('x-amz-content-sha256');
+  });
+
+  it('does not add payload hash signing for other AWS services', async () => {
+    const signedRequest = await signRequest({
+      ...awsV4Config,
+      service: 'es'
+    });
+
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toBeUndefined();
+    expect(getHeader(signedRequest.headers, 'authorization')).not.toContain('x-amz-content-sha256');
+  });
+
+  it('hashes the payload after applying the full transform chain', async () => {
+    const signedRequest = await signRequest(awsV4Config, {
+      data: 'Bruno',
+      transformRequest: [
+        (data) => `${data}-first`,
+        (data) => `${data}-second`
+      ]
+    });
+
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toBe(sha256('Bruno-first-second'));
+  });
+
+  it('preserves an existing payload hash header', async () => {
+    const signedRequest = await signRequest(awsV4Config, {
+      headers: new axios.AxiosHeaders({
+        'Content-Type': 'application/json',
+        'X-Amz-Content-Sha256': 'precomputed-content-hash'
+      })
+    });
+
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toBe('precomputed-content-hash');
     expect(getHeader(signedRequest.headers, 'authorization')).toContain('x-amz-content-sha256');
   });
 });

--- a/packages/bruno-cli/tests/runner/awsv4auth-helper.spec.js
+++ b/packages/bruno-cli/tests/runner/awsv4auth-helper.spec.js
@@ -1,0 +1,52 @@
+const axios = require('axios');
+const { addAwsV4Interceptor } = require('../../src/runner/awsv4auth-helper');
+
+const awsV4Config = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  service: 'aoss',
+  region: 'us-east-1'
+};
+
+function createAxiosInstance() {
+  return {
+    interceptors: {
+      request: {
+        use: jest.fn()
+      }
+    }
+  };
+}
+
+function getHeader(headers, name) {
+  if (typeof headers.get === 'function') {
+    return headers.get(name);
+  }
+
+  const key = Object.keys(headers).find((headerName) => headerName.toLowerCase() === name.toLowerCase());
+  return key ? headers[key] : undefined;
+}
+
+describe('addAwsV4Interceptor', () => {
+  it('adds payload hash signing for OpenSearch Serverless requests', async () => {
+    const axiosInstance = createAxiosInstance();
+
+    addAwsV4Interceptor(axiosInstance, {
+      awsv4config: awsV4Config
+    });
+
+    const interceptor = axiosInstance.interceptors.request.use.mock.calls[0][0];
+    const signedRequest = await interceptor({
+      method: 'put',
+      url: 'https://search-example.us-east-1.aoss.amazonaws.com/index-name/_doc/1',
+      transformRequest: axios.defaults.transformRequest,
+      headers: new axios.AxiosHeaders({
+        'Content-Type': 'application/json'
+      }),
+      data: JSON.stringify({ title: 'Bruno' })
+    });
+
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toMatch(/^[a-f0-9]{64}$/);
+    expect(getHeader(signedRequest.headers, 'authorization')).toContain('x-amz-content-sha256');
+  });
+});

--- a/packages/bruno-cli/tests/runner/awsv4auth-helper.spec.js
+++ b/packages/bruno-cli/tests/runner/awsv4auth-helper.spec.js
@@ -57,7 +57,7 @@ describe('addAwsV4Interceptor', () => {
   it('adds payload hash signing for OpenSearch Serverless requests', async () => {
     const signedRequest = await signRequest(awsV4Config);
 
-    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toMatch(/^[a-f0-9]{64}$/);
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toBe(sha256(JSON.stringify({ title: 'Bruno' })));
     expect(getHeader(signedRequest.headers, 'authorization')).toContain('x-amz-content-sha256');
   });
 

--- a/packages/bruno-electron/src/ipc/network/awsv4auth-helper.js
+++ b/packages/bruno-electron/src/ipc/network/awsv4auth-helper.js
@@ -1,8 +1,50 @@
+const { createHash } = require('node:crypto');
 const { fromIni } = require('@aws-sdk/credential-providers');
 const { aws4Interceptor } = require('aws4-axios');
 
 function isStrPresent(str) {
   return str && str !== '' && str !== 'undefined';
+}
+
+function shouldAddContentSha(awsv4) {
+  return String(awsv4.service || '').toLowerCase() === 'aoss';
+}
+
+function getTransformer(config) {
+  const { transformRequest } = config;
+  if (typeof transformRequest === 'function') {
+    return transformRequest;
+  }
+
+  if (Array.isArray(transformRequest) && transformRequest.length) {
+    return transformRequest[0];
+  }
+}
+
+function setHeader(headers, name, value) {
+  if (headers && typeof headers.set === 'function') {
+    headers.set(name, value);
+    return;
+  }
+
+  headers[name] = value;
+}
+
+function addContentShaHeader(config) {
+  config.headers = config.headers || {};
+
+  const transformer = getTransformer(config);
+  const data = transformer ? transformer.call(config, config.data, config.headers) : config.data;
+  const hash = createHash('sha256').update(data ?? '', 'utf8').digest('hex');
+
+  setHeader(config.headers, 'X-Amz-Content-Sha256', hash);
+}
+
+function withContentShaHeader(interceptor) {
+  return async (config) => {
+    addContentShaHeader(config);
+    return interceptor(config);
+  };
 }
 
 async function resolveAwsV4Credentials(request) {
@@ -48,7 +90,7 @@ function addAwsV4Interceptor(axiosInstance, request) {
     }
   });
 
-  axiosInstance.interceptors.request.use(interceptor);
+  axiosInstance.interceptors.request.use(shouldAddContentSha(awsv4) ? withContentShaHeader(interceptor) : interceptor);
 }
 
 module.exports = {

--- a/packages/bruno-electron/src/ipc/network/awsv4auth-helper.js
+++ b/packages/bruno-electron/src/ipc/network/awsv4auth-helper.js
@@ -10,15 +10,26 @@ function shouldAddContentSha(awsv4) {
   return String(awsv4.service || '').toLowerCase() === 'aoss';
 }
 
-function getTransformer(config) {
+function getTransformers(config) {
   const { transformRequest } = config;
   if (typeof transformRequest === 'function') {
-    return transformRequest;
+    return [transformRequest];
   }
 
-  if (Array.isArray(transformRequest) && transformRequest.length) {
-    return transformRequest[0];
+  if (Array.isArray(transformRequest)) {
+    return transformRequest.filter((transformer) => typeof transformer === 'function');
   }
+
+  return [];
+}
+
+function getHeader(headers, name) {
+  if (headers && typeof headers.get === 'function') {
+    return headers.get(name);
+  }
+
+  const key = Object.keys(headers || {}).find((headerName) => headerName.toLowerCase() === name.toLowerCase());
+  return key ? headers[key] : undefined;
 }
 
 function setHeader(headers, name, value) {
@@ -30,12 +41,43 @@ function setHeader(headers, name, value) {
   headers[name] = value;
 }
 
+function getHashPayload(data) {
+  if (data == null) {
+    return '';
+  }
+
+  if (typeof data === 'string' || Buffer.isBuffer(data)) {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data);
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  }
+}
+
+function applyTransformers(config) {
+  return getTransformers(config).reduce((data, transformer) => {
+    return transformer.call(config, data, config.headers);
+  }, config.data);
+}
+
 function addContentShaHeader(config) {
   config.headers = config.headers || {};
 
-  const transformer = getTransformer(config);
-  const data = transformer ? transformer.call(config, config.data, config.headers) : config.data;
-  const hash = createHash('sha256').update(data ?? '', 'utf8').digest('hex');
+  if (getHeader(config.headers, 'X-Amz-Content-Sha256') != null) {
+    return;
+  }
+
+  const payload = getHashPayload(applyTransformers(config));
+  if (payload === undefined) {
+    return;
+  }
+
+  const hash = createHash('sha256').update(payload).digest('hex');
 
   setHeader(config.headers, 'X-Amz-Content-Sha256', hash);
 }

--- a/packages/bruno-electron/tests/network/awsv4auth-helper.spec.js
+++ b/packages/bruno-electron/tests/network/awsv4auth-helper.spec.js
@@ -1,3 +1,4 @@
+const { createHash } = require('node:crypto');
 const axios = require('axios');
 const { addAwsV4Interceptor } = require('../../src/ipc/network/awsv4auth-helper');
 
@@ -27,26 +28,70 @@ function getHeader(headers, name) {
   return key ? headers[key] : undefined;
 }
 
+function sha256(payload) {
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+async function signRequest(awsv4config, config = {}) {
+  const axiosInstance = createAxiosInstance();
+
+  addAwsV4Interceptor(axiosInstance, {
+    awsv4config
+  });
+
+  const interceptor = axiosInstance.interceptors.request.use.mock.calls[0][0];
+
+  return interceptor({
+    method: 'put',
+    url: 'https://search-example.us-east-1.aoss.amazonaws.com/index-name/_doc/1',
+    transformRequest: axios.defaults.transformRequest,
+    headers: new axios.AxiosHeaders({
+      'Content-Type': 'application/json'
+    }),
+    data: JSON.stringify({ title: 'Bruno' }),
+    ...config
+  });
+}
+
 describe('addAwsV4Interceptor', () => {
   it('adds payload hash signing for OpenSearch Serverless requests', async () => {
-    const axiosInstance = createAxiosInstance();
-
-    addAwsV4Interceptor(axiosInstance, {
-      awsv4config: awsV4Config
-    });
-
-    const interceptor = axiosInstance.interceptors.request.use.mock.calls[0][0];
-    const signedRequest = await interceptor({
-      method: 'put',
-      url: 'https://search-example.us-east-1.aoss.amazonaws.com/index-name/_doc/1',
-      transformRequest: axios.defaults.transformRequest,
-      headers: new axios.AxiosHeaders({
-        'Content-Type': 'application/json'
-      }),
-      data: JSON.stringify({ title: 'Bruno' })
-    });
+    const signedRequest = await signRequest(awsV4Config);
 
     expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toMatch(/^[a-f0-9]{64}$/);
+    expect(getHeader(signedRequest.headers, 'authorization')).toContain('x-amz-content-sha256');
+  });
+
+  it('does not add payload hash signing for other AWS services', async () => {
+    const signedRequest = await signRequest({
+      ...awsV4Config,
+      service: 'es'
+    });
+
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toBeUndefined();
+    expect(getHeader(signedRequest.headers, 'authorization')).not.toContain('x-amz-content-sha256');
+  });
+
+  it('hashes the payload after applying the full transform chain', async () => {
+    const signedRequest = await signRequest(awsV4Config, {
+      data: 'Bruno',
+      transformRequest: [
+        (data) => `${data}-first`,
+        (data) => `${data}-second`
+      ]
+    });
+
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toBe(sha256('Bruno-first-second'));
+  });
+
+  it('preserves an existing payload hash header', async () => {
+    const signedRequest = await signRequest(awsV4Config, {
+      headers: new axios.AxiosHeaders({
+        'Content-Type': 'application/json',
+        'X-Amz-Content-Sha256': 'precomputed-content-hash'
+      })
+    });
+
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toBe('precomputed-content-hash');
     expect(getHeader(signedRequest.headers, 'authorization')).toContain('x-amz-content-sha256');
   });
 });

--- a/packages/bruno-electron/tests/network/awsv4auth-helper.spec.js
+++ b/packages/bruno-electron/tests/network/awsv4auth-helper.spec.js
@@ -57,7 +57,7 @@ describe('addAwsV4Interceptor', () => {
   it('adds payload hash signing for OpenSearch Serverless requests', async () => {
     const signedRequest = await signRequest(awsV4Config);
 
-    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toMatch(/^[a-f0-9]{64}$/);
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toBe(sha256(JSON.stringify({ title: 'Bruno' })));
     expect(getHeader(signedRequest.headers, 'authorization')).toContain('x-amz-content-sha256');
   });
 

--- a/packages/bruno-electron/tests/network/awsv4auth-helper.spec.js
+++ b/packages/bruno-electron/tests/network/awsv4auth-helper.spec.js
@@ -1,0 +1,52 @@
+const axios = require('axios');
+const { addAwsV4Interceptor } = require('../../src/ipc/network/awsv4auth-helper');
+
+const awsV4Config = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  service: 'aoss',
+  region: 'us-east-1'
+};
+
+function createAxiosInstance() {
+  return {
+    interceptors: {
+      request: {
+        use: jest.fn()
+      }
+    }
+  };
+}
+
+function getHeader(headers, name) {
+  if (typeof headers.get === 'function') {
+    return headers.get(name);
+  }
+
+  const key = Object.keys(headers).find((headerName) => headerName.toLowerCase() === name.toLowerCase());
+  return key ? headers[key] : undefined;
+}
+
+describe('addAwsV4Interceptor', () => {
+  it('adds payload hash signing for OpenSearch Serverless requests', async () => {
+    const axiosInstance = createAxiosInstance();
+
+    addAwsV4Interceptor(axiosInstance, {
+      awsv4config: awsV4Config
+    });
+
+    const interceptor = axiosInstance.interceptors.request.use.mock.calls[0][0];
+    const signedRequest = await interceptor({
+      method: 'put',
+      url: 'https://search-example.us-east-1.aoss.amazonaws.com/index-name/_doc/1',
+      transformRequest: axios.defaults.transformRequest,
+      headers: new axios.AxiosHeaders({
+        'Content-Type': 'application/json'
+      }),
+      data: JSON.stringify({ title: 'Bruno' })
+    });
+
+    expect(getHeader(signedRequest.headers, 'x-amz-content-sha256')).toMatch(/^[a-f0-9]{64}$/);
+    expect(getHeader(signedRequest.headers, 'authorization')).toContain('x-amz-content-sha256');
+  });
+});


### PR DESCRIPTION
## Summary

- add the `X-Amz-Content-Sha256` payload hash before signing AWS SigV4 requests for the `aoss` service
- keep the header in the canonical signed headers so OpenSearch Serverless write requests can authenticate
- cover both CLI and Electron SigV4 helper paths

Fixes #8149

## Verification

- `npm test --workspace=packages/bruno-cli -- tests/runner/awsv4auth-helper.spec.js --runInBand`
- `npm test --workspace=packages/bruno-cli -- tests/runner/prepare-request.spec.js --runInBand`
- `npm test --workspace=packages/bruno-electron -- tests/network/awsv4auth-helper.spec.js --runInBand`
- `npm test --workspace=packages/bruno-electron -- tests/prepare-request.test.js --runInBand`
- `npm run lint -- packages/bruno-cli/src/runner/awsv4auth-helper.js packages/bruno-cli/tests/runner/awsv4auth-helper.spec.js packages/bruno-electron/src/ipc/network/awsv4auth-helper.js packages/bruno-electron/tests/network/awsv4auth-helper.spec.js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Scope: packages/bruno-cli and packages/bruno-electron (CLI + Electron workspaces).
- Problem fixed: SigV4 signing for OpenSearch Serverless (service "aoss") omitted the X-Amz-Content-Sha256 payload-hash from signed headers, causing 403 on write (PUT/POST) requests (fixes issue `#8149`).
- What changed:
  - Add X-Amz-Content-Sha256 header for aoss requests and ensure it is set before the aws4 signing interceptor runs.
  - Compute SHA-256 hex digest of the request payload after applying Axios transformRequest chain (handles string, Buffer, ArrayBuffer, and ArrayBuffer views; returns '' for null/undefined).
  - Preserve any pre-existing X-Amz-Content-Sha256 header value (do not overwrite).
  - Apply the same change to both codepaths: packages/bruno-cli/src/runner/awsv4auth-helper.js and packages/bruno-electron/src/ipc/network/awsv4auth-helper.js.
  - Wrapper helper (withContentShaHeader) added to run content-hash injection immediately before aws4Interceptor.
- Tests:
  - New Jest specs added in packages/bruno-cli/tests/runner/awsv4auth-helper.spec.js and packages/bruno-electron/tests/network/awsv4auth-helper.spec.js verifying:
    - aoss requests receive a 64-char SHA-256 x-amz-content-sha256 and that authorization contains x-amz-content-sha256.
    - Non-aoss services are unaffected (no header, not referenced in authorization).
    - Payload hash is computed after transformRequest chain.
    - Existing X-Amz-Content-Sha256 header is preserved and still referenced.
- Public API: exported function signatures (addAwsV4Interceptor, resolveAwsV4Credentials) unchanged.
- Files touched (high level): 
  - packages/bruno-cli/src/runner/awsv4auth-helper.js (+ tests)
  - packages/bruno-electron/src/ipc/network/awsv4auth-helper.js (+ tests)
- Verification notes (from PR): run awsv4auth-helper tests in both packages with --runInBand, lint the helper and test files, and run git diff --check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->