### PR TITLE
fix(SSE-text/event-stream):  sse response body is empty in res.getBody() for app and cli

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -73,6 +73,12 @@ const hasStreamHeaders = (headers) => {
   return headerSplit.indexOf('text/event-stream') > -1;
 };
 
+const buildResponseBodyFromStreamChunks = (sseChunks, headers, disableParsingResponseJson) => {
+  const dataBuffer = Buffer.concat(sseChunks);
+  const { data } = parseDataFromResponse({ data: dataBuffer, headers }, disableParsingResponseJson);
+  return { data, dataBuffer };
+};
+
 const promisifyStream = async (stream, abortController, closeOnFirst) => {
   const chunks = [];
 
@@ -1246,11 +1252,9 @@ const registerNetworkIpc = (mainWindow) => {
       if (isResponseStream) {
         axiosDataStream.on('close', () => {
           try {
-            // Rebuild the full body from the chunks accumulated during streaming so that
-            // post-response scripts, assertions and tests can access res.getBody().
-            const dataBuffer = Buffer.concat(sseChunks);
-            const { data } = parseDataFromResponse(
-              { data: dataBuffer, headers: response.headers },
+            const { data, dataBuffer } = buildResponseBodyFromStreamChunks(
+              sseChunks,
+              response.headers,
               request.__brunoDisableParsingResponseJson
             );
             response.data = data;
@@ -2269,3 +2273,4 @@ module.exports.configureRequest = configureRequest;
 module.exports.getCertsAndProxyConfig = getCertsAndProxyConfig;
 module.exports.fetchGqlSchemaHandler = fetchGqlSchemaHandler;
 module.exports.executeRequestOnFailHandler = executeRequestOnFailHandler;
+module.exports.buildResponseBodyFromStreamChunks = buildResponseBodyFromStreamChunks;

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1014,6 +1014,7 @@ const registerNetworkIpc = (mainWindow) => {
       }
 
       let response, responseTime, axiosDataStream;
+      const sseChunks = [];
       try {
         /** @type {import('axios').AxiosResponse} */
         response = await axiosInstance(request);
@@ -1243,7 +1244,18 @@ const registerNetworkIpc = (mainWindow) => {
         }
       };
       if (isResponseStream) {
-        axiosDataStream.on('close', () => runPostScripts().then());
+        axiosDataStream.on('close', () => {
+          // Rebuild the full body from the chunks accumulated during streaming so that
+          // post-response scripts, assertions and tests can access res.getBody().
+          const dataBuffer = Buffer.concat(sseChunks);
+          const { data } = parseDataFromResponse(
+            { data: dataBuffer, headers: response.headers },
+            request.__brunoDisableParsingResponseJson
+          );
+          response.data = data;
+          response.dataBuffer = dataBuffer;
+          runPostScripts().then();
+        });
       } else {
         await runPostScripts();
       }
@@ -1254,6 +1266,7 @@ const registerNetworkIpc = (mainWindow) => {
         headers: response.headers,
         data: response.data,
         stream: isResponseStream ? axiosDataStream : null,
+        sseChunks: isResponseStream ? sseChunks : null,
         cancelTokenUid: cancelTokenUid,
         dataBuffer: response.dataBuffer.toString('base64'),
         size: Buffer.byteLength(response.dataBuffer),
@@ -1332,6 +1345,8 @@ const registerNetworkIpc = (mainWindow) => {
       response.stream = { running: response.status >= 200 && response.status < 300 };
 
       stream.on('data', (newData) => {
+        // Collect the raw chunk so runRequest can rebuild the full body on stream close.
+        response.sseChunks?.push(newData);
         seq += 1;
 
         const parsed = parseDataFromResponse({ data: newData, headers: {} });

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1245,16 +1245,22 @@ const registerNetworkIpc = (mainWindow) => {
       };
       if (isResponseStream) {
         axiosDataStream.on('close', () => {
-          // Rebuild the full body from the chunks accumulated during streaming so that
-          // post-response scripts, assertions and tests can access res.getBody().
-          const dataBuffer = Buffer.concat(sseChunks);
-          const { data } = parseDataFromResponse(
-            { data: dataBuffer, headers: response.headers },
-            request.__brunoDisableParsingResponseJson
-          );
-          response.data = data;
-          response.dataBuffer = dataBuffer;
-          runPostScripts().then();
+          try {
+            // Rebuild the full body from the chunks accumulated during streaming so that
+            // post-response scripts, assertions and tests can access res.getBody().
+            const dataBuffer = Buffer.concat(sseChunks);
+            const { data } = parseDataFromResponse(
+              { data: dataBuffer, headers: response.headers },
+              request.__brunoDisableParsingResponseJson
+            );
+            response.data = data;
+            response.dataBuffer = dataBuffer;
+          } catch (error) {
+            console.error('Error rebuilding response body from SSE chunks:', error);
+          }
+          runPostScripts().catch((error) => {
+            console.error('Error running post-response scripts for SSE stream:', error);
+          });
         });
       } else {
         await runPostScripts();

--- a/packages/bruno-tests/collection/sse/sse finite stream.bru
+++ b/packages/bruno-tests/collection/sse/sse finite stream.bru
@@ -1,0 +1,35 @@
+meta {
+  name: sse finite stream
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{localhost}}/api/sse/finite
+  body: none
+  auth: none
+}
+
+script:post-response {
+  const body = res.getBody();
+  bru.setVar("sseBody", typeof body === "string" ? body : JSON.stringify(body));
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("content-type is text/event-stream", function() {
+    expect(res.headers["content-type"]).to.include("text/event-stream");
+  });
+
+  test("res.getBody() contains all 3 SSE events in order", function() {
+    const body = res.getBody();
+    expect(body).to.include("data: Hello");
+    expect(body).to.include("data: from");
+    expect(body).to.include("data: SSE");
+    expect(body.indexOf("data: Hello")).to.be.lessThan(body.indexOf("data: from"));
+    expect(body.indexOf("data: from")).to.be.lessThan(body.indexOf("data: SSE"));
+  });
+}

--- a/packages/bruno-tests/src/sse/index.js
+++ b/packages/bruno-tests/src/sse/index.js
@@ -55,4 +55,27 @@ router.post('/reset', (req, res) => {
   res.json({ message: 'Reset complete', activeConnections: 0 });
 });
 
+// GET /api/sse/finite?messages=Hello,from,SSE - Sends one event per message then closes.
+router.get('/finite', (req, res) => {
+  const messages = ['Hello', 'from', 'SSE'];
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive'
+  });
+
+  let index = 0;
+  const interval = setInterval(() => {
+    res.write(`data: ${messages[index]}\n\n`);
+    index += 1;
+    if (index >= messages.length) {
+      clearInterval(interval);
+      res.end();
+    }
+  }, 50);
+
+  req.on('close', () => clearInterval(interval));
+});
+
 module.exports = router;

--- a/packages/bruno-tests/src/sse/index.js
+++ b/packages/bruno-tests/src/sse/index.js
@@ -55,7 +55,7 @@ router.post('/reset', (req, res) => {
   res.json({ message: 'Reset complete', activeConnections: 0 });
 });
 
-// GET /api/sse/finite?messages=Hello,from,SSE - Sends one event per message then closes.
+// GET /api/sse/finite - Sends one event per message then closes.
 router.get('/finite', (req, res) => {
   const messages = ['Hello', 'from', 'SSE'];
 


### PR DESCRIPTION
### Description

Currently users are not able to get SSE response body in scripts. This is needed by some users so fixing this by collecting the responses and adding them to response body so that it is available in post scripts.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3465)

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

## Bug

The desktop app always requests responses as a stream
(`responseType: 'stream'`). For non-streaming responses it drains the stream
into a full buffer via `promisifyStream` before running post-response logic.

For SSE responses, the single-request path deliberately **skips** that drain so
chunks can be forwarded to the renderer live, and hard-codes the body to empty:

The streamed chunks were forwarded to the renderer for the live view and then
discarded — nothing ever reconstituted them into response.data. So when
post-response scripts, assertions, and tests ran on the stream's close event,
they read an empty body.

## Fix
Accumulate the streamed chunks (in the existing renderer-forwarding data
listener — the single stream consumer) and, on stream close, rebuild
response.data / response.dataBuffer from them before running
post-response scripts. This mirrors what the Collection Runner already does,
without adding a second stream listener (which would change flowing-mode timing
and risk dropping early chunks from the live UI).

All changes are in packages/bruno-electron/src/ipc/network/index.js:

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now buffer and rebuild streamed data on close, ensuring complete response content and reliable post-processing for server-sent events.
* **New Features**
  * Streaming response payloads expose buffered SSE chunks for inspection by consumers.
* **Tests**
  * Added automated test and server route validating a finite SSE stream's headers, message order, and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->