### PR TITLE
feat(woof): add WOOF easter egg

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -37,7 +37,7 @@ const { cookiesStore } = require('../../store/cookies');
 const registerGrpcEventHandlers = require('./grpc-event-handlers');
 const { registerWsEventHandlers } = require('./ws-event-handlers');
 const { getCertsAndProxyConfig, buildCertsAndProxyConfig } = require('./cert-utils');
-const { buildWoofResponse } = require('../../utils/woof');
+const { easterEggResponse } = require('../../utils/woof');
 const { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType } = require('@usebruno/common').utils;
 
 const ERROR_OCCURRED_WHILE_EXECUTING_REQUEST = 'Error occurred while executing the request!';
@@ -877,7 +877,7 @@ const registerNetworkIpc = (mainWindow) => {
 
     // Every good boy deserves a response.
     if (request.method && request.method.toUpperCase() === 'WOOF') {
-      return buildWoofResponse(request);
+      return easterEggResponse(request);
     }
 
     request.__bruno__executionMode = 'standalone';

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -873,6 +873,45 @@ const registerNetworkIpc = (mainWindow) => {
 
     const abortController = new AbortController();
     const request = await prepareRequest(item, collection, abortController);
+
+    // Every good boy deserves a response.
+    if (request.method && request.method.toUpperCase() === 'WOOF') {
+      const woofStart = Date.now();
+      const body = [
+        'Woof! Woof!',
+        '',
+        '       __',
+        '   (___()\'`;',
+        '   /,    /`',
+        '   \\\\"--\\\\',
+        '',
+        'Bruno fetched your request. Good human.'
+      ].join('\n');
+      const buffer = Buffer.from(body, 'utf-8');
+      return {
+        status: 200,
+        statusText: 'Woof!',
+        headers: {
+          'content-type': 'text/plain; charset=utf-8',
+          'x-good-boy': 'true',
+          'x-fetched-by': 'bruno'
+        },
+        data: body,
+        dataBuffer: buffer.toString('base64'),
+        size: buffer.byteLength,
+        duration: Date.now() - woofStart,
+        url: request.url,
+        timeline: [],
+        requestSent: {
+          url: request.url,
+          method: 'WOOF',
+          headers: request.headers,
+          data: null,
+          timestamp: woofStart
+        }
+      };
+    }
+
     request.__bruno__executionMode = 'standalone';
     request.responseType = 'stream';
     // flag to see if the stream needs to be handled as an actual stream or

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -37,6 +37,7 @@ const { cookiesStore } = require('../../store/cookies');
 const registerGrpcEventHandlers = require('./grpc-event-handlers');
 const { registerWsEventHandlers } = require('./ws-event-handlers');
 const { getCertsAndProxyConfig, buildCertsAndProxyConfig } = require('./cert-utils');
+const { buildWoofResponse } = require('../../utils/woof');
 const { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType } = require('@usebruno/common').utils;
 
 const ERROR_OCCURRED_WHILE_EXECUTING_REQUEST = 'Error occurred while executing the request!';
@@ -876,40 +877,7 @@ const registerNetworkIpc = (mainWindow) => {
 
     // Every good boy deserves a response.
     if (request.method && request.method.toUpperCase() === 'WOOF') {
-      const woofStart = Date.now();
-      const body = [
-        'Woof! Woof!',
-        '',
-        '       __',
-        '   (___()\'`;',
-        '   /,    /`',
-        '   \\\\"--\\\\',
-        '',
-        'Bruno fetched your request. Good human.'
-      ].join('\n');
-      const buffer = Buffer.from(body, 'utf-8');
-      return {
-        status: 200,
-        statusText: 'Woof!',
-        headers: {
-          'content-type': 'text/plain; charset=utf-8',
-          'x-good-boy': 'true',
-          'x-fetched-by': 'bruno'
-        },
-        data: body,
-        dataBuffer: buffer.toString('base64'),
-        size: buffer.byteLength,
-        duration: Date.now() - woofStart,
-        url: request.url,
-        timeline: [],
-        requestSent: {
-          url: request.url,
-          method: 'WOOF',
-          headers: request.headers,
-          data: null,
-          timestamp: woofStart
-        }
-      };
+      return buildWoofResponse(request);
     }
 
     request.__bruno__executionMode = 'standalone';

--- a/packages/bruno-electron/src/utils/woof.js
+++ b/packages/bruno-electron/src/utils/woof.js
@@ -1,4 +1,4 @@
-const buildWoofResponse = (request) => {
+const easterEggResponse = (request) => {
   const woofStart = Date.now();
   const body = [
     'Woof! Woof!',
@@ -35,4 +35,4 @@ const buildWoofResponse = (request) => {
   };
 };
 
-module.exports = { buildWoofResponse };
+module.exports = { easterEggResponse };

--- a/packages/bruno-electron/src/utils/woof.js
+++ b/packages/bruno-electron/src/utils/woof.js
@@ -1,0 +1,38 @@
+const buildWoofResponse = (request) => {
+  const woofStart = Date.now();
+  const body = [
+    'Woof! Woof!',
+    '',
+    '       __',
+    '   (___()\'`;',
+    '   /,    /`',
+    '   \\\\"--\\\\',
+    '',
+    'Bruno fetched your request. Good human.'
+  ].join('\n');
+  const buffer = Buffer.from(body, 'utf-8');
+  return {
+    status: 200,
+    statusText: 'Woof!',
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-good-boy': 'true',
+      'x-fetched-by': 'bruno'
+    },
+    data: body,
+    dataBuffer: buffer.toString('base64'),
+    size: buffer.byteLength,
+    duration: Date.now() - woofStart,
+    url: request.url,
+    timeline: [],
+    requestSent: {
+      url: request.url,
+      method: 'WOOF',
+      headers: request.headers,
+      data: null,
+      timestamp: woofStart
+    }
+  };
+};
+
+module.exports = { buildWoofResponse };


### PR DESCRIPTION
```
Woof! Woof!

       __
   (___()'`;
   /,    /`
   \\"--\\
```

Bruno fetched your request. Good human.

---

### Description

Adds a small easter egg: setting the HTTP method to `WOOF` (any case) short-circuits the network call and returns a synthetic `200 Woof!` response — Bruno's mascot answering on behalf of the request. No real traffic is sent.

**Where it lives** — a single early-return inside `runRequest` in `packages/bruno-electron/src/ipc/network/index.js`, immediately after `prepareRequest` returns and before any side-effectful work (pre-request scripts, axios config, network call). Pre-request scripts, tests, and post-response scripts are intentionally skipped — the response is synthetic, so running user assertions against it would be misleading.

**Response shape**
- `status: 200`, `statusText: "Woof!"`
- Headers: `content-type: text/plain; charset=utf-8`, `x-good-boy: true`, `x-fetched-by: bruno`
- Body: a small dog ASCII + "Bruno fetched your request. Good human."
- Matches the success-response shape returned by the normal axios path, so the renderer needs no changes.

**Why no UI/schema changes are needed**
- The HTTP method dropdown already supports custom methods via the "+ Add Custom" option (`HttpMethodSelector`).
- The schema accepts any non-empty string for `method` (`packages/bruno-schema/src/collections/index.js`).
- The bru parser handles arbitrary methods via the `httpcustom` rule (`packages/bruno-lang/v2/src/bruToJson.js`).

**How to try it**
1. Open any HTTP request.
2. Method dropdown → **+ Add Custom** → type `WOOF` → Send.
3. Response pane shows `200 Woof!` and the ASCII body. No traffic in DevTools Network.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a special request type that returns an instant “Woof!” response instead of running the usual request flow.
  * The response includes standard HTTP-style details like status, headers, body content, and timing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->