### PR TITLE
Feature(size/L): BRU-2542 Choose environments to include and show versions in the Generate Documentation modal

### DIFF
--- a/packages/bruno-app/src/components/Errors/IpcErrorModal/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Errors/IpcErrorModal/StyledWrapper.js
@@ -4,6 +4,8 @@ const StyledWrapper = styled.div`
   color: ${(props) => props.theme.colors.danger};
   pre {
     color: ${(props) => props.theme.colors.danger};
+    max-height: 60vh;
+    overflow: auto;
   }
 `;
 

--- a/packages/bruno-app/src/components/Errors/IpcErrorModal/index.js
+++ b/packages/bruno-app/src/components/Errors/IpcErrorModal/index.js
@@ -22,7 +22,7 @@ const IpcErrorModal = ({ error }) => {
               disableCloseOnOutsideClick={true}
               disableEscapeKey={true}
             >
-              <pre className="w-full flex flex-wrap whitespace-pre-wrap">{error}</pre>
+              <pre className="w-full whitespace-pre-wrap break-words">{error}</pre>
             </Modal>
           </Portal>
         </StyledWrapper>

--- a/packages/bruno-app/src/components/Errors/IpcErrorModal/index.js
+++ b/packages/bruno-app/src/components/Errors/IpcErrorModal/index.js
@@ -22,7 +22,7 @@ const IpcErrorModal = ({ error }) => {
               disableCloseOnOutsideClick={true}
               disableEscapeKey={true}
             >
-              <pre className="w-full whitespace-pre-wrap break-words">{error}</pre>
+              <pre className="w-full flex flex-wrap whitespace-pre-wrap">{error}</pre>
             </Modal>
           </Portal>
         </StyledWrapper>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.js
@@ -1,0 +1,27 @@
+import React, { memo } from 'react';
+import { formatCollectionVersion } from 'utils/collections/index';
+
+/**
+ * Read-only display of the collection's current version and a summary of its
+ * contents (folder + request counts). Presentational and prop-driven so it can be
+ * reused wherever the collection version needs to be shown. Version formatting is
+ * delegated to `formatCollectionVersion` for consistency across the UI.
+ */
+const CollectionVersionInfo = ({ version, folderCount = 0, requestCount = 0 }) => {
+  const folderLabel = folderCount === 1 ? 'Folder' : 'Folders';
+  const requestLabel = requestCount === 1 ? 'request' : 'requests';
+
+  return (
+    <div className="version-info">
+      <div className="version-line">
+        <span className="version-label">Collection Version:</span>{' '}
+        <span className="version-value">{formatCollectionVersion(version)}</span>
+      </div>
+      <p className="version-summary">
+        {`${folderCount} ${folderLabel} • ${requestCount} ${requestLabel}`}
+      </p>
+    </div>
+  );
+};
+
+export default memo(CollectionVersionInfo);

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.js
@@ -1,23 +1,35 @@
 import React, { memo } from 'react';
-import { formatCollectionVersion } from 'utils/collections/index';
+import semver from 'semver';
+
+const DEFAULT_VERSION = 'v1.0.0';
+
+/**
+ * Normalise a raw collection version for display: coerce partials to a full
+ * major.minor.patch ("1" -> "v1.0.0", "2.1" -> "v2.1.0"), keep a single "v"
+ * prefix, preserve pre-releases ("1.0.0-beta" -> "v1.0.0-beta"), and fall back to
+ * the default when the version is unset or unparseable.
+ */
+const formatVersion = (version) => {
+  const coerced = semver.coerce(version, { includePrerelease: true });
+  return coerced ? `v${coerced.version}` : DEFAULT_VERSION;
+};
 
 /**
  * Read-only display of the collection's current version and a summary of its
  * contents (folder + request counts). Presentational and prop-driven so it can be
- * reused wherever the collection version needs to be shown. Version formatting is
- * delegated to `formatCollectionVersion` for consistency across the UI.
+ * reused wherever the collection version needs to be shown.
  */
 const CollectionVersionInfo = ({ version, folderCount = 0, requestCount = 0 }) => {
   const folderLabel = folderCount === 1 ? 'Folder' : 'Folders';
   const requestLabel = requestCount === 1 ? 'request' : 'requests';
 
   return (
-    <div className="version-info">
+    <div className="version-info" data-testid="version-info">
       <div className="version-line">
         <span className="version-label">Collection Version:</span>{' '}
-        <span className="version-value">{formatCollectionVersion(version)}</span>
+        <span className="version-value" data-testid="version-value">{formatVersion(version)}</span>
       </div>
-      <p className="version-summary">
+      <p className="version-summary" data-testid="version-summary">
         {`${folderCount} ${folderLabel} • ${requestCount} ${requestLabel}`}
       </p>
     </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.js
@@ -1,0 +1,33 @@
+import React, { useMemo, memo } from 'react';
+import ColorBadge from 'components/ColorBadge';
+
+/**
+ * A selectable list of collection environments (checkbox + color dot + name).
+ * Selection is controlled by the parent via `selectedUids`. Presentational and
+ * prop-driven so it can be reused wherever an environment multi-select is needed.
+ */
+const EnvironmentSelectionList = ({ environments = [], selectedUids = [], onToggle, disabled = false }) => {
+  // O(1) membership checks regardless of how many environments are rendered.
+  const selectedSet = useMemo(() => new Set(selectedUids), [selectedUids]);
+
+  return (
+    <div className="env-list" role="group" aria-label="Environments to include">
+      {environments.map((env) => (
+        <label key={env?.uid} className="env-row">
+          <input
+            type="checkbox"
+            className="env-checkbox"
+            checked={selectedSet.has(env?.uid)}
+            disabled={disabled}
+            onChange={() => onToggle(env?.uid)}
+            data-testid={`env-select-${env?.uid}`}
+          />
+          <ColorBadge color={env?.color} size={8} />
+          <span className="env-name truncate">{env?.name}</span>
+        </label>
+      ))}
+    </div>
+  );
+};
+
+export default memo(EnvironmentSelectionList);

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.js
@@ -50,7 +50,7 @@ const EnvironmentSelectionList = ({
 
   const renderEnvironment = useCallback(
     (_index, env) => (
-      <label className="env-row">
+      <label className="env-row" data-testid="env-row">
         <input
           type="checkbox"
           className="env-checkbox"
@@ -77,7 +77,7 @@ const EnvironmentSelectionList = ({
     <>
       <div className="env-section-header">
         <div className="env-section-heading">
-          <h4 className="env-section-title">{title}</h4>
+          <h4 className="env-section-title" data-testid="env-section-title">{title}</h4>
           <span className="env-section-count" data-testid="env-selected-count">
             ({selectedCount}/{environments.length} selected)
           </span>
@@ -92,7 +92,7 @@ const EnvironmentSelectionList = ({
             onChange={handleToggleAll}
             data-testid="env-select-all"
           />
-          <span className="env-select-all-label">Select All</span>
+          <span className="env-select-all-label" data-testid="env-select-all-label">Select All</span>
         </label>
       </div>
       <Virtuoso

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, memo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, memo } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import ColorBadge from 'components/ColorBadge';
 
@@ -12,13 +12,39 @@ const MAX_VISIBLE_ROWS = 5;
 const ENV_ROW_HEIGHT = 34;
 
 /**
- * A selectable, virtualised list of collection environments (checkbox + color dot + name).
- * Selection is controlled by the parent via `selectedUids`. Presentational and
+ * A selectable, virtualised list of collection environments (checkbox + color dot + name)
+ * with a header that carries the title and a tri-state "select all" checkbox.
+ *
+ * Selection is controlled by the parent via `selectedUids`; `onToggleAll(nextSelectAll)`
+ * fires with the desired state when the header checkbox is clicked. Presentational and
  * prop-driven so it can be reused wherever an environment multi-select is needed.
  */
-const EnvironmentSelectionList = ({ environments = [], selectedUids = [], onToggle, disabled = false }) => {
+const EnvironmentSelectionList = ({
+  environments = [],
+  selectedUids = [],
+  onToggle,
+  onToggleAll,
+  title = 'Environments',
+  disabled = false
+}) => {
   // O(1) membership checks regardless of how many environments are rendered.
   const selectedSet = useMemo(() => new Set(selectedUids), [selectedUids]);
+
+  const selectedCount = useMemo(
+    () => environments.reduce((count, env) => (selectedSet.has(env?.uid) ? count + 1 : count), 0),
+    [environments, selectedSet]
+  );
+  const allSelected = environments.length > 0 && selectedCount === environments.length;
+  const someSelected = selectedCount > 0 && !allSelected;
+
+  const selectAllRef = useRef(null);
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someSelected;
+    }
+  }, [someSelected]);
+
+  const handleToggleAll = useCallback((event) => onToggleAll?.(event.target.checked), [onToggleAll]);
 
   const computeItemKey = useCallback((_index, env) => env?.uid, []);
 
@@ -48,17 +74,39 @@ const EnvironmentSelectionList = ({ environments = [], selectedUids = [], onTogg
   const visibleRows = Math.min(environments.length, MAX_VISIBLE_ROWS);
 
   return (
-    <Virtuoso
-      className="env-list"
-      role="group"
-      aria-label="Environments to include"
-      style={{ height: visibleRows * ENV_ROW_HEIGHT }}
-      data={environments}
-      computeItemKey={computeItemKey}
-      itemContent={renderEnvironment}
-      fixedItemHeight={ENV_ROW_HEIGHT}
-      increaseViewportBy={ENV_ROW_HEIGHT * 3}
-    />
+    <>
+      <div className="env-section-header">
+        <div className="env-section-heading">
+          <h4 className="env-section-title">{title}</h4>
+          <span className="env-section-count" data-testid="env-selected-count">
+            ({selectedCount}/{environments.length} selected)
+          </span>
+        </div>
+        <label className="env-select-all">
+          <input
+            ref={selectAllRef}
+            type="checkbox"
+            className="env-checkbox"
+            checked={allSelected}
+            disabled={disabled}
+            onChange={handleToggleAll}
+            data-testid="env-select-all"
+          />
+          <span className="env-select-all-label">Select All</span>
+        </label>
+      </div>
+      <Virtuoso
+        className="env-list"
+        role="group"
+        aria-label={title}
+        style={{ height: visibleRows * ENV_ROW_HEIGHT }}
+        data={environments}
+        computeItemKey={computeItemKey}
+        itemContent={renderEnvironment}
+        fixedItemHeight={ENV_ROW_HEIGHT}
+        increaseViewportBy={ENV_ROW_HEIGHT * 3}
+      />
+    </>
   );
 };
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.js
@@ -1,8 +1,18 @@
-import React, { useMemo, memo } from 'react';
+import React, { useCallback, useMemo, memo } from 'react';
+import { Virtuoso } from 'react-virtuoso';
 import ColorBadge from 'components/ColorBadge';
 
+// Show at most 5 environments at a glance; the list virtualises and scrolls beyond
+// that, so it stays performant even for collections with hundreds of environments
+// (only the visible rows are ever in the DOM).
+const MAX_VISIBLE_ROWS = 5;
+
+// Fixed row height (px). MUST stay in sync with the `.env-row` height in StyledWrapper.js,
+// since it is passed to Virtuoso as `fixedItemHeight`.
+const ENV_ROW_HEIGHT = 34;
+
 /**
- * A selectable list of collection environments (checkbox + color dot + name).
+ * A selectable, virtualised list of collection environments (checkbox + color dot + name).
  * Selection is controlled by the parent via `selectedUids`. Presentational and
  * prop-driven so it can be reused wherever an environment multi-select is needed.
  */
@@ -10,23 +20,45 @@ const EnvironmentSelectionList = ({ environments = [], selectedUids = [], onTogg
   // O(1) membership checks regardless of how many environments are rendered.
   const selectedSet = useMemo(() => new Set(selectedUids), [selectedUids]);
 
+  const computeItemKey = useCallback((_index, env) => env?.uid, []);
+
+  const renderEnvironment = useCallback(
+    (_index, env) => (
+      <label className="env-row">
+        <input
+          type="checkbox"
+          className="env-checkbox"
+          checked={selectedSet.has(env?.uid)}
+          disabled={disabled}
+          onChange={() => onToggle?.(env?.uid)}
+          data-testid={`env-select-${env?.uid}`}
+        />
+        <ColorBadge color={env?.color} size={8} />
+        <span className="env-name truncate">{env?.name}</span>
+      </label>
+    ),
+    [selectedSet, disabled, onToggle]
+  );
+
+  if (!environments.length) {
+    return null;
+  }
+
+  // Fit the list to its content, capped at MAX_VISIBLE_ROWS — beyond that it scrolls.
+  const visibleRows = Math.min(environments.length, MAX_VISIBLE_ROWS);
+
   return (
-    <div className="env-list" role="group" aria-label="Environments to include">
-      {environments.map((env) => (
-        <label key={env?.uid} className="env-row">
-          <input
-            type="checkbox"
-            className="env-checkbox"
-            checked={selectedSet.has(env?.uid)}
-            disabled={disabled}
-            onChange={() => onToggle(env?.uid)}
-            data-testid={`env-select-${env?.uid}`}
-          />
-          <ColorBadge color={env?.color} size={8} />
-          <span className="env-name truncate">{env?.name}</span>
-        </label>
-      ))}
-    </div>
+    <Virtuoso
+      className="env-list"
+      role="group"
+      aria-label="Environments to include"
+      style={{ height: visibleRows * ENV_ROW_HEIGHT }}
+      data={environments}
+      computeItemKey={computeItemKey}
+      itemContent={renderEnvironment}
+      fixedItemHeight={ENV_ROW_HEIGHT}
+      increaseViewportBy={ENV_ROW_HEIGHT * 3}
+    />
   );
 };
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
@@ -46,13 +46,57 @@ const StyledWrapper = styled.div`
       .env-section {
         padding: 1rem;
 
+        .env-checkbox {
+          width: 1rem;
+          height: 1rem;
+          margin: 0;
+          flex-shrink: 0;
+          cursor: pointer;
+        }
+
+        .env-section-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 0.5rem;
+          margin-bottom: 0.75rem;
+        }
+
+        .env-section-heading {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          min-width: 0;
+        }
+
+        .env-section-count {
+          font-size: ${(props) => props.theme.font.size.xs};
+          color: ${(props) => props.theme.colors.text.muted};
+          white-space: nowrap;
+        }
+
         .env-section-title {
-          margin: 0 0 0.75rem;
+          margin: 0;
           font-size: ${(props) => props.theme.font.size.xs};
           font-weight: 600;
           letter-spacing: 0.05em;
           text-transform: uppercase;
           color: ${(props) => props.theme.colors.text.muted};
+        }
+
+        .env-select-all {
+          display: flex;
+          align-items: center;
+          gap: 0.375rem;
+          margin: 0;
+          cursor: pointer;
+          user-select: none;
+
+          .env-select-all-label {
+            font-size: ${(props) => props.theme.font.size.sm};
+            color: ${(props) => props.theme.colors.text.muted};
+            white-space: nowrap;
+          }
         }
 
         .env-row {
@@ -64,14 +108,6 @@ const StyledWrapper = styled.div`
           height: 34px;
           cursor: pointer;
           margin: 0;
-
-          .env-checkbox {
-            width: 1rem;
-            height: 1rem;
-            margin: 0;
-            flex-shrink: 0;
-            cursor: pointer;
-          }
 
           .env-name {
             font-size: ${(props) => props.theme.font.size.sm};

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
@@ -13,27 +13,80 @@ const StyledWrapper = styled.div`
       line-height: 1.6;
     }
 
-    .preview-container {
+    .config-card {
+      border: 1px solid ${(props) => props.theme.border.border1};
       border-radius: ${(props) => props.theme.border.radius.md};
       overflow: hidden;
-      border: 1px solid ${(props) => props.theme.border.border1};
 
-      .preview-label {
-        top: 0.5rem;
-        right: 0.5rem;
-        padding: 0.125rem 0.5rem;
-        font-size: ${(props) => props.theme.font.size.xs};
-        font-weight: 500;
-        color: #3b82f6;
-        background-color: rgba(59, 130, 246, 0.1);
-        border: 1px dashed rgba(59, 130, 246, 0.4);
-        border-radius: ${(props) => props.theme.border.radius.sm};
+      .version-info {
+        padding: 0.75rem 1rem;
+        background-color: ${(props) => props.theme.background.mantle};
+
+        .version-line {
+          font-size: ${(props) => props.theme.font.size.sm};
+          color: ${(props) => props.theme.text};
+        }
+
+        .version-label {
+          font-weight: 500;
+        }
+
+        .version-summary {
+          margin: 0.25rem 0 0;
+          font-size: ${(props) => props.theme.font.size.xs};
+          color: ${(props) => props.theme.colors.text.muted};
+        }
       }
 
-      .preview-image {
-        width: 100%;
-        height: auto;
-        display: block;
+      .card-divider {
+        height: 1px;
+        background-color: ${(props) => props.theme.border.border1};
+      }
+
+      .env-section {
+        padding: 1rem;
+
+        .env-section-title {
+          margin: 0 0 0.75rem;
+          font-size: ${(props) => props.theme.font.size.xs};
+          font-weight: 600;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: ${(props) => props.theme.colors.text.muted};
+        }
+
+        .env-list {
+          display: flex;
+          flex-direction: column;
+          gap: 0.625rem;
+        }
+
+        .env-row {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          cursor: pointer;
+          margin: 0;
+
+          .env-checkbox {
+            width: 1rem;
+            height: 1rem;
+            margin: 0;
+            flex-shrink: 0;
+            cursor: pointer;
+          }
+
+          .env-name {
+            font-size: ${(props) => props.theme.font.size.sm};
+            color: ${(props) => props.theme.text};
+            min-width: 0;
+          }
+        }
+
+        .env-empty {
+          font-size: ${(props) => props.theme.font.size.sm};
+          color: ${(props) => props.theme.colors.text.muted};
+        }
       }
     }
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
@@ -55,16 +55,13 @@ const StyledWrapper = styled.div`
           color: ${(props) => props.theme.colors.text.muted};
         }
 
-        .env-list {
-          display: flex;
-          flex-direction: column;
-          gap: 0.625rem;
-        }
-
         .env-row {
           display: flex;
           align-items: center;
           gap: 0.5rem;
+          /* Fixed row height — MUST match ENV_ROW_HEIGHT (Virtuoso fixedItemHeight)
+             in EnvironmentSelectionList. The inter-row spacing is baked in here. */
+          height: 34px;
           cursor: pointer;
           margin: 0;
 
@@ -81,11 +78,6 @@ const StyledWrapper = styled.div`
             color: ${(props) => props.theme.text};
             min-width: 0;
           }
-        }
-
-        .env-empty {
-          font-size: ${(props) => props.theme.font.size.sm};
-          color: ${(props) => props.theme.colors.text.muted};
         }
       }
     }

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -8,6 +8,7 @@ import toast from 'react-hot-toast';
 import { IconBook, IconCheck, IconAlertTriangle, IconLoader2 } from '@tabler/icons';
 
 import Modal from 'components/Modal';
+import Portal from 'components/Portal';
 import StyledWrapper from './StyledWrapper';
 import CollectionVersionInfo from './CollectionVersionInfo';
 import EnvironmentSelectionList from './EnvironmentSelectionList';
@@ -52,14 +53,16 @@ const buildHtmlDocument = (collectionName, escapedYamlContent) => `<!DOCTYPE htm
 </html>`;
 
 const CollectionNotFound = ({ onClose }) => (
-  <Modal size="md" title="Generate Documentation" confirmText="Close" handleConfirm={onClose} hideCancel>
-    <StyledWrapper className="w-[500px]">
-      <div className="flex items-center gap-2 text-warning">
-        <IconAlertTriangle size={16} className="shrink-0" />
-        <span>Collection not found. It may have been deleted or is no longer available.</span>
-      </div>
-    </StyledWrapper>
-  </Modal>
+  <Portal>
+    <Modal size="md" title="Generate Documentation" confirmText="Close" handleConfirm={onClose} hideCancel>
+      <StyledWrapper className="w-[500px]">
+        <div className="flex items-center gap-2 text-warning">
+          <IconAlertTriangle size={16} className="shrink-0" />
+          <span>Collection not found. It may have been deleted or is no longer available.</span>
+        </div>
+      </StyledWrapper>
+    </Modal>
+  </Portal>
 );
 
 const GenerateDocumentation = ({ onClose, collectionUid }) => {
@@ -176,65 +179,67 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
   }
 
   return (
-    <Modal
-      size="md"
-      title="Generate Documentation"
-      confirmText={isLoading ? 'Loading...' : 'Generate'}
-      cancelText="Cancel"
-      handleConfirm={isLoading ? undefined : handleGenerate}
-      handleCancel={onClose}
-      confirmDisabled={isLoading}
-    >
-      <StyledWrapper className="w-[500px]">
-        {isLoading ? (
-          <div className="flex items-center justify-center gap-3 py-8">
-            <IconLoader2 size={20} className="animate-spin" />
-            <span>Loading collection...</span>
-          </div>
-        ) : (
-          <div className="content">
-            <h3 className="title flex items-center gap-2 mt-2 font-medium">
-              <IconBook size={18} />
-              <span>Interactive API Documentation</span>
-            </h3>
-            <p className="description mb-4">
-              Generate a standalone HTML file that can be hosted anywhere or shared with your team.
-            </p>
-
-            <ul className="features flex flex-col list-none gap-2 p-0 mb-4">
-              {FEATURES.map((feature) => (
-                <li key={feature} className="flex items-center gap-2.5">
-                  <IconCheck size={16} className="check-icon flex-shrink-0" />
-                  <span>{feature}</span>
-                </li>
-              ))}
-            </ul>
-
-            <div className="config-card mb-4">
-              <CollectionVersionInfo version={currentVersion} folderCount={folderCount} requestCount={requestCount} />
-              {environments.length > 0 && (
-                <Fragment>
-                  <div className="card-divider" />
-                  <div className="env-section">
-                    <EnvironmentSelectionList
-                      title="Environments to include"
-                      environments={environments}
-                      selectedUids={selectedEnvUids}
-                      onToggle={toggleEnv}
-                      onToggleAll={toggleAllEnvs}
-                    />
-                  </div>
-                </Fragment>
-              )}
+    <Portal>
+      <Modal
+        size="md"
+        title="Generate Documentation"
+        confirmText={isLoading ? 'Loading...' : 'Generate'}
+        cancelText="Cancel"
+        handleConfirm={isLoading ? undefined : handleGenerate}
+        handleCancel={onClose}
+        confirmDisabled={isLoading}
+      >
+        <StyledWrapper className="w-[500px]">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-3 py-8">
+              <IconLoader2 size={20} className="animate-spin" />
+              <span>Loading collection...</span>
             </div>
+          ) : (
+            <div className="content">
+              <h3 className="title flex items-center gap-2 mt-2 font-medium">
+                <IconBook size={18} />
+                <span>Interactive API Documentation</span>
+              </h3>
+              <p className="description mb-4">
+                Generate a standalone HTML file that can be hosted anywhere or shared with your team.
+              </p>
 
-            <p className="note m-0">
-              The generated file loads OpenCollection's JavaScript and CSS files from a CDN, which requires an internet connection.
-            </p>
-          </div>
-        )}
-      </StyledWrapper>
-    </Modal>
+              <ul className="features flex flex-col list-none gap-2 p-0 mb-4">
+                {FEATURES.map((feature) => (
+                  <li key={feature} className="flex items-center gap-2.5">
+                    <IconCheck size={16} className="check-icon flex-shrink-0" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="config-card mb-4">
+                <CollectionVersionInfo version={currentVersion} folderCount={folderCount} requestCount={requestCount} />
+                {environments.length > 0 && (
+                  <Fragment>
+                    <div className="card-divider" />
+                    <div className="env-section">
+                      <EnvironmentSelectionList
+                        title="Environments to include"
+                        environments={environments}
+                        selectedUids={selectedEnvUids}
+                        onToggle={toggleEnv}
+                        onToggleAll={toggleAllEnvs}
+                      />
+                    </div>
+                  </Fragment>
+                )}
+              </div>
+
+              <p className="note m-0">
+                The generated file loads OpenCollection's JavaScript and CSS files from a CDN, which requires an internet connection.
+              </p>
+            </div>
+          )}
+        </StyledWrapper>
+      </Modal>
+    </Portal>
   );
 };
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState, Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import { cloneDeep } from 'lodash';
 import * as FileSaver from 'file-saver';
@@ -9,9 +9,10 @@ import { IconBook, IconCheck, IconAlertTriangle, IconLoader2 } from '@tabler/ico
 
 import Modal from 'components/Modal';
 import StyledWrapper from './StyledWrapper';
-import demoImage from './demo.png';
+import CollectionVersionInfo from './CollectionVersionInfo';
+import EnvironmentSelectionList from './EnvironmentSelectionList';
 import { useApp } from 'providers/App';
-import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsLoading, sortItemsBySidebarOrder } from 'utils/collections/index';
+import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsLoading, sortItemsBySidebarOrder, getCollectionItemCounts } from 'utils/collections/index';
 import { brunoToOpenCollection } from '@usebruno/converters';
 import { sanitizeName } from 'utils/common/regex';
 import { escapeHtml } from 'utils/response';
@@ -72,6 +73,37 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
     [collection]
   );
 
+  // The collection's current version (read-only here); formatted for display below.
+  const currentVersion = collection?.version;
+
+  // Folder + request counts, computed from the collection tree (recursively).
+  const { folderCount, requestCount } = useMemo(
+    () => getCollectionItemCounts(collection?.items),
+    [collection?.items]
+  );
+
+  const environments = useMemo(() => collection?.environments || [], [collection?.environments]);
+
+  // Track *deselected* environments so all environments — including any that load
+  // after mount — stay selected by default, matching the design.
+  const [deselectedEnvUids, setDeselectedEnvUids] = useState(() => new Set());
+  const selectedEnvUids = useMemo(
+    () => environments.filter((env) => !deselectedEnvUids.has(env.uid)).map((env) => env.uid),
+    [environments, deselectedEnvUids]
+  );
+
+  const toggleEnv = useCallback((uid) => {
+    setDeselectedEnvUids((prev) => {
+      const next = new Set(prev);
+      if (next.has(uid)) {
+        next.delete(uid);
+      } else {
+        next.add(uid);
+      }
+      return next;
+    });
+  }, []);
+
   const handleGenerate = useCallback(() => {
     try {
       const collectionCopy = cloneDeep(collection);
@@ -80,8 +112,20 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
       // ) at every depth, so the generated docs match the collection shown in the sidebar.
       collectionCopy.items = sortItemsBySidebarOrder(collectionCopy.items);
 
+      // Only include the environments the user kept selected in the generated docs.
+      const selectedSet = new Set(selectedEnvUids);
+      collectionCopy.environments = (collectionCopy.environments || []).filter((env) => selectedSet.has(env.uid));
+
       const transformedCollection = transformCollectionToSaveToExportAsFile(collectionCopy);
       const openCollection = brunoToOpenCollection(transformedCollection);
+
+      // The docs are generated from the current collection version (when set).
+      if (currentVersion) {
+        openCollection.info = {
+          ...openCollection.info,
+          version: currentVersion
+        };
+      }
 
       openCollection.extensions = {
         ...openCollection.extensions,
@@ -119,7 +163,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
       console.error('Error generating documentation:', error);
       toast.error('Failed to generate documentation');
     }
-  }, [collection, version, onClose]);
+  }, [collection, version, onClose, currentVersion, selectedEnvUids]);
 
   if (!collection) {
     return <CollectionNotFound onClose={onClose} />;
@@ -151,11 +195,6 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
               Generate a standalone HTML file that can be hosted anywhere or shared with your team.
             </p>
 
-            <div className="preview-container relative mb-4">
-              <span className="preview-label absolute">Sample Output</span>
-              <img src={demoImage} alt="Documentation preview" className="preview-image" />
-            </div>
-
             <ul className="features flex flex-col list-none gap-2 p-0 mb-4">
               {FEATURES.map((feature) => (
                 <li key={feature} className="flex items-center gap-2.5">
@@ -164,6 +203,23 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
                 </li>
               ))}
             </ul>
+
+            <div className="config-card mb-4">
+              <CollectionVersionInfo version={currentVersion} folderCount={folderCount} requestCount={requestCount} />
+              {environments.length > 0 && (
+                <Fragment>
+                  <div className="card-divider" />
+                  <div className="env-section">
+                    <h4 className="env-section-title">Environments to include</h4>
+                    <EnvironmentSelectionList
+                      environments={environments}
+                      selectedUids={selectedEnvUids}
+                      onToggle={toggleEnv}
+                    />
+                  </div>
+                </Fragment>
+              )}
+            </div>
 
             <p className="note m-0">
               The generated file loads OpenCollection's JavaScript and CSS files from a CDN, which requires an internet connection.

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -104,6 +104,12 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
     });
   }, []);
 
+  // Select all -> nothing deselected; deselect all -> every environment deselected.
+  const toggleAllEnvs = useCallback(
+    (selectAll) => setDeselectedEnvUids(selectAll ? new Set() : new Set(environments.map((env) => env.uid))),
+    [environments]
+  );
+
   const handleGenerate = useCallback(() => {
     try {
       const collectionCopy = cloneDeep(collection);
@@ -210,11 +216,12 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
                 <Fragment>
                   <div className="card-divider" />
                   <div className="env-section">
-                    <h4 className="env-section-title">Environments to include</h4>
                     <EnvironmentSelectionList
+                      title="Environments to include"
                       environments={environments}
                       selectedUids={selectedEnvUids}
                       onToggle={toggleEnv}
+                      onToggleAll={toggleAllEnvs}
                     />
                   </div>
                 </Fragment>

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -5,41 +5,6 @@ import { sortByNameThenSequence } from 'utils/common/index';
 import path from 'utils/common/path';
 import { isRequestTagsIncluded } from '@usebruno/common';
 
-export const DEFAULT_COLLECTION_VERSION = 'v1.0.0';
-
-/**
- * Formats a raw collection version for consistent display across the UI.
- * Numeric versions are padded to a full major.minor.patch and prefixed with "v"
- * ("1" -> "v1.0.0", "2.1" -> "v2.1.0"); an existing "v"/"V" is preserved (no double "v").
- * Non-numeric / pre-release versions are shown as-is (only prefixed), and an unset
- * version falls back to the default.
- */
-export const formatCollectionVersion = (version) => {
-  if (version === null || version === undefined) return DEFAULT_COLLECTION_VERSION;
-
-  const raw = String(version).trim();
-  if (!raw) return DEFAULT_COLLECTION_VERSION;
-
-  // Drop an existing leading "v"/"V" so we never end up with "vv...".
-  const core = raw.replace(/^v/i, '').trim();
-  if (!core) return DEFAULT_COLLECTION_VERSION;
-
-  const segments = core.split('.');
-  const isNumeric = segments.every((segment) => /^\d+$/.test(segment));
-
-  // Only pad versions made up entirely of numeric segments; anything else
-  // (pre-release, build metadata, etc.) is shown as-is to stay precise.
-  if (!isNumeric) {
-    return `v${core}`;
-  }
-
-  while (segments.length < 3) {
-    segments.push('0');
-  }
-
-  return `v${segments.join('.')}`;
-};
-
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
   if (!str || !str.length || !isString(str)) {
     return '';

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -5,6 +5,41 @@ import { sortByNameThenSequence } from 'utils/common/index';
 import path from 'utils/common/path';
 import { isRequestTagsIncluded } from '@usebruno/common';
 
+export const DEFAULT_COLLECTION_VERSION = 'v1.0.0';
+
+/**
+ * Formats a raw collection version for consistent display across the UI.
+ * Numeric versions are padded to a full major.minor.patch and prefixed with "v"
+ * ("1" -> "v1.0.0", "2.1" -> "v2.1.0"); an existing "v"/"V" is preserved (no double "v").
+ * Non-numeric / pre-release versions are shown as-is (only prefixed), and an unset
+ * version falls back to the default.
+ */
+export const formatCollectionVersion = (version) => {
+  if (version === null || version === undefined) return DEFAULT_COLLECTION_VERSION;
+
+  const raw = String(version).trim();
+  if (!raw) return DEFAULT_COLLECTION_VERSION;
+
+  // Drop an existing leading "v"/"V" so we never end up with "vv...".
+  const core = raw.replace(/^v/i, '').trim();
+  if (!core) return DEFAULT_COLLECTION_VERSION;
+
+  const segments = core.split('.');
+  const isNumeric = segments.every((segment) => /^\d+$/.test(segment));
+
+  // Only pad versions made up entirely of numeric segments; anything else
+  // (pre-release, build metadata, etc.) is shown as-is to stay precise.
+  if (!isNumeric) {
+    return `v${core}`;
+  }
+
+  while (segments.length < 3) {
+    segments.push('0');
+  }
+
+  return `v${segments.join('.')}`;
+};
+
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
   if (!str || !str.length || !isString(str)) {
     return '';
@@ -886,6 +921,21 @@ export const isItemARequest = (item) => {
 
 export const isItemAFolder = (item) => {
   return !item.hasOwnProperty('request') && item.type === 'folder';
+};
+
+/**
+ * Counts the folders and requests in a collection's item tree, recursively at every
+ * depth. Used to summarise a collection (e.g. in the Generate Documentation modal).
+ *
+ * @param {Array} items - The collection's `items` tree.
+ * @returns {{ folderCount: number, requestCount: number }}
+ */
+export const getCollectionItemCounts = (items = []) => {
+  const flattened = flattenItems(items);
+  return {
+    folderCount: flattened.filter(isItemAFolder).length,
+    requestCount: flattened.filter(isItemARequest).length
+  };
 };
 
 /**

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem, formatCollectionVersion, DEFAULT_COLLECTION_VERSION, getCollectionItemCounts } from './index';
+import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -84,42 +84,6 @@ describe('transformRequestToSaveToFilesystem', () => {
 
     expect(transformed.request.params[0].annotations).toEqual([{ name: 'param-note', value: 'keep me' }]);
     expect(transformed.request.headers[0].annotations).toEqual([{ name: 'header-note', value: 'keep me' }]);
-  });
-});
-
-describe('formatCollectionVersion', () => {
-  it('pads numeric versions to a full major.minor.patch with a "v" prefix', () => {
-    expect(formatCollectionVersion('1')).toBe('v1.0.0');
-    expect(formatCollectionVersion('2.1')).toBe('v2.1.0');
-    expect(formatCollectionVersion('1.0.0')).toBe('v1.0.0');
-    expect(formatCollectionVersion('3.4.5')).toBe('v3.4.5');
-  });
-
-  it('does not double-prefix an existing "v"/"V"', () => {
-    expect(formatCollectionVersion('v2.1')).toBe('v2.1.0');
-    expect(formatCollectionVersion('V3')).toBe('v3.0.0');
-    expect(formatCollectionVersion('v1.0.0')).toBe('v1.0.0');
-  });
-
-  it('coerces numbers to a normalised version', () => {
-    expect(formatCollectionVersion(1)).toBe('v1.0.0');
-    expect(formatCollectionVersion(2)).toBe('v2.0.0');
-  });
-
-  it('keeps extra numeric segments without truncating', () => {
-    expect(formatCollectionVersion('1.2.3.4')).toBe('v1.2.3.4');
-  });
-
-  it('shows non-numeric / pre-release versions as-is (only prefixed)', () => {
-    expect(formatCollectionVersion('1.0.0-beta')).toBe('v1.0.0-beta');
-    expect(formatCollectionVersion('2.0.0-rc.1')).toBe('v2.0.0-rc.1');
-  });
-
-  it('falls back to the default when no version is set', () => {
-    expect(formatCollectionVersion(undefined)).toBe(DEFAULT_COLLECTION_VERSION);
-    expect(formatCollectionVersion(null)).toBe(DEFAULT_COLLECTION_VERSION);
-    expect(formatCollectionVersion('')).toBe(DEFAULT_COLLECTION_VERSION);
-    expect(formatCollectionVersion('   ')).toBe(DEFAULT_COLLECTION_VERSION);
   });
 });
 

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem } from './index';
+import { mergeHeaders, transformRequestToSaveToFilesystem, formatCollectionVersion, DEFAULT_COLLECTION_VERSION, getCollectionItemCounts } from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -84,5 +84,87 @@ describe('transformRequestToSaveToFilesystem', () => {
 
     expect(transformed.request.params[0].annotations).toEqual([{ name: 'param-note', value: 'keep me' }]);
     expect(transformed.request.headers[0].annotations).toEqual([{ name: 'header-note', value: 'keep me' }]);
+  });
+});
+
+describe('formatCollectionVersion', () => {
+  it('pads numeric versions to a full major.minor.patch with a "v" prefix', () => {
+    expect(formatCollectionVersion('1')).toBe('v1.0.0');
+    expect(formatCollectionVersion('2.1')).toBe('v2.1.0');
+    expect(formatCollectionVersion('1.0.0')).toBe('v1.0.0');
+    expect(formatCollectionVersion('3.4.5')).toBe('v3.4.5');
+  });
+
+  it('does not double-prefix an existing "v"/"V"', () => {
+    expect(formatCollectionVersion('v2.1')).toBe('v2.1.0');
+    expect(formatCollectionVersion('V3')).toBe('v3.0.0');
+    expect(formatCollectionVersion('v1.0.0')).toBe('v1.0.0');
+  });
+
+  it('coerces numbers to a normalised version', () => {
+    expect(formatCollectionVersion(1)).toBe('v1.0.0');
+    expect(formatCollectionVersion(2)).toBe('v2.0.0');
+  });
+
+  it('keeps extra numeric segments without truncating', () => {
+    expect(formatCollectionVersion('1.2.3.4')).toBe('v1.2.3.4');
+  });
+
+  it('shows non-numeric / pre-release versions as-is (only prefixed)', () => {
+    expect(formatCollectionVersion('1.0.0-beta')).toBe('v1.0.0-beta');
+    expect(formatCollectionVersion('2.0.0-rc.1')).toBe('v2.0.0-rc.1');
+  });
+
+  it('falls back to the default when no version is set', () => {
+    expect(formatCollectionVersion(undefined)).toBe(DEFAULT_COLLECTION_VERSION);
+    expect(formatCollectionVersion(null)).toBe(DEFAULT_COLLECTION_VERSION);
+    expect(formatCollectionVersion('')).toBe(DEFAULT_COLLECTION_VERSION);
+    expect(formatCollectionVersion('   ')).toBe(DEFAULT_COLLECTION_VERSION);
+  });
+});
+
+describe('getCollectionItemCounts', () => {
+  it('counts folders and requests recursively at every depth', () => {
+    const items = [
+      {
+        type: 'folder',
+        name: 'Zoo',
+        items: [
+          { type: 'http-request', name: 'Lion', request: {} },
+          { type: 'graphql-request', name: 'Bear', request: {} }
+        ]
+      },
+      {
+        type: 'folder',
+        name: 'Aviary',
+        items: [
+          {
+            type: 'folder',
+            name: 'Nest',
+            items: [{ type: 'http-request', name: 'Egg', request: {} }]
+          }
+        ]
+      },
+      { type: 'http-request', name: 'RootReq', request: {} }
+    ];
+
+    // Folders: Zoo, Aviary, Nest -> 3. Requests: Lion, Bear, Egg, RootReq -> 4.
+    expect(getCollectionItemCounts(items)).toEqual({ folderCount: 3, requestCount: 4 });
+  });
+
+  it('counts every request transport type', () => {
+    const items = [
+      { type: 'http-request', request: {} },
+      { type: 'graphql-request', request: {} },
+      { type: 'grpc-request', request: {} },
+      { type: 'ws-request', request: {} }
+    ];
+
+    expect(getCollectionItemCounts(items)).toEqual({ folderCount: 0, requestCount: 4 });
+  });
+
+  it('returns zero counts for empty or missing items', () => {
+    expect(getCollectionItemCounts([])).toEqual({ folderCount: 0, requestCount: 0 });
+    expect(getCollectionItemCounts(undefined)).toEqual({ folderCount: 0, requestCount: 0 });
   });
 });

--- a/tests/collection/generate-docs/fixtures/collection/environments/Development.bru
+++ b/tests/collection/generate-docs/fixtures/collection/environments/Development.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: https://dev.example.com
+}

--- a/tests/collection/generate-docs/fixtures/collection/environments/Production.bru
+++ b/tests/collection/generate-docs/fixtures/collection/environments/Production.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: https://api.example.com
+}

--- a/tests/collection/generate-docs/fixtures/collection/environments/Staging.bru
+++ b/tests/collection/generate-docs/fixtures/collection/environments/Staging.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: https://staging.example.com
+}

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -4,7 +4,6 @@ import { generateCollectionDocs } from '../../utils/page';
 import { buildCommonLocators } from '../../utils/page/locators';
 import {
   getCollectionTreeStructure,
-  waitForCollectionMount,
   type CollectionTreeItem
 } from '../../utils/page/mounting';
 
@@ -130,8 +129,6 @@ test.describe('Generate Documentation', () => {
   }) => {
     const locators = buildCommonLocators(page);
 
-    await waitForCollectionMount(page, COLLECTION_NAME);
-
     await locators.sidebar.collection(COLLECTION_NAME).hover();
     await locators.actions.collectionActions(COLLECTION_NAME).click();
     await locators.generateDocs.menuItem().click();
@@ -151,7 +148,6 @@ test.describe('Generate Documentation', () => {
   }) => {
     const locators = buildCommonLocators(page);
 
-    await waitForCollectionMount(page, COLLECTION_NAME);
     await locators.sidebar.collection(COLLECTION_NAME).hover();
     await locators.actions.collectionActions(COLLECTION_NAME).click();
     await locators.generateDocs.menuItem().click();
@@ -176,7 +172,6 @@ test.describe('Generate Documentation', () => {
   }) => {
     const locators = buildCommonLocators(page);
 
-    await waitForCollectionMount(page, COLLECTION_NAME);
     await locators.sidebar.collection(COLLECTION_NAME).hover();
     await locators.actions.collectionActions(COLLECTION_NAME).click();
     await locators.generateDocs.menuItem().click();

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -78,6 +78,29 @@ const sidebarItemsToNameTree = (items: CollectionTreeItem[] = []): NameTree[] =>
     return node;
   });
 
+/**
+ * Environments defined in the fixture collection (one `.bru` file each under
+ * `environments/`). All of them should be selected by default in the modal.
+ */
+const EXPECTED_ENVIRONMENTS = ['Production', 'Development', 'Staging'];
+
+/** Extract the full embedded OpenCollection payload from the generated docs HTML. */
+const parseGeneratedOpenCollection = (html: string): Record<string, any> => {
+  const match = html.match(/const collectionData = ("(?:\\.|[^"\\])*");/);
+  if (!match) {
+    throw new Error('Could not find the embedded collection data in the generated documentation');
+  }
+  const yamlContent = JSON.parse(match[1]) as string;
+  return jsyaml.load(yamlContent) as Record<string, any>;
+};
+
+/** Names of the environments embedded in the generated docs (under config.environments). */
+const generatedEnvironmentNames = (html: string): string[] => {
+  const oc = parseGeneratedOpenCollection(html);
+  const environments = (oc?.config?.environments ?? []) as Array<Record<string, any>>;
+  return environments.map((env) => env?.name);
+};
+
 test.describe('Generate Documentation', () => {
   test('orders generated docs to match the sidebar tree (folders by seq, then requests by seq, recursively)', async ({
     pageWithUserData: page
@@ -121,5 +144,91 @@ test.describe('Generate Documentation', () => {
     // Cancel so the test leaves no download behind.
     await locators.generateDocs.cancelButton().click();
     await expect(modal).toBeHidden();
+  });
+
+  test('shows the current collection version formatted as a v-prefixed semver', async ({
+    pageWithUserData: page
+  }) => {
+    const locators = buildCommonLocators(page);
+
+    await waitForCollectionMount(page, COLLECTION_NAME);
+    await locators.sidebar.collection(COLLECTION_NAME).hover();
+    await locators.actions.collectionActions(COLLECTION_NAME).click();
+    await locators.generateDocs.menuItem().click();
+
+    const modal = locators.generateDocs.modal();
+    await expect(modal).toBeVisible();
+
+    // The fixture's bruno.json version ("1") is normalised for display to "v1.0.0".
+    await expect(locators.generateDocs.versionInfo()).toContainText('Collection Version:');
+    await expect(locators.generateDocs.versionValue()).toHaveText('v1.0.0');
+
+    // The fixture has 2 folders (Zoo, Aviary) and 5 requests (Lion, Bear, Parrot,
+    // ReqAlpha, ReqBeta), counted recursively across the whole tree.
+    await expect(locators.generateDocs.versionCounts()).toHaveText('2 Folders • 5 requests');
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('lists every environment under "Environments to include", all selected by default', async ({
+    pageWithUserData: page
+  }) => {
+    const locators = buildCommonLocators(page);
+
+    await waitForCollectionMount(page, COLLECTION_NAME);
+    await locators.sidebar.collection(COLLECTION_NAME).hover();
+    await locators.actions.collectionActions(COLLECTION_NAME).click();
+    await locators.generateDocs.menuItem().click();
+
+    const modal = locators.generateDocs.modal();
+    await expect(modal).toBeVisible();
+    await expect(locators.generateDocs.environmentsTitle()).toBeVisible();
+
+    for (const name of EXPECTED_ENVIRONMENTS) {
+      await expect(locators.generateDocs.environmentRow(name)).toBeVisible();
+      await expect(locators.generateDocs.environmentCheckbox(name)).toBeChecked();
+    }
+
+    // Exactly the fixture's environments are listed — nothing more.
+    await expect(locators.generateDocs.environmentRows()).toHaveCount(EXPECTED_ENVIRONMENTS.length);
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('includes every environment in the generated docs by default', async ({
+    pageWithUserData: page
+  }) => {
+    const locators = buildCommonLocators(page);
+
+    // Ensure all environments have loaded (and stay checked) before generating.
+    const { content } = await generateCollectionDocs(page, COLLECTION_NAME, async () => {
+      for (const name of EXPECTED_ENVIRONMENTS) {
+        await expect(locators.generateDocs.environmentCheckbox(name)).toBeChecked();
+      }
+    });
+
+    expect(generatedEnvironmentNames(content).sort()).toEqual([...EXPECTED_ENVIRONMENTS].sort());
+  });
+
+  test('excludes a deselected environment from the generated docs', async ({
+    pageWithUserData: page
+  }) => {
+    const locators = buildCommonLocators(page);
+
+    const { content } = await generateCollectionDocs(page, COLLECTION_NAME, async () => {
+      // Wait for all environments to load, then deselect a single one.
+      for (const name of EXPECTED_ENVIRONMENTS) {
+        await expect(locators.generateDocs.environmentCheckbox(name)).toBeChecked();
+      }
+      await locators.generateDocs.environmentCheckbox('Development').uncheck();
+      await expect(locators.generateDocs.environmentCheckbox('Development')).not.toBeChecked();
+    });
+
+    const envNames = generatedEnvironmentNames(content);
+    expect(envNames).toContain('Production');
+    expect(envNames).toContain('Staging');
+    expect(envNames).not.toContain('Development');
   });
 });

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -1,5 +1,5 @@
 import jsyaml from 'js-yaml';
-import { test, expect } from '../../../playwright';
+import { test, expect, Page } from '../../../playwright';
 import { generateCollectionDocs } from '../../utils/page';
 import { buildCommonLocators } from '../../utils/page/locators';
 import {
@@ -98,6 +98,27 @@ const generatedEnvironmentNames = (html: string): string[] => {
   const oc = parseGeneratedOpenCollection(html);
   const environments = (oc?.config?.environments ?? []) as Array<Record<string, any>>;
   return environments.map((env) => env?.name);
+};
+
+/** Text rendered by the header count, e.g. `(2/3 selected)`. */
+const selectedCountText = (selected: number): string => `(${selected}/${EXPECTED_ENVIRONMENTS.length} selected)`;
+
+/**
+ * Open the Generate Documentation modal from the collection context menu and wait until
+ * every fixture environment row has rendered, so selection/count assertions are stable.
+ */
+const openDocsModalWithEnvironments = async (page: Page) => {
+  const locators = buildCommonLocators(page);
+
+  await locators.sidebar.collection(COLLECTION_NAME).hover();
+  await locators.actions.collectionActions(COLLECTION_NAME).click();
+  await locators.generateDocs.menuItem().click();
+
+  const modal = locators.generateDocs.modal();
+  await expect(modal).toBeVisible();
+  await expect(locators.generateDocs.environmentRows()).toHaveCount(EXPECTED_ENVIRONMENTS.length);
+
+  return { locators, modal };
 };
 
 test.describe('Generate Documentation', () => {
@@ -225,5 +246,93 @@ test.describe('Generate Documentation', () => {
     expect(envNames).toContain('Production');
     expect(envNames).toContain('Staging');
     expect(envNames).not.toContain('Development');
+  });
+
+  test('checks "Select All" and shows a full count when every environment is selected by default', async ({
+    pageWithUserData: page
+  }) => {
+    const { locators, modal } = await openDocsModalWithEnvironments(page);
+
+    await expect(locators.generateDocs.selectAllLabel()).toContainText('Select All');
+    await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked();
+    await expect(locators.generateDocs.selectedCount()).toHaveText(
+      selectedCountText(EXPECTED_ENVIRONMENTS.length)
+    );
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('shows "Select All" as indeterminate with a partial count when one environment is deselected', async ({
+    pageWithUserData: page
+  }) => {
+    const { locators, modal } = await openDocsModalWithEnvironments(page);
+
+    await locators.generateDocs.environmentCheckbox('Development').uncheck();
+
+    // Some-but-not-all selected -> tri-state checkbox shows the indeterminate state.
+    await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked({ indeterminate: true });
+    await expect(locators.generateDocs.selectedCount()).toHaveText(
+      selectedCountText(EXPECTED_ENVIRONMENTS.length - 1)
+    );
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('clicking "Select All" deselects every environment, emptying the checkbox and count', async ({
+    pageWithUserData: page
+  }) => {
+    const { locators, modal } = await openDocsModalWithEnvironments(page);
+    await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked();
+
+    await locators.generateDocs.selectAllCheckbox().click();
+
+    await expect(locators.generateDocs.selectAllCheckbox()).not.toBeChecked();
+    await expect(locators.generateDocs.selectedCount()).toHaveText(selectedCountText(0));
+    for (const name of EXPECTED_ENVIRONMENTS) {
+      await expect(locators.generateDocs.environmentCheckbox(name)).not.toBeChecked();
+    }
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('clicking "Select All" from a partial selection re-selects every environment', async ({
+    pageWithUserData: page
+  }) => {
+    const { locators, modal } = await openDocsModalWithEnvironments(page);
+
+    // Drop into the partial (indeterminate) state first.
+    await locators.generateDocs.environmentCheckbox('Development').uncheck();
+    await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked({ indeterminate: true });
+
+    // Clicking the tri-state checkbox while partial selects everything.
+    await locators.generateDocs.selectAllCheckbox().click();
+
+    await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked();
+    await expect(locators.generateDocs.selectedCount()).toHaveText(
+      selectedCountText(EXPECTED_ENVIRONMENTS.length)
+    );
+    for (const name of EXPECTED_ENVIRONMENTS) {
+      await expect(locators.generateDocs.environmentCheckbox(name)).toBeChecked();
+    }
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('deselecting everything via "Select All" excludes all environments from the generated docs', async ({
+    pageWithUserData: page
+  }) => {
+    const locators = buildCommonLocators(page);
+
+    const { content } = await generateCollectionDocs(page, COLLECTION_NAME, async () => {
+      await expect(locators.generateDocs.environmentRows()).toHaveCount(EXPECTED_ENVIRONMENTS.length);
+      await locators.generateDocs.selectAllCheckbox().click();
+      await expect(locators.generateDocs.selectedCount()).toHaveText(selectedCountText(0));
+    });
+
+    expect(generatedEnvironmentNames(content)).toEqual([]);
   });
 });

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1774,7 +1774,8 @@ const openWorkspaceFromDialog = async (app: any, page: any, targetPath: string) 
  */
 const generateCollectionDocs = async (
   page: Page,
-  collectionName: string
+  collectionName: string,
+  beforeGenerate?: () => Promise<void>
 ): Promise<{ content: string; fileName: string }> => {
   return await test.step(`Generate docs for collection "${collectionName}"`, async () => {
     const locators = buildCommonLocators(page);
@@ -1798,6 +1799,12 @@ const generateCollectionDocs = async (
     await expect(modal).toBeVisible({ timeout: 5000 });
     const generateButton = locators.generateDocs.generateButton();
     await expect(generateButton).toBeEnabled({ timeout: 10000 });
+
+    // Let the caller interact with the modal (e.g. toggle environment selection)
+    // after it is ready and before the docs are generated.
+    if (beforeGenerate) {
+      await beforeGenerate();
+    }
 
     // Arm the renderer-side interception before the save fires. `file-saver`
     // (v2) reads the Blob through `URL.createObjectURL` and then triggers the

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -127,6 +127,10 @@ export const buildCommonLocators = (page: Page) => ({
     versionCounts: () => page.locator('.bruno-modal .version-summary'),
     // Environment selection list
     environmentsTitle: () => page.locator('.bruno-modal .env-section-title'),
+    // Header controls: tri-state "select all" checkbox + "X/Y selected" count
+    selectAllCheckbox: () => page.locator('.bruno-modal').getByTestId('env-select-all'),
+    selectAllLabel: () => page.locator('.bruno-modal .env-select-all'),
+    selectedCount: () => page.locator('.bruno-modal').getByTestId('env-selected-count'),
     environmentRows: () => page.locator('.bruno-modal .env-row'),
     environmentRow: (name: string) =>
       page.locator('.bruno-modal .env-row').filter({ has: page.getByText(name, { exact: true }) }),

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -120,7 +120,21 @@ export const buildCommonLocators = (page: Page) => ({
     }),
     heading: () => page.locator('.bruno-modal').getByText('Interactive API Documentation'),
     generateButton: () => page.locator('.bruno-modal').getByRole('button', { name: 'Generate', exact: true }),
-    cancelButton: () => page.locator('.bruno-modal').getByRole('button', { name: 'Cancel', exact: true })
+    cancelButton: () => page.locator('.bruno-modal').getByRole('button', { name: 'Cancel', exact: true }),
+    // Collection version (read-only) display
+    versionInfo: () => page.locator('.bruno-modal .version-info'),
+    versionValue: () => page.locator('.bruno-modal .version-value'),
+    versionCounts: () => page.locator('.bruno-modal .version-summary'),
+    // Environment selection list
+    environmentsTitle: () => page.locator('.bruno-modal .env-section-title'),
+    environmentRows: () => page.locator('.bruno-modal .env-row'),
+    environmentRow: (name: string) =>
+      page.locator('.bruno-modal .env-row').filter({ has: page.getByText(name, { exact: true }) }),
+    environmentCheckbox: (name: string) =>
+      page
+        .locator('.bruno-modal .env-row')
+        .filter({ has: page.getByText(name, { exact: true }) })
+        .locator('input[type="checkbox"]')
   },
   runnerResults: {
     itemPath: (name: string) => page.getByTestId('runner-result-item').filter({ hasText: name })

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -122,23 +122,25 @@ export const buildCommonLocators = (page: Page) => ({
     generateButton: () => page.locator('.bruno-modal').getByRole('button', { name: 'Generate', exact: true }),
     cancelButton: () => page.locator('.bruno-modal').getByRole('button', { name: 'Cancel', exact: true }),
     // Collection version (read-only) display
-    versionInfo: () => page.locator('.bruno-modal .version-info'),
-    versionValue: () => page.locator('.bruno-modal .version-value'),
-    versionCounts: () => page.locator('.bruno-modal .version-summary'),
+    versionInfo: () => page.locator('.bruno-modal').getByTestId('version-info'),
+    versionValue: () => page.locator('.bruno-modal').getByTestId('version-value'),
+    versionCounts: () => page.locator('.bruno-modal').getByTestId('version-summary'),
     // Environment selection list
-    environmentsTitle: () => page.locator('.bruno-modal .env-section-title'),
+    environmentsTitle: () => page.locator('.bruno-modal').getByTestId('env-section-title'),
     // Header controls: tri-state "select all" checkbox + "X/Y selected" count
     selectAllCheckbox: () => page.locator('.bruno-modal').getByTestId('env-select-all'),
-    selectAllLabel: () => page.locator('.bruno-modal .env-select-all'),
+    selectAllLabel: () => page.locator('.bruno-modal').getByTestId('env-select-all-label'),
     selectedCount: () => page.locator('.bruno-modal').getByTestId('env-selected-count'),
-    environmentRows: () => page.locator('.bruno-modal .env-row'),
+    environmentRows: () => page.locator('.bruno-modal').getByTestId('env-row'),
     environmentRow: (name: string) =>
-      page.locator('.bruno-modal .env-row').filter({ has: page.getByText(name, { exact: true }) }),
+      page.locator('.bruno-modal').getByTestId('env-row').filter({ has: page.getByText(name, { exact: true }) }),
+    // A row has exactly one checkbox; its data-testid is uid-keyed, so select it by role within the named row.
     environmentCheckbox: (name: string) =>
       page
-        .locator('.bruno-modal .env-row')
+        .locator('.bruno-modal')
+        .getByTestId('env-row')
         .filter({ has: page.getByText(name, { exact: true }) })
-        .locator('input[type="checkbox"]')
+        .getByRole('checkbox')
   },
   runnerResults: {
     itemPath: (name: string) => page.getByTestId('runner-result-item').filter({ hasText: name })


### PR DESCRIPTION
### Description

Problem
Generated docs include every environment in the collection, with no way to scope which envs ship in the exported docs, so internal, local, or staging envs leak into docs shared externally. The modal also gives no indication of which collection version the docs are generated from.

https://usebruno.atlassian.net/browse/BRU-2542
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<img width="2674" height="1534" alt="image" src="https://github.com/user-attachments/assets/b51dca51-7b4d-4254-b5ae-9f16fb106c41" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an environment-selection UI to collection documentation generation with virtualized rows, tri-state “Select All,” and environment filtering that updates embedded generated output.
  * Added a configuration card showing the normalized collection version (with `v` prefix) plus folder/request counts.

* **Style / UX**
  * Improved the error modal by constraining content height and enabling scrolling.

* **Quality**
  * Added utilities and expanded tests/fixtures to verify version/count formatting and full environment-selection scenarios (including none selected).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->