### PR TITLE
fix:serialize object variable values before copying to clipboard

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -153,8 +153,13 @@ const getCopyButton = (getVariableValue, onCopyCallback) => {
     // Resolve the latest value at click time so edits/saves are reflected.
     const valueToCopy = typeof getVariableValue === 'function' ? getVariableValue() : getVariableValue;
 
+    const valueStr
+      = typeof valueToCopy === 'object' && valueToCopy !== null
+        ? JSON.stringify(valueToCopy, null, 2)
+        : String(valueToCopy ?? '');
+
     navigator.clipboard
-      .writeText(valueToCopy ?? '')
+      .writeText(valueStr)
       .then(() => {
         isCopied = true;
         copyButton.innerHTML = CHECKMARK_ICON_SVG_TEXT;

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -95,7 +95,15 @@ const updateValueDisplay = (valueDisplay, value, isSecret, isMasked, isRevealed)
   }
 
   if (typeof value === 'object') {
-    valueDisplay.textContent = value === null ? 'null' : JSON.stringify(value, null, 2);
+    if (value === null) {
+      valueDisplay.textContent = 'null';
+    } else {
+      try {
+        valueDisplay.textContent = JSON.stringify(value, null, 2);
+      } catch {
+        valueDisplay.textContent = String(value);
+      }
+    }
     return;
   }
 
@@ -153,10 +161,16 @@ const getCopyButton = (getVariableValue, onCopyCallback) => {
     // Resolve the latest value at click time so edits/saves are reflected.
     const valueToCopy = typeof getVariableValue === 'function' ? getVariableValue() : getVariableValue;
 
-    const valueStr
-      = typeof valueToCopy === 'object' && valueToCopy !== null
-        ? JSON.stringify(valueToCopy, null, 2)
-        : String(valueToCopy ?? '');
+    let valueStr;
+    if (typeof valueToCopy === 'object' && valueToCopy !== null) {
+      try {
+        valueStr = JSON.stringify(valueToCopy, null, 2);
+      } catch {
+        valueStr = String(valueToCopy);
+      }
+    } else {
+      valueStr = String(valueToCopy ?? '');
+    }
 
     navigator.clipboard
       .writeText(valueStr)

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -154,9 +154,7 @@ const getCopyButton = (getVariableValue, onCopyCallback) => {
     // Resolve the latest value at click time so edits/saves are reflected.
     const valueToCopy = typeof getVariableValue === 'function' ? getVariableValue() : getVariableValue;
 
-    const valueStr = typeof valueToCopy === 'object' && valueToCopy !== null
-      ? toDisplayString(valueToCopy, String(valueToCopy))
-      : String(valueToCopy ?? '');
+    const valueStr = toDisplayString(valueToCopy, String(valueToCopy));
 
     navigator.clipboard
       .writeText(valueStr)

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -7,6 +7,7 @@
  */
 
 import { interpolate, mockDataFunctions, timeBasedDynamicVars } from '@usebruno/common';
+import { toDisplayString } from '@usebruno/common/utils';
 import { getVariableScope, isVariableSecret, getAllVariables, findCollectionByUid, findItemInCollectionByItemUid } from 'utils/collections';
 import { updateVariableInScope } from 'providers/ReduxStore/slices/collections/actions';
 import store from 'providers/ReduxStore';
@@ -95,15 +96,7 @@ const updateValueDisplay = (valueDisplay, value, isSecret, isMasked, isRevealed)
   }
 
   if (typeof value === 'object') {
-    if (value === null) {
-      valueDisplay.textContent = 'null';
-    } else {
-      try {
-        valueDisplay.textContent = JSON.stringify(value, null, 2);
-      } catch {
-        valueDisplay.textContent = String(value);
-      }
-    }
+    valueDisplay.textContent = value === null ? 'null' : toDisplayString(value, String(value));
     return;
   }
 
@@ -161,16 +154,9 @@ const getCopyButton = (getVariableValue, onCopyCallback) => {
     // Resolve the latest value at click time so edits/saves are reflected.
     const valueToCopy = typeof getVariableValue === 'function' ? getVariableValue() : getVariableValue;
 
-    let valueStr;
-    if (typeof valueToCopy === 'object' && valueToCopy !== null) {
-      try {
-        valueStr = JSON.stringify(valueToCopy, null, 2);
-      } catch {
-        valueStr = String(valueToCopy);
-      }
-    } else {
-      valueStr = String(valueToCopy ?? '');
-    }
+    const valueStr = typeof valueToCopy === 'object' && valueToCopy !== null
+      ? toDisplayString(valueToCopy, String(valueToCopy))
+      : String(valueToCopy ?? '');
 
     navigator.clipboard
       .writeText(valueStr)

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -421,6 +421,28 @@ describe('renderVarInfo', () => {
       expect(copyButton.classList.contains('copy-success')).toBe(false);
     });
 
+    it('should copy plain object values as formatted JSON', async () => {
+      const { copyButton } = setupRender({ apiKey: { host: 'localhost', port: 8080 } });
+
+      copyButton.click();
+      await jest.runAllTimersAsync();
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        JSON.stringify({ host: 'localhost', port: 8080 }, null, 2)
+      );
+    });
+
+    it('should fall back to String() for circular objects and still write to clipboard', async () => {
+      const circular = {};
+      circular.self = circular;
+      const { copyButton } = setupRender({ apiKey: circular });
+
+      copyButton.click();
+      await jest.runAllTimersAsync();
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(String(circular));
+    });
+
     it('should log to the console when the variable value is not copied', async () => {
       const { copyButton } = setupRender({ apiKey: 'cause-clipboard-error' });
 

--- a/packages/bruno-common/src/utils/index.ts
+++ b/packages/bruno-common/src/utils/index.ts
@@ -38,3 +38,7 @@ export {
   BRUNO_VARIABLE_DATATYPES,
   isBrunoVariableDataType
 } from './datatype';
+
+export {
+  toDisplayString
+} from './string';

--- a/packages/bruno-common/src/utils/string.ts
+++ b/packages/bruno-common/src/utils/string.ts
@@ -1,0 +1,15 @@
+export const toDisplayString = (value: unknown, fallback = '', indentation = 2): string => {
+  if (value == null || value === '') return fallback;
+
+  if (typeof value === 'string') return value;
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, indentation);
+    } catch {
+      return fallback;
+    }
+  }
+
+  return String(value);
+};

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -3,6 +3,8 @@ import {
   createCollection,
   closeAllCollections,
   createRequest,
+  createFolder,
+  expandFolder,
   createEnvironment,
   addEnvironmentVariables,
   saveEnvironment,
@@ -632,6 +634,86 @@ test.describe('Variable Tooltip', () => {
 
       const updatedClipboard = await page.evaluate(() => navigator.clipboard.readText());
       expect(updatedClipboard).toBe('original-copy-edited');
+    });
+  });
+
+  test('should copy pretty-printed JSON for an object-typed folder variable', async ({ page, createTmpDir }) => {
+    const collectionName = 'tooltip-object-copy-test';
+    const folderName = 'objFolder';
+    const objectValue = { city: 'NYC', zip: 10001 };
+
+    const expectedJson = JSON.stringify(objectValue, null, 2);
+
+    await test.step('Create a folder with an object-typed folder variable', async () => {
+      await createCollection(page, collectionName, await createTmpDir('tooltip-object-collection'));
+      await createFolder(page, folderName, collectionName);
+
+      const locators = buildCommonLocators(page);
+
+      // Open Folder Settings > Vars tab
+      const folderRow = locators.sidebar.folder(folderName);
+      await folderRow.dblclick();
+      await locators.paneTabs.folderSettingsTab('vars').click();
+
+      // Add the variable row and type its value
+      const tableContainer = page.getByTestId('folder-vars-req').first();
+      const lastRow = tableContainer.locator('tbody tr').last();
+      const nameInput = lastRow.locator('input[type="text"]').first();
+      await nameInput.click();
+      await page.keyboard.type('objVar');
+
+      const namedRow = tableContainer.locator('tbody tr[data-row-name="objVar"]');
+      await expect(namedRow).toBeVisible();
+
+      const valueEditor = namedRow.locator('[data-testid="column-value"] .CodeMirror').first();
+      await valueEditor.click({ force: true });
+      await expect(valueEditor).toHaveClass(/CodeMirror-focused/);
+      await page.keyboard.insertText(JSON.stringify(objectValue));
+
+      // Switch the variable's dataType from the default `string` to `object`
+      const typeTrigger = locators.dataTypeSelector.typeLabel(namedRow);
+      await typeTrigger.click();
+      await locators.dataTypeSelector.menuItem('object').click();
+      await expect(typeTrigger).toHaveText('object');
+
+      await page.getByRole('button', { name: 'Save', exact: true }).first().click();
+      await page.waitForTimeout(500);
+    });
+
+    await test.step('Create request inside the folder referencing the object variable', async () => {
+      await expandFolder(page, folderName);
+      await createRequest(page, 'Object Copy Request', folderName, { inFolder: true });
+
+      const locators = buildCommonLocators(page);
+      await locators.sidebar.folderRequest(folderName, 'Object Copy Request').click();
+
+      const urlEditor = page.locator('#request-url .CodeMirror');
+      await urlEditor.click();
+      await page.keyboard.type('https://api.example.com?data={{objVar}}');
+      await page.keyboard.press(saveShortcut);
+    });
+
+    await test.step('Tooltip shows pretty-printed JSON and copy button copies it verbatim', async () => {
+      const urlEditor = page.locator('#request-url .CodeMirror');
+      const objVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'objVar' }).first();
+      await objVar.hover();
+
+      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
+      await expect(tooltip).toBeVisible();
+      await expect(tooltip.locator('.var-scope-badge')).toContainText('Folder');
+
+      // Parse back and deep-compare so the assertion isn't coupled to whitespace.
+      const valueDisplay = tooltip.locator('.var-value-editable-display');
+      await expect.poll(async () => JSON.parse((await valueDisplay.textContent()) ?? 'null')).toEqual(objectValue);
+
+      const copyButton = tooltip.locator('.copy-button');
+      await copyButton.click();
+
+      // Success state confirms writeText resolved before we read the clipboard.
+      await expect(copyButton.locator('svg polyline')).toBeVisible({ timeout: 1000 });
+
+      const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+      expect(clipboardText).toBe(expectedJson);
     });
   });
 });


### PR DESCRIPTION
### Description

Copying a variable with an object value from the hover popup writes [object Object] to the clipboard instead of the actual value.navigator.clipboard.writeText() expects a string. When the resolved variable value is an object passing it directly causes the browser to coerce it to [object Object]. The fix serializes the value with JSON.stringify before writing to the clipboard.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3630)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hover tooltip copy-to-clipboard for non-null object values by serializing resolved values via a shared `toDisplayString` helper (prevents copying `[object Object]`).
  * Ensured `null` is explicitly displayed/copied as `null`.
  * Added safe fallbacks for non-JSON-serializable/circular values (copies `String(value)` instead).

* **Shared Utility Changes (bruno-common)**
  * Added `toDisplayString(value, fallback, indentation)` in `packages/bruno-common/src/utils/string.ts`, with re-export from `packages/bruno-common/src/utils/index.ts`.

* **UI Behavior Changes (bruno-app)**
  * Updated `packages/bruno-app/src/utils/codemirror/brunoVarInfo.js` to:
    * Render object values using `toDisplayString` (while preserving the explicit `'null'` display).
    * Precompute the clipboard string (`toDisplayString(...)`) and pass that string to `navigator.clipboard.writeText(valueStr)`.

* **Tests**
  * Updated `packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js` with Jest coverage for:
    * Plain objects copying as pretty-printed JSON.
    * Circular objects copying using `String(value)`.
  * Added a Playwright test in `tests/variable-tooltip/variable-tooltip.spec.ts` validating that an object-typed folder variable:
    * Shows pretty-printed JSON in the tooltip.
    * Copies the JSON verbatim to the clipboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->