### PR TITLE
bugfix: await the websocket visibility assertion so it actually runs

### DIFF
--- a/tests/websockets/connection.spec.ts
+++ b/tests/websockets/connection.spec.ts
@@ -8,7 +8,7 @@ test.describe.serial('websockets', () => {
   test('websocket requests are visible', async ({ pageWithUserData: page, restartApp }) => {
     await page.locator('#sidebar-collection-name').click();
 
-    expect(page.locator('span.item-name').filter({ hasText: BRU_REQ_NAME })).toBeVisible();
+    await expect(page.locator('span.item-name').filter({ hasText: BRU_REQ_NAME })).toBeVisible();
   });
 
   test('websocket connects', async ({ pageWithUserData: page, restartApp }) => {


### PR DESCRIPTION
### Description

The first websocket E2E test, 'websocket requests are visible', has its only
assertion floating without an await:

```js
test('websocket requests are visible', async ({ pageWithUserData: page, restartApp }) => {
  await page.locator('#sidebar-collection-name').click();

  expect(page.locator('span.item-name').filter({ hasText: BRU_REQ_NAME })).toBeVisible();
});
```

`expect(locator).toBeVisible()` is a Playwright web-first matcher: it returns a
Promise that polls and retries until the element is visible or the timeout
elapses. Because the call is not awaited, the Promise is created and discarded,
the assertion never runs, and the test passes whether or not the websocket
request is actually visible in the sidebar. Since this is the sole assertion in
the test, the test provided no real coverage.

The other six `expect(...)` calls in the same file are all already awaited, so
this is the one line that drifted from the file's own idiom.

The coding standards already flag this class of issue: CODING_STANDARDS.md calls
out "fake assertions" and "fake internal state checks" as things to avoid in
tests. A web-first matcher that is never awaited is exactly that, a check that
looks like an assertion but enforces nothing.

The fix adds the missing `await`:

```diff
-    expect(page.locator('span.item-name').filter({ hasText: BRU_REQ_NAME })).toBeVisible();
+    await expect(page.locator('span.item-name').filter({ hasText: BRU_REQ_NAME })).toBeVisible();
```

Scope is intentionally limited to this one missing-await in this one file. No
test titles, selectors, or behavior are changed.

#### Verified locally

Re-fetched and reviewed against main on 2026-06-20. Ran the repository preflight
against the changed spec:

```
  smell-delta    PASS  total 8->7, p0 3->2, ast 1->0
  ast-artifacts  PASS  postfix rules clean on 1 file(s)
  tsc            SKIP  no tsconfig.json found above changed files
  lint           SKIP  eslint not installed in the repo (node_modules/.bin/eslint absent)
  spec-run       SKIP  playwright not installed in the repo (node_modules/.bin/playwright absent)
  diff-hygiene   PASS  only intended files, no formatting churn
  authoring      PASS  no slop punctuation, 0 comment line(s), no test renames
PREFLIGHT 0 fail(s)
```

Not run locally: the Playwright websocket E2E suite, TypeScript, and lint. This
clone has no installed dependencies, so the preflight skipped the spec run, tsc,
and eslint. The change is a one-character assertion strengthening within an
existing test and adds no new code paths.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** (not applicable, test-only change)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by improving async handling in WebSocket connection tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->