### PR TITLE
fix: show scripted requests in network tab

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/NetworkTab/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Devtools/Console/NetworkTab/StyledWrapper.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { rgba } from 'polished';
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -170,7 +171,34 @@ const StyledWrapper = styled.div`
     }
   }
 
-  .request-method   { padding: 2px 8px 2px 16px; }
+  .request-method {
+    padding: 2px 8px 2px 16px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .tl-badge {
+    display: inline-block;
+    font-size: 9px;
+    font-weight: 600;
+    padding: 1px 5px;
+    border-radius: 8px;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    width: fit-content;
+  }
+
+  .tl-badge--scripted {
+    background: ${(props) => rgba(props.theme.colors.text.yellow, 0.12)};
+    color: ${(props) => props.theme.colors.text.yellow};
+  }
+
+  .tl-badge--run-request {
+    background: ${(props) => rgba(props.theme.colors.text.purple, 0.14)};
+    color: ${(props) => props.theme.colors.text.purple};
+  }
   .request-status   { padding: 2px 8px; }
 
   .method-badge {

--- a/packages/bruno-app/src/components/Devtools/Console/NetworkTab/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/NetworkTab/index.js
@@ -10,11 +10,12 @@ import {
   setSelectedRequest
 } from 'providers/ReduxStore/slices/logs';
 import { useResizableColumns } from 'hooks/useResizableColumns';
+import { getBadge } from 'utils/request-source-badges';
 import StyledWrapper from './StyledWrapper';
 import { sortRequests } from './utils';
 
 const COLUMNS = [
-  { key: 'method', label: 'Method', width: 80, align: 'left' },
+  { key: 'method', label: 'Method', width: 130, align: 'left' },
   { key: 'status', label: 'Status', width: 70, align: 'left' },
   { key: 'domain', label: 'Domain', width: 180, align: 'left' },
   { key: 'path', label: 'Path', width: 300, align: 'left' },
@@ -44,11 +45,13 @@ const StatusBadge = ({ status, statusCode }) => {
 };
 
 const RequestRow = ({ request, isSelected, onClick, gridTemplateColumns }) => {
-  const { data } = request;
+  const { data, type, source } = request;
   const { request: req, response: res, timestamp } = data;
+  const isScripted = type === 'scripted-request';
+  const badge = isScripted ? getBadge({ source, isOauth2: false }) : null;
 
   const formatTime = (timestamp) => {
-    const date = new Date(timestamp);
+    const date = new Date(timestamp ?? request.timestamp);
     return date.toLocaleTimeString('en-US', {
       hour12: false,
       hour: '2-digit',
@@ -103,6 +106,7 @@ const RequestRow = ({ request, isSelected, onClick, gridTemplateColumns }) => {
     >
       <div className="request-method">
         <MethodBadge method={req?.method} />
+        {badge && <span className={badge.badgeClass}>script</span>}
       </div>
 
       <div className="request-status">
@@ -158,7 +162,7 @@ const NetworkTab = () => {
     collections.forEach((collection) => {
       if (collection.timeline) {
         collection.timeline
-          .filter((entry) => entry.type === 'request')
+          .filter((entry) => entry.type === 'request' || entry.type === 'scripted-request')
           .forEach((entry) => {
             requests.push({
               ...entry,

--- a/packages/bruno-app/src/components/Devtools/Console/NetworkTab/index.spec.js
+++ b/packages/bruno-app/src/components/Devtools/Console/NetworkTab/index.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { ThemeProvider } from 'providers/Theme';
@@ -24,6 +24,27 @@ const makeRequest = (overrides = {}) => ({
       ...('size' in overrides ? { size: overrides.size } : { size: 512 })
     },
     timestamp: overrides.timestamp ?? 1000
+  }
+});
+
+const makeScriptedRequest = (overrides = {}) => ({
+  type: 'scripted-request',
+  timestamp: overrides.timestamp ?? 1000,
+  collectionUid: overrides.collectionUid ?? 'col-1',
+  itemUid: overrides.itemUid ?? 'item-1',
+  collectionName: 'Test Collection',
+  data: {
+    request: {
+      method: overrides.method ?? 'GET',
+      url: overrides.url ?? 'https://example.com/api/scripted'
+    },
+    response: {
+      status: overrides.status ?? 200,
+      statusCode: overrides.statusCode ?? 200,
+      ...('duration' in overrides ? { duration: overrides.duration } : { duration: 100 }),
+      ...('size' in overrides ? { size: overrides.size } : { size: 512 })
+    },
+    ...('dataTimestamp' in overrides ? { timestamp: overrides.dataTimestamp } : {})
   }
 });
 
@@ -203,5 +224,53 @@ describe('sort results', () => {
     fireEvent.click(screen.getByTestId('network-header-method'));
     fireEvent.click(screen.getByTestId('network-header-method'));
     expect(getRowMethods()).toEqual(['POST', 'GET', 'DELETE']);
+  });
+});
+
+describe('scripted requests', () => {
+  it('renders scripted requests in the network list', () => {
+    renderNetworkTab([
+      makeScriptedRequest({
+        itemUid: 'scripted',
+        method: 'POST',
+        url: 'https://example.com/api/scripted'
+      })
+    ]);
+
+    expect(screen.getAllByTestId('network-request-row')).toHaveLength(1);
+    expect(screen.getByText('POST')).toBeInTheDocument();
+    expect(screen.getByText('/api/scripted')).toBeInTheDocument();
+  });
+
+  it('shows a script badge on scripted request rows', () => {
+    renderNetworkTab([
+      makeScriptedRequest({ itemUid: 'scripted' })
+    ]);
+
+    const row = screen.getAllByTestId('network-request-row')[0];
+
+    expect(within(row).getByText('script')).toBeInTheDocument();
+  });
+
+  it('does not show a script badge on regular request rows', () => {
+    renderNetworkTab([
+      makeRequest({ itemUid: 'regular' })
+    ]);
+
+    const row = screen.getAllByTestId('network-request-row')[0];
+
+    expect(within(row).queryByText('script')).not.toBeInTheDocument();
+  });
+
+  it('uses the top-level timestamp when data.timestamp is missing', () => {
+    renderNetworkTab([
+      makeScriptedRequest({
+        itemUid: 'scripted',
+        timestamp: 1710000000000
+      })
+    ]);
+
+    expect(screen.getAllByTestId('network-request-row')).toHaveLength(1);
+    expect(screen.queryByText('Invalid Date')).not.toBeInTheDocument();
   });
 });

--- a/packages/bruno-app/src/components/Devtools/Console/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.js
@@ -321,7 +321,7 @@ const NetworkFilterDropdown = ({ filters, requestCounts, onFilterToggle, onToggl
 
           <div className="filter-dropdown-options">
             {Object.entries(filters).map(([method, enabled]) => (
-              <label key={method} className="filter-option">
+              <label key={method} className="filter-option" data-testid={`network-filter-option-${method}`}>
                 <input
                   type="checkbox"
                   checked={enabled}
@@ -329,7 +329,7 @@ const NetworkFilterDropdown = ({ filters, requestCounts, onFilterToggle, onToggl
                 />
                 <div className="filter-option-content">
                   <span className="filter-option-label">{method}</span>
-                  <span className="filter-option-count">({requestCounts[method] || 0})</span>
+                  <span className="filter-option-count" data-testid={`network-filter-count-${method}`}>({requestCounts[method] || 0})</span>
                 </div>
               </label>
             ))}
@@ -408,7 +408,7 @@ const Console = () => {
     collections.forEach((collection) => {
       if (collection.timeline) {
         collection.timeline
-          .filter((entry) => entry.type === 'request')
+          .filter((entry) => entry.type === 'request' || entry.type === 'scripted-request')
           .forEach((entry) => {
             requests.push({
               ...entry,

--- a/packages/bruno-app/src/components/Devtools/Console/index.spec.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.spec.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { ThemeProvider } from 'providers/Theme';
+
+jest.mock('./TerminalTab', () => () => null);
+jest.mock('./RequestDetailsPanel', () => () => null);
+jest.mock('./ErrorDetailsPanel', () => () => null);
+jest.mock('../Performance', () => () => null);
+
+import Console from './index';
+
+const makeRequest = (overrides = {}) => ({
+  type: 'request',
+  timestamp: overrides.timestamp ?? 1000,
+  collectionUid: overrides.collectionUid ?? 'col-1',
+  itemUid: overrides.itemUid ?? 'item-1',
+  data: {
+    request: {
+      method: overrides.method ?? 'GET',
+      url: overrides.url ?? 'https://example.com/api/users'
+    },
+    response: {
+      status: overrides.status ?? 200,
+      statusCode: overrides.statusCode ?? 200,
+      duration: overrides.duration ?? 100,
+      size: overrides.size ?? 512
+    },
+    timestamp: overrides.timestamp ?? 1000
+  }
+});
+
+const makeScriptedRequest = (overrides = {}) => ({
+  type: 'scripted-request',
+  timestamp: overrides.timestamp ?? 1000,
+  collectionUid: overrides.collectionUid ?? 'col-1',
+  itemUid: overrides.itemUid ?? 'item-1',
+  data: {
+    request: {
+      method: overrides.method ?? 'GET',
+      url: overrides.url ?? 'https://example.com/api/scripted'
+    },
+    response: {
+      status: overrides.status ?? 200,
+      statusCode: overrides.statusCode ?? 200,
+      duration: overrides.duration ?? 100,
+      size: overrides.size ?? 512
+    }
+  }
+});
+
+const ALL_LOG_FILTERS = { error: true, warn: true, info: true, log: true };
+const ALL_NETWORK_FILTERS = { GET: true, POST: true, PUT: true, DELETE: true, PATCH: true, HEAD: true, OPTIONS: true };
+
+const renderConsole = (timeline = []) => {
+  const store = configureStore({
+    reducer: {
+      collections: (state = {
+        collections: [{
+          uid: 'col-1',
+          name: 'Test Collection',
+          timeline
+        }]
+      }) => state,
+      logs: (state = {
+        logs: [],
+        filters: ALL_LOG_FILTERS,
+        activeTab: 'network',
+        selectedRequest: null,
+        selectedError: null,
+        networkFilters: ALL_NETWORK_FILTERS,
+        debugErrors: [],
+        requestDetailsPanelWidth: 360
+      }) => state
+    }
+  });
+
+  return render(
+    <Provider store={store}>
+      <ThemeProvider>
+        <Console />
+      </ThemeProvider>
+    </Provider>
+  );
+};
+
+describe('network filter counts', () => {
+  it('includes scripted requests in method counts', () => {
+    renderConsole([
+      makeRequest({ itemUid: 'main-get', method: 'GET' }),
+      makeScriptedRequest({ itemUid: 'scripted-get', method: 'GET' }),
+      makeRequest({ itemUid: 'main-post', method: 'POST' })
+    ]);
+
+    fireEvent.click(screen.getByTitle('Filter requests by method'));
+
+    expect(screen.getByTestId('network-filter-option-GET')).toBeInTheDocument();
+    expect(screen.getByTestId('network-filter-option-POST')).toBeInTheDocument();
+    expect(screen.getByTestId('network-filter-count-GET')).toHaveTextContent('(2)');
+    expect(screen.getByTestId('network-filter-count-POST')).toHaveTextContent('(1)');
+  });
+});

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/entryMeta.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/entryMeta.js
@@ -1,11 +1,4 @@
-// Keys must match getEntryKind() in buildEntries.js.
-// `kind` is a stable identifier used for data-testids (e.g. timeline-badge-pre).
-export const ENTRY_KINDS = {
-  main: { kind: 'main', chipLabel: 'Request', badgeLabel: 'request', badgeClass: 'tl-badge tl-badge--main' },
-  oauth: { kind: 'oauth', chipLabel: 'OAuth', badgeLabel: 'oauth2.0', badgeClass: 'tl-badge tl-badge--oauth2' },
-  pre: { kind: 'pre', chipLabel: 'Pre-Request', badgeLabel: 'sendRequest', badgeClass: 'tl-badge tl-badge--scripted' },
-  post: { kind: 'post', chipLabel: 'Post-Response', badgeLabel: 'runRequest', badgeClass: 'tl-badge tl-badge--run-request' }
-};
+import { ENTRY_KINDS, getBadge } from 'utils/request-source-badges';
 
 export const FILTER_CHIPS = [
   { id: 'all', label: 'All' },
@@ -15,9 +8,4 @@ export const FILTER_CHIPS = [
   { id: 'oauth', label: ENTRY_KINDS.oauth.chipLabel }
 ];
 
-export const getBadge = ({ source, isOauth2 }) => {
-  if (isOauth2) return ENTRY_KINDS.oauth;
-  if (!source || source === 'main') return ENTRY_KINDS.main;
-  if (source === 'runRequest') return ENTRY_KINDS.post;
-  return ENTRY_KINDS.pre;
-};
+export { ENTRY_KINDS, getBadge };

--- a/packages/bruno-app/src/utils/request-source-badges.js
+++ b/packages/bruno-app/src/utils/request-source-badges.js
@@ -1,0 +1,15 @@
+// Keys must match getEntryKind() in buildEntries.js.
+// `kind` is a stable identifier used for data-testids (e.g. timeline-badge-pre).
+export const ENTRY_KINDS = {
+  main: { kind: 'main', chipLabel: 'Request', badgeLabel: 'request', badgeClass: 'tl-badge tl-badge--main' },
+  oauth: { kind: 'oauth', chipLabel: 'OAuth', badgeLabel: 'oauth2.0', badgeClass: 'tl-badge tl-badge--oauth2' },
+  pre: { kind: 'pre', chipLabel: 'Pre-Request', badgeLabel: 'sendRequest', badgeClass: 'tl-badge tl-badge--scripted' },
+  post: { kind: 'post', chipLabel: 'Post-Response', badgeLabel: 'runRequest', badgeClass: 'tl-badge tl-badge--run-request' }
+};
+
+export const getBadge = ({ source, isOauth2 }) => {
+  if (isOauth2) return ENTRY_KINDS.oauth;
+  if (!source || source === 'main') return ENTRY_KINDS.main;
+  if (source === 'runRequest') return ENTRY_KINDS.post;
+  return ENTRY_KINDS.pre;
+};

--- a/packages/bruno-app/src/utils/request-source-badges.spec.js
+++ b/packages/bruno-app/src/utils/request-source-badges.spec.js
@@ -1,0 +1,19 @@
+import { ENTRY_KINDS, getBadge } from './request-source-badges';
+
+describe('request-source-badges', () => {
+  it('returns the main badge when source is missing', () => {
+    expect(getBadge({ source: undefined, isOauth2: false })).toEqual(ENTRY_KINDS.main);
+  });
+
+  it('returns the pre-request badge for sendRequest sources', () => {
+    expect(getBadge({ source: 'sendRequest', isOauth2: false })).toEqual(ENTRY_KINDS.pre);
+  });
+
+  it('returns the post-response badge for runRequest sources', () => {
+    expect(getBadge({ source: 'runRequest', isOauth2: false })).toEqual(ENTRY_KINDS.post);
+  });
+
+  it('returns the oauth badge for oauth entries regardless of source', () => {
+    expect(getBadge({ source: 'sendRequest', isOauth2: true })).toEqual(ENTRY_KINDS.oauth);
+  });
+});


### PR DESCRIPTION
## Description

PR #8210 scoped scripted requests (`bru.sendRequest()` / `bru.runRequest()`) to their correct item in the Timeline tab. This PR completes that work by surfacing those same calls in the Network DevTools tab.

The Network DevTools tab now captures HTTP calls made via `bru.sendRequest()` and `bru.runRequest()` inside pre/post scripts, in addition to direct requests.

The Network tab is intended to show all outgoing HTTP traffic. Scripted requests generate real HTTP calls, but were previously excluded, making it harder to debug request flows that rely on pre/post scripts. These calls already appear in the Timeline tab for the originating request; this change makes them visible in the global Network view as well.

Script-originated requests are labeled with a badge in the Method column so they remain distinguishable from direct requests.

### Changes

* Updated the `collection.timeline` filter in both `NetworkTab` and `Console` to include `scripted-request` entries alongside regular requests.
* Added a timestamp fallback (`data.timestamp ?? entry.timestamp`) since scripted requests do not populate `data.timestamp`.
* Added a small script badge in the Method column to distinguish scripted requests from direct requests, reusing the existing Timeline badge styling.
* Added unit tests covering scripted request rendering, badge visibility, and timestamp fallback behavior.

Before:

<img width="1920" height="1032" alt="Captura de tela de 2026-06-14 16-52-32" src="https://github.com/user-attachments/assets/0b62d62a-2e7d-4d18-9747-5132dec29566" />
<img width="1920" height="1032" alt="Captura de tela de 2026-06-14 16-52-26" src="https://github.com/user-attachments/assets/b84caa71-1129-4bd6-bd21-d328da9c8551" />

After:


<img width="1920" height="1032" alt="Captura de tela de 2026-06-14 16-53-04" src="https://github.com/user-attachments/assets/4e5ca1ff-1a49-4cee-9807-1545cae7168a" />
<img width="1920" height="1032" alt="Captura de tela de 2026-06-14 16-53-19" src="https://github.com/user-attachments/assets/119c4e36-1ac4-4277-b55a-f6d1c5e7ad3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visual “script” badges to identify scripted requests in the developer tools Network tab.
  * Network tab now includes scripted-request entries alongside regular requests, including method filter counts.

* **Improvements**
  * Script badge and request-source badges are now consistent across the app.
  * Updated Network tab time rendering to prevent “Invalid Date” when timestamps are missing.
  * Refreshed badge styling to better match the active theme.

* **Testing**
  * Added/updated tests for scripted rows, badge visibility, timestamp fallback behavior, and method-count filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->