### PR TITLE
fix: show unsaved changes prompt when closing tab with Cmd+W

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -206,7 +206,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
 
   // Close tab shortcut — draft-aware, only active for the focused tab
   useKeybinding('closeTab', () => {
-    if (tab.type === 'request' || tab.type === 'grpc-request' || tab.type === 'ws-request' || tab.type === 'graphql-request') {
+    if (tab.type === 'request' || tab.type === 'http-request' || tab.type === 'grpc-request' || tab.type === 'ws-request' || tab.type === 'graphql-request') {
       if (hasChanges) {
         setShowConfirmClose(true);
       } else {


### PR DESCRIPTION
### Description

Fixes #8244
Fixes #3264

[JIRA](https://usebruno.atlassian.net/browse/BRU-3561)

Pressing `Cmd+W` / `Ctrl+W` on a modified request tab closed it immediately
without the unsaved-changes prompt because the `closeTab` handler's condition
was missing the `'http-request'` type. Added it so HTTP tabs get the same
dirty-state check as all other request types.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed close tab keyboard shortcut to consistently display unsaved changes confirmation across all request types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->