### PR TITLE
fix: Folder Sequencing When we try to move any folder at the bottom o…

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -54,7 +54,12 @@ import {
 } from 'src/selectors/tab';
 import { isEqual } from 'lodash';
 import { createEmptyStateMenuItems } from 'utils/collections/emptyStateRequest';
-import { calculateDraggedItemNewPathname, getInitialExampleName, findParentItemInCollection } from 'utils/collections/index';
+import {
+  canCollectionItemBeDropped,
+  determineCollectionItemDrop,
+  getInitialExampleName,
+  findParentItemInCollection
+} from 'utils/collections/index';
 import { sortByNameThenSequence } from 'utils/common/index';
 import { getRevealInFolderLabel } from 'utils/common/platform';
 import CreateExampleModal from 'components/ResponseExample/CreateExampleModal';
@@ -137,6 +142,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   }, { enabled: isKeyboardFocused && isFolder, deps: [isKeyboardFocused, isFolder] });
 
   const [dropType, setDropType] = useState(null); // 'adjacent' or 'inside'
+  const [dropPosition, setDropPosition] = useState(null); // 'above' or 'below' when adjacent
 
   const [{ isDragging }, drag, dragPreview] = useDrag({
     type: 'collection-item',
@@ -164,55 +170,22 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     }
   }, [isTabForItemActive]);
 
-  const determineDropType = (monitor) => {
-    const hoverBoundingRect = ref.current?.getBoundingClientRect();
-    const clientOffset = monitor.getClientOffset();
-    if (!hoverBoundingRect || !clientOffset) return null;
-
-    const clientY = clientOffset.y - hoverBoundingRect.top;
-    const folderUpperThreshold = hoverBoundingRect.height * 0.35;
-    const fileUpperThreshold = hoverBoundingRect.height * 0.5;
-
-    if (isItemAFolder(item)) {
-      return clientY < folderUpperThreshold ? 'adjacent' : 'inside';
-    } else {
-      return clientY < fileUpperThreshold ? 'adjacent' : null;
-    }
-  };
-
-  // Which sidebar section an item belongs to. The sidebar renders these three
-  // sections in order (folders → apps → requests), each sorted by seq independently.
-  const getSidebarSection = (i) => {
-    if (isItemAFolder(i)) return 'folder';
-    if (i?.type === 'app') return 'app';
-    return 'request';
+  const resolveDropFromMonitor = (monitor) => {
+    return determineCollectionItemDrop({
+      item,
+      hoverBoundingRect: ref.current?.getBoundingClientRect(),
+      clientOffset: monitor.getClientOffset()
+    });
   };
 
   const canItemBeDropped = ({ draggedItem, targetItem, dropType }) => {
-    const { uid: targetItemUid, pathname: targetItemPathname } = targetItem;
-    const { uid: draggedItemUid, pathname: draggedItemPathname, sourceCollectionUid } = draggedItem;
-
-    if (draggedItemUid === targetItemUid) return false;
-
-    // The sidebar renders items grouped by section (folders → apps → requests) and
-    // sorts each section by seq independently. An 'adjacent' drop between two different
-    // sections could never move the item across sections visually, so reject it.
-    // 'inside' drops on a folder are unaffected (that's a directory move, not a reorder).
-    if (dropType === 'adjacent' && getSidebarSection(draggedItem) !== getSidebarSection(targetItem)) {
-      return false;
-    }
-
-    // For cross-collection moves, we allow the drop
-    if (sourceCollectionUid !== collectionUid) {
-      return true;
-    }
-
-    const newPathname = calculateDraggedItemNewPathname({ draggedItem, targetItem, dropType, collectionPathname });
-    if (!newPathname) return false;
-
-    if (targetItemPathname?.startsWith(draggedItemPathname)) return false;
-
-    return true;
+    return canCollectionItemBeDropped({
+      draggedItem,
+      targetItem,
+      dropType,
+      collectionUid,
+      collectionPathname
+    });
   };
 
   const [{ isOver, canDrop }, drop] = useDrop({
@@ -223,11 +196,17 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
       if (draggedItemUid === targetItemUid) return;
 
-      const dropType = determineDropType(monitor);
+      const drop = resolveDropFromMonitor(monitor);
+      if (!drop) {
+        setDropType(null);
+        setDropPosition(null);
+        return;
+      }
 
-      const _canItemBeDropped = canItemBeDropped({ draggedItem, targetItem: item, dropType });
+      const _canItemBeDropped = canItemBeDropped({ draggedItem, targetItem: item, dropType: drop.dropType });
 
-      setDropType(_canItemBeDropped ? dropType : null);
+      setDropType(_canItemBeDropped ? drop.dropType : null);
+      setDropPosition(_canItemBeDropped ? drop.dropPosition : null);
     },
     drop: async (draggedItem, monitor) => {
       const { uid: targetItemUid } = item;
@@ -235,18 +214,41 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
       if (draggedItemUid === targetItemUid) return;
 
-      const dropType = determineDropType(monitor);
-      if (!dropType) return;
-      if (!canItemBeDropped({ draggedItem, targetItem: item, dropType })) return;
+      const drop = resolveDropFromMonitor(monitor);
+      if (!drop) return;
 
-      await dispatch(handleCollectionItemDrop({ targetItem: item, draggedItem, dropType, collectionUid }));
+      if (!canItemBeDropped({ draggedItem, targetItem: item, dropType: drop.dropType })) return;
+
+      await dispatch(handleCollectionItemDrop({
+        targetItem: item,
+        draggedItem,
+        dropType: drop.dropType,
+        dropPosition: drop.dropPosition,
+        collectionUid
+      }));
       setDropType(null);
+      setDropPosition(null);
     },
-    canDrop: (draggedItem) => draggedItem.uid !== item.uid,
+    canDrop: (draggedItem, monitor) => {
+      if (draggedItem.uid === item.uid) return false;
+
+      const drop = resolveDropFromMonitor(monitor);
+      if (!drop) return false;
+
+      return canItemBeDropped({ draggedItem, targetItem: item, dropType: drop.dropType });
+    },
     collect: (monitor) => ({
-      isOver: monitor.isOver()
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop()
     })
   });
