### PR TITLE
feat(curl): add support for Windows CMD-style curl command parsing an…

### DIFF
--- a/packages/bruno-app/src/utils/curl/parse-curl.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.js
@@ -518,10 +518,34 @@ const cleanRequest = (request) => {
 };
 
 /**
+ * Detect and decode Windows CMD-style curl commands.
+ *
+ * Browsers' "Copy as cURL (cmd)" wraps every argument in `^"..."^"` and
+ * caret-escapes special characters (e.g. `"` becomes `^\^"`, `{` becomes `^{`),
+ * continuing lines with a trailing `^`. The `shell-quote` parser only understands
+ * POSIX/bash syntax, so these carets leak into the parsed result.
+ *
+ * Since CMD always escapes a literal caret as `^^`, every remaining caret is an
+ * escape character: stripping the caret before the character it escapes (including
+ * line-continuation newlines) yields an equivalent bash-style command.
+ */
+const normalizeWindowsCmdCurl = (curlCommand) => {
+  // `^"` is the hallmark of the cmd format; leave other commands untouched
+  if (!/\^"/.test(curlCommand)) {
+    return curlCommand;
+  }
+
+  // A caret escapes the following character (including line-continuation newlines)
+  return curlCommand.replace(/\^([\s\S])/g, '$1');
+};
+
+/**
  * Clean up curl command
  * Handles escape sequences, line continuations, and method concatenation
  */
 const cleanCurlCommand = (curlCommand) => {
+  // Decode Windows CMD caret-escaping before bash-oriented processing
+  curlCommand = normalizeWindowsCmdCurl(curlCommand);
   // Handle bash ANSI $'..' escapes by decoding common sequences
   curlCommand = curlCommand.replace(/\$'((?:\\.|[^'])*)'/g, (match, group) => quoteForShell(decodeAnsiEscapes(group)));
   // Convert escaped single quotes to shell quote pattern

--- a/packages/bruno-app/src/utils/curl/parse-curl.spec.js
+++ b/packages/bruno-app/src/utils/curl/parse-curl.spec.js
@@ -929,4 +929,40 @@ describe('parseCurlCommand', () => {
       });
     });
   });
+
+  describe('Windows CMD format (Copy as cURL (cmd))', () => {
+    it('should decode caret-escaping, line continuations and quoted values', () => {
+      const result = parseCurlCommand(
+        'curl ^"https://api.example.com/v1/intake^" ^\r\n'
+        + '  -H ^"Content-Type: application/json^" ^\r\n'
+        + '  -H ^"sec-ch-ua: ^\\^"Brave^\\^";v=^\\^"149^\\^"^" ^\r\n'
+        + '  --data-raw ^"^{^\\^"pageNum^\\^":1,^\\^"name^\\^":^\\^"John^\\^"^}^"'
+      );
+
+      expect(result).toEqual({
+        method: 'post',
+        url: 'https://api.example.com/v1/intake',
+        urlWithoutQuery: 'https://api.example.com/v1/intake',
+        headers: {
+          'Content-Type': 'application/json',
+          'sec-ch-ua': '"Brave";v="149"'
+        },
+        data: '{"pageNum":1,"name":"John"}',
+        isDataRaw: true
+      });
+    });
+
+    it('should not alter bash-style commands that contain no caret-quoting', () => {
+      const result = parseCurlCommand(`
+        curl -X POST --data '{"a":1}' https://api.example.com/v1/intake
+      `);
+
+      expect(result).toEqual({
+        method: 'post',
+        url: 'https://api.example.com/v1/intake',
+        urlWithoutQuery: 'https://api.example.com/v1/intake',
+        data: '{"a":1}'
+      });
+    });
+  });
 });


### PR DESCRIPTION
…d tests

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows CMD curl commands are now fully supported with automatic normalization of escape sequences and line continuations, enabling seamless import without manual editing.

* **Tests**
  * Added comprehensive test coverage for Windows CMD curl parsing, verifying escape sequence handling, CRLF line continuations, quoted value decoding, and backward compatibility with bash-style commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->