### PR TITLE
fix(transient): scope bruno- lookup to transient base, not full path

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -112,8 +112,9 @@ const getTransientScratchPrefix = () => {
 
 // Check if a path is within the transient directory
 const isTransientPath = (filePath) => {
+  const normalizedFilePath = path.normalize(filePath);
   const transientBase = getTransientDirectoryBase();
-  return filePath.startsWith(transientBase + path.sep) || filePath.startsWith(transientBase);
+  return normalizedFilePath.startsWith(transientBase + path.sep) || normalizedFilePath === transientBase;
 };
 
 const envHasSecrets = (environment = {}) => {
@@ -123,11 +124,14 @@ const envHasSecrets = (environment = {}) => {
 };
 
 const findCollectionPathByItemPath = (filePath) => {
-  const parts = filePath.split(path.sep);
-  const index = parts.findIndex((part) => part.startsWith('bruno-'));
+  const normalizedFilePath = path.normalize(filePath);
 
-  if (isTransientPath(filePath) && index !== -1) {
-    const transientDirPath = parts.slice(0, index + 1).join(path.sep);
+  if (isTransientPath(normalizedFilePath)) {
+    const transientBase = getTransientDirectoryBase();
+    const transientDirName = path.relative(transientBase, normalizedFilePath).split(path.sep)[0];
+    if (!transientDirName) return null;
+
+    const transientDirPath = path.join(transientBase, transientDirName);
     const metadataPath = path.join(transientDirPath, 'metadata.json');
     try {
       const metadataContent = fs.readFileSync(metadataPath, 'utf8');
@@ -151,9 +155,6 @@ const findCollectionPathByItemPath = (filePath) => {
   // Find the collection path that contains this file
   // Sort by length descending to find the most specific (deepest) match first
   const sortedPaths = allCollectionPaths.sort((a, b) => b.length - a.length);
-
-  // Normalize the file path for comparison
-  const normalizedFilePath = path.normalize(filePath);
 
   for (const collectionPath of sortedPaths) {
     const normalizedCollectionPath = path.normalize(collectionPath);


### PR DESCRIPTION
## Summary

[JIRA](https://usebruno.atlassian.net/browse/BRU-3514)

`findCollectionPathByItemPath` scanned every segment of the file path for a `bruno-` prefix to find the transient collection directory. For users whose username starts with `bruno-` (e.g. `bruno-alice`), the home-directory segment matched first and the function tried to read `metadata.json` from the wrong directory.

Scope the lookup to the first path segment **under the transient base** (`<userData>/tmp/transient`), which by construction is the actual transient collection directory. No user-controlled path component above the base can collide.

## Test plan

- [ ] On a machine where the OS username starts with \`bruno-\`, create a transient/scratch request and confirm it opens correctly.
- [ ] Regular (non-transient) collections still resolve via the existing watcher-paths fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transient collection path resolution logic to more reliably identify and process collection directories, including better handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->