### PR TITLE
fix: prevent redundant workspace switch toast

### DIFF
--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -146,10 +146,10 @@ const AppTitleBar = () => {
   };
 
   const handleWorkspaceSwitch = async (workspaceUid) => {
-    const result = await dispatch(switchWorkspace(workspaceUid));
-    if (result) {
-      toast.success(`Switched to ${getWorkspaceDisplayName(workspaces.find((w) => w.uid === workspaceUid)?.name)}`);
-    }
+    if (workspaceUid === activeWorkspaceUid) return;
+
+    dispatch(switchWorkspace(workspaceUid));
+    toast.success(`Switched to ${getWorkspaceDisplayName(workspaces.find((w) => w.uid === workspaceUid)?.name)}`);
   };
 
   const handleOpenWorkspace = async () => {

--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -145,7 +145,7 @@ const AppTitleBar = () => {
     }
   };
 
-  const handleWorkspaceSwitch = async (workspaceUid) => {
+  const handleWorkspaceSwitch = (workspaceUid) => {
     if (workspaceUid === activeWorkspaceUid) return;
 
     dispatch(switchWorkspace(workspaceUid));

--- a/packages/bruno-app/src/components/AppTitleBar/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/index.js
@@ -145,9 +145,11 @@ const AppTitleBar = () => {
     }
   };
 
-  const handleWorkspaceSwitch = (workspaceUid) => {
-    dispatch(switchWorkspace(workspaceUid));
-    toast.success(`Switched to ${getWorkspaceDisplayName(workspaces.find((w) => w.uid === workspaceUid)?.name)}`);
+  const handleWorkspaceSwitch = async (workspaceUid) => {
+    const result = await dispatch(switchWorkspace(workspaceUid));
+    if (result) {
+      toast.success(`Switched to ${getWorkspaceDisplayName(workspaces.find((w) => w.uid === workspaceUid)?.name)}`);
+    }
   };
 
   const handleOpenWorkspace = async () => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -695,8 +695,11 @@ export const switchWorkspace = (workspaceUid) => {
       if (!completed && pendingCollectionPathnames.length > 0) {
         scheduleSnapshotHydrationTimeout(dispatch, getState, workspaceUid);
       }
+
+      return true;
     } catch (error) {
       console.error('Failed to switch workspace:', error);
+      return false;
     } finally {
       const state = getState();
       const hasHydrationSession = Boolean(state.app.snapshotHydration?.workspaceUid);
@@ -704,8 +707,6 @@ export const switchWorkspace = (workspaceUid) => {
         dispatch(setSnapshotReady(true));
       }
     }
-
-    return true;
   };
 };
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -574,16 +574,11 @@ export const switchWorkspace = (workspaceUid) => {
     dispatch(clearSnapshotHydrationSession());
 
     try {
-      const currentActiveWorkspaceUid = getState().workspaces.activeWorkspaceUid;
-      if (currentActiveWorkspaceUid === workspaceUid) {
-        return false;
-      }
-
       dispatch(setActiveWorkspace(workspaceUid));
 
       const workspace = getState().workspaces.workspaces.find((w) => w.uid === workspaceUid);
       if (!workspace) {
-        return false;
+        return;
       }
 
       const fullSnapshot = await ipcRenderer.invoke('renderer:snapshot:get').catch(() => null);
@@ -695,11 +690,8 @@ export const switchWorkspace = (workspaceUid) => {
       if (!completed && pendingCollectionPathnames.length > 0) {
         scheduleSnapshotHydrationTimeout(dispatch, getState, workspaceUid);
       }
-
-      return true;
     } catch (error) {
       console.error('Failed to switch workspace:', error);
-      return false;
     } finally {
       const state = getState();
       const hasHydrationSession = Boolean(state.app.snapshotHydration?.workspaceUid);

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -574,11 +574,16 @@ export const switchWorkspace = (workspaceUid) => {
     dispatch(clearSnapshotHydrationSession());
 
     try {
+      const currentActiveWorkspaceUid = getState().workspaces.activeWorkspaceUid;
+      if (currentActiveWorkspaceUid === workspaceUid) {
+        return false;
+      }
+
       dispatch(setActiveWorkspace(workspaceUid));
 
       const workspace = getState().workspaces.workspaces.find((w) => w.uid === workspaceUid);
       if (!workspace) {
-        return;
+        return false;
       }
 
       const fullSnapshot = await ipcRenderer.invoke('renderer:snapshot:get').catch(() => null);
@@ -699,6 +704,8 @@ export const switchWorkspace = (workspaceUid) => {
         dispatch(setSnapshotReady(true));
       }
     }
+
+    return true;
   };
 };
 


### PR DESCRIPTION
### Description
Fixes: #8075 
[JIRA](https://usebruno.atlassian.net/browse/BRU-3478)

This PR fixes only one bug that was mentioned in that issue.

#### Issue:
Issue 2: Workspace switch toast appears unnecessarily
Steps to Reproduce:

Open a workspace
Click on the same currently active workspace again
Actual Result
A workspace switch toast/notification is displayed even though the user is already inside the selected workspace.

Expected Result
No toast or workspace switch action should occur when clicking the currently active workspace.

#### Fix: 
- Add a check inside `handleWorkspaceSwitch` to return `false` if the selected workspace is already active.

#### Before

https://github.com/user-attachments/assets/b3a4b7d6-2244-4218-82b3-3ec5f1c508f5

#### After

https://github.com/user-attachments/assets/661954e9-9cfe-4580-84dc-a0e203bdcb56



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace switching now ignores requests to switch to the already-active workspace, preventing redundant operations. This removes misleading success notifications for no-op switches, reduces unnecessary processing, and improves UI consistency by ensuring success toasts appear only when an actual switch occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->