### PR TITLE
feat(websocket): show full message name in a tooltip on hover

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
@@ -25,7 +25,7 @@ const EnvironmentListContent = ({
               <span>No Environment</span>
             </div>
             <ToolHint
-              anchorSelect="[data-tooltip-content]"
+              tooltipId="environment-name-tooltip"
               place="right"
               positionStrategy="fixed"
               tooltipStyle={{
@@ -40,6 +40,7 @@ const EnvironmentListContent = ({
                     key={env.uid}
                     className={`dropdown-item ${env.uid === activeEnvironmentUid ? 'dropdown-item-active' : ''}`}
                     onClick={() => onEnvironmentSelect(env)}
+                    data-tooltip-id="environment-name-tooltip"
                     data-tooltip-content={env.name}
                     data-tooltip-hidden={env.name?.length < 90}
                   >

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/StyledWrapper.js
@@ -2,10 +2,20 @@ import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
   border-bottom: 1px solid ${(props) => props.theme.border.border0};
-  transition: opacity 0.15s ease;
+
+  /* Dim the row content when disabled, but not the tooltip */
+  .accordion-left > :not(.toolhint),
+  .accordion-actions,
+  .accordion-body {
+    transition: opacity 0.15s ease;
+  }
 
   &.disabled {
-    opacity: 0.45;
+    .accordion-left > :not(.toolhint),
+    .accordion-actions,
+    .accordion-body {
+      opacity: 0.45;
+    }
   }
 
   .accordion-header {
@@ -23,6 +33,12 @@ const StyledWrapper = styled.div`
       flex: 1;
       min-width: 0;
       color: ${(props) => props.theme.text};
+
+      .message-label-anchor {
+        display: flex;
+        min-width: 0;
+        overflow: hidden;
+      }
 
       .message-label {
         font-size: ${(props) => props.theme.font.size.sm};

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 import { updateRequestBody } from 'providers/ReduxStore/slices/collections';
 import { saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { useTheme } from 'providers/Theme';
-import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { queueWsMessage, isWsConnectionActive, connectWS } from 'utils/network/index';
 import { findCollectionByUid, findEnvironmentInCollection } from 'utils/collections/index';
@@ -54,14 +54,6 @@ export const SingleWSMessage = ({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(displayName);
   const labelTooltipId = `ws-msg-label-${message.uid ?? index}`;
-  const labelRef = useRef(null);
-  const [isLabelTruncated, setIsLabelTruncated] = useState(false);
-  const handleLabelMouseEnter = () => {
-    const el = labelRef.current;
-    if (el) {
-      setIsLabelTruncated(el.scrollWidth > el.clientWidth);
-    }
-  };
 
   // Auto-focus the name input when this is a newly created message
   useEffect(() => {
@@ -175,52 +167,56 @@ export const SingleWSMessage = ({
   }, [collections]);
 
   return (
-    <>
-      <StyledWrapper
-        className={!isSelected ? 'disabled' : ''}
-        onMouseDownCapture={() => {
-          if (!isSelected) setTimeout(onSelect, 0);
+    <StyledWrapper
+      className={!isSelected ? 'disabled' : ''}
+      onMouseDownCapture={() => {
+        if (!isSelected) setTimeout(onSelect, 0);
+      }}
+    >
+      <div
+        className="accordion-header"
+        data-testid={`ws-message-header-${index}`}
+        role="button"
+        tabIndex={0}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+          }
         }}
       >
-        <div
-          className="accordion-header"
-          data-testid={`ws-message-header-${index}`}
-          role="button"
-          tabIndex={0}
-          onClick={onToggle}
-          onKeyDown={(e) => {
-            if (e.target !== e.currentTarget) return;
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              onToggle();
-            }
-          }}
-        >
-          <div className="accordion-left">
-            {isExpanded ? (
-              <IconChevronDown size={14} strokeWidth={2} />
-            ) : (
-              <IconChevronRight size={14} strokeWidth={2} />
-            )}
-            {isEditing ? (
-              <input
-                ref={(node) => node?.focus()}
-                className="name-input"
-                data-testid={`ws-message-name-input-${index}`}
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                onKeyDown={handleNameKeyDown}
-                onBlur={handleNameBlur}
-                onClick={(e) => e.stopPropagation()}
-              />
-            ) : (
+        <div className="accordion-left">
+          {isExpanded ? (
+            <IconChevronDown size={14} strokeWidth={2} />
+          ) : (
+            <IconChevronRight size={14} strokeWidth={2} />
+          )}
+          {isEditing ? (
+            <input
+              ref={(node) => node?.focus()}
+              className="name-input"
+              data-testid={`ws-message-name-input-${index}`}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onKeyDown={handleNameKeyDown}
+              onBlur={handleNameBlur}
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <ToolHint
+              text={displayName}
+              toolhintId={labelTooltipId}
+              className="message-label-anchor"
+              place="bottom-start"
+              positionStrategy="fixed"
+              tooltipTestId="ws-message-name-tooltip"
+              tooltipStyle={{ maxWidth: '320px', whiteSpace: 'normal', wordBreak: 'break-word' }}
+            >
               <span
-                ref={labelRef}
                 className="message-label"
                 data-testid={`ws-message-label-${index}`}
-                data-tooltip-id={labelTooltipId}
-                data-tooltip-content={displayName}
-                onMouseEnter={handleLabelMouseEnter}
                 onClick={(e) => {
                   e.preventDefault();
                   onToggle();
@@ -229,52 +225,43 @@ export const SingleWSMessage = ({
               >
                 {displayName}
               </span>
-            )}
-          </div>
-          <div className="accordion-actions" onClick={(e) => e.stopPropagation()}>
-            <div className="hover-actions">
-              <ToolHint text="Send" toolhintId={`send-msg-${index}`}>
-                <button onClick={onSendMessage} className="hover-action-btn" data-testid={`ws-send-msg-${index}`}>
-                  <IconSend size={14} strokeWidth={1.5} />
+            </ToolHint>
+          )}
+        </div>
+        <div className="accordion-actions" onClick={(e) => e.stopPropagation()}>
+          <div className="hover-actions">
+            <ToolHint text="Send" toolhintId={`send-msg-${index}`}>
+              <button onClick={onSendMessage} className="hover-action-btn" data-testid={`ws-send-msg-${index}`}>
+                <IconSend size={14} strokeWidth={1.5} />
+              </button>
+            </ToolHint>
+            {(body.ws || []).length > 1 && (
+              <ToolHint text="Delete" toolhintId={`delete-msg-${index}`}>
+                <button onClick={onDeleteMessage} className="hover-action-btn delete" data-testid={`ws-delete-msg-${index}`}>
+                  <IconTrash size={14} strokeWidth={1.5} />
                 </button>
               </ToolHint>
-              {(body.ws || []).length > 1 && (
-                <ToolHint text="Delete" toolhintId={`delete-msg-${index}`}>
-                  <button onClick={onDeleteMessage} className="hover-action-btn delete" data-testid={`ws-delete-msg-${index}`}>
-                    <IconTrash size={14} strokeWidth={1.5} />
-                  </button>
-                </ToolHint>
-              )}
-            </div>
-            <WSRequestBodyMode mode={displayMode} onModeChange={onUpdateMessageType} />
+            )}
           </div>
+          <WSRequestBodyMode mode={displayMode} onModeChange={onUpdateMessageType} />
         </div>
-        {isExpanded && (
-          <div className="accordion-body" data-testid={`ws-message-body-${index}`} style={{ height: editorHeight }}>
-            <CodeEditor
-              collection={collection}
-              theme={displayedTheme}
-              font={get(preferences, 'font.codeFont', 'default')}
-              fontSize={get(preferences, 'font.codeFontSize')}
-              value={content}
-              onEdit={onEdit}
-              onRun={handleRun}
-              onSave={onSave}
-              mode={codemirrorMode[displayMode] ?? 'text/plain'}
-              enableVariableHighlighting={true}
-            />
-          </div>
-        )}
-      </StyledWrapper>
-      <ToolHint
-        text={displayName}
-        tooltipId={labelTooltipId}
-        place="bottom-start"
-        hidden={!isLabelTruncated}
-        positionStrategy="fixed"
-        tooltipTestId="ws-message-name-tooltip"
-        tooltipStyle={{ maxWidth: '320px', whiteSpace: 'normal', wordBreak: 'break-word' }}
-      />
-    </>
+      </div>
+      {isExpanded && (
+        <div className="accordion-body" data-testid={`ws-message-body-${index}`} style={{ height: editorHeight }}>
+          <CodeEditor
+            collection={collection}
+            theme={displayedTheme}
+            font={get(preferences, 'font.codeFont', 'default')}
+            fontSize={get(preferences, 'font.codeFontSize')}
+            value={content}
+            onEdit={onEdit}
+            onRun={handleRun}
+            onSave={onSave}
+            mode={codemirrorMode[displayMode] ?? 'text/plain'}
+            enableVariableHighlighting={true}
+          />
+        </div>
+      )}
+    </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -53,6 +53,15 @@ export const SingleWSMessage = ({
 
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(displayName);
+  const labelTooltipId = `ws-msg-label-${message.uid ?? index}`;
+  const labelRef = useRef(null);
+  const [isLabelTruncated, setIsLabelTruncated] = useState(false);
+  const handleLabelMouseEnter = () => {
+    const el = labelRef.current;
+    if (el) {
+      setIsLabelTruncated(el.scrollWidth > el.clientWidth);
+    }
+  };
 
   // Auto-focus the name input when this is a newly created message
   useEffect(() => {
@@ -166,91 +175,106 @@ export const SingleWSMessage = ({
   }, [collections]);
 
   return (
-    <StyledWrapper
-      className={!isSelected ? 'disabled' : ''}
-      onMouseDownCapture={() => {
-        if (!isSelected) setTimeout(onSelect, 0);
-      }}
-    >
-      <div
-        className="accordion-header"
-        data-testid={`ws-message-header-${index}`}
-        role="button"
-        tabIndex={0}
-        onClick={onToggle}
-        onKeyDown={(e) => {
-          if (e.target !== e.currentTarget) return;
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onToggle();
-          }
+    <>
+      <StyledWrapper
+        className={!isSelected ? 'disabled' : ''}
+        onMouseDownCapture={() => {
+          if (!isSelected) setTimeout(onSelect, 0);
         }}
       >
-        <div className="accordion-left">
-          {isExpanded ? (
-            <IconChevronDown size={14} strokeWidth={2} />
-          ) : (
-            <IconChevronRight size={14} strokeWidth={2} />
-          )}
-          {isEditing ? (
-            <input
-              ref={(node) => node?.focus()}
-              className="name-input"
-              data-testid={`ws-message-name-input-${index}`}
-              value={editValue}
-              onChange={(e) => setEditValue(e.target.value)}
-              onKeyDown={handleNameKeyDown}
-              onBlur={handleNameBlur}
-              onClick={(e) => e.stopPropagation()}
-            />
-          ) : (
-            <span
-              className="message-label"
-              data-testid={`ws-message-label-${index}`}
-              onClick={(e) => {
-                e.preventDefault();
-                onToggle();
-              }}
-              onDoubleClick={handleNameClick}
-            >
-              {displayName}
-            </span>
-          )}
-        </div>
-        <div className="accordion-actions" onClick={(e) => e.stopPropagation()}>
-          <div className="hover-actions">
-            <ToolHint text="Send" toolhintId={`send-msg-${index}`}>
-              <button onClick={onSendMessage} className="hover-action-btn" data-testid={`ws-send-msg-${index}`}>
-                <IconSend size={14} strokeWidth={1.5} />
-              </button>
-            </ToolHint>
-            {(body.ws || []).length > 1 && (
-              <ToolHint text="Delete" toolhintId={`delete-msg-${index}`}>
-                <button onClick={onDeleteMessage} className="hover-action-btn delete" data-testid={`ws-delete-msg-${index}`}>
-                  <IconTrash size={14} strokeWidth={1.5} />
-                </button>
-              </ToolHint>
+        <div
+          className="accordion-header"
+          data-testid={`ws-message-header-${index}`}
+          role="button"
+          tabIndex={0}
+          onClick={onToggle}
+          onKeyDown={(e) => {
+            if (e.target !== e.currentTarget) return;
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onToggle();
+            }
+          }}
+        >
+          <div className="accordion-left">
+            {isExpanded ? (
+              <IconChevronDown size={14} strokeWidth={2} />
+            ) : (
+              <IconChevronRight size={14} strokeWidth={2} />
+            )}
+            {isEditing ? (
+              <input
+                ref={(node) => node?.focus()}
+                className="name-input"
+                data-testid={`ws-message-name-input-${index}`}
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onKeyDown={handleNameKeyDown}
+                onBlur={handleNameBlur}
+                onClick={(e) => e.stopPropagation()}
+              />
+            ) : (
+              <span
+                ref={labelRef}
+                className="message-label"
+                data-testid={`ws-message-label-${index}`}
+                data-tooltip-id={labelTooltipId}
+                data-tooltip-content={displayName}
+                onMouseEnter={handleLabelMouseEnter}
+                onClick={(e) => {
+                  e.preventDefault();
+                  onToggle();
+                }}
+                onDoubleClick={handleNameClick}
+              >
+                {displayName}
+              </span>
             )}
           </div>
-          <WSRequestBodyMode mode={displayMode} onModeChange={onUpdateMessageType} />
+          <div className="accordion-actions" onClick={(e) => e.stopPropagation()}>
+            <div className="hover-actions">
+              <ToolHint text="Send" toolhintId={`send-msg-${index}`}>
+                <button onClick={onSendMessage} className="hover-action-btn" data-testid={`ws-send-msg-${index}`}>
+                  <IconSend size={14} strokeWidth={1.5} />
+                </button>
+              </ToolHint>
+              {(body.ws || []).length > 1 && (
+                <ToolHint text="Delete" toolhintId={`delete-msg-${index}`}>
+                  <button onClick={onDeleteMessage} className="hover-action-btn delete" data-testid={`ws-delete-msg-${index}`}>
+                    <IconTrash size={14} strokeWidth={1.5} />
+                  </button>
+                </ToolHint>
+              )}
+            </div>
+            <WSRequestBodyMode mode={displayMode} onModeChange={onUpdateMessageType} />
+          </div>
         </div>
-      </div>
-      {isExpanded && (
-        <div className="accordion-body" data-testid={`ws-message-body-${index}`} style={{ height: editorHeight }}>
-          <CodeEditor
-            collection={collection}
-            theme={displayedTheme}
-            font={get(preferences, 'font.codeFont', 'default')}
-            fontSize={get(preferences, 'font.codeFontSize')}
-            value={content}
-            onEdit={onEdit}
-            onRun={handleRun}
-            onSave={onSave}
-            mode={codemirrorMode[displayMode] ?? 'text/plain'}
-            enableVariableHighlighting={true}
-          />
-        </div>
-      )}
-    </StyledWrapper>
+        {isExpanded && (
+          <div className="accordion-body" data-testid={`ws-message-body-${index}`} style={{ height: editorHeight }}>
+            <CodeEditor
+              collection={collection}
+              theme={displayedTheme}
+              font={get(preferences, 'font.codeFont', 'default')}
+              fontSize={get(preferences, 'font.codeFontSize')}
+              value={content}
+              onEdit={onEdit}
+              onRun={handleRun}
+              onSave={onSave}
+              mode={codemirrorMode[displayMode] ?? 'text/plain'}
+              enableVariableHighlighting={true}
+            />
+          </div>
+        )}
+      </StyledWrapper>
+      <ToolHint
+        text={displayName}
+        tooltipId={labelTooltipId}
+        place="bottom-start"
+        hidden={!isLabelTruncated}
+        positionStrategy="fixed"
+        tooltipTestId="ws-message-name-tooltip"
+        tooltipStyle={{ maxWidth: '320px', whiteSpace: 'normal', wordBreak: 'break-word' }}
+      />
+    </>
   );
 };

--- a/packages/bruno-app/src/components/ToolHint/index.js
+++ b/packages/bruno-app/src/components/ToolHint/index.js
@@ -5,6 +5,7 @@ import { useTheme } from 'providers/Theme';
 const ToolHint = ({
   text,
   toolhintId,
+  tooltipId,
   anchorSelect,
   children,
   tooltipStyle = {},
@@ -15,7 +16,8 @@ const ToolHint = ({
   theme = null,
   className = '',
   delayShow = 200,
-  dataTestId
+  dataTestId,
+  tooltipTestId
 }) => {
   const { theme: contextTheme } = useTheme();
   const appliedTheme = theme || contextTheme;
@@ -32,17 +34,21 @@ const ToolHint = ({
     color: toolhintTextColor
   };
 
-  const toolhintProps_final = anchorSelect
-    ? { anchorSelect }
-    : { anchorId: toolhintId };
+  const usesExternalAnchor = Boolean(tooltipId || anchorSelect);
+  const toolhintProps_final = tooltipId
+    ? { id: tooltipId }
+    : anchorSelect
+      ? { anchorSelect }
+      : { anchorId: toolhintId };
 
   return (
     <>
-      {!anchorSelect && <span id={toolhintId} className={className} data-testid={dataTestId}>{children}</span>}
-      {anchorSelect && children}
+      {!usesExternalAnchor && <span id={toolhintId} className={className} data-testid={dataTestId}>{children}</span>}
+      {usesExternalAnchor && children}
       <ReactToolHint
         {...toolhintProps_final}
-        content={anchorSelect ? undefined : text}
+        content={usesExternalAnchor ? undefined : text}
+        render={tooltipTestId ? ({ content }) => <span data-testid={tooltipTestId}>{content}</span> : undefined}
         className="toolhint"
         offset={offset}
         place={place}

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page, ElectronApplication, waitForReadyPage as waitForReadyPageImpl } from '../../../playwright';
 import process from 'node:process';
 import * as path from 'path';
-import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators } from './locators';
+import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators, buildWebsocketCommonLocators } from './locators';
 import { waitForCollectionMount } from './mounting';
 
 type SandboxMode = 'safe' | 'developer';
@@ -1937,6 +1937,24 @@ const generateCollectionDocs = async (
   });
 };
 
+/**
+ * Rename a websocket message by double-clicking its label and typing a new name.
+ * @param page - The page object
+ * @param index - The zero-based index of the message in the list
+ * @param name - The new message name
+ */
+const renameWsMessage = async (page: Page, index: number, name: string) => {
+  await test.step(`Rename websocket message ${index} to "${name}"`, async () => {
+    const ws = buildWebsocketCommonLocators(page);
+    await ws.message.label(index).dblclick();
+    const nameInput = ws.message.nameInput(index);
+    await expect(nameInput).toBeVisible();
+    await nameInput.selectText();
+    await page.keyboard.type(name);
+    await nameInput.press('Enter');
+  });
+};
+
 export {
   waitForReadyPage,
   dismissImportIssuesToasts,
@@ -2013,7 +2031,8 @@ export {
   closeGenerateCodeDialog,
   openRequestInFolder,
   setUrlEncoding,
-  generateCollectionDocs
+  generateCollectionDocs,
+  renameWsMessage
 };
 
 export type { SandboxMode, EnvironmentType, EnvironmentVariable, ImportCollectionOptions, CreateRequestOptions, CreateUntitledRequestOptions, CreateTransientRequestOptions, AssertionInput };

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -238,6 +238,11 @@ export const buildWebsocketCommonLocators = (page: Page) => ({
         .filter({ hasText: /^Close Connection$/ })
   },
   messages: () => page.locator('.ws-message'),
+  message: {
+    label: (index: number) => page.getByTestId(`ws-message-label-${index}`),
+    nameInput: (index: number) => page.getByTestId(`ws-message-name-input-${index}`),
+    nameTooltip: () => page.getByTestId('ws-message-name-tooltip')
+  },
   toolbar: {
     latestFirst: () => page.getByRole('button', { name: 'Latest First' }),
     latestLast: () => page.getByRole('button', { name: 'Latest Last' }),

--- a/tests/websockets/multi-message-bru/message-name-tooltip.spec.ts
+++ b/tests/websockets/multi-message-bru/message-name-tooltip.spec.ts
@@ -13,7 +13,7 @@ test.describe('websocket message name tooltip', () => {
     await closeAllCollections(page);
   });
 
-  test('shows the full name on hover only when the label is truncated', async ({
+  test('shows the full name in a tooltip on hover', async ({
     pageWithUserData: page
   }) => {
     const ws = buildWebsocketCommonLocators(page);
@@ -22,26 +22,22 @@ test.describe('websocket message name tooltip', () => {
     const messageLabel = ws.message.label(0);
     const tooltip = ws.message.nameTooltip();
 
-    await test.step('short name that fits → no tooltip on hover', async () => {
+    await test.step('short name → tooltip shows the name on hover', async () => {
       await renameWsMessage(page, 0, 'hi');
       await expect(messageLabel).toHaveText('hi');
 
-      // a short name fits, so it isn't truncated — the "only when truncated" gate stays off
-      await expect
-        .poll(() => messageLabel.evaluate((el) => el.scrollWidth > el.clientWidth))
-        .toBe(false);
-
       await messageLabel.hover();
-      await expect(tooltip).toHaveCount(0);
+      await expect(tooltip).toBeVisible({ timeout: 15000 });
+      await expect(tooltip).toContainText('hi');
     });
 
-    await test.step('long, truncated name → tooltip reveals the full name', async () => {
+    await test.step('long name → label is truncated and tooltip reveals the full name', async () => {
       await renameWsMessage(page, 0, LONG_NAME);
       await expect(messageLabel).toHaveText(LONG_NAME);
       // the label itself is clipped with an ellipsis...
       await expect(messageLabel).toHaveCSS('text-overflow', 'ellipsis');
 
-      // ...but hovering surfaces the full name in the tooltip
+      // ...and hovering surfaces the full name in the tooltip
       await messageLabel.hover();
       await expect(tooltip).toBeVisible({ timeout: 15000 });
       await expect(tooltip).toContainText(LONG_NAME);

--- a/tests/websockets/multi-message-bru/message-name-tooltip.spec.ts
+++ b/tests/websockets/multi-message-bru/message-name-tooltip.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '../../../playwright';
+import { openRequest, closeAllCollections, renameWsMessage } from '../../utils/page/actions';
+import { buildWebsocketCommonLocators } from '../../utils/page/locators';
+
+const COLLECTION_NAME = 'ws-multi-message';
+const SINGLE_MSG_REQ = 'ws-single-msg';
+
+const LONG_NAME
+  = 'this is a very long websocket message name that should be truncated with an ellipsis';
+
+test.describe('websocket message name tooltip', () => {
+  test.afterAll(async ({ pageWithUserData: page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('shows the full name on hover only when the label is truncated', async ({
+    pageWithUserData: page
+  }) => {
+    const ws = buildWebsocketCommonLocators(page);
+    await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
+
+    const messageLabel = ws.message.label(0);
+    const tooltip = ws.message.nameTooltip();
+
+    await test.step('short name that fits → no tooltip on hover', async () => {
+      await renameWsMessage(page, 0, 'hi');
+      await expect(messageLabel).toHaveText('hi');
+
+      // a short name fits, so it isn't truncated — the "only when truncated" gate stays off
+      await expect
+        .poll(() => messageLabel.evaluate((el) => el.scrollWidth > el.clientWidth))
+        .toBe(false);
+
+      await messageLabel.hover();
+      await expect(tooltip).toHaveCount(0);
+    });
+
+    await test.step('long, truncated name → tooltip reveals the full name', async () => {
+      await renameWsMessage(page, 0, LONG_NAME);
+      await expect(messageLabel).toHaveText(LONG_NAME);
+      // the label itself is clipped with an ellipsis...
+      await expect(messageLabel).toHaveCSS('text-overflow', 'ellipsis');
+
+      // ...but hovering surfaces the full name in the tooltip
+      await messageLabel.hover();
+      await expect(tooltip).toBeVisible({ timeout: 15000 });
+      await expect(tooltip).toContainText(LONG_NAME);
+    });
+  });
+});

--- a/tests/websockets/multi-message-yml/message-name-tooltip.spec.ts
+++ b/tests/websockets/multi-message-yml/message-name-tooltip.spec.ts
@@ -13,7 +13,7 @@ test.describe('websocket message name tooltip (yml format)', () => {
     await closeAllCollections(page);
   });
 
-  test('shows the full name on hover only when the label is truncated', async ({
+  test('shows the full name in a tooltip on hover', async ({
     pageWithUserData: page
   }) => {
     const ws = buildWebsocketCommonLocators(page);
@@ -22,26 +22,22 @@ test.describe('websocket message name tooltip (yml format)', () => {
     const messageLabel = ws.message.label(0);
     const tooltip = ws.message.nameTooltip();
 
-    await test.step('short name that fits → no tooltip on hover', async () => {
+    await test.step('short name → tooltip shows the name on hover', async () => {
       await renameWsMessage(page, 0, 'hi');
       await expect(messageLabel).toHaveText('hi');
 
-      // a short name fits, so it isn't truncated — the "only when truncated" gate stays off
-      await expect
-        .poll(() => messageLabel.evaluate((el) => el.scrollWidth > el.clientWidth))
-        .toBe(false);
-
       await messageLabel.hover();
-      await expect(tooltip).toHaveCount(0);
+      await expect(tooltip).toBeVisible({ timeout: 15000 });
+      await expect(tooltip).toContainText('hi');
     });
 
-    await test.step('long, truncated name → tooltip reveals the full name', async () => {
+    await test.step('long name → label is truncated and tooltip reveals the full name', async () => {
       await renameWsMessage(page, 0, LONG_NAME);
       await expect(messageLabel).toHaveText(LONG_NAME);
       // the label itself is clipped with an ellipsis...
       await expect(messageLabel).toHaveCSS('text-overflow', 'ellipsis');
 
-      // ...but hovering surfaces the full name in the tooltip
+      // ...and hovering surfaces the full name in the tooltip
       await messageLabel.hover();
       await expect(tooltip).toBeVisible({ timeout: 15000 });
       await expect(tooltip).toContainText(LONG_NAME);

--- a/tests/websockets/multi-message-yml/message-name-tooltip.spec.ts
+++ b/tests/websockets/multi-message-yml/message-name-tooltip.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '../../../playwright';
+import { openRequest, closeAllCollections, renameWsMessage } from '../../utils/page/actions';
+import { buildWebsocketCommonLocators } from '../../utils/page/locators';
+
+const COLLECTION_NAME = 'ws-multi-message-yml';
+const SINGLE_MSG_REQ = 'ws-single-msg';
+
+const LONG_NAME
+  = 'this is a very long websocket message name that should be truncated with an ellipsis';
+
+test.describe('websocket message name tooltip (yml format)', () => {
+  test.afterAll(async ({ pageWithUserData: page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('shows the full name on hover only when the label is truncated', async ({
+    pageWithUserData: page
+  }) => {
+    const ws = buildWebsocketCommonLocators(page);
+    await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
+
+    const messageLabel = ws.message.label(0);
+    const tooltip = ws.message.nameTooltip();
+
+    await test.step('short name that fits → no tooltip on hover', async () => {
+      await renameWsMessage(page, 0, 'hi');
+      await expect(messageLabel).toHaveText('hi');
+
+      // a short name fits, so it isn't truncated — the "only when truncated" gate stays off
+      await expect
+        .poll(() => messageLabel.evaluate((el) => el.scrollWidth > el.clientWidth))
+        .toBe(false);
+
+      await messageLabel.hover();
+      await expect(tooltip).toHaveCount(0);
+    });
+
+    await test.step('long, truncated name → tooltip reveals the full name', async () => {
+      await renameWsMessage(page, 0, LONG_NAME);
+      await expect(messageLabel).toHaveText(LONG_NAME);
+      // the label itself is clipped with an ellipsis...
+      await expect(messageLabel).toHaveCSS('text-overflow', 'ellipsis');
+
+      // ...but hovering surfaces the full name in the tooltip
+      await messageLabel.hover();
+      await expect(tooltip).toBeVisible({ timeout: 15000 });
+      await expect(tooltip).toContainText(LONG_NAME);
+    });
+  });
+});


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3295)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * WebSocket message names now show a hover tooltip with the full value when truncated.
  * Environment name tooltips are more reliably attached and positioned.

* **Bug Fixes**
  * Tooltip rendering for externally anchored hints is now consistent, including for message-label hover states.

* **Tests**
  * Added Playwright specs for WebSocket message name tooltip behavior and updated shared locators/utilities for interacting with message labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->