### PR TITLE
fix: close tabs on middle-click over close overlay

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/GradientCloseButton/index.js
@@ -4,8 +4,27 @@ import DraftTabIcon from '../DraftTabIcon';
 import StyledWrapper from './StyledWrapper';
 
 const GradientCloseButton = ({ onClick, hasChanges = false }) => {
+  // Prevent the browser's autoscroll (triggered on middle-button mousedown)
+  const handleMouseDown = (e) => {
+    if (e.button === 1) {
+      e.preventDefault();
+    }
+  };
+
+  const handleMouseUp = (e) => {
+    if (e.button === 1) {
+      e.preventDefault();
+      e.stopPropagation();
+      onClick?.(e);
+    }
+  };
+
   return (
-    <StyledWrapper className={`close-gradient ${hasChanges ? 'has-changes' : ''}`}>
+    <StyledWrapper
+      className={`close-gradient ${hasChanges ? 'has-changes' : ''}`}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+    >
       <div className="close-icon-container" onClick={onClick} data-testid="request-tab-close-icon">
         <span className="draft-icon-wrapper" data-testid="tab-draft-icon">
           <DraftTabIcon />


### PR DESCRIPTION
### Description

The tab close affordance uses a wider hover overlay than the visible icon. That overlay intercepted middle-click mouseup events before they reach the tab label, so middle-click close sotpped working on the right side of the tab.

This fixes #8378 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable. (in the issue)**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved middle-click behavior on request tab close buttons by preventing unintended browser autoscroll.
  * Made middle-button interactions more reliable by stopping default behavior and ensuring the close action still fires when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->