### PR TITLE
fix/request - Binary body type - show warning on file not exists in system

### DIFF
--- a/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
@@ -76,6 +76,26 @@ const StyledWrapper = styled.div`
       margin-right: 4px;
     }
 
+    &.has-warning {
+      background-color: #BB931B1A;
+      font-weight: 500;
+      border-radius: 4px;
+      padding: 4px;
+    }
+
+    .warning-icon {
+      color: #BB931B;
+      margin-right: 4px;
+    }
+
+    .warning-tooltip {
+      background-color: #BB931B1A;
+      color: #856404; 
+      margin: 2px;
+      border-radius: 6px;
+      padding: 4px;
+    }
+
     .file-name {
       flex: 1;
       font-size: 12px;

--- a/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
@@ -77,20 +77,20 @@ const StyledWrapper = styled.div`
     }
 
     &.has-warning {
-      background-color: #BB931B1A;
+      background-color: ${(props) => props.theme.status.warning.background};
       font-weight: 500;
       border-radius: 4px;
       padding: 4px;
     }
 
     .warning-icon {
-      color: #BB931B;
+      color: ${(props) => props.theme.status.warning.text};
       margin-right: 4px;
     }
 
     .warning-tooltip {
-      background-color: #BB931B1A;
-      color: #856404; 
+      background-color: ${(props) => props.theme.status.warning.background};
+      color: ${(props) => props.theme.status.warning.text};
       margin: 2px;
       border-radius: 6px;
       padding: 4px;

--- a/packages/bruno-app/src/components/FilePickerEditor/index.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/index.js
@@ -36,10 +36,7 @@ const FilePickerEditor = ({
   const [hasMissingFiles, setHasMissingFiles] = useState(false);
 
   const filePaths = (isSingleFilePicker ? [value] : value || []).filter((v) => v != null && v != '');
-  const filenames = filePaths.map((v) => {
-    const separator = isWindowsOS() ? '\\' : '/';
-    return v.split(separator).pop();
-  });
+  const filenames = filePaths.map((v) => v.split(/[\\/]/).pop());
 
   // title is shown when hovering over the button
   const title = filenames.map((v) => `- ${v}`).join('\n');

--- a/packages/bruno-app/src/components/FilePickerEditor/index.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/index.js
@@ -1,8 +1,10 @@
-import React from 'react';
-import { getRelativePathWithinBasePath } from 'utils/common/path';
+import React, { useEffect, useId, useState } from 'react';
+import { getRelativePathWithinBasePath, getAbsoluteFilePath } from 'utils/common/path';
+import { existsSync } from 'utils/filesystem';
 import { useDispatch } from 'react-redux';
 import { browseFiles } from 'providers/ReduxStore/slices/collections/actions';
 import { IconX, IconUpload, IconFile } from '@tabler/icons';
+import { Tooltip } from 'react-tooltip';
 import { isWindowsOS } from 'utils/common/platform';
 import StyledWrapper from './StyledWrapper';
 
@@ -30,15 +32,54 @@ const FilePickerEditor = ({
   icon: CustomIcon
 }) => {
   const dispatch = useDispatch();
-  const filenames = (isSingleFilePicker ? [value] : value || [])
-    .filter((v) => v != null && v != '')
-    .map((v) => {
-      const separator = isWindowsOS() ? '\\' : '/';
-      return v.split(separator).pop();
-    });
+  const warningTooltipId = `file-picker-warning-${useId().replace(/:/g, '')}`;
+  const [hasMissingFiles, setHasMissingFiles] = useState(false);
+
+  const filePaths = (isSingleFilePicker ? [value] : value || []).filter((v) => v != null && v != '');
+  const filenames = filePaths.map((v) => {
+    const separator = isWindowsOS() ? '\\' : '/';
+    return v.split(separator).pop();
+  });
 
   // title is shown when hovering over the button
   const title = filenames.map((v) => `- ${v}`).join('\n');
+
+  // Verify that the selected file(s) still exist on disk and warn the user otherwise
+  useEffect(() => {
+    let isMounted = true;
+
+    if (filePaths.length === 0) {
+      setHasMissingFiles(false);
+      return;
+    }
+
+    Promise.all(
+      filePaths.map(async (filePath) => {
+        try {
+          const absolutePath = collection?.pathname
+            ? getAbsoluteFilePath(collection.pathname, filePath)
+            : filePath;
+          return await existsSync(absolutePath);
+        } catch (error) {
+          return false;
+        }
+      })
+    )
+      .then((results) => {
+        if (isMounted) {
+          setHasMissingFiles(results.some((exists) => !exists));
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setHasMissingFiles(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [JSON.stringify(filePaths), collection?.pathname]);
 
   const browse = () => {
     if (readOnly) return;
@@ -97,11 +138,28 @@ const FilePickerEditor = ({
     return (
       <StyledWrapper>
         <div
-          className={`file-picker-selected ${readOnly ? 'read-only' : ''}`}
+          className={`file-picker-selected ${readOnly ? 'read-only' : ''} ${hasMissingFiles ? 'has-warning' : ''}`}
           title={title}
           onClick={!readOnly ? browse : undefined}
         >
-          <IconFile size={16} className="file-icon" />
+          {hasMissingFiles ? (
+            <>
+              <svg
+                data-tooltip-id={warningTooltipId}
+                className="warning-icon"
+                xmlns="http://www.w3.org/2000/svg"
+                width={16}
+                height={16}
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M12 1.67c.955 0 1.845 .467 2.39 1.247l.105 .16l8.114 13.548a2.914 2.914 0 0 1 -2.307 4.363l-.195 .008h-16.225a2.914 2.914 0 0 1 -2.582 -4.2l.099 -.185l8.11 -13.538a2.914 2.914 0 0 1 2.491 -1.401zm.01 13.33l-.127 .007a1 1 0 0 0 0 1.986l.117 .007l.127 -.007a1 1 0 0 0 0 -1.986l-.117 -.007zm-.01 -7a1 1 0 0 0 -.993 .883l-.007 .117v4l.007 .117a1 1 0 0 0 1.986 0l.007 -.117v-4l-.007 -.117a1 1 0 0 0 -.993 -.883z" />
+              </svg>
+
+            </>
+          ) : (
+            <IconFile size={16} className="file-icon" />
+          )}
           <span className="file-name">
             {renderButtonText(filenames)}
           </span>
@@ -114,6 +172,15 @@ const FilePickerEditor = ({
             >
               <IconX size={16} />
             </button>
+          )}
+          {hasMissingFiles && (
+            <Tooltip
+              id={warningTooltipId}
+              className="tooltip-mod max-w-lg"
+              place="bottom-end"
+            >
+              <div className="warning-tooltip">The file above is not in the given directory, please upload it again.</div>
+            </Tooltip>
           )}
         </div>
       </StyledWrapper>

--- a/tests/request/binary-file/binary-file-missing-warning.spec.ts
+++ b/tests/request/binary-file/binary-file-missing-warning.spec.ts
@@ -1,0 +1,66 @@
+import * as path from 'path';
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, openCollection, selectRequestPaneTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const MISSING_FILE_WARNING = 'The file above is not in the given directory, please upload it again.';
+
+test.describe('File / Binary body missing-file warning', () => {
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('should show warning for missing binary file', async ({ page, electronApp, createTmpDir }) => {
+    const collectionFile = path.resolve(__dirname, 'fixtures', 'binary-file-missing-warning.yml');
+    const locators = buildCommonLocators(page);
+
+    const importDir = await createTmpDir('imported-collection');
+
+    await electronApp.evaluate(({ dialog }, { importDir }) => {
+      const originalShowOpenDialog = dialog.showOpenDialog;
+      dialog.showOpenDialog = async () => {
+        dialog.showOpenDialog = originalShowOpenDialog;
+        return {
+          canceled: false,
+          filePaths: [importDir]
+        };
+      };
+    }, { importDir });
+
+    await test.step('Import collection', async () => {
+      await locators.plusMenu.button().click();
+      await locators.plusMenu.importCollection().click();
+      const importModal = locators.import.modal();
+      await importModal.waitFor({ state: 'visible' });
+      await locators.import.fileInput().setInputFiles(collectionFile);
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 5000 });
+      const locationModal = locators.import.locationModal();
+      await expect(locationModal.getByText('Binary body type')).toBeVisible();
+      await locators.import.browseLink(locationModal).click();
+      await locators.import.importButton(locationModal).click();
+      await locationModal.waitFor({ state: 'hidden' });
+      await openCollection(page, 'Binary body type');
+      await expect(locators.sidebar.collection('Binary body type')).toBeVisible();
+    });
+
+    await test.step('shows a warning when the binary file does not exist on disk', async () => {
+      await locators.sidebar.request('Binary body - missing file').click();
+      await expect(locators.request.pane()).toBeVisible();
+      await selectRequestPaneTab(page, 'Body');
+
+      const filePicker = page.locator('.file-picker-selected').first();
+      await expect(filePicker).toBeVisible({ timeout: 5000 });
+      await expect(filePicker.locator('.file-name')).toHaveText('missing-payload.bin');
+
+      // Warning: the missing-file styling, icon and tooltip must be present.
+      await expect(filePicker).toHaveClass(/has-warning/);
+      const warningIcon = filePicker.locator('.warning-icon');
+      await expect(warningIcon).toBeVisible();
+
+      await warningIcon.hover();
+      const tooltip = page.locator('.tooltip-mod');
+      await expect(tooltip).toBeVisible();
+      await expect(tooltip).toContainText(MISSING_FILE_WARNING);
+    });
+  });
+});

--- a/tests/request/binary-file/fixtures/binary-file-missing-warning.yml
+++ b/tests/request/binary-file/fixtures/binary-file-missing-warning.yml
@@ -1,0 +1,41 @@
+opencollection: 1.0.0
+info:
+  name: Binary body type
+config:
+  proxy:
+    inherit: true
+    config:
+      protocol: http
+      hostname: ''
+      port: ''
+      auth:
+        username: ''
+        password: ''
+      bypassProxy: ''
+items:
+  - info:
+      name: Binary body - missing file
+      type: http
+      seq: 2
+    http:
+      method: POST
+      url: https://api.com/users
+      body:
+        type: file
+        data:
+          - filePath: ./missing-payload.bin
+            contentType: ''
+            selected: true
+      auth: inherit
+    settings:
+      encodeUrl: true
+      timeout: 0
+      followRedirects: true
+      maxRedirects: 5
+bundled: true
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git
+    exportedUsing: Bruno


### PR DESCRIPTION
Jira link: https://usebruno.atlassian.net/browse/BRU-3118

### Description

When a request has binary/file body type and if the file doesn't exist in the system, then it shows a warning message to the user.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The file picker now checks whether selected file paths exist locally and flags missing selections.
  * When files are missing, it displays a warning indicator (including a warning icon) and shows a hover tooltip explaining which files can’t be found.
* **Tests**
  * Added an end-to-end UI test and fixture to verify the “missing binary file” warning in the request pane.
* **Style/UI**
  * Improved warning-state styling for the file picker button, including warning icon spacing and tooltip presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->