### PR TITLE
chore(e2e): cleanup network tests

### DIFF
--- a/tests/devtools/network/network-log-details-scroll.spec.ts
+++ b/tests/devtools/network/network-log-details-scroll.spec.ts
@@ -1,30 +1,21 @@
-import { test, expect, type Locator } from '../../../playwright';
-import { openCollection, openRequest, sendRequest } from '../../utils/page';
+import { test, expect } from '../../../playwright';
+import {
+  buildCommonLocators,
+  isLocatorVisibleInScroller,
+  openCollection,
+  openDevToolsConsoleTab,
+  openRequest,
+  selectFirstDevToolsNetworkRequest,
+  selectRequestDetailsPanelTab,
+  sendRequest
+} from '../../utils/page';
 
 const COLLECTION_NAME = 'network-log-scroll';
 const REQUEST_NAME = 'network-log-scroll';
 
-const isEntryVisibleInScroller = async (scroller: Locator, entry: Locator) => {
-  const entryHandle = await entry.elementHandle();
-  if (!entryHandle) {
-    return false;
-  }
-
-  return scroller.evaluate((container, entryEl) => {
-    const containerRect = container.getBoundingClientRect();
-    const entryRect = entryEl.getBoundingClientRect();
-
-    return (
-      entryRect.height > 0
-      && entryRect.top >= containerRect.top - 1
-      && entryRect.bottom <= containerRect.bottom + 1
-    );
-  }, entryHandle);
-};
-
 test.describe('DevTools Network Log Details Scroll', () => {
   test('last network log lines are visible and scrollable in request details panel', async ({ pageWithUserData: page }) => {
-    await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+    const { devTools } = buildCommonLocators(page);
 
     await test.step('Open fixture request and send it', async () => {
       await openCollection(page, COLLECTION_NAME);
@@ -32,31 +23,16 @@ test.describe('DevTools Network Log Details Scroll', () => {
       await sendRequest(page, 200);
     });
 
-    await test.step('Open DevTools Network tab and select the request', async () => {
-      await page.locator('button[data-trigger="dev-tools"]').click();
-      await expect(page.locator('.console-header')).toBeVisible();
+    await openDevToolsConsoleTab(page, 'Network');
+    await selectFirstDevToolsNetworkRequest(page);
 
-      const networkTab = page.locator('.console-tab').filter({ hasText: 'Network' });
-      await expect(networkTab).toBeVisible();
-      await networkTab.click();
-      await expect(networkTab).toHaveClass(/active/);
-
-      const requestRow = page.getByTestId('network-request-row').first();
-      await expect(requestRow).toBeVisible();
-      await requestRow.click();
-    });
-
-    const panel = page.locator('.details-panel-wrapper');
-    const outerScroller = panel.locator('.panel-content');
-    const innerScroller = panel.locator('.network-logs-wrapper .network-logs-container');
-    const lastEntry = innerScroller.locator('.network-logs-entry').last();
+    const detailsPanel = devTools.requestDetailsPanel();
+    const outerScroller = detailsPanel.content();
+    const innerScroller = detailsPanel.networkLogsContainer();
+    const lastEntry = detailsPanel.networkLogEntries().last();
 
     await test.step('Open Network sub-tab in request details panel', async () => {
-      await expect(panel.getByText('Request Details')).toBeVisible();
-      const networkSubTab = panel.locator('.tab-button').filter({ hasText: 'Network' });
-      await expect(networkSubTab).toBeVisible();
-      await networkSubTab.click();
-      await expect(networkSubTab).toHaveClass(/active/);
+      await selectRequestDetailsPanelTab(page, 'Network');
       await expect(innerScroller).toBeVisible();
     });
 
@@ -67,14 +43,16 @@ test.describe('DevTools Network Log Details Scroll', () => {
     });
 
     await test.step('Outer panel scroll alone does not reveal the last log line', async () => {
-      const initialOuterScrollTop = await outerScroller.evaluate((el) => el.scrollTop);
-      expect(initialOuterScrollTop).toBe(0);
+      expect(await outerScroller.evaluate((el) => el.scrollTop)).toBe(0);
 
       await outerScroller.evaluate((el) => {
         el.scrollTop = el.scrollHeight;
       });
 
-      await expect.poll(() => isEntryVisibleInScroller(innerScroller, lastEntry)).toBe(false);
+      await expect.poll(
+        () => isLocatorVisibleInScroller(innerScroller, lastEntry),
+        { message: 'Last network log entry should remain hidden until the nested scroller moves' }
+      ).toBe(false);
 
       await outerScroller.evaluate((el) => {
         el.scrollTop = 0;
@@ -83,19 +61,17 @@ test.describe('DevTools Network Log Details Scroll', () => {
 
     await test.step('Scroll nested inner container and verify last log line is visible in viewport', async () => {
       await expect(async () => {
-        await innerScroller.evaluate((el) => {
+        const scrollTop = await innerScroller.evaluate((el) => {
           el.scrollTop = el.scrollHeight;
+          return el.scrollTop;
         });
-
-        const scrollTop = await innerScroller.evaluate((el) => el.scrollTop);
         expect(scrollTop).toBeGreaterThan(0);
 
         await expect(lastEntry).toBeVisible({ timeout: 1000 });
-        expect(await isEntryVisibleInScroller(innerScroller, lastEntry)).toBe(true);
+        expect(await isLocatorVisibleInScroller(innerScroller, lastEntry)).toBe(true);
       }).toPass({ timeout: 10000 });
 
-      const outerScrollTop = await outerScroller.evaluate((el) => el.scrollTop);
-      expect(outerScrollTop).toBe(0);
+      expect(await outerScroller.evaluate((el) => el.scrollTop)).toBe(0);
     });
   });
 });

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1320,6 +1320,68 @@ const selectRequestPaneTab = async (page: Page, tabName: string) => {
   await selectPaneTab(page, '[data-testid="request-pane"] > .px-4', tabName);
 };
 
+const openDevToolsConsoleTab = async (page: Page, tabName: string) => {
+  await test.step(`Open DevTools "${tabName}" tab`, async () => {
+    const { devTools } = buildCommonLocators(page);
+    if (!(await devTools.header().isVisible())) {
+      await devTools.trigger().click();
+    }
+    await expect(devTools.header()).toBeVisible();
+
+    const tab = devTools.tab(tabName);
+    await expect(tab).toBeVisible();
+    await tab.click();
+    await expect(tab).toHaveClass(/active/);
+  });
+};
+
+const selectFirstDevToolsNetworkRequest = async (page: Page) => {
+  await test.step('Select first DevTools network request', async () => {
+    const { devTools } = buildCommonLocators(page);
+    const detailsPanel = devTools.requestDetailsPanel();
+    const requestRows = devTools.networkRequestRows();
+    await expect
+      .poll(() => requestRows.count(), {
+        message: 'Waiting for network requests to appear in DevTools',
+        timeout: 15000
+      })
+      .toBeGreaterThan(0);
+
+    const requestRow = requestRows.first();
+    await expect(requestRow).toBeVisible();
+    await requestRow.click();
+    await expect(detailsPanel.root()).toBeVisible();
+    await expect(detailsPanel.root()).toContainText('Request Details');
+  });
+};
+
+const selectRequestDetailsPanelTab = async (page: Page, tabName: string) => {
+  await test.step(`Select request details "${tabName}" tab`, async () => {
+    const tab = buildCommonLocators(page).devTools.requestDetailsPanel().tab(tabName);
+    await expect(tab).toBeVisible();
+    await tab.click();
+    await expect(tab).toHaveClass(/active/);
+  });
+};
+
+const isLocatorVisibleInScroller = async (scroller: Locator, target: Locator) => {
+  const targetHandle = await target.elementHandle();
+  if (!targetHandle) {
+    return false;
+  }
+
+  return scroller.evaluate((container, targetEl) => {
+    const containerRect = container.getBoundingClientRect();
+    const targetRect = targetEl.getBoundingClientRect();
+
+    return (
+      targetRect.height > 0
+      && targetRect.top >= containerRect.top - 1
+      && targetRect.bottom <= containerRect.bottom + 1
+    );
+  }, targetHandle);
+};
+
 const selectRequestBodyMode = async (page: Page, mode: string) => {
   await test.step(`Select request body mode "${mode}"`, async () => {
     await selectRequestPaneTab(page, 'Body');
@@ -2292,6 +2354,10 @@ export {
   getResponseBody,
   expectResponseContains,
   selectRequestPaneTab,
+  openDevToolsConsoleTab,
+  selectFirstDevToolsNetworkRequest,
+  selectRequestDetailsPanelTab,
+  isLocatorVisibleInScroller,
   selectRequestBodyMode,
   selectResponsePaneTab,
   mockBrowseFiles,

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -242,6 +242,24 @@ export const buildCommonLocators = (page: Page) => ({
     itemHeader: (item: Locator) => item.getByTestId('timeline-item-header'),
     clearButton: () => page.getByRole('button', { name: 'Clear Timeline' })
   },
+  devTools: {
+    trigger: () => page.locator('button[data-trigger="dev-tools"]'),
+    header: () => page.locator('.console-header'),
+    tab: (name: string) =>
+      page.locator('.console-header .console-tab').filter({ hasText: name }),
+    networkRequestRows: () =>
+      page.locator('.console-content [data-testid="network-request-row"]'),
+    requestDetailsPanel: () => {
+      const panel = () => page.locator('.console-content .details-panel-wrapper');
+      return {
+        root: panel,
+        content: () => panel().locator('.panel-content'),
+        tab: (name: string) => panel().locator('.tab-button').filter({ hasText: name }),
+        networkLogsContainer: () => panel().locator('.network-logs-wrapper .network-logs-container'),
+        networkLogEntries: () => panel().locator('.network-logs-container .network-logs-entry')
+      };
+    }
+  },
   plusMenu: {
     button: () => page.getByTestId('collections-header-add-menu'),
     createCollection: () => page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Create collection' }),


### PR DESCRIPTION
### Description

Extension of https://github.com/usebruno/bruno/pull/8329 to cleanup the tests for `main`, it's okay if not cherry-picked, same test just better abstractions

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced DevTools testing infrastructure with centralized helper utilities for improved test maintainability and consistency in network request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->