### PR TITLE
test(preferences): set default preferences values

### DIFF
--- a/playwright/index.ts
+++ b/playwright/index.ts
@@ -1,10 +1,30 @@
 import { test as baseTest, BrowserContext, ElectronApplication, Page, TestInfo } from '@playwright/test';
+import { merge } from 'lodash-es';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { version } from '../packages/bruno-app/package.json';
 
 const electronAppPath = path.join(__dirname, '../packages/bruno-electron');
+
+const PREFERENCES_FILE = 'preferences.json';
+
+/**
+ * Default preferences for the app - preferences.json file.
+ * This is overridden by the init-user-data/preferences.json file if it exists.
+ *
+ * Uses lodash/merge to merge the default preferences with the init-user-data/preferences.json file.
+ *   - Note: arrays are merged by index, not concatenated. (e.g. lastOpenedCollections, lastOpenedWorkspaces, etc.)
+ */
+const defaultPreferences = {
+  preferences: {
+    onboarding: {
+      hasLaunchedBefore: true,
+      hasSeenWelcomeModal: true,
+      lastSeenVersion: version
+    }
+  }
+};
 
 const existsAsync = (filepath: string) => fs.promises.access(filepath).then(() => true).catch(() => false);
 
@@ -234,24 +254,18 @@ export const test = baseTest.extend<
                 throw new Error(`\tNo replacement for {{${key}}} in ${path.join(initUserDataPath, file)}`);
               }
             });
+            if (file === PREFERENCES_FILE) {
+              content = JSON.stringify(merge({}, defaultPreferences, JSON.parse(content)), null, 2);
+            }
             await fs.promises.writeFile(path.join(userDataPath, file), content, 'utf-8');
           }
         } else {
           // No initUserDataPath provided: create default preferences to skip onboarding
           // BUT only if preferences.json doesn't already exist
-          const prefsPath = path.join(userDataPath, 'preferences.json');
+          const prefsPath = path.join(userDataPath, PREFERENCES_FILE);
           const prefsExist = await existsAsync(prefsPath);
 
           if (!prefsExist) {
-            const defaultPreferences = {
-              preferences: {
-                onboarding: {
-                  hasLaunchedBefore: true,
-                  hasSeenWelcomeModal: true,
-                  lastSeenVersion: version
-                }
-              }
-            };
             await fs.promises.writeFile(
               prefsPath,
               JSON.stringify(defaultPreferences, null, 2),

--- a/tests/changelog/init-user-data-existing/preferences.json
+++ b/tests/changelog/init-user-data-existing/preferences.json
@@ -5,7 +5,8 @@
   "preferences": {
     "onboarding": {
       "hasLaunchedBefore": true,
-      "hasSeenWelcomeModal": true
+      "hasSeenWelcomeModal": true,
+      "lastSeenVersion": null
     }
   }
 }


### PR DESCRIPTION
### Description

Set default preferences values to be overridden by tests with custom preferences

[JIRA](https://usebruno.atlassian.net/browse/BRU-3631)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved user preferences initialization and management by implementing automatic merging of preference data during app startup, ensuring smoother preference handling across application launches.
  * Added application version tracking within user preferences to enhance support for version-aware onboarding experiences.

* **Chores**
  * Updated test fixtures to reflect new preference structure with version tracking fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->