### PR TITLE
(size/XS)fix(openapi): copy cURL icon now respects the theme variables

### DIFF
--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
@@ -683,8 +683,6 @@ const StyledWrapper = styled.div`
 
       .copy-to-clipboard {
         button {
-          background: ${(props) => props.theme.background.mantle};
-          border: 1px solid ${(props) => props.theme.border.border1};
           border-radius: 3px;
         }
       }


### PR DESCRIPTION
### Description
The background overwrites the svg colour and hence makes it invisible 
[JIRA](https://usebruno.atlassian.net/browse/BRU-3515)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
<img width="543" height="602" alt="Screenshot 2026-06-19 at 1 35 07 PM" src="https://github.com/user-attachments/assets/efd5d375-a366-4c50-ae63-1cdc112f5855" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined styling for the copy button in the API specification panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->