### PR TITLE
fix:Draft icon indicator on Workspace Environment tab

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/StyledWrapper.js
@@ -93,11 +93,20 @@ const StyledWrapper = styled.div.attrs((props) => ({
   }
 
   li:hover &.has-changes {
-    .draft-icon-wrapper { 
-      display: none; 
+    .draft-icon-wrapper {
+      display: none;
     }
-    .close-icon-wrapper { 
-      display: flex; 
+    .close-icon-wrapper {
+      display: flex;
+    }
+  }
+
+  &.no-close,
+  li:hover &.no-close {
+    pointer-events: none;
+
+    .draft-icon-wrapper {
+      display: flex;
     }
   }
 `;

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/StyledWrapper.js
@@ -34,7 +34,7 @@ const StyledWrapper = styled.div.attrs((props) => ({
     );
   }
 
-  li:hover &,
+  li:hover &:not(.no-close),
   &.has-changes {
     opacity: 1;
     pointer-events: auto;
@@ -56,6 +56,12 @@ const StyledWrapper = styled.div.attrs((props) => ({
       .close-icon {
         color: ${(props) => props.theme.requestTabs.icon.hoverColor};
       }
+    }
+  }
+
+  &.no-close .close-icon-container {
+    &:hover {
+      background-color: transparent;
     }
   }
 
@@ -82,17 +88,18 @@ const StyledWrapper = styled.div.attrs((props) => ({
   }
 
   &.has-changes:not(li:hover &) {
-    .draft-icon-wrapper { 
+    .draft-icon-wrapper {
       display: flex;
       align-items: center;
       justify-content: center;
     }
-    .close-icon-wrapper { 
-      display: none; 
+    .close-icon-wrapper {
+      display: none;
     }
   }
 
-  li:hover &.has-changes {
+  /* Closable tabs: hovering shows the close icon, replacing the draft icon */
+  li:hover &:not(.no-close) {
     .draft-icon-wrapper {
       display: none;
     }
@@ -101,12 +108,15 @@ const StyledWrapper = styled.div.attrs((props) => ({
     }
   }
 
-  &.no-close,
-  li:hover &.no-close {
-    pointer-events: none;
-
+  /* Non-closable tabs with changes: keep the draft icon visible even on hover */
+  &.no-close.has-changes {
     .draft-icon-wrapper {
       display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .close-icon-wrapper {
+      display: none;
     }
   }
 `;

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/index.js
@@ -3,18 +3,20 @@ import CloseTabIcon from '../CloseTabIcon';
 import DraftTabIcon from '../DraftTabIcon';
 import StyledWrapper from './StyledWrapper';
 
-const GradientCloseButton = ({ onClick, hasChanges = false, closeable = true }) => {
+const GradientCloseButton = ({ onClick, hasChanges = false }) => {
+  const canClose = typeof onClick === 'function';
+
   return (
-    <StyledWrapper className={`close-gradient ${hasChanges ? 'has-changes' : ''} ${closeable ? '' : 'no-close'}`}>
+    <StyledWrapper className={`close-gradient ${hasChanges ? 'has-changes' : ''} ${canClose ? '' : 'no-close'}`}>
       <div
         className="close-icon-container"
-        onClick={closeable ? onClick : undefined}
-        data-testid={closeable ? 'request-tab-close-icon' : 'request-tab-draft-icon'}
+        onClick={canClose ? onClick : undefined}
+        data-testid={canClose ? 'request-tab-close-icon' : 'request-tab-draft-icon'}
       >
         <span className="draft-icon-wrapper" data-testid="tab-draft-icon">
           <DraftTabIcon />
         </span>
-        {closeable && (
+        {canClose && (
           <span className="close-icon-wrapper">
             <CloseTabIcon />
           </span>

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/index.js
@@ -3,16 +3,22 @@ import CloseTabIcon from '../CloseTabIcon';
 import DraftTabIcon from '../DraftTabIcon';
 import StyledWrapper from './StyledWrapper';
 
-const GradientCloseButton = ({ onClick, hasChanges = false }) => {
+const GradientCloseButton = ({ onClick, hasChanges = false, closeable = true }) => {
   return (
-    <StyledWrapper className={`close-gradient ${hasChanges ? 'has-changes' : ''}`}>
-      <div className="close-icon-container" onClick={onClick} data-testid="request-tab-close-icon">
+    <StyledWrapper className={`close-gradient ${hasChanges ? 'has-changes' : ''} ${closeable ? '' : 'no-close'}`}>
+      <div
+        className="close-icon-container"
+        onClick={closeable ? onClick : undefined}
+        data-testid={closeable ? 'request-tab-close-icon' : 'request-tab-draft-icon'}
+      >
         <span className="draft-icon-wrapper" data-testid="tab-draft-icon">
           <DraftTabIcon />
         </span>
-        <span className="close-icon-wrapper">
-          <CloseTabIcon />
-        </span>
+        {closeable && (
+          <span className="close-icon-wrapper">
+            <CloseTabIcon />
+          </span>
+        )}
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
@@ -121,9 +121,8 @@ const SpecialTab = ({ handleCloseClick, type, tabName, handleDoubleClick, hasDra
       >
         {getTabInfo(type, tabName)}
       </div>
-      {handleCloseClick
-        ? <GradientCloseButton hasChanges={hasDraft} onClick={(e) => handleCloseClick(e)} />
-        : hasDraft && <GradientCloseButton hasChanges={hasDraft} closeable={false} />}
+
+      <GradientCloseButton hasChanges={hasDraft} onClick={handleCloseClick} />
     </>
   );
 };

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
@@ -124,7 +124,7 @@ const SpecialTab = ({ handleCloseClick, type, tabName, handleDoubleClick, hasDra
       </div>
       {handleCloseClick
         ? <GradientCloseButton hasChanges={hasDraft} onClick={(e) => handleCloseClick(e)} />
-        : hasDraft && <DraftTabIcon />}
+        : hasDraft && <span data-testid="request-tab-draft-icon"><DraftTabIcon /></span>}
     </>
   );
 };

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import GradientCloseButton from './GradientCloseButton';
-import DraftTabIcon from './DraftTabIcon';
 import { IconVariable, IconSettings, IconRun, IconFolder, IconDatabase, IconWorld, IconHome, IconFileCode, IconConfetti } from '@tabler/icons';
 import OpenAPISyncIcon from 'components/Icons/OpenAPISync';
 
@@ -124,7 +123,7 @@ const SpecialTab = ({ handleCloseClick, type, tabName, handleDoubleClick, hasDra
       </div>
       {handleCloseClick
         ? <GradientCloseButton hasChanges={hasDraft} onClick={(e) => handleCloseClick(e)} />
-        : hasDraft && <span data-testid="request-tab-draft-icon"><DraftTabIcon /></span>}
+        : hasDraft && <GradientCloseButton hasChanges={hasDraft} closeable={false} />}
     </>
   );
 };

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/SpecialTab.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import GradientCloseButton from './GradientCloseButton';
+import DraftTabIcon from './DraftTabIcon';
 import { IconVariable, IconSettings, IconRun, IconFolder, IconDatabase, IconWorld, IconHome, IconFileCode, IconConfetti } from '@tabler/icons';
 import OpenAPISyncIcon from 'components/Icons/OpenAPISync';
 
@@ -121,7 +122,9 @@ const SpecialTab = ({ handleCloseClick, type, tabName, handleDoubleClick, hasDra
       >
         {getTabInfo(type, tabName)}
       </div>
-      {handleCloseClick && <GradientCloseButton hasChanges={hasDraft} onClick={(e) => handleCloseClick(e)} />}
+      {handleCloseClick
+        ? <GradientCloseButton hasChanges={hasDraft} onClick={(e) => handleCloseClick(e)} />
+        : hasDraft && <DraftTabIcon />}
     </>
   );
 };

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -261,7 +261,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
             .catch(() => toast.error('An error occurred while saving the changes'));
         }
       }
-    } else if (tab.type === 'global-environment-settings') {
+    } else if (tab.type === 'global-environment-settings' || tab.type === 'workspaceEnvironments') {
       if (globalEnvironmentDraft) {
         const { environmentUid, variables } = globalEnvironmentDraft;
         if (environmentUid?.startsWith('dotenv:')) {

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -202,7 +202,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   const hasFolderDraft = tab.type === 'folder-settings' && folder?.draft;
   const hasEnvironmentDraft = tab.type === 'environment-settings' && collection?.environmentsDraft;
   const globalEnvironmentDraft = useSelector((state) => state.globalEnvironments.globalEnvironmentDraft);
-  const hasGlobalEnvironmentDraft = tab.type === 'global-environment-settings' && globalEnvironmentDraft;
+  const hasGlobalEnvironmentDraft = (tab.type === 'global-environment-settings' || tab.type === 'workspaceEnvironments') && globalEnvironmentDraft;
 
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const isActive = tab.uid === activeTabUid;
@@ -483,7 +483,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
         ) : tab.type === 'workspaceOverview' ? (
           <SpecialTab handleCloseClick={null} type={tab.type} />
         ) : tab.type === 'workspaceEnvironments' ? (
-          <SpecialTab handleCloseClick={null} type={tab.type} />
+          <SpecialTab handleCloseClick={null} type={tab.type} hasDraft={hasGlobalEnvironmentDraft} />
         ) : (
           <SpecialTab handleCloseClick={handleCloseClick} handleDoubleClick={() => dispatch(makeTabPermanent({ uid: tab.uid }))} type={tab.type} />
         )}


### PR DESCRIPTION
### Description
JIRA:https://usebruno.atlassian.net/browse/BRU-3033

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Fixed the draft indicator not showing on the workspace environment tab. The tab shares the same Redux draft state as global-environment-settings but was missing from the type check, never received the hasDraft prop, and SpecialTab had no way to render the dot without a close button.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
<img width="1014" height="720" alt="image" src="https://github.com/user-attachments/assets/a24283a8-6b1c-4b65-88cb-747f1f7b1e11" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Workspace environments tab now displays a draft indicator for unsaved changes, aligned with global environment settings.

**UI Changes**
- Updated special tab controls to better reflect whether a close action is available: the interface now switches between draft and close states accordingly, including improved hover/visibility behavior.

**Keyboard Shortcuts**
- The tab “save” shortcut now follows the same draft-aware save flow used for global environment settings across both relevant tab types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->