### PR TITLE
feat(collections): add option to delete collection folder from disk o…

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/ConfirmCollectionCloseDrafts.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/ConfirmCollectionCloseDrafts.js
@@ -200,6 +200,7 @@ const ConfirmCollectionCloseDrafts = ({ onClose, collection, collectionUid }) =>
         <label className="mt-6 flex items-start gap-2 cursor-pointer text-sm select-none">
           <input
             type="checkbox"
+            data-testid="confirm-close-drafts-delete-folder-checkbox"
             checked={deleteFolder}
             onChange={(e) => setDeleteFolder(e.target.checked)}
             className="mt-1"

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/ConfirmCollectionCloseDrafts.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/ConfirmCollectionCloseDrafts.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import filter from 'lodash/filter';
 import { useDispatch, useSelector } from 'react-redux';
 import { flattenItems, isItemARequest, hasRequestChanges, findCollectionByUid } from 'utils/collections';
@@ -16,6 +16,7 @@ const MAX_UNSAVED_REQUESTS_TO_SHOW = 5;
 
 const ConfirmCollectionCloseDrafts = ({ onClose, collection, collectionUid }) => {
   const dispatch = useDispatch();
+  const [deleteFolder, setDeleteFolder] = useState(false);
 
   const latestCollection = useSelector((state) => findCollectionByUid(state.collections.collections, collectionUid));
 
@@ -61,24 +62,30 @@ const ConfirmCollectionCloseDrafts = ({ onClose, collection, collectionUid }) =>
     if (currentDrafts.length > 0) {
       dispatch(saveMultipleRequests(currentDrafts))
         .then(() => {
-          dispatch(removeCollection(collectionUid))
+          dispatch(removeCollection(collectionUid, { deleteFolder }))
             .then(() => {
-              toast.success('Collection removed from workspace');
+              toast.success(deleteFolder ? 'Collection removed and folder moved to trash' : 'Collection removed from workspace');
               onClose();
             })
-            .catch(() => toast.error('An error occurred while removing the collection'));
+            .catch((error) => {
+              console.error(error);
+              toast.error(error?.message || 'An error occurred while removing the collection');
+            });
         })
         .catch(() => {
           toast.error('Failed to save requests!');
         });
     } else {
       // No non-transient drafts, just remove the collection
-      dispatch(removeCollection(collectionUid))
+      dispatch(removeCollection(collectionUid, { deleteFolder }))
         .then(() => {
-          toast.success('Collection removed from workspace');
+          toast.success(deleteFolder ? 'Collection removed and folder moved to trash' : 'Collection removed from workspace');
           onClose();
         })
-        .catch(() => toast.error('An error occurred while removing the collection'));
+        .catch((error) => {
+          console.error(error);
+          toast.error(error?.message || 'An error occurred while removing the collection');
+        });
     }
   };
 
@@ -92,12 +99,15 @@ const ConfirmCollectionCloseDrafts = ({ onClose, collection, collectionUid }) =>
     });
 
     // Then remove the collection
-    dispatch(removeCollection(collectionUid))
+    dispatch(removeCollection(collectionUid, { deleteFolder }))
       .then(() => {
-        toast.success('Collection removed from workspace');
+        toast.success(deleteFolder ? 'Collection removed and folder moved to trash' : 'Collection removed from workspace');
         onClose();
       })
-      .catch(() => toast.error('An error occurred while removing the collection'));
+      .catch((error) => {
+        console.error(error);
+        toast.error(error?.message || 'An error occurred while removing the collection');
+      });
   };
 
   const handleSaveTransient = (draft) => {
@@ -187,7 +197,22 @@ const ConfirmCollectionCloseDrafts = ({ onClose, collection, collectionUid }) =>
           </div>
         )}
 
