### PR TITLE
fix(windows): npm run dev

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -28,9 +28,24 @@ const electronDir = path.join(rootDir, 'packages/bruno-electron');
 
 let electronProcess = null;
 let detectedPort = null;
+let electronStarted = false;
+let fallbackTimer = null;
+
+// rsbuild's default dev server port; used as a fallback if the port line is never parsed
+const DEFAULT_DEV_PORT = process.env.BRUNO_DEV_PORT || '3000';
+
+// How long to wait for the port line before launching Electron on the default port
+const PORT_DETECT_TIMEOUT_MS = 30000;
+
+// Accumulate stdout so the port line is matched even when it arrives split across chunks
+let outputBuffer = '';
+
+// Strip ANSI color/escape codes so the regex isn't broken by colorized output (common on Windows)
+const stripAnsi = (str) => str.replace(/\x1b\[[0-9;]*m/g, '');
 
 // Regex to match rsbuild's local URL output (e.g., "➜ Local:    http://localhost:3000/")
-const portRegex = /Local:\s+http:\/\/localhost:(\d+)/;
+// Tolerant of extra characters between "Local:" and the URL on the same line.
+const portRegex = /Local:[^\n]*?localhost:(\d+)/;
 
 console.log(`\n${colors.bright}${colors.yellow}🚀 Starting Bruno development environment...${colors.reset}\n`);
 
@@ -41,15 +56,28 @@ const webProcess = spawn('npm', ['run', 'dev'], {
   shell: true
 });
 
+// Safety net: if the port line is never detected (e.g. unexpected output formatting),
+// launch Electron on the default port so the single `npm run dev` flow still works.
+fallbackTimer = setTimeout(() => {
+  if (!electronStarted) {
+    log.warn(`Could not detect dev server port from output; falling back to port ${colors.bright}${DEFAULT_DEV_PORT}${colors.reset}`);
+    startElectron(DEFAULT_DEV_PORT);
+  }
+}, PORT_DETECT_TIMEOUT_MS);
+
 webProcess.stdout.on('data', (data) => {
   const output = data.toString();
   process.stdout.write(output);
 
   // Try to detect the port from rsbuild output
   if (!detectedPort) {
-    const match = output.match(portRegex);
+    // Match against the accumulated, ANSI-stripped output so a split or
+    // colorized "Local: http://localhost:PORT" line is still detected (Windows).
+    outputBuffer += stripAnsi(output);
+    const match = outputBuffer.match(portRegex);
     if (match) {
       detectedPort = match[1];
+      outputBuffer = '';
       log.success(`Detected dev server on port ${colors.bright}${detectedPort}${colors.reset}`);
       startElectron(detectedPort);
     }
@@ -66,6 +94,16 @@ webProcess.on('close', (code) => {
 });
 
 function startElectron(port) {
+  // Guard against launching Electron twice (port detection + fallback timer racing)
+  if (electronStarted) {
+    return;
+  }
+  electronStarted = true;
+  if (fallbackTimer) {
+    clearTimeout(fallbackTimer);
+    fallbackTimer = null;
+  }
+
   log.info(`Starting Electron with ${colors.cyan}BRUNO_DEV_PORT=${port}${colors.reset}`);
 
   electronProcess = spawn('npm', ['run', 'dev'], {
@@ -85,6 +123,10 @@ function startElectron(port) {
 }
 
 function cleanup() {
+  if (fallbackTimer) {
+    clearTimeout(fallbackTimer);
+    fallbackTimer = null;
+  }
   if (webProcess && !webProcess.killed) {
     webProcess.kill();
   }


### PR DESCRIPTION


### Description

Instead of opening separate terminals (dev:web and dev:electron) commands for Building Bruno in Local, Fixed the Build issue with single command (npm run dev) for Windows

- Improved dev server port detection in scripts/dev.js so Electron starts automatically on Windows.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved stability of the development build process with enhanced startup reliability and automatic fallback mechanisms for initialization edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->