### PR TITLE
fix: Add removeDirectory to filesystem utils in OSS 

### DIFF
--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -137,6 +137,18 @@ const createDirectory = async (dir) => {
   return fs.mkdirSync(dir);
 };
 
+const removeDirectory = async (dir) => {
+  if (!dir) {
+    throw new Error(`directory: path is null`);
+  }
+
+  if (!fs.existsSync(dir)) {
+    throw new Error(`directory: ${dir} does not exist`);
+  }
+
+  return fs.rmdirSync(dir, { recursive: true });
+};
+
 const browseDirectory = async (win) => {
   const { filePaths } = await dialog.showOpenDialog(win, {
     properties: ['openDirectory', 'createDirectory']
@@ -551,6 +563,7 @@ module.exports = {
   hasBruExtension,
   hasRequestExtension,
   createDirectory,
+  removeDirectory,
   browseDirectory,
   browseFiles,
   chooseFileToSave,


### PR DESCRIPTION
### Description

Introduce removeDirectory(dir) to the filesystem utilities.  This function was missing in the OSS.
<img width="1470" height="925" alt="image" src="https://github.com/user-attachments/assets/6fd2f181-b4d3-4016-9c5e-08c0169b7091" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directory cleanup and removal functionality for improved file management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->