### PR TITLE
fix(electron): store client certificate passphrase encrypted instead of plaintext

### DIFF
--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -91,6 +91,29 @@ const hydrateCollectionRootWithUuid = (collectionRoot) => {
   return collectionRoot;
 };
 
+/**
+ * Hydrate client certificate passphrases from the secrets store.
+ * Passphrases are not written to disk, so they are restored from the encrypted
+ * secrets store and decrypted onto the matching certs after reading bruno.json.
+ *
+ * @param {object} brunoConfig - The parsed bruno config (mutated in place).
+ * @param {string} collectionPath - The collection path used to look up secrets.
+ * @returns {object} The bruno config with cert passphrases hydrated.
+ */
+const hydrateCertPassphrases = (brunoConfig, collectionPath) => {
+  const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
+  if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
+    brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
+      const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
+      if (stored && stored.passphrase) {
+        return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
+      }
+      return cert;
+    });
+  }
+  return brunoConfig;
+};
+
 const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) => {
   try {
     const basename = path.basename(pathname);
@@ -207,16 +230,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
       brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
 
       // Hydrate cert passphrases from the secrets store (they are not written to disk)
-      const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
-      if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
-        brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
-          const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
-          if (stored && stored.passphrase) {
-            return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
-          }
-          return cert;
-        });
-      }
+      brunoConfig = hydrateCertPassphrases(brunoConfig, collectionPath);
 
       setBrunoConfig(collectionUid, brunoConfig);
 
@@ -270,16 +284,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
         brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
 
         // Hydrate cert passphrases from the secrets store (they are not written to disk)
-        const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
-        if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
-          brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
-            const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
-            if (stored && stored.passphrase) {
-              return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
-            }
-            return cert;
-          });
-        }
+        brunoConfig = hydrateCertPassphrases(brunoConfig, collectionPath);
 
         setBrunoConfig(collectionUid, brunoConfig);
 
@@ -457,16 +462,7 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
 
       // Hydrate cert passphrases from the secrets store (they are not written to disk)
-      const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
-      if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
-        brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
-          const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
-          if (stored && stored.passphrase) {
-            return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
-          }
-          return cert;
-        });
-      }
+      brunoConfig = hydrateCertPassphrases(brunoConfig, collectionPath);
 
       setBrunoConfig(collectionUid, brunoConfig);
 
@@ -522,16 +518,7 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
         brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
 
         // Hydrate cert passphrases from the secrets store (they are not written to disk)
-        const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
-        if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
-          brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
-            const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
-            if (stored && stored.passphrase) {
-              return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
-            }
-            return cert;
-          });
-        }
+        brunoConfig = hydrateCertPassphrases(brunoConfig, collectionPath);
 
         setBrunoConfig(collectionUid, brunoConfig);
 

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -206,6 +206,18 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
       // Transform the config to add exists metadata for protobuf files and import paths
       brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
 
+      // Hydrate cert passphrases from the secrets store (they are not written to disk)
+      const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
+      if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
+        brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
+          const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
+          if (stored && stored.passphrase) {
+            return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
+          }
+          return cert;
+        });
+      }
+
       setBrunoConfig(collectionUid, brunoConfig);
 
       const payload = {
@@ -256,6 +268,18 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
       if (format === 'yml') {
         // Transform the config to add exists metadata for protobuf files and import paths
         brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
+
+        // Hydrate cert passphrases from the secrets store (they are not written to disk)
+        const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
+        if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
+          brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
+            const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
+            if (stored && stored.passphrase) {
+              return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
+            }
+            return cert;
+          });
+        }
 
         setBrunoConfig(collectionUid, brunoConfig);
 
@@ -484,6 +508,18 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       if (format === 'yml') {
         // Transform the config to add exists metadata for protobuf files and import paths
         brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
+
+        // Hydrate cert passphrases from the secrets store (they are not written to disk)
+        const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
+        if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
+          brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
+            const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
+            if (stored && stored.passphrase) {
+              return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
+            }
+            return cert;
+          });
+        }
 
         setBrunoConfig(collectionUid, brunoConfig);
 

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -456,6 +456,18 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       // Transform the config to add file existence checks for protobuf files and import paths
       brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
 
