### PR TITLE
fix(CLI): Multipart Form Body Not Sent — Body Mode Mismatch in prepare-request

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -408,8 +408,10 @@ const prepareRequest = async (item = {}, collection = {}) => {
     axiosRequest.data = enabledParams;
   }
 
-  if (request.body.mode === 'multipartForm') {
-    axiosRequest.headers['content-type'] = 'multipart/form-data';
+  if (request.body.mode === 'multipartForm' || request.body.mode === 'multipart-form') {
+    if (!contentTypeDefined) {
+      axiosRequest.headers['content-type'] = 'multipart/form-data';
+    }
     const enabledParams = filter(request.body.multipartForm, (p) => p.enabled);
     axiosRequest.data = enabledParams;
   }

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -478,7 +478,7 @@ const prepareRequest = async (item, collection = {}, abortController) => {
     axiosRequest.data = enabledParams;
   }
 
-  if (request.body.mode === 'multipartForm') {
+  if (request.body.mode === 'multipartForm' || request.body.mode === 'multipart-form') {
     if (!contentTypeDefined) {
       axiosRequest.headers['content-type'] = 'multipart/form-data';
     }

--- a/packages/bruno-electron/tests/network/prepare-request.spec.js
+++ b/packages/bruno-electron/tests/network/prepare-request.spec.js
@@ -64,4 +64,50 @@ describe('prepare-request: prepareRequest', () => {
       expect(result.data.variables).toBe('{"apiPermissions": {{permissionsJSON}}}');
     });
   });
+
+  describe('Multipart form body', () => {
+    it.each(['multipartForm', 'multipart-form'])(
+      'sets multipart/form-data content-type and data for mode "%s"',
+      async (mode) => {
+        const request = {
+          method: 'POST',
+          url: 'test-domain',
+          body: {
+            mode,
+            multipartForm: [
+              { name: 'file', value: ['/path/to/test-image.png'], type: 'file', enabled: true },
+              { name: 'field', value: 'hello', type: 'text', enabled: true },
+              { name: 'ignored', value: 'nope', type: 'text', enabled: false }
+            ]
+          },
+          auth: { mode: 'none' }
+        };
+
+        const result = await prepareRequest({ request, collection: { pathname: '' } });
+
+        expect(result.headers['content-type']).toEqual('multipart/form-data');
+        expect(result.data).toEqual([
+          { name: 'file', value: ['/path/to/test-image.png'], type: 'file', enabled: true },
+          { name: 'field', value: 'hello', type: 'text', enabled: true }
+        ]);
+      }
+    );
+
+    it('does not override an explicitly set content-type', async () => {
+      const request = {
+        method: 'POST',
+        url: 'test-domain',
+        headers: [{ name: 'content-type', value: 'multipart/form-data; boundary=custom', enabled: true }],
+        body: {
+          mode: 'multipart-form',
+          multipartForm: [{ name: 'field', value: 'hello', type: 'text', enabled: true }]
+        },
+        auth: { mode: 'none' }
+      };
+
+      const result = await prepareRequest({ request, collection: { pathname: '' } });
+
+      expect(result.headers['content-type']).toEqual('multipart/form-data; boundary=custom');
+    });
+  });
 });


### PR DESCRIPTION
Jira link: https://usebruno.atlassian.net/browse/BRU-3204

### Description

Fixes multipart-form requests being sent with no body and no Content-Type header.
The .bru parser emits body.mode as kebab-case (multipart-form), but prepare-request.js only checked the camelCase multipartForm, so the branch never matched.
Updated the check to accept both multipartForm and multipart-form so the multipart/form-data header and form data are set correctly.
Added regression tests in prepare-request.spec.js covering both casings and preserving an explicitly set Content-Type.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multipart form data request handling to recognize and process requests in multiple format modes
  * Improved content-type header behavior to preserve custom content-type definitions when already specified

* **Tests**
  * Added comprehensive test coverage for multipart form body handling to verify correct request processing and header management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->