### PR TITLE
Fix (import): Postman import: OAuth2 tokenPlacement not set correctly, Header Prefix field hidden and value lost

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
@@ -282,7 +282,6 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
               { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
             ]}
-            data-testid="grant-type-selector"
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.js
@@ -282,6 +282,7 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
               { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
             ]}
+            data-testid="grant-type-selector"
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >
@@ -295,7 +296,7 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
       {
         tokenPlacement === 'header'
           ? (
-              <div className="flex items-center gap-4 w-full" key="input-token-prefix">
+              <div className="flex items-center gap-4 w-full" key="input-token-prefix" data-testid="token-header-prefix">
                 <label className="block min-w-[140px]">Header Prefix</label>
                 <div className="single-line-editor-wrapper flex-1">
                   <SingleLineEditor
@@ -311,7 +312,7 @@ const OAuth2AuthorizationCode = ({ save, item = {}, request, handleRun, updateAu
               </div>
             )
           : (
-              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
+              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key" data-testid="token-query-param-key">
                 <label className="block min-w-[140px]">Query Param Key</label>
                 <div className="single-line-editor-wrapper flex-1">
                   <SingleLineEditor

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/ClientCredentials/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/ClientCredentials/index.js
@@ -172,7 +172,6 @@ const OAuth2ClientCredentials = ({ save, item = {}, request, handleRun, updateAu
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
               { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
             ]}
-            data-testid="grant-type-selector"
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/ClientCredentials/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/ClientCredentials/index.js
@@ -172,6 +172,7 @@ const OAuth2ClientCredentials = ({ save, item = {}, request, handleRun, updateAu
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
               { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
             ]}
+            data-testid="grant-type-selector"
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >
@@ -185,7 +186,7 @@ const OAuth2ClientCredentials = ({ save, item = {}, request, handleRun, updateAu
       {
         tokenPlacement === 'header'
           ? (
-              <div className="flex items-center gap-4 w-full" key="input-token-prefix">
+              <div className="flex items-center gap-4 w-full" key="input-token-prefix" data-testid="token-header-prefix">
                 <label className="block min-w-[140px]">Header Prefix</label>
                 <div className="single-line-editor-wrapper flex-1">
                   <SingleLineEditor
@@ -201,7 +202,7 @@ const OAuth2ClientCredentials = ({ save, item = {}, request, handleRun, updateAu
               </div>
             )
           : (
-              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
+              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key" data-testid="token-query-param-key">
                 <label className="block min-w-[140px]">Query Param Key</label>
                 <div className="single-line-editor-wrapper flex-1">
                   <SingleLineEditor

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Implicit/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Implicit/index.js
@@ -217,6 +217,7 @@ const OAuth2Implicit = ({ save, item = {}, request, handleRun, updateAuth, colle
               { id: 'header', label: 'Headers', onClick: () => handleChange('tokenPlacement', 'header') },
               { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
             ]}
+            data-testid="grant-type-selector"
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >
@@ -229,7 +230,7 @@ const OAuth2Implicit = ({ save, item = {}, request, handleRun, updateAuth, colle
       </div>
 
       {tokenPlacement == 'header' ? (
-        <div className="flex items-center gap-4 w-full" key="input-token-header-prefix">
+        <div className="flex items-center gap-4 w-full" key="input-token-header-prefix" data-testid="token-header-prefix">
           <label className="block min-w-[140px]">Header Prefix</label>
           <div className="oauth2-input-wrapper flex-1">
             <SingleLineEditor
@@ -245,7 +246,7 @@ const OAuth2Implicit = ({ save, item = {}, request, handleRun, updateAuth, colle
           </div>
         </div>
       ) : (
-        <div className="flex items-center gap-4 w-full" key="input-token-query-key">
+        <div className="flex items-center gap-4 w-full" key="input-token-query-key" data-testid="token-query-param-key">
           <label className="block min-w-[140px]">URL Query Key</label>
           <div className="oauth2-input-wrapper flex-1">
             <SingleLineEditor

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Implicit/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Implicit/index.js
@@ -217,7 +217,6 @@ const OAuth2Implicit = ({ save, item = {}, request, handleRun, updateAuth, colle
               { id: 'header', label: 'Headers', onClick: () => handleChange('tokenPlacement', 'header') },
               { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
             ]}
-            data-testid="grant-type-selector"
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/PasswordCredentials/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/PasswordCredentials/index.js
@@ -176,7 +176,6 @@ const OAuth2PasswordCredentials = ({ save, item = {}, request, handleRun, update
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
               { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
             ]}
-            data-testid="grant-type-selector"
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/PasswordCredentials/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/PasswordCredentials/index.js
@@ -176,6 +176,7 @@ const OAuth2PasswordCredentials = ({ save, item = {}, request, handleRun, update
               { id: 'header', label: 'Header', onClick: () => handleChange('tokenPlacement', 'header') },
               { id: 'url', label: 'URL', onClick: () => handleChange('tokenPlacement', 'url') }
             ]}
+            data-testid="grant-type-selector"
             selectedItemId={tokenPlacement}
             placement="bottom-end"
           >
@@ -189,7 +190,7 @@ const OAuth2PasswordCredentials = ({ save, item = {}, request, handleRun, update
       {
         tokenPlacement === 'header'
           ? (
-              <div className="flex items-center gap-4 w-full" key="input-token-prefix">
+              <div className="flex items-center gap-4 w-full" key="input-token-prefix" data-testid="token-header-prefix">
                 <label className="block min-w-[140px]">Header Prefix</label>
                 <div className="single-line-editor-wrapper flex-1">
                   <SingleLineEditor
@@ -205,7 +206,7 @@ const OAuth2PasswordCredentials = ({ save, item = {}, request, handleRun, update
               </div>
             )
           : (
-              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
+              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key" data-testid="token-query-param-key">
                 <label className="block min-w-[140px]">Query Param Key</label>
                 <div className="single-line-editor-wrapper flex-1">
                   <SingleLineEditor

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -325,6 +325,8 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
         scope: findValueUsingKey('scope'),
         state: findValueUsingKey('state'),
         tokenPlacement: findValueUsingKey('addTokenTo') === 'header' ? 'header' : 'url',
+        tokenHeaderPrefix: findValueUsingKey('headerPrefix'),
+        tokenQueryKey: 'access_token',
         credentialsPlacement: findValueUsingKey('client_authentication') === 'body' ? 'body' : 'basic_auth_header'
       };
 

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
@@ -278,6 +278,8 @@ describe('processAuth', () => {
       state: 'test-state',
       pkce: false,
       tokenPlacement: 'header',
+      tokenHeaderPrefix: 'Bearer',
+      tokenQueryKey: '',
       credentialsPlacement: 'body'
     });
   });
@@ -312,6 +314,8 @@ describe('processAuth', () => {
       scope: 'test-scope',
       state: 'test-state',
       tokenPlacement: 'header',
+      tokenHeaderPrefix: 'Bearer',
+      tokenQueryKey: '',
       credentialsPlacement: 'body'
     });
   });
@@ -342,6 +346,8 @@ describe('processAuth', () => {
       scope: 'test-scope',
       state: 'test-state',
       tokenPlacement: 'header',
+      tokenHeaderPrefix: 'Bearer',
+      tokenQueryKey: '',
       credentialsPlacement: 'body'
     });
   });
@@ -362,6 +368,8 @@ describe('processAuth', () => {
       scope: '',
       state: '',
       tokenPlacement: 'url',
+      tokenHeaderPrefix: '',
+      tokenQueryKey: 'access_token',
       credentialsPlacement: 'basic_auth_header'
     });
   });
@@ -381,6 +389,8 @@ describe('processAuth', () => {
       scope: '',
       state: '',
       tokenPlacement: 'url',
+      tokenHeaderPrefix: '',
+      tokenQueryKey: 'access_token',
       credentialsPlacement: 'basic_auth_header'
     });
   });
@@ -416,6 +426,8 @@ describe('processAuth', () => {
       state: 'test-state',
       pkce: true,
       tokenPlacement: 'header',
+      tokenHeaderPrefix: 'Bearer',
+      tokenQueryKey: '',
       credentialsPlacement: 'body'
     });
   });
@@ -434,6 +446,8 @@ describe('processAuth', () => {
         scope: 'test-scope',
         state: 'test-state',
         addTokenTo: 'header',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: '',
         client_authentication: 'body'
       }
     };
@@ -450,6 +464,8 @@ describe('processAuth', () => {
       scope: 'test-scope',
       state: 'test-state',
       tokenPlacement: 'header',
+      tokenHeaderPrefix: 'Bearer',
+      tokenQueryKey: '',
       credentialsPlacement: 'body'
     });
   });

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
@@ -278,8 +278,8 @@ describe('processAuth', () => {
       state: 'test-state',
       pkce: false,
       tokenPlacement: 'header',
-      tokenHeaderPrefix: 'Bearer',
-      tokenQueryKey: '',
+      tokenHeaderPrefix: '',
+      tokenQueryKey: 'access_token',
       credentialsPlacement: 'body'
     });
   });
@@ -314,8 +314,8 @@ describe('processAuth', () => {
       scope: 'test-scope',
       state: 'test-state',
       tokenPlacement: 'header',
-      tokenHeaderPrefix: 'Bearer',
-      tokenQueryKey: '',
+      tokenHeaderPrefix: '',
+      tokenQueryKey: 'access_token',
       credentialsPlacement: 'body'
     });
   });
@@ -346,8 +346,8 @@ describe('processAuth', () => {
       scope: 'test-scope',
       state: 'test-state',
       tokenPlacement: 'header',
-      tokenHeaderPrefix: 'Bearer',
-      tokenQueryKey: '',
+      tokenHeaderPrefix: '',
+      tokenQueryKey: 'access_token',
       credentialsPlacement: 'body'
     });
   });
@@ -426,8 +426,8 @@ describe('processAuth', () => {
       state: 'test-state',
       pkce: true,
       tokenPlacement: 'header',
-      tokenHeaderPrefix: 'Bearer',
-      tokenQueryKey: '',
+      tokenHeaderPrefix: '',
+      tokenQueryKey: 'access_token',
       credentialsPlacement: 'body'
     });
   });
@@ -464,8 +464,8 @@ describe('processAuth', () => {
       scope: 'test-scope',
       state: 'test-state',
       tokenPlacement: 'header',
-      tokenHeaderPrefix: 'Bearer',
-      tokenQueryKey: '',
+      tokenHeaderPrefix: '',
+      tokenQueryKey: 'access_token',
       credentialsPlacement: 'body'
     });
   });

--- a/tests/import/postman/fixtures/postman-import-oauth2-token-placement-collection.json
+++ b/tests/import/postman/fixtures/postman-import-oauth2-token-placement-collection.json
@@ -1,0 +1,61 @@
+{
+  "info": {
+    "_postman_id": "b1c2d3e4-1111-2222-3333-444455556666",
+    "name": "OAuth2 Token Placement",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "54316404"
+  },
+  "item": [
+    {
+      "name": "OAuth2 Token in Header",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            { "key": "grant_type", "value": "authorization_code", "type": "string" },
+            { "key": "addTokenTo", "value": "header", "type": "string" },
+            { "key": "headerPrefix", "value": "Bearer", "type": "string" },
+            { "key": "authUrl", "value": "https://example.com/auth", "type": "string" },
+            { "key": "accessTokenUrl", "value": "https://example.com/token", "type": "string" },
+            { "key": "clientId", "value": "client-id", "type": "string" },
+            { "key": "clientSecret", "value": "client-secret", "type": "string" }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.com/header",
+          "protocol": "https",
+          "host": ["api", "com"],
+          "path": ["header"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "OAuth2 Token in URL",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            { "key": "grant_type", "value": "authorization_code", "type": "string" },
+            { "key": "addTokenTo", "value": "queryParams", "type": "string" },
+            { "key": "authUrl", "value": "https://example.com/auth", "type": "string" },
+            { "key": "accessTokenUrl", "value": "https://example.com/token", "type": "string" },
+            { "key": "clientId", "value": "client-id", "type": "string" },
+            { "key": "clientSecret", "value": "client-secret", "type": "string" }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.com/url",
+          "protocol": "https",
+          "host": ["api", "com"],
+          "path": ["url"]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/tests/import/postman/import-oauth2-token-placement-collection.spec.ts
+++ b/tests/import/postman/import-oauth2-token-placement-collection.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+import { closeAllCollections, openCollection, selectRequestPaneTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe('Import Postman Collection with OAuth2 token placement', () => {
+  let originalShowOpenDialog;
+
+  test.beforeAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      originalShowOpenDialog = dialog.showOpenDialog;
+    });
+  });
+
+  test.afterAll(async ({ electronApp, page }) => {
+    await closeAllCollections(page);
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = originalShowOpenDialog;
+    });
+  });
+
+  test('token placement drives which field is displayed after import', async ({ page, electronApp, createTmpDir }) => {
+    const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-import-oauth2-token-placement-collection.json');
+    const locators = buildCommonLocators(page);
+    const oauth2 = locators.auth.oauth2;
+
+    const importDir = await createTmpDir('imported-collection');
+
+    await electronApp.evaluate(({ dialog }, { importDir }) => {
+      dialog.showOpenDialog = async () => ({
+        canceled: false,
+        filePaths: [importDir]
+      });
+    }, { importDir });
+
+    await test.step('Import collection', async () => {
+      await locators.plusMenu.button().click();
+      await locators.plusMenu.importCollection().click();
+      const importModal = locators.import.modal();
+      await importModal.waitFor({ state: 'visible' });
+      await locators.import.fileInput().setInputFiles(postmanFile);
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 5000 });
+      const locationModal = locators.import.locationModal();
+      await expect(locationModal.getByText('OAuth2 Token Placement')).toBeVisible();
+      await locators.import.browseLink(locationModal).click();
+      await locators.import.importButton(locationModal).click();
+      await locationModal.waitFor({ state: 'hidden' });
+      await openCollection(page, 'OAuth2 Token Placement');
+      await expect(locators.sidebar.collection('OAuth2 Token Placement')).toBeVisible();
+    });
+
+    await test.step('Header placement shows the Header Prefix field, hides the Query Param Key field', async () => {
+      await locators.sidebar.request('OAuth2 Token in Header').click();
+      await expect(locators.request.pane()).toBeVisible();
+      await selectRequestPaneTab(page, 'Auth');
+
+      await expect(oauth2.tokenHeaderPrefixField()).toBeVisible();
+      await expect(oauth2.tokenQueryParamKeyField()).not.toBeVisible({ timeout: 1000 });
+    });
+
+    await test.step('URL placement shows the Query Param Key field, hides the Header Prefix field', async () => {
+      await locators.sidebar.request('OAuth2 Token in URL').click();
+      await expect(locators.request.pane()).toBeVisible();
+      await selectRequestPaneTab(page, 'Auth');
+
+      await expect(oauth2.tokenQueryParamKeyField()).toBeVisible();
+      await expect(oauth2.tokenHeaderPrefixField()).not.toBeVisible({ timeout: 1000 });
+    });
+  });
+});

