### PR TITLE
fix(electron): use shell spawn for npm.cmd on Windows only

### DIFF
--- a/packages/bruno-electron/src/utils/install-packages.js
+++ b/packages/bruno-electron/src/utils/install-packages.js
@@ -1,8 +1,12 @@
 const { spawn } = require('child_process');
 
-// npm package name grammar (scoped + unscoped). Conservative enough to prevent
-// shell-metachar smuggling even though spawn() runs without a shell.
+// npm package name grammar (scoped + unscoped). On Windows, .cmd/.bat spawn uses
+// a shell (CVE-2024-27980); names must not contain shell metacharacters.
 const NPM_NAME_REGEX = /^(?:@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*$/i;
+
+const shouldUseShellForNpmSpawn = (npmCommand, platform = process.platform) => {
+  return platform === 'win32' && /\.(cmd|bat)$/i.test(npmCommand);
+};
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // npm installs can legitimately take minutes
 const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024; // bound captured stdout/stderr
@@ -33,7 +37,8 @@ const runNpmInstall = ({
   spawnFn = spawn,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   maxOutputBytes = DEFAULT_MAX_OUTPUT_BYTES,
-  npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm',
+  platform = process.platform
 }) => {
   const installed = Array.from(new Set(packages));
   const args = ['install', '--save', ...installed];
@@ -53,7 +58,11 @@ const runNpmInstall = ({
 
     let child;
     try {
-      child = spawnFn(npmCommand, args, { cwd: collectionPath, env: process.env, shell: false });
+      child = spawnFn(npmCommand, args, {
+        cwd: collectionPath,
+        env: process.env,
+        shell: shouldUseShellForNpmSpawn(npmCommand, platform)
+      });
     } catch (err) {
       finish({ success: false, exitCode: -1, stderr: err.message, errorCode: 'SPAWN_FAILED' });
       return;
@@ -100,6 +109,7 @@ const runNpmInstall = ({
 
 module.exports = {
   isValidNpmPackageName,
+  shouldUseShellForNpmSpawn,
   runNpmInstall,
   NPM_NAME_REGEX,
   DEFAULT_TIMEOUT_MS,

--- a/packages/bruno-electron/tests/utils/install-packages.spec.js
+++ b/packages/bruno-electron/tests/utils/install-packages.spec.js
@@ -55,7 +55,7 @@ describe('runNpmInstall', () => {
     expect(result.installed).toEqual(['dayjs']);
   });
 
-  test('passes the correct npm args, cwd, and runs without a shell', async () => {
+  test('passes the correct npm args, cwd, and runs without a shell on Unix', async () => {
     const child = makeFakeChild();
     const spawnFn = jest.fn(() => child);
 
@@ -63,7 +63,8 @@ describe('runNpmInstall', () => {
       collectionPath: '/my/coll',
       packages: ['dayjs', 'dayjs', 'zod'],
       spawnFn,
-      npmCommand: 'npm'
+      npmCommand: 'npm',
+      platform: 'darwin'
     });
     child.emit('close', 0);
     await promise;
@@ -72,6 +73,48 @@ describe('runNpmInstall', () => {
       'npm',
       ['install', '--save', 'dayjs', 'zod'],
       expect.objectContaining({ cwd: '/my/coll', shell: false })
+    );
+  });
+
+  test('uses shell on Windows when npm command is a .cmd file', async () => {
+    const child = makeFakeChild();
+    const spawnFn = jest.fn(() => child);
+
+    const promise = runNpmInstall({
+      collectionPath: 'C:\\coll',
+      packages: ['dayjs'],
+      spawnFn,
+      npmCommand: 'npm.cmd',
+      platform: 'win32'
+    });
+    child.emit('close', 0);
+    await promise;
+
+    expect(spawnFn).toHaveBeenCalledWith(
+      'npm.cmd',
+      ['install', '--save', 'dayjs'],
+      expect.objectContaining({ cwd: 'C:\\coll', shell: true })
+    );
+  });
+
+  test('does not use shell on Windows for bare npm command', async () => {
+    const child = makeFakeChild();
+    const spawnFn = jest.fn(() => child);
+
+    const promise = runNpmInstall({
+      collectionPath: 'C:\\coll',
+      packages: ['dayjs'],
+      spawnFn,
+      npmCommand: 'npm',
+      platform: 'win32'
+    });
+    child.emit('close', 0);
+    await promise;
+
+    expect(spawnFn).toHaveBeenCalledWith(
+      'npm',
+      ['install', '--save', 'dayjs'],
+      expect.objectContaining({ cwd: 'C:\\coll', shell: false })
     );
   });
 


### PR DESCRIPTION
### Description

### Added {shell:true} for windows ERR: 'spawn EINVAL' 
When importing a Postman collection that references npm packages in scripts (via pm.require), Bruno surfaces the "Install packages" dialog. The error that I found was a ERR: spawn EINVAL. This was specifically on Windows when nodejs attempts to execute a script using child_process.spawn() or spawnSync(). This was introduced, apparently, to address CVE_2024-27980, which makes Node explicitly reject direct execution of these files.  

I added a change to use the flag {shell:true} only for windows for now since I could only replicate it on windows. 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm package installation compatibility on Windows systems with enhanced shell command handling to prevent metacharacter-related issues
  * Strengthened npm package name validation for improved security

* **Tests**
  * Added comprehensive platform-specific test coverage for npm package installation scenarios across Windows and Unix environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->