+
+  useEffect(() => {
+    if (!isOver) {
+      setDropType(null);
+      setDropPosition(null);
+    }
+  }, [isOver]);
 
   const iconClassName = classnames({
     'rotate-90': !itemIsCollapsed
@@ -259,8 +261,9 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   const itemRowClassName = classnames('flex collection-item-name relative items-center', {
     'item-focused-in-tab': isTabForItemActive,
     'item-hovered': isOver && canDrop,
-    'drop-target': isOver && dropType === 'inside',
-    'drop-target-above': isOver && dropType === 'adjacent',
+    'drop-target': isOver && canDrop && dropType === 'inside',
+    'drop-target-above': isOver && canDrop && dropType === 'adjacent' && dropPosition === 'above',
+    'drop-target-below': isOver && canDrop && dropType === 'adjacent' && dropPosition === 'below',
     'item-keyboard-focused': isKeyboardFocused
   });
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -135,14 +135,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     return false;
   }, { enabled: isKeyboardFocused, deps: [isKeyboardFocused] });
 
-  useKeybinding('newRequest', () => {
-    if (!isFolder) return false;
-    setNewRequestModalOpen(true);
-    return false;
-  }, { enabled: isKeyboardFocused && isFolder, deps: [isKeyboardFocused, isFolder] });
-
-  const [dropType, setDropType] = useState(null); // 'adjacent' or 'inside'
-  const [dropPosition, setDropPosition] = useState(null); // 'above' or 'below' when adjacent
+  const [dropType, setDropType] = useState(null); // 'above', 'inside' or 'below'
 
   const [{ isDragging }, drag, dragPreview] = useDrag({
     type: 'collection-item',
@@ -196,17 +189,15 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
       if (draggedItemUid === targetItemUid) return;
 
-      const drop = resolveDropFromMonitor(monitor);
-      if (!drop) {
+      const dropType = resolveDropFromMonitor(monitor);
+      if (!dropType) {
         setDropType(null);
-        setDropPosition(null);
         return;
       }
 
-      const _canItemBeDropped = canItemBeDropped({ draggedItem, targetItem: item, dropType: drop.dropType });
+      const _canItemBeDropped = canItemBeDropped({ draggedItem, targetItem: item, dropType });
 
-      setDropType(_canItemBeDropped ? drop.dropType : null);
-      setDropPosition(_canItemBeDropped ? drop.dropPosition : null);
+      setDropType(_canItemBeDropped ? dropType : null);
     },
     drop: async (draggedItem, monitor) => {
       const { uid: targetItemUid } = item;
@@ -214,28 +205,26 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
       if (draggedItemUid === targetItemUid) return;
 
-      const drop = resolveDropFromMonitor(monitor);
-      if (!drop) return;
+      const dropType = resolveDropFromMonitor(monitor);
+      if (!dropType) return;
 
-      if (!canItemBeDropped({ draggedItem, targetItem: item, dropType: drop.dropType })) return;
+      if (!canItemBeDropped({ draggedItem, targetItem: item, dropType })) return;
 
       await dispatch(handleCollectionItemDrop({
         targetItem: item,
         draggedItem,
-        dropType: drop.dropType,
-        dropPosition: drop.dropPosition,
+        dropType,
         collectionUid
       }));
       setDropType(null);
-      setDropPosition(null);
     },
     canDrop: (draggedItem, monitor) => {
       if (draggedItem.uid === item.uid) return false;
 
-      const drop = resolveDropFromMonitor(monitor);
-      if (!drop) return false;
+      const dropType = resolveDropFromMonitor(monitor);
+      if (!dropType) return false;
 
-      return canItemBeDropped({ draggedItem, targetItem: item, dropType: drop.dropType });
+      return canItemBeDropped({ draggedItem, targetItem: item, dropType });
     },
     collect: (monitor) => ({
       isOver: monitor.isOver(),
@@ -246,7 +235,6 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   useEffect(() => {
     if (!isOver) {
       setDropType(null);
-      setDropPosition(null);
     }
   }, [isOver]);
 
@@ -262,8 +250,8 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     'item-focused-in-tab': isTabForItemActive,
     'item-hovered': isOver && canDrop,
     'drop-target': isOver && canDrop && dropType === 'inside',
-    'drop-target-above': isOver && canDrop && dropType === 'adjacent' && dropPosition === 'above',
-    'drop-target-below': isOver && canDrop && dropType === 'adjacent' && dropPosition === 'below',
+    'drop-target-above': isOver && canDrop && dropType === 'above',
+    'drop-target-below': isOver && canDrop && dropType === 'below',
     'item-keyboard-focused': isKeyboardFocused
   });
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -270,7 +270,7 @@ const Collection = ({ collection, searchText }) => {
         setDropType('inside');
       } else {
         // For collections, show line indicator (adjacent drop)
-        setDropType('adjacent');
+        setDropType('above');
       }
     },
     drop: (draggedItem, monitor) => {
@@ -326,7 +326,7 @@ const Collection = ({ collection, searchText }) => {
   }
 
   const collectionRowClassName = classnames('flex py-1 collection-name items-center', {
-    'item-hovered': isOver && dropType === 'adjacent', // For collection-to-collection moves (show line)
+    'item-hovered': isOver && dropType === 'above', // For collection-to-collection moves (show line)
     'drop-target': isOver && dropType === 'inside', // For collection-item drops (highlight full area)
     'collection-focused-in-tab': isCollectionFocused && !isKeyboardFocused,
     'collection-keyboard-focused': isKeyboardFocused

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -86,7 +86,8 @@ import {
   calculateDraggedItemNewPathname,
   transformFolderRootToSave,
   getTreePathFromCollectionToItem,
-  mergeHeaders
+  mergeHeaders,
+  isPathOrDescendant
 } from 'utils/collections/index';
 import { sanitizeName } from 'utils/common/regex';
 import { applyScriptEnvVars, getScriptModifiedKeys } from 'utils/environments';
@@ -1316,7 +1317,7 @@ export const handleCollectionItemDrop
             collectionPathname: collection.pathname
           });
           if (!newPathname) return;
-          if (targetItemPathname?.startsWith(draggedItemPathname)) return;
+          if (isPathOrDescendant(targetItemPathname, draggedItemPathname)) return;
 
           if (isCrossFormatMove && isItemAFolder(draggedItem)) {
             toast.error('Moving folders between collections with different formats is not supported');

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1206,7 +1206,7 @@ export const moveItem
     };
 
 export const handleCollectionItemDrop
-  = ({ targetItem, draggedItem, dropType, dropPosition = 'above', collectionUid }) =>
+  = ({ targetItem, draggedItem, dropType, collectionUid }) =>
     (dispatch, getState) => {
       const state = getState();
       const collection = findCollectionByUid(state.collections.collections, collectionUid);
@@ -1268,7 +1268,7 @@ export const handleCollectionItemDrop
         }
 
         // Update sequences in the target directory (if dropping adjacent)
-        if (dropType === 'adjacent') {
+        if (dropType === 'above' || dropType === 'below') {
           const targetItemSequence = targetItemDirectoryItems.find((i) => i.uid === targetItemUid)?.seq;
 
           const draggedItemWithNewPathAndSequence = {
@@ -1282,7 +1282,7 @@ export const handleCollectionItemDrop
             items: [...targetItemDirectoryItems, draggedItemWithNewPathAndSequence],
             targetItemUid,
             draggedItemUid,
-            dropPosition
+            dropType
           });
 
           if (reorderedTargetItems?.length) {
@@ -1291,7 +1291,7 @@ export const handleCollectionItemDrop
         }
       };
 
-      const handleReorderInSameLocation = async ({ draggedItem, targetItem, targetItemDirectoryItems, dropPosition }) => {
+      const handleReorderInSameLocation = async ({ draggedItem, targetItem, targetItemDirectoryItems, dropType }) => {
         const { uid: targetItemUid } = targetItem;
         const { uid: draggedItemUid } = draggedItem;
 
@@ -1300,7 +1300,7 @@ export const handleCollectionItemDrop
           items: targetItemDirectoryItems,
           targetItemUid,
           draggedItemUid,
-          dropPosition
+          dropType
         });
 
         if (reorderedItems?.length) {
@@ -1341,7 +1341,7 @@ export const handleCollectionItemDrop
               dropType
             });
           } else {
-            await handleReorderInSameLocation({ draggedItem, targetItemDirectoryItems, targetItem, dropPosition });
+            await handleReorderInSameLocation({ draggedItem, targetItemDirectoryItems, targetItem, dropType });
           }
 
           if (isCrossCollectionMove) {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1205,7 +1205,7 @@ export const moveItem
     };
 
 export const handleCollectionItemDrop
