### PR TITLE
feat(dev-tools-network-tab)/persists sort network column and request details widths

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/NetworkTab/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/NetworkTab/index.js
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
+import { usePersistedState } from 'hooks/usePersistedState';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   IconNetwork,
@@ -133,7 +134,7 @@ const RequestRow = ({ request, isSelected, onClick, gridTemplateColumns }) => {
 
 const NetworkTab = () => {
   const dispatch = useDispatch();
-  const [sortConfig, setSortConfig] = useState({ key: null, direction: null });
+  const [sortConfig, setSortConfig] = usePersistedState({ key: 'devtools-network-sort', default: { key: null, direction: null } });
   const gridTemplateColumns = useMemo(() => getGridTemplate(COLUMNS), []);
   const separatorPositions = useMemo(() => getSeparatorPositions(COLUMNS), []);
   const { networkFilters, selectedRequest } = useSelector((state) => state.logs);

--- a/packages/bruno-app/src/components/Devtools/Console/NetworkTab/index.spec.js
+++ b/packages/bruno-app/src/components/Devtools/Console/NetworkTab/index.spec.js
@@ -55,6 +55,10 @@ const renderNetworkTab = (requests = []) => {
   );
 };
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('sort state cycle', () => {
   const requests = [
     makeRequest({ itemUid: 'a', method: 'GET' }),
@@ -161,6 +165,26 @@ describe('sort results', () => {
     fireEvent.click(screen.getByTestId('network-header-method'));
     // MethodBadge always renders uppercase; sort order should treat 'post' == 'POST'
     expect(getRowMethods()).toEqual(['DELETE', 'GET', 'POST']);
+  });
+
+  it('restores sort config after close and reopen', () => {
+    const requests = [
+      makeRequest({ itemUid: '1', method: 'POST' }),
+      makeRequest({ itemUid: '2', method: 'GET' }),
+      makeRequest({ itemUid: '3', method: 'DELETE' })
+    ];
+
+    // First mount — set sort to method descending
+    const { unmount } = renderNetworkTab(requests);
+    fireEvent.click(screen.getByTestId('network-header-method')); // asc
+    fireEvent.click(screen.getByTestId('network-header-method')); // desc
+    expect(getRowMethods()).toEqual(['POST', 'GET', 'DELETE']);
+    unmount(); // simulate closing devtools
+
+    // Second mount — sort should be restored from localStorage
+    renderNetworkTab(requests);
+    expect(screen.getByTestId('sort-icon-desc')).toBeInTheDocument();
+    expect(getRowMethods()).toEqual(['POST', 'GET', 'DELETE']);
   });
 
   it('preserves insertion order when sort is cleared', () => {

--- a/packages/bruno-app/src/components/Devtools/Console/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { usePersistedState } from 'hooks/usePersistedState';
 import { useSelector, useDispatch } from 'react-redux';
 import ReactJson from 'react-json-view';
 import { useTheme } from 'providers/Theme';
@@ -23,8 +24,7 @@ import {
   setActiveTab,
   clearDebugErrors,
   updateNetworkFilter,
-  toggleAllNetworkFilters,
-  updateRequestDetailsPanelWidth
+  toggleAllNetworkFilters
 } from 'providers/ReduxStore/slices/logs';
 
 import NetworkTab from './NetworkTab';
@@ -386,7 +386,7 @@ const Console = () => {
   const dispatch = useDispatch();
   const { logs, filters, activeTab, selectedRequest, selectedError, networkFilters, debugErrors } = useSelector((state) => state.logs);
   const collections = useSelector((state) => state.collections.collections);
-  const savedDetailsPanelWidth = useSelector((state) => state.logs.requestDetailsPanelWidth);
+  const [savedDetailsPanelWidth, setSavedDetailsPanelWidth] = usePersistedState({ key: 'devtools-details-panel-width', default: 400 });
   const consoleRef = useRef(null);
 
   const { width: detailsPanelWidth, handleDragStart: handleDetailsPanelDragStart } = useResizablePanel({
@@ -394,7 +394,7 @@ const Console = () => {
     minWidth: MIN_DETAILS_PANEL_WIDTH,
     maxWidth: MAX_DETAILS_PANEL_WIDTH,
     direction: 'right',
-    onResizeEnd: (newWidth) => dispatch(updateRequestDetailsPanelWidth({ requestDetailsPanelWidth: newWidth }))
+    onResizeEnd: (newWidth) => setSavedDetailsPanelWidth(newWidth)
   });
 
   const logCounts = logs.reduce((counts, log) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/logs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/logs.js
@@ -9,6 +9,9 @@ export const TABS = {
 
 export const TAB_IDENFIERS = Object.values(TABS);
 
+const MAX_LOGS = 1000;
+const MAX_DEBUG_ERRORS = 500;
+
 const initialState = {
   logs: [],
   debugErrors: [],
@@ -31,10 +34,7 @@ const initialState = {
     OPTIONS: true
   },
   selectedRequest: null,
-  selectedError: null,
-  maxLogs: 1000,
-  maxDebugErrors: 500,
-  requestDetailsPanelWidth: 400
+  selectedError: null
 };
 
 export const logsSlice = createSlice({
@@ -53,8 +53,8 @@ export const logsSlice = createSlice({
 
       state.logs.push(newLog);
 
-      if (state.logs.length > state.maxLogs) {
-        state.logs = state.logs.slice(-state.maxLogs);
+      if (state.logs.length > MAX_LOGS) {
+        state.logs = state.logs.slice(-MAX_LOGS);
       }
     },
     addDebugError: (state, action) => {
@@ -72,8 +72,8 @@ export const logsSlice = createSlice({
 
       state.debugErrors.push(newError);
 
-      if (state.debugErrors.length > state.maxDebugErrors) {
-        state.debugErrors = state.debugErrors.slice(-state.maxDebugErrors);
+      if (state.debugErrors.length > MAX_DEBUG_ERRORS) {
+        state.debugErrors = state.debugErrors.slice(-MAX_DEBUG_ERRORS);
       }
     },
     clearLogs: (state) => {
@@ -90,12 +90,6 @@ export const logsSlice = createSlice({
     },
     setActiveTab: (state, action) => {
       state.activeTab = action.payload;
-      if (action.payload !== 'network') {
-        state.selectedRequest = null;
-      }
-      if (action.payload !== 'debug') {
-        state.selectedError = null;
-      }
     },
     updateFilter: (state, action) => {
       const { filterType, enabled } = action.payload;
@@ -128,9 +122,6 @@ export const logsSlice = createSlice({
     },
     clearSelectedError: (state) => {
       state.selectedError = null;
-    },
-    updateRequestDetailsPanelWidth: (state, action) => {
-      state.requestDetailsPanelWidth = action.payload.requestDetailsPanelWidth;
     }
   }
 });
@@ -150,8 +141,7 @@ export const {
   setSelectedRequest,
   clearSelectedRequest,
   setSelectedError,
-  clearSelectedError,
-  updateRequestDetailsPanelWidth
+  clearSelectedError
 } = logsSlice.actions;
 
 export default logsSlice.reducer;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/logs.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/logs.spec.js
@@ -1,0 +1,26 @@
+import reducer, { setActiveTab, setSelectedRequest, clearSelectedRequest } from './logs';
+
+const mockRequest = { itemUid: 'item-1', timestamp: 1000, data: {} };
+
+describe('setActiveTab', () => {
+  it('preserves selectedRequest when switching away from network tab', () => {
+    const stateWithRequest = reducer(undefined, setSelectedRequest(mockRequest));
+    expect(stateWithRequest.selectedRequest).toEqual(mockRequest);
+
+    const stateAfterSwitch = reducer(stateWithRequest, setActiveTab('console'));
+    expect(stateAfterSwitch.selectedRequest).toEqual(mockRequest);
+  });
+
+  it('preserves selectedRequest when switching back to network tab', () => {
+    let state = reducer(undefined, setSelectedRequest(mockRequest));
+    state = reducer(state, setActiveTab('console'));
+    state = reducer(state, setActiveTab('network'));
+    expect(state.selectedRequest).toEqual(mockRequest);
+  });
+
+  it('clears selectedRequest only when explicitly dispatching clearSelectedRequest', () => {
+    let state = reducer(undefined, setSelectedRequest(mockRequest));
+    state = reducer(state, clearSelectedRequest());
+    expect(state.selectedRequest).toBeNull();
+  });
+});


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3468)

This PR improves devtools state persistence by migrating ephemeral UI state out of Redux and into `localStorage` via `usePersistedState`. It also fixes a bug where the Network request details panel was incorrectly dismissed on tab switches.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

## Changes

https://github.com/user-attachments/assets/70d60953-4e74-4955-87e4-174c0cc72426


### Network Tab: Persist Sort Config
 
**`NetworkTab/index.js`**
 
Sort column and direction were stored in local component state (`useState`), so they reset every time the devtools panel was closed. Replaced with `usePersistedState` keyed to `devtools-network-sort`.

### Bug Fix: Details Panel Dismissed on Tab Switch
 
**`slices/logs.js`**
 
`setActiveTab` was unconditionally nulling `selectedRequest` whenever the user navigated away from the Network tab. This meant the request details panel was always lost on tab switches, even though it should survive.
 
### Request Details Panel: Migrate Width from Redux to localStorage
 
**`Console/index.js`** · **`slices/logs.js`**
 
Panel width was stored in Redux state (`requestDetailsPanelWidth`) and persisted via a dedicated action (`updateRequestDetailsPanelWidth`). Since this is purely UI preference with no cross-component dependencies, it's been moved to `usePersistedState` keyed to `devtools-details-panel-width`.
 
Removed from Redux:
- `requestDetailsPanelWidth` initial state field
- `updateRequestDetailsPanelWidth` reducer and export

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network tab column sorting now persists across browser sessions

* **Tests**
  * Added test coverage for persisted state behavior and session restoration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->