### PR TITLE
fix(workspace): keep workspace nav tabs visible when editing docs

### DIFF
--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/StyledWrapper.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/StyledWrapper.js
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
-  height: 100%;
+  flex: 1 1 0%;
+  min-height: 0;
 
   .overview-layout {
     display: flex;


### PR DESCRIPTION
### Description

When a workspace had many collections and the user opened **Workspace Docs** for editing, the workspace name and tabs disappeared and could not be recovered.

Fixes [BRU-3562](https://usebruno.atlassian.net/browse/BRU-3562)

### Screen Recording


https://github.com/user-attachments/assets/90a52ed2-45c5-432d-9b71-f0c1b4789c2e



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized internal layout handling for improved component flexibility and sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->