### PR TITLE
fix(tests): resolve folder-level no-auth test failures

### DIFF
--- a/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
+++ b/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
@@ -15,81 +15,83 @@ import {
 } from '../../utils/page';
 import { AUTH_MODE_LABELS } from '../../utils/constants';
 
-test.afterEach(async ({ page }) => {
-  await closeAllCollections(page);
-});
-
-test('Request inherits No Auth from the folder — collection Bearer Token is overridden', async ({ page, createTmpDir }) => {
-  const collectionName = 'folder-no-auth-inheritance';
-  const locators = buildCommonLocators(page);
-
-  await test.step('Create a collection', async () => {
-    await createCollection(page, collectionName, await createTmpDir());
+test.describe('Folder No Auth Stops Inheritance', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
   });
 
-  await test.step('Set auth type for the collection as Bearer Token', async () => {
-    await locators.paneTabs.collectionSettingsTab('auth').click();
-    await selectAuthMode(page, AUTH_MODE_LABELS.BEARER);
-    await typeIntoField(page, 'Token', 'your_secret_token');
-    await page.getByRole('button', { name: 'Save' }).click();
-  });
+  test('Request inherits No Auth from the folder — collection Bearer Token is overridden', async ({ page, createTmpDir }) => {
+    const collectionName = 'folder-no-auth-inheritance';
+    const locators = buildCommonLocators(page);
 
-  await test.step('Create folder-1 inside the collection and set auth type for folder-1 as No Auth', async () => {
-    await createFolder(page, 'folder-1', collectionName, true);
-    await locators.sidebar.folder('folder-1').dblclick();
-    await locators.paneTabs.folderSettingsTab('auth').click();
-    await selectAuthMode(page, AUTH_MODE_LABELS.NONE);
-    await page.getByRole('button', { name: 'Save' }).click();
-  });
-
-  await test.step('Create an HTTP request inside folder-1 and set auth type for the request as Inherit', async () => {
-    const requestName = 'http-request-1';
-    await createRequest(page, requestName, 'folder-1', {
-      inFolder: true,
-      requestType: 'http',
-      method: 'GET',
-      url: 'https://testbench-sanity.usebruno.com/api/auth/bearer/protected'
+    await test.step('Create a collection', async () => {
+      await createCollection(page, collectionName, await createTmpDir());
     });
-    await openRequest(page, collectionName, requestName);
-    await selectRequestPaneTab(page, 'Auth');
-    await selectAuthMode(page, AUTH_MODE_LABELS.INHERIT);
-    await saveRequest(page);
-  });
 
-  await test.step('Send the request and open the Timeline tab', async () => {
-    await sendRequest(page);
-    await selectResponsePaneTab(page, 'Timeline');
-  });
+    await test.step('Set auth type for the collection as Bearer Token', async () => {
+      await locators.paneTabs.collectionSettingsTab('auth').click();
+      await selectAuthMode(page, AUTH_MODE_LABELS.BEARER);
+      await typeIntoField(page, 'Token', 'your_secret_token');
+      await page.getByRole('button', { name: 'Save' }).click();
+    });
 
-  await test.step('Verify the response status code is 401 Unauthorized', async () => {
-    await expect(locators.response.statusCode()).toContainText('401 Unauthorized');
-  });
+    await test.step('Create folder-1 inside the collection and set auth type for folder-1 as No Auth', async () => {
+      await createFolder(page, 'folder-1', collectionName, true);
+      await locators.sidebar.folder('folder-1').dblclick();
+      await locators.paneTabs.folderSettingsTab('auth').click();
+      await selectAuthMode(page, AUTH_MODE_LABELS.NONE);
+      await page.getByRole('button', { name: 'Save' }).click();
+    });
 
-  await test.step('Open the latest timeline entry and verify no Authorization header was sent', async () => {
-    const timelineItem = locators.timeline.lastItem();
-    await locators.timeline.itemHeader(timelineItem).click();
-    await expect(timelineItem).toContainText('No Headers');
-    await locators.timeline.clearButton().click();
-  });
+    await test.step('Create an HTTP request inside folder-1 and set auth type for the request as Inherit', async () => {
+      const requestName = 'http-request-1';
+      await createRequest(page, requestName, 'folder-1', {
+        inFolder: true,
+        requestType: 'http',
+        method: 'GET',
+        url: 'https://testbench-sanity.usebruno.com/api/auth/bearer/protected'
+      });
+      await openRequest(page, collectionName, requestName);
+      await selectRequestPaneTab(page, 'Auth');
+      await selectAuthMode(page, AUTH_MODE_LABELS.INHERIT);
+      await saveRequest(page);
+    });
 
-  await test.step('Change folder-1 auth type to Bearer Token with the expected token', async () => {
-    await locators.sidebar.folder('folder-1').dblclick();
-    await locators.paneTabs.folderSettingsTab('auth').click();
-    await selectAuthMode(page, AUTH_MODE_LABELS.BEARER);
-    await typeIntoField(page, 'Token', 'your_secret_token');
-    await page.getByRole('button', { name: 'Save' }).click();
-  });
+    await test.step('Send the request and open the Timeline tab', async () => {
+      await sendRequest(page);
+      await selectResponsePaneTab(page, 'Timeline');
+    });
 
-  await test.step('Send the request again and verify the response status code is 200', async () => {
-    await openRequest(page, collectionName, 'http-request-1');
-    await sendRequest(page);
-    await selectResponsePaneTab(page, 'Timeline');
-    await expect(locators.response.statusCode()).toContainText('200');
-  });
+    await test.step('Verify the response status code is 401 Unauthorized', async () => {
+      await expect(locators.response.statusCode()).toContainText('401 Unauthorized');
+    });
 
-  await test.step('Open the latest timeline entry and verify the Bearer token was sent', async () => {
-    const timelineItem = locators.timeline.lastItem();
-    await locators.timeline.itemHeader(timelineItem).click();
-    await expect(timelineItem).toContainText('Bearer your_secret_token');
+    await test.step('Open the latest timeline entry and verify no Authorization header was sent', async () => {
+      const timelineItem = locators.timeline.lastItem();
+      await locators.timeline.itemHeader(timelineItem).click();
+      await expect(timelineItem).toContainText('No Headers');
+      await locators.timeline.clearButton().click();
+    });
+
+    await test.step('Change folder-1 auth type to Bearer Token with the expected token', async () => {
+      await locators.sidebar.folder('folder-1').dblclick();
+      await locators.paneTabs.folderSettingsTab('auth').click();
+      await selectAuthMode(page, AUTH_MODE_LABELS.BEARER);
+      await typeIntoField(page, 'Token', 'your_secret_token');
+      await page.getByRole('button', { name: 'Save' }).click();
+    });
+
+    await test.step('Send the request again and verify the response status code is 200', async () => {
+      await openRequest(page, collectionName, 'http-request-1');
+      await sendRequest(page);
+      await selectResponsePaneTab(page, 'Timeline');
+      await expect(locators.response.statusCode()).toContainText('200');
+    });
+
+    await test.step('Open the latest timeline entry and verify the Bearer token was sent', async () => {
+      const timelineItem = locators.timeline.lastItem();
+      await locators.timeline.itemHeader(timelineItem).click();
+      await expect(timelineItem).toContainText('Bearer your_secret_token');
+    });
   });
 });

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -553,6 +553,20 @@ const removeCollection = async (page: Page, collectionName: string) => {
 };
 
 /**
+ * Expand a folder in the sidebar so its child requests/subfolders become visible.
+ * No-op if the folder is already expanded.
+ */
+const expandFolder = async (page: Page, folderName: string) => {
+  await test.step(`Expand folder "${folderName}"`, async () => {
+    const locators = buildCommonLocators(page);
+    const chevron = locators.folder.chevron(folderName);
+    await chevron.waitFor({ state: 'visible', timeout: 5000 });
+    const isExpanded = await chevron.evaluate((el: HTMLElement) => el.classList.contains('rotate-90'));
+    if (!isExpanded) await chevron.click();
+  });
+};
+
+/**
  * Create a folder inside a collection or another folder
  * @param page - The page object
  * @param folderName - The name of the folder to create
@@ -573,6 +587,7 @@ const createFolder = async (
       await locators.sidebar.collection(parentName).hover();
       await locators.actions.collectionActions(parentName).click();
     } else {
+      await expandFolder(page, parentName);
       await locators.sidebar.folder(parentName).hover();
       await locators.actions.collectionItemActions(parentName).click();
     }
@@ -581,20 +596,6 @@ const createFolder = async (
     await page.getByTestId('new-folder-input').fill(folderName);
     await locators.modal.button('Create').click();
     await expect(locators.sidebar.folder(folderName)).toBeVisible();
-  });
-};
-
-/**
- * Expand a folder in the sidebar so its child requests/subfolders become visible.
- * No-op if the folder is already expanded.
- */
-const expandFolder = async (page: Page, folderName: string) => {
-  await test.step(`Expand folder "${folderName}"`, async () => {
-    const locators = buildCommonLocators(page);
-    const chevron = locators.folder.chevron(folderName);
-    await chevron.waitFor({ state: 'visible', timeout: 5000 });
-    const isExpanded = await chevron.evaluate((el: HTMLElement) => el.classList.contains('rotate-90'));
-    if (!isExpanded) await chevron.click();
   });
 };
 


### PR DESCRIPTION
### Description

Wrapped the afterEach hook and the test inside a test.describe('Folder No Auth Stops Inheritance', ...) block.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test structure and refactored utility organization for improved maintainability and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->