### PR TITLE
fix(curl-import): preserve colons in basic-auth password

### DIFF
--- a/packages/bruno-app/src/utils/curl/parse-curl.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.js
@@ -216,7 +216,9 @@ const setAuth = (request, value) => {
     return;
   }
 
-  const [username, password] = value.split(':');
+  const separatorIndex = value.indexOf(':');
+  const username = separatorIndex === -1 ? value : value.slice(0, separatorIndex);
+  const password = separatorIndex === -1 ? '' : value.slice(separatorIndex + 1);
 
   // Store credentials temporarily for finalization in post-processing
   request.authCredentials = {

--- a/packages/bruno-app/src/utils/curl/parse-curl.spec.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.spec.js
@@ -273,6 +273,40 @@ describe('parseCurlCommand', () => {
       });
     });
 
+    // curl splits user:password on the FIRST colon only; the password may itself
+    // contain colons (e.g. tokens, base64). Bruno must preserve everything after
+    // the first colon. Verified against curl's documented behavior.
+    const colonPasswordCases = [
+      {
+        title: 'single embedded colon',
+        curl: `curl -u "admin:p:a:s:s" https://api.example.com`,
+        username: 'admin',
+        password: 'p:a:s:s'
+      },
+      {
+        title: '--user long-form alias',
+        curl: `curl --user "admin:a:b:c" https://api.example.com`,
+        username: 'admin',
+        password: 'a:b:c'
+      },
+      {
+        title: 'leading and trailing colons',
+        curl: `curl -u "admin::token::" https://api.example.com`,
+        username: 'admin',
+        password: ':token::'
+      }
+    ];
+
+    for (const { title, curl, username, password } of colonPasswordCases) {
+      it(`should preserve colons in the password (${title})`, () => {
+        const result = parseCurlCommand(curl);
+        expect(result.auth).toEqual({
+          mode: 'basic',
+          basic: { username, password }
+        });
+      });
+    }
+
     it('should parse digest authentication', () => {
       const result = parseCurlCommand(`
         curl --digest -u "myuser:mypass" https://api.example.com/digest


### PR DESCRIPTION
### Description

Fixes #8205.

When importing a cURL command with `-u user:password`, Bruno truncated the password at the first colon because `setAuth()` split on every colon and destructured only the first two parts:

```js
const [username, password] = value.split(':');
```

curl splits the `-u` value on the **first** colon only — the password may itself contain colons (e.g. tokens, base64). This change matches that behavior by finding the first colon and slicing around it:

```js
const separatorIndex = value.indexOf(':');
const username = separatorIndex === -1 ? value : value.slice(0, separatorIndex);
const password = separatorIndex === -1 ? '' : value.slice(separatorIndex + 1);
```

The `separatorIndex === -1` branch preserves existing behavior for `-u username` with no colon (password becomes `''`).

Added data-driven regression tests covering an embedded colon, the `--user` long-form alias, and leading/trailing colons. All `parse-curl` tests pass (55/55).

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential parsing in curl commands for basic authentication. Passwords containing colons are now correctly preserved during parsing instead of being incorrectly split on all colon occurrences.

* **Tests**
  * Added extensive test coverage for curl authentication parsing with edge cases, including passwords with embedded colons, leading/trailing colons, and long-form credential syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->