### PR TITLE
fix(tests): update timeline item locators and improve response status code assertion

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -145,6 +145,7 @@ const TimelineItem = ({
           aria-expanded={isExpanded}
           onClick={toggleExpand}
           onKeyDown={handleRowKeyDown}
+          data-testid="timeline-item-header"
         >
           <div className="tl-col-chev">
             {isExpanded ? <IconChevronDown size={14} strokeWidth={2} /> : <IconChevronRight size={14} strokeWidth={2} />}

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/index.js
@@ -109,7 +109,7 @@ const Timeline = ({ collection, item }) => {
 
             if (isGrpcRequest) {
               return (
-                <div key={index} className="timeline-event">
+                <div key={index} className="timeline-event" data-testid="timeline-item">
                   <GrpcTimelineItem
                     timestamp={eventTimestamp}
                     request={request}
@@ -124,7 +124,7 @@ const Timeline = ({ collection, item }) => {
             }
 
             return (
-              <div key={index} className="timeline-event">
+              <div key={index} className="timeline-event" data-testid="timeline-item">
                 <TimelineItem
                   timestamp={timestamp}
                   request={request}
@@ -139,7 +139,7 @@ const Timeline = ({ collection, item }) => {
 
           if (entry.type === 'oauth2' && entry._oauth2Child) {
             return (
-              <div key={index} className="timeline-event">
+              <div key={index} className="timeline-event" data-testid="timeline-item">
                 <TimelineItem
                   timestamp={entry.timestamp}
                   request={entry._oauth2Child.request}
@@ -155,7 +155,7 @@ const Timeline = ({ collection, item }) => {
 
           if (entry.type === 'scripted-request') {
             return (
-              <div key={index} className="timeline-event">
+              <div key={index} className="timeline-event" data-testid="timeline-item">
                 <TimelineItem
                   timestamp={entry.timestamp}
                   request={entry.data?.request}

--- a/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
+++ b/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
@@ -62,7 +62,7 @@ test('Request inherits No Auth from the folder — collection Bearer Token is ov
   });
 
   await test.step('Verify the response status code is 401 Unauthorized', async () => {
-    await expect(locators.response.statusCode()).toContainText('401');
+    await expect(locators.response.statusCode()).toContainText('401 Unauthorized');
   });
 
   await test.step('Open the latest timeline entry and verify no Authorization header was sent', async () => {

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -130,9 +130,9 @@ export const buildCommonLocators = (page: Page) => ({
     jsonTreeLine: () => page.locator('.response-pane .object-content')
   },
   timeline: {
-    items: () => page.locator('.timeline-item'),
-    lastItem: () => page.locator('.timeline-item').last(),
-    itemHeader: (item: Locator) => item.locator('.oauth-request-item-header'),
+    items: () => page.getByTestId('timeline-item'),
+    lastItem: () => page.getByTestId('timeline-item').last(),
+    itemHeader: (item: Locator) => item.getByTestId('timeline-item-header'),
     clearButton: () => page.getByRole('button', { name: 'Clear Timeline' })
   },
   plusMenu: {


### PR DESCRIPTION
**Jira link: https://usebruno.atlassian.net/browse/BRU-3386**

### Description

Switch Timeline E2E locators to data-testids (added timeline-item / timeline-item-header) so they no longer break on CSS-class refactors and Playwrite test scrips failing issue fixed

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test identifiers to timeline components for more precise automated testing
  * Updated test utility locators to use new component test IDs
  * Enhanced authentication status assertion validation for improved test accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->