+      // Hydrate cert passphrases from the secrets store (they are not written to disk)
+      const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
+      if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
+        brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
+          const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
+          if (stored && stored.passphrase) {
+            return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
+          }
+          return cert;
+        });
+      }
+
       setBrunoConfig(collectionUid, brunoConfig);
 
       const payload = {

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -6,6 +6,10 @@ const { isDirectory, getCollectionStats, normalizeAndResolvePath } = require('..
 const { generateUidBasedOnHash } = require('../utils/common');
 const { transformBrunoConfigAfterRead } = require('../utils/transformBrunoConfig');
 const { parseCollection } = require('@usebruno/filestore');
+const { decryptStringSafe } = require('../utils/encryption');
+const EnvironmentSecretsStore = require('../store/env-secrets');
+
+const environmentSecretsStore = new EnvironmentSecretsStore();
 
 // Track scratch collection paths (temp directories for workspace scratch requests)
 const scratchCollectionPaths = new Set();
@@ -124,6 +128,19 @@ const openCollection = async (win, watcher, collectionPath, options = {}) => {
       let brunoConfig = await getCollectionConfigFile(collectionPath);
       const uid = generateUidBasedOnHash(collectionPath);
       brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
+
+      // Hydrate cert passphrases from the secrets store (they are not written to disk)
+      const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
+      if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
+        brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
+          const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
+          if (stored && stored.passphrase) {
+            return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
+          }
+          return cert;
+        });
+      }
+
       const { size, filesCount } = await getCollectionStats(collectionPath);
       brunoConfig.size = size;
       brunoConfig.filesCount = filesCount;
