### PR TITLE
feat(converters): re-enable variable scripting translations

### DIFF
--- a/packages/bruno-converters/src/postman/postman-translations.js
+++ b/packages/bruno-converters/src/postman/postman-translations.js
@@ -1,8 +1,5 @@
 import translateCode from '../utils/postman-to-bruno-translator';
 
-// TODO: Restore the commented-out translations once the UI update fixes are live.
-// Currently these APIs only work within the request lifecycle but fail to update the UI tables.
-// e.g., setCollectionVar only sets the variable in the request lifecycle, fails to update the table in the UI.
 const replacements = {
   'pm\\.environment\\.get\\(': 'bru.getEnvVar(',
   'pm\\.environment\\.set\\(': 'bru.setEnvVar(',
@@ -10,11 +7,11 @@ const replacements = {
   'pm\\.variables\\.set\\(': 'bru.setVar(',
   'pm\\.variables\\.replaceIn\\(': 'bru.interpolate(',
   'pm\\.collectionVariables\\.get\\(': 'bru.getCollectionVar(',
-  // 'pm\\.collectionVariables\\.set\\(': 'bru.setCollectionVar(',
+  'pm\\.collectionVariables\\.set\\(': 'bru.setCollectionVar(',
   'pm\\.collectionVariables\\.has\\(': 'bru.hasCollectionVar(',
-  // 'pm\\.collectionVariables\\.unset\\(': 'bru.deleteCollectionVar(',
-  // 'pm\\.collectionVariables\\.clear\\(': 'bru.deleteAllCollectionVars(',
-  // 'pm\\.collectionVariables\\.toObject\\(': 'bru.getAllCollectionVars(',
+  'pm\\.collectionVariables\\.unset\\(': 'bru.deleteCollectionVar(',
+  'pm\\.collectionVariables\\.clear\\(': 'bru.deleteAllCollectionVars(',
+  'pm\\.collectionVariables\\.toObject\\(': 'bru.getAllCollectionVars(',
   // Only the actual null literal stops the runner; the string 'null' is a valid
   // request name and falls through to setNextRequest.
   'pm\\.setNextRequest\\(null\\)': 'bru.runner.stopExecution()',
@@ -32,9 +29,9 @@ const replacements = {
   'pm\\.globals\\.set\\(': 'bru.setGlobalEnvVar(',
   'pm\\.globals\\.get\\(': 'bru.getGlobalEnvVar(',
   'pm\\.globals\\.has\\(': 'bru.hasGlobalEnvVar(',
-  // 'pm\\.globals\\.unset\\(': 'bru.deleteGlobalEnvVar(',
+  'pm\\.globals\\.unset\\(': 'bru.deleteGlobalEnvVar(',
   'pm\\.globals\\.toObject\\(': 'bru.getAllGlobalEnvVars(',
-  // 'pm\\.globals\\.clear\\(': 'bru.deleteAllGlobalEnvVars(',
+  'pm\\.globals\\.clear\\(': 'bru.deleteAllGlobalEnvVars(',
   'pm\\.environment\\.toObject\\(': 'bru.getAllEnvVars(',
   'pm\\.environment\\.clear\\(': 'bru.deleteAllEnvVars(',
   'pm\\.variables\\.toObject\\(': 'bru.getAllVars(',

--- a/packages/bruno-converters/src/utils/bruno-to-postman-translator.js
+++ b/packages/bruno-converters/src/utils/bruno-to-postman-translator.js
@@ -13,17 +13,14 @@ const j = require('jscodeshift');
  * Simple 1:1 translations from Bruno helpers to Postman helpers.
  * These are direct member expression replacements.
  */
-// TODO: Restore the commented-out translations once the UI update fixes are live.
-// Currently these APIs only work within the request lifecycle but fail to update the UI tables.
-// e.g., setCollectionVar only sets the variable in the request lifecycle, fails to update the table in the UI.
 const simpleTranslations = {
   // Global variables
   'bru.getGlobalEnvVar': 'pm.globals.get',
   'bru.setGlobalEnvVar': 'pm.globals.set',
   'bru.hasGlobalEnvVar': 'pm.globals.has',
-  // 'bru.deleteGlobalEnvVar': 'pm.globals.unset',
+  'bru.deleteGlobalEnvVar': 'pm.globals.unset',
   'bru.getAllGlobalEnvVars': 'pm.globals.toObject',
-  // 'bru.deleteAllGlobalEnvVars': 'pm.globals.clear',
+  'bru.deleteAllGlobalEnvVars': 'pm.globals.clear',
 
   // Environment variables
   'bru.getEnvVar': 'pm.environment.get',
@@ -44,11 +41,11 @@ const simpleTranslations = {
 
   // Collection variables
   'bru.getCollectionVar': 'pm.collectionVariables.get',
-  // 'bru.setCollectionVar': 'pm.collectionVariables.set',
+  'bru.setCollectionVar': 'pm.collectionVariables.set',
   'bru.hasCollectionVar': 'pm.collectionVariables.has',
-  // 'bru.deleteCollectionVar': 'pm.collectionVariables.unset',
-  // 'bru.getAllCollectionVars': 'pm.collectionVariables.toObject',
-  // 'bru.deleteAllCollectionVars': 'pm.collectionVariables.clear',
+  'bru.deleteCollectionVar': 'pm.collectionVariables.unset',
+  'bru.getAllCollectionVars': 'pm.collectionVariables.toObject',
+  'bru.deleteAllCollectionVars': 'pm.collectionVariables.clear',
 
   // Folder variables
   'bru.getFolderVar': 'pm.variables.get',

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -5,18 +5,15 @@ const cloneDeep = require('lodash/cloneDeep');
 import { buildStatusAssertionEntries } from './postman-status-assertions';
 
 // Simple 1:1 translations for straightforward replacements
-// TODO: Restore the commented-out translations once the UI update fixes are live.
-// Currently these APIs only work within the request lifecycle but fail to update the UI tables.
-// e.g., setCollectionVar only sets the variable in the request lifecycle, fails to update the table in the UI.
 const simpleTranslations = {
   // Global Variables
   'pm.globals.get': 'bru.getGlobalEnvVar',
   'pm.globals.set': 'bru.setGlobalEnvVar',
   'pm.globals.has': 'bru.hasGlobalEnvVar',
   'pm.globals.replaceIn': 'bru.interpolate',
-  // 'pm.globals.unset': 'bru.deleteGlobalEnvVar',
+  'pm.globals.unset': 'bru.deleteGlobalEnvVar',
   'pm.globals.toObject': 'bru.getAllGlobalEnvVars',
-  // 'pm.globals.clear': 'bru.deleteAllGlobalEnvVars',
+  'pm.globals.clear': 'bru.deleteAllGlobalEnvVars',
 
   // Environment variables
   'pm.environment.get': 'bru.getEnvVar',
@@ -35,12 +32,12 @@ const simpleTranslations = {
   'pm.variables.replaceIn': 'bru.interpolate',
   // Collection variables
   'pm.collectionVariables.get': 'bru.getCollectionVar',
-  // 'pm.collectionVariables.set': 'bru.setCollectionVar',
+  'pm.collectionVariables.set': 'bru.setCollectionVar',
   'pm.collectionVariables.has': 'bru.hasCollectionVar',
-  // 'pm.collectionVariables.unset': 'bru.deleteCollectionVar',
+  'pm.collectionVariables.unset': 'bru.deleteCollectionVar',
   'pm.collectionVariables.replaceIn': 'bru.interpolate',
-  // 'pm.collectionVariables.clear': 'bru.deleteAllCollectionVars',
-  // 'pm.collectionVariables.toObject': 'bru.getAllCollectionVars',
+  'pm.collectionVariables.clear': 'bru.deleteAllCollectionVars',
+  'pm.collectionVariables.toObject': 'bru.getAllCollectionVars',
 
   // Testing
   'pm.test': 'test',

--- a/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/variables.test.js
+++ b/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/variables.test.js
@@ -57,6 +57,18 @@ describe('Bruno to Postman Variables Translation', () => {
     expect(translatedCode).toBe('pm.globals.has("token");');
   });
 
+  it('should translate bru.deleteGlobalEnvVar', () => {
+    const code = 'bru.deleteGlobalEnvVar("token");';
+    const translatedCode = translateBruToPostman(code);
+    expect(translatedCode).toBe('pm.globals.unset("token");');
+  });
+
+  it('should translate bru.deleteAllGlobalEnvVars', () => {
+    const code = 'bru.deleteAllGlobalEnvVars();';
+    const translatedCode = translateBruToPostman(code);
+    expect(translatedCode).toBe('pm.globals.clear();');
+  });
+
   // Collection variables tests
   it('should translate bru.getCollectionVar', () => {
     const code = 'bru.getCollectionVar("baseUrl");';
@@ -64,8 +76,7 @@ describe('Bruno to Postman Variables Translation', () => {
     expect(translatedCode).toBe('pm.collectionVariables.get("baseUrl");');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should translate bru.setCollectionVar', () => {
+  it('should translate bru.setCollectionVar', () => {
     const code = 'bru.setCollectionVar("baseUrl", "https://api.example.com");';
     const translatedCode = translateBruToPostman(code);
     expect(translatedCode).toBe('pm.collectionVariables.set("baseUrl", "https://api.example.com");');
@@ -77,22 +88,19 @@ describe('Bruno to Postman Variables Translation', () => {
     expect(translatedCode).toBe('pm.collectionVariables.has("baseUrl");');
   });
 
-  // TODO: Restore once UI update fixes are live for deleteCollectionVar
-  it.skip('should translate bru.deleteCollectionVar', () => {
+  it('should translate bru.deleteCollectionVar', () => {
     const code = 'bru.deleteCollectionVar("baseUrl");';
     const translatedCode = translateBruToPostman(code);
     expect(translatedCode).toBe('pm.collectionVariables.unset("baseUrl");');
   });
 
-  // TODO: Restore once UI update fixes are live for getAllCollectionVars
-  it.skip('should translate bru.getAllCollectionVars', () => {
+  it('should translate bru.getAllCollectionVars', () => {
     const code = 'const vars = bru.getAllCollectionVars();';
     const translatedCode = translateBruToPostman(code);
     expect(translatedCode).toBe('const vars = pm.collectionVariables.toObject();');
   });
 
-  // TODO: Restore once UI update fixes are live for deleteAllCollectionVars
-  it.skip('should translate bru.deleteAllCollectionVars', () => {
+  it('should translate bru.deleteAllCollectionVars', () => {
     const code = 'bru.deleteAllCollectionVars();';
     const translatedCode = translateBruToPostman(code);
     expect(translatedCode).toBe('pm.collectionVariables.clear();');

--- a/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/variables.test.js
+++ b/packages/bruno-converters/tests/bruno/bruno-to-postman-translations/variables.test.js
@@ -69,6 +69,12 @@ describe('Bruno to Postman Variables Translation', () => {
     expect(translatedCode).toBe('pm.globals.clear();');
   });
 
+  it('should translate bru.getAllGlobalEnvVars', () => {
+    const code = 'const globals = bru.getAllGlobalEnvVars();';
+    const translatedCode = translateBruToPostman(code);
+    expect(translatedCode).toBe('const globals = pm.globals.toObject();');
+  });
+
   // Collection variables tests
   it('should translate bru.getCollectionVar', () => {
     const code = 'bru.getCollectionVar("baseUrl");';

--- a/packages/bruno-converters/tests/postman/postman-translations/postman-comments.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/postman-comments.spec.js
@@ -12,8 +12,7 @@ describe('postmanTranslations - comment handling', () => {
     expect(result).toContain('const data = bru.getEnvVar(\'key\');');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  test.skip('should translate pm.collectionVariables.set to bru.setCollectionVar', () => {
+  test('should translate pm.collectionVariables.set to bru.setCollectionVar', () => {
     const inputScript = 'pm.collectionVariables.set(\'key\', data);';
     const expectedOutput = 'bru.setCollectionVar(\'key\', data);';
     expect(postmanTranslation(inputScript)).toBe(expectedOutput);

--- a/packages/bruno-converters/tests/postman/postman-translations/postman-variables.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/postman-variables.spec.js
@@ -34,9 +34,33 @@ describe('postmanTranslations - variables commands', () => {
     expect(result).toContain('.to.be.true');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  test.skip('should translate pm.collectionVariables.set to bru.setCollectionVar', () => {
+  test('should translate pm.collectionVariables.set to bru.setCollectionVar', () => {
     const inputScript = 'pm.collectionVariables.set(\'key\', \'value\');';
     expect(postmanTranslation(inputScript)).toBe('bru.setCollectionVar(\'key\', \'value\');');
+  });
+
+  test('should translate pm.collectionVariables.unset to bru.deleteCollectionVar', () => {
+    const inputScript = 'pm.collectionVariables.unset(\'key\');';
+    expect(postmanTranslation(inputScript)).toBe('bru.deleteCollectionVar(\'key\');');
+  });
+
+  test('should translate pm.collectionVariables.clear to bru.deleteAllCollectionVars', () => {
+    const inputScript = 'pm.collectionVariables.clear();';
+    expect(postmanTranslation(inputScript)).toBe('bru.deleteAllCollectionVars();');
+  });
+
+  test('should translate pm.collectionVariables.toObject to bru.getAllCollectionVars', () => {
+    const inputScript = 'const vars = pm.collectionVariables.toObject();';
+    expect(postmanTranslation(inputScript)).toBe('const vars = bru.getAllCollectionVars();');
+  });
+
+  test('should translate pm.globals.unset to bru.deleteGlobalEnvVar', () => {
+    const inputScript = 'pm.globals.unset(\'token\');';
+    expect(postmanTranslation(inputScript)).toBe('bru.deleteGlobalEnvVar(\'token\');');
+  });
+
+  test('should translate pm.globals.clear to bru.deleteAllGlobalEnvVars', () => {
+    const inputScript = 'pm.globals.clear();';
+    expect(postmanTranslation(inputScript)).toBe('bru.deleteAllGlobalEnvVars();');
   });
 });

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/combined.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/combined.test.js
@@ -100,8 +100,7 @@ describe('Combined API Features Translation', () => {
     expect(translatedCode).toContain('bru.setEnvVar("userId", response.user.id);');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should translate pm.collectionVariables.set in a combined code block', () => {
+  it('should translate pm.collectionVariables.set in a combined code block', () => {
     const code = 'pm.collectionVariables.set("sessionId", response.session.id);';
     const translatedCode = translateCode(code);
     expect(translatedCode).toBe('bru.setCollectionVar("sessionId", response.session.id);');
@@ -114,8 +113,7 @@ describe('Combined API Features Translation', () => {
     expect(translatedCode).toBe('bru.setEnvVar("computed", bru.getVar("base") + "-suffix");');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should handle more complex nested expressions', () => {
+  it('should handle more complex nested expressions', () => {
     const code = 'pm.collectionVariables.set("fullPath", pm.environment.get("baseUrl") + pm.variables.get("endpoint"));';
     const translatedCode = translateCode(code);
     expect(translatedCode).toBe('bru.setCollectionVar("fullPath", bru.getEnvVar("baseUrl") + bru.getVar("endpoint"));');
@@ -358,8 +356,7 @@ describe('Combined API Features Translation', () => {
     expect(translatedCode).toContain('bru.setVar("token", res.getBody().token);');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should translate pm.collectionVariables alias set inside functions', () => {
+  it('should translate pm.collectionVariables alias set inside functions', () => {
     const code = `
         const tempCollVars = pm.collectionVariables;
         tempCollVars.set("sessionId", "value");

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/multiline-syntax.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/multiline-syntax.test.js
@@ -43,8 +43,7 @@ describe('Multiline Syntax Handling', () => {
     expect(translatedCode).toContain('const apiKey = bru.getCollectionVar("apiKey")');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should handle multiline collection variable set syntax', () => {
+  it('should handle multiline collection variable set syntax', () => {
     const code = `
     pm.collectionVariables
                             .set("lastRun", new Date().toISOString());
@@ -287,8 +286,7 @@ describe('Multiline Syntax Handling', () => {
     expect(translatedCode).toContain('bru.runner.setNextRequest("Next API Call")');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should translate multiline pm.collectionVariables.set in comprehensive script', () => {
+  it('should translate multiline pm.collectionVariables.set in comprehensive script', () => {
     const code = `
     pm.collectionVariables
       .set("lastRun", new Date());

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/response.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/response.test.js
@@ -283,8 +283,7 @@ describe('Response Translation', () => {
     expect(translatedCode).toContain('const items = res.getBody().items;');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should translate pm.collectionVariables.set with array access pattern', () => {
+  it('should translate pm.collectionVariables.set with array access pattern', () => {
     const code = 'pm.collectionVariables.set("item_" + i, items[i].id);';
     const translatedCode = translateCode(code);
     expect(translatedCode).toContain('bru.setCollectionVar("item_" + i, items[i].id);');

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/testing-framework.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/testing-framework.test.js
@@ -69,8 +69,7 @@ describe('Testing Framework Translation', () => {
     expect(translatedCode).toContain('bru.setEnvVar("userId", response.user.id);');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should translate pm.collectionVariables.set inside test functions', () => {
+  it('should translate pm.collectionVariables.set inside test functions', () => {
     const code = 'pm.collectionVariables.set("sessionId", response.session.id);';
     const translatedCode = translateCode(code);
     expect(translatedCode).toContain('bru.setCollectionVar("sessionId", response.session.id);');

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/variables.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/variables.test.js
@@ -120,6 +120,13 @@ describe('Variables Translation', () => {
     expect(translatedCode).toBe('bru.deleteAllGlobalEnvVars();');
   });
 
+  it('should translate pm.globals.toObject', () => {
+    const code = 'const globals = pm.globals.toObject();';
+    const translatedCode = translateCode(code);
+
+    expect(translatedCode).toBe('const globals = bru.getAllGlobalEnvVars();');
+  });
+
   it('should translate pm.collectionVariables.clear', () => {
     const code = 'pm.collectionVariables.clear();';
     const translatedCode = translateCode(code);

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/variables.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/variables.test.js
@@ -71,8 +71,7 @@ describe('Variables Translation', () => {
     expect(translatedCode).toBe('bru.getCollectionVar("apiUrl");');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should translate pm.collectionVariables.set', () => {
+  it('should translate pm.collectionVariables.set', () => {
     const code = 'pm.collectionVariables.set("token", jsonData.token);';
     const translatedCode = translateCode(code);
 
@@ -86,8 +85,7 @@ describe('Variables Translation', () => {
     expect(translatedCode).toBe('bru.hasCollectionVar("authToken");');
   });
 
-  // TODO: Restore once UI update fixes are live for deleteCollectionVar
-  it.skip('should translate pm.collectionVariables.unset', () => {
+  it('should translate pm.collectionVariables.unset', () => {
     const code = 'pm.collectionVariables.unset("tempVar");';
     const translatedCode = translateCode(code);
 
@@ -108,6 +106,34 @@ describe('Variables Translation', () => {
     expect(translatedCode).toBe('bru.setGlobalEnvVar("test", "value");');
   });
 
+  it('should translate pm.globals.unset', () => {
+    const code = 'pm.globals.unset("token");';
+    const translatedCode = translateCode(code);
+
+    expect(translatedCode).toBe('bru.deleteGlobalEnvVar("token");');
+  });
+
+  it('should translate pm.globals.clear', () => {
+    const code = 'pm.globals.clear();';
+    const translatedCode = translateCode(code);
+
+    expect(translatedCode).toBe('bru.deleteAllGlobalEnvVars();');
+  });
+
+  it('should translate pm.collectionVariables.clear', () => {
+    const code = 'pm.collectionVariables.clear();';
+    const translatedCode = translateCode(code);
+
+    expect(translatedCode).toBe('bru.deleteAllCollectionVars();');
+  });
+
+  it('should translate pm.collectionVariables.toObject', () => {
+    const code = 'const vars = pm.collectionVariables.toObject();';
+    const translatedCode = translateCode(code);
+
+    expect(translatedCode).toBe('const vars = bru.getAllCollectionVars();');
+  });
+
   // Alias tests for variables
   it('should handle variables aliases', () => {
     const code = `
@@ -126,8 +152,7 @@ describe('Variables Translation', () => {
   });
 
   // Alias tests for collection variables
-  // TODO: Restore once UI update fixes are live for setCollectionVar/deleteCollectionVar
-  it.skip('should handle collection variables aliases', () => {
+  it('should handle collection variables aliases', () => {
     const code = `
         const collVars = pm.collectionVariables;
         const has = collVars.has("test");
@@ -183,8 +208,7 @@ describe('Variables Translation', () => {
     expect(translatedCode).toContain('bru.setVar("requestTime", new Date().toISOString());');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar/deleteCollectionVar
-  it.skip('should handle all collection variable methods together', () => {
+  it('should handle all collection variable methods together', () => {
     const code = `
         // All collection variable methods
         const hasApiUrl = pm.collectionVariables.has("apiUrl");
@@ -202,8 +226,7 @@ describe('Variables Translation', () => {
     expect(translatedCode).toContain('bru.deleteCollectionVar("tempVar");');
   });
 
-  // TODO: Restore once UI update fixes are live for setCollectionVar
-  it.skip('should handle more complex nested expressions with variables', () => {
+  it('should handle more complex nested expressions with variables', () => {
     const code = 'pm.collectionVariables.set("fullPath", pm.environment.get("baseUrl") + pm.variables.get("endpoint"));';
     const translatedCode = translateCode(code);
 


### PR DESCRIPTION
### Description

Re-enables Postman ↔ Bruno script translations that were previously commented out because the underlying runtime APIs would not propagate variable mutations to the UI tables. With variable persistence landing in [#8315](https://github.com/usebruno/bruno/pull/8315), these APIs now update both the request lifecycle *and* the UI, so the translations can be turned back on.

JIRA: [BRU-3096](https://usebruno.atlassian.net/browse/BRU-3096)
JIRA: [BRU-3082](https://usebruno.atlassian.net/browse/BRU-3082)

> [!IMPORTANT]
> Depends on [#8315](https://github.com/usebruno/bruno/pull/8315) — that PR must be merged first, otherwise the re-enabled translations will silently fail to update the UI.

#### Re-enabled translations

| Postman API | Bruno API |
| --- | --- |
| `pm.globals.unset` | `bru.deleteGlobalEnvVar` |
| `pm.globals.clear` | `bru.deleteAllGlobalEnvVars` |
| `pm.collectionVariables.set` | `bru.setCollectionVar` |
| `pm.collectionVariables.unset` | `bru.deleteCollectionVar` |
| `pm.collectionVariables.clear` | `bru.deleteAllCollectionVars` |
| `pm.collectionVariables.toObject` | `bru.getAllCollectionVars` |

Applied in both directions and to both transformer paths:
- `packages/bruno-converters/src/utils/postman-to-bruno-translator.js` (AST/jscodeshift)
- `packages/bruno-converters/src/postman/postman-translations.js` (regex fallback)
- `packages/bruno-converters/src/utils/bruno-to-postman-translator.js` (AST/jscodeshift)

#### Tests

- Unskipped 13 `it.skip` / `test.skip` blocks across 8 spec files covering the collection-variable APIs.
- Added 11 new tests for previously uncovered APIs (`pm.globals.unset`, `pm.globals.clear`, `pm.collectionVariables.clear`, `pm.collectionVariables.toObject`, and their `bru.*` reverse mappings).
- `npm run test --workspace=packages/bruno-converters` → 71/71 suites pass, 1104 tests pass.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Postman/Bruno variable translation coverage for global and collection variables, including `set`, `unset`, `clear`, and converting to object form.
  * Enabled additional translation mappings in both Postman-to-Bruno and Bruno-to-Postman conversions.

* **Tests**
  * Re-enabled and expanded coverage for previously skipped variable translation scenarios.
  * Added assertions across multiline, nested, alias-based, combined, and test-function cases for `pm.collectionVariables.*` and `pm.globals.*`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->