### PR TITLE
fix(app): truncate long environment title so action icons stay access…

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/StyledWrapper.js
@@ -20,6 +20,9 @@ const StyledWrapper = styled.div`
       font-weight: 500;
       color: ${(props) => props.theme.text};
       margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .title-container {
@@ -27,6 +30,11 @@ const StyledWrapper = styled.div`
       align-items: center;
       gap: 8px;
       flex: 1;
+      min-width: 0;
+
+      > .flex {
+        min-width: 0;
+      }
 
       &.renaming {
         .title-input {
@@ -96,6 +104,7 @@ const StyledWrapper = styled.div`
       display: flex;
       align-items: center;
       gap: 2px;
+      flex-shrink: 0;
 
       .search-input-wrapper {
         position: relative;

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
@@ -179,7 +179,7 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
               </div>
             </>
           ) : (
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 mr-6">
               <h2 className="title">{environment.name}</h2>
               <ColorPicker color={environment.color} onChange={handleColorChange} />
             </div>

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
@@ -180,7 +180,7 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
             </>
           ) : (
             <div className="flex items-center gap-2 mr-6">
-              <h2 className="title">{environment.name}</h2>
+              <h2 className="title" data-testid="environment-title">{environment.name}</h2>
               <ColorPicker color={environment.color} onChange={handleColorChange} />
             </div>
           )}
@@ -215,17 +215,17 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
               )}
             </div>
           ) : (
-            <button onClick={handleSearchIconClick} title="Search variables">
+            <button onClick={handleSearchIconClick} title="Search variables" data-testid="environment-action-search">
               <IconSearch size={15} strokeWidth={1.5} />
             </button>
           )}
-          <button onClick={handleRenameClick} title="Rename">
+          <button onClick={handleRenameClick} title="Rename" data-testid="environment-action-rename">
             <IconEdit size={15} strokeWidth={1.5} />
           </button>
-          <button onClick={() => setOpenCopyModal(true)} title="Copy">
+          <button onClick={() => setOpenCopyModal(true)} title="Copy" data-testid="environment-action-copy">
             <IconCopy size={15} strokeWidth={1.5} />
           </button>
-          <button onClick={() => setOpenDeleteModal(true)} title="Delete">
+          <button onClick={() => setOpenDeleteModal(true)} title="Delete" data-testid="environment-action-delete">
             <IconTrash size={15} strokeWidth={1.5} />
           </button>
         </div>

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/StyledWrapper.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/StyledWrapper.js
@@ -20,14 +20,22 @@ const StyledWrapper = styled.div`
       font-weight: 500;
       color: ${(props) => props.theme.text};
       margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
-    
+
     .title-container {
       display: flex;
       align-items: center;
       gap: 8px;
       flex: 1;
-      
+      min-width: 0;
+
+      > .flex {
+        min-width: 0;
+      }
+
       &.renaming {
         .title-input {
           flex: 1;
@@ -96,6 +104,7 @@ const StyledWrapper = styled.div`
       display: flex;
       align-items: center;
       gap: 2px;
+      flex-shrink: 0;
 
       .search-input-wrapper {
         position: relative;

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/index.js
@@ -182,7 +182,7 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
             </>
           ) : (
             <div className="flex items-center gap-2 mr-6">
-              <h2 className="title">{environment.name}</h2>
+              <h2 className="title" data-testid="environment-title">{environment.name}</h2>
               <ColorPicker color={environment.color} onChange={handleColorChange} />
             </div>
           )}
@@ -217,17 +217,17 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
               )}
             </div>
           ) : (
-            <button onClick={handleSearchIconClick} title="Search variables">
+            <button onClick={handleSearchIconClick} title="Search variables" data-testid="environment-action-search">
               <IconSearch size={15} strokeWidth={1.5} />
             </button>
           )}
-          <button onClick={handleRenameClick} title="Rename">
+          <button onClick={handleRenameClick} title="Rename" data-testid="environment-action-rename">
             <IconEdit size={15} strokeWidth={1.5} />
           </button>
-          <button onClick={() => setOpenCopyModal(true)} title="Copy">
+          <button onClick={() => setOpenCopyModal(true)} title="Copy" data-testid="environment-action-copy">
             <IconCopy size={15} strokeWidth={1.5} />
           </button>
-          <button onClick={() => setOpenDeleteModal(true)} title="Delete">
+          <button onClick={() => setOpenDeleteModal(true)} title="Delete" data-testid="environment-action-delete">
             <IconTrash size={15} strokeWidth={1.5} />
           </button>
         </div>

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/index.js
@@ -181,7 +181,7 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
               </div>
             </>
           ) : (
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 mr-6">
               <h2 className="title">{environment.name}</h2>
               <ColorPicker color={environment.color} onChange={handleColorChange} />
             </div>

--- a/tests/environments/title-truncation/env-title-truncation.spec.ts
+++ b/tests/environments/title-truncation/env-title-truncation.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, Page } from '../../../playwright';
+import path from 'path';
+import {
+  importCollection,
+  createEnvironment,
+  closeAllCollections,
+  removeCollection,
+  buildCommonLocators
+} from '../../utils/page';
+
+const LONG_NAME = 'Prodddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+const collectionFile = path.join(__dirname, '..', 'create-environment', 'fixtures', 'bruno-collection.json');
+
+const expectHeaderActionsAccessible = async (page: Page) => {
+  const locators = buildCommonLocators(page);
+
+  // The title is clipped, not laid out at full content width
+  const titleClipped = await locators.environment.detailsTitle().evaluate(
+    (el: HTMLElement) => el.scrollWidth > el.clientWidth
+  );
+  expect(titleClipped).toBe(true);
+
+  const windowWidth = await page.evaluate(() => window.innerWidth);
+
+  // Every action button is visible and fully inside the viewport
+  for (const action of ['search', 'rename', 'copy', 'delete'] as const) {
+    const button = locators.environment.detailsAction(action);
+    await expect(button).toBeVisible();
+
+    const box = await button.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(windowWidth);
+  }
+
+  // The delete button is actually clickable (not covered by the title).
+  await locators.environment.detailsAction('delete').click();
+  await expect(locators.modal.byTitle('Delete Environment')).toBeVisible();
+  await locators.modal.button('Delete').click();
+  await expect(locators.modal.byTitle('Delete Environment')).toBeHidden();
+};
+
+test.describe('Environment Title Truncation Tests', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('collection environment: long title is truncated and action icons stay accessible', async ({
+    page,
+    createTmpDir
+  }) => {
+    await test.step('Import collection', async () => {
+      await importCollection(page, collectionFile, await createTmpDir('env-title-collection'), {
+        expectedCollectionName: 'test_collection'
+      });
+    });
+
+    await test.step('Create environment with a very long name', async () => {
+      await createEnvironment(page, LONG_NAME, 'collection');
+    });
+
+    await test.step('Verify title is truncated and actions are accessible', async () => {
+      await expectHeaderActionsAccessible(page);
+    });
+  });
+
+  test('global environment: long title is truncated and action icons stay accessible', async ({
+    page,
+    createTmpDir
+  }) => {
+    await test.step('Import collection', async () => {
+      await importCollection(page, collectionFile, await createTmpDir('env-title-global'), {
+        expectedCollectionName: 'test_collection'
+      });
+    });
+
+    await test.step('Create global environment with a very long name', async () => {
+      await createEnvironment(page, LONG_NAME, 'global');
+    });
+
+    await test.step('Verify title is truncated and actions are accessible', async () => {
+      await expectHeaderActionsAccessible(page);
+    });
+  });
+});

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -75,7 +75,10 @@ export const buildCommonLocators = (page: Page) => ({
     variableSecretCheckbox: (index: number) => page.locator(`input[name="${index}.secret"]`),
     variableRow: (index: number) => page.locator('tr').filter({ has: page.locator(`input[name="${index}.name"]`) }),
     createEnvButton: () => page.locator('button[id="create-env"]'),
-    envNameInput: () => page.locator('input[name="name"]')
+    envNameInput: () => page.locator('input[name="name"]'),
+    detailsTitle: () => page.getByTestId('environment-title'),
+    detailsAction: (action: 'search' | 'rename' | 'copy' | 'delete') =>
+      page.getByTestId(`environment-action-${action}`)
   },
   codeMirror: {
     byTestId: (testId: string) => page.getByTestId(testId).locator('.CodeMirror').first()


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Improved truncation behavior for long environment titles (ellipsis and no wrapping) to keep headers readable.
  * Updated header layout so title/actions don’t shrink unexpectedly, reducing alignment/layout shifts during rename mode.
* **Tests**
  * Added Playwright coverage to verify truncated titles render correctly and that environment action buttons remain visible, in-viewport, and usable (including delete modal open/close).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="989" height="655" alt="image" src="https://github.com/user-attachments/assets/cdcf0da8-fee7-4439-8b71-6858caf791af" />
