### PR TITLE
fix(ai): validate provider keys via /v1/models instead of a generatio…

### DIFF
--- a/packages/bruno-electron/src/ipc/ai/index.js
+++ b/packages/bruno-electron/src/ipc/ai/index.js
@@ -4,7 +4,6 @@ const { getPreferences } = require('../../store/preferences');
 const { aiKeyStore } = require('../../store/ai-keys');
 const {
   PROVIDERS,
-  MODEL_DEFINITIONS,
   listProviders,
   listModels,
   getModel,
@@ -107,18 +106,20 @@ const registerAiIpc = (mainWindow) => {
       return { ok: false, error: `${PROVIDERS[providerId].label} is disabled` };
     }
 
-    const probeModel = Object.entries(MODEL_DEFINITIONS)
-      .find(([, def]) => def.provider === providerId);
-    if (!probeModel) {
-      return { ok: false, error: `No models registered for ${providerId}` };
-    }
-
     try {
-      const model = resolveModel(probeModel[0]);
-      await generateText({ model, prompt: 'ping', maxOutputTokens: 1 });
-      return { ok: true };
+      const res = await PROVIDERS[providerId].validateApiKey({ apiKey });
+      if (res.ok) {
+        return { ok: true };
+      }
+      if (res.status === 401 || res.status === 403) {
+        return { ok: false, error: 'Invalid API key' };
+      }
+      if (res.status === 429) {
+        return { ok: false, error: 'Rate limited — try again in a moment' };
+      }
+      return { ok: false, error: `Could not verify key (HTTP ${res.status})` };
     } catch (err) {
-      return { ok: false, error: err.message || 'Connection failed' };
+      return { ok: false, error: 'Could not reach provider. Check your network connection.' };
     }
   });
 

--- a/packages/bruno-electron/src/ipc/ai/providers.js
+++ b/packages/bruno-electron/src/ipc/ai/providers.js
@@ -7,14 +7,20 @@ const PROVIDERS = {
     label: 'OpenAI',
     apiKeyPlaceholder: 'sk-...',
     apiKeyHelpUrl: 'https://platform.openai.com/api-keys',
-    createSdk: ({ apiKey }) => createOpenAI({ apiKey })
+    createSdk: ({ apiKey }) => createOpenAI({ apiKey }),
+    validateApiKey: ({ apiKey }) => fetch('https://api.openai.com/v1/models', {
+      headers: { Authorization: `Bearer ${apiKey}` }
+    })
   },
   anthropic: {
     id: 'anthropic',
     label: 'Anthropic',
     apiKeyPlaceholder: 'sk-ant-...',
     apiKeyHelpUrl: 'https://console.anthropic.com/settings/keys',
-    createSdk: ({ apiKey }) => createAnthropic({ apiKey })
+    createSdk: ({ apiKey }) => createAnthropic({ apiKey }),
+    validateApiKey: ({ apiKey }) => fetch('https://api.anthropic.com/v1/models', {
+      headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' }
+    })
   }
 };
 

--- a/packages/bruno-electron/src/ipc/ai/providers.js
+++ b/packages/bruno-electron/src/ipc/ai/providers.js
@@ -9,7 +9,8 @@ const PROVIDERS = {
     apiKeyHelpUrl: 'https://platform.openai.com/api-keys',
     createSdk: ({ apiKey }) => createOpenAI({ apiKey }),
     validateApiKey: ({ apiKey }) => fetch('https://api.openai.com/v1/models', {
-      headers: { Authorization: `Bearer ${apiKey}` }
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(10000)
     })
   },
   anthropic: {
@@ -19,7 +20,8 @@ const PROVIDERS = {
     apiKeyHelpUrl: 'https://console.anthropic.com/settings/keys',
     createSdk: ({ apiKey }) => createAnthropic({ apiKey }),
     validateApiKey: ({ apiKey }) => fetch('https://api.anthropic.com/v1/models', {
-      headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' }
+      headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
+      signal: AbortSignal.timeout(10000)
     })
   }
 };


### PR DESCRIPTION
[BRU-3640](https://usebruno.atlassian.net/browse/BRU-3640)

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI provider API key validation with more direct and reliable verification
  * Enhanced error messaging for validation failures, including invalid credentials, rate limiting, network connectivity issues, and provider unavailability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->