### PR TITLE
feat(cli): persist env, global-env, and collection var changes from scripts

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -362,6 +362,9 @@ const handler = async function (argv) {
     let envVars = {};
     let envFileDescriptor = null;
     let globalEnvFileDescriptor = null;
+    // Names overridden via --env-var. Tracked so the persistence layer never writes these
+    // transient values back to disk — common case is CI overriding secrets the CLI can't decrypt.
+    const envVarOverrides = new Set();
 
     const resolveEnvFileFormat = (filePath) => {
       const ext = path.extname(filePath).toLowerCase();
@@ -510,6 +513,7 @@ const handler = async function (argv) {
             process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE);
           }
           envVars[match[1]] = match[2];
+          envVarOverrides.add(match[1]);
         }
       }
     }
@@ -635,7 +639,8 @@ const handler = async function (argv) {
     const persistPaths = {
       envFile: envFileDescriptor,
       globalEnvFile: globalEnvFileDescriptor,
-      collectionRootPath
+      collectionRootPath,
+      envVarOverrides
     };
 
     // Fetch system proxy once for all requests (skip if --noproxy flag is set)

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -362,9 +362,11 @@ const handler = async function (argv) {
     let envVars = {};
     let envFileDescriptor = null;
     let globalEnvFileDescriptor = null;
-    // Names overridden via --env-var. Tracked so the persistence layer never writes these
-    // transient values back to disk — common case is CI overriding secrets the CLI can't decrypt.
-    const envVarOverrides = new Set();
+    // --env-var overrides as Map<name, injected value>. The persistence layer compares the
+    // script's resulting value against the injected value to tell a leaked override (same
+    // value passed through unchanged) apart from a deliberate same-named script write that
+    // must reach disk. Typical use: CI injects a secret the CLI can't decrypt at rest.
+    const envVarOverrides = new Map();
 
     const resolveEnvFileFormat = (filePath) => {
       const ext = path.extname(filePath).toLowerCase();
@@ -513,7 +515,7 @@ const handler = async function (argv) {
             process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE);
           }
           envVars[match[1]] = match[2];
-          envVarOverrides.add(match[1]);
+          envVarOverrides.set(match[1], match[2]);
         }
       }
     }

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -360,6 +360,15 @@ const handler = async function (argv) {
 
     const runtimeVariables = {};
     let envVars = {};
+    let envFileDescriptor = null;
+    let globalEnvFileDescriptor = null;
+
+    const resolveEnvFileFormat = (filePath) => {
+      const ext = path.extname(filePath).toLowerCase();
+      if (ext === '.json') return 'json';
+      if (ext === '.yml' || ext === '.yaml') return 'yml';
+      return 'bru';
+    };
 
     // Helper to load environment variables from a file
     const loadEnvFromFile = (filePath, nameOverride) => {
@@ -398,6 +407,7 @@ const handler = async function (argv) {
       }
       try {
         envVars = loadEnvFromFile(envFilePath);
+        envFileDescriptor = { path: envFilePath, format: resolveEnvFileFormat(envFilePath) };
       } catch (err) {
         console.error(chalk.red(`Failed to parse environment file: ${err.message}`));
         process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
@@ -415,6 +425,7 @@ const handler = async function (argv) {
       try {
         const collectionEnvVars = loadEnvFromFile(collectionEnvFilePath, env);
         envVars = { ...envVars, ...collectionEnvVars };
+        envFileDescriptor = { path: collectionEnvFilePath, format: collection.format };
       } catch (err) {
         console.error(chalk.red(`Failed to parse Environment file: ${err.message}`));
         process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
@@ -470,6 +481,7 @@ const handler = async function (argv) {
         const globalEnvJson = parseEnvironment(globalEnvContent, { format: 'yml' });
         globalEnvVars = getEnvVars(globalEnvJson);
         globalEnvVars.__name__ = globalEnv;
+        globalEnvFileDescriptor = { path: globalEnvFilePath, format: 'yml' };
       } catch (err) {
         console.error(chalk.red(`Failed to parse global environment: ${err.message}`));
         process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
@@ -618,6 +630,14 @@ const handler = async function (argv) {
 
     const runtime = getJsSandboxRuntime(sandbox);
 
+    const collectionRootFile = collection.format === 'yml' ? 'opencollection.yml' : 'collection.bru';
+    const collectionRootPath = path.join(collectionPath, collectionRootFile);
+    const persistPaths = {
+      envFile: envFileDescriptor,
+      globalEnvFile: globalEnvFileDescriptor,
+      collectionRootPath
+    };
+
     // Fetch system proxy once for all requests (skip if --noproxy flag is set)
     if (!noproxy) {
       try {
@@ -647,7 +667,8 @@ const handler = async function (argv) {
             runtime,
             collection,
             runSingleRequestByPathname,
-            globalEnvVars
+            globalEnvVars,
+            persistPaths
           );
           resolve(res?.response);
         }
@@ -674,7 +695,8 @@ const handler = async function (argv) {
         runtime,
         collection,
         runSingleRequestByPathname,
-        globalEnvVars
+        globalEnvVars,
+        persistPaths
       );
 
       const isLastRun = currentRequestIndex === requestItems.length - 1;

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -366,7 +366,7 @@ const handler = async function (argv) {
     const resolveEnvFileFormat = (filePath) => {
       const ext = path.extname(filePath).toLowerCase();
       if (ext === '.json') return 'json';
-      if (ext === '.yml' || ext === '.yaml') return 'yml';
+      if (ext === '.yml') return 'yml';
       return 'bru';
     };
 
@@ -383,11 +383,11 @@ const handler = async function (argv) {
         const rawName = normalizedEnv?.name;
         const trimmedName = typeof rawName === 'string' ? rawName.trim() : '';
         result.__name__ = trimmedName || path.basename(filePath, '.json');
-      } else if (fileExt === '.yml' || fileExt === '.yaml') {
+      } else if (fileExt === '.yml') {
         const content = fs.readFileSync(filePath, 'utf8');
         const envJson = parseEnvironment(content, { format: 'yml' });
         result = getEnvVars(envJson);
-        result.__name__ = nameOverride || path.basename(filePath, fileExt);
+        result.__name__ = nameOverride || path.basename(filePath, '.yml');
       } else {
         const content = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
         const envJson = parseEnvironment(content, { format: 'bru' });

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -763,7 +763,7 @@ const runSingleRequest = async function (
     const postResponseVars = get(item, 'request.vars.res');
     if (postResponseVars?.length) {
       const varsRuntime = new VarsRuntime({ runtime: scriptingConfig?.runtime });
-      const varsResult = varsRuntime.runPostResponseVars(
+      varsRuntime.runPostResponseVars(
         postResponseVars,
         request,
         response,
@@ -772,7 +772,6 @@ const runSingleRequest = async function (
         collectionPath,
         processEnvVars
       );
-      syncVariableUpdates(varsResult, request);
     }
 
     // run post response script

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -105,12 +105,19 @@ const runSingleRequest = async function (
       globalEnvVars,
       request: currentRequest
     });
-    persistVariableUpdates(result, {
-      envFile: persistPaths.envFile,
-      globalEnvFile: persistPaths.globalEnvFile,
-      collection,
-      collectionRootPath: persistPaths.collectionRootPath
-    });
+    // Persistence is a side effect — never tank the run for it. In CI, env files may sit on
+    // read-only mounts or the user's shell may lack write permissions; log and continue.
+    try {
+      persistVariableUpdates(result, {
+        envFile: persistPaths.envFile,
+        globalEnvFile: persistPaths.globalEnvFile,
+        collection,
+        collectionRootPath: persistPaths.collectionRootPath,
+        envVarOverrides: persistPaths.envVarOverrides
+      });
+    } catch (err) {
+      console.warn(chalk.yellow(`Warning: failed to persist variable updates: ${err.message}`));
+    }
   };
   const { pathname: itemPathname } = item;
   const relativeItemPathname = path.relative(collectionPath, itemPathname);

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -770,7 +770,7 @@ const runSingleRequest = async function (
     const postResponseVars = get(item, 'request.vars.res');
     if (postResponseVars?.length) {
       const varsRuntime = new VarsRuntime({ runtime: scriptingConfig?.runtime });
-      varsRuntime.runPostResponseVars(
+      const result = varsRuntime.runPostResponseVars(
         postResponseVars,
         request,
         response,
@@ -779,6 +779,9 @@ const runSingleRequest = async function (
         collectionPath,
         processEnvVars
       );
+      // Expressions can invoke bru.setEnvVar / setGlobalEnvVar / setCollectionVar as a side effect,
+      // mirroring how the desktop app surfaces these mutations after the vars block.
+      syncVariableUpdates(result, request);
     }
 
     // run post response script

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -9,6 +9,7 @@ const { interpolateString, interpolateObject } = require('./interpolate-string')
 const { ScriptRuntime, TestRuntime, VarsRuntime, AssertRuntime, formatErrorWithContext, SCRIPT_TYPES } = require('@usebruno/js');
 const { stripExtension } = require('../utils/filesystem');
 const { getOptions } = require('../utils/bru');
+const { applyVariableUpdates, persistVariableUpdates } = require('../utils/persist-variables');
 const { makeAxiosInstance } = require('../utils/axios-instance');
 const { addAwsV4Interceptor, resolveAwsV4Credentials } = require('./awsv4auth-helper');
 const { setupProxyAgents } = require('../utils/proxy-util');
@@ -93,8 +94,24 @@ const runSingleRequest = async function (
   runtime,
   collection,
   runSingleRequestByPathname,
-  globalEnvVars = {}
+  globalEnvVars = {},
+  persistPaths = {}
 ) {
+  const syncVariableUpdates = (result, currentRequest) => {
+    if (!result) return;
+    applyVariableUpdates(result, {
+      envVariables,
+      runtimeVariables,
+      globalEnvVars,
+      request: currentRequest
+    });
+    persistVariableUpdates(result, {
+      envFile: persistPaths.envFile,
+      globalEnvFile: persistPaths.globalEnvFile,
+      collection,
+      collectionRootPath: persistPaths.collectionRootPath
+    });
+  };
   const { pathname: itemPathname } = item;
   const relativeItemPathname = path.relative(collectionPath, itemPathname);
 
@@ -228,6 +245,7 @@ const runSingleRequest = async function (
           scriptingConfig,
           runSingleRequestByPathname,
           collectionName);
+        syncVariableUpdates(result, request);
         if (result?.nextRequestName !== undefined) {
           nextRequestName = result.nextRequestName;
         }
@@ -280,6 +298,9 @@ const runSingleRequest = async function (
 
         // Extract partial results from the error (tests that passed before the error)
         preRequestTestResults = error?.partialResults?.results || [];
+
+        // Persist any variable changes the script made before erroring
+        syncVariableUpdates(error?.partialResults, request);
 
         // Preserve nextRequestName if it was set before the error
         if (error?.partialResults?.nextRequestName !== undefined) {
@@ -742,7 +763,7 @@ const runSingleRequest = async function (
     const postResponseVars = get(item, 'request.vars.res');
     if (postResponseVars?.length) {
       const varsRuntime = new VarsRuntime({ runtime: scriptingConfig?.runtime });
-      varsRuntime.runPostResponseVars(
+      const varsResult = varsRuntime.runPostResponseVars(
         postResponseVars,
         request,
         response,
@@ -751,6 +772,7 @@ const runSingleRequest = async function (
         collectionPath,
         processEnvVars
       );
+      syncVariableUpdates(varsResult, request);
     }
 
     // run post response script
@@ -771,6 +793,7 @@ const runSingleRequest = async function (
           runSingleRequestByPathname,
           collectionName
         );
+        syncVariableUpdates(result, request);
         if (result?.nextRequestName !== undefined) {
           nextRequestName = result.nextRequestName;
         }
@@ -801,6 +824,8 @@ const runSingleRequest = async function (
             isScriptError: true
           }
         ];
+
+        syncVariableUpdates(error?.partialResults, request);
 
         if (error?.partialResults?.nextRequestName !== undefined) {
           nextRequestName = error.partialResults.nextRequestName;
@@ -847,6 +872,7 @@ const runSingleRequest = async function (
           runSingleRequestByPathname,
           collectionName
         );
+        syncVariableUpdates(result, request);
         testResults = get(result, 'results', []);
 
         if (result?.nextRequestName !== undefined) {
@@ -878,6 +904,8 @@ const runSingleRequest = async function (
             isScriptError: true
           }
         ];
+
+        syncVariableUpdates(error?.partialResults, request);
 
         if (error?.partialResults?.nextRequestName !== undefined) {
           nextRequestName = error.partialResults.nextRequestName;

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -1,8 +1,19 @@
 const fs = require('fs');
 const { stringifyEnvironment, stringifyCollection, parseEnvironment } = require('@usebruno/filestore');
+const { getDataTypeFromValue } = require('@usebruno/common').utils;
 const { parseEnvironmentJson } = require('./environment');
 
 const INTERNAL_KEYS = new Set(['__name__']);
+
+const applyInferredDataType = (variable, value) => {
+  const inferred = getDataTypeFromValue(value);
+  if (inferred === 'string') {
+    delete variable.dataType;
+  } else {
+    variable.dataType = inferred;
+  }
+  return variable;
+};
 
 const stripInternal = (vars) => {
   const out = {};
@@ -48,12 +59,16 @@ const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw) => {
   const scriptKeys = new Set(Object.keys(scriptVars));
   const next = (variables || [])
     .filter((v) => (v.enabled === false ? true : scriptKeys.has(v.name)))
-    .map((v) => (v.enabled !== false && scriptKeys.has(v.name) ? { ...v, value: scriptVars[v.name] } : v));
+    .map((v) => {
+      if (v.enabled === false || !scriptKeys.has(v.name)) return v;
+      return applyInferredDataType({ ...v, value: scriptVars[v.name] }, scriptVars[v.name]);
+    });
 
   const presentEnabled = new Set(next.filter((v) => v.enabled !== false).map((v) => v.name));
   for (const key of scriptKeys) {
     if (presentEnabled.has(key)) continue;
-    next.push({ name: key, value: scriptVars[key], type: 'text', enabled: true, secret: false });
+    const entry = { name: key, value: scriptVars[key], type: 'text', enabled: true, secret: false };
+    next.push(applyInferredDataType(entry, scriptVars[key]));
   }
   return next;
 };
@@ -62,12 +77,16 @@ const mergeScriptVarsIntoCollectionVarsList = (variables, scriptVars) => {
   const scriptKeys = new Set(Object.keys(scriptVars || {}));
   const next = (variables || [])
     .filter((v) => (v.enabled === false ? true : scriptKeys.has(v.name)))
-    .map((v) => (v.enabled !== false && scriptKeys.has(v.name) ? { ...v, value: scriptVars[v.name] } : v));
+    .map((v) => {
+      if (v.enabled === false || !scriptKeys.has(v.name)) return v;
+      return applyInferredDataType({ ...v, value: scriptVars[v.name] }, scriptVars[v.name]);
+    });
 
   const presentEnabled = new Set(next.filter((v) => v.enabled !== false).map((v) => v.name));
   for (const key of scriptKeys) {
     if (presentEnabled.has(key)) continue;
-    next.push({ name: key, value: scriptVars[key], type: 'request', enabled: true });
+    const entry = { name: key, value: scriptVars[key], type: 'request', enabled: true };
+    next.push(applyInferredDataType(entry, scriptVars[key]));
   }
   return next;
 };

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -3,8 +3,26 @@ const { stringifyEnvironment, stringifyCollection, parseEnvironment } = require(
 const { getDataTypeFromValue } = require('@usebruno/common').utils;
 const { parseEnvironmentJson } = require('./environment');
 
+/**
+ * Bruno stashes the env name inside the vars map under `__name__`; it is metadata, never a real variable.
+ */
 const INTERNAL_KEYS = new Set(['__name__']);
 
+/**
+ * Sets or removes the `dataType` field on a variable based on the JS type of `value`.
+ * `string` is the implicit default on disk — omit the field rather than writing `dataType: string`.
+ *
+ * @param {{ name: string, value: any, dataType?: string }} variable - Variable entry to mutate in place.
+ * @param {any} value - JS value whose type drives the inference.
+ * @returns {object} The same `variable` reference, after mutation.
+ *
+ * @example
+ * applyInferredDataType({ name: 'port', value: 3000 }, 3000);
+ *  → { name: 'port', value: 3000, dataType: 'number' }
+ *
+ * applyInferredDataType({ name: 'host', value: 'x', dataType: 'number' }, 'x');
+ *  → { name: 'host', value: 'x' }   // dataType deleted
+ */
 const applyInferredDataType = (variable, value) => {
   const inferred = getDataTypeFromValue(value);
   if (inferred === 'string') {
@@ -15,6 +33,16 @@ const applyInferredDataType = (variable, value) => {
   return variable;
 };
 
+/**
+ * Returns a shallow copy of `vars` with internal keys (`__name__`) removed.
+ *
+ * @param {Object<string, any>} vars - Flat name→value map; may be null/undefined.
+ * @returns {Object<string, any>} New object without internal keys.
+ *
+ * @example
+ * stripInternal({ token: 'abc', __name__: 'dev' });
+ *  → { token: 'abc' }
+ */
 const stripInternal = (vars) => {
   const out = {};
   for (const [k, v] of Object.entries(vars || {})) {
@@ -23,6 +51,21 @@ const stripInternal = (vars) => {
   return out;
 };
 
+/**
+ * In-place replace of `target`'s contents with `source`'s, while preserving `target.__name__`.
+ * Callers hold long-lived references to `target`, so a fresh object would not propagate.
+ * Keys missing from `source` are deleted — this is how `bru.deleteEnvVar` flows through.
+ *
+ * @param {Object<string, any>} target - Object mutated in place.
+ * @param {Object<string, any>} source - Desired end state (minus internal keys).
+ * @returns {void}
+ *
+ * @example
+ * const target = { a: 1, b: 2, __name__: 'dev' };
+ * overwriteMap(target, { a: 9, c: 3 });
+ * -> target is now { a: 9, c: 3, __name__: 'dev' }
+ * -> b deleted, c added, __name__ preserved
+ */
 const overwriteMap = (target, source) => {
   const preservedName = target.__name__;
   for (const key of Object.keys(target)) {
@@ -38,6 +81,35 @@ const overwriteMap = (target, source) => {
   }
 };
 
+/**
+ * Sync a runtime result into the in-memory maps the next request will read. No disk I/O.
+ * Env / runtime / global maps are mutated by reference; collection vars are replaced on the request.
+ *
+ * @param {{
+ *   envVariables?: Object,
+ *   runtimeVariables?: Object,
+ *   collectionVariables?: Object,
+ *   globalEnvironmentVariables?: Object
+ * } | null} result - Runtime return value; any field may be null to indicate "unchanged".
+ * @param {{
+ *   envVariables: Object,
+ *   runtimeVariables: Object,
+ *   globalEnvVars: Object,
+ *   request: Object
+ * }} ctx - The long-lived maps and the current request object to update.
+ * @returns {void}
+ *
+ * @example
+ * After a script calls `bru.setEnvVar('token', 'abc')`:
+ * const result = {
+ *   envVariables: { token: 'abc' },
+ *   runtimeVariables: null,
+ *   collectionVariables: null,
+ *   globalEnvironmentVariables: null
+ * };
+ * applyVariableUpdates(result, { envVariables, runtimeVariables, globalEnvVars, request });
+ * -> envVariables now contains `token: 'abc'`, and the next request sees it.
+ */
 const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEnvVars, request }) => {
   if (!result) return;
   if (result.envVariables && envVariables) {
@@ -49,21 +121,74 @@ const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEn
   if (result.globalEnvironmentVariables && globalEnvVars) {
     overwriteMap(globalEnvVars, result.globalEnvironmentVariables);
   }
+  // Collection vars live on the per-request object, not a shared map — replace the field outright.
   if (result.collectionVariables && request) {
     request.collectionVariables = stripInternal(result.collectionVariables);
   }
 };
 
-const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw) => {
+/**
+ * Reconcile the env file's array of variable entries against the script's flat name→value map.
+ * - Disabled entries are always preserved (user intent — toggled off, not deleted).
+ * - Enabled entries absent from script output are dropped (so `bru.deleteEnvVar` reaches disk).
+ * - New script keys are appended as enabled text vars with inferred dataType.
+ * - `overrides`: names supplied via CLI `--env-var`. Their values are never persisted, and the
+ *   file's existing entry for those names is preserved untouched.
+ *
+ * @param {Array<{ name: string, value: any, enabled?: boolean, type?: string, secret?: boolean, dataType?: string }>} variables
+ *   Existing entries from the env file.
+ * @param {Object<string, any>} scriptVarsRaw - Flat map from the script runtime; may include `__name__`.
+ * @param {{ overrides?: Set<string> }} [options] - Names to exclude from persistence.
+ * @returns {Array<object>} New array of merged variable entries.
+ *
+ * @example
+ * const variables = [
+ *   { name: 'host',  value: 'old',  enabled: true,  type: 'text', secret: false },
+ *   { name: 'stale', value: 'gone', enabled: true,  type: 'text', secret: false },
+ *   { name: 'off',   value: 'kept', enabled: false, type: 'text', secret: false }
+ * ];
+ * const scriptVarsRaw = { host: 'new', port: 3000, __name__: 'dev' };
+ * mergeScriptVarsIntoEnvList(variables, scriptVarsRaw);
+ * → [
+ *     { name: 'host', value: 'new',  enabled: true,  type: 'text', secret: false },                          // updated
+ *     { name: 'off',  value: 'kept', enabled: false, type: 'text', secret: false },                          // preserved (disabled)
+ *     { name: 'port', value: 3000,   enabled: true,  type: 'text', secret: false, dataType: 'number' }       // appended
+ *   ]
+ * -> `stale` was dropped (enabled but absent from script output).
+ *
+ * @example
+ * With CLI override `--env-var token=transient`:
+ * mergeScriptVarsIntoEnvList(
+ *   [{ name: 'token', value: 'real', enabled: true, type: 'text', secret: true }],
+ *   { token: 'transient', other: 'x' },
+ *   { overrides: new Set(['token']) }
+ * );
+ * → [
+ *     { name: 'token', value: 'real', enabled: true, type: 'text', secret: true },         // preserved unchanged
+ *     { name: 'other', value: 'x',    enabled: true, type: 'text', secret: false }         // appended
+ *   ]
+ */
+const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw, options = {}) => {
+  const overrides = options.overrides instanceof Set ? options.overrides : new Set();
   const scriptVars = stripInternal(scriptVarsRaw);
+  // CLI --env-var values are transient — never reach disk. Drop them before the merge sees them.
+  for (const key of overrides) delete scriptVars[key];
   const scriptKeys = new Set(Object.keys(scriptVars));
+
   const next = (variables || [])
-    .filter((v) => (v.enabled === false ? true : scriptKeys.has(v.name)))
+    .filter((v) => {
+      if (v.enabled === false) return true;
+      if (scriptKeys.has(v.name)) return true;
+      // Keep the file's entry for an overridden name even if the script didn't echo it back.
+      if (overrides.has(v.name)) return true;
+      return false;
+    })
     .map((v) => {
       if (v.enabled === false || !scriptKeys.has(v.name)) return v;
       return applyInferredDataType({ ...v, value: scriptVars[v.name] }, scriptVars[v.name]);
     });
 
+  // Skip names that already appear as enabled entries; a same-named disabled entry still gets a fresh enabled row appended.
   const presentEnabled = new Set(next.filter((v) => v.enabled !== false).map((v) => v.name));
   for (const key of scriptKeys) {
     if (presentEnabled.has(key)) continue;
@@ -73,6 +198,25 @@ const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw) => {
   return next;
 };
 
+/**
+ * Same shape as {@link mergeScriptVarsIntoEnvList}, with collection-var conventions:
+ * `type: 'request'`, no `secret` field, no `__name__` to strip.
+ *
+ * @param {Array<{ name: string, value: any, enabled?: boolean, type?: string, dataType?: string }>} variables
+ *   Existing entries from the collection root.
+ * @param {Object<string, any>} scriptVars - Flat map from the script runtime.
+ * @returns {Array<object>} New array of merged collection-var entries.
+ *
+ * @example
+ * mergeScriptVarsIntoCollectionVarsList(
+ *   [{ name: 'region', value: 'us', enabled: true, type: 'request' }],
+ *   { region: 'eu', retries: 3 }
+ * );
+ * → [
+ *     { name: 'region',  value: 'eu', enabled: true, type: 'request' },
+ *     { name: 'retries', value: 3,    enabled: true, type: 'request', dataType: 'number' }
+ *   ]
+ */
 const mergeScriptVarsIntoCollectionVarsList = (variables, scriptVars) => {
   const scriptKeys = new Set(Object.keys(scriptVars || {}));
   const next = (variables || [])
@@ -91,13 +235,51 @@ const mergeScriptVarsIntoCollectionVarsList = (variables, scriptVars) => {
   return next;
 };
 
+/**
+ * Idempotency guard: skip the write when serialized output is byte-identical.
+ *
+ * @param {string} filePath - Absolute path to write.
+ * @param {string} content - Serialized new content.
+ * @param {string} existing - Current on-disk content.
+ * @returns {boolean} `true` if the file was written, `false` if unchanged.
+ *
+ * @example
+ * writeIfChanged('Prod.bru', 'vars { x: 1 }', 'vars { x: 1 }'); // → false (no write)
+ * writeIfChanged('Prod.bru', 'vars { x: 2 }', 'vars { x: 1 }'); // → true  (file updated)
+ */
 const writeIfChanged = (filePath, content, existing) => {
   if (content === existing) return false;
   fs.writeFileSync(filePath, content);
   return true;
 };
 
-const persistEnvFile = (envFile, scriptVars) => {
+/**
+ * Read → merge → write one env file. Used for both per-env and global-env files
+ * (same shape, different descriptor).
+ *
+ * @param {{ path: string, format: 'json' | 'yml' | 'bru' } | null | undefined} envFile - Env file descriptor; no-op when missing.
+ * @param {Object<string, any>} scriptVars - Flat map of vars the script declared.
+ * @param {{ overrides?: Set<string> }} [options] - Names supplied via `--env-var`; excluded from persistence.
+ * @returns {void}
+ *
+ * @example
+ * persistEnvFile(
+ *   { path: '/coll/environments/Dev.bru', format: 'bru' },
+ *   { host: 'api.example.com', port: 3000 }
+ * );
+ * -> on-disk before:
+ *   vars {
+ *     host: localhost
+ *   }
+ * -> on-disk after:
+ *   vars {
+ *     host: api.example.com
+ *     @number
+ *     port: 3000
+ *   }
+ */
+const persistEnvFile = (envFile, scriptVars, options = {}) => {
+  // No descriptor means no `--env` flag was passed — nothing to persist to.
   if (!envFile || !envFile.path) return;
   const { path: filePath, format } = envFile;
   if (!fs.existsSync(filePath)) return;
@@ -108,10 +290,12 @@ const persistEnvFile = (envFile, scriptVars) => {
     try {
       parsed = JSON.parse(existingRaw);
     } catch {
+      // Bail rather than overwrite a malformed user file with our best guess.
       return;
     }
     const normalized = parseEnvironmentJson(parsed);
-    const mergedVars = mergeScriptVarsIntoEnvList(normalized.variables || [], scriptVars);
+    const mergedVars = mergeScriptVarsIntoEnvList(normalized.variables || [], scriptVars, options);
+    // Spread preserves any top-level fields the user has beyond `variables` (name, metadata, etc.).
     const next = { ...parsed, variables: mergedVars };
     const content = JSON.stringify(next, null, 2) + '\n';
     writeIfChanged(filePath, content, existingRaw);
@@ -119,14 +303,34 @@ const persistEnvFile = (envFile, scriptVars) => {
   }
 
   const existingRaw = fs.readFileSync(filePath, 'utf8');
+  // Bru parser expects \n line endings; yml parser is tolerant.
   const sourceForParse = format === 'bru' ? existingRaw.replace(/\r\n/g, '\n') : existingRaw;
   const parsed = parseEnvironment(sourceForParse, { format });
-  const mergedVars = mergeScriptVarsIntoEnvList(parsed.variables || [], scriptVars);
+  const mergedVars = mergeScriptVarsIntoEnvList(parsed.variables || [], scriptVars, options);
   const next = { ...parsed, variables: mergedVars };
   const content = stringifyEnvironment(next, { format });
   writeIfChanged(filePath, content, existingRaw);
 };
 
+/**
+ * Mutate the in-memory collection root and write it out. The mutation matters:
+ * subsequent requests in the same iteration read `collection.root` and must see the updated vars.
+ *
+ * @param {{ root?: object, format: 'bru' | 'yml', brunoConfig?: object }} collection - Loaded collection; mutated in place.
+ * @param {Object<string, any>} scriptCollVars - Flat map of collection vars the script declared.
+ * @param {string} collectionRootPath - Absolute path to the collection root file (`collection.bru` / `opencollection.yml`).
+ * @returns {void}
+ *
+ * @example
+ * -> collection.root.request.vars.req before: [{ name: 'region', value: 'us', enabled: true, type: 'request' }]
+ * persistCollectionVars(collection, { region: 'eu', retries: 3 }, '/coll/collection.bru');
+ * -> collection.root.request.vars.req after:
+ *   [
+ *     { name: 'region',  value: 'eu', enabled: true, type: 'request' },
+ *     { name: 'retries', value: 3,    enabled: true, type: 'request', dataType: 'number' }
+ *   ]
+ * -> `collection.bru` on disk is rewritten with the same content.
+ */
 const persistCollectionVars = (collection, scriptCollVars, collectionRootPath) => {
   if (!collection || !collectionRootPath) return;
   const collectionRoot = collection.root || {};
@@ -147,9 +351,42 @@ const persistCollectionVars = (collection, scriptCollVars, collectionRootPath) =
   }
 };
 
-const persistVariableUpdates = (result, { envFile, globalEnvFile, collection, collectionRootPath }) => {
+/**
+ * Disk-write counterpart to {@link applyVariableUpdates}.
+ * Runtime vars are intentionally not persisted — they are ephemeral by definition.
+ *
+ * @param {{
+ *   envVariables?: Object,
+ *   collectionVariables?: Object,
+ *   globalEnvironmentVariables?: Object,
+ *   runtimeVariables?: Object
+ * } | null} result - Runtime return value; any field may be null to indicate "unchanged".
+ * @param {{
+ *   envFile?: { path: string, format: 'json' | 'yml' | 'bru' },
+ *   globalEnvFile?: { path: string, format: 'json' | 'yml' | 'bru' },
+ *   collection: object,
+ *   collectionRootPath: string,
+ *   envVarOverrides?: Set<string>
+ * }} targets - Where each kind of var should land on disk. `envVarOverrides` lists names
+ *   supplied via CLI `--env-var`; they are never persisted to the active env file.
+ * @returns {void}
+ *
+ * @example
+ * Script runs `bru.setEnvVar('token', 'abc')` and `bru.setCollectionVar('region', 'eu')`.
+ * const result = {
+ *   envVariables: { token: 'abc' },
+ *   collectionVariables: { region: 'eu' },
+ *   runtimeVariables: null,
+ *   globalEnvironmentVariables: null
+ * };
+ * persistVariableUpdates(result, { envFile, globalEnvFile, collection, collectionRootPath });
+ * -> writes `token: abc` into the active env file and `region: eu` into the collection root file.
+ */
+const persistVariableUpdates = (result, { envFile, globalEnvFile, collection, collectionRootPath, envVarOverrides }) => {
   if (!result) return;
-  if (result.envVariables) persistEnvFile(envFile, result.envVariables);
+  const envOpts = envVarOverrides ? { overrides: envVarOverrides } : undefined;
+  if (result.envVariables) persistEnvFile(envFile, result.envVariables, envOpts);
+  // `--env-var` overrides apply only to the active env, not the global env.
   if (result.globalEnvironmentVariables) persistEnvFile(globalEnvFile, result.globalEnvironmentVariables);
   if (result.collectionVariables) persistCollectionVars(collection, result.collectionVariables, collectionRootPath);
 };

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -302,21 +302,11 @@ const persistEnvFile = (envFile, scriptVars, options = {}) => {
 
   if (format === 'json') {
     const existingRaw = fs.readFileSync(filePath, 'utf8');
-    let parsed;
-    try {
-      parsed = JSON.parse(existingRaw);
-    } catch {
-      // Bail rather than overwrite a malformed user file with our best guess.
-      return;
-    }
+    const parsed = JSON.parse(existingRaw);
     // Validate shape, but merge against the raw `parsed.variables` so per-entry fields the
     // CLI doesn't recognize (uid, dataType, custom metadata) survive on entries the script
     // didn't touch — parseEnvironmentJson's normalizer would otherwise strip them.
-    try {
-      parseEnvironmentJson(parsed);
-    } catch {
-      return;
-    }
+    parseEnvironmentJson(parsed);
 
     const rawVariables = Array.isArray(parsed.variables) ? parsed.variables.filter(Boolean) : [];
     const mergedVars = mergeScriptVarsIntoEnvList(rawVariables, scriptVars, options);

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -371,12 +371,14 @@ const persistCollectionVars = (collection, scriptCollVars, collectionRootPath) =
  * } | null} result - Runtime return value; any field may be null to indicate "unchanged".
  * @param {{
  *   envFile?: { path: string, format: 'json' | 'yml' | 'bru' },
- *   globalEnvFile?: { path: string, format: 'json' | 'yml' | 'bru' },
+ *   globalEnvFile?: { path: string, format: 'yml' },
  *   collection: object,
  *   collectionRootPath: string,
  *   envVarOverrides?: Set<string>
  * }} targets - Where each kind of var should land on disk. `envVarOverrides` lists names
  *   supplied via CLI `--env-var`; they are never persisted to the active env file.
+ *   `globalEnvFile.format` is yml-only because the CLI's `--global-env <name>` flag looks
+ *   up `<workspace>/environments/<name>.yml` (no JSON/bru equivalent exists today).
  * @returns {void}
  *
  * @example

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -1,0 +1,143 @@
+const fs = require('fs');
+const { stringifyEnvironment, stringifyCollection, parseEnvironment } = require('@usebruno/filestore');
+const { parseEnvironmentJson } = require('./environment');
+
+const INTERNAL_KEYS = new Set(['__name__']);
+
+const stripInternal = (vars) => {
+  const out = {};
+  for (const [k, v] of Object.entries(vars || {})) {
+    if (!INTERNAL_KEYS.has(k)) out[k] = v;
+  }
+  return out;
+};
+
+const overwriteMap = (target, source) => {
+  const preservedName = target.__name__;
+  for (const key of Object.keys(target)) {
+    if (INTERNAL_KEYS.has(key)) continue;
+    if (!(key in source)) delete target[key];
+  }
+  for (const [key, value] of Object.entries(source)) {
+    if (INTERNAL_KEYS.has(key)) continue;
+    target[key] = value;
+  }
+  if (preservedName !== undefined && target.__name__ === undefined) {
+    target.__name__ = preservedName;
+  }
+};
+
+const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEnvVars, request }) => {
+  if (!result) return;
+  if (result.envVariables && envVariables) {
+    overwriteMap(envVariables, result.envVariables);
+  }
+  if (result.runtimeVariables && runtimeVariables) {
+    overwriteMap(runtimeVariables, result.runtimeVariables);
+  }
+  if (result.globalEnvironmentVariables && globalEnvVars) {
+    overwriteMap(globalEnvVars, result.globalEnvironmentVariables);
+  }
+  if (result.collectionVariables && request) {
+    request.collectionVariables = stripInternal(result.collectionVariables);
+  }
+};
+
+const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw) => {
+  const scriptVars = stripInternal(scriptVarsRaw);
+  const scriptKeys = new Set(Object.keys(scriptVars));
+  const next = (variables || [])
+    .filter((v) => (v.enabled === false ? true : scriptKeys.has(v.name)))
+    .map((v) => (v.enabled !== false && scriptKeys.has(v.name) ? { ...v, value: scriptVars[v.name] } : v));
+
+  const presentEnabled = new Set(next.filter((v) => v.enabled !== false).map((v) => v.name));
+  for (const key of scriptKeys) {
+    if (presentEnabled.has(key)) continue;
+    next.push({ name: key, value: scriptVars[key], type: 'text', enabled: true, secret: false });
+  }
+  return next;
+};
+
+const mergeScriptVarsIntoCollectionVarsList = (variables, scriptVars) => {
+  const scriptKeys = new Set(Object.keys(scriptVars || {}));
+  const next = (variables || [])
+    .filter((v) => (v.enabled === false ? true : scriptKeys.has(v.name)))
+    .map((v) => (v.enabled !== false && scriptKeys.has(v.name) ? { ...v, value: scriptVars[v.name] } : v));
+
+  const presentEnabled = new Set(next.filter((v) => v.enabled !== false).map((v) => v.name));
+  for (const key of scriptKeys) {
+    if (presentEnabled.has(key)) continue;
+    next.push({ name: key, value: scriptVars[key], type: 'request', enabled: true });
+  }
+  return next;
+};
+
+const writeIfChanged = (filePath, content, existing) => {
+  if (content === existing) return false;
+  fs.writeFileSync(filePath, content);
+  return true;
+};
+
+const persistEnvFile = (envFile, scriptVars) => {
+  if (!envFile || !envFile.path) return;
+  const { path: filePath, format } = envFile;
+  if (!fs.existsSync(filePath)) return;
+
+  if (format === 'json') {
+    const existingRaw = fs.readFileSync(filePath, 'utf8');
+    let parsed;
+    try {
+      parsed = JSON.parse(existingRaw);
+    } catch {
+      return;
+    }
+    const normalized = parseEnvironmentJson(parsed);
+    const mergedVars = mergeScriptVarsIntoEnvList(normalized.variables || [], scriptVars);
+    const next = { ...parsed, variables: mergedVars };
+    const content = JSON.stringify(next, null, 2) + '\n';
+    writeIfChanged(filePath, content, existingRaw);
+    return;
+  }
+
+  const existingRaw = fs.readFileSync(filePath, 'utf8');
+  const sourceForParse = format === 'bru' ? existingRaw.replace(/\r\n/g, '\n') : existingRaw;
+  const parsed = parseEnvironment(sourceForParse, { format });
+  const mergedVars = mergeScriptVarsIntoEnvList(parsed.variables || [], scriptVars);
+  const next = { ...parsed, variables: mergedVars };
+  const content = stringifyEnvironment(next, { format });
+  writeIfChanged(filePath, content, existingRaw);
+};
+
+const persistCollectionVars = (collection, scriptCollVars, collectionRootPath) => {
+  if (!collection || !collectionRootPath) return;
+  const collectionRoot = collection.root || {};
+  collectionRoot.request = collectionRoot.request || {};
+  collectionRoot.request.vars = collectionRoot.request.vars || {};
+  const existingVars = collectionRoot.request.vars.req || [];
+  const merged = mergeScriptVarsIntoCollectionVarsList(existingVars, scriptCollVars);
+  collectionRoot.request.vars.req = merged;
+  collection.root = collectionRoot;
+
+  const format = collection.format;
+  const content = stringifyCollection(collectionRoot, collection.brunoConfig || {}, { format });
+  const existing = fs.existsSync(collectionRootPath) ? fs.readFileSync(collectionRootPath, 'utf8') : null;
+  if (existing !== null) {
+    writeIfChanged(collectionRootPath, content, existing);
+  } else {
+    fs.writeFileSync(collectionRootPath, content);
+  }
+};
+
+const persistVariableUpdates = (result, { envFile, globalEnvFile, collection, collectionRootPath }) => {
+  if (!result) return;
+  if (result.envVariables) persistEnvFile(envFile, result.envVariables);
+  if (result.globalEnvironmentVariables) persistEnvFile(globalEnvFile, result.globalEnvironmentVariables);
+  if (result.collectionVariables) persistCollectionVars(collection, result.collectionVariables, collectionRootPath);
+};
+
+module.exports = {
+  applyVariableUpdates,
+  persistVariableUpdates,
+  mergeScriptVarsIntoEnvList,
+  mergeScriptVarsIntoCollectionVarsList
+};

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -275,7 +275,7 @@ const writeIfChanged = (filePath, content, existing) => {
  *
  * @param {{ path: string, format: 'json' | 'yml' | 'bru' } | null | undefined} envFile - Env file descriptor; no-op when missing.
  * @param {Object<string, any>} scriptVars - Flat map of vars the script declared.
- * @param {{ overrides?: Set<string> }} [options] - Names supplied via `--env-var`; excluded from persistence.
+ * @param {{ overrides?: Map<string, string> }} [options] - `--env-var name=value` entries keyed by name → injected value; forwarded to `mergeScriptVarsIntoEnvList` to keep override values off disk.
  * @returns {void}
  *
  * @example

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -293,8 +293,16 @@ const persistEnvFile = (envFile, scriptVars, options = {}) => {
       // Bail rather than overwrite a malformed user file with our best guess.
       return;
     }
-    const normalized = parseEnvironmentJson(parsed);
-    const mergedVars = mergeScriptVarsIntoEnvList(normalized.variables || [], scriptVars, options);
+    // Validate shape, but merge against the raw `parsed.variables` so per-entry fields the
+    // CLI doesn't recognize (uid, dataType, custom metadata) survive on entries the script
+    // didn't touch — parseEnvironmentJson's normalizer would otherwise strip them.
+    try {
+      parseEnvironmentJson(parsed);
+    } catch {
+      return;
+    }
+    const rawVariables = Array.isArray(parsed.variables) ? parsed.variables : [];
+    const mergedVars = mergeScriptVarsIntoEnvList(rawVariables, scriptVars, options);
     // Spread preserves any top-level fields the user has beyond `variables` (name, metadata, etc.).
     const next = { ...parsed, variables: mergedVars };
     const content = JSON.stringify(next, null, 2) + '\n';
@@ -386,8 +394,12 @@ const persistVariableUpdates = (result, { envFile, globalEnvFile, collection, co
   if (!result) return;
   const envOpts = envVarOverrides ? { overrides: envVarOverrides } : undefined;
   if (result.envVariables) persistEnvFile(envFile, result.envVariables, envOpts);
-  // `--env-var` overrides apply only to the active env, not the global env.
-  if (result.globalEnvironmentVariables) persistEnvFile(globalEnvFile, result.globalEnvironmentVariables);
+  // Defense-in-depth: the bru runtime keeps envVariables and globalEnvironmentVariables as
+  // separate maps and never auto-syncs between them, so the override can't reach the global
+  // env map through normal flow. Still, pass the override filter through — if a user script
+  // ever copies via `bru.setGlobalEnvVar(k, bru.getVar(k))`, the override value won't land
+  // on disk in the global env file.
+  if (result.globalEnvironmentVariables) persistEnvFile(globalEnvFile, result.globalEnvironmentVariables, envOpts);
   if (result.collectionVariables) persistCollectionVars(collection, result.collectionVariables, collectionRootPath);
 };
 

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -132,13 +132,14 @@ const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEn
  * - Disabled entries are always preserved (user intent — toggled off, not deleted).
  * - Enabled entries absent from script output are dropped (so `bru.deleteEnvVar` reaches disk).
  * - New script keys are appended as enabled text vars with inferred dataType.
- * - `overrides`: names supplied via CLI `--env-var`. Their values are never persisted, and the
- *   file's existing entry for those names is preserved untouched.
+ * - `overrides`: names supplied via CLI `--env-var` keyed to their injected value. The leaked
+ *   override value never reaches disk and the file's entry is preserved, but a deliberate
+ *   script write of a *different* value for the same name still persists.
  *
  * @param {Array<{ name: string, value: any, enabled?: boolean, type?: string, secret?: boolean, dataType?: string }>} variables
  *   Existing entries from the env file.
  * @param {Object<string, any>} scriptVarsRaw - Flat map from the script runtime; may include `__name__`.
- * @param {{ overrides?: Set<string> }} [options] - Names to exclude from persistence.
+ * @param {{ overrides?: Map<string, string> }} [options] - Names → injected override values.
  * @returns {Array<object>} New array of merged variable entries.
  *
  * @example
@@ -161,18 +162,33 @@ const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEn
  * mergeScriptVarsIntoEnvList(
  *   [{ name: 'token', value: 'real', enabled: true, type: 'text', secret: true }],
  *   { token: 'transient', other: 'x' },
- *   { overrides: new Set(['token']) }
+ *   { overrides: new Map([['token', 'transient']]) }
  * );
  * → [
  *     { name: 'token', value: 'real', enabled: true, type: 'text', secret: true },         // preserved unchanged
  *     { name: 'other', value: 'x',    enabled: true, type: 'text', secret: false }         // appended
  *   ]
+ *
+ * @example
+ * Script *deliberately* sets the overridden key to a new value:
+ * mergeScriptVarsIntoEnvList(
+ *   [{ name: 'token', value: 'real', enabled: true, type: 'text', secret: true }],
+ *   { token: 'rotated' },
+ *   { overrides: new Map([['token', 'transient']]) }
+ * );
+ * → [{ name: 'token', value: 'rotated', enabled: true, type: 'text', secret: true }]      // persisted
  */
 const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw, options = {}) => {
-  const overrides = options.overrides instanceof Set ? options.overrides : new Set();
+  const overrides = options.overrides instanceof Map ? options.overrides : new Map();
   const scriptVars = stripInternal(scriptVarsRaw);
-  // CLI --env-var values are transient — never reach disk. Drop them before the merge sees them.
-  for (const key of overrides) delete scriptVars[key];
+  // Drop a script value only when it still matches the injected override — a different
+  // value means the script deliberately wrote it (e.g. `bru.setEnvVar('token', 'rotated')`)
+  // and must reach disk.
+  for (const [key, overrideValue] of overrides) {
+    if (key in scriptVars && scriptVars[key] === overrideValue) {
+      delete scriptVars[key];
+    }
+  }
   const scriptKeys = new Set(Object.keys(scriptVars));
 
   const next = (variables || [])
@@ -301,7 +317,8 @@ const persistEnvFile = (envFile, scriptVars, options = {}) => {
     } catch {
       return;
     }
-    const rawVariables = Array.isArray(parsed.variables) ? parsed.variables : [];
+
+    const rawVariables = Array.isArray(parsed.variables) ? parsed.variables.filter(Boolean) : [];
     const mergedVars = mergeScriptVarsIntoEnvList(rawVariables, scriptVars, options);
     // Spread preserves any top-level fields the user has beyond `variables` (name, metadata, etc.).
     const next = { ...parsed, variables: mergedVars };
@@ -374,9 +391,10 @@ const persistCollectionVars = (collection, scriptCollVars, collectionRootPath) =
  *   globalEnvFile?: { path: string, format: 'yml' },
  *   collection: object,
  *   collectionRootPath: string,
- *   envVarOverrides?: Set<string>
- * }} targets - Where each kind of var should land on disk. `envVarOverrides` lists names
- *   supplied via CLI `--env-var`; they are never persisted to the active env file.
+ *   envVarOverrides?: Map<string, string>
+ * }} targets - Where each kind of var should land on disk. `envVarOverrides` maps each
+ *   CLI `--env-var name=value` to its injected value; that value is never persisted, but a
+ *   deliberate same-named script write with a different value still reaches disk.
  *   `globalEnvFile.format` is yml-only because the CLI's `--global-env <name>` flag looks
  *   up `<workspace>/environments/<name>.yml` (no JSON/bru equivalent exists today).
  * @returns {void}

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -711,6 +711,7 @@ get {
 
 tests {
   bru.setEnvVar("beforeThrow", 42);
+  bru.setCollectionVar("collBeforeThrow", true);
   throw new Error("boom");
 }
 `
@@ -726,5 +727,8 @@ tests {
 
     const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
     expect(envContent).toMatch(/@number\s+beforeThrow:\s*42/);
+
+    const collectionBru = fs.readFileSync(path.join(tmpDir, 'collection.bru'), 'utf8');
+    expect(collectionBru).toMatch(/@boolean\s+collBeforeThrow:\s*true/);
   }, 60_000);
 });

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -7,7 +7,6 @@ const { spawn } = require('child_process');
 
 const CLI_BIN = path.resolve(__dirname, '..', '..', 'bin', 'bru.js');
 
-// Writes a fixture file, creating any missing parent directories first (mkdir -p semantics).
 const writeFixtureFile = (filePath, content) => {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content);
@@ -39,8 +38,6 @@ script:post-response {
 `;
 
 describe('CLI run — typed env + collection vars set via scripts are persisted to disk', () => {
-  // The CLI needs a reachable HTTP target so its post-response script can run.
-  // Spin up a throwaway local server so the test doesn't depend on the network.
   let server;
   let baseUrl;
   let tmpDir;
@@ -67,9 +64,8 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  // spawnSync would block jest's event loop, leaving the in-process HTTP server unable to
-  // answer the CLI's request — leading to ECONNREFUSED and the post-response script never
-  // running. Use async spawn so the server stays responsive.
+  // spawnSync blocks jest's event loop, starving the in-process HTTP server → ECONNREFUSED.
+  // Use async spawn so the server stays responsive.
   const runCli = (args, cwd = tmpDir) =>
     new Promise((resolve, reject) => {
       const child = spawn(process.execPath, [CLI_BIN, ...args], { cwd, env: { ...process.env } });
@@ -102,10 +98,7 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
     expect(collectionBru).toMatch(/collStr:\s*plain/);
   };
 
-  // Run the same fixture under both sandboxes — they wrap different JS runtimes (`nodevm` vs
-  // `quickjs`) but must produce identical persisted disk state. See
-  // packages/bruno-cli/src/commands/run.js getJsSandboxRuntime: 'safe' → quickjs, anything
-  // else → nodevm.
+  // 'safe' → quickjs, anything else → nodevm. Both runtimes must produce identical disk state.
   it.each([
     ['developer'],
     ['safe']
@@ -128,8 +121,6 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
       'run', 'set-typed-vars.bru', '--env', 'Test', '--sandbox', sandbox, '--noproxy'
     ]);
 
-    // If the CLI hard-fails (non-zero exit + no request output), surface its stderr so the
-    // failure mode is obvious instead of a cryptic "file content didn't match" assertion below.
     if (result.code !== 0) {
       throw new Error(
         `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
@@ -139,11 +130,8 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
     assertDiskState();
   }, 60_000);
 
-  // Global env vars live in the workspace, not the collection. The CLI finds them by walking
-  // up from cwd looking for workspace.yml (or honoring --workspace-path), then reading
-  // <workspace>/environments/<name>.yml. Persistence routes through the same
-  // persistVariableUpdates path as env/collection vars — see run.js:484 for the
-  // globalEnvFileDescriptor wiring.
+  // Global env vars live in the workspace, not the collection — CLI walks up from cwd looking
+  // for workspace.yml, then reads <workspace>/environments/<name>.yml.
   it.each([
     ['developer'],
     ['safe']
@@ -151,8 +139,6 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
     const workspaceDir = path.join(tmpDir, 'workspace');
     const collectionDir = path.join(workspaceDir, 'typed-cli-collection');
 
-    // The CLI's workspace check only looks for the file's existence — see run.js
-    // findWorkspacePath. A minimal valid YAML body keeps the fixture small.
     writeFixtureFile(
       path.join(workspaceDir, 'workspace.yml'),
       'opencollection: 1.0.0\ninfo:\n  name: "Test Workspace"\n  type: workspace\ncollections:\n  - name: "typed-cli-collection"\n    path: "typed-cli-collection"\nspecs:\ndocs: \'\'\n'
@@ -203,9 +189,7 @@ script:post-response {
       );
     }
 
-    // The yml env serializer encodes typed values as `value: { type, data }` blocks — see
-    // packages/bruno-filestore/src/formats/yml/common/datatype.ts. Strings stay as raw
-    // `value: …` with no type block.
+    // yml encodes typed values as `value: { type, data }` blocks; strings stay as raw `value:`.
     const written = fs.readFileSync(path.join(workspaceDir, 'environments', 'Global.yml'), 'utf8');
     expect(written).toMatch(/name:\s*globalNum[\s\S]*?type:\s*number[\s\S]*?data:\s*['"]?99/);
     expect(written).toMatch(/name:\s*globalBool[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?false/);
@@ -214,13 +198,9 @@ script:post-response {
     expect(written).not.toMatch(/name:\s*baseUrl[\s\S]*?type:\s*string/);
   }, 60_000);
 
-  // Verifies the explicit --workspace-path flag (vs. cwd walk-up via findWorkspacePath at
-  // run.js:440). With the collection sitting OUTSIDE the workspace tree, the auto-detect
-  // walk-up cannot find workspace.yml — the only way the CLI locates the global env file is
-  // via the explicit flag. Persistence must still route correctly through that code path.
+  // Collection lives outside the workspace tree, so cwd walk-up can't find workspace.yml —
+  // only --workspace-path can locate it.
   it('persists typed global env vars when --workspace-path is provided explicitly', async () => {
-    // Workspace and collection are siblings — auto-detect walk-up from the collection dir
-    // never reaches the workspace, so --workspace-path is the only way the CLI finds it.
     const workspaceDir = path.join(tmpDir, 'workspace');
     const collectionDir = path.join(tmpDir, 'standalone-collection');
 
@@ -284,10 +264,8 @@ script:post-response {
     expect(written).toMatch(/name:\s*globalBool[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?false/);
   }, 60_000);
 
-  // --env-file is the only CLI surface that supports JSON env files (--global-env and --env
-  // are locked to yml / bru-or-yml respectively). End-to-end coverage of the JSON branch in
-  // persistEnvFile, including the shape-preservation guarantee: uid and custom fields on
-  // entries the script doesn't touch must survive the round trip.
+  // --env-file is the only CLI surface that supports JSON env files. uid + custom fields on
+  // untouched entries must survive the rewrite.
   it('persists typed env vars to a --env-file JSON file and preserves per-entry uid / custom fields', async () => {
     writeFixtureFile(
       path.join(tmpDir, 'bruno.json'),
@@ -298,9 +276,6 @@ script:post-response {
       'meta {\n  name: json-env-collection\n  seq: 1\n}\n'
     );
 
-    // Existing entries carry uid + custom fields to verify the rewrite path doesn't strip
-    // them. `host` will be echoed back unchanged by the script (used by the request URL);
-    // `untouched` will not appear in the script's writes at all.
     writeFixtureFile(
       path.join(tmpDir, 'External.json'),
       JSON.stringify({
@@ -348,27 +323,20 @@ script:post-response {
     }
 
     const written = JSON.parse(fs.readFileSync(path.join(tmpDir, 'External.json'), 'utf8'));
-    // Top-level metadata preserved
     expect(written.uid).toBe('env-uid-abc');
     const byName = Object.fromEntries(written.variables.map((v) => [v.name, v]));
-    // New typed vars from the script
     expect(byName.port).toMatchObject({ value: 3000, dataType: 'number' });
     expect(byName.enabled).toMatchObject({ value: true, dataType: 'boolean' });
-    // Untouched entry retains uid + custom field
     expect(byName.untouched).toMatchObject({
       value: 'stays-put',
       uid: 'var-untouched',
       custom: 'keep-me'
     });
-    // Echoed-back entry retains uid + custom field
     expect(byName.host).toMatchObject({ uid: 'var-host', custom: 'keep-host' });
   }, 60_000);
 
-  // End-to-end coverage of resolveEnvFileFormat's extension-detection branching for the
-  // two non-JSON formats. The persistence behavior for yml / bru is already proven via
-  // --env (.bru) and --global-env (.yml); these tests prove that --env-file <path>.yml
-  // and --env-file <path>.bru also wire through correctly — descriptor format inferred
-  // from the extension, parser/serializer selected accordingly.
+  // --env-file infers format from extension — yml/bru wiring is covered separately by --env
+  // and --global-env. These tests prove the --env-file <path>.{yml,bru} branches.
   it('persists typed env vars to a --env-file YAML file with type/data blocks', async () => {
     writeFixtureFile(
       path.join(tmpDir, 'bruno.json'),
@@ -416,20 +384,16 @@ script:post-response {
       );
     }
 
-    // yml serializer encodes typed values as `value: { type, data }` blocks.
     const written = fs.readFileSync(path.join(tmpDir, 'External.yml'), 'utf8');
     expect(written).toMatch(/name:\s*port[\s\S]*?type:\s*number[\s\S]*?data:\s*['"]?3000/);
     expect(written).toMatch(/name:\s*enabled[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?true/);
-    // String values stay as raw `value: ...` — no type/data block.
     expect(written).toMatch(/name:\s*host[\s\S]*?value:\s*['"]?http:\/\/127\.0\.0\.1/);
     expect(written).not.toMatch(/name:\s*host[\s\S]*?type:\s*string/);
   }, 60_000);
 
-  // JSON natively supports typed values (`"value": 42`, `"value": true`, `"value": {…}`),
-  // so a JSON env file can seed with real JS types directly — no `dataType` tag needed.
-  // The script then touches an UNRELATED key, which forces the runtime to echo back the
-  // full env map. Every seeded typed value must survive that echo intact — same type, same
-  // value, and `dataType` gets auto-annotated to match the JS type.
+  // JSON natively types values via JSON.parse — no dataType tag needed on seed. Script touches
+  // an unrelated key, forcing a full-env echo; seeded values must survive intact with
+  // auto-annotated dataType.
   it('preserves pre-existing native typed values in --env-file JSON when script touches unrelated keys', async () => {
     writeFixtureFile(
       path.join(tmpDir, 'bruno.json'),
@@ -445,7 +409,6 @@ script:post-response {
         name: 'External',
         variables: [
           { name: 'host', value: baseUrl },
-          // Native typed values — no dataType tag needed; JSON.parse keeps the JS type.
           { name: 'seedNum', value: 42 },
           { name: 'seedBool', value: true },
           { name: 'seedObj', value: { region: 'eu', port: 3000 } },
@@ -488,16 +451,13 @@ script:post-response {
 
     const written = JSON.parse(fs.readFileSync(path.join(tmpDir, 'External.json'), 'utf8'));
     const byName = Object.fromEntries(written.variables.map((v) => [v.name, v]));
-    // Native types preserved AND auto-annotated with dataType matching the JS type.
     expect(byName.seedNum).toMatchObject({ value: 42, dataType: 'number' });
     expect(byName.seedBool).toMatchObject({ value: true, dataType: 'boolean' });
     expect(byName.seedObj).toMatchObject({ value: { region: 'eu', port: 3000 }, dataType: 'object' });
     // Arrays are `typeof === 'object'` in JS, so they get dataType: 'object'.
     expect(byName.seedArr).toMatchObject({ value: [1, 2, 3], dataType: 'object' });
-    // String stays string — no dataType added.
     expect(byName.host.value).toBe(baseUrl);
     expect(byName.host.dataType).toBeUndefined();
-    // The trigger key the script wrote is also there.
     expect(byName.trigger).toMatchObject({ value: 'x' });
     expect(byName.trigger.dataType).toBeUndefined();
   }, 60_000);
@@ -549,20 +509,15 @@ script:post-response {
       );
     }
 
-    // .bru serializer emits typed values as `@dataType` decorators on the preceding line.
     const written = fs.readFileSync(path.join(tmpDir, 'External.bru'), 'utf8');
     expect(written).toMatch(/@number\s+port:\s*3000/);
     expect(written).toMatch(/@boolean\s+enabled:\s*true/);
-    // String values get no annotation.
     expect(written).not.toMatch(/@string\s+host/);
     expect(written).toMatch(/host:\s*http:\/\/127\.0\.0\.1/);
   }, 60_000);
 
-  // Regression guard at the CLI binary boundary: --env-var values are transient (the CLI
-  // can't decrypt at-rest secrets, so users pass them in for a single run). Even though a
-  // script writes an unrelated env var — which dirties the env scope and makes the runtime
-  // echo back the full envVariables map including the override — the on-disk env file must
-  // keep its real secret untouched.
+  // --env-var values are transient. Even when a script write triggers full-env echo, the
+  // override must NOT replace the on-disk secret.
   it('does not persist --env-var override values into the env file', async () => {
     writeFixtureFile(
       path.join(tmpDir, 'bruno.json'),
@@ -611,17 +566,14 @@ script:post-response {
     }
 
     const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
-    // Real on-disk secret preserved
     expect(envContent).toMatch(/token:\s*real-secret-on-disk/);
-    // Transient override value NEVER reaches disk
     expect(envContent).not.toContain('transient-cli-value');
-    // Unrelated key from the script is persisted normally
     expect(envContent).toMatch(/unrelated:\s*value/);
   }, 60_000);
 
-  // Regression guard for the partial-results path: when a post-response script throws
-  // after writing a var, run-single-request.js still calls syncVariableUpdates with
-  // `error.partialResults`. The on-disk env file must reflect the pre-throw write.
+  // When a post-response script throws after writing a var, run-single-request.js calls
+  // syncVariableUpdates with `error.partialResults`. The on-disk env file must reflect the
+  // pre-throw write.
   it('persists vars written before a post-response script error (partial results)', async () => {
     writeFixtureFile(
       path.join(tmpDir, 'bruno.json'),
@@ -656,12 +608,13 @@ script:post-response {
 `
     );
 
-    // CLI exits non-zero (the thrown script is logged as a failed post-response test, which
-    // trips the failedPostResponseTests check in run.js). That failure IS the case we want
-    // to exercise — persistence runs from the script's partial results regardless.
-    await runCli([
+    const result = await runCli([
       'run', 'set-then-throw.bru', '--env', 'Test', '--sandbox', 'developer', '--noproxy'
     ]);
+
+    // Pin failure exit first — otherwise the persistence assertion below could pass for the
+    // wrong reason (e.g. the script never ran).
+    expect(result.code).not.toBe(0);
 
     const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
     expect(envContent).toMatch(/@number\s+beforeThrow:\s*42/);

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -603,6 +603,7 @@ get {
 
 script:post-response {
   bru.setEnvVar("beforeThrow", 42);
+  bru.setCollectionVar("collBeforeThrow", true);
   throw new Error("boom");
 }
 `
@@ -618,6 +619,9 @@ script:post-response {
 
     const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
     expect(envContent).toMatch(/@number\s+beforeThrow:\s*42/);
+
+    const collectionBru = fs.readFileSync(path.join(tmpDir, 'collection.bru'), 'utf8');
+    expect(collectionBru).toMatch(/@boolean\s+collBeforeThrow:\s*true/);
   }, 60_000);
 
   // Vars set from inside a `tests {}` block reach disk through the same syncVariableUpdates

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -293,6 +293,86 @@ script:post-response {
     expect(written).toMatch(/name:\s*globalBool[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?false/);
   }, 60_000);
 
+  // --env-file is the only CLI surface that supports JSON env files (--global-env and --env
+  // are locked to yml / bru-or-yml respectively). End-to-end coverage of the JSON branch in
+  // persistEnvFile, including the shape-preservation guarantee: uid and custom fields on
+  // entries the script doesn't touch must survive the round trip.
+  it('persists typed env vars to a --env-file JSON file and preserves per-entry uid / custom fields', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'json-env-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: json-env-collection\n  seq: 1\n}\n'
+    );
+
+    // Existing entries carry uid + custom fields to verify the rewrite path doesn't strip
+    // them. `host` will be echoed back unchanged by the script (used by the request URL);
+    // `untouched` will not appear in the script's writes at all.
+    writeFixtureFile(
+      path.join(tmpDir, 'External.json'),
+      JSON.stringify({
+        name: 'External',
+        uid: 'env-uid-abc',
+        variables: [
+          { name: 'host', value: baseUrl, uid: 'var-host', custom: 'keep-host' },
+          { name: 'untouched', value: 'stays-put', uid: 'var-untouched', custom: 'keep-me' }
+        ]
+      }, null, 2) + '\n'
+    );
+
+    writeFixtureFile(
+      path.join(tmpDir, 'set-typed-vars.bru'),
+      `meta {
+  name: set-typed-vars
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setEnvVar("port", 3000);
+  bru.setEnvVar("enabled", true);
+}
+`
+    );
+
+    const result = await runCli([
+      'run', 'set-typed-vars.bru',
+      '--env-file', 'External.json',
+      '--sandbox', 'developer',
+      '--noproxy'
+    ]);
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    const written = JSON.parse(fs.readFileSync(path.join(tmpDir, 'External.json'), 'utf8'));
+    // Top-level metadata preserved
+    expect(written.uid).toBe('env-uid-abc');
+    const byName = Object.fromEntries(written.variables.map((v) => [v.name, v]));
+    // New typed vars from the script
+    expect(byName.port).toMatchObject({ value: 3000, dataType: 'number' });
+    expect(byName.enabled).toMatchObject({ value: true, dataType: 'boolean' });
+    // Untouched entry retains uid + custom field
+    expect(byName.untouched).toMatchObject({
+      value: 'stays-put',
+      uid: 'var-untouched',
+      custom: 'keep-me'
+    });
+    // Echoed-back entry retains uid + custom field
+    expect(byName.host).toMatchObject({ uid: 'var-host', custom: 'keep-host' });
+  }, 60_000);
+
   // Regression guard at the CLI binary boundary: --env-var values are transient (the CLI
   // can't decrypt at-rest secrets, so users pass them in for a single run). Even though a
   // script writes an unrelated env var — which dirties the env scope and makes the runtime

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -70,18 +70,9 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
   // spawnSync would block jest's event loop, leaving the in-process HTTP server unable to
   // answer the CLI's request — leading to ECONNREFUSED and the post-response script never
   // running. Use async spawn so the server stays responsive.
-  //
-  // SHELL=/bin/sh: the CLI bootstrap (packages/bruno-cli/src/index.js) calls
-  // `initializeShellEnv()` unconditionally, which spawns $SHELL via the `shell-env` package
-  // to source the user's dotfiles. Forcing /bin/sh standardizes that across machines (a
-  // developer with fish/zsh shouldn't have their dotfiles sourced into the test env) and
-  // keeps the bootstrap fast and deterministic.
   const runCli = (args, cwd = tmpDir) =>
     new Promise((resolve, reject) => {
-      const child = spawn(process.execPath, [CLI_BIN, ...args], {
-        cwd,
-        env: { ...process.env, SHELL: '/bin/sh' }
-      });
+      const child = spawn(process.execPath, [CLI_BIN, ...args], { cwd, env: { ...process.env } });
       let stdout = '';
       let stderr = '';
       child.stdout.on('data', (chunk) => { stdout += chunk; });
@@ -626,5 +617,53 @@ script:post-response {
     expect(envContent).not.toContain('transient-cli-value');
     // Unrelated key from the script is persisted normally
     expect(envContent).toMatch(/unrelated:\s*value/);
+  }, 60_000);
+
+  // Regression guard for the partial-results path: when a post-response script throws
+  // after writing a var, run-single-request.js still calls syncVariableUpdates with
+  // `error.partialResults`. The on-disk env file must reflect the pre-throw write.
+  it('persists vars written before a post-response script error (partial results)', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'partial-results-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: partial-results-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'environments', 'Test.bru'),
+      `vars {\n  host: ${baseUrl}\n}\n`
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'set-then-throw.bru'),
+      `meta {
+  name: set-then-throw
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setEnvVar("beforeThrow", 42);
+  throw new Error("boom");
+}
+`
+    );
+
+    // CLI exits non-zero (the thrown script is logged as a failed post-response test, which
+    // trips the failedPostResponseTests check in run.js). That failure IS the case we want
+    // to exercise — persistence runs from the script's partial results regardless.
+    await runCli([
+      'run', 'set-then-throw.bru', '--env', 'Test', '--sandbox', 'developer', '--noproxy'
+    ]);
+
+    const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
+    expect(envContent).toMatch(/@number\s+beforeThrow:\s*42/);
   }, 60_000);
 });

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -434,6 +434,83 @@ script:post-response {
     expect(written).not.toMatch(/name:\s*host[\s\S]*?type:\s*string/);
   }, 60_000);
 
+  // JSON natively supports typed values (`"value": 42`, `"value": true`, `"value": {…}`),
+  // so a JSON env file can seed with real JS types directly — no `dataType` tag needed.
+  // The script then touches an UNRELATED key, which forces the runtime to echo back the
+  // full env map. Every seeded typed value must survive that echo intact — same type, same
+  // value, and `dataType` gets auto-annotated to match the JS type.
+  it('preserves pre-existing native typed values in --env-file JSON when script touches unrelated keys', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'json-types-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: json-types-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'External.json'),
+      JSON.stringify({
+        name: 'External',
+        variables: [
+          { name: 'host', value: baseUrl },
+          // Native typed values — no dataType tag needed; JSON.parse keeps the JS type.
+          { name: 'seedNum', value: 42 },
+          { name: 'seedBool', value: true },
+          { name: 'seedObj', value: { region: 'eu', port: 3000 } },
+          { name: 'seedArr', value: [1, 2, 3] }
+        ]
+      }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'touch-unrelated.bru'),
+      `meta {
+  name: touch-unrelated
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setEnvVar("trigger", "x");
+}
+`
+    );
+
+    const result = await runCli([
+      'run', 'touch-unrelated.bru',
+      '--env-file', 'External.json',
+      '--sandbox', 'developer',
+      '--noproxy'
+    ]);
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    const written = JSON.parse(fs.readFileSync(path.join(tmpDir, 'External.json'), 'utf8'));
+    const byName = Object.fromEntries(written.variables.map((v) => [v.name, v]));
+    // Native types preserved AND auto-annotated with dataType matching the JS type.
+    expect(byName.seedNum).toMatchObject({ value: 42, dataType: 'number' });
+    expect(byName.seedBool).toMatchObject({ value: true, dataType: 'boolean' });
+    expect(byName.seedObj).toMatchObject({ value: { region: 'eu', port: 3000 }, dataType: 'object' });
+    // Arrays are `typeof === 'object'` in JS, so they get dataType: 'object'.
+    expect(byName.seedArr).toMatchObject({ value: [1, 2, 3], dataType: 'object' });
+    // String stays string — no dataType added.
+    expect(byName.host.value).toBe(baseUrl);
+    expect(byName.host.dataType).toBeUndefined();
+    // The trigger key the script wrote is also there.
+    expect(byName.trigger).toMatchObject({ value: 'x' });
+    expect(byName.trigger.dataType).toBeUndefined();
+  }, 60_000);
+
   it('persists typed env vars to a --env-file .bru file with @dataType annotations', async () => {
     writeFixtureFile(
       path.join(tmpDir, 'bruno.json'),

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -7,7 +7,8 @@ const { spawn } = require('child_process');
 
 const CLI_BIN = path.resolve(__dirname, '..', '..', 'bin', 'bru.js');
 
-const writeFileSyncMkdirP = (filePath, content) => {
+// Writes a fixture file, creating any missing parent directories first (mkdir -p semantics).
+const writeFixtureFile = (filePath, content) => {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content);
 };
@@ -69,6 +70,12 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
   // spawnSync would block jest's event loop, leaving the in-process HTTP server unable to
   // answer the CLI's request — leading to ECONNREFUSED and the post-response script never
   // running. Use async spawn so the server stays responsive.
+  //
+  // SHELL=/bin/sh: the CLI bootstrap (packages/bruno-cli/src/index.js) calls
+  // `initializeShellEnv()` unconditionally, which spawns $SHELL via the `shell-env` package
+  // to source the user's dotfiles. Forcing /bin/sh standardizes that across machines (a
+  // developer with fish/zsh shouldn't have their dotfiles sourced into the test env) and
+  // keeps the bootstrap fast and deterministic.
   const runCli = (args, cwd = tmpDir) =>
     new Promise((resolve, reject) => {
       const child = spawn(process.execPath, [CLI_BIN, ...args], {
@@ -82,22 +89,6 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
       child.on('error', reject);
       child.on('close', (code) => resolve({ code, stdout, stderr }));
     });
-
-  const writeFixture = () => {
-    writeFileSyncMkdirP(
-      path.join(tmpDir, 'bruno.json'),
-      JSON.stringify({ version: '1', name: 'typed-cli-collection', type: 'collection' }, null, 2) + '\n'
-    );
-    writeFileSyncMkdirP(
-      path.join(tmpDir, 'collection.bru'),
-      'meta {\n  name: typed-cli-collection\n  seq: 1\n}\n'
-    );
-    writeFileSyncMkdirP(
-      path.join(tmpDir, 'environments', 'Test.bru'),
-      `vars {\n  host: ${baseUrl}\n}\n`
-    );
-    writeFileSyncMkdirP(path.join(tmpDir, 'set-typed-vars.bru'), REQUEST_BRU);
-  };
 
   const assertDiskState = () => {
     const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
@@ -128,7 +119,19 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
     ['developer'],
     ['safe']
   ])('writes @number/@boolean/@object annotations after CLI run (--sandbox %s)', async (sandbox) => {
-    writeFixture();
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'typed-cli-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: typed-cli-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'environments', 'Test.bru'),
+      `vars {\n  host: ${baseUrl}\n}\n`
+    );
+    writeFixtureFile(path.join(tmpDir, 'set-typed-vars.bru'), REQUEST_BRU);
 
     const result = await runCli([
       'run', 'set-typed-vars.bru', '--env', 'Test', '--sandbox', sandbox, '--noproxy'
@@ -159,24 +162,24 @@ describe('CLI run — typed env + collection vars set via scripts are persisted 
 
     // The CLI's workspace check only looks for the file's existence — see run.js
     // findWorkspacePath. A minimal valid YAML body keeps the fixture small.
-    writeFileSyncMkdirP(
+    writeFixtureFile(
       path.join(workspaceDir, 'workspace.yml'),
       'opencollection: 1.0.0\ninfo:\n  name: "Test Workspace"\n  type: workspace\ncollections:\n  - name: "typed-cli-collection"\n    path: "typed-cli-collection"\nspecs:\ndocs: \'\'\n'
     );
-    writeFileSyncMkdirP(
+    writeFixtureFile(
       path.join(workspaceDir, 'environments', 'Global.yml'),
       `name: Global\nvariables:\n  - name: baseUrl\n    value: ${baseUrl}\n    enabled: true\n    secret: false\n`
     );
 
-    writeFileSyncMkdirP(
+    writeFixtureFile(
       path.join(collectionDir, 'bruno.json'),
       JSON.stringify({ version: '1', name: 'typed-cli-collection', type: 'collection' }, null, 2) + '\n'
     );
-    writeFileSyncMkdirP(
+    writeFixtureFile(
       path.join(collectionDir, 'collection.bru'),
       'meta {\n  name: typed-cli-collection\n  seq: 1\n}\n'
     );
-    writeFileSyncMkdirP(
+    writeFixtureFile(
       path.join(collectionDir, 'set-typed-global-vars.bru'),
       `meta {
   name: set-typed-global-vars
@@ -218,5 +221,136 @@ script:post-response {
     expect(written).toMatch(/name:\s*globalObj[\s\S]*?type:\s*object[\s\S]*?data:[\s\S]*?tier/);
     expect(written).toMatch(/name:\s*baseUrl[\s\S]*?value:\s*['"]?http:\/\/127\.0\.0\.1/);
     expect(written).not.toMatch(/name:\s*baseUrl[\s\S]*?type:\s*string/);
+  }, 60_000);
+
+  // Verifies the explicit --workspace-path flag (vs. cwd walk-up via findWorkspacePath at
+  // run.js:440). With the collection sitting OUTSIDE the workspace tree, the auto-detect
+  // walk-up cannot find workspace.yml — the only way the CLI locates the global env file is
+  // via the explicit flag. Persistence must still route correctly through that code path.
+  it('persists typed global env vars when --workspace-path is provided explicitly', async () => {
+    // Workspace and collection are siblings — auto-detect walk-up from the collection dir
+    // never reaches the workspace, so --workspace-path is the only way the CLI finds it.
+    const workspaceDir = path.join(tmpDir, 'workspace');
+    const collectionDir = path.join(tmpDir, 'standalone-collection');
+
+    writeFixtureFile(
+      path.join(workspaceDir, 'workspace.yml'),
+      'opencollection: 1.0.0\ninfo:\n  name: "Test Workspace"\n  type: workspace\ncollections:\nspecs:\ndocs: \'\'\n'
+    );
+    writeFixtureFile(
+      path.join(workspaceDir, 'environments', 'Global.yml'),
+      `name: Global\nvariables:\n  - name: baseUrl\n    value: ${baseUrl}\n    enabled: true\n    secret: false\n`
+    );
+
+    writeFixtureFile(
+      path.join(collectionDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'standalone-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(collectionDir, 'collection.bru'),
+      'meta {\n  name: standalone-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(collectionDir, 'set-typed-global-vars.bru'),
+      `meta {
+  name: set-typed-global-vars
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setGlobalEnvVar("globalNum", 99);
+  bru.setGlobalEnvVar("globalBool", false);
+}
+`
+    );
+
+    const result = await runCli(
+      [
+        'run', 'set-typed-global-vars.bru',
+        '--global-env', 'Global',
+        '--workspace-path', workspaceDir,
+        '--sandbox', 'developer',
+        '--noproxy'
+      ],
+      collectionDir
+    );
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    const written = fs.readFileSync(path.join(workspaceDir, 'environments', 'Global.yml'), 'utf8');
+    expect(written).toMatch(/name:\s*globalNum[\s\S]*?type:\s*number[\s\S]*?data:\s*['"]?99/);
+    expect(written).toMatch(/name:\s*globalBool[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?false/);
+  }, 60_000);
+
+  // Regression guard at the CLI binary boundary: --env-var values are transient (the CLI
+  // can't decrypt at-rest secrets, so users pass them in for a single run). Even though a
+  // script writes an unrelated env var — which dirties the env scope and makes the runtime
+  // echo back the full envVariables map including the override — the on-disk env file must
+  // keep its real secret untouched.
+  it('does not persist --env-var override values into the env file', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'override-leak-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: override-leak-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'environments', 'Test.bru'),
+      `vars {\n  host: ${baseUrl}\n  token: real-secret-on-disk\n}\n`
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'set-unrelated.bru'),
+      `meta {
+  name: set-unrelated
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setEnvVar("unrelated", "value");
+}
+`
+    );
+
+    const result = await runCli([
+      'run', 'set-unrelated.bru',
+      '--env', 'Test',
+      '--env-var', 'token=transient-cli-value',
+      '--sandbox', 'developer',
+      '--noproxy'
+    ]);
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
+    // Real on-disk secret preserved
+    expect(envContent).toMatch(/token:\s*real-secret-on-disk/);
+    // Transient override value NEVER reaches disk
+    expect(envContent).not.toContain('transient-cli-value');
+    // Unrelated key from the script is persisted normally
+    expect(envContent).toMatch(/unrelated:\s*value/);
   }, 60_000);
 });

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -1,0 +1,222 @@
+const { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+const { spawn } = require('child_process');
+
+const CLI_BIN = path.resolve(__dirname, '..', '..', 'bin', 'bru.js');
+
+const writeFileSyncMkdirP = (filePath, content) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+};
+
+const REQUEST_BRU = `meta {
+  name: set-typed-vars
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setEnvVar("envNum", 42);
+  bru.setEnvVar("envBool", true);
+  bru.setEnvVar("envObj", { port: 3000, ssl: true });
+  bru.setEnvVar("envStr", "hello");
+
+  bru.setCollectionVar("collNum", 7);
+  bru.setCollectionVar("collBool", false);
+  bru.setCollectionVar("collObj", { region: "eu", retries: 3 });
+  bru.setCollectionVar("collStr", "plain");
+}
+`;
+
+describe('CLI run — typed env + collection vars set via scripts are persisted to disk', () => {
+  // The CLI needs a reachable HTTP target so its post-response script can run.
+  // Spin up a throwaway local server so the test doesn't depend on the network.
+  let server;
+  let baseUrl;
+  let tmpDir;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-cli-typed-persist-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // spawnSync would block jest's event loop, leaving the in-process HTTP server unable to
+  // answer the CLI's request — leading to ECONNREFUSED and the post-response script never
+  // running. Use async spawn so the server stays responsive.
+  const runCli = (args, cwd = tmpDir) =>
+    new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [CLI_BIN, ...args], {
+        cwd,
+        env: { ...process.env, SHELL: '/bin/sh' }
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += chunk; });
+      child.stderr.on('data', (chunk) => { stderr += chunk; });
+      child.on('error', reject);
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+  const writeFixture = () => {
+    writeFileSyncMkdirP(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'typed-cli-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFileSyncMkdirP(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: typed-cli-collection\n  seq: 1\n}\n'
+    );
+    writeFileSyncMkdirP(
+      path.join(tmpDir, 'environments', 'Test.bru'),
+      `vars {\n  host: ${baseUrl}\n}\n`
+    );
+    writeFileSyncMkdirP(path.join(tmpDir, 'set-typed-vars.bru'), REQUEST_BRU);
+  };
+
+  const assertDiskState = () => {
+    const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
+    expect(envContent).toMatch(/@number\s+envNum:\s*42/);
+    expect(envContent).toMatch(/@boolean\s+envBool:\s*true/);
+    expect(envContent).toMatch(/@object\s+envObj:/);
+    expect(envContent).toContain('"port": 3000');
+    expect(envContent).toContain('"ssl": true');
+    // 'string' is the implicit default — never materialized as an annotation.
+    expect(envContent).not.toMatch(/@string\s+envStr/);
+    expect(envContent).toMatch(/envStr:\s*hello/);
+
+    const collectionBru = fs.readFileSync(path.join(tmpDir, 'collection.bru'), 'utf8');
+    expect(collectionBru).toMatch(/@number\s+collNum:\s*7/);
+    expect(collectionBru).toMatch(/@boolean\s+collBool:\s*false/);
+    expect(collectionBru).toMatch(/@object\s+collObj:/);
+    expect(collectionBru).toContain('"region": "eu"');
+    expect(collectionBru).toContain('"retries": 3');
+    expect(collectionBru).not.toMatch(/@string\s+collStr/);
+    expect(collectionBru).toMatch(/collStr:\s*plain/);
+  };
+
+  // Run the same fixture under both sandboxes — they wrap different JS runtimes (`nodevm` vs
+  // `quickjs`) but must produce identical persisted disk state. See
+  // packages/bruno-cli/src/commands/run.js getJsSandboxRuntime: 'safe' → quickjs, anything
+  // else → nodevm.
+  it.each([
+    ['developer'],
+    ['safe']
+  ])('writes @number/@boolean/@object annotations after CLI run (--sandbox %s)', async (sandbox) => {
+    writeFixture();
+
+    const result = await runCli([
+      'run', 'set-typed-vars.bru', '--env', 'Test', '--sandbox', sandbox, '--noproxy'
+    ]);
+
+    // If the CLI hard-fails (non-zero exit + no request output), surface its stderr so the
+    // failure mode is obvious instead of a cryptic "file content didn't match" assertion below.
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    assertDiskState();
+  }, 60_000);
+
+  // Global env vars live in the workspace, not the collection. The CLI finds them by walking
+  // up from cwd looking for workspace.yml (or honoring --workspace-path), then reading
+  // <workspace>/environments/<name>.yml. Persistence routes through the same
+  // persistVariableUpdates path as env/collection vars — see run.js:484 for the
+  // globalEnvFileDescriptor wiring.
+  it.each([
+    ['developer'],
+    ['safe']
+  ])('writes typed global env vars back to <workspace>/environments/<name>.yml (--sandbox %s)', async (sandbox) => {
+    const workspaceDir = path.join(tmpDir, 'workspace');
+    const collectionDir = path.join(workspaceDir, 'typed-cli-collection');
+
+    // The CLI's workspace check only looks for the file's existence — see run.js
+    // findWorkspacePath. A minimal valid YAML body keeps the fixture small.
+    writeFileSyncMkdirP(
+      path.join(workspaceDir, 'workspace.yml'),
+      'opencollection: 1.0.0\ninfo:\n  name: "Test Workspace"\n  type: workspace\ncollections:\n  - name: "typed-cli-collection"\n    path: "typed-cli-collection"\nspecs:\ndocs: \'\'\n'
+    );
+    writeFileSyncMkdirP(
+      path.join(workspaceDir, 'environments', 'Global.yml'),
+      `name: Global\nvariables:\n  - name: baseUrl\n    value: ${baseUrl}\n    enabled: true\n    secret: false\n`
+    );
+
+    writeFileSyncMkdirP(
+      path.join(collectionDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'typed-cli-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFileSyncMkdirP(
+      path.join(collectionDir, 'collection.bru'),
+      'meta {\n  name: typed-cli-collection\n  seq: 1\n}\n'
+    );
+    writeFileSyncMkdirP(
+      path.join(collectionDir, 'set-typed-global-vars.bru'),
+      `meta {
+  name: set-typed-global-vars
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setGlobalEnvVar("globalNum", 99);
+  bru.setGlobalEnvVar("globalBool", false);
+  bru.setGlobalEnvVar("globalObj", { tier: "premium", limit: 100 });
+}
+`
+    );
+
+    const result = await runCli(
+      ['run', 'set-typed-global-vars.bru', '--global-env', 'Global', '--sandbox', sandbox, '--noproxy'],
+      collectionDir
+    );
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    // The yml env serializer encodes typed values as `value: { type, data }` blocks — see
+    // packages/bruno-filestore/src/formats/yml/common/datatype.ts. Strings stay as raw
+    // `value: …` with no type block.
+    const written = fs.readFileSync(path.join(workspaceDir, 'environments', 'Global.yml'), 'utf8');
+    expect(written).toMatch(/name:\s*globalNum[\s\S]*?type:\s*number[\s\S]*?data:\s*['"]?99/);
+    expect(written).toMatch(/name:\s*globalBool[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?false/);
+    expect(written).toMatch(/name:\s*globalObj[\s\S]*?type:\s*object[\s\S]*?data:[\s\S]*?tier/);
+    expect(written).toMatch(/name:\s*baseUrl[\s\S]*?value:\s*['"]?http:\/\/127\.0\.0\.1/);
+    expect(written).not.toMatch(/name:\s*baseUrl[\s\S]*?type:\s*string/);
+  }, 60_000);
+});

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -678,6 +678,57 @@ tests {
     expect(collectionBru).toMatch(/@boolean\s+collFromTests:\s*true/);
   }, 60_000);
 
+  it('persists env/collection vars mutated as a side effect of vars:post-response expressions', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'vars-side-effect-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: vars-side-effect-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'environments', 'Test.bru'),
+      `vars {\n  host: ${baseUrl}\n}\n`
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'set-from-vars-block.bru'),
+      `meta {
+  name: set-from-vars-block
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+vars:post-response {
+  envSideEffect: bru.setEnvVar("envFromVars", 42)
+  collSideEffect: bru.setCollectionVar("collFromVars", true)
+}
+`
+    );
+
+    const result = await runCli([
+      'run', 'set-from-vars-block.bru', '--env', 'Test', '--sandbox', 'developer', '--noproxy'
+    ]);
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
+    expect(envContent).toMatch(/@number\s+envFromVars:\s*42/);
+
+    const collectionBru = fs.readFileSync(path.join(tmpDir, 'collection.bru'), 'utf8');
+    expect(collectionBru).toMatch(/@boolean\s+collFromVars:\s*true/);
+  }, 60_000);
+
   // A throw at the top of `tests {}` (outside any test() callback) is caught by test-runtime,
   // which attaches in-flight env/collection mutations to `error.partialResults`. The CLI
   // catch at run-single-request.js:914 syncs those partials so pre-throw writes still land

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -373,6 +373,123 @@ script:post-response {
     expect(byName.host).toMatchObject({ uid: 'var-host', custom: 'keep-host' });
   }, 60_000);
 
+  // End-to-end coverage of resolveEnvFileFormat's extension-detection branching for the
+  // two non-JSON formats. The persistence behavior for yml / bru is already proven via
+  // --env (.bru) and --global-env (.yml); these tests prove that --env-file <path>.yml
+  // and --env-file <path>.bru also wire through correctly — descriptor format inferred
+  // from the extension, parser/serializer selected accordingly.
+  it('persists typed env vars to a --env-file YAML file with type/data blocks', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'yml-envfile-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: yml-envfile-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'External.yml'),
+      `name: External\nvariables:\n  - name: host\n    value: ${baseUrl}\n    enabled: true\n    secret: false\n`
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'set-typed-vars.bru'),
+      `meta {
+  name: set-typed-vars
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setEnvVar("port", 3000);
+  bru.setEnvVar("enabled", true);
+}
+`
+    );
+
+    const result = await runCli([
+      'run', 'set-typed-vars.bru',
+      '--env-file', 'External.yml',
+      '--sandbox', 'developer',
+      '--noproxy'
+    ]);
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    // yml serializer encodes typed values as `value: { type, data }` blocks.
+    const written = fs.readFileSync(path.join(tmpDir, 'External.yml'), 'utf8');
+    expect(written).toMatch(/name:\s*port[\s\S]*?type:\s*number[\s\S]*?data:\s*['"]?3000/);
+    expect(written).toMatch(/name:\s*enabled[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?true/);
+    // String values stay as raw `value: ...` — no type/data block.
+    expect(written).toMatch(/name:\s*host[\s\S]*?value:\s*['"]?http:\/\/127\.0\.0\.1/);
+    expect(written).not.toMatch(/name:\s*host[\s\S]*?type:\s*string/);
+  }, 60_000);
+
+  it('persists typed env vars to a --env-file .bru file with @dataType annotations', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'bru-envfile-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: bru-envfile-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'External.bru'),
+      `vars {\n  host: ${baseUrl}\n}\n`
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'set-typed-vars.bru'),
+      `meta {
+  name: set-typed-vars
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+script:post-response {
+  bru.setEnvVar("port", 3000);
+  bru.setEnvVar("enabled", true);
+}
+`
+    );
+
+    const result = await runCli([
+      'run', 'set-typed-vars.bru',
+      '--env-file', 'External.bru',
+      '--sandbox', 'developer',
+      '--noproxy'
+    ]);
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    // .bru serializer emits typed values as `@dataType` decorators on the preceding line.
+    const written = fs.readFileSync(path.join(tmpDir, 'External.bru'), 'utf8');
+    expect(written).toMatch(/@number\s+port:\s*3000/);
+    expect(written).toMatch(/@boolean\s+enabled:\s*true/);
+    // String values get no annotation.
+    expect(written).not.toMatch(/@string\s+host/);
+    expect(written).toMatch(/host:\s*http:\/\/127\.0\.0\.1/);
+  }, 60_000);
+
   // Regression guard at the CLI binary boundary: --env-var values are transient (the CLI
   // can't decrypt at-rest secrets, so users pass them in for a single run). Even though a
   // script writes an unrelated env var — which dirties the env scope and makes the runtime

--- a/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/run-typed-persistence.spec.js
@@ -619,4 +619,112 @@ script:post-response {
     const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
     expect(envContent).toMatch(/@number\s+beforeThrow:\s*42/);
   }, 60_000);
+
+  // Vars set from inside a `tests {}` block reach disk through the same syncVariableUpdates
+  // path as the post-response script, but via run-single-request.js:881 instead of :802.
+  // Sandbox-agnostic plumbing — runtime equivalence is already covered by the dual-sandbox
+  // happy-path tests above; single-sandbox here matches the analogous L577 case.
+  it('persists vars set inside a tests {} block', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'tests-block-persist-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: tests-block-persist-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'environments', 'Test.bru'),
+      `vars {\n  host: ${baseUrl}\n}\n`
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'set-from-tests.bru'),
+      `meta {
+  name: set-from-tests
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+tests {
+  test("sets vars from the tests block", function () {
+    bru.setEnvVar("envFromTests", 42);
+    bru.setCollectionVar("collFromTests", true);
+    expect(true).to.equal(true);
+  });
+}
+`
+    );
+
+    const result = await runCli([
+      'run', 'set-from-tests.bru', '--env', 'Test', '--sandbox', 'developer', '--noproxy'
+    ]);
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
+    expect(envContent).toMatch(/@number\s+envFromTests:\s*42/);
+
+    const collectionBru = fs.readFileSync(path.join(tmpDir, 'collection.bru'), 'utf8');
+    expect(collectionBru).toMatch(/@boolean\s+collFromTests:\s*true/);
+  }, 60_000);
+
+  // A throw at the top of `tests {}` (outside any test() callback) is caught by test-runtime,
+  // which attaches in-flight env/collection mutations to `error.partialResults`. The CLI
+  // catch at run-single-request.js:914 syncs those partials so pre-throw writes still land
+  // on disk — same contract as the post-response partial-results case above.
+  it('persists vars written before a tests-block script error (partial results)', async () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'tests-block-partial-results-collection', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'collection.bru'),
+      'meta {\n  name: tests-block-partial-results-collection\n  seq: 1\n}\n'
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'environments', 'Test.bru'),
+      `vars {\n  host: ${baseUrl}\n}\n`
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'set-then-throw-in-tests.bru'),
+      `meta {
+  name: set-then-throw-in-tests
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+tests {
+  bru.setEnvVar("beforeThrow", 42);
+  throw new Error("boom");
+}
+`
+    );
+
+    const result = await runCli([
+      'run', 'set-then-throw-in-tests.bru', '--env', 'Test', '--sandbox', 'developer', '--noproxy'
+    ]);
+
+    // Pin failure exit first — otherwise the persistence assertion below could pass for the
+    // wrong reason (e.g. the script never ran).
+    expect(result.code).not.toBe(0);
+
+    const envContent = fs.readFileSync(path.join(tmpDir, 'environments', 'Test.bru'), 'utf8');
+    expect(envContent).toMatch(/@number\s+beforeThrow:\s*42/);
+  }, 60_000);
 });

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -355,3 +355,117 @@ describe('typed-value inference', () => {
     expect(flagVar.dataType).toBe('boolean');
   });
 });
+
+describe('script-driven typed vars: disk content has the right dataType annotations', () => {
+  // The .bru serializer emits `@number\n  port: 3000` (annotation on its own line) — see
+  // packages/bruno-lang/v2/src/utils.js serializeAnnotations + serializeVar.
+  it('persists @number/@boolean/@object annotations in a .bru env file', () => {
+    const filePath = writeFile('Test.bru', 'vars {\n  host: https://example.test\n}\n');
+
+    persistVariableUpdates(
+      {
+        envVariables: {
+          host: 'https://example.test',
+          envNum: 42,
+          envBool: true,
+          envObj: { port: 3000, ssl: true },
+          envStr: 'hello'
+        }
+      },
+      { envFile: { path: filePath, format: 'bru' } }
+    );
+
+    const written = fs.readFileSync(filePath, 'utf8');
+    expect(written).toMatch(/@number\s+envNum:\s*42/);
+    expect(written).toMatch(/@boolean\s+envBool:\s*true/);
+    expect(written).toMatch(/@object\s+envObj:/);
+    expect(written).toContain('"port": 3000');
+    expect(written).toContain('"ssl": true');
+    // 'string' is the implicit default — never materialized as an annotation.
+    expect(written).not.toMatch(/@string\s+envStr/);
+    expect(written).toMatch(/envStr:\s*hello/);
+  });
+
+  it('persists @number/@boolean/@object annotations in collection.bru for collection vars', () => {
+    const collectionRootPath = writeFile(
+      'collection.bru',
+      'meta {\n  name: typed-collection\n  seq: 1\n}\n'
+    );
+    const collection = {
+      format: 'bru',
+      brunoConfig: { name: 'typed-collection' },
+      root: {
+        meta: { name: 'typed-collection', seq: 1 },
+        request: { vars: { req: [] } }
+      }
+    };
+
+    persistVariableUpdates(
+      {
+        collectionVariables: {
+          collNum: 7,
+          collBool: false,
+          collObj: { region: 'eu', retries: 3 },
+          collStr: 'plain'
+        }
+      },
+      { collection, collectionRootPath }
+    );
+
+    const written = fs.readFileSync(collectionRootPath, 'utf8');
+    expect(written).toMatch(/@number\s+collNum:\s*7/);
+    expect(written).toMatch(/@boolean\s+collBool:\s*false/);
+    expect(written).toMatch(/@object\s+collObj:/);
+    expect(written).toContain('"region": "eu"');
+    expect(written).toContain('"retries": 3');
+    expect(written).not.toMatch(/@string\s+collStr/);
+    expect(written).toMatch(/collStr:\s*plain/);
+  });
+
+  // The yml serializer encodes typed values as a `{ type, data }` block instead of `@dataType`
+  // decorators — see packages/bruno-filestore/src/formats/yml/common/datatype.ts.
+  it('persists typed global env vars to a yml global env file with type/data blocks', () => {
+    const globalPath = writeFile(
+      'global.yml',
+      'name: global\nvariables:\n  - name: baseUrl\n    value: https://example.test\n'
+    );
+
+    persistVariableUpdates(
+      {
+        globalEnvironmentVariables: {
+          baseUrl: 'https://example.test',
+          globalNum: 99,
+          globalBool: false,
+          globalObj: { tier: 'premium', limit: 100 }
+        }
+      },
+      { globalEnvFile: { path: globalPath, format: 'yml' } }
+    );
+
+    const written = fs.readFileSync(globalPath, 'utf8');
+    expect(written).toMatch(/name:\s*globalNum[\s\S]*?type:\s*number[\s\S]*?data:\s*['"]?99/);
+    expect(written).toMatch(/name:\s*globalBool[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?false/);
+    expect(written).toMatch(/name:\s*globalObj[\s\S]*?type:\s*object[\s\S]*?data:[\s\S]*?tier/);
+    // 'string' values stay as raw `value: ...` — no type/data block.
+    expect(written).toMatch(/name:\s*baseUrl[\s\S]*?value:\s*https:\/\/example\.test/);
+    expect(written).not.toMatch(/name:\s*baseUrl[\s\S]*?type:\s*string/);
+  });
+
+  // Regression guard: a script that writes a string to a previously typed key must drop the
+  // annotation so the disk shape matches the new value's inferred dataType.
+  it('drops the @number annotation in a .bru env file when a script downgrades the value to a string', () => {
+    const filePath = writeFile(
+      'Test.bru',
+      'vars {\n  @number\n  count: 1\n}\n'
+    );
+
+    persistVariableUpdates(
+      { envVariables: { count: 'now-a-string' } },
+      { envFile: { path: filePath, format: 'bru' } }
+    );
+
+    const written = fs.readFileSync(filePath, 'utf8');
+    expect(written).not.toMatch(/@number/);
+    expect(written).toMatch(/count:\s*now-a-string/);
+  });
+});

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -469,3 +469,81 @@ describe('script-driven typed vars: disk content has the right dataType annotati
     expect(written).toMatch(/count:\s*now-a-string/);
   });
 });
+
+// Regression guards for --env-var leak: CLI overrides commonly carry secret material
+// (the CLI can't decrypt secret vars at rest, so users pass them in transiently).
+// Those values must never reach disk, and the file's existing entry must be preserved.
+describe('mergeScriptVarsIntoEnvList — --env-var overrides', () => {
+  it('does not persist an override value even when the script returns it back in the env map', () => {
+    const variables = [
+      { name: 'token', value: 'real-secret', enabled: true, type: 'text', secret: true },
+      { name: 'host', value: 'localhost', enabled: true, type: 'text', secret: false }
+    ];
+    // Runtime returns the full env map (because some other var was dirtied), including the override.
+    const scriptVars = { token: 'transient-cli-value', host: 'api.example.com' };
+
+    const merged = mergeScriptVarsIntoEnvList(variables, scriptVars, {
+      overrides: new Set(['token'])
+    });
+
+    const tokenEntry = merged.find((v) => v.name === 'token');
+    expect(tokenEntry).toBeDefined();
+    expect(tokenEntry.value).toBe('real-secret');
+    expect(tokenEntry.secret).toBe(true);
+
+    const hostEntry = merged.find((v) => v.name === 'host');
+    expect(hostEntry.value).toBe('api.example.com');
+  });
+
+  it('does not drop an overridden file entry when the script does not echo it back', () => {
+    const variables = [
+      { name: 'token', value: 'real-secret', enabled: true, type: 'text', secret: true }
+    ];
+    // Script touched something else; runtime returns env without `token` since the override
+    // was filtered out before this call (or simply was never in the map).
+    const merged = mergeScriptVarsIntoEnvList(variables, { other: 'x' }, {
+      overrides: new Set(['token'])
+    });
+
+    expect(merged.find((v) => v.name === 'token')).toMatchObject({ value: 'real-secret', secret: true });
+  });
+
+  it('does not append a new entry for an override key the script also set', () => {
+    const merged = mergeScriptVarsIntoEnvList([], { token: 'transient', x: '1' }, {
+      overrides: new Set(['token'])
+    });
+
+    expect(merged.find((v) => v.name === 'token')).toBeUndefined();
+    expect(merged.find((v) => v.name === 'x')).toBeDefined();
+  });
+});
+
+describe('persistVariableUpdates — disk error resilience', () => {
+  // CI runs may execute against read-only mounts. The PR's design choice is to log + continue.
+  // The actual try/catch lives in run-single-request.js; persistVariableUpdates itself surfaces
+  // the throw, which is what we verify here — the caller is the one that swallows it.
+  it('surfaces fs errors to the caller (caller is expected to catch and warn)', () => {
+    const filePath = path.join(tmpBase, 'Locked.bru');
+    fs.writeFileSync(filePath, 'vars {\n  host: old\n}\n');
+    fs.chmodSync(filePath, 0o444);
+
+    let threw = false;
+    try {
+      persistVariableUpdates(
+        { envVariables: { host: 'new' } },
+        { envFile: { path: filePath, format: 'bru' } }
+      );
+    } catch (err) {
+      threw = true;
+      expect(err.code).toMatch(/EACCES|EPERM/);
+    } finally {
+      fs.chmodSync(filePath, 0o644);
+    }
+
+    // On some filesystems / OS combos chmod 444 doesn't block root-equivalent writes (e.g.
+    // running as root in a container). Skip the assertion in that case rather than fail noisily.
+    if (process.getuid && process.getuid() !== 0) {
+      expect(threw).toBe(true);
+    }
+  });
+});

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -227,4 +227,131 @@ describe('persistVariableUpdates — collection vars', () => {
       { collection, collectionRootPath: undefined }
     )).not.toThrow();
   });
+
+  it('writes collection vars back to opencollection.yml for yml-format collections', () => {
+    const collectionRootPath = writeFile('opencollection.yml',
+      'opencollection: 1.0.0\ninfo:\n  name: yml-collection\nrequest:\n  vars:\n    - name: k1\n      value: old\n'
+    );
+    const collection = {
+      format: 'yml',
+      brunoConfig: { name: 'yml-collection' },
+      root: {
+        meta: null,
+        request: {
+          headers: [],
+          auth: { mode: 'none' },
+          script: { req: null, res: null },
+          tests: null,
+          vars: { req: [{ uid: 'v1', name: 'k1', value: 'old', enabled: true, type: 'request' }], res: [] }
+        }
+      }
+    };
+    persistVariableUpdates(
+      { collectionVariables: { k1: 'new', k2: 'fresh' } },
+      { collection, collectionRootPath }
+    );
+    const written = fs.readFileSync(collectionRootPath, 'utf8');
+    expect(written).toMatch(/name:\s*k1/);
+    expect(written).toMatch(/value:\s*new/);
+    expect(written).toMatch(/name:\s*k2/);
+    expect(written).toMatch(/value:\s*fresh/);
+  });
+});
+
+describe('persistVariableUpdates — .bru env format', () => {
+  it('round-trips a .bru env file', () => {
+    const filePath = writeFile('dev.bru',
+      'vars {\n  host: old\n  token: keep\n}\n'
+    );
+    persistVariableUpdates(
+      { envVariables: { host: 'new', extra: 'added', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'bru' } }
+    );
+    const written = fs.readFileSync(filePath, 'utf8');
+    expect(written).toMatch(/host:\s*new/);
+    expect(written).toMatch(/extra:\s*added/);
+    expect(written).not.toMatch(/token:\s*keep/);
+    expect(written).not.toMatch(/__name__/);
+  });
+});
+
+describe('persistVariableUpdates — global env file', () => {
+  it('routes globalEnvironmentVariables result to the globalEnvFile descriptor', () => {
+    const envPath = writeFile('dev.yml',
+      'name: dev\nvariables:\n  - name: host\n    value: stale\n'
+    );
+    const globalPath = writeFile('global.yml',
+      'name: global\nvariables:\n  - name: region\n    value: us\n'
+    );
+    persistVariableUpdates(
+      { globalEnvironmentVariables: { region: 'eu', extra: 'new' } },
+      {
+        envFile: { path: envPath, format: 'yml' },
+        globalEnvFile: { path: globalPath, format: 'yml' }
+      }
+    );
+    // global file got the script's payload
+    expect(fs.readFileSync(globalPath, 'utf8')).toMatch(/value:\s*eu/);
+    // env file untouched — no envVariables in result
+    expect(fs.readFileSync(envPath, 'utf8')).toMatch(/stale/);
+  });
+});
+
+describe('typed-value inference', () => {
+  it('infers number / boolean / object dataType for newly-added env vars', () => {
+    const filePath = writeFile('typed.yml', 'name: typed\nvariables: []\n');
+    persistVariableUpdates(
+      { envVariables: { count: 42, flag: true, cfg: { port: 3000 } } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    const { parseEnvironment } = require('@usebruno/filestore');
+    const reparsed = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    const byName = Object.fromEntries(reparsed.variables.map((v) => [v.name, v]));
+    expect(byName.count).toMatchObject({ value: 42, dataType: 'number' });
+    expect(byName.flag).toMatchObject({ value: true, dataType: 'boolean' });
+    expect(byName.cfg).toMatchObject({ value: { port: 3000 }, dataType: 'object' });
+  });
+
+  it('preserves existing dataType when script writes the same typed value', () => {
+    const filePath = writeFile('typed.yml',
+      'name: typed\nvariables:\n  - name: count\n    value:\n      type: number\n      data: "1"\n'
+    );
+    persistVariableUpdates(
+      { envVariables: { count: 5 } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    const { parseEnvironment } = require('@usebruno/filestore');
+    const reparsed = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    expect(reparsed.variables[0]).toMatchObject({ name: 'count', value: 5, dataType: 'number' });
+  });
+
+  it('drops dataType when a previously typed key is set back to a string', () => {
+    const filePath = writeFile('typed.yml',
+      'name: typed\nvariables:\n  - name: val\n    value:\n      type: number\n      data: 1\n'
+    );
+    persistVariableUpdates(
+      { envVariables: { val: 'now-a-string' } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    const written = fs.readFileSync(filePath, 'utf8');
+    expect(written).not.toMatch(/type:\s*number/);
+    expect(written).toMatch(/value:\s*now-a-string/);
+  });
+
+  it('infers dataType for newly-added collection vars', () => {
+    const collectionRootPath = writeFile('collection.bru', 'meta {\n  name: t\n  seq: 1\n}\n');
+    const collection = {
+      format: 'bru',
+      brunoConfig: { name: 't' },
+      root: { meta: { name: 't', seq: 1 }, request: { vars: { req: [] } } }
+    };
+    persistVariableUpdates(
+      { collectionVariables: { count: 7, flag: false } },
+      { collection, collectionRootPath }
+    );
+    const countVar = collection.root.request.vars.req.find((v) => v.name === 'count');
+    const flagVar = collection.root.request.vars.req.find((v) => v.name === 'flag');
+    expect(countVar.dataType).toBe('number');
+    expect(flagVar.dataType).toBe('boolean');
+  });
 });

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -481,6 +481,95 @@ describe('typed-value inference', () => {
   });
 });
 
+// The inference rule (getDataTypeFromValue in @usebruno/common/utils) is purely:
+//   string → drop dataType (string is the implicit default)
+//   number → 'number'
+//   boolean → 'boolean'
+//   object → 'object'  (arrays are typeof 'object' in JS, so they go here too)
+//   null / undefined → 'string' (treated as no-type-info → drop)
+// Existing dataType on disk does NOT influence the inference — only the new JS value's type.
+describe('typed-value inference matrix — dataType derived from the new JS value type', () => {
+  const { parseEnvironment } = require('@usebruno/filestore');
+
+  // Tuple shape: [ label, scriptValue, expectedDataType, expectedValue ]
+  //  - label             : human-readable name interpolated into the test title
+  //  - scriptValue       : the value `bru.setEnvVar('v', X)` puts in the env map
+  //  - expectedDataType  : what `dataType` should end up on disk (or undefined if absent)
+  //  - expectedValue     : what the value should round-trip to through the yml parser
+  it.each([
+    ['string', 'hello', undefined, 'hello'],
+    ['number', 42, 'number', 42],
+    ['number (zero)', 0, 'number', 0],
+    ['boolean (true)', true, 'boolean', true],
+    ['boolean (false)', false, 'boolean', false],
+    ['object', { port: 3000 }, 'object', { port: 3000 }],
+    ['array (typeof object)', [1, 2, 3], 'object', [1, 2, 3]],
+    // null collapses to '' through yml round-trip; the inference rule still treats it as
+    // string (no dataType). undefined behaves the same way.
+    ['null (→ string, empty)', null, undefined, '']
+  ])('script writes %s → on-disk dataType is %s', (_label, value, expectedDataType, expectedValue) => {
+    const filePath = writeFile('inference.yml',
+      'name: t\nvariables:\n  - name: v\n    value: original\n'
+    );
+    persistVariableUpdates(
+      { envVariables: { v: value } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    const reparsed = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    expect(reparsed.variables[0].value).toEqual(expectedValue);
+    if (expectedDataType === undefined) {
+      expect(reparsed.variables[0].dataType).toBeUndefined();
+    } else {
+      expect(reparsed.variables[0].dataType).toBe(expectedDataType);
+    }
+  });
+});
+
+// Cross-type transitions: the rule above means inference IGNORES the existing dataType on
+// disk. Whatever type the script writes is what lands on disk. This matters because a
+// user-written `dataType: number` annotation can be silently dropped (or flipped to another
+// type) the first time a script writes a different-typed value to that key.
+describe('typed-value inference: cross-type transitions ignore the existing on-disk dataType', () => {
+  const { parseEnvironment, stringifyEnvironment } = require('@usebruno/filestore');
+
+  const seedYmlEnv = (seedVar) => stringifyEnvironment(
+    {
+      name: 't',
+      variables: [{ name: 'v', enabled: true, secret: false, ...seedVar }]
+    },
+    { format: 'yml' }
+  );
+
+  // Tuple shape: [ label, seed, scriptValue, expected ]
+  //  - label             : human-readable name interpolated into the test title
+  //  - seed              : { value, dataType? } — variable's initial on-disk state.
+  //                        Omit dataType to seed a plain string.
+  //  - scriptValue       : the value `bru.setEnvVar('v', X)` puts in the env map after parse
+  //  - expected          : { value, dataType } end state on disk after persistVariableUpdates;
+  //                        `dataType: undefined` asserts the field is absent on disk
+  it.each([
+    ['number → boolean (annotation flips)', { value: 42, dataType: 'number' }, true, { value: true, dataType: 'boolean' }],
+    ['number → object', { value: 42, dataType: 'number' }, { x: 1 }, { value: { x: 1 }, dataType: 'object' }],
+    ['boolean → number', { value: true, dataType: 'boolean' }, 99, { value: 99, dataType: 'number' }],
+    ['object → string (annotation dropped)', { value: { port: 3000 }, dataType: 'object' }, 'now-a-string', { value: 'now-a-string', dataType: undefined }],
+    ['string → number (annotation added)', { value: 'was-a-string' }, 42, { value: 42, dataType: 'number' }]
+  ])('%s', (_label, seed, scriptValue, expected) => {
+    const filePath = writeFile('xform.yml', seedYmlEnv(seed));
+    persistVariableUpdates(
+      { envVariables: { v: scriptValue } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    const reparsed = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    const entry = reparsed.variables[0];
+    expect(entry.value).toEqual(expected.value);
+    if (expected.dataType === undefined) {
+      expect(entry.dataType).toBeUndefined();
+    } else {
+      expect(entry.dataType).toBe(expected.dataType);
+    }
+  });
+});
+
 describe('script-driven typed vars: disk content has the right dataType annotations', () => {
   // The .bru serializer emits `@number\n  port: 3000` (annotation on its own line) — see
   // packages/bruno-lang/v2/src/utils.js serializeAnnotations + serializeVar.

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const { describe, it, expect, beforeEach, afterEach, jest: jestObj } = require('@jest/globals');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -9,10 +9,12 @@ const {
   mergeScriptVarsIntoCollectionVarsList
 } = require('../../src/utils/persist-variables');
 
-const tmpBase = path.join(os.tmpdir(), 'bruno-cli-persist-vars-tests');
+// Each test gets a unique temp dir — mkdtempSync prevents cross-test contamination if any
+// future test shares a filename, and lets the file work safely under concurrent jest workers.
+let tmpBase;
 
 beforeEach(() => {
-  fs.mkdirSync(tmpBase, { recursive: true });
+  tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-persist-vars-'));
 });
 
 afterEach(() => {
@@ -190,15 +192,18 @@ describe('persistVariableUpdates — env file', () => {
     const filePath = writeFile('dev.yml',
       'name: dev\nvariables:\n  - name: host\n    value: same\n'
     );
-    const before = fs.statSync(filePath).mtimeMs;
-    const wait = Date.now() + 5;
-    while (Date.now() < wait) { /* spin to ensure mtime can change */ }
-    persistVariableUpdates(
-      { envVariables: { host: 'same', __name__: 'dev' } },
-      { envFile: { path: filePath, format: 'yml' } }
-    );
-    const after = fs.statSync(filePath).mtimeMs;
-    expect(after).toBe(before);
+    // Spy on writeFileSync instead of comparing mtimes — some filesystems (HFS+, FAT32) have
+    // coarse mtime resolution and would silently pass even if a write occurred.
+    const spy = jestObj.spyOn(fs, 'writeFileSync');
+    try {
+      persistVariableUpdates(
+        { envVariables: { host: 'same', __name__: 'dev' } },
+        { envFile: { path: filePath, format: 'yml' } }
+      );
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('is a no-op when the env file does not exist', () => {
@@ -221,6 +226,72 @@ describe('persistVariableUpdates — env file', () => {
     const written = fs.readFileSync(filePath, 'utf8');
     expect(written).toMatch(/stash/);
     expect(written).toMatch(/disabled:\s*true/);
+  });
+
+  // End-to-end of the `bru.deleteEnvVar` flow: the runtime returns an envVariables map that
+  // simply omits the deleted key, and that omission must reach disk. (The merge filter is
+  // covered as a unit at the mergeScriptVarsIntoEnvList level; this verifies the full
+  // persistEnvFile path including the file write.)
+  it('deletes an enabled key from disk when the script removed it from the env map', () => {
+    const filePath = writeFile('dev.bru',
+      'vars {\n  host: keep\n  token: gone\n}\n'
+    );
+    persistVariableUpdates(
+      // Note: `token` absent — simulates `bru.deleteEnvVar("token")`.
+      { envVariables: { host: 'keep', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'bru' } }
+    );
+    const written = fs.readFileSync(filePath, 'utf8');
+    expect(written).toMatch(/host:\s*keep/);
+    expect(written).not.toMatch(/token/);
+  });
+});
+
+// Design contract: runtime vars live for the duration of the run and never reach disk.
+// A future refactor that wires runtime persistence by accident would be a leak risk
+// (runtime is where ephemeral state like generated tokens lives) — guard against it.
+describe('persistVariableUpdates — runtimeVariables are NEVER persisted', () => {
+  it('does not touch any file when only runtimeVariables is dirtied', () => {
+    const envPath = writeFile('dev.yml',
+      'name: dev\nvariables:\n  - name: host\n    value: original\n'
+    );
+    const globalPath = writeFile('global.yml',
+      'name: global\nvariables:\n  - name: region\n    value: us\n'
+    );
+    const collectionRootPath = writeFile('collection.bru',
+      'meta {\n  name: t\n  seq: 1\n}\n'
+    );
+    const collection = {
+      format: 'bru',
+      brunoConfig: { name: 't' },
+      root: { meta: { name: 't', seq: 1 }, request: { vars: { req: [] } } }
+    };
+
+    const spy = jestObj.spyOn(fs, 'writeFileSync');
+    try {
+      persistVariableUpdates(
+        // Only runtimeVariables dirtied; envVariables/globalEnvironmentVariables/collectionVariables null.
+        {
+          envVariables: null,
+          globalEnvironmentVariables: null,
+          collectionVariables: null,
+          runtimeVariables: { ephemeral: 'should-not-persist' }
+        },
+        {
+          envFile: { path: envPath, format: 'yml' },
+          globalEnvFile: { path: globalPath, format: 'yml' },
+          collection,
+          collectionRootPath
+        }
+      );
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Sanity check: files on disk unchanged.
+    expect(fs.readFileSync(envPath, 'utf8')).toMatch(/original/);
+    expect(fs.readFileSync(globalPath, 'utf8')).toMatch(/region/);
   });
 });
 

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -347,7 +347,15 @@ describe('persistVariableUpdates — collection vars', () => {
       }
     };
     persistVariableUpdates(
-      { collectionVariables: { k1: 'new', k2: 'fresh' } },
+      {
+        collectionVariables: {
+          k1: 'new',
+          k2: 'fresh',
+          count: 42,
+          flag: false,
+          cfg: { tier: 'premium', limit: 100 }
+        }
+      },
       { collection, collectionRootPath }
     );
     const written = fs.readFileSync(collectionRootPath, 'utf8');
@@ -355,6 +363,12 @@ describe('persistVariableUpdates — collection vars', () => {
     expect(written).toMatch(/value:\s*new/);
     expect(written).toMatch(/name:\s*k2/);
     expect(written).toMatch(/value:\s*fresh/);
+    // Typed collection vars round-trip via the OC `{ type, data }` struct.
+    expect(written).toMatch(/name:\s*count[\s\S]*?type:\s*number[\s\S]*?data:\s*['"]?42/);
+    expect(written).toMatch(/name:\s*flag[\s\S]*?type:\s*boolean[\s\S]*?data:\s*['"]?false/);
+    expect(written).toMatch(/name:\s*cfg[\s\S]*?type:\s*object[\s\S]*?data:[\s\S]*?tier/);
+    // Plain strings stay as raw `value: ...` — no type/data block, no `type: string`.
+    expect(written).not.toMatch(/name:\s*k1[\s\S]*?type:\s*string/);
   });
 });
 

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -1,0 +1,230 @@
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  applyVariableUpdates,
+  persistVariableUpdates,
+  mergeScriptVarsIntoEnvList,
+  mergeScriptVarsIntoCollectionVarsList
+} = require('../../src/utils/persist-variables');
+
+const tmpBase = path.join(os.tmpdir(), 'bruno-cli-persist-vars-tests');
+
+beforeEach(() => {
+  fs.mkdirSync(tmpBase, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpBase, { recursive: true, force: true });
+});
+
+const writeFile = (name, content) => {
+  const filePath = path.join(tmpBase, name);
+  fs.writeFileSync(filePath, content);
+  return filePath;
+};
+
+describe('mergeScriptVarsIntoEnvList', () => {
+  it('updates existing enabled var values', () => {
+    const variables = [
+      { name: 'host', value: 'old', enabled: true, type: 'text', secret: false }
+    ];
+    const merged = mergeScriptVarsIntoEnvList(variables, { host: 'new' });
+    expect(merged).toHaveLength(1);
+    expect(merged[0].value).toBe('new');
+  });
+
+  it('appends new keys not present in the file', () => {
+    const variables = [];
+    const merged = mergeScriptVarsIntoEnvList(variables, { token: 'abc' });
+    expect(merged).toEqual([
+      { name: 'token', value: 'abc', enabled: true, type: 'text', secret: false }
+    ]);
+  });
+
+  it('removes enabled keys that disappeared from script output', () => {
+    const variables = [
+      { name: 'a', value: '1', enabled: true, type: 'text', secret: false },
+      { name: 'b', value: '2', enabled: true, type: 'text', secret: false }
+    ];
+    const merged = mergeScriptVarsIntoEnvList(variables, { a: '1' });
+    expect(merged.map((v) => v.name)).toEqual(['a']);
+  });
+
+  it('preserves disabled variables even when absent from script output', () => {
+    const variables = [
+      { name: 'a', value: '1', enabled: false, type: 'text', secret: false }
+    ];
+    const merged = mergeScriptVarsIntoEnvList(variables, { b: '2' });
+    const names = merged.map((v) => v.name).sort();
+    expect(names).toEqual(['a', 'b']);
+    expect(merged.find((v) => v.name === 'a').enabled).toBe(false);
+  });
+
+  it('ignores the internal __name__ key', () => {
+    const merged = mergeScriptVarsIntoEnvList([], { __name__: 'dev', host: 'x' });
+    expect(merged).toEqual([
+      { name: 'host', value: 'x', enabled: true, type: 'text', secret: false }
+    ]);
+  });
+});
+
+describe('mergeScriptVarsIntoCollectionVarsList', () => {
+  it('updates, adds, and removes collection vars symmetrically', () => {
+    const variables = [
+      { name: 'keep', value: '1', enabled: true, type: 'request' },
+      { name: 'gone', value: '2', enabled: true, type: 'request' },
+      { name: 'disabled', value: '3', enabled: false, type: 'request' }
+    ];
+    const merged = mergeScriptVarsIntoCollectionVarsList(variables, { keep: '1-updated', fresh: '4' });
+    const byName = Object.fromEntries(merged.map((v) => [v.name, v]));
+    expect(byName.keep.value).toBe('1-updated');
+    expect(byName.fresh.value).toBe('4');
+    expect(byName.disabled).toBeDefined();
+    expect(byName.gone).toBeUndefined();
+  });
+});
+
+describe('applyVariableUpdates', () => {
+  it('mirrors dirty scopes into shared in-memory maps', () => {
+    const envVariables = { host: 'old', __name__: 'dev' };
+    const runtimeVariables = { stale: '1' };
+    const globalEnvVars = { region: 'us' };
+    const request = { collectionVariables: { color: 'red' } };
+
+    applyVariableUpdates(
+      {
+        envVariables: { host: 'new', token: 'abc', __name__: 'dev' },
+        runtimeVariables: { fresh: '2' },
+        globalEnvironmentVariables: { region: 'eu' },
+        collectionVariables: { color: 'blue' }
+      },
+      { envVariables, runtimeVariables, globalEnvVars, request }
+    );
+
+    expect(envVariables).toEqual({ host: 'new', token: 'abc', __name__: 'dev' });
+    expect(runtimeVariables).toEqual({ fresh: '2' });
+    expect(globalEnvVars).toEqual({ region: 'eu' });
+    expect(request.collectionVariables).toEqual({ color: 'blue' });
+  });
+
+  it('leaves untouched scopes alone when result fields are null', () => {
+    const envVariables = { host: 'old', __name__: 'dev' };
+    const runtimeVariables = { keep: '1' };
+    applyVariableUpdates(
+      { envVariables: null, runtimeVariables: null, globalEnvironmentVariables: null, collectionVariables: null },
+      { envVariables, runtimeVariables, globalEnvVars: {}, request: {} }
+    );
+    expect(envVariables).toEqual({ host: 'old', __name__: 'dev' });
+    expect(runtimeVariables).toEqual({ keep: '1' });
+  });
+});
+
+describe('persistVariableUpdates — env file', () => {
+  it('round-trips a yml env file', () => {
+    const filePath = writeFile('dev.yml',
+      'name: dev\nvariables:\n  - name: host\n    value: old\n  - name: token\n    value: keep\n'
+    );
+    persistVariableUpdates(
+      { envVariables: { host: 'new', extra: 'added', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    const written = fs.readFileSync(filePath, 'utf8');
+    expect(written).toMatch(/host/);
+    expect(written).toMatch(/new/);
+    expect(written).toMatch(/extra/);
+    expect(written).not.toMatch(/keep/);
+    expect(written).not.toMatch(/__name__/);
+  });
+
+  it('round-trips a json env file', () => {
+    const filePath = writeFile('dev.json', JSON.stringify({
+      name: 'dev',
+      variables: [
+        { name: 'host', value: 'old' },
+        { name: 'token', value: 'keep' }
+      ]
+    }, null, 2));
+    persistVariableUpdates(
+      { envVariables: { host: 'new', extra: 'added', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'json' } }
+    );
+    const written = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const byName = Object.fromEntries(written.variables.map((v) => [v.name, v.value]));
+    expect(byName.host).toBe('new');
+    expect(byName.extra).toBe('added');
+    expect(byName.token).toBeUndefined();
+  });
+
+  it('content-comparison guard skips rewrites that are byte-identical', () => {
+    const filePath = writeFile('dev.yml',
+      'name: dev\nvariables:\n  - name: host\n    value: same\n'
+    );
+    const before = fs.statSync(filePath).mtimeMs;
+    const wait = Date.now() + 5;
+    while (Date.now() < wait) { /* spin to ensure mtime can change */ }
+    persistVariableUpdates(
+      { envVariables: { host: 'same', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    const after = fs.statSync(filePath).mtimeMs;
+    expect(after).toBe(before);
+  });
+
+  it('is a no-op when the env file does not exist', () => {
+    const filePath = path.join(tmpBase, 'missing.yml');
+    persistVariableUpdates(
+      { envVariables: { host: 'new' } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it('preserves disabled vars when the script set unrelated keys', () => {
+    const filePath = writeFile('dev.yml',
+      'name: dev\nvariables:\n  - name: host\n    value: x\n  - name: stash\n    value: y\n    disabled: true\n'
+    );
+    persistVariableUpdates(
+      { envVariables: { host: 'x', extra: 'z' } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+    const written = fs.readFileSync(filePath, 'utf8');
+    expect(written).toMatch(/stash/);
+    expect(written).toMatch(/disabled:\s*true/);
+  });
+});
+
+describe('persistVariableUpdates — collection vars', () => {
+  it('writes collection vars back to collection.bru', () => {
+    const collectionRootPath = writeFile('collection.bru',
+      'meta {\n  name: test\n  seq: 1\n}\n\nvars:pre-request {\n  k1: old\n}\n'
+    );
+    const collection = {
+      format: 'bru',
+      brunoConfig: { name: 'test' },
+      root: {
+        meta: { name: 'test', seq: 1 },
+        request: {
+          vars: { req: [{ name: 'k1', value: 'old', enabled: true, type: 'request' }] }
+        }
+      }
+    };
+    persistVariableUpdates(
+      { collectionVariables: { k1: 'new', k2: 'fresh' } },
+      { collection, collectionRootPath }
+    );
+    const written = fs.readFileSync(collectionRootPath, 'utf8');
+    expect(written).toMatch(/k1:\s*new/);
+    expect(written).toMatch(/k2:\s*fresh/);
+    expect(collection.root.request.vars.req.map((v) => v.name).sort()).toEqual(['k1', 'k2']);
+  });
+
+  it('does nothing if no collectionRootPath given', () => {
+    const collection = { format: 'bru', root: {} };
+    expect(() => persistVariableUpdates(
+      { collectionVariables: { k1: 'v' } },
+      { collection, collectionRootPath: undefined }
+    )).not.toThrow();
+  });
+});

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -157,6 +157,35 @@ describe('persistVariableUpdates — env file', () => {
     expect(byName.token).toBeUndefined();
   });
 
+  // Regression guard: the JSON normalizer (parseEnvironmentJson) only declares the four
+  // fields it knows about. We must NOT round-trip through it for the on-disk write — entries
+  // should keep uid, custom metadata, and (for natural typed values) dataType.
+  it('preserves uid / dataType / unknown fields on json entries', () => {
+    const filePath = writeFile('dev.json', JSON.stringify({
+      name: 'dev',
+      uid: 'env-uid-123',
+      variables: [
+        // Natural JS number with dataType tag — script will echo it back as `42` (number).
+        { name: 'port', value: 42, dataType: 'number', uid: 'var-1', custom: 'keep-me' },
+        { name: 'host', value: 'old', uid: 'var-2' }
+      ]
+    }, null, 2));
+    persistVariableUpdates(
+      { envVariables: { port: 42, host: 'new', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'json' } }
+    );
+    const written = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    expect(written.uid).toBe('env-uid-123');
+    const byName = Object.fromEntries(written.variables.map((v) => [v.name, v]));
+    expect(byName.port).toMatchObject({
+      value: 42,
+      dataType: 'number',
+      uid: 'var-1',
+      custom: 'keep-me'
+    });
+    expect(byName.host).toMatchObject({ value: 'new', uid: 'var-2' });
+  });
+
   it('content-comparison guard skips rewrites that are byte-identical', () => {
     const filePath = writeFile('dev.yml',
       'name: dev\nvariables:\n  - name: host\n    value: same\n'
@@ -294,6 +323,31 @@ describe('persistVariableUpdates — global env file', () => {
     expect(fs.readFileSync(globalPath, 'utf8')).toMatch(/value:\s*eu/);
     // env file untouched — no envVariables in result
     expect(fs.readFileSync(envPath, 'utf8')).toMatch(/stale/);
+  });
+
+  // Defense-in-depth: the runtime can't currently leak an --env-var override into the
+  // globalEnvironmentVariables result (envVariables and globalEnvironmentVariables are
+  // separate maps in the bru sandbox). But if a user script ever copies between the two
+  // — e.g. `bru.setGlobalEnvVar('token', bru.getVar('token'))` — the override must still
+  // be filtered before reaching the global env file.
+  it('respects envVarOverrides when persisting to the global env file', () => {
+    const globalPath = writeFile('global.yml',
+      'name: global\nvariables:\n  - name: token\n    value: real-global-secret\n  - name: region\n    value: us\n'
+    );
+    persistVariableUpdates(
+      // Simulates a user script that copied the env override into the global env scope.
+      { globalEnvironmentVariables: { token: 'transient-cli-value', region: 'eu' } },
+      {
+        globalEnvFile: { path: globalPath, format: 'yml' },
+        envVarOverrides: new Set(['token'])
+      }
+    );
+    const written = fs.readFileSync(globalPath, 'utf8');
+    // token's on-disk value must NOT be the transient override
+    expect(written).not.toMatch(/transient-cli-value/);
+    expect(written).toMatch(/real-global-secret/);
+    // unrelated keys still update
+    expect(written).toMatch(/value:\s*eu/);
   });
 });
 

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -410,7 +410,7 @@ describe('persistVariableUpdates — global env file', () => {
       { globalEnvironmentVariables: { token: 'transient-cli-value', region: 'eu' } },
       {
         globalEnvFile: { path: globalPath, format: 'yml' },
-        envVarOverrides: new Set(['token'])
+        envVarOverrides: new Map([['token', 'transient-cli-value']])
       }
     );
     const written = fs.readFileSync(globalPath, 'utf8');
@@ -697,7 +697,7 @@ describe('mergeScriptVarsIntoEnvList — --env-var overrides', () => {
     const scriptVars = { token: 'transient-cli-value', host: 'api.example.com' };
 
     const merged = mergeScriptVarsIntoEnvList(variables, scriptVars, {
-      overrides: new Set(['token'])
+      overrides: new Map([['token', 'transient-cli-value']])
     });
 
     const tokenEntry = merged.find((v) => v.name === 'token');
@@ -716,48 +716,68 @@ describe('mergeScriptVarsIntoEnvList — --env-var overrides', () => {
     // Script touched something else; runtime returns env without `token` since the override
     // was filtered out before this call (or simply was never in the map).
     const merged = mergeScriptVarsIntoEnvList(variables, { other: 'x' }, {
-      overrides: new Set(['token'])
+      overrides: new Map([['token', 'transient-cli-value']])
     });
 
     expect(merged.find((v) => v.name === 'token')).toMatchObject({ value: 'real-secret', secret: true });
   });
 
-  it('does not append a new entry for an override key the script also set', () => {
+  it('does not append a new entry for an override key when the script echoes back the override value', () => {
     const merged = mergeScriptVarsIntoEnvList([], { token: 'transient', x: '1' }, {
-      overrides: new Set(['token'])
+      overrides: new Map([['token', 'transient']])
     });
 
     expect(merged.find((v) => v.name === 'token')).toBeUndefined();
     expect(merged.find((v) => v.name === 'x')).toBeDefined();
   });
+
+  // A deliberate `bru.setEnvVar('token', 'rotated')` must persist even when the CLI also
+  // injected `--env-var token=transient`. We can tell it apart from the leak because the
+  // script's value differs from the injected override value.
+  it('persists a deliberate same-named script write that differs from the override value', () => {
+    const variables = [
+      { name: 'token', value: 'real', enabled: true, type: 'text', secret: true }
+    ];
+    const merged = mergeScriptVarsIntoEnvList(variables, { token: 'rotated' }, {
+      overrides: new Map([['token', 'transient-cli-value']])
+    });
+
+    const tokenEntry = merged.find((v) => v.name === 'token');
+    expect(tokenEntry).toBeDefined();
+    expect(tokenEntry.value).toBe('rotated');
+    // Existing on-disk metadata (secret flag) is preserved during the update.
+    expect(tokenEntry.secret).toBe(true);
+  });
 });
 
 describe('persistVariableUpdates — disk error resilience', () => {
-  // CI runs may execute against read-only mounts. The PR's design choice is to log + continue.
-  // The actual try/catch lives in run-single-request.js; persistVariableUpdates itself surfaces
-  // the throw, which is what we verify here — the caller is the one that swallows it.
+  // CI runs may execute against read-only mounts. The design choice is to log + continue;
+  // the try/catch lives in run-single-request.js. persistVariableUpdates itself surfaces the
+  // throw, which is what we verify here — the caller is the one that swallows it.
+  // fs.writeFileSync is mocked to throw EACCES so the assertion holds on every OS (root in
+  // a container can write through a chmod 0o444, and Windows doesn't honor unix bits).
   it('surfaces fs errors to the caller (caller is expected to catch and warn)', () => {
     const filePath = path.join(tmpBase, 'Locked.bru');
     fs.writeFileSync(filePath, 'vars {\n  host: old\n}\n');
-    fs.chmodSync(filePath, 0o444);
 
-    let threw = false;
+    const writeErr = Object.assign(new Error('locked'), { code: 'EACCES' });
+    const spy = jestObj.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw writeErr;
+    });
+
+    let thrown;
     try {
       persistVariableUpdates(
         { envVariables: { host: 'new' } },
         { envFile: { path: filePath, format: 'bru' } }
       );
     } catch (err) {
-      threw = true;
-      expect(err.code).toMatch(/EACCES|EPERM/);
+      thrown = err;
     } finally {
-      fs.chmodSync(filePath, 0o644);
+      spy.mockRestore();
     }
 
-    // On some filesystems / OS combos chmod 444 doesn't block root-equivalent writes (e.g.
-    // running as root in a container). Skip the assertion in that case rather than fail noisily.
-    if (process.getuid && process.getuid() !== 0) {
-      expect(threw).toBe(true);
-    }
+    expect(thrown).toBe(writeErr);
+    expect(thrown.code).toBe('EACCES');
   });
 });


### PR DESCRIPTION
[JIRA](https://usebruno.atlassian.net/browse/BRU-3529)

Brings the variable-persistence behavior from #8315 to the CLI. Scripts that call `bru.setEnvVar` / `bru.setGlobalEnvVar` / `bru.setCollectionVar` (and their `delete*` counterparts) now write changes back to disk in addition to mutating in-memory state — matching desktop-app behavior on the same branch.

> [!IMPORTANT]
> Depends on #8315 and must be merged **after** it.

### Scopes persisted

| Scope | Target file |
|---|---|
| Env vars | `--env` env file, or `--env-file` |
| Global env vars | `<workspace>/environments/<globalEnv>.yml` |
| Collection vars | `collection.bru` / `opencollection.yml` |
| Runtime vars | In-memory only (never persisted) |

### Highlights

- **Typed values** — non-string writes (`bru.setEnvVar('count', 42)`) get the right `dataType` (`number` / `boolean` / `object`); matching `.bru` / `.yml` annotations land on disk.
- **Disabled vars preserved** through merge — toggled-off ≠ deleted.
- **Idempotent writes** — content-comparison guard skips byte-identical re-writes.
- **`--env-var` transient overrides** never reach disk; the file's existing entry (incl. `secret: true`) is preserved untouched.
- **JSON env file shape preservation** — `uid`, `dataType`, and user-set custom metadata survive on entries the script doesn't echo back.
- **CI-safe** — persistence is wrapped in try/catch so read-only mounts log a warning and the run continues.

### Tests

- **34 unit tests** in `tests/utils/persist-variables.spec.js` — merge logic, file round-trips (`.yml` / `.bru` / `.json` / collection root), typed-value inference, override regression guards, runtime-vars-NEVER-persisted design guard, content-comparison via `writeFileSync` spy, disk-error resilience.
- **9 integration tests** in `tests/integration/run-typed-persistence.spec.js` driving the real `bin/bru.js` against a local HTTP server, both `developer` and `safe` sandboxes — typed annotations on `.bru` and `.yml` via `--env` / `--global-env`, `--workspace-path` explicit flag, `--env-file` round-trip across all three formats (`.json` / `.yml` / `.bru`) including JSON `uid` / custom-field shape preservation, `--env-var` leak guard.

#### Contribution Checklist

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist environment, global environment, and collection variable updates back to disk after script execution, including post-response and test phases, with format-aware handling for JSON/YAML/.bru.
  * Added typed value reconciliation when writing env/collection files.
* **Bug Fixes**
  * `--env-var` overrides are transient and no longer persisted to env files.
  * On script/test failure, only the already-written variable changes are kept (partial results).
* **Tests**
  * Added integration and unit coverage for typed persistence, override transience, `__name__` handling, and partial-write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->