### PR TITLE
fix(app): make multi-file environment import resilient and idempotent

### DIFF
--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.js
@@ -8,7 +8,6 @@ import importBrunoEnvironment from 'utils/importers/bruno-environment';
 import { readMultipleFiles } from 'utils/importers/file-reader';
 import { importEnvironment } from 'providers/ReduxStore/slices/collections/actions';
 import { addGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
-import { toastError } from 'utils/common/error';
 import { sanitizeName } from 'utils/common/regex';
 import { IconFileImport } from '@tabler/icons';
 
@@ -44,13 +43,13 @@ const ImportEnvironmentModal = ({ type = 'collection', collection, onClose, onEn
     const toImport = [];
     let skipped = 0;
     for (const env of named) {
-      const key = sanitizeName(env.name);
-      if (seen.has(key)) {
+      const name = sanitizeName(env.name);
+      if (seen.has(name)) {
         skipped++;
-      } else {
-        seen.add(key);
-        toImport.push(env);
+        continue;
       }
+      seen.add(name);
+      toImport.push({ ...env, name });
     }
 
     let imported = 0;
@@ -107,17 +106,18 @@ const ImportEnvironmentModal = ({ type = 'collection', collection, onClose, onEn
   };
 
   const handleImportEnvironment = async (files) => {
-    let parsedFiles;
-    try {
-      parsedFiles = await readMultipleFiles(Array.from(files));
-    } catch (err) {
-      toastError(err, 'Import environment failed');
-      return;
-    }
-
     const environments = [];
     const parseFailures = [];
-    for (const parsedFile of parsedFiles) {
+    for (const file of Array.from(files)) {
+      let parsedFile;
+      try {
+        [parsedFile] = await readMultipleFiles([file]);
+      } catch (err) {
+        console.error(`Failed to read ${file.name}:`, err);
+        parseFailures.push({ name: file.name, message: err?.message || String(err) });
+        continue;
+      }
+
       try {
         const format = detectEnvironmentFormat(parsedFile.content);
         const result

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.js
@@ -2,17 +2,19 @@ import React, { useState } from 'react';
 import Portal from 'components/Portal';
 import Modal from 'components/Modal';
 import toast from 'react-hot-toast';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import importPostmanEnvironment from 'utils/importers/postman-environment';
 import importBrunoEnvironment from 'utils/importers/bruno-environment';
 import { readMultipleFiles } from 'utils/importers/file-reader';
 import { importEnvironment } from 'providers/ReduxStore/slices/collections/actions';
 import { addGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import { toastError } from 'utils/common/error';
+import { sanitizeName } from 'utils/common/regex';
 import { IconFileImport } from '@tabler/icons';
 
 const ImportEnvironmentModal = ({ type = 'collection', collection, onClose, onEnvironmentCreated }) => {
   const dispatch = useDispatch();
+  const globalEnvironments = useSelector((state) => state.globalEnvironments.globalEnvironments) || [];
   const [isDragOver, setIsDragOver] = useState(false);
 
   const isGlobal = type === 'global';
@@ -26,39 +28,68 @@ const ImportEnvironmentModal = ({ type = 'collection', collection, onClose, onEn
   const modalTestId = isGlobal ? 'import-global-environment-modal' : 'import-environment-modal';
   const importTestId = isGlobal ? 'import-global-environment' : 'import-environment';
 
-  const processEnvironments = async (environments, successMessage) => {
-    const validEnvironments = environments.filter((env) => {
-      if (env.name && env.name !== 'undefined') {
-        return true;
-      } else {
-        toast.error('Failed to import environment: env has no name');
-        return false;
-      }
-    });
+  const processEnvironments = async (environments, parseFailures = []) => {
+    const failures = [...parseFailures];
 
-    if (validEnvironments.length === 0) {
-      toast.error('No valid environments found to import');
-      return;
+    const named = [];
+    let unnamed = 0;
+    for (const env of environments) {
+      if (env.name && env.name !== 'undefined') named.push(env);
+      else unnamed++;
     }
 
-    try {
-      // Process environments sequentially to ensure unique name checking considers previously imported environments
-      let importedCount = 0;
-      for (const environment of validEnvironments) {
+    const existing = isGlobal ? globalEnvironments : collection?.environments || [];
+    const seen = new Set(existing.map((e) => sanitizeName(e.name || '')));
+
+    const toImport = [];
+    let skipped = 0;
+    for (const env of named) {
+      const key = sanitizeName(env.name);
+      if (seen.has(key)) {
+        skipped++;
+      } else {
+        seen.add(key);
+        toImport.push(env);
+      }
+    }
+
+    let imported = 0;
+    for (const environment of toImport) {
+      try {
         const action = isGlobal
           ? addGlobalEnvironment({ name: environment.name, variables: environment.variables, color: environment.color })
           : importEnvironment({ name: environment.name, variables: environment.variables, color: environment.color, collectionUid: collection?.uid });
 
         await dispatch(action);
-        importedCount++;
+        imported++;
+      } catch (error) {
+        console.error(`Failed to import environment "${environment.name}":`, error);
+        failures.push({ name: environment.name, message: error?.message || String(error) });
       }
-
-      toast.success(`${importedCount > 1 ? `${importedCount} environments` : 'Environment'} imported successfully`);
-    } catch (error) {
-      toast.error('An error occurred while importing the environment(s)');
-      console.error(error);
-      throw error;
     }
+
+    if (imported > 0) {
+      toast.success(`Imported ${imported} environment${imported > 1 ? 's' : ''}.`);
+    }
+
+    const notes = [];
+    if (skipped > 0) notes.push(`${skipped} already existed and ${skipped > 1 ? 'were' : 'was'} skipped`);
+    if (unnamed > 0) notes.push(`${unnamed} had no name`);
+    if (failures.length > 0) {
+      const names = failures.map((f) => f.name).slice(0, 3).join(', ');
+      const more = failures.length > 3 ? ` and ${failures.length - 3} more` : '';
+      notes.push(`${failures.length} failed (${names}${more})`);
+    }
+
+    if (notes.length > 0) {
+      const message = notes.join('; ') + '.';
+      if (failures.length > 0) toast.error(message);
+      else toast(message);
+    } else if (imported === 0) {
+      toast.error('No valid environments found to import.');
+    }
+
+    return { imported, skipped, unnamed, failures };
   };
 
   const detectEnvironmentFormat = (data) => {
@@ -76,27 +107,39 @@ const ImportEnvironmentModal = ({ type = 'collection', collection, onClose, onEn
   };
 
   const handleImportEnvironment = async (files) => {
+    let parsedFiles;
     try {
-      // Read and parse all files
-      const parsedFiles = await readMultipleFiles(Array.from(files));
-
-      // Detect format from first file's content
-      const format = detectEnvironmentFormat(parsedFiles[0].content);
-      let environments;
-
-      if (format === 'postman') {
-        environments = await importPostmanEnvironment(parsedFiles);
-      } else {
-        environments = await importBrunoEnvironment(parsedFiles);
-      }
-
-      await processEnvironments(environments);
-      onClose();
-      if (onEnvironmentCreated) {
-        onEnvironmentCreated();
-      }
+      parsedFiles = await readMultipleFiles(Array.from(files));
     } catch (err) {
       toastError(err, 'Import environment failed');
+      return;
+    }
+
+    const environments = [];
+    const parseFailures = [];
+    for (const parsedFile of parsedFiles) {
+      try {
+        const format = detectEnvironmentFormat(parsedFile.content);
+        const result
+          = format === 'postman'
+            ? await importPostmanEnvironment([parsedFile])
+            : await importBrunoEnvironment([parsedFile]);
+        environments.push(...result);
+      } catch (err) {
+        console.error(`Failed to parse ${parsedFile.fileName}:`, err);
+        parseFailures.push({ name: parsedFile.fileName, message: err?.message || String(err) });
+      }
+    }
+
+    const summary = await processEnvironments(environments, parseFailures);
+
+    if (summary.imported === 0 && summary.skipped === 0) {
+      return;
+    }
+
+    onClose();
+    if (summary.imported > 0 && onEnvironmentCreated) {
+      onEnvironmentCreated();
     }
   };
 

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.js
@@ -33,7 +33,8 @@ const ImportEnvironmentModal = ({ type = 'collection', collection, onClose, onEn
     const named = [];
     let unnamed = 0;
     for (const env of environments) {
-      if (env.name && env.name !== 'undefined') named.push(env);
+      const name = typeof env.name === 'string' ? sanitizeName(env.name) : '';
+      if (name && name !== 'undefined') named.push({ ...env, name });
       else unnamed++;
     }
 
@@ -43,13 +44,13 @@ const ImportEnvironmentModal = ({ type = 'collection', collection, onClose, onEn
     const toImport = [];
     let skipped = 0;
     for (const env of named) {
-      const name = sanitizeName(env.name);
-      if (seen.has(name)) {
+      const key = env.name;
+      if (seen.has(key)) {
         skipped++;
         continue;
       }
-      seen.add(name);
-      toImport.push({ ...env, name });
+      seen.add(key);
+      toImport.push(env);
     }
 
     let imported = 0;

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.spec.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.spec.js
@@ -132,16 +132,37 @@ describe('ImportEnvironmentModal — batch import summary', () => {
     expect(onEnvironmentCreated).not.toHaveBeenCalled();
   });
 
-  it('counts unnamed environments while still importing the named ones', async () => {
+  it('counts unnamed Postman environments while still importing the named ones', async () => {
+    // The Bruno importer defaults missing names to 'Imported Environment', so a
+    // genuinely nameless environment only reaches processEnvironments via Postman.
     setupFiles({
-      'mixed.json': { content: brunoContent([{ name: 'Named', variables: [] }, { variables: [] }]) }
+      'mixed.postman.json': { content: postmanContent([{ name: 'Named', variables: [] }, { variables: [] }]) }
     });
     renderModal({ collection: collectionWith([]) });
 
-    dropFiles('import-environment', [makeFile('mixed.json')]);
+    dropFiles('import-environment', [makeFile('mixed.postman.json')]);
 
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 1 environment.'));
     await waitFor(() => expect(toast).toHaveBeenCalledWith('1 had no name.'));
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats non-string and empty-after-sanitize names as unnamed', async () => {
+    setupFiles({
+      'odd.json': {
+        content: brunoContent([
+          { name: 12345, variables: [] },
+          { name: '///', variables: [] },
+          { name: 'Valid', variables: [] }
+        ])
+      }
+    });
+    renderModal({ collection: collectionWith([]) });
+
+    dropFiles('import-environment', [makeFile('odd.json')]);
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 1 environment.'));
+    await waitFor(() => expect(toast).toHaveBeenCalledWith('2 had no name.'));
     expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.spec.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.spec.js
@@ -1,0 +1,205 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, waitFor, fireEvent, createEvent } from '@testing-library/react';
+
+jest.mock('components/Portal', () => ({ __esModule: true, default: ({ children }) => children }));
+jest.mock('components/Modal', () => ({ __esModule: true, default: ({ children }) => children }));
+jest.mock('@tabler/icons', () => ({ __esModule: true, IconFileImport: () => null }));
+
+jest.mock('react-hot-toast', () => {
+  const fn = jest.fn();
+  fn.success = jest.fn();
+  fn.error = jest.fn();
+  return { __esModule: true, default: fn };
+});
+
+let mockDispatch;
+let mockSelectorState;
+jest.mock('react-redux', () => ({
+  __esModule: true,
+  useDispatch: () => mockDispatch,
+  useSelector: (selector) => selector(mockSelectorState)
+}));
+
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  __esModule: true,
+  importEnvironment: jest.fn((payload) => ({ thunk: 'importEnvironment', ...payload }))
+}));
+jest.mock('providers/ReduxStore/slices/global-environments', () => ({
+  __esModule: true,
+  addGlobalEnvironment: jest.fn((payload) => ({ thunk: 'addGlobalEnvironment', ...payload }))
+}));
+
+jest.mock('utils/importers/postman-environment', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('utils/importers/bruno-environment', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('utils/importers/file-reader', () => ({ __esModule: true, readMultipleFiles: jest.fn() }));
+
+import toast from 'react-hot-toast';
+import { importEnvironment } from 'providers/ReduxStore/slices/collections/actions';
+import { addGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
+import importPostmanEnvironment from 'utils/importers/postman-environment';
+import importBrunoEnvironment from 'utils/importers/bruno-environment';
+import { readMultipleFiles } from 'utils/importers/file-reader';
+import ImportEnvironmentModal from './index';
+
+const brunoContent = (envs) => ({ info: { type: 'bruno-environment' }, envs });
+const postmanContent = (envs) => ({ id: 'pm-id', values: [], envs });
+
+const makeFile = (name) => new File(['{}'], name, { type: 'application/json' });
+const collectionWith = (environments) => ({ uid: 'col-1', name: 'Col', environments });
+
+// map: { 'file.json': { content } | { error } }
+const setupFiles = (map) => {
+  readMultipleFiles.mockImplementation(async (files) => {
+    const file = files[0];
+    const entry = map[file.name];
+    if (!entry || entry.error) {
+      throw new Error(entry?.error || `Unable to parse JSON file: ${file.name}`);
+    }
+    return [{ fileName: file.name, content: entry.content }];
+  });
+};
+
+const dropFiles = (testId, files) => {
+  const node = screen.getByTestId(testId);
+  const event = createEvent.drop(node);
+  Object.defineProperty(event, 'dataTransfer', { value: { files } });
+  fireEvent(node, event);
+};
+
+const renderModal = (props = {}) =>
+  render(<ImportEnvironmentModal type="collection" onClose={() => {}} onEnvironmentCreated={() => {}} {...props} />);
+
+describe('ImportEnvironmentModal — batch import summary', () => {
+  beforeEach(() => {
+    mockDispatch = jest.fn(() => Promise.resolve());
+    mockSelectorState = { globalEnvironments: { globalEnvironments: [] } };
+
+    const passthrough = async ([parsedFile]) => {
+      if (parsedFile.content.importError) throw new Error(parsedFile.content.importError);
+      return parsedFile.content.envs || [];
+    };
+    importBrunoEnvironment.mockImplementation(passthrough);
+    importPostmanEnvironment.mockImplementation(passthrough);
+  });
+
+  it('imports a mix of Bruno and Postman files and reports the combined count', async () => {
+    setupFiles({
+      'bruno.json': { content: brunoContent([{ name: 'B1', variables: [] }]) },
+      'postman.json': { content: postmanContent([{ name: 'P1', variables: [] }]) }
+    });
+    const onClose = jest.fn();
+    const onEnvironmentCreated = jest.fn();
+    renderModal({ collection: collectionWith([]), onClose, onEnvironmentCreated });
+
+    dropFiles('import-environment', [makeFile('bruno.json'), makeFile('postman.json')]);
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 2 environments.'));
+    expect(importBrunoEnvironment).toHaveBeenCalledTimes(1);
+    expect(importPostmanEnvironment).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(onEnvironmentCreated).toHaveBeenCalled();
+  });
+
+  it('imports valid files even when one file is malformed, and reports the failure', async () => {
+    setupFiles({
+      'good1.json': { content: brunoContent([{ name: 'Good1', variables: [] }]) },
+      'bad.json': { error: 'Unable to parse JSON file: bad.json' },
+      'good2.json': { content: postmanContent([{ name: 'Good2', variables: [] }]) }
+    });
+    renderModal({ collection: collectionWith([]) });
+
+    dropFiles('import-environment', [makeFile('good1.json'), makeFile('bad.json'), makeFile('good2.json')]);
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 2 environments.'));
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('1 failed (bad.json)')));
+  });
+
+  it('skips environments whose name already exists', async () => {
+    setupFiles({ 'dup.json': { content: brunoContent([{ name: 'Existing', variables: [] }]) } });
+    const onClose = jest.fn();
+    const onEnvironmentCreated = jest.fn();
+    renderModal({ collection: collectionWith([{ name: 'Existing' }]), onClose, onEnvironmentCreated });
+
+    dropFiles('import-environment', [makeFile('dup.json')]);
+
+    await waitFor(() => expect(toast).toHaveBeenCalledWith('1 already existed and was skipped.'));
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(onEnvironmentCreated).not.toHaveBeenCalled();
+  });
+
+  it('counts unnamed environments while still importing the named ones', async () => {
+    setupFiles({
+      'mixed.json': { content: brunoContent([{ name: 'Named', variables: [] }, { variables: [] }]) }
+    });
+    renderModal({ collection: collectionWith([]) });
+
+    dropFiles('import-environment', [makeFile('mixed.json')]);
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 1 environment.'));
+    await waitFor(() => expect(toast).toHaveBeenCalledWith('1 had no name.'));
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a failure when an environment fails to dispatch but imports the rest', async () => {
+    setupFiles({
+      'two.json': { content: brunoContent([{ name: 'Ok', variables: [] }, { name: 'Will-Fail', variables: [] }]) }
+    });
+    mockDispatch.mockImplementation((action) => {
+      if (action.name === 'Will-Fail') return Promise.reject(new Error('disk full'));
+      return Promise.resolve();
+    });
+    renderModal({ collection: collectionWith([]) });
+
+    dropFiles('import-environment', [makeFile('two.json')]);
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 1 environment.'));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('1 failed (Will-Fail)')));
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports when nothing valid was found to import', async () => {
+    setupFiles({ 'empty.json': { content: brunoContent([]) } });
+    const onClose = jest.fn();
+    renderModal({ collection: collectionWith([]), onClose });
+
+    dropFiles('import-environment', [makeFile('empty.json')]);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('No valid environments found to import.'));
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  describe('name normalization', () => {
+    it('passes a sanitized name to importEnvironment for collection imports', async () => {
+      setupFiles({
+        'env.json': { content: brunoContent([{ name: 'Prod/Env', variables: [{ name: 'k' }], color: 'red' }]) }
+      });
+      renderModal({ type: 'collection', collection: collectionWith([]) });
+
+      dropFiles('import-environment', [makeFile('env.json')]);
+
+      await waitFor(() => expect(importEnvironment).toHaveBeenCalledTimes(1));
+      expect(importEnvironment).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Prod-Env', collectionUid: 'col-1' })
+      );
+    });
+
+    it('passes a sanitized name to addGlobalEnvironment for global imports', async () => {
+      setupFiles({
+        'env.json': { content: brunoContent([{ name: 'Prod/Env', variables: [{ name: 'k' }], color: 'red' }]) }
+      });
+      mockSelectorState = { globalEnvironments: { globalEnvironments: [] } };
+      renderModal({ type: 'global', collection: undefined });
+
+      dropFiles('import-global-environment', [makeFile('env.json')]);
+
+      await waitFor(() => expect(addGlobalEnvironment).toHaveBeenCalledTimes(1));
+      expect(addGlobalEnvironment).toHaveBeenCalledWith(expect.objectContaining({ name: 'Prod-Env' }));
+    });
+  });
+});

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.spec.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/index.spec.js
@@ -75,12 +75,15 @@ describe('ImportEnvironmentModal — batch import summary', () => {
     mockDispatch = jest.fn(() => Promise.resolve());
     mockSelectorState = { globalEnvironments: { globalEnvironments: [] } };
 
-    const passthrough = async ([parsedFile]) => {
+    const readEnvs = ([parsedFile]) => {
       if (parsedFile.content.importError) throw new Error(parsedFile.content.importError);
       return parsedFile.content.envs || [];
     };
-    importBrunoEnvironment.mockImplementation(passthrough);
-    importPostmanEnvironment.mockImplementation(passthrough);
+    // Mirror importBrunoEnvironment: a missing name is normalized to 'Imported Environment'.
+    importBrunoEnvironment.mockImplementation(async (files) =>
+      readEnvs(files).map((env) => ({ ...env, name: env.name || 'Imported Environment' }))
+    );
+    importPostmanEnvironment.mockImplementation(async (files) => readEnvs(files));
   });
 
   it('imports a mix of Bruno and Postman files and reports the combined count', async () => {
@@ -132,6 +135,31 @@ describe('ImportEnvironmentModal — batch import summary', () => {
     expect(onEnvironmentCreated).not.toHaveBeenCalled();
   });
 
+  it('skips a within-batch duplicate whose sanitized name collapses, without a "copy" suffix', async () => {
+    setupFiles({
+      'batch.json': {
+        content: brunoContent([
+          { name: 'Prod/Env', variables: [{ name: 'first' }] },
+          { name: 'Prod-Env', variables: [{ name: 'second' }] }
+        ])
+      }
+    });
+    renderModal({ collection: collectionWith([]) });
+
+    dropFiles('import-environment', [makeFile('batch.json')]);
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 1 environment.'));
+    await waitFor(() => expect(toast).toHaveBeenCalledWith('1 already existed and was skipped.'));
+    expect(importEnvironment).toHaveBeenCalledTimes(1);
+    expect(importEnvironment).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Prod-Env', variables: [{ name: 'first' }] })
+    );
+    expect(importEnvironment).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: expect.stringContaining('copy') })
+    );
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
   it('counts unnamed Postman environments while still importing the named ones', async () => {
     // The Bruno importer defaults missing names to 'Imported Environment', so a
     // genuinely nameless environment only reaches processEnvironments via Postman.
@@ -144,6 +172,18 @@ describe('ImportEnvironmentModal — batch import summary', () => {
 
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 1 environment.'));
     await waitFor(() => expect(toast).toHaveBeenCalledWith('1 had no name.'));
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('imports an unnamed Bruno environment as "Imported Environment" per the importer contract', async () => {
+    setupFiles({ 'noname.json': { content: brunoContent([{ variables: [] }]) } });
+    renderModal({ collection: collectionWith([]) });
+
+    dropFiles('import-environment', [makeFile('noname.json')]);
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Imported 1 environment.'));
+    expect(importEnvironment).toHaveBeenCalledWith(expect.objectContaining({ name: 'Imported Environment' }));
+    expect(toast).not.toHaveBeenCalledWith('1 had no name.');
     expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Fixes #8373

### Description

Importing several environment files at once is fragile. One bad file makes the whole batch fail, a failure partway through leaves some environments written to disk behind a generic error, and re-importing the same files quietly creates `… copy` duplicates. This PR reads and parses each file on its own so the batch survives bad input, skips environments that already exist, and replaces the generic toast with a short summary of what happened.

### Root cause

Three separate problems in `handleImportEnvironment` and `processEnvironments`:

1. Every file was read up front in a single `readMultipleFiles(Array.from(files))` call and the format was detected from the first file only (`detectEnvironmentFormat(parsedFiles[0].content)`), then one importer was run over every file. A malformed file makes the read throw and aborts the whole import; a selection that mixes Bruno and Postman exports throws inside the importer and aborts the rest. Either way nothing gets imported.

2. `processEnvironments` looped with `await dispatch(action)` inside a single `try`. If the third of five environments failed, the first two were already written to disk, the loop threw, and the user saw `An error occurred while importing the environment(s)` with no idea which ones made it.

3. The client never checks existing names. The only guard is the Electron handler `renderer:create-environment`, which calls `generateUniqueName()`, so re-importing the same file produces `X copy`, then `X copy 2`, and so on.

### The fix

Each file is now **read and parsed on its own** — the loop calls `readMultipleFiles([file])` per file and detects its format individually, so a single malformed JSON only fails that file and is collected as a failure instead of aborting the batch. A mixed Bruno/Postman selection imports each file with its own detected format.

Each environment is dispatched in its own `try/catch` and failures are collected, so one failure doesn't take down the rest of the batch.

Before importing, the code builds a set of existing names (`collection.environments` for collection scope, the `globalEnvironments` selector for global scope) keyed by `sanitizeName`, the same function the Electron handler uses, and skips any name that already exists. The incoming batch is also deduped against itself. The name is normalized **once** with `sanitizeName` and that value is reused for the dedupe check and for the `importEnvironment` / `addGlobalEnvironment` payloads, so the collection and global branches behave identically and never re-import raw names. Re-importing the same file is now a no-op instead of stacking copies.

Feedback is one summary: an `Imported N environments.` toast, plus a note of how many were skipped, unnamed, or failed. The modal stays open only when nothing was imported and nothing was skipped so the user can retry; otherwise it closes and fires `onEnvironmentCreated` only if something was actually imported.

The change is contained to the modal component. Importers, actions, and the Electron handler are untouched, and it reuses the existing `readMultipleFiles`, `importPostmanEnvironment`, `importBrunoEnvironment`, `sanitizeName`, `importEnvironment`, and `addGlobalEnvironment`.

### Before / After

| Scenario | Before | After |
| --- | --- | --- |
| One malformed file among several | Whole import aborts, nothing imported | Bad file reported, the rest imported |
| Mixed Bruno + Postman selection | Wrong importer throws, import aborts | Each file imported with its own detected format |
| One env fails mid-batch | Partial write plus a generic error | The rest import, the failure is listed |
| Re-import the same file | Stacks `X copy`, `X copy 2` | Names that already exist are skipped |
| Result feedback | `N environments imported successfully` or a generic error | `Imported N environments.` plus a skipped/unnamed/failed note |

### Verification

Tested manually in the app, in both collection and global scope:

- A folder of valid Bruno envs imports cleanly with one success toast.
- A corrupt JSON in the set is reported while the rest import.
- A mixed Bruno and Postman selection imports both formats.
- Re-importing the same set imports nothing and skips everything already present, with no `copy` duplicates on disk.
- An env with no name is counted under "had no name".

ESLint passes on the changed files. The change is contained to the modal component, with no API or behavior changes to importers, actions, or the Electron handler. Added a Jest spec for the modal (`ImportEnvironmentModal/index.spec.js`, 8 tests, all passing) covering mixed Bruno/Postman selections, a malformed file alongside valid ones, duplicate-name skips, unnamed environments, partial dispatch failures, the "nothing valid found" path, and name normalization across the collection and global branches.

---

- [ ] I've used AI significantly to create this pull request
- [x] The pull request only addresses one issue or adds one feature.
- [x] The pull request does not introduce any breaking changes
- [ ] I have added screenshots or gifs to help explain the change if applicable.
- [x] I have read the contribution guidelines.
- [x] Create an issue and link to the pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-file environment import can handle mixed Postman/Bruno files in one batch.
  * Import now presents a detailed batch summary (imported, skipped duplicates, unnamed) and shows specific failure notes when issues occur.

* **Bug Fixes**
  * Duplicate detection and import routing are improved by normalizing environment names.
  * Import failures for individual environments no longer prevent other valid environments from importing.
  * The import dialog remains open when no environments were effectively imported.

* **Tests**
  * Added coverage for mixed imports, partial failures, duplicates, unnamed handling, and summary/toast behavior (including name normalization).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->