-        <div className="flex justify-between mt-6">
+        <label className="mt-6 flex items-start gap-2 cursor-pointer text-sm select-none">
+          <input
+            type="checkbox"
+            checked={deleteFolder}
+            onChange={(e) => setDeleteFolder(e.target.checked)}
+            className="mt-1"
+          />
+          <span>
+            Also delete folder from disk
+            <span className="block text-muted text-xs mt-0.5">
+              The folder will be moved to your system trash.
+            </span>
+          </span>
+        </label>
+
+        <div className="flex justify-between mt-4">
           <div>
             <Button color="danger" onClick={handleDiscardAll}>
               Discard All and Remove

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
@@ -72,6 +72,7 @@ const RemoveCollection = ({ onClose, collectionUid }) => {
         <label className="mt-4 flex items-start gap-2 cursor-pointer text-sm select-none">
           <input
             type="checkbox"
+            data-testid="remove-collection-delete-folder-checkbox"
             checked={deleteFolder}
             onChange={(e) => setDeleteFolder(e.target.checked)}
             className="mt-1"

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
@@ -1,8 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import Modal from 'components/Modal';
 import { useDispatch, useSelector } from 'react-redux';
-import { IconAlertCircle } from '@tabler/icons';
 import { removeCollection } from 'providers/ReduxStore/slices/collections/actions';
 import { findCollectionByUid, flattenItems, isItemARequest, hasRequestChanges } from 'utils/collections/index';
 import filter from 'lodash/filter';
@@ -12,6 +11,7 @@ import StyledWrapper from './StyledWrapper';
 const RemoveCollection = ({ onClose, collectionUid }) => {
   const dispatch = useDispatch();
   const collection = useSelector((state) => findCollectionByUid(state.collections.collections, collectionUid));
+  const [deleteFolder, setDeleteFolder] = useState(false);
 
   // Detect drafts in the collection
   const drafts = useMemo(() => {
@@ -26,12 +26,15 @@ const RemoveCollection = ({ onClose, collectionUid }) => {
       onClose();
       return;
     }
-    dispatch(removeCollection(collection.uid))
+    dispatch(removeCollection(collection.uid, { deleteFolder }))
       .then(() => {
-        toast.success('Collection removed from workspace');
+        toast.success(deleteFolder ? 'Collection removed and folder moved to trash' : 'Collection removed from workspace');
         onClose();
       })
-      .catch(() => toast.error('An error occurred while removing the collection'));
+      .catch((error) => {
+        console.error(error);
+        toast.error(error?.message || 'An error occurred while removing the collection');
+      });
   };
 
   if (!collection) {
@@ -40,7 +43,13 @@ const RemoveCollection = ({ onClose, collectionUid }) => {
 
   // If there are drafts, show the draft confirmation modal
   if (drafts.length > 0) {
-    return <ConfirmCollectionCloseDrafts onClose={onClose} collection={collection} collectionUid={collectionUid} />;
+    return (
+      <ConfirmCollectionCloseDrafts
+        onClose={onClose}
+        collection={collection}
+        collectionUid={collectionUid}
+      />
+    );
   }
 
   // Otherwise, show the standard remove confirmation modal
@@ -49,7 +58,7 @@ const RemoveCollection = ({ onClose, collectionUid }) => {
       <Modal
         size="sm"
         title="Remove Collection"
-        confirmText="Remove"
+        confirmText={deleteFolder ? 'Remove and Delete folder' : 'Remove'}
         confirmButtonColor="danger"
         handleConfirm={onConfirm}
         handleCancel={onClose}
@@ -59,9 +68,27 @@ const RemoveCollection = ({ onClose, collectionUid }) => {
           <div className="collection-name">{collection.name}</div>
           <div className="collection-path">{collection.pathname}</div>
         </div>
-        <p className="mt-4 text-muted text-sm">
-          It will still be available in the filesystem at the above location and can be re-opened later.
-        </p>
+
+        <label className="mt-4 flex items-start gap-2 cursor-pointer text-sm select-none">
+          <input
+            type="checkbox"
+            checked={deleteFolder}
+            onChange={(e) => setDeleteFolder(e.target.checked)}
+            className="mt-1"
+          />
+          <span>
+            Also delete folder from disk
+            <span className="block text-muted text-xs mt-0.5">
+              The folder will be moved to your system trash.
+            </span>
+          </span>
+        </label>
+
+        {!deleteFolder && (
+          <p className="mt-4 text-muted text-sm">
+            It will still be available in the filesystem at the above location and can be re-opened later.
+          </p>
+        )}
       </Modal>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/Sidebar/Collections/RemoveCollectionsModal/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/RemoveCollectionsModal/index.js
@@ -114,13 +114,28 @@ const RemoveCollectionsModal = ({ collectionUids, onClose }) => {
   const handleCloseAllCollections = () => {
     const removalPromises = collectionUids.map((uid) => dispatch(removeCollection(uid, { deleteFolder })));
 
-    Promise.all(removalPromises)
-      .then(() => {
-        toast.success(deleteFolder ? 'Closed all collections and moved folders to trash' : 'Closed all collections');
-      })
-      .catch((error) => {
-        console.error('Error closing collections:', error);
-        toast.error(error?.message || 'An error occurred while closing collections');
+    Promise.allSettled(removalPromises)
+      .then((results) => {
+        const succeeded = results.filter((r) => r.status === 'fulfilled').length;
+        const failures = results.filter((r) => r.status === 'rejected');
+
+        if (failures.length === 0) {
+          toast.success(deleteFolder ? 'Closed all collections and moved folders to trash' : 'Closed all collections');
+          return;
+        }
+
+        failures.forEach(({ reason }) => {
+          console.error('Error closing collection:', reason);
+          toast.error(reason?.message || 'An error occurred while closing a collection');
+        });
+
+        if (succeeded > 0) {
+          toast.success(
+            deleteFolder
+              ? `Closed ${succeeded} of ${results.length} collections and moved folders to trash`
+              : `Closed ${succeeded} of ${results.length} collections`
+          );
+        }
       })
       .finally(() => {
         onClose();
@@ -229,6 +244,7 @@ const RemoveCollectionsModal = ({ collectionUids, onClose }) => {
               <label className="mt-6 flex items-start gap-2 cursor-pointer text-sm select-none">
                 <input
                   type="checkbox"
+                  data-testid="remove-collections-drafts-delete-folder-checkbox"
                   checked={deleteFolder}
                   onChange={(e) => setDeleteFolder(e.target.checked)}
                   className="mt-1"
@@ -272,6 +288,7 @@ const RemoveCollectionsModal = ({ collectionUids, onClose }) => {
               <label className="mt-4 flex items-start gap-2 cursor-pointer text-sm select-none">
                 <input
                   type="checkbox"
+                  data-testid="remove-collections-delete-folder-checkbox"
                   checked={deleteFolder}
                   onChange={(e) => setDeleteFolder(e.target.checked)}
                   className="mt-1"

--- a/packages/bruno-app/src/components/Sidebar/Collections/RemoveCollectionsModal/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/RemoveCollectionsModal/index.js
@@ -50,6 +50,7 @@ const RemoveCollectionsModal = ({ collectionUids, onClose }) => {
   const dispatch = useDispatch();
   const allCollections = useSelector((state) => state.collections.collections || []);
   const [showAllCollections, setShowAllCollections] = useState(false);
+  const [deleteFolder, setDeleteFolder] = useState(false);
 
   const allDrafts = useMemo(() => {
     const requestDrafts = [];
@@ -111,15 +112,15 @@ const RemoveCollectionsModal = ({ collectionUids, onClose }) => {
     = allDrafts.collectionDrafts.length > 0 || allDrafts.folderDrafts.length > 0 || allDrafts.requestDrafts.length > 0;
 
   const handleCloseAllCollections = () => {
-    const removalPromises = collectionUids.map((uid) => dispatch(removeCollection(uid)));
+    const removalPromises = collectionUids.map((uid) => dispatch(removeCollection(uid, { deleteFolder })));
 
     Promise.all(removalPromises)
       .then(() => {
-        toast.success('Closed all collections');
+        toast.success(deleteFolder ? 'Closed all collections and moved folders to trash' : 'Closed all collections');
       })
       .catch((error) => {
         console.error('Error closing collections:', error);
-        toast.error('An error occurred while closing collections');
+        toast.error(error?.message || 'An error occurred while closing collections');
       })
       .finally(() => {
         onClose();
@@ -225,10 +226,25 @@ const RemoveCollectionsModal = ({ collectionUids, onClose }) => {
                 </div>
               </div>
 
-              <div className="flex justify-between mt-6">
+              <label className="mt-6 flex items-start gap-2 cursor-pointer text-sm select-none">
+                <input
+                  type="checkbox"
+                  checked={deleteFolder}
+                  onChange={(e) => setDeleteFolder(e.target.checked)}
+                  className="mt-1"
+                />
+                <span>
+                  Also delete folders from disk
+                  <span className="block text-xs text-gray-500 mt-0.5">
+                    Folders will be moved to your system trash.
+                  </span>
+                </span>
+              </label>
+
+              <div className="flex justify-between mt-4">
                 <div>
                   <Button color="danger" onClick={handleDiscard}>
-                    Discard and Close
+                    {deleteFolder ? 'Discard and Delete' : 'Discard and Close'}
                   </Button>
                 </div>
                 <div>
@@ -236,7 +252,7 @@ const RemoveCollectionsModal = ({ collectionUids, onClose }) => {
                     Cancel
                   </Button>
                   <Button onClick={handleSave}>
-                    Save and Close
+                    {deleteFolder ? 'Save and Delete' : 'Save and Close'}
                   </Button>
                 </div>
               </div>
@@ -252,15 +268,35 @@ const RemoveCollectionsModal = ({ collectionUids, onClose }) => {
                   </>
                 )}
               </div>
-              <div className="mt-4 text-xs text-gray-500">
-                Collections will be removed from the current workspace but will still be available in the file system and can be re-opened later.
-              </div>
+
+              <label className="mt-4 flex items-start gap-2 cursor-pointer text-sm select-none">
+                <input
+                  type="checkbox"
+                  checked={deleteFolder}
+                  onChange={(e) => setDeleteFolder(e.target.checked)}
+                  className="mt-1"
+                />
+                <span>
+                  Also delete {hasMultipleCollections ? 'folders' : 'folder'} from disk
+                  <span className="block text-xs text-gray-500 mt-0.5">
+                    {hasMultipleCollections ? 'Folders' : 'Folder'} will be moved to your system trash.
+                  </span>
+                </span>
+              </label>
+
+              {!deleteFolder && (
+                <div className="mt-4 text-xs text-gray-500">
+                  Collections will be removed from the current workspace but will still be available in the file system and can be re-opened later.
+                </div>
+              )}
               <div className="flex justify-end mt-6">
                 <Button className="mr-2" color="secondary" variant="ghost" onClick={handleCancel} data-testid="modal-close-button">
                   Cancel
                 </Button>
-                <Button color="warning" onClick={handleCloseAllCollections}>
-                  {hasMultipleCollections ? 'Close All' : 'Close'}
+                <Button color={deleteFolder ? 'danger' : 'warning'} onClick={handleCloseAllCollections}>
+                  {deleteFolder
+                    ? (hasMultipleCollections ? 'Close All and Delete' : 'Close and Delete')
+                    : (hasMultipleCollections ? 'Close All' : 'Close')}
                 </Button>
               </div>
             </>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2416,7 +2416,7 @@ export const selectEnvironment = (environmentUid, collectionUid) => (dispatch, g
   });
 };
 
-export const removeCollection = (collectionUid) => (dispatch, getState) => {
+export const removeCollection = (collectionUid, options = {}) => (dispatch, getState) => {
   return new Promise((resolve, reject) => {
     const state = getState();
     const collection = findCollectionByUid(state.collections.collections, collectionUid);
@@ -2439,7 +2439,7 @@ export const removeCollection = (collectionUid) => (dispatch, getState) => {
     }
 
     ipcRenderer
-      .invoke('renderer:remove-collection', collection.pathname, collectionUid, workspaceId)
+      .invoke('renderer:remove-collection', collection.pathname, collectionUid, workspaceId, { deleteFolder: !!options.deleteFolder })
       .then(() => {
         // Check if the collection still exists in other workspaces
         return ipcRenderer.invoke('renderer:get-collection-workspaces', collection.pathname);

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1255,6 +1255,17 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
   });
 
   ipcMain.handle('renderer:remove-collection', async (event, collectionPath, collectionUid, workspacePath, options = {}) => {
+    // Move the folder to the OS trash first. If this fails (e.g. permission denied),
+    // abort before any workspace state is mutated so the UI and on-disk state stay in sync.
+    if (options && options.deleteFolder && collectionPath) {
+      try {
+        await shell.trashItem(collectionPath);
+      } catch (error) {
+        console.error('Error moving collection folder to trash:', error);
+        throw new Error(`Failed to delete collection folder: ${error?.message || error}`);
+      }
+    }
+
     if (watcher && mainWindow) {
       watcher.removeWatcher(collectionPath, mainWindow, collectionUid);
 
@@ -1282,16 +1293,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       cleanupSpecFilesForCollection(collectionPath);
     } catch (error) {
       console.error('Error cleaning up spec files for removed collection:', error);
-    }
-
-    // Optionally delete the collection folder from disk (moved to OS trash).
-    if (options && options.deleteFolder && collectionPath) {
-      try {
-        await shell.trashItem(collectionPath);
-      } catch (error) {
-        console.error('Error moving collection folder to trash:', error);
-        throw new Error(`Failed to delete collection folder: ${error?.message || error}`);
-      }
     }
   });
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1254,7 +1254,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
     }
   });
 
-  ipcMain.handle('renderer:remove-collection', async (event, collectionPath, collectionUid, workspacePath) => {
+  ipcMain.handle('renderer:remove-collection', async (event, collectionPath, collectionUid, workspacePath, options = {}) => {
     if (watcher && mainWindow) {
       watcher.removeWatcher(collectionPath, mainWindow, collectionUid);
 
@@ -1282,6 +1282,16 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       cleanupSpecFilesForCollection(collectionPath);
     } catch (error) {
       console.error('Error cleaning up spec files for removed collection:', error);
+    }
+
+    // Optionally delete the collection folder from disk (moved to OS trash).
+    if (options && options.deleteFolder && collectionPath) {
+      try {
+        await shell.trashItem(collectionPath);
+      } catch (error) {
+        console.error('Error moving collection folder to trash:', error);
+        throw new Error(`Failed to delete collection folder: ${error?.message || error}`);
+      }
     }
   });
 


### PR DESCRIPTION
### Description

  Adds an opt-in **"Also delete folder from disk"** checkbox to the Remove Collection / Close Collections modals.

  When the box is checked, in addition to detaching the collection from the workspace, the collection folder is moved to the **OS trash**
   via Electron's `shell.trashItem`. The default behaviour is unchanged — the checkbox is off by default, so existing flows still only
  detach the collection.
  
  **Motivation.** Today the only way to fully get rid of a collection is to remove it from Bruno and then delete the folder manually in a
   file manager. This is friction for users who created a collection in the wrong place, are cleaning up experiments, or want to retire a
   workspace. Using `shell.trashItem` (not `fs.rm`) keeps the operation reversible — the folder lands in the OS trash and can be
  restored.
  
  **Changes.**                                                                          

  - `bruno-electron/src/ipc/collection.js` — `renderer:remove-collection` now accepts an `options` object. When `options.deleteFolder ===
   true`, after the in-app cleanup the handler calls `shell.trashItem(collectionPath)`. Errors are surfaced back to the renderer so the
  toast can show the real message.
  - `bruno-app/.../RemoveCollection/index.js`, `ConfirmCollectionCloseDrafts.js`, `RemoveCollectionsModal/index.js` — new `deleteFolder`
  checkbox with a short hint that the folder will be moved to the OS trash. Toast text and the primary-button label switch based on the
  choice.                                                                               
  - `bruno-app/.../slices/collections/actions.js` — `removeCollection(uid, options)` forwards `{ deleteFolder }` through IPC.
  - Error toasts now surface `error.message` instead of the generic "An error occurred…" string.

  **UX summary.**

  | Checkbox | Result | Toast |
  |---|---|---|
  | off (default) | Collection detached from workspace, folder untouched | `Collection removed from workspace` |
  | on | Collection detached, folder moved to OS trash | `Collection removed and folder moved to trash` |
  | on, error | Collection stays in workspace, folder untouched | real `error.message` |

  **Test plan.**

  - Remove a collection without checking the box → folder remains on disk, workspace updated.
  - Remove a collection with the box checked → folder appears in the OS trash (Recycle Bin on Windows, Trash on macOS, Trash on
  Linux/GIO).
  - Remove a collection with unsaved drafts → both "Save and Delete" and "Discard and Delete" paths honour the checkbox.
  - Remove multiple collections at once → all selected folders go to trash.
  - Read-only or locked folder → error toast shows the real OS error, collection stays in the workspace.

  **Notes.**

  - Intentionally restricted to `shell.trashItem`; hard delete (`fs.rm`) is not exposed.
  - Could be hardened by validating `collectionPath` against the list of registered collections before calling `shell.trashItem` (same
  class of concern raised in #8274 for `renderer:delete-item`). Happy to add that here if maintainers prefer.

  #### Contribution Checklist:
  
  - [x] **I've used AI significantly to create this pull request**
  - [x] **The pull request only addresses one issue or adds one feature.**              
  - [x] **The pull request does not introduce any breaking changes**
  - [ ] **I have added screenshots or gifs to help explain the change if applicable.**
  - [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
  - [ ] **Create an issue and link to the pull request.**

  Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please
  consider submitting them as separate pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to also delete collection folders from disk when removing collections.
  * Updated confirmation dialogs and button labels to reflect the chosen deletion behavior.
* **Bug Fixes**
  * Improved removal error handling with more informative messages when operations fail.
* **Other**
  * Enhanced “remove all” behavior to better handle partial failures, with success messaging that reflects how many removals completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->