### PR TITLE
Set active workspace as default terminal cwd

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/TerminalTab/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/TerminalTab/index.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { useSelector } from 'react-redux';
 import { IconTerminal2, IconPlus } from '@tabler/icons';
 import { useTheme } from 'providers/Theme';
 import StyledWrapper from './StyledWrapper';
@@ -218,6 +219,11 @@ const TerminalTab = () => {
   const [sessions, setSessions] = useState([]);
   const [activeSessionId, setActiveSessionId] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const activeWorkspacePathname = useSelector((state) => {
+    const { workspaces = [], activeWorkspaceUid } = state.workspaces || {};
+    const activeWorkspace = workspaces.find((w) => w.uid === activeWorkspaceUid);
+    return activeWorkspace?.pathname || null;
+  });
   const { theme } = useTheme();
   const terminalTheme = getTerminalTheme(theme);
 
@@ -260,7 +266,8 @@ const TerminalTab = () => {
       if (!window.ipcRenderer) return null;
 
       try {
-        const options = cwd ? { cwd } : {};
+        const resolvedCwd = cwd || activeWorkspacePathname;
+        const options = resolvedCwd ? { cwd: resolvedCwd } : {};
         const newSessionId = await window.ipcRenderer.invoke('terminal:create', options);
         if (newSessionId) {
           await loadSessions(newSessionId);
@@ -272,7 +279,7 @@ const TerminalTab = () => {
       }
       return null;
     },
-    [loadSessions]
+    [loadSessions, activeWorkspacePathname]
   );
 
   // Listen for requests to open terminal at specific CWD


### PR DESCRIPTION
This PR updates the Terminal tab so new sessions created with the + button start in the active workspace directory by default. Contextual Open in Terminal actions still pass their explicit cwd.
Tested manually by creating a new terminal session and verifying pwd points to the active workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal sessions now default to the active workspace directory when opened, ensuring commands run in the correct project context.
  * New terminals omit an empty working-directory setting when none is available, preventing unintended path behavior.
  * Terminal creation now responds to workspace changes so newly opened sessions reflect the current workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->