### PR TITLE
fix(editable-table): expand values cells on focus

### DIFF
--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -119,10 +119,6 @@ const StyledWrapper = styled.div`
           align-items: center;
         }
 
-        > div:not(.drag-handle) > * {
-          min-height: 0;
-        }
-
         /* Handle CodeMirror editors overflow */
         .cm-editor {
           max-width: 100%;

--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -102,9 +102,25 @@ const StyledWrapper = styled.div`
         box-sizing: border-box;
 
         > div:not(.drag-handle) {
-          height: 33px;
-          max-height: 33px;
+          height: 1.5em;
+          max-height: 1.5em;
           overflow: hidden;
+          align-items: flex-start;
+        }
+
+        > div:not(.drag-handle) > * {
+          min-height: 0;
+        }
+
+        &:focus-within > div:not(.drag-handle) {
+          height: auto;
+          max-height: none;
+          overflow: visible;
+          align-items: center;
+        }
+
+        > div:not(.drag-handle) > * {
+          min-height: 0;
         }
 
         /* Handle CodeMirror editors overflow */
@@ -122,15 +138,33 @@ const StyledWrapper = styled.div`
             max-width: 100%;
           }
 
-          .cm-line {
+        .cm-line {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
           }
         }
+
+        &:focus-within {
+          height: auto;
+          max-height: none;
+          overflow: visible;
+          white-space: normal;
+          text-overflow: clip;
+        }
+
+        &:focus-within > div:not(.drag-handle) {
+          height: auto;
+          max-height: none;
+          overflow: visible;
+        }
+
+        &:focus-within .single-line-editor,
+        &:focus-within .single-line-editor .CodeMirror {
+          height: auto !important;
+        }
       }
     }
-  }
 
   &.has-checkbox tbody td:nth-child(1) {
     width: 25px;

--- a/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
@@ -20,11 +20,11 @@ const StyledWrapper = styled.div`
     }
   }
 
-  .CodeMirror {
+    .CodeMirror {
     background: transparent;
     height: fit-content;
     font-size: ${(props) => props.theme.font.size.base};
-    line-height: 30px;
+    line-height: 1.5;
     display: flex;
     flex-direction: column;
     max-height: 200px;
@@ -46,8 +46,6 @@ const StyledWrapper = styled.div`
     }
 
     .CodeMirror-cursor {
-      height: 20px !important;
-      margin-top: 5px !important;
       border-left: 1px solid ${(props) => props.theme.text} !important;
     }
 

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -39,10 +39,10 @@ class MultiLineEditor extends Component {
      * in request tabs. Falling through with CodeMirror.Pass when onRun is absent
      * would re-introduce the newline in collection/folder-level editors.
      */
-    const runShortcut = () => {};
+    const runShortcut = () => { };
 
     this.editor = CodeMirror(this.editorRef.current, {
-      lineWrapping: false,
+      lineWrapping: true,
       lineNumbers: false,
       theme: this.props.theme === 'dark' ? 'monokai' : 'default',
       placeholder: this.props.placeholder,
@@ -55,8 +55,8 @@ class MultiLineEditor extends Component {
       readOnly: this.props.readOnly,
       tabindex: 0,
       extraKeys: {
-        'Cmd-F': () => {},
-        'Ctrl-F': () => {},
+        'Cmd-F': () => { },
+        'Ctrl-F': () => { },
         'Cmd-Enter': runShortcut,
         'Ctrl-Enter': runShortcut,
         // Tabbing disabled to make tabindex work

--- a/packages/bruno-app/src/components/SingleLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/StyledWrapper.js
@@ -16,7 +16,7 @@ const StyledWrapper = styled.div`
     background: transparent;
     height: ${(props) => (props.$isCompact ? '1.375rem' : '2.125rem')};
     font-size: ${(props) => props.theme.font.size.base};
-    line-height: ${(props) => (props.$isCompact ? '1.375rem' : '1.875rem')};
+    line-height: 1.5;
     overflow: hidden;
 
     .CodeMirror-scroll {
@@ -40,8 +40,6 @@ const StyledWrapper = styled.div`
     }
 
     .CodeMirror-cursor {
-      height: ${(props) => (props.$isCompact ? '0.875rem' : '1.25rem')} !important;
-      margin-top: ${(props) => (props.$isCompact ? '0.25rem' : '0.3125rem')} !important;
       border-left: 1px solid ${(props) => props.theme.text} !important;
     }
 

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -45,7 +45,7 @@ class SingleLineEditor extends Component {
 
     this.editor = CodeMirror(this.editorRef.current, {
       placeholder: this.props.placeholder ?? '',
-      lineWrapping: false,
+      lineWrapping: true,
       lineNumbers: false,
       theme: this.props.theme === 'dark' ? 'monokai' : 'default',
       mode: 'brunovariables',


### PR DESCRIPTION
### Description

Issue #8179 pretty much explains the entire problem. The two main causes were:
1. CodeMirror's `lineWrapping` was set to `false`. Long lines would never wrap.
2. The CSS for the table that holds the key-value pairs for each request had fixed heights and hidden overflow, clipping any content beyond a line.

### Changes

TL;DR: After the changes, writing multi-line text on the table's key cells automatically makes them expand vertically just enough so the content can be clearly visualized. The change applies to the tables in params, body and header tabs.

**`MultiLineEditor/index.js`** — enabled `lineWrapping: true` so CodeMirror wraps long text and calculates content height correctly.

**`MultiLineEditor/StyledWrapper.js`** — replaced hardcoded `line-height: 30px` with proportional `line-height: 1.5` for proper multi-line spacing. Removed `height`/`margin-top` `!important` overrides on `.CodeMirror-cursor` so CM5 sizes the cursor dynamically to match the line-height.

**`SingleLineEditor/index.js`** — enabled `lineWrapping: true` (same as MultiLineEditor) for consistency in the request headers tab.

**`SingleLineEditor/StyledWrapper.js`** — replaced hardcoded `line-height: 1.875rem` with `line-height: 1.5`. Removed cursor `!important` overrides (same pattern).

**`EditableTable/StyledWrapper.js`** — added three `:focus-within` rules:

- `td:focus-within` — removes `height`/`max-height`/`overflow`/`nowrap` constraints on the cell when its editor is focused, letting content grow vertically.
- `td:focus-within > div` — removes constraints on the content wrapper, with `align-items: center` for proper centering.
- Blurred state inner div uses `height: 1.5em` with `align-items: flex-start` and `min-height: 0` on children, clipping cleanly to exactly one line of text.

### Videos showing before vs. after
#### Before

https://github.com/user-attachments/assets/38c50dbe-179e-4b41-ba15-a35fdbdba630

#### After

https://github.com/user-attachments/assets/01424099-4467-4739-87b9-1f6edc45f97c


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled text wrapping in single- and multi-line editors for improved visibility of long content.
  * Improved table cell editor styling to better manage height, overflow, and behavior during focus and resizing.
  * Standardized cursor appearance and line-height across editors for a more consistent, stable editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->