### PR TITLE
fix(grpc): gRPC request loses all messages except the first on save for yaml collection

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcBody/index.js
@@ -39,7 +39,7 @@ const MessageToolbar = ({
         </ToolHint>
 
         <ToolHint text="Generate sample" toolhintId={`regenerate-msg-${index}`}>
-          <button onClick={onRegenerateMessage} className="toolbar-btn">
+          <button onClick={onRegenerateMessage} className="toolbar-btn" data-testid={`grpc-regenerate-message-${index}`}>
             <IconRefresh size={16} strokeWidth={1.5} />
           </button>
         </ToolHint>

--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -281,6 +281,7 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
                   <div
                     className="dropdown-item"
                     key="show-file-format"
+                    data-testid="show-file-format-toggle"
                     onClick={(e) => {
                       dropdownTippyRef.current.hide();
                       setShowFileFormat(!showFileFormat);

--- a/packages/bruno-filestore/src/formats/yml/items/parseGrpcRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseGrpcRequest.ts
@@ -1,6 +1,6 @@
 import type { Item as BrunoItem } from '@usebruno/schema-types/collection/item';
 import type { GrpcRequest as BrunoGrpcRequest } from '@usebruno/schema-types/requests/grpc';
-import type { GrpcRequest, GrpcMetadata } from '@opencollection/types/requests/grpc';
+import type { GrpcRequest, GrpcMetadata, GrpcMessageVariant } from '@opencollection/types/requests/grpc';
 import type { KeyValue as BrunoKeyValue } from '@usebruno/schema-types/common/key-value';
 import { toBrunoAuth } from '../common/auth';
 import { toBrunoVariables } from '../common/variables';
@@ -57,10 +57,16 @@ const parseGrpcRequest = (ocRequest: GrpcRequest): BrunoItem => {
   };
 
   // message
-  if (isNonEmptyString(grpc?.message)) {
+  const rawMessage = grpc?.message;
+  if (Array.isArray(rawMessage)) {
+    brunoRequest.body.grpc = (rawMessage as GrpcMessageVariant[]).map(({ title, message }, index) => ({
+      name: title || `message ${index + 1}`,
+      content: ensureString(message)
+    }));
+  } else if (isNonEmptyString(rawMessage)) {
     brunoRequest.body.grpc = [{
       name: '',
-      content: grpc?.message as string
+      content: rawMessage as string
     }];
   }
 

--- a/packages/bruno-filestore/src/formats/yml/items/stringifyGrpcRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/stringifyGrpcRequest.ts
@@ -1,7 +1,7 @@
 import type { Item as BrunoItem } from '@usebruno/schema-types/collection/item';
 import type { KeyValue as BrunoKeyValue } from '@usebruno/schema-types/common/key-value';
 import type { GrpcRequest as BrunoGrpcRequest } from '@usebruno/schema-types/requests/grpc';
-import type { GrpcRequest, GrpcMetadata, GrpcMessage, GrpcRequestInfo, GrpcRequestDetails, GrpcRequestRuntime } from '@opencollection/types/requests/grpc';
+import type { GrpcRequest, GrpcMetadata, GrpcMessageVariant, GrpcMessage, GrpcRequestInfo, GrpcRequestDetails, GrpcRequestRuntime } from '@opencollection/types/requests/grpc';
 import type { Auth } from '@opencollection/types/common/auth';
 import type { Scripts } from '@opencollection/types/common/scripts';
 import type { Variable } from '@opencollection/types/common/variables';
@@ -73,16 +73,11 @@ const stringifyGrpcRequest = (item: BrunoItem): string => {
 
     // message
     if (brunoRequest.body?.mode === 'grpc' && brunoRequest.body.grpc?.length) {
-      const messages = brunoRequest.body.grpc;
-
-      // todo: bruno app supports only one message for now
-      // update this when bruno app supports multiple messages
-      if (messages.length) {
-        const message: GrpcMessage = messages[0].content || '';
-        if (message.trim().length) {
-          grpc.message = message;
-        }
-      }
+      const messages: GrpcMessageVariant[] = brunoRequest.body.grpc.map(({ name, content }, index) => ({
+        title: name || `message ${index + 1}`,
+        message: content || ''
+      }));
+      grpc.message = messages;
     }
 
     // auth

--- a/tests/grpc/multi-message-yml/multi-message.spec.ts
+++ b/tests/grpc/multi-message-yml/multi-message.spec.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { bruToJsonV2 } from '@usebruno/lang';
+import { expect, test } from '../../../playwright';
+import {
+  addGrpcMessage,
+  createCollection,
+  createRequest,
+  generateGrpcSampleMessage,
+  saveRequest,
+  selectGrpcMethod
+} from '../../utils/page/actions';
+
+const REQUEST_NAME = 'grpc-multi-msg';
+const GRPC_URL = 'grpcb.in:9000';
+const GRPC_METHOD = 'BidiHello';
+
+type GrpcRequestYml = {
+  grpc?: {
+    message?: { title: string; message: string }[];
+  };
+};
+
+const FORMATS = [
+  { format: 'yml', collectionName: 'grpc-yml-multi-msg', tmpDirPrefix: 'grpc-yml-collection' },
+  { format: 'bru', collectionName: 'grpc-bru-multi-msg', tmpDirPrefix: 'grpc-bru-collection' }
+] as const;
+
+for (const { format, collectionName, tmpDirPrefix } of FORMATS) {
+  test.describe.serial(`grpc multi-message (${format} format)`, () => {
+    let collectionPath: string;
+
+    test('creates a gRPC request with multiple messages and saves it', async ({ page, createTmpDir }) => {
+      collectionPath = await createTmpDir(tmpDirPrefix);
+
+      await createCollection(page, collectionName, collectionPath, format);
+      await createRequest(page, REQUEST_NAME, collectionName, { url: GRPC_URL, requestType: 'grpc' });
+      await selectGrpcMethod(page, GRPC_METHOD);
+
+      await addGrpcMessage(page);
+      await addGrpcMessage(page);
+      await generateGrpcSampleMessage(page, 0);
+      await generateGrpcSampleMessage(page, 1);
+      await generateGrpcSampleMessage(page, 2);
+
+      await saveRequest(page);
+
+      const messageContainers = page.getByTestId('grpc-messages-container').locator('.message-container');
+      await expect(messageContainers).toHaveCount(3, { timeout: 5000 });
+    });
+
+    test(`verifies all messages are saved in the request .${format} file`, async () => {
+      const requestFilePath = path.join(collectionPath, collectionName, `${REQUEST_NAME}.${format}`);
+      expect(fs.existsSync(requestFilePath)).toBe(true);
+
+      const fileContent = fs.readFileSync(requestFilePath, 'utf8');
+
+      if (format === 'yml') {
+        const parsed = yaml.load(fileContent) as GrpcRequestYml;
+        const messages = parsed.grpc?.message ?? [];
+        expect(messages.length).toBe(3);
+      } else if (format === 'bru') {
+        const parsed = bruToJsonV2(fileContent) as { body?: { grpc?: { name: string; content: string }[] } };
+        const messages = parsed.body?.grpc ?? [];
+        expect(messages.length).toBe(3);
+      }
+    });
+  });
+}

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1,9 +1,11 @@
 import { test, expect, Page, ElectronApplication, waitForReadyPage as waitForReadyPageImpl } from '../../../playwright';
 import process from 'node:process';
 import * as path from 'path';
-import { buildCommonLocators, buildScriptErrorLocators } from './locators';
+import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators } from './locators';
 
 type SandboxMode = 'safe' | 'developer';
+
+type CollectionFormat = 'bru' | 'yml';
 
 type WaitForAppReadyOptions = {
   timeout?: number;
@@ -101,7 +103,7 @@ const createCollection = async (
   page,
   collectionName: string,
   collectionLocation: string,
-  format: 'bru' | 'yml' = 'yml'
+  format: CollectionFormat = 'yml'
 ) => {
   await test.step(`Create ${format} collection "${collectionName}"`, async () => {
     await page.getByTestId('collections-header-add-menu').click();
@@ -1341,7 +1343,8 @@ const saveRequest = async (page: Page) => {
  */
 const addGrpcMessage = async (page: Page) => {
   await test.step('Add gRPC message', async () => {
-    await page.getByTestId('grpc-add-message-button').click();
+    const locators = buildGrpcCommonLocators(page);
+    await locators.request.addMessageButton().click();
   });
 };
 
@@ -1352,7 +1355,8 @@ const addGrpcMessage = async (page: Page) => {
  */
 const generateGrpcSampleMessage = async (page: Page, index: number = 0) => {
   await test.step(`Generate sample for gRPC message #${index}`, async () => {
-    await page.getByTestId(`grpc-regenerate-message-${index}`).click();
+    const locators = buildGrpcCommonLocators(page);
+    await locators.request.regenerateMessage(index).click();
   });
 };
 
@@ -1363,11 +1367,11 @@ const generateGrpcSampleMessage = async (page: Page, index: number = 0) => {
  */
 const selectGrpcMethod = async (page: Page, methodName: string) => {
   await test.step(`Select gRPC method "${methodName}"`, async () => {
-    await page.getByTestId('grpc-method-dropdown-trigger').click();
-    const dropdown = page.getByTestId('grpc-methods-dropdown');
-    await dropdown.waitFor({ state: 'visible', timeout: 5000 });
-    await dropdown.getByTestId('grpc-method-item').filter({ hasText: methodName }).first().click();
-    await expect(page.getByTestId('selected-grpc-method-name')).toContainText(methodName);
+    const locators = buildGrpcCommonLocators(page);
+    await locators.method.dropdownTrigger().click();
+    await locators.method.dropdown().waitFor({ state: 'visible', timeout: 5000 });
+    await locators.method.item(methodName).first().click();
+    await expect(locators.method.selectedName()).toContainText(methodName);
   });
 };
 

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -101,9 +101,9 @@ const createCollection = async (
   page,
   collectionName: string,
   collectionLocation: string,
-  format?: 'bru' | 'yml'
+  format: 'bru' | 'yml' = 'yml'
 ) => {
-  await test.step(`Create collection "${collectionName}"`, async () => {
+  await test.step(`Create ${format} collection "${collectionName}"`, async () => {
     await page.getByTestId('collections-header-add-menu').click();
     await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Create collection' }).click();
 
@@ -1336,6 +1336,42 @@ const saveRequest = async (page: Page) => {
 };
 
 /**
+ * Click the gRPC "Add Message" button to append a new message to the request
+ * @param page - The page object
+ */
+const addGrpcMessage = async (page: Page) => {
+  await test.step('Add gRPC message', async () => {
+    await page.getByTestId('grpc-add-message-button').click();
+  });
+};
+
+/**
+ * Click the "Generate sample" button on a gRPC message to populate it with a sample payload
+ * @param page - The page object
+ * @param index - The 0-based index of the message (default: 0)
+ */
+const generateGrpcSampleMessage = async (page: Page, index: number = 0) => {
+  await test.step(`Generate sample for gRPC message #${index}`, async () => {
+    await page.getByTestId(`grpc-regenerate-message-${index}`).click();
+  });
+};
+
+/**
+ * Open the gRPC method dropdown and select a method by name
+ * @param page - The page object
+ * @param methodName - The name of the gRPC method to select (e.g. "BidiHello")
+ */
+const selectGrpcMethod = async (page: Page, methodName: string) => {
+  await test.step(`Select gRPC method "${methodName}"`, async () => {
+    await page.getByTestId('grpc-method-dropdown-trigger').click();
+    const dropdown = page.getByTestId('grpc-methods-dropdown');
+    await dropdown.waitFor({ state: 'visible', timeout: 5000 });
+    await dropdown.getByTestId('grpc-method-item').filter({ hasText: methodName }).first().click();
+    await expect(page.getByTestId('selected-grpc-method-name')).toContainText(methodName);
+  });
+};
+
+/**
  * Close all open request tabs using the right-click context menu
  * @param page - The page object
  * @returns void
@@ -1684,6 +1720,9 @@ export {
   editAssertion,
   deleteAssertion,
   saveRequest,
+  addGrpcMessage,
+  generateGrpcSampleMessage,
+  selectGrpcMethod,
   closeAllTabs,
   createWorkspace,
   switchWorkspace,

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -237,13 +237,18 @@ export const buildGrpcCommonLocators = (page: Page) => ({
   ...buildCommonLocators(page),
   method: {
     dropdownTrigger: () => page.getByTestId('grpc-method-dropdown-trigger'),
-    indicator: () => page.getByTestId('grpc-method-indicator')
+    indicator: () => page.getByTestId('grpc-method-indicator'),
+    dropdown: () => page.getByTestId('grpc-methods-dropdown'),
+    item: (methodName: string) =>
+      page.getByTestId('grpc-methods-dropdown').getByTestId('grpc-method-item').filter({ hasText: methodName }),
+    selectedName: () => page.getByTestId('selected-grpc-method-name')
   },
   request: {
     queryUrlContainer: () => page.getByTestId('grpc-query-url-container'),
     sendButton: () => page.getByTestId('grpc-send-request-button'),
     messagesContainer: () => page.getByTestId('grpc-messages-container'),
     addMessageButton: () => page.getByTestId('grpc-add-message-button'),
+    regenerateMessage: (index: number) => page.getByTestId(`grpc-regenerate-message-${index}`),
     sendMessage: (index: number) => page.getByTestId(`grpc-send-message-${index}`),
     endConnectionButton: () => page.getByTestId('grpc-end-connection-button'),
     cancelConnectionButton: () => page.getByTestId('grpc-cancel-connection-button')


### PR DESCRIPTION
**Jira link: https://usebruno.atlassian.net/browse/BRU-3271**

### Description

In YAML collections, saving a gRPC request with multiple client messages only persisted the first message. On reload, all additional messages were lost.

This happened because both the YAML stringifier and parser handled grpc.message as a single string (legacy behavior from single-message support), instead of supporting multiple messages.

### Fix
Updated stringifier to save grpc.message as an array (GrpcMessageVariant[])
Updated parser to read and restore all messages correctly
Added an end-to-end test to verify multiple messages are persisted
Minor test utility improvements for gRPC request handling

### Compatibility

The fix matches the shape already used by the .bru format and by the
opencollection schema (`GrpcMessageVariant[]`), so requests round-trip cleanly
between formats. Existing yml requests written by older versions (with
`grpc.message` as a string) won't auto-migrate — they'll be treated as having
no messages until re-saved. If we want to preserve those, we can add a fallback
branch in the parser.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Before:
<img width="2914" height="1652" alt="image" src="https://github.com/user-attachments/assets/d047f8cf-2ea7-4060-9ba8-f4b2ab729dfb" />


After: 
<img width="1462" height="828" alt="Screenshot 2026-05-05 at 12 58 27 PM" src="https://github.com/user-attachments/assets/41a9cc1c-c1e3-44ae-ba86-38451d066a33" />


Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * gRPC requests now support multiple messages, each with independent sample generation and per-message controls.
* **Usability**
  * Collection sidebar file-format toggle and per-message sample controls improved for more reliable UI behavior.
* **Tests**
  * End-to-end tests added for creating multi-message gRPC requests, generating samples, and saving; test utilities updated to support multi-message flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->