### PR TITLE
(size/XS)fix:BRU-3515 Copy cURL icon not visible

### DIFF
--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
@@ -683,7 +683,6 @@ const StyledWrapper = styled.div`
 
       .copy-to-clipboard {
         button {
-          background-color: ${(props) => props.theme.background.muted} ;
           border-radius: 3px;
         }
       }

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
@@ -683,8 +683,7 @@ const StyledWrapper = styled.div`
 
       .copy-to-clipboard {
         button {
-          background: ${(props) => props.theme.background.mantle};
-          border: 1px solid ${(props) => props.theme.border.border1};
+          background-color: ${(props) => props.theme.background.muted} ;
           border-radius: 3px;
         }
       }


### PR DESCRIPTION
### Description
In the OpenAPI spec viewer (Swagger renderer), the Copy cURL icon renders with a fixed color that does not track the selected theme. In some themes the icon has poor contrast against the background and is hard to see, breaking visual consistency with the rest of the viewer.
https://usebruno.atlassian.net/browse/BRU-3515
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
<img width="543" height="602" alt="Screenshot 2026-06-19 at 1 35 07 PM" src="https://github.com/user-attachments/assets/3c3c0b52-7be5-4a4e-af31-fcba4190bd1e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the copy-to-clipboard button styling in the API specification panel to use muted theme background color for improved visual consistency, removing older background and border styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->