-  = ({ targetItem, draggedItem, dropType, collectionUid }) =>
+  = ({ targetItem, draggedItem, dropType, dropPosition = 'above', collectionUid }) =>
     (dispatch, getState) => {
       const state = getState();
       const collection = findCollectionByUid(state.collections.collections, collectionUid);
@@ -1280,7 +1280,8 @@ export const handleCollectionItemDrop
           const reorderedTargetItems = getReorderedItemsInTargetDirectory({
             items: [...targetItemDirectoryItems, draggedItemWithNewPathAndSequence],
             targetItemUid,
-            draggedItemUid
+            draggedItemUid,
+            dropPosition
           });
 
           if (reorderedTargetItems?.length) {
@@ -1289,7 +1290,7 @@ export const handleCollectionItemDrop
         }
       };
 
-      const handleReorderInSameLocation = async ({ draggedItem, targetItem, targetItemDirectoryItems }) => {
+      const handleReorderInSameLocation = async ({ draggedItem, targetItem, targetItemDirectoryItems, dropPosition }) => {
         const { uid: targetItemUid } = targetItem;
         const { uid: draggedItemUid } = draggedItem;
 
@@ -1297,7 +1298,8 @@ export const handleCollectionItemDrop
         const reorderedItems = getReorderedItemsInTargetDirectory({
           items: targetItemDirectoryItems,
           targetItemUid,
-          draggedItemUid
+          draggedItemUid,
+          dropPosition
         });
 
         if (reorderedItems?.length) {
@@ -1338,7 +1340,7 @@ export const handleCollectionItemDrop
               dropType
             });
           } else {
-            await handleReorderInSameLocation({ draggedItem, targetItemDirectoryItems, targetItem });
+            await handleReorderInSameLocation({ draggedItem, targetItemDirectoryItems, targetItem, dropPosition });
           }
 
           if (isCrossCollectionMove) {

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1529,7 +1529,7 @@ export const calculateNewSequence = (isDraggedItem, targetSequence, draggedSeque
   return targetSequence > draggedSequence ? targetSequence - 1 : targetSequence;
 };
 
-export const getReorderedItemsInTargetDirectory = ({ items, targetItemUid, draggedItemUid, dropPosition = 'above' }) => {
+export const getReorderedItemsInTargetDirectory = ({ items, targetItemUid, draggedItemUid, dropType = 'above' }) => {
   const itemsWithFixedSequences = resetSequencesInFolder(cloneDeep(items));
   const sortedItems = [...itemsWithFixedSequences].sort((a, b) => a.seq - b.seq);
 
@@ -1538,10 +1538,7 @@ export const getReorderedItemsInTargetDirectory = ({ items, targetItemUid, dragg
 
   if (targetIndex === -1 || draggedIndex === -1) return [];
 
-  let newIndex = targetIndex;
-  if (dropPosition === 'below') {
-    newIndex = targetIndex + 1;
-  }
+  let newIndex = dropType === 'below' ? targetIndex + 1 : targetIndex;
   if (draggedIndex < newIndex) {
     newIndex -= 1;
   }
@@ -1574,37 +1571,28 @@ export const calculateDraggedItemNewPathname = ({ draggedItem, targetItem, dropT
 
   if (dropType === 'inside' && (isTargetItemAFolder || isTargetTheCollection)) {
     return path.join(targetItemPathname, draggedItemFilename);
-  } else if (dropType === 'adjacent') {
+  } else if (dropType === 'above' || dropType === 'below') {
     return path.join(targetItemDirname, draggedItemFilename);
   }
   return null;
 };
 
-/**
- * Resolves drop intent from hover position.
- * - dropType: semantic target — drop beside (adjacent) or into (inside) the item
- * - dropPosition: edge for adjacent drops only — above or below the target row
- */
 export const determineCollectionItemDrop = ({ item, hoverBoundingRect, clientOffset }) => {
   if (!hoverBoundingRect || !clientOffset) return null;
 
   const clientY = clientOffset.y - hoverBoundingRect.top;
-  const midpoint = hoverBoundingRect.height * 0.5;
 
   if (isItemAFolder(item)) {
-    const folderUpperThreshold = hoverBoundingRect.height * 0.35;
+    const folderUpperThreshold = hoverBoundingRect.height * 0.3;
+    const folderLowerThreshold = hoverBoundingRect.height * 0.7;
 
-    if (clientY < folderUpperThreshold) {
-      return { dropType: 'adjacent', dropPosition: 'above' };
-    }
-
-    return { dropType: 'inside', dropPosition: null };
+    if (clientY < folderUpperThreshold) return 'above';
+    if (clientY > folderLowerThreshold) return 'below';
+    return 'inside';
   }
 
-  return {
-    dropType: 'adjacent',
-    dropPosition: clientY < midpoint ? 'above' : 'below'
-  };
+  const midpoint = hoverBoundingRect.height * 0.5;
+  return clientY < midpoint ? 'above' : 'below';
 };
 
 /**

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1529,24 +1529,30 @@ export const calculateNewSequence = (isDraggedItem, targetSequence, draggedSeque
   return targetSequence > draggedSequence ? targetSequence - 1 : targetSequence;
 };
 
-export const getReorderedItemsInTargetDirectory = ({ items, targetItemUid, draggedItemUid }) => {
+export const getReorderedItemsInTargetDirectory = ({ items, targetItemUid, draggedItemUid, dropPosition = 'above' }) => {
   const itemsWithFixedSequences = resetSequencesInFolder(cloneDeep(items));
-  const targetItem = findItem(itemsWithFixedSequences, targetItemUid);
-  const draggedItem = findItem(itemsWithFixedSequences, draggedItemUid);
-  const targetSequence = targetItem?.seq;
-  const draggedSequence = draggedItem?.seq;
-  itemsWithFixedSequences?.forEach((item) => {
-    const isDraggedItem = item?.uid === draggedItemUid;
-    const isBetween = isItemBetweenSequences(item?.seq, draggedSequence, targetSequence);
-    if (isBetween) {
-      item.seq += targetSequence > draggedSequence ? -1 : 1;
-    }
-    const newSequence = calculateNewSequence(isDraggedItem, targetSequence, draggedSequence);
-    if (newSequence !== null) {
-      item.seq = newSequence;
-    }
+  const sortedItems = [...itemsWithFixedSequences].sort((a, b) => a.seq - b.seq);
+
+  const targetIndex = sortedItems.findIndex((i) => i.uid === targetItemUid);
+  const draggedIndex = sortedItems.findIndex((i) => i.uid === draggedItemUid);
+
+  if (targetIndex === -1 || draggedIndex === -1) return [];
+
+  let newIndex = targetIndex;
+  if (dropPosition === 'below') {
+    newIndex = targetIndex + 1;
+  }
+  if (draggedIndex < newIndex) {
+    newIndex -= 1;
+  }
+
+  const [draggedItem] = sortedItems.splice(draggedIndex, 1);
+  sortedItems.splice(newIndex, 0, draggedItem);
+
+  sortedItems.forEach((item, index) => {
+    item.seq = index + 1;
   });
-  // only return items that have been reordered
+
   return itemsWithFixedSequences.filter((item) =>
     items?.find((originalItem) => originalItem?.uid === item?.uid)?.seq !== item?.seq
   );
@@ -1572,6 +1578,57 @@ export const calculateDraggedItemNewPathname = ({ draggedItem, targetItem, dropT
     return path.join(targetItemDirname, draggedItemFilename);
   }
   return null;
+};
+
+/**
+ * Resolves drop intent from hover position.
+ * - dropType: semantic target — drop beside (adjacent) or into (inside) the item
+ * - dropPosition: edge for adjacent drops only — above or below the target row
+ */
+export const determineCollectionItemDrop = ({ item, hoverBoundingRect, clientOffset }) => {
+  if (!hoverBoundingRect || !clientOffset) return null;
+
+  const clientY = clientOffset.y - hoverBoundingRect.top;
+  const midpoint = hoverBoundingRect.height * 0.5;
+
+  if (isItemAFolder(item)) {
+    const folderUpperThreshold = hoverBoundingRect.height * 0.35;
+
+    if (clientY < folderUpperThreshold) {
+      return { dropType: 'adjacent', dropPosition: 'above' };
+    }
+
+    return { dropType: 'inside', dropPosition: null };
+  }
+
+  return {
+    dropType: 'adjacent',
+    dropPosition: clientY < midpoint ? 'above' : 'below'
+  };
+};
+
+export const canCollectionItemBeDropped = ({
+  draggedItem,
+  targetItem,
+  dropType,
+  collectionUid,
+  collectionPathname
+}) => {
+  const { uid: targetItemUid, pathname: targetItemPathname } = targetItem;
+  const { uid: draggedItemUid, pathname: draggedItemPathname, sourceCollectionUid } = draggedItem;
+
+  if (draggedItemUid === targetItemUid) return false;
+
+  if (sourceCollectionUid !== collectionUid) {
+    return true;
+  }
+
+  const newPathname = calculateDraggedItemNewPathname({ draggedItem, targetItem, dropType, collectionPathname });
+  if (!newPathname) return false;
+
+  if (targetItemPathname?.startsWith(draggedItemPathname)) return false;
+
+  return true;
 };
 
 // item sequence utils - END

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1,7 +1,7 @@
 import { cloneDeep, isEqual, sortBy, filter, map, isString, findIndex, find, each, get } from 'lodash';
 import { uuid } from 'utils/common';
 import { sortByNameThenSequence } from 'utils/common/index';
-import path from 'utils/common/path';
+import path, { normalizePath } from 'utils/common/path';
 import { isRequestTagsIncluded } from '@usebruno/common';
 
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
@@ -1607,6 +1607,20 @@ export const determineCollectionItemDrop = ({ item, hoverBoundingRect, clientOff
   };
 };
 
+/**
+ * Separator-aware ancestry check between two filesystem pathnames.
+ *
+ * Returns true when `childPathname` is the same as, or a descendant of, `ancestorPathname`.
+ * Uses path-segment boundaries so siblings like "/users-archive" are NOT treated as
+ * descendants of "/users". Normalizes separators and trailing slashes for cross-platform safety.
+ */
+export const isPathOrDescendant = (childPathname, ancestorPathname) => {
+  if (!childPathname || !ancestorPathname) return false;
+  const child = normalizePath(childPathname);
+  const ancestor = normalizePath(ancestorPathname);
+  return child === ancestor || child.startsWith(`${ancestor}/`);
+};
+
 export const canCollectionItemBeDropped = ({
   draggedItem,
   targetItem,
@@ -1626,7 +1640,7 @@ export const canCollectionItemBeDropped = ({
   const newPathname = calculateDraggedItemNewPathname({ draggedItem, targetItem, dropType, collectionPathname });
   if (!newPathname) return false;
 
-  if (targetItemPathname?.startsWith(draggedItemPathname)) return false;
+  if (isPathOrDescendant(targetItemPathname, draggedItemPathname)) return false;
 
   return true;
 };

--- a/packages/bruno-app/src/utils/tests/collections/drag-and-drop.spec.js
+++ b/packages/bruno-app/src/utils/tests/collections/drag-and-drop.spec.js
@@ -4,6 +4,7 @@ import {
   determineCollectionItemDrop,
   getReorderedItemsInTargetDirectory
 } from 'utils/collections/index';
+import { sortByNameThenSequence } from 'utils/common/index';
 import path from 'utils/common/path';
 
 const collectionPathname = path.join(path.sep, 'collections', 'my-collection');
@@ -55,7 +56,7 @@ describe('determineCollectionItemDrop', () => {
     ).toBeNull();
   });
 
-  it('returns adjacent+above for the top half of a request row', () => {
+  it('returns above for the top half of a request row', () => {
     const rect = createBoundingRect(100, 32);
 
     expect(
@@ -64,10 +65,10 @@ describe('determineCollectionItemDrop', () => {
         hoverBoundingRect: rect,
         clientOffset: { x: 0, y: 110 }
       })
-    ).toEqual({ dropType: 'adjacent', dropPosition: 'above' });
+    ).toBe('above');
   });
 
-  it('returns adjacent+below for the bottom half of a request row', () => {
+  it('returns below for the bottom half of a request row', () => {
     const rect = createBoundingRect(100, 32);
 
     expect(
@@ -76,31 +77,43 @@ describe('determineCollectionItemDrop', () => {
         hoverBoundingRect: rect,
         clientOffset: { x: 0, y: 122 }
       })
-    ).toEqual({ dropType: 'adjacent', dropPosition: 'below' });
+    ).toBe('below');
   });
 
-  it('returns adjacent+above for the top 35% of a folder row', () => {
+  it('returns above for the top 30% of a folder row', () => {
     const rect = createBoundingRect(100, 40);
 
     expect(
       determineCollectionItemDrop({
         item: folderItem,
         hoverBoundingRect: rect,
-        clientOffset: { x: 0, y: 112 }
+        clientOffset: { x: 0, y: 108 }
       })
-    ).toEqual({ dropType: 'adjacent', dropPosition: 'above' });
+    ).toBe('above');
   });
 
-  it('returns inside for the bottom 65% of a folder row', () => {
+  it('returns inside for the middle of a folder row', () => {
     const rect = createBoundingRect(100, 40);
 
     expect(
       determineCollectionItemDrop({
         item: folderItem,
         hoverBoundingRect: rect,
-        clientOffset: { x: 0, y: 128 }
+        clientOffset: { x: 0, y: 120 }
       })
-    ).toEqual({ dropType: 'inside', dropPosition: null });
+    ).toBe('inside');
+  });
+
+  it('returns below for the bottom 30% of a folder row (BRU-1112: move folder to end)', () => {
+    const rect = createBoundingRect(100, 40);
+
+    expect(
+      determineCollectionItemDrop({
+        item: folderItem,
+        hoverBoundingRect: rect,
+        clientOffset: { x: 0, y: 134 }
+      })
+    ).toBe('below');
   });
 });
 
@@ -116,11 +129,11 @@ describe('calculateDraggedItemNewPathname', () => {
     expect(result).toBe(path.join(folderPathname, 'create-user.bru'));
   });
 
-  it('returns a sibling path for adjacent drops', () => {
+  it('returns a sibling path for above/below drops', () => {
     const result = calculateDraggedItemNewPathname({
       draggedItem: draggedRequest,
       targetItem: requestItem,
-      dropType: 'adjacent',
+      dropType: 'above',
       collectionPathname
     });
 
@@ -144,7 +157,7 @@ describe('canCollectionItemBeDropped', () => {
     const result = canCollectionItemBeDropped({
       draggedItem: { ...requestItem, sourceCollectionUid: 'collection-1' },
       targetItem: requestItem,
-      dropType: 'adjacent',
+      dropType: 'above',
       collectionUid: 'collection-1',
       collectionPathname
     });
@@ -202,11 +215,11 @@ describe('canCollectionItemBeDropped', () => {
     expect(result).toBe(true);
   });
 
-  it('returns true for valid same-collection adjacent drops regardless of position', () => {
+  it('returns true for valid same-collection sibling drops regardless of position', () => {
     const result = canCollectionItemBeDropped({
       draggedItem: { ...draggedRequest, sourceCollectionUid: 'collection-1' },
       targetItem: requestItem,
-      dropType: 'adjacent',
+      dropType: 'above',
       collectionUid: 'collection-1',
       collectionPathname
     });
@@ -243,7 +256,7 @@ describe('getReorderedItemsInTargetDirectory', () => {
       items: folderItems,
       targetItemUid: 'b',
       draggedItemUid: 'd',
-      dropPosition: 'above'
+      dropType: 'above'
     });
 
     expect(getSeqMap(reorderedItems)).toEqual({
@@ -258,7 +271,7 @@ describe('getReorderedItemsInTargetDirectory', () => {
       items: folderItems,
       targetItemUid: 'b',
       draggedItemUid: 'a',
-      dropPosition: 'below'
+      dropType: 'below'
     });
 
     // a moves from seq 1 to 2; b shifts up from 2 to 1
@@ -273,7 +286,7 @@ describe('getReorderedItemsInTargetDirectory', () => {
       items: folderItems,
       targetItemUid: 'b',
       draggedItemUid: 'd',
-      dropPosition: 'below'
+      dropType: 'below'
     });
 
     // d moves from seq 4 to 3; c shifts down from 3 to 4
@@ -309,5 +322,53 @@ describe('getReorderedItemsInTargetDirectory', () => {
     });
 
     expect(reorderedItems).toEqual([]);
+  });
+});
+
+describe('reordering a folder in a directory that also contains files', () => {
+  const items = [
+    { uid: 'fa', name: 'A', type: 'folder', seq: 1 },
+    { uid: 'fb', name: 'B', type: 'folder', seq: 2 },
+    { uid: 'fc', name: 'C', type: 'folder', seq: 3 },
+    { uid: 'rx', name: 'X', type: 'http-request', seq: 4 }
+  ];
+
+  const applyReorder = (original, changed) =>
+    original.map((item) => changed.find((c) => c.uid === item.uid) || item);
+
+  const isFolder = (item) => item.type === 'folder';
+
+  const renderOrder = (allItems) => ({
+    folders: sortByNameThenSequence(allItems.filter(isFolder)).map((i) => i.name),
+    files: allItems
+      .filter((i) => !isFolder(i))
+      .sort((a, b) => a.seq - b.seq)
+      .map((i) => i.name)
+  });
+
+  it('moves the first folder to the end of the folder group (drop below the last folder)', () => {
+    const reordered = getReorderedItemsInTargetDirectory({
+      items,
+      targetItemUid: 'fc',
+      draggedItemUid: 'fa',
+      dropType: 'below'
+    });
+
+    const final = applyReorder(items, reordered);
+
+    expect(renderOrder(final)).toEqual({ folders: ['B', 'C', 'A'], files: ['X'] });
+  });
+
+  it('moves the first folder to the end of the folder group (drop above the first file)', () => {
+    const reordered = getReorderedItemsInTargetDirectory({
+      items,
+      targetItemUid: 'rx',
+      draggedItemUid: 'fa',
+      dropType: 'above'
+    });
+
+    const final = applyReorder(items, reordered);
+
+    expect(renderOrder(final)).toEqual({ folders: ['B', 'C', 'A'], files: ['X'] });
   });
 });

--- a/packages/bruno-app/src/utils/tests/collections/drag-and-drop.spec.js
+++ b/packages/bruno-app/src/utils/tests/collections/drag-and-drop.spec.js
@@ -4,10 +4,11 @@ import {
   determineCollectionItemDrop,
   getReorderedItemsInTargetDirectory
 } from 'utils/collections/index';
+import path from 'utils/common/path';
 
-const collectionPathname = '/collections/my-collection';
-const folderPathname = '/collections/my-collection/users';
-const requestPathname = '/collections/my-collection/users/get-users.bru';
+const collectionPathname = path.join(path.sep, 'collections', 'my-collection');
+const folderPathname = path.join(collectionPathname, 'users');
+const requestPathname = path.join(folderPathname, 'get-users.bru');
 
 const folderItem = {
   uid: 'folder-1',
@@ -30,7 +31,7 @@ const draggedRequest = {
   type: 'http-request',
   name: 'create-user',
   filename: 'create-user.bru',
-  pathname: '/collections/my-collection/create-user.bru',
+  pathname: path.join(collectionPathname, 'create-user.bru'),
   request: { method: 'POST', url: 'https://example.com' },
   sourceCollectionUid: 'collection-1'
 };
@@ -112,7 +113,7 @@ describe('calculateDraggedItemNewPathname', () => {
       collectionPathname
     });
 
-    expect(result).toBe('/collections/my-collection/users/create-user.bru');
+    expect(result).toBe(path.join(folderPathname, 'create-user.bru'));
   });
 
   it('returns a sibling path for adjacent drops', () => {
@@ -123,7 +124,7 @@ describe('calculateDraggedItemNewPathname', () => {
       collectionPathname
     });
 
-    expect(result).toBe('/collections/my-collection/users/create-user.bru');
+    expect(result).toBe(path.join(folderPathname, 'create-user.bru'));
   });
 
   it('returns null when dropping inside a request', () => {
@@ -174,6 +175,31 @@ describe('canCollectionItemBeDropped', () => {
     });
 
     expect(result).toBe(false);
+  });
+
+  it('allows dropping a folder next to a sibling whose name shares its prefix', () => {
+    const usersFolder = {
+      uid: 'users-folder',
+      type: 'folder',
+      pathname: '/collections/my-collection/users',
+      filename: 'users'
+    };
+    const usersArchiveFolder = {
+      uid: 'users-archive-folder',
+      type: 'folder',
+      pathname: '/collections/my-collection/users-archive',
+      filename: 'users-archive'
+    };
+
+    const result = canCollectionItemBeDropped({
+      draggedItem: { ...usersFolder, sourceCollectionUid: 'collection-1' },
+      targetItem: usersArchiveFolder,
+      dropType: 'inside',
+      collectionUid: 'collection-1',
+      collectionPathname
+    });
+
+    expect(result).toBe(true);
   });
 
   it('returns true for valid same-collection adjacent drops regardless of position', () => {

--- a/packages/bruno-app/src/utils/tests/collections/drag-and-drop.spec.js
+++ b/packages/bruno-app/src/utils/tests/collections/drag-and-drop.spec.js
@@ -1,0 +1,287 @@
+import {
+  calculateDraggedItemNewPathname,
+  canCollectionItemBeDropped,
+  determineCollectionItemDrop,
+  getReorderedItemsInTargetDirectory
+} from 'utils/collections/index';
+
+const collectionPathname = '/collections/my-collection';
+const folderPathname = '/collections/my-collection/users';
+const requestPathname = '/collections/my-collection/users/get-users.bru';
+
+const folderItem = {
+  uid: 'folder-1',
+  type: 'folder',
+  name: 'users',
+  pathname: folderPathname
+};
+
+const requestItem = {
+  uid: 'request-1',
+  type: 'http-request',
+  name: 'get-users',
+  filename: 'get-users.bru',
+  pathname: requestPathname,
+  request: { method: 'GET', url: 'https://example.com' }
+};
+
+const draggedRequest = {
+  uid: 'request-2',
+  type: 'http-request',
+  name: 'create-user',
+  filename: 'create-user.bru',
+  pathname: '/collections/my-collection/create-user.bru',
+  request: { method: 'POST', url: 'https://example.com' },
+  sourceCollectionUid: 'collection-1'
+};
+
+const createBoundingRect = (top = 100, height = 32) => ({
+  top,
+  height,
+  bottom: top + height,
+  left: 0,
+  right: 200
+});
+
+describe('determineCollectionItemDrop', () => {
+  it('returns null when hover bounds or client offset are missing', () => {
+    expect(
+      determineCollectionItemDrop({
+        item: requestItem,
+        hoverBoundingRect: null,
+        clientOffset: { x: 0, y: 110 }
+      })
+    ).toBeNull();
+  });
+
+  it('returns adjacent+above for the top half of a request row', () => {
+    const rect = createBoundingRect(100, 32);
+
+    expect(
+      determineCollectionItemDrop({
+        item: requestItem,
+        hoverBoundingRect: rect,
+        clientOffset: { x: 0, y: 110 }
+      })
+    ).toEqual({ dropType: 'adjacent', dropPosition: 'above' });
+  });
+
+  it('returns adjacent+below for the bottom half of a request row', () => {
+    const rect = createBoundingRect(100, 32);
+
+    expect(
+      determineCollectionItemDrop({
+        item: requestItem,
+        hoverBoundingRect: rect,
+        clientOffset: { x: 0, y: 122 }
+      })
+    ).toEqual({ dropType: 'adjacent', dropPosition: 'below' });
+  });
+
+  it('returns adjacent+above for the top 35% of a folder row', () => {
+    const rect = createBoundingRect(100, 40);
+
+    expect(
+      determineCollectionItemDrop({
+        item: folderItem,
+        hoverBoundingRect: rect,
+        clientOffset: { x: 0, y: 112 }
+      })
+    ).toEqual({ dropType: 'adjacent', dropPosition: 'above' });
+  });
+
+  it('returns inside for the bottom 65% of a folder row', () => {
+    const rect = createBoundingRect(100, 40);
+
+    expect(
+      determineCollectionItemDrop({
+        item: folderItem,
+        hoverBoundingRect: rect,
+        clientOffset: { x: 0, y: 128 }
+      })
+    ).toEqual({ dropType: 'inside', dropPosition: null });
+  });
+});
+
+describe('calculateDraggedItemNewPathname', () => {
+  it('returns a path inside the target folder for inside drops', () => {
+    const result = calculateDraggedItemNewPathname({
+      draggedItem: draggedRequest,
+      targetItem: folderItem,
+      dropType: 'inside',
+      collectionPathname
+    });
+
+    expect(result).toBe('/collections/my-collection/users/create-user.bru');
+  });
+
+  it('returns a sibling path for adjacent drops', () => {
+    const result = calculateDraggedItemNewPathname({
+      draggedItem: draggedRequest,
+      targetItem: requestItem,
+      dropType: 'adjacent',
+      collectionPathname
+    });
+
+    expect(result).toBe('/collections/my-collection/users/create-user.bru');
+  });
+
+  it('returns null when dropping inside a request', () => {
+    const result = calculateDraggedItemNewPathname({
+      draggedItem: draggedRequest,
+      targetItem: requestItem,
+      dropType: 'inside',
+      collectionPathname
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('canCollectionItemBeDropped', () => {
+  it('returns false when dragging an item onto itself', () => {
+    const result = canCollectionItemBeDropped({
+      draggedItem: { ...requestItem, sourceCollectionUid: 'collection-1' },
+      targetItem: requestItem,
+      dropType: 'adjacent',
+      collectionUid: 'collection-1',
+      collectionPathname
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when dropping a folder onto its descendant', () => {
+    const parentFolder = {
+      uid: 'parent-folder',
+      type: 'folder',
+      pathname: '/collections/my-collection/parent',
+      filename: 'parent'
+    };
+    const childFolder = {
+      uid: 'child-folder',
+      type: 'folder',
+      pathname: '/collections/my-collection/parent/child',
+      filename: 'child'
+    };
+
+    const result = canCollectionItemBeDropped({
+      draggedItem: { ...parentFolder, sourceCollectionUid: 'collection-1' },
+      targetItem: childFolder,
+      dropType: 'inside',
+      collectionUid: 'collection-1',
+      collectionPathname
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true for valid same-collection adjacent drops regardless of position', () => {
+    const result = canCollectionItemBeDropped({
+      draggedItem: { ...draggedRequest, sourceCollectionUid: 'collection-1' },
+      targetItem: requestItem,
+      dropType: 'adjacent',
+      collectionUid: 'collection-1',
+      collectionPathname
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('allows cross-collection drops without same-collection path checks', () => {
+    const result = canCollectionItemBeDropped({
+      draggedItem: { ...draggedRequest, sourceCollectionUid: 'other-collection' },
+      targetItem: folderItem,
+      dropType: 'inside',
+      collectionUid: 'collection-1',
+      collectionPathname
+    });
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('getReorderedItemsInTargetDirectory', () => {
+  const folderItems = [
+    { uid: 'a', name: 'A', seq: 1 },
+    { uid: 'b', name: 'B', seq: 2 },
+    { uid: 'c', name: 'C', seq: 3 },
+    { uid: 'd', name: 'D', seq: 4 }
+  ];
+
+  const getSeqMap = (reorderedItems) =>
+    Object.fromEntries(reorderedItems.map((item) => [item.uid, item.seq]));
+
+  it('moves an item above the target', () => {
+    const reorderedItems = getReorderedItemsInTargetDirectory({
+      items: folderItems,
+      targetItemUid: 'b',
+      draggedItemUid: 'd',
+      dropPosition: 'above'
+    });
+
+    expect(getSeqMap(reorderedItems)).toEqual({
+      d: 2,
+      b: 3,
+      c: 4
+    });
+  });
+
+  it('moves an item below the target', () => {
+    const reorderedItems = getReorderedItemsInTargetDirectory({
+      items: folderItems,
+      targetItemUid: 'b',
+      draggedItemUid: 'a',
+      dropPosition: 'below'
+    });
+
+    // a moves from seq 1 to 2; b shifts up from 2 to 1
+    expect(getSeqMap(reorderedItems)).toEqual({
+      b: 1,
+      a: 2
+    });
+  });
+
+  it('moves an item from below to below the target', () => {
+    const reorderedItems = getReorderedItemsInTargetDirectory({
+      items: folderItems,
+      targetItemUid: 'b',
+      draggedItemUid: 'd',
+      dropPosition: 'below'
+    });
+
+    // d moves from seq 4 to 3; c shifts down from 3 to 4
+    expect(getSeqMap(reorderedItems)).toEqual({
+      d: 3,
+      c: 4
+    });
+  });
+
+  it('returns an empty array when target or dragged item is missing', () => {
+    expect(
+      getReorderedItemsInTargetDirectory({
+        items: folderItems,
+        targetItemUid: 'missing',
+        draggedItemUid: 'a'
+      })
+    ).toEqual([]);
+
+    expect(
+      getReorderedItemsInTargetDirectory({
+        items: folderItems,
+        targetItemUid: 'a',
+        draggedItemUid: 'missing'
+      })
+    ).toEqual([]);
+  });
+
+  it('returns an empty array when no sequence changes are needed', () => {
+    const reorderedItems = getReorderedItemsInTargetDirectory({
+      items: folderItems,
+      targetItemUid: 'b',
+      draggedItemUid: 'b'
+    });
+
+    expect(reorderedItems).toEqual([]);
+  });
+});


### PR DESCRIPTION
**JIRA: BRU-1112**

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced collection drag-and-drop placement with clear **above / inside / below** semantics and centralized drop validation/permission checks.
  * Improved destination resolution and reordering behavior using placement-aware resequencing for more stable move results.

* **Bug Fixes**
  * Fixed inconsistent hover/drop placement and ensured the drop target visuals and eligibility checks align with the resolved placement.
  * Strengthened prevention of invalid moves into descendant items.

* **Tests**
  * Added/expanded Jest coverage for placement detection, destination pathname calculation, drop eligibility rules, and above/below reordering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->