### PR TITLE
fix(openapi):validate API spec imports 

### DIFF
--- a/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
@@ -20,10 +20,10 @@ const getPreviewParseError = (content) => {
       parsed = jsyaml.load(content);
     }
   } catch {
-    return 'Unable to render preview: content is not valid YAML or JSON.';
+    return 'Unable to render preview: content is not a valid YAML or JSON.';
   }
   if (!parsed || typeof parsed !== 'object') {
-    return 'Unable to render preview: content is not valid YAML or JSON.';
+    return 'Unable to render preview: content is not a valid OpenAPI specification.';
   }
   return null;
 };
@@ -78,6 +78,11 @@ const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthC
   useEffect(() => {
     setSwaggerReady(false);
     clearTimeout(previewTimeoutRef.current);
+
+    if (!content || !content.trim()) {
+      setPreviewError('Unable to render preview: No API definition provided.');
+      return;
+    }
 
     const parseErr = getPreviewParseError(content);
     if (parseErr) {

--- a/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
@@ -1,11 +1,32 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import get from 'lodash/get';
+import jsyaml from 'js-yaml';
 import { useTheme } from 'providers/Theme';
 import { useSelector } from 'react-redux';
-import { IconDeviceFloppy, IconLoader2 } from '@tabler/icons';
+import { IconAlertCircle, IconDeviceFloppy, IconLoader2 } from '@tabler/icons';
 import CodeEditor from './FileEditor/CodeEditor/index';
 import Swagger from './Renderers/Swagger';
 import { useDragResize } from 'hooks/useDragResize';
+
+const PREVIEW_TIMEOUT_MS = 15000;
+
+const getPreviewParseError = (content) => {
+  if (!content || typeof content !== 'string') return null;
+  let parsed;
+  try {
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      parsed = jsyaml.load(content);
+    }
+  } catch {
+    return 'Unable to render preview: content is not valid YAML or JSON.';
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return 'Unable to render preview: content is not valid YAML or JSON.';
+  }
+  return null;
+};
 
 const MIN_LEFT_PANE_WIDTH = 300;
 const MIN_RIGHT_PANE_WIDTH = 450;
@@ -51,16 +72,35 @@ const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthC
     : { flex: '1 1 50%', minWidth: 0 };
 
   const [swaggerReady, setSwaggerReady] = useState(false);
+  const [previewError, setPreviewError] = useState(null);
+  const previewTimeoutRef = useRef(null);
 
   useEffect(() => {
     setSwaggerReady(false);
+    clearTimeout(previewTimeoutRef.current);
+
+    const parseErr = getPreviewParseError(content);
+    if (parseErr) {
+      setPreviewError(parseErr);
+      return;
+    }
+    setPreviewError(null);
+
+    previewTimeoutRef.current = setTimeout(() => {
+      setPreviewError('Preview timed out. The spec may be too large or contain unsupported content.');
+    }, PREVIEW_TIMEOUT_MS);
+
+    return () => clearTimeout(previewTimeoutRef.current);
   }, [content]);
 
   const handleSwaggerComplete = useCallback(() => {
     // Double rAF: wait for one full paint cycle so Swagger is actually on screen
     // before hiding the loader — avoids a flash of unrendered content.
     requestAnimationFrame(() => {
-      requestAnimationFrame(() => setSwaggerReady(true));
+      requestAnimationFrame(() => {
+        clearTimeout(previewTimeoutRef.current);
+        setSwaggerReady(true);
+      });
     });
   }, []);
 
@@ -101,19 +141,33 @@ const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthC
         className="api-spec-right-pane relative"
         style={{ flex: '1 1 50%', minWidth: 0 }}
       >
-        <div style={{ visibility: swaggerReady ? 'visible' : 'hidden', height: '100%' }}>
-          <Swagger spec={content} onComplete={handleSwaggerComplete} />
-        </div>
-        {!swaggerReady && (
+        {previewError ? (
           <div
-            className="absolute inset-0 flex items-center justify-center gap-2"
+            className="absolute inset-0 flex items-center justify-center p-8"
             style={{ background: theme.bg }}
           >
-            <div className="flex items-center justify-center gap-2 opacity-70">
-              <IconLoader2 size={20} className="animate-spin" />
-              <span>Generating preview…</span>
+            <div className="flex flex-col items-center gap-3 text-center opacity-70">
+              <IconAlertCircle size={28} strokeWidth={1.5} />
+              <span className="text-sm">{previewError}</span>
             </div>
           </div>
+        ) : (
+          <>
+            <div style={{ visibility: swaggerReady ? 'visible' : 'hidden', height: '100%' }}>
+              <Swagger spec={content} onComplete={handleSwaggerComplete} />
+            </div>
+            {!swaggerReady && (
+              <div
+                className="absolute inset-0 flex items-center justify-center gap-2"
+                style={{ background: theme.bg }}
+              >
+                <div className="flex items-center justify-center gap-2 opacity-70">
+                  <IconLoader2 size={20} className="animate-spin" />
+                  <span>Generating preview…</span>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
     </section>

--- a/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
@@ -16,16 +16,13 @@ const getPreviewParseError = (content) => {
   if (!content || typeof content !== 'string') return null;
   let parsed;
   try {
-    try {
-      parsed = JSON.parse(content);
-    } catch {
-      parsed = jsyaml.load(content);
-    }
+    parsed = JSON.parse(content);
   } catch {
-    return SPEC_PREVIEW_ERRORS.INVALID_YAML_JSON;
-  }
-  if (!parsed || typeof parsed !== 'object') {
-    return SPEC_PREVIEW_ERRORS.INVALID_OPENAPI;
+    try {
+      parsed = jsyaml.load(content);
+    } catch {
+      return SPEC_PREVIEW_ERRORS.INVALID_YAML_JSON;
+    }
   }
   if (!isOpenApiSpec(parsed)) {
     return SPEC_PREVIEW_ERRORS.INVALID_OPENAPI;

--- a/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
@@ -8,6 +8,7 @@ import { isOpenApiSpec } from 'utils/importers/openapi-collection';
 import CodeEditor from './FileEditor/CodeEditor/index';
 import Swagger from './Renderers/Swagger';
 import { useDragResize } from 'hooks/useDragResize';
+import { SPEC_PREVIEW_ERRORS } from './constants';
 
 const PREVIEW_TIMEOUT_MS = 15000;
 
@@ -21,13 +22,13 @@ const getPreviewParseError = (content) => {
       parsed = jsyaml.load(content);
     }
   } catch {
-    return 'Unable to render preview: content is not a valid YAML or JSON.';
+    return SPEC_PREVIEW_ERRORS.INVALID_YAML_JSON;
   }
   if (!parsed || typeof parsed !== 'object') {
-    return 'Unable to render preview: content is not a valid OpenAPI specification.';
+    return SPEC_PREVIEW_ERRORS.INVALID_OPENAPI;
   }
   if (!isOpenApiSpec(parsed)) {
-    return 'Unable to render preview: content is not a valid OpenAPI specification.';
+    return SPEC_PREVIEW_ERRORS.INVALID_OPENAPI;
   }
   return null;
 };
@@ -84,7 +85,7 @@ const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthC
     clearTimeout(previewTimeoutRef.current);
 
     if (!content || !content.trim()) {
-      setPreviewError('Unable to render preview: No API definition provided.');
+      setPreviewError(SPEC_PREVIEW_ERRORS.EMPTY);
       return;
     }
 
@@ -96,7 +97,7 @@ const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthC
     setPreviewError(null);
 
     previewTimeoutRef.current = setTimeout(() => {
-      setPreviewError('Preview timed out. The spec may be too large or contain unsupported content.');
+      setPreviewError(SPEC_PREVIEW_ERRORS.TIMEOUT);
     }, PREVIEW_TIMEOUT_MS);
 
     return () => clearTimeout(previewTimeoutRef.current);

--- a/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
@@ -4,6 +4,7 @@ import jsyaml from 'js-yaml';
 import { useTheme } from 'providers/Theme';
 import { useSelector } from 'react-redux';
 import { IconAlertCircle, IconDeviceFloppy, IconLoader2 } from '@tabler/icons';
+import { isOpenApiSpec } from 'utils/importers/openapi-collection';
 import CodeEditor from './FileEditor/CodeEditor/index';
 import Swagger from './Renderers/Swagger';
 import { useDragResize } from 'hooks/useDragResize';
@@ -23,6 +24,9 @@ const getPreviewParseError = (content) => {
     return 'Unable to render preview: content is not a valid YAML or JSON.';
   }
   if (!parsed || typeof parsed !== 'object') {
+    return 'Unable to render preview: content is not a valid OpenAPI specification.';
+  }
+  if (!isOpenApiSpec(parsed)) {
     return 'Unable to render preview: content is not a valid OpenAPI specification.';
   }
   return null;

--- a/packages/bruno-app/src/components/ApiSpecPanel/constants.ts
+++ b/packages/bruno-app/src/components/ApiSpecPanel/constants.ts
@@ -1,0 +1,6 @@
+export const SPEC_PREVIEW_ERRORS = {
+  EMPTY: 'Unable to render preview: No API definition provided.',
+  INVALID_YAML_JSON: 'Unable to render preview: content is not a valid YAML or JSON.',
+  INVALID_OPENAPI: 'Unable to render preview: content is not a valid OpenAPI specification.',
+  TIMEOUT: 'Preview timed out. The spec may be too large or contain unsupported content.'
+} as const;

--- a/packages/bruno-app/src/utils/importers/openapi-collection.js
+++ b/packages/bruno-app/src/utils/importers/openapi-collection.js
@@ -11,6 +11,10 @@ export const convertOpenapiToBruno = (data, options = {}) => {
 };
 
 export const isOpenApiSpec = (data) => {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+
   if (typeof data.info !== 'object' || data.info === null) {
     return false;
   }

--- a/packages/bruno-electron/src/app/apiSpecs.js
+++ b/packages/bruno-electron/src/app/apiSpecs.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 const { dialog, ipcMain } = require('electron');
 const { normalizeAndResolvePath } = require('../utils/filesystem');
 const { generateUidBasedOnHash } = require('../utils/common');
@@ -10,6 +11,33 @@ const {
 } = require('../utils/workspace-config');
 
 const DEFAULT_WORKSPACE_NAME = 'My Workspace';
+
+const VALID_API_SPEC_EXTENSIONS = ['.yaml', '.yml', '.json'];
+
+const validateApiSpec = (filePath) => {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!VALID_API_SPEC_EXTENSIONS.includes(ext)) {
+    throw new Error('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.');
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  let parsed;
+  try {
+    parsed = ext === '.json' ? JSON.parse(content) : yaml.load(content);
+  } catch {
+    throw new Error('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.');
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.');
+  }
+
+  const hasSpecVersion = typeof parsed.openapi === 'string' || typeof parsed.swagger === 'string';
+  if (!hasSpecVersion || typeof parsed.info !== 'object' || parsed.info === null) {
+    throw new Error('Invalid OpenAPI spec. The file must contain a valid OpenAPI (3.x) or Swagger (2.0) specification.');
+  }
+};
 
 const prepareWorkspaceConfigForClient = (workspaceConfig, isDefault) => {
   if (isDefault) {
@@ -24,7 +52,8 @@ const prepareWorkspaceConfigForClient = (workspaceConfig, isDefault) => {
 
 const openApiSpecDialog = async (win, watcher, options = {}) => {
   const { filePaths } = await dialog.showOpenDialog(win, {
-    properties: ['openFile', 'createFile']
+    properties: ['openFile', 'createFile'],
+    filters: [{ name: 'OpenAPI Spec', extensions: ['yaml', 'yml', 'json'] }]
   });
 
   if (filePaths && filePaths[0]) {
@@ -39,6 +68,8 @@ const openApiSpecDialog = async (win, watcher, options = {}) => {
 
 const openApiSpec = async (win, watcher, apiSpecPath, options = {}) => {
   try {
+    validateApiSpec(apiSpecPath);
+
     const uid = generateUidBasedOnHash(apiSpecPath);
 
     if (options.workspacePath) {
@@ -97,7 +128,7 @@ const openApiSpec = async (win, watcher, apiSpecPath, options = {}) => {
   } catch (err) {
     if (!options.dontSendDisplayErrors) {
       win.webContents.send('main:display-error', {
-        error: err.message || 'An error occurred while opening the apiSpec'
+        message: err.message || 'An error occurred while opening the apiSpec'
       });
     }
   }

--- a/packages/bruno-electron/src/app/apiSpecs.js
+++ b/packages/bruno-electron/src/app/apiSpecs.js
@@ -19,24 +19,6 @@ const validateApiSpec = (filePath) => {
   if (!VALID_API_SPEC_EXTENSIONS.includes(ext)) {
     throw new Error('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.');
   }
-
-  const content = fs.readFileSync(filePath, 'utf8');
-
-  let parsed;
-  try {
-    parsed = ext === '.json' ? JSON.parse(content) : yaml.load(content);
-  } catch {
-    throw new Error('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.');
-  }
-
-  if (!parsed || typeof parsed !== 'object') {
-    throw new Error('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.');
-  }
-
-  const hasSpecVersion = typeof parsed.openapi === 'string' || typeof parsed.swagger === 'string';
-  if (!hasSpecVersion || typeof parsed.info !== 'object' || parsed.info === null) {
-    throw new Error('Invalid OpenAPI spec. The file must contain a valid OpenAPI (3.x) or Swagger (2.0) specification.');
-  }
 };
 
 const prepareWorkspaceConfigForClient = (workspaceConfig, isDefault) => {
@@ -116,10 +98,14 @@ const openApiSpec = async (win, watcher, apiSpecPath, options = {}) => {
         json: (() => {
           const ext = require('path').extname(apiSpecPath).toLowerCase();
           const content = require('fs').readFileSync(apiSpecPath, 'utf8');
-          if (ext === '.yaml' || ext === '.yml') {
-            return require('js-yaml').load(content);
-          } else if (ext === '.json') {
-            return JSON.parse(content);
+          try {
+            if (ext === '.yaml' || ext === '.yml') {
+              return require('js-yaml').load(content);
+            } else if (ext === '.json') {
+              return JSON.parse(content);
+            }
+          } catch {
+            return null;
           }
           return null;
         })()

--- a/packages/bruno-electron/src/app/apiSpecs.js
+++ b/packages/bruno-electron/src/app/apiSpecs.js
@@ -1,9 +1,9 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { dialog, ipcMain } = require('electron');
 const { normalizeAndResolvePath } = require('../utils/filesystem');
 const { generateUidBasedOnHash } = require('../utils/common');
-const { parseApiSpecContent, rawContent } = require('../utils/apiSpecs');
+const { parseApiSpecContent } = require('../utils/apiSpecs');
 const {
   addApiSpecToWorkspace,
   readWorkspaceConfig,
@@ -92,13 +92,16 @@ const openApiSpec = async (win, watcher, apiSpecPath, options = {}) => {
     if (!watcher.hasWatcher(apiSpecPath)) {
       ipcMain.emit('main:apispec-opened', win, apiSpecPath, uid, options.workspacePath);
     } else {
+      const rawContent = fs.readFileSync(apiSpecPath, 'utf8');
+      const extension = path.extname(apiSpecPath);
+
       win.webContents.send('main:apispec-tree-updated', 'addFile', {
         pathname: apiSpecPath,
         uid: uid,
-        raw: rawContent(apiSpecPath),
+        raw: rawContent,
         name: path.basename(apiSpecPath, path.extname(apiSpecPath)),
         filename: path.basename(apiSpecPath),
-        json: parseApiSpecContent(apiSpecPath)
+        json: parseApiSpecContent(rawContent, extension)
       });
     }
   } catch (err) {

--- a/packages/bruno-electron/src/app/apiSpecs.js
+++ b/packages/bruno-electron/src/app/apiSpecs.js
@@ -12,12 +12,15 @@ const {
 
 const DEFAULT_WORKSPACE_NAME = 'My Workspace';
 
+const INVALID_EXTENSION_MESSAGE
+  = 'Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.';
+
 const VALID_API_SPEC_EXTENSIONS = ['.yaml', '.yml', '.json'];
 
 const validateApiSpec = (filePath) => {
   const ext = path.extname(filePath).toLowerCase();
   if (!VALID_API_SPEC_EXTENSIONS.includes(ext)) {
-    throw new Error('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.');
+    throw new Error(INVALID_EXTENSION_MESSAGE);
   }
 };
 
@@ -122,5 +125,6 @@ const openApiSpec = async (win, watcher, apiSpecPath, options = {}) => {
 
 module.exports = {
   openApiSpec,
-  openApiSpecDialog
+  openApiSpecDialog,
+  INVALID_EXTENSION_MESSAGE
 };

--- a/packages/bruno-electron/src/app/apiSpecs.js
+++ b/packages/bruno-electron/src/app/apiSpecs.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const path = require('path');
-const yaml = require('js-yaml');
 const { dialog, ipcMain } = require('electron');
 const { normalizeAndResolvePath } = require('../utils/filesystem');
 const { generateUidBasedOnHash } = require('../utils/common');
+const { parseApiSpecContent, rawContent } = require('../utils/apiSpecs');
 const {
   addApiSpecToWorkspace,
   readWorkspaceConfig,
@@ -95,23 +95,10 @@ const openApiSpec = async (win, watcher, apiSpecPath, options = {}) => {
       win.webContents.send('main:apispec-tree-updated', 'addFile', {
         pathname: apiSpecPath,
         uid: uid,
-        raw: require('fs').readFileSync(apiSpecPath, 'utf8'),
-        name: require('path').basename(apiSpecPath, require('path').extname(apiSpecPath)),
-        filename: require('path').basename(apiSpecPath),
-        json: (() => {
-          const ext = require('path').extname(apiSpecPath).toLowerCase();
-          const content = require('fs').readFileSync(apiSpecPath, 'utf8');
-          try {
-            if (ext === '.yaml' || ext === '.yml') {
-              return require('js-yaml').load(content);
-            } else if (ext === '.json') {
-              return JSON.parse(content);
-            }
-          } catch {
-            return null;
-          }
-          return null;
-        })()
+        raw: rawContent(apiSpecPath),
+        name: path.basename(apiSpecPath, path.extname(apiSpecPath)),
+        filename: path.basename(apiSpecPath),
+        json: parseApiSpecContent(apiSpecPath)
       });
     }
   } catch (err) {

--- a/packages/bruno-electron/src/app/apiSpecsWatcher.js
+++ b/packages/bruno-electron/src/app/apiSpecsWatcher.js
@@ -17,7 +17,11 @@ const parseApiSpecContent = (pathname) => {
   let content = fs.readFileSync(pathname, 'utf8');
 
   if (extension === '.yaml' || extension === '.yml') {
-    return yaml.load(content);
+    try {
+      return yaml.load(content);
+    } catch {
+      return null;
+    }
   } else if (extension === '.json') {
     return safeParseJSON(content);
   }

--- a/packages/bruno-electron/src/app/apiSpecsWatcher.js
+++ b/packages/bruno-electron/src/app/apiSpecsWatcher.js
@@ -1,9 +1,10 @@
 const _ = require('lodash');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const chokidar = require('chokidar');
 const { getApiSpecUid } = require('../cache/apiSpecUids');
 const { isDirectory } = require('../utils/filesystem');
-const { parseApiSpecContent, rawContent } = require('../utils/apiSpecs');
+const { parseApiSpecContent } = require('../utils/apiSpecs');
 
 const hasApiSpecExtension = (filename) => {
   if (!filename || typeof filename !== 'string') return false;
@@ -20,9 +21,11 @@ const add = async (win, pathname) => {
   try {
     const basename = path.basename(pathname);
     const file = {};
-    const apiSpecContent = parseApiSpecContent(pathname);
+    const raw = fs.readFileSync(pathname, 'utf8');
+    const extension = path.extname(pathname);
+    const apiSpecContent = parseApiSpecContent(raw, extension);
 
-    file.raw = rawContent(pathname);
+    file.raw = raw;
     file.name = apiSpecContent?.info?.title || basename.split('.')[0];
     file.filename = basename;
     file.pathname = pathname;
@@ -39,9 +42,11 @@ const change = async (win, pathname) => {
   try {
     const basename = path.basename(pathname);
     const file = {};
-    const apiSpecContent = parseApiSpecContent(pathname);
+    const raw = fs.readFileSync(pathname, 'utf8');
+    const extension = path.extname(pathname);
+    const apiSpecContent = parseApiSpecContent(raw, extension);
 
-    file.raw = rawContent(pathname);
+    file.raw = raw;
     file.name = apiSpecContent?.info?.title || basename.split('.')[0];
     file.filename = basename;
     file.pathname = pathname;

--- a/packages/bruno-electron/src/app/apiSpecsWatcher.js
+++ b/packages/bruno-electron/src/app/apiSpecsWatcher.js
@@ -5,7 +5,6 @@ const chokidar = require('chokidar');
 const { getApiSpecUid } = require('../cache/apiSpecUids');
 const yaml = require('js-yaml');
 const { isDirectory } = require('../utils/filesystem');
-const { safeParseJSON } = require('../utils/common');
 
 const hasApiSpecExtension = (filename) => {
   if (!filename || typeof filename !== 'string') return false;
@@ -23,7 +22,11 @@ const parseApiSpecContent = (pathname) => {
       return null;
     }
   } else if (extension === '.json') {
-    return safeParseJSON(content);
+    try {
+      return JSON.parse(content);
+    } catch {
+      return null;
+    }
   }
   return null;
 };

--- a/packages/bruno-electron/src/app/apiSpecsWatcher.js
+++ b/packages/bruno-electron/src/app/apiSpecsWatcher.js
@@ -1,34 +1,13 @@
 const _ = require('lodash');
-const fs = require('fs');
 const path = require('path');
 const chokidar = require('chokidar');
 const { getApiSpecUid } = require('../cache/apiSpecUids');
-const yaml = require('js-yaml');
 const { isDirectory } = require('../utils/filesystem');
+const { parseApiSpecContent, rawContent } = require('../utils/apiSpecs');
 
 const hasApiSpecExtension = (filename) => {
   if (!filename || typeof filename !== 'string') return false;
   return ['yaml', 'yml', 'json'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
-};
-
-const parseApiSpecContent = (pathname) => {
-  const extension = path.extname(pathname).toLowerCase();
-  let content = fs.readFileSync(pathname, 'utf8');
-
-  if (extension === '.yaml' || extension === '.yml') {
-    try {
-      return yaml.load(content);
-    } catch {
-      return null;
-    }
-  } else if (extension === '.json') {
-    try {
-      return JSON.parse(content);
-    } catch {
-      return null;
-    }
-  }
-  return null;
 };
 
 const hydrateApiSpecWithUuid = (apiSpec, pathname) => {
@@ -43,7 +22,7 @@ const add = async (win, pathname) => {
     const file = {};
     const apiSpecContent = parseApiSpecContent(pathname);
 
-    file.raw = fs.readFileSync(pathname, 'utf8');
+    file.raw = rawContent(pathname);
     file.name = apiSpecContent?.info?.title || basename.split('.')[0];
     file.filename = basename;
     file.pathname = pathname;
@@ -62,7 +41,7 @@ const change = async (win, pathname) => {
     const file = {};
     const apiSpecContent = parseApiSpecContent(pathname);
 
-    file.raw = fs.readFileSync(pathname, 'utf8');
+    file.raw = rawContent(pathname);
     file.name = apiSpecContent?.info?.title || basename.split('.')[0];
     file.filename = basename;
     file.pathname = pathname;

--- a/packages/bruno-electron/src/utils/apiSpecs.js
+++ b/packages/bruno-electron/src/utils/apiSpecs.js
@@ -1,19 +1,12 @@
-const fs = require('fs');
-const path = require('path');
 const yaml = require('js-yaml');
 
-const rawContent = (pathname) => {
-  return fs.readFileSync(pathname, 'utf8');
-};
-
-const parseApiSpecContent = (pathname) => {
-  const extension = path.extname(pathname).toLowerCase();
-  const content = rawContent(pathname);
+const parseApiSpecContent = (content, extension) => {
+  const ext = (extension || '').toLowerCase();
 
   try {
-    if (extension === '.yaml' || extension === '.yml') {
+    if (ext === '.yaml' || ext === '.yml') {
       return yaml.load(content);
-    } else if (extension === '.json') {
+    } else if (ext === '.json') {
       return JSON.parse(content);
     }
   } catch {
@@ -23,4 +16,4 @@ const parseApiSpecContent = (pathname) => {
   return null;
 };
 
-module.exports = { parseApiSpecContent, rawContent };
+module.exports = { parseApiSpecContent };

--- a/packages/bruno-electron/src/utils/apiSpecs.js
+++ b/packages/bruno-electron/src/utils/apiSpecs.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const rawContent = (pathname) => {
+  return fs.readFileSync(pathname, 'utf8');
+};
+
+const parseApiSpecContent = (pathname) => {
+  const extension = path.extname(pathname).toLowerCase();
+  const content = rawContent(pathname);
+
+  try {
+    if (extension === '.yaml' || extension === '.yml') {
+      return yaml.load(content);
+    } else if (extension === '.json') {
+      return JSON.parse(content);
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+};
+
+module.exports = { parseApiSpecContent, rawContent };

--- a/packages/bruno-electron/tests/app/apiSpecs.spec.js
+++ b/packages/bruno-electron/tests/app/apiSpecs.spec.js
@@ -90,4 +90,18 @@ describe('openApiSpec', () => {
     );
     expect(win.webContents.send).not.toHaveBeenCalledWith('main:display-error', expect.anything());
   });
+
+  test('opens a broken JSON file with a valid extension without throwing, resolving json to null', async () => {
+    const specPath = writeSpecFile('broken.json', '{\n  "openapi": "3.0.0",\n  "info": {\n    "title": "Test"\n    "version": "1.0.0"\n  },\n  "paths": {\n');
+    watcher.hasWatcher.mockReturnValue(true);
+
+    await openApiSpec(win, watcher, specPath);
+
+    expect(win.webContents.send).toHaveBeenCalledWith(
+      'main:apispec-tree-updated',
+      'addFile',
+      expect.objectContaining({ pathname: specPath, json: null })
+    );
+    expect(win.webContents.send).not.toHaveBeenCalledWith('main:display-error', expect.anything());
+  });
 });

--- a/packages/bruno-electron/tests/app/apiSpecs.spec.js
+++ b/packages/bruno-electron/tests/app/apiSpecs.spec.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
+const { INVALID_EXTENSION_MESSAGE } = require('../../src/app/apiSpecs');
 
 jest.mock('electron', () => ({
   dialog: { showOpenDialog: jest.fn() },
@@ -39,7 +40,7 @@ describe('openApiSpec', () => {
       await openApiSpec(win, watcher, specPath);
 
       expect(win.webContents.send).toHaveBeenCalledWith('main:display-error', {
-        message: 'Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.'
+        message: INVALID_EXTENSION_MESSAGE
       });
       expect(ipcMain.emit).not.toHaveBeenCalled();
     }

--- a/packages/bruno-electron/tests/app/apiSpecs.spec.js
+++ b/packages/bruno-electron/tests/app/apiSpecs.spec.js
@@ -1,0 +1,92 @@
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+jest.mock('electron', () => ({
+  dialog: { showOpenDialog: jest.fn() },
+  ipcMain: { emit: jest.fn() }
+}));
+
+const { ipcMain } = require('electron');
+const { openApiSpec } = require('../../src/app/apiSpecs');
+
+describe('openApiSpec', () => {
+  let tmpDir;
+  let win;
+  let watcher;
+
+  const writeSpecFile = (filename, content) => {
+    const filePath = path.join(tmpDir, filename);
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-apispec-'));
+    win = { webContents: { send: jest.fn() } };
+    watcher = { hasWatcher: jest.fn() };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test.each(['spec.txt', 'spec.xml', 'spec', 'spec.yamlx'])(
+    'rejects a file with an unsupported extension (%s)',
+    async (filename) => {
+      const specPath = writeSpecFile(filename, 'This is a plain text file, not an OpenAPI spec.');
+
+      await openApiSpec(win, watcher, specPath);
+
+      expect(win.webContents.send).toHaveBeenCalledWith('main:display-error', {
+        message: 'Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.'
+      });
+      expect(ipcMain.emit).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each(['openapi.yaml', 'openapi.yml', 'openapi.json', 'openapi.YAML', 'openapi.Json'])(
+    'accepts a file with a supported extension (%s)',
+    async (filename) => {
+      const specPath = writeSpecFile(filename, '{}');
+      watcher.hasWatcher.mockReturnValue(false);
+
+      await openApiSpec(win, watcher, specPath);
+
+      expect(win.webContents.send).not.toHaveBeenCalledWith('main:display-error', expect.anything());
+      expect(ipcMain.emit).toHaveBeenCalledWith('main:apispec-opened', win, specPath, expect.any(String), undefined);
+    }
+  );
+
+  test('does not send a display error when dontSendDisplayErrors is set', async () => {
+    const specPath = writeSpecFile('spec.txt', 'not a spec');
+
+    await openApiSpec(win, watcher, specPath, { dontSendDisplayErrors: true });
+
+    expect(win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  test('opens a valid spec by emitting main:apispec-opened', async () => {
+    const specPath = writeSpecFile('openapi.yaml', 'openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n');
+    watcher.hasWatcher.mockReturnValue(false);
+
+    await openApiSpec(win, watcher, specPath);
+
+    expect(ipcMain.emit).toHaveBeenCalledWith('main:apispec-opened', win, specPath, expect.any(String), undefined);
+    expect(win.webContents.send).not.toHaveBeenCalledWith('main:display-error', expect.anything());
+  });
+
+  test('opens a malformed file with a valid extension without throwing, resolving json to null', async () => {
+    const specPath = writeSpecFile('malformed.yaml', 'openapi: 3.0.0\ninfo:\n  title: Test\n   version: : :\npaths: [');
+    watcher.hasWatcher.mockReturnValue(true);
+
+    await openApiSpec(win, watcher, specPath);
+
+    expect(win.webContents.send).toHaveBeenCalledWith(
+      'main:apispec-tree-updated',
+      'addFile',
+      expect.objectContaining({ pathname: specPath, json: null })
+    );
+    expect(win.webContents.send).not.toHaveBeenCalledWith('main:display-error', expect.anything());
+  });
+});

--- a/tests/import/openapi/api-spec-panel-validation.spec.ts
+++ b/tests/import/openapi/api-spec-panel-validation.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../../playwright';
 import * as path from 'path';
+import { openApiSpecFromDialog, openApiSpecSidebarItem } from '../../utils/page/openapi/render-spec';
 import { SPEC_PREVIEW_ERRORS } from '../../../packages/bruno-app/src/components/ApiSpecPanel/constants';
 import { INVALID_EXTENSION_MESSAGE } from '../../../packages/bruno-electron/src/app/apiSpecs';
 
@@ -19,105 +20,55 @@ test.describe('API Spec Panel - open & preview validation', () => {
 
   test('Reject a file with an unsupported extension', async ({ page, electronApp }) => {
     const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-invalid-extension.txt');
-
-    // Mock the native file dialog to return the fixture path
-    await electronApp.evaluate(({ dialog }, openApiFile) => {
-      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
-    }, openApiFile);
-
-    await page.getByTestId('api-specs-header-add-menu').click();
-    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
-
+    await openApiSpecFromDialog(page, electronApp, openApiFile);
     await expect(
       page.getByText(INVALID_EXTENSION_MESSAGE)
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible();
   });
 
   test('Show the empty-spec message when opening an empty file', async ({ page, electronApp }) => {
     const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-empty.yaml');
-
-    await electronApp.evaluate(({ dialog }, openApiFile) => {
-      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
-    }, openApiFile);
-
-    await page.getByTestId('api-specs-header-add-menu').click();
-    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
-
-    // Opened spec shows up in the sidebar; click it to render the preview pane
-    await page.locator('.api-spec-item').filter({ hasText: 'openapi-empty' }).click();
-
-    await expect(page.getByText(SPEC_PREVIEW_ERRORS.EMPTY)).toBeVisible({
-      timeout: 10000
-    });
+    await openApiSpecFromDialog(page, electronApp, openApiFile);
+    await openApiSpecSidebarItem(page, 'openapi-empty');
+    await expect(page.getByText(SPEC_PREVIEW_ERRORS.EMPTY)).toBeVisible();
   });
 
   test('Show a parse error when opening malformed YAML', async ({ page, electronApp }) => {
     const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-malformed.yaml');
-
-    await electronApp.evaluate(({ dialog }, openApiFile) => {
-      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
-    }, openApiFile);
-
-    await page.getByTestId('api-specs-header-add-menu').click();
-    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
-
-    await page.locator('.api-spec-item').filter({ hasText: 'openapi-malformed' }).click();
-
+    await openApiSpecFromDialog(page, electronApp, openApiFile);
+    await openApiSpecSidebarItem(page, 'openapi-malformed');
     await expect(
       page.getByText(SPEC_PREVIEW_ERRORS.INVALID_YAML_JSON)
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible();
   });
 
   test('Show a parse error when opening malformed JSON', async ({ page, electronApp }) => {
     const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-broken.json');
-
-    await electronApp.evaluate(({ dialog }, openApiFile) => {
-      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
-    }, openApiFile);
-
-    await page.getByTestId('api-specs-header-add-menu').click();
-    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
-
-    await page.locator('.api-spec-item').filter({ hasText: 'openapi-broken' }).click();
-
+    await openApiSpecFromDialog(page, electronApp, openApiFile);
+    await openApiSpecSidebarItem(page, 'openapi-broken');
     await expect(
       page.getByText(SPEC_PREVIEW_ERRORS.INVALID_YAML_JSON)
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible();
   });
 
   test('Show a spec error when the file parses but is not a valid OpenAPI document', async ({ page, electronApp }) => {
     const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-missing-info.yaml');
 
-    await electronApp.evaluate(({ dialog }, openApiFile) => {
-      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
-    }, openApiFile);
-
-    await page.getByTestId('api-specs-header-add-menu').click();
-    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
-
-    await page.locator('.api-spec-item').filter({ hasText: 'openapi-missing-info' }).click();
-
+    await openApiSpecFromDialog(page, electronApp, openApiFile);
+    await openApiSpecSidebarItem(page, 'openapi-missing-info');
     // Parses as an object but lacks the openapi/swagger + info contract, so it must fail
     // fast with a precise message rather than falling through to the preview timeout.
     await expect(
       page.getByText(SPEC_PREVIEW_ERRORS.INVALID_OPENAPI)
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible();
   });
 
   test('Render a valid spec without any preview error', async ({ page, electronApp }) => {
     const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-simple.json');
-
-    await electronApp.evaluate(({ dialog }, openApiFile) => {
-      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
-    }, openApiFile);
-
-    await page.getByTestId('api-specs-header-add-menu').click();
-    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
-
-    await page.locator('.api-spec-item').filter({ hasText: 'Simple Test API' }).click();
-
+    await openApiSpecFromDialog(page, electronApp, openApiFile);
+    await openApiSpecSidebarItem(page, 'Simple Test API');
     // Panel opens for the valid spec (filename shown in the header) and no preview error appears
-    await expect(page.getByText('openapi-simple.json')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('openapi-simple.json')).toBeVisible();
     await expect(page.getByText(/Unable to render preview/i)).toHaveCount(0);
   });
 });

--- a/tests/import/openapi/api-spec-panel-validation.spec.ts
+++ b/tests/import/openapi/api-spec-panel-validation.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+
+test.describe('API Spec Panel - open & preview validation', () => {
+  let originalShowOpenDialog: any;
+
+  test.beforeAll(async ({ electronApp }) => {
+    // save the original showOpenDialog function
+    await electronApp.evaluate(({ dialog }) => {
+      originalShowOpenDialog = dialog.showOpenDialog;
+    });
+  });
+
+  test.afterAll(async ({ electronApp }) => {
+    // restore the original showOpenDialog function
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = originalShowOpenDialog;
+    });
+  });
+
+  test('Reject a file with an unsupported extension', async ({ page, electronApp }) => {
+    const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-invalid-extension.txt');
+
+    // Mock the native file dialog to return the fixture path
+    await electronApp.evaluate(({ dialog }, openApiFile) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
+    }, openApiFile);
+
+    await page.getByTestId('api-specs-header-add-menu').click();
+    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
+
+    await expect(
+      page.getByText('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.')
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Show the empty-spec message when opening an empty file', async ({ page, electronApp }) => {
+    const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-empty.yaml');
+
+    await electronApp.evaluate(({ dialog }, openApiFile) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
+    }, openApiFile);
+
+    await page.getByTestId('api-specs-header-add-menu').click();
+    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
+
+    // Opened spec shows up in the sidebar; click it to render the preview pane
+    await page.locator('.api-spec-item').filter({ hasText: 'openapi-empty' }).click();
+
+    await expect(page.getByText('Unable to render preview: No API definition provided.')).toBeVisible({
+      timeout: 10000
+    });
+  });
+
+  test('Show a parse error when opening malformed YAML', async ({ page, electronApp }) => {
+    const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-malformed.yaml');
+
+    await electronApp.evaluate(({ dialog }, openApiFile) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
+    }, openApiFile);
+
+    await page.getByTestId('api-specs-header-add-menu').click();
+    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
+
+    await page.locator('.api-spec-item').filter({ hasText: 'openapi-malformed' }).click();
+
+    await expect(
+      page.getByText('Unable to render preview: content is not a valid YAML or JSON.')
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Show a spec error when the file parses but is not a valid OpenAPI document', async ({ page, electronApp }) => {
+    const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-missing-info.yaml');
+
+    await electronApp.evaluate(({ dialog }, openApiFile) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
+    }, openApiFile);
+
+    await page.getByTestId('api-specs-header-add-menu').click();
+    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
+
+    await page.locator('.api-spec-item').filter({ hasText: 'openapi-missing-info' }).click();
+
+    // Parses as an object but lacks the openapi/swagger + info contract, so it must fail
+    // fast with a precise message rather than falling through to the preview timeout.
+    await expect(
+      page.getByText('Unable to render preview: content is not a valid OpenAPI specification.')
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Render a valid spec without any preview error', async ({ page, electronApp }) => {
+    const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-simple.json');
+
+    await electronApp.evaluate(({ dialog }, openApiFile) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
+    }, openApiFile);
+
+    await page.getByTestId('api-specs-header-add-menu').click();
+    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
+
+    await page.locator('.api-spec-item').filter({ hasText: 'Simple Test API' }).click();
+
+    // Panel opens for the valid spec (filename shown in the header) and no preview error appears
+    await expect(page.getByText('openapi-simple.json')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/Unable to render preview/)).toHaveCount(0);
+  });
+});

--- a/tests/import/openapi/api-spec-panel-validation.spec.ts
+++ b/tests/import/openapi/api-spec-panel-validation.spec.ts
@@ -68,6 +68,23 @@ test.describe('API Spec Panel - open & preview validation', () => {
     ).toBeVisible({ timeout: 10000 });
   });
 
+  test('Show a parse error when opening malformed JSON', async ({ page, electronApp }) => {
+    const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-broken.json');
+
+    await electronApp.evaluate(({ dialog }, openApiFile) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [openApiFile] });
+    }, openApiFile);
+
+    await page.getByTestId('api-specs-header-add-menu').click();
+    await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
+
+    await page.locator('.api-spec-item').filter({ hasText: 'openapi-broken' }).click();
+
+    await expect(
+      page.getByText(SPEC_PREVIEW_ERRORS.INVALID_YAML_JSON)
+    ).toBeVisible({ timeout: 10000 });
+  });
+
   test('Show a spec error when the file parses but is not a valid OpenAPI document', async ({ page, electronApp }) => {
     const openApiFile = path.resolve(__dirname, 'fixtures', 'openapi-missing-info.yaml');
 

--- a/tests/import/openapi/api-spec-panel-validation.spec.ts
+++ b/tests/import/openapi/api-spec-panel-validation.spec.ts
@@ -1,20 +1,19 @@
 import { test, expect } from '../../../playwright';
 import * as path from 'path';
+import { SPEC_PREVIEW_ERRORS } from '../../../packages/bruno-app/src/components/ApiSpecPanel/constants';
+import { INVALID_EXTENSION_MESSAGE } from '../../../packages/bruno-electron/src/app/apiSpecs';
 
 test.describe('API Spec Panel - open & preview validation', () => {
-  let originalShowOpenDialog: any;
-
   test.beforeAll(async ({ electronApp }) => {
-    // save the original showOpenDialog function
     await electronApp.evaluate(({ dialog }) => {
-      originalShowOpenDialog = dialog.showOpenDialog;
+      (dialog as any).__savedShowOpenDialog = dialog.showOpenDialog;
     });
   });
 
   test.afterAll(async ({ electronApp }) => {
-    // restore the original showOpenDialog function
     await electronApp.evaluate(({ dialog }) => {
-      dialog.showOpenDialog = originalShowOpenDialog;
+      dialog.showOpenDialog = (dialog as any).__savedShowOpenDialog;
+      delete (dialog as any).__savedShowOpenDialog;
     });
   });
 
@@ -30,7 +29,7 @@ test.describe('API Spec Panel - open & preview validation', () => {
     await page.getByTestId('api-specs-header-add-menu-open-api-spec').click();
 
     await expect(
-      page.getByText('Invalid file format. Please select a valid OpenAPI spec in YAML or JSON format.')
+      page.getByText(INVALID_EXTENSION_MESSAGE)
     ).toBeVisible({ timeout: 10000 });
   });
 
@@ -47,7 +46,7 @@ test.describe('API Spec Panel - open & preview validation', () => {
     // Opened spec shows up in the sidebar; click it to render the preview pane
     await page.locator('.api-spec-item').filter({ hasText: 'openapi-empty' }).click();
 
-    await expect(page.getByText('Unable to render preview: No API definition provided.')).toBeVisible({
+    await expect(page.getByText(SPEC_PREVIEW_ERRORS.EMPTY)).toBeVisible({
       timeout: 10000
     });
   });
@@ -65,7 +64,7 @@ test.describe('API Spec Panel - open & preview validation', () => {
     await page.locator('.api-spec-item').filter({ hasText: 'openapi-malformed' }).click();
 
     await expect(
-      page.getByText('Unable to render preview: content is not a valid YAML or JSON.')
+      page.getByText(SPEC_PREVIEW_ERRORS.INVALID_YAML_JSON)
     ).toBeVisible({ timeout: 10000 });
   });
 
@@ -84,7 +83,7 @@ test.describe('API Spec Panel - open & preview validation', () => {
     // Parses as an object but lacks the openapi/swagger + info contract, so it must fail
     // fast with a precise message rather than falling through to the preview timeout.
     await expect(
-      page.getByText('Unable to render preview: content is not a valid OpenAPI specification.')
+      page.getByText(SPEC_PREVIEW_ERRORS.INVALID_OPENAPI)
     ).toBeVisible({ timeout: 10000 });
   });
 
@@ -102,6 +101,6 @@ test.describe('API Spec Panel - open & preview validation', () => {
 
     // Panel opens for the valid spec (filename shown in the header) and no preview error appears
     await expect(page.getByText('openapi-simple.json')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(/Unable to render preview/)).toHaveCount(0);
+    await expect(page.getByText(/Unable to render preview/i)).toHaveCount(0);
   });
 });

--- a/tests/import/openapi/fixtures/openapi-broken.json
+++ b/tests/import/openapi/fixtures/openapi-broken.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Malformed OpenAPI"
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "summary": "Test endpoint",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/import/openapi/fixtures/openapi-invalid-extension.txt
+++ b/tests/import/openapi/fixtures/openapi-invalid-extension.txt
@@ -1,0 +1,1 @@
+This is a plain text file, not an OpenAPI spec.

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -1,7 +1,11 @@
 import { Page, Locator } from '../../../playwright';
+import { buildApiSpecPanelLocators } from './openapi/render-spec';
 
 export const buildCommonLocators = (page: Page) => ({
   runner: () => page.getByTestId('run-button'),
+  openApi: {
+    render: buildApiSpecPanelLocators(page)
+  },
   saveButton: () => page
     .locator('.infotip')
     .filter({ hasText: /^Save/ }),

--- a/tests/utils/page/openapi/render-spec.ts
+++ b/tests/utils/page/openapi/render-spec.ts
@@ -1,0 +1,30 @@
+import { test, Page, ElectronApplication } from '../../../../playwright';
+
+export const buildApiSpecPanelLocators = (page: Page) => ({
+  addMenuButton: () => page.getByTestId('api-specs-header-add-menu'),
+  openApiSpecMenuItem: () => page.getByTestId('api-specs-header-add-menu-open-api-spec'),
+  sidebarItem: (name: string) => page.locator('.api-spec-item').filter({ hasText: name })
+});
+
+export const openApiSpecFromDialog = async (
+  page: Page,
+  electronApp: ElectronApplication,
+  filePath: string
+): Promise<void> => {
+  await test.step(`Open API spec from path: ${filePath}`, async () => {
+    await electronApp.evaluate(({ dialog }, filePath) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [filePath] });
+    }, filePath);
+
+    const { addMenuButton, openApiSpecMenuItem } = buildApiSpecPanelLocators(page);
+    await addMenuButton().click();
+    await openApiSpecMenuItem().click();
+  });
+};
+
+export const openApiSpecSidebarItem = async (page: Page, name: string): Promise<void> => {
+  await test.step(`Open API spec sidebar item "${name}"`, async () => {
+    const { sidebarItem } = buildApiSpecPanelLocators(page);
+    await sidebarItem(name).click();
+  });
+};


### PR DESCRIPTION

### Description
JIRA:https://usebruno.atlassian.net/browse/BRU-3622
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Earlier, the spec viewer accepted any type of file. To resolve this, the following changes have been made:

1)Added filters so only .json, .yaml, and .yml files can be selected.
2)If a user bypasses the first validation stage, the frontend (SpecViewer.js) also validates the file content.
3)In case of a very large file, a 15-second timeout triggers an error state instead of an infinite loading state.
#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
<img width="1470" height="956" alt="Screenshot 2026-06-21 at 5 03 00 PM" src="https://github.com/user-attachments/assets/2f0ce4a2-7ed8-48c9-ad0a-b5b876be5bd3" />
<img width="754" height="387" alt="Screenshot 2026-06-21 at 5 01 32 PM" src="https://github.com/user-attachments/assets/5161a4f4-cdb3-4314-93e0-2e2417e0699d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added client-side YAML/JSON parsing with OpenAPI-like validation before showing the Swagger preview
  * Added user-facing preview errors (including parse/contract failures) and a “Preview timed out…” fallback

* **Bug Fixes**
  * Prevented loader flashing by waiting until the preview is fully rendered
  * Improved handling for unsupported file extensions and malformed content (no crashes; clearer messages)

* **Tests**
  * Added Jest and Playwright/Electron coverage for extension validation, empty/malformed specs, contract errors, and successful preview rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->