### PR TITLE
fix(tests): update locators for save button in presets indicator tests

### DIFF
--- a/tests/collection/presets-indicator.spec.ts
+++ b/tests/collection/presets-indicator.spec.ts
@@ -40,7 +40,7 @@ test.describe('Presets status dot in collection settings', () => {
 
     await test.step('Select gRPC request type and save', async () => {
       await locators.presets.requestType('grpc').check();
-      await locators.presets.save().click();
+      await locators.presets.saveBtn().click();
     });
 
     await test.step('Verify Presets dot appears when a non-default request type is selected', async () => {
@@ -50,7 +50,7 @@ test.describe('Presets status dot in collection settings', () => {
     await test.step('Switch back to HTTP and set a request URL, then save', async () => {
       await locators.presets.requestType('http').check();
       await locators.presets.requestUrl().fill('https://example.com');
-      await locators.presets.save().click();
+      await locators.presets.saveBtn().click();
     });
 
     await test.step('Verify Presets dot remains visible when request URL is set', async () => {
@@ -60,7 +60,7 @@ test.describe('Presets status dot in collection settings', () => {
     await test.step('Clear the request URL with HTTP selected, then save (returns to default values)', async () => {
       await locators.presets.requestUrl().fill('');
       await expect(locators.presets.requestType('http')).toBeChecked();
-      await locators.presets.save().click();
+      await locators.presets.saveBtn().click();
     });
 
     await test.step('Verify Presets dot is hidden after returning to defaults', async () => {

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -107,7 +107,7 @@ export const buildCommonLocators = (page: Page) => ({
     requestType: (type: 'http' | 'graphql' | 'grpc' | 'ws') =>
       page.getByTestId(`presets-request-type-${type}`),
     requestUrl: () => page.getByTestId('presets-request-url'),
-    save: () => page.getByTestId('presets-save-btn')
+    saveBtn: () => page.getByTestId('presets-save-btn')
   },
   tags: {
     input: () => page.getByTestId('tag-input').getByRole('textbox'),


### PR DESCRIPTION
**Jira link: https://usebruno.atlassian.net/browse/BRU-3386**

### Description

changed the locators name preset.save() to preset.saveBtn()

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test locator references to maintain consistency across preset control tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->