--- a/tests/import/postman/import-oauth2-token-placement-collection.spec.ts
+++ b/tests/import/postman/import-oauth2-token-placement-collection.spec.ts
@@ -55,6 +55,7 @@ test.describe('Import Postman Collection with OAuth2 token placement', () => {
       await selectRequestPaneTab(page, 'Auth');
 
       await expect(oauth2.tokenHeaderPrefixField()).toBeVisible();
+      await expect(oauth2.tokenHeaderPrefixField().locator('.CodeMirror-line')).toHaveText('Bearer');
       await expect(oauth2.tokenQueryParamKeyField()).not.toBeVisible({ timeout: 1000 });
     });
 
@@ -64,6 +65,7 @@ test.describe('Import Postman Collection with OAuth2 token placement', () => {
       await selectRequestPaneTab(page, 'Auth');
 
       await expect(oauth2.tokenQueryParamKeyField()).toBeVisible();
+      await expect(oauth2.tokenQueryParamKeyField().locator('.CodeMirror-line')).toHaveText('access_token');
       await expect(oauth2.tokenHeaderPrefixField()).not.toBeVisible({ timeout: 1000 });
     });
   });

--- a/tests/import/postman/import-oauth2-token-placement-collection.spec.ts
+++ b/tests/import/postman/import-oauth2-token-placement-collection.spec.ts
@@ -4,19 +4,8 @@ import { closeAllCollections, openCollection, selectRequestPaneTab } from '../..
 import { buildCommonLocators } from '../../utils/page/locators';
 
 test.describe('Import Postman Collection with OAuth2 token placement', () => {
-  let originalShowOpenDialog;
-
-  test.beforeAll(async ({ electronApp }) => {
-    await electronApp.evaluate(({ dialog }) => {
-      originalShowOpenDialog = dialog.showOpenDialog;
-    });
-  });
-
-  test.afterAll(async ({ electronApp, page }) => {
+  test.afterAll(async ({ page }) => {
     await closeAllCollections(page);
-    await electronApp.evaluate(({ dialog }) => {
-      dialog.showOpenDialog = originalShowOpenDialog;
-    });
   });
 
   test('token placement drives which field is displayed after import', async ({ page, electronApp, createTmpDir }) => {
@@ -27,10 +16,14 @@ test.describe('Import Postman Collection with OAuth2 token placement', () => {
     const importDir = await createTmpDir('imported-collection');
 
     await electronApp.evaluate(({ dialog }, { importDir }) => {
-      dialog.showOpenDialog = async () => ({
-        canceled: false,
-        filePaths: [importDir]
-      });
+      const originalShowOpenDialog = dialog.showOpenDialog;
+      dialog.showOpenDialog = async () => {
+        dialog.showOpenDialog = originalShowOpenDialog;
+        return {
+          canceled: false,
+          filePaths: [importDir]
+        };
+      };
     }, { importDir });
 
     await test.step('Import collection', async () => {
@@ -56,7 +49,7 @@ test.describe('Import Postman Collection with OAuth2 token placement', () => {
 
       await expect(oauth2.tokenHeaderPrefixField()).toBeVisible();
       await expect(oauth2.tokenHeaderPrefixField().locator('.CodeMirror-line')).toHaveText('Bearer');
-      await expect(oauth2.tokenQueryParamKeyField()).not.toBeVisible({ timeout: 1000 });
+      await expect(oauth2.tokenQueryParamKeyField()).toHaveCount(0);
     });
 
     await test.step('URL placement shows the Query Param Key field, hides the Header Prefix field', async () => {
@@ -66,7 +59,7 @@ test.describe('Import Postman Collection with OAuth2 token placement', () => {
 
       await expect(oauth2.tokenQueryParamKeyField()).toBeVisible();
       await expect(oauth2.tokenQueryParamKeyField().locator('.CodeMirror-line')).toHaveText('access_token');
-      await expect(oauth2.tokenHeaderPrefixField()).not.toBeVisible({ timeout: 1000 });
+      await expect(oauth2.tokenHeaderPrefixField()).toHaveCount(0);
     });
   });
 });

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -96,7 +96,9 @@ export const buildCommonLocators = (page: Page) => ({
       placementLabel: () => page.getByTestId('auth-placement-label')
     },
     oauth2: {
-      grantTypeDropdown: () => page.getByTestId('grant-type-dropdown')
+      grantTypeDropdown: () => page.getByTestId('grant-type-dropdown'),
+      tokenHeaderPrefixField: () => page.getByTestId('token-header-prefix'),
+      tokenQueryParamKeyField: () => page.getByTestId('token-query-param-key')
     },
     modeSelector: () => page.getByTestId('auth-mode-selector'),
     modeLabel: () => page.getByTestId('auth-mode-label'),

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -96,7 +96,7 @@ export const buildCommonLocators = (page: Page) => ({
       placementLabel: () => page.getByTestId('auth-placement-label')
     },
     oauth2: {
-      grantTypeDropdown: () => page.getByTestId('grant-type-selector'),
+      grantTypeDropdown: () => page.getByTestId('grant-type-dropdown'),
       tokenHeaderPrefixField: () => page.getByTestId('token-header-prefix'),
       tokenQueryParamKeyField: () => page.getByTestId('token-query-param-key')
     },

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -96,7 +96,7 @@ export const buildCommonLocators = (page: Page) => ({
       placementLabel: () => page.getByTestId('auth-placement-label')
     },
     oauth2: {
-      grantTypeDropdown: () => page.getByTestId('grant-type-dropdown'),
+      grantTypeDropdown: () => page.getByTestId('grant-type-selector'),
       tokenHeaderPrefixField: () => page.getByTestId('token-header-prefix'),
       tokenQueryParamKeyField: () => page.getByTestId('token-query-param-key')
     },


### PR DESCRIPTION

https://usebruno.atlassian.net/browse/BRU-3283

### Description

Added tokenHeaderPrefix and tokenQueryKey to baseOAuth2Config object in postman-to-bruno.js. When tokenPlacement is  header, it shows value of tokenHeaderPrefix. If tokenPlacement is url, it shows value of tokenQueryKey.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UI test hooks for OAuth2 auth controls (token placement selector, header prefix, query-param key).

* **Tests**
  * Added import fixture and end-to-end tests validating OAuth2 token placement (header vs query) and related fields.

* **Bug Fixes**
  * OAuth2 token placement settings (header prefix and query-parameter key) are preserved and displayed correctly after import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->