@@ -158,6 +175,18 @@ const openCollection = async (win, watcher, collectionPath, options = {}) => {
     brunoConfig.ignore = [...new Set([...defaultIgnores, ...userIgnores])];
 
     brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
+
+    // Hydrate cert passphrases from the secrets store (they are not written to disk)
+    const certPassphrases = environmentSecretsStore.getCertPassphrases(collectionPath);
+    if (certPassphrases.length && brunoConfig?.clientCertificates?.certs) {
+      brunoConfig.clientCertificates.certs = brunoConfig.clientCertificates.certs.map((cert) => {
+        const stored = certPassphrases.find((cp) => cp.domain === cert.domain && cp.type === cert.type);
+        if (stored && stored.passphrase) {
+          return { ...cert, passphrase: decryptStringSafe(stored.passphrase).value };
+        }
+        return cert;
+      });
+    }
 
     const { size, filesCount } = await getCollectionStats(collectionPath);
     brunoConfig.size = size;

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1668,7 +1668,19 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
   ipcMain.handle('renderer:update-bruno-config', async (event, brunoConfig, collectionPath, collectionRoot) => {
     try {
-      const transformedBrunoConfig = transformBrunoConfigBeforeSave(brunoConfig);
+      // Store cert passphrases securely, then strip them before writing to disk
+      const certs = brunoConfig?.clientCertificates?.certs || [];
+      environmentSecretsStore.storeCertPassphrases(collectionPath, certs);
+
+      const configToWrite = _.cloneDeep(brunoConfig);
+      if (configToWrite?.clientCertificates?.certs) {
+        configToWrite.clientCertificates.certs = configToWrite.clientCertificates.certs.map((cert) => {
+          const { passphrase, ...rest } = cert;
+          return rest;
+        });
+      }
+
+      const transformedBrunoConfig = transformBrunoConfigBeforeSave(configToWrite);
       const format = getCollectionFormat(collectionPath);
 
       if (format === 'bru') {

--- a/packages/bruno-electron/src/store/env-secrets.js
+++ b/packages/bruno-electron/src/store/env-secrets.js
@@ -125,6 +125,43 @@ class EnvironmentSecretsStore {
     _.remove(collection.environments, (e) => e.name === environmentName);
     this.store.set('collections', collections);
   }
+
+  storeCertPassphrases(collectionPathname, certs) {
+    const normalizedPathname = posixifyPath(collectionPathname);
+    const certPassphrases = (certs || [])
+      .filter((cert) => cert.passphrase)
+      .map((cert) => ({
+        domain: cert.domain,
+        type: cert.type,
+        passphrase: encryptStringSafe(cert.passphrase).value
+      }));
+
+    const collections = this.store.get('collections') || [];
+    const collection = _.find(collections, (c) => posixifyPath(c.path) === normalizedPathname);
+
+    if (!collection) {
+      if (certPassphrases.length > 0) {
+        collections.push({
+          path: normalizedPathname,
+          environments: [],
+          certPassphrases
+        });
+        this.store.set('collections', collections);
+      }
+      return;
+    }
+
+    collection.certPassphrases = certPassphrases;
+    this.store.set('collections', collections);
+  }
+
+  getCertPassphrases(collectionPathname) {
+    const normalizedPathname = posixifyPath(collectionPathname);
+    const collections = this.store.get('collections') || [];
+    const collection = _.find(collections, (c) => posixifyPath(c.path) === normalizedPathname);
+    if (!collection) return [];
+    return collection.certPassphrases || [];
+  }
 }
 
 module.exports = EnvironmentSecretsStore;


### PR DESCRIPTION
### Description

Fixes #8281

Client certificate passphrases (PFX/PEM) were being written in plaintext to
`opencollection.yml` and `bruno.json`. Since collections are typically committed
to Git and shared across teams, this exposed passphrases to anyone with repo
access and permanently stored them in Git history.

**Before (vulnerable):**
```yaml
config:
  clientCertificates:
    - domain: example.com
      type: pkcs12
      pkcs12FilePath: ../certs/test.pfx
      passphrase: MySecretPassword123
```

**After (fixed):**
```yaml
config:
  clientCertificates:
    - domain: example.com
      type: pkcs12
      pkcs12FilePath: ../certs/test.pfx
```

The passphrase is no longer present in the file. It is stored encrypted in
Bruno's local secrets.json (same store used for secret environment variables),
encrypted via safeStorage (OS keychain) / AES-256 fallback.

Root cause: The renderer:update-bruno-config IPC handler was writing the
full brunoConfig — including passphrase — directly to disk without any
sanitization.

Fix: Extended the existing EnvironmentSecretsStore (the same system Bruno
already uses for secret environment variables) with two new methods:
storeCertPassphrases() and getCertPassphrases(). The passphrase is now:

1. On save — encrypted and stored in secrets.json. The passphrase field
is stripped from brunoConfig before it is written to disk.
2. On load — hydrated back into the in-memory brunoConfig from the secrets
store before being sent to the renderer and setBrunoConfig(), so the UI and
TLS connections continue to work correctly.

No new encryption primitives, no new IPC calls, no new store files — the fix
follows Bruno's existing secret handling pattern exactly.

Files changed:
- packages/bruno-electron/src/store/env-secrets.js — added storeCertPassphrases / getCertPassphrases
- packages/bruno-electron/src/ipc/collection.js — strip passphrase before writing, store encrypted
- packages/bruno-electron/src/app/collection-watcher.js — hydrate passphrase on file change (3 handlers)
- packages/bruno-electron/src/app/collections.js — hydrate passphrase on collection open

Backward compatible: existing collections with plaintext passphrases are
migrated automatically on the next save — no manual action required.

Contribution Checklist:

- [x] I've used AI significantly to create this pull request
- [x] The pull request only addresses one issue or adds one feature.
- [x] The pull request does not introduce any breaking changes
- [x] I have added screenshots or gifs to help explain the change if applicable.
- [x] I have read the contribution guidelines (https://github.com/usebruno/bruno/blob/main/contributing.md).
- [x] Create an issue and link to the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Security Improvements**
  * TLS client certificate passphrases are now stored encrypted per collection path rather than persisted in plain text.
  * When a collection is opened and configuration is processed, passphrases are securely retrieved and automatically hydrated into the in-memory certificate entries.
  * Updates coming from the renderer now sanitize saved configurations by removing passphrase fields before persisting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->