### PR TITLE
chore: improve bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.yaml
+++ b/.github/ISSUE_TEMPLATE/BugReport.yaml
@@ -49,14 +49,14 @@ body:
   - type: textarea
     attributes:
       label: Describe the bug
-      description: A clear and concise description of the bug and how it's effecting your work. 
+      description: A clear and concise description of the bug and how it's affecting your work
     validations:
       required: true
 
   - type: textarea
     attributes:
       label: Steps to reproduce
-      description: The exact steps that can be performd to reproduce the issue 
+      description: The exact steps that can be performed to reproduce the issue
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/BugReport.yaml
+++ b/.github/ISSUE_TEMPLATE/BugReport.yaml
@@ -49,14 +49,21 @@ body:
   - type: textarea
     attributes:
       label: Describe the bug
-      description: A clear and concise description of the bug and how it's effecting your work along with steps to reproduce. 
+      description: A clear and concise description of the bug and how it's effecting your work. 
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: .bru file to reproduce the bug
-      description: Attach your .bru file here that can reproduce the problem.
+      label: Steps to reproduce
+      description: The exact steps that can be performd to reproduce the issue 
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Collection to reproduce 
+      description: If possible, please attach the collection where the bug is present
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Discussions
     url: https://github.com/usebruno/bruno/discussions


### PR DESCRIPTION
Improves the bug report issue template to make it easier to triage incoming reports.

### Changes
- Add a dedicated, required **Steps to reproduce** field instead of folding repro steps into the description.
- Replace the `.bru file to reproduce` prompt with an optional **Collection to reproduce** field. 
- Set `blank_issues_enabled: false` so new issues go through the templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the bug report form to request a clearer description and separate, required fields for **steps to reproduce** and the **collection to reproduce**.
  * Removed the prior dedicated file field and adjusted guidance/wording to better match the new workflow.
* **Chores**
  * Disabled creating blank issues so new issues use the provided templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->