### PR TITLE
fix(ui): open response pane at a minimum height on expand

### DIFF
--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -43,6 +43,7 @@ import GlobalEnvironmentSettings from 'components/Environments/GlobalEnvironment
 import OpenAPISyncTab from 'components/OpenAPISyncTab';
 import OpenAPISpecTab from 'components/OpenAPISpecTab';
 import CollapsedPanelIndicator from './CollapsedPanelIndicator';
+import { clampRequestHeightForResponse } from './paneSize';
 import { IconLoader2 } from '@tabler/icons';
 
 const MIN_LEFT_PANE_WIDTH = 300;
@@ -267,10 +268,15 @@ const RequestTabPanel = () => {
   const handleResponseIndicatorClickExpand = useCallback(() => {
     expandResponse();
     if (!isVerticalLayoutRef.current || !mainSectionRef.current) return;
-    const mainRect = mainSectionRef.current.getBoundingClientRect();
-    const maxRequestHeight = mainRect.height - RESPONSE_EXPAND_MIN_HEIGHT;
-    if (topPaneHeight > maxRequestHeight) {
-      setTopPaneHeight(Math.max(MIN_TOP_PANE_HEIGHT, maxRequestHeight));
+    const { height: containerHeight } = mainSectionRef.current.getBoundingClientRect();
+    const clampedHeight = clampRequestHeightForResponse(
+      topPaneHeight,
+      containerHeight,
+      RESPONSE_EXPAND_MIN_HEIGHT,
+      MIN_TOP_PANE_HEIGHT
+    );
+    if (clampedHeight != null) {
+      setTopPaneHeight(clampedHeight);
     }
   }, [expandResponse, topPaneHeight, setTopPaneHeight]);
 

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -51,6 +51,8 @@ const MIN_TOP_PANE_HEIGHT = 150;
 const MIN_BOTTOM_PANE_HEIGHT = 150;
 const COLLAPSE_EDGE_THRESHOLD = 80;
 const EXPAND_EDGE_THRESHOLD = 100;
+// Minimum response pane height to show placeholder content on click-expand
+const RESPONSE_EXPAND_MIN_HEIGHT = 300;
 
 const RequestTabPanel = () => {
   const dispatch = useDispatch();
@@ -261,6 +263,16 @@ const RequestTabPanel = () => {
     applyPointerResize(e);
     startDragging(e);
   }, [expandResponse, applyPointerResize, startDragging]);
+
+  const handleResponseIndicatorClickExpand = useCallback(() => {
+    expandResponse();
+    if (!isVerticalLayoutRef.current || !mainSectionRef.current) return;
+    const mainRect = mainSectionRef.current.getBoundingClientRect();
+    const maxRequestHeight = mainRect.height - RESPONSE_EXPAND_MIN_HEIGHT;
+    if (topPaneHeight > maxRequestHeight) {
+      setTopPaneHeight(Math.max(MIN_TOP_PANE_HEIGHT, maxRequestHeight));
+    }
+  }, [expandResponse, topPaneHeight, setTopPaneHeight]);
 
   useEffect(() => {
     document.addEventListener('mouseup', handleMouseUp);
@@ -563,7 +575,7 @@ const RequestTabPanel = () => {
             <CollapsedPanelIndicator
               panelType="response"
               isVertical={isVerticalLayout}
-              onExpand={expandResponse}
+              onExpand={handleResponseIndicatorClickExpand}
               onDragStart={handleResponseIndicatorDragStart}
               dragThresholdPx={isVerticalLayout ? MIN_BOTTOM_PANE_HEIGHT / 2 : MIN_RIGHT_PANE_WIDTH / 2}
             />

--- a/packages/bruno-app/src/components/RequestTabPanel/paneSize.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/paneSize.js
@@ -1,0 +1,14 @@
+/**
+ * Clamps the request pane height to leave room for the response pane.
+ * Returns null if no clamping is needed.
+ */
+export const clampRequestHeightForResponse = (
+  currentRequestHeight,
+  containerHeight,
+  minResponseHeight,
+  minRequestHeight
+) => {
+  const maxRequestHeight = containerHeight - minResponseHeight;
+  if (currentRequestHeight <= maxRequestHeight) return null;
+  return Math.max(minRequestHeight, maxRequestHeight);
+};

--- a/packages/bruno-app/src/components/RequestTabPanel/paneSize.spec.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/paneSize.spec.js
@@ -1,0 +1,32 @@
+import { clampRequestHeightForResponse } from './paneSize';
+
+// Mirrors RequestTabPanel's constants
+const MIN_TOP_PANE_HEIGHT = 150;
+const RESPONSE_EXPAND_MIN_HEIGHT = 300;
+
+const clamp = (currentRequestHeight, containerHeight) =>
+  clampRequestHeightForResponse(currentRequestHeight, containerHeight, RESPONSE_EXPAND_MIN_HEIGHT, MIN_TOP_PANE_HEIGHT);
+
+describe('clampRequestHeightForResponse', () => {
+  it('shrinks the request pane so the response opens without squishing', () => {
+    const containerHeight = 800;
+    const result = clamp(760, containerHeight);
+    expect(result).toBe(500);
+  });
+
+  it('floors at the request minimum in a short window', () => {
+    const containerHeight = 400;
+    const result = clamp(380, containerHeight);
+    expect(result).toBe(MIN_TOP_PANE_HEIGHT);
+  });
+
+  it('floors at the request minimum even when the window cannot fit both panes', () => {
+    // 200px container results in a negative maxRequestHeight, so the MIN_TOP_PANE_HEIGHT is returned.
+    expect(clamp(380, 200)).toBe(MIN_TOP_PANE_HEIGHT);
+  });
+
+  it('returns null when the response already has enough room, no clamping needed', () => {
+    // Request with height 400 leaves the response with enough room, so no clamping is needed.
+    expect(clamp(400, 1000)).toBeNull();
+  });
+});


### PR DESCRIPTION
### Description

In vertical layout, expanding the Response Pane from a collapsed state could restore it at an unusably small height, causing content and icons to appear squished or clipped.  This PR fixes the issue by ensuring the Response Pane reopens with sufficient space to render correctly, without reintroducing that overflow regression.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3352)

### Screen Recording

https://github.com/user-attachments/assets/1db825a2-505b-41b4-83eb-02c6679e130c



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response panel expansion in vertical layout: expanding the response now preserves a minimum visible response area, automatically reduces the request pane when needed, and prevents the request pane from becoming too large. This ensures both request and response panels remain visible and usable, including on smaller windows where space is limited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->