### PR TITLE
Bug(XS): BRU-1128 bug fix OpenAPI import error message UI distortion

### DIFF
--- a/packages/bruno-app/src/components/Errors/IpcErrorModal/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Errors/IpcErrorModal/StyledWrapper.js
@@ -4,6 +4,8 @@ const StyledWrapper = styled.div`
   color: ${(props) => props.theme.colors.danger};
   pre {
     color: ${(props) => props.theme.colors.danger};
+    max-height: 60vh;
+    overflow: auto;
   }
 `;
 

--- a/packages/bruno-app/src/components/Errors/IpcErrorModal/index.js
+++ b/packages/bruno-app/src/components/Errors/IpcErrorModal/index.js
@@ -22,7 +22,7 @@ const IpcErrorModal = ({ error }) => {
               disableCloseOnOutsideClick={true}
               disableEscapeKey={true}
             >
-              <pre className="w-full flex flex-wrap whitespace-pre-wrap">{error}</pre>
+              <pre className="w-full whitespace-pre-wrap break-words">{error}</pre>
             </Modal>
           </Portal>
         </StyledWrapper>


### PR DESCRIPTION
### Description


Problem
When the Import Collection → Git Repository flow fails (404, non-repo URL, auth, network, etc.), the resulting error modal renders the raw multi-line git stderr inside a small fixed-size modal with no height cap or scroll. Longer errors visually overflow and look distorted. See attached screenshot.


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
https://usebruno.atlassian.net/browse/BRU-1128


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.



<img width="2836" height="1458" alt="image" src="https://github.com/user-attachments/assets/d1c16463-3c79-40f7-a9a4-d900927561dd" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced error modal styling with improved text wrapping and scrolling capabilities for error messages, ensuring better readability of lengthy error content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->