### PR TITLE
feat: added the clear network timeline button for all collections

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import ReactJson from 'react-json-view';
 import { useTheme } from 'providers/Theme';
+import { clearTimeline } from 'providers/ReduxStore/slices/collections';
 import {
   IconX,
   IconTrash,
@@ -432,6 +433,12 @@ const Console = () => {
     dispatch(clearLogs());
   };
 
+  const handleClearNetworkTimeline = () => {
+    collections.forEach((collection) => {
+      dispatch(clearTimeline({ collectionUid: collection.uid }));
+    });
+  };
+
   const handleClearDebugErrors = () => {
     dispatch(clearDebugErrors());
   };
@@ -521,6 +528,15 @@ const Console = () => {
                 onFilterToggle={handleNetworkFilterToggle}
                 onToggleAll={handleToggleAllNetworkFilters}
               />
+            </div>
+            <div className="action-controls">
+              <button
+                className="control-button"
+                onClick={handleClearNetworkTimeline}
+                title="Clear network logs"
+              >
+                <IconTrash size={16} strokeWidth={1.5} />
+              </button>
             </div>
           </div>
         );


### PR DESCRIPTION
### Description

When using Bruno, I always rely on the Network panel inside DevTools. Due to messy tests and long API testing sessions, the Network panel tends to clutter up very quickly. 

With this change, it is now possible to clear the network logs by clicking the trash icon button. 

This clear button works for all collections as the Network panel registers the requests for all collections.

<img width="3420" height="2224" alt="2026-06-10 18-23-31" src="https://github.com/user-attachments/assets/8b6487af-714f-451b-ad69-cc5df3229105" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
