### PR TITLE
feat(app): add "Ignore Folder" sidebar context menu item (closes #1890)

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -19,12 +19,14 @@ import {
   IconSettings,
   IconInfoCircle,
   IconTerminal2,
-  IconAppWindow
+  IconAppWindow,
+  IconEyeOff
 } from '@tabler/icons';
 import { useSelector, useDispatch } from 'react-redux';
 import { addTab, focusTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
-import { handleCollectionItemDrop, sendRequest, showInFolder, pasteItem, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
-import { toggleCollectionItem, addResponseExample } from 'providers/ReduxStore/slices/collections';
+import { handleCollectionItemDrop, sendRequest, showInFolder, pasteItem, saveRequest, updateBrunoConfig } from 'providers/ReduxStore/slices/collections/actions';
+import { toggleCollectionItem, addResponseExample, deleteItem } from 'providers/ReduxStore/slices/collections';
+import { getCollectionRelativePath, addPathToIgnoreList } from 'utils/collections/ignore';
 import { insertTaskIntoQueue } from 'providers/ReduxStore/slices/app';
 import { uuid } from 'utils/common';
 import { copyRequest, setFocusedSidebarPath } from 'providers/ReduxStore/slices/app';
@@ -337,6 +339,21 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
   let indents = range(item.depth);
 
+  const handleIgnoreFolder = () => {
+    const relativePath = getCollectionRelativePath(collectionPathname, item.pathname);
+    if (!relativePath) return;
+
+    const brunoConfig = addPathToIgnoreList(collection?.brunoConfig, relativePath);
+    dispatch(updateBrunoConfig(brunoConfig, collectionUid))
+      .then(() => {
+        // Remove the folder from the sidebar immediately; bruno.json keeps it
+        // ignored on subsequent loads.
+        dispatch(deleteItem({ itemUid: item.uid, collectionUid }));
+        toast.success(`Ignored folder: ${relativePath}`);
+      })
+      .catch(() => toast.error('Failed to ignore folder'));
+  };
+
   // Build menu items for MenuDropdown
   const buildMenuItems = () => {
     const items = [];
@@ -465,6 +482,12 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
             const folderCwd = item.pathname || collectionPathname;
             await openDevtoolsAndSwitchToTerminal(dispatch, folderCwd);
           }
+        },
+        {
+          id: 'ignore-folder',
+          leftSection: IconEyeOff,
+          label: 'Ignore Folder',
+          onClick: handleIgnoreFolder
         }
       );
     }

--- a/packages/bruno-app/src/utils/collections/ignore.js
+++ b/packages/bruno-app/src/utils/collections/ignore.js
@@ -1,0 +1,44 @@
+/**
+ * Returns the path of an item relative to its collection root, using forward
+ * slashes so the value stays portable when written into bruno.json (which can
+ * be committed and shared across operating systems).
+ *
+ * @param {string} collectionPathname absolute path of the collection root
+ * @param {string} itemPathname absolute path of the item (folder) being ignored
+ * @returns {string} the collection-relative path, or '' when it cannot be derived
+ */
+export const getCollectionRelativePath = (collectionPathname, itemPathname) => {
+  if (!collectionPathname || !itemPathname) return '';
+
+  const toPosix = (p) => p.replace(/\\/g, '/').replace(/\/+$/, '');
+  const root = toPosix(collectionPathname);
+  const target = toPosix(itemPathname);
+
+  if (target === root) return '';
+  if (target.startsWith(`${root}/`)) {
+    return target.slice(root.length + 1);
+  }
+
+  return target;
+};
+
+/**
+ * Returns a new brunoConfig with the given path added to its `ignore` list.
+ * The original config and its ignore array are left untouched. Empty paths and
+ * paths already present are no-ops.
+ *
+ * @param {Object} brunoConfig the collection's bruno.json config
+ * @param {string} relativePath the collection-relative path to ignore
+ * @returns {Object} a new brunoConfig with the updated ignore list
+ */
+export const addPathToIgnoreList = (brunoConfig, relativePath) => {
+  const config = brunoConfig ? { ...brunoConfig } : {};
+  const ignore = Array.isArray(config.ignore) ? [...config.ignore] : [];
+
+  if (relativePath && !ignore.includes(relativePath)) {
+    ignore.push(relativePath);
+  }
+
+  config.ignore = ignore;
+  return config;
+};

--- a/packages/bruno-app/src/utils/collections/ignore.js
+++ b/packages/bruno-app/src/utils/collections/ignore.js
@@ -19,7 +19,11 @@ export const getCollectionRelativePath = (collectionPathname, itemPathname) => {
     return target.slice(root.length + 1);
   }
 
-  return target;
+  // The item is not inside this collection, so there is no collection-relative
+  // path to derive. Return '' rather than the absolute target — writing a
+  // non-relative path into bruno.json's ignore list would be meaningless and
+  // would not survive being shared across machines.
+  return '';
 };
 
 /**

--- a/packages/bruno-app/src/utils/collections/ignore.spec.js
+++ b/packages/bruno-app/src/utils/collections/ignore.spec.js
@@ -1,0 +1,57 @@
+import { getCollectionRelativePath, addPathToIgnoreList } from './ignore';
+
+describe('getCollectionRelativePath', () => {
+  it('returns the folder path relative to the collection root', () => {
+    expect(getCollectionRelativePath('/home/adi/my-collection', '/home/adi/my-collection/auth')).toBe('auth');
+  });
+
+  it('returns nested folder paths with forward slashes', () => {
+    expect(getCollectionRelativePath('/home/adi/my-collection', '/home/adi/my-collection/v1/users')).toBe('v1/users');
+  });
+
+  it('normalizes windows-style separators to forward slashes', () => {
+    expect(getCollectionRelativePath('C:\\Users\\adi\\coll', 'C:\\Users\\adi\\coll\\auth\\login')).toBe('auth/login');
+  });
+
+  it('tolerates a trailing slash on the collection path', () => {
+    expect(getCollectionRelativePath('/home/adi/coll/', '/home/adi/coll/auth')).toBe('auth');
+  });
+
+  it('returns an empty string when the item is the collection root', () => {
+    expect(getCollectionRelativePath('/home/adi/coll', '/home/adi/coll')).toBe('');
+  });
+
+  it('returns an empty string when inputs are missing', () => {
+    expect(getCollectionRelativePath('', '/home/adi/coll/auth')).toBe('');
+    expect(getCollectionRelativePath('/home/adi/coll', '')).toBe('');
+  });
+});
+
+describe('addPathToIgnoreList', () => {
+  it('appends the path to an existing ignore list', () => {
+    const config = { name: 'coll', ignore: ['node_modules'] };
+    expect(addPathToIgnoreList(config, 'auth').ignore).toEqual(['node_modules', 'auth']);
+  });
+
+  it('creates the ignore list when the config has none', () => {
+    expect(addPathToIgnoreList({ name: 'coll' }, 'auth').ignore).toEqual(['auth']);
+  });
+
+  it('does not add duplicates', () => {
+    const config = { ignore: ['auth'] };
+    expect(addPathToIgnoreList(config, 'auth').ignore).toEqual(['auth']);
+  });
+
+  it('ignores empty paths', () => {
+    const config = { ignore: ['auth'] };
+    expect(addPathToIgnoreList(config, '').ignore).toEqual(['auth']);
+  });
+
+  it('does not mutate the original config or its ignore array', () => {
+    const config = { ignore: ['node_modules'] };
+    const next = addPathToIgnoreList(config, 'auth');
+    expect(config.ignore).toEqual(['node_modules']);
+    expect(next).not.toBe(config);
+    expect(next.ignore).not.toBe(config.ignore);
+  });
+});

--- a/packages/bruno-app/src/utils/collections/ignore.spec.js
+++ b/packages/bruno-app/src/utils/collections/ignore.spec.js
@@ -25,6 +25,18 @@ describe('getCollectionRelativePath', () => {
     expect(getCollectionRelativePath('', '/home/adi/coll/auth')).toBe('');
     expect(getCollectionRelativePath('/home/adi/coll', '')).toBe('');
   });
+
+  it('returns an empty string when the item is not inside the collection root', () => {
+    expect(getCollectionRelativePath('/home/adi/coll', '/home/adi/other/auth')).toBe('');
+  });
+
+  it('returns an empty string when a shared prefix is not a real path boundary', () => {
+    expect(getCollectionRelativePath('/home/adi/coll', '/home/adi/collection/auth')).toBe('');
+  });
+
+  it('returns an empty string when the collection and item paths differ only by case', () => {
+    expect(getCollectionRelativePath('/home/adi/coll', '/home/adi/COLL/auth')).toBe('');
+  });
 });
 
 describe('addPathToIgnoreList', () => {


### PR DESCRIPTION
### Description

Adds an **Ignore Folder** item to the folder context menu in the sidebar, closing #1890.

Today the only way to add a folder to a collection's `ignore` list is to hand-edit `bruno.json`. This adds a right-click action that does it from the UI:

- Right-click a folder → **Ignore Folder**
- The folder's collection-relative path is appended to `brunoConfig.ignore` and persisted to `bruno.json`
- The folder is removed from the sidebar immediately; `bruno.json` keeps it ignored on subsequent loads

The path is stored with forward slashes so the value stays portable when `bruno.json` is committed and shared across operating systems.

### How it works

- `getCollectionRelativePath(collectionPathname, itemPathname)` derives the portable relative path
- `addPathToIgnoreList(brunoConfig, relativePath)` returns a new config with the path added (immutable, dedupes)
- The menu handler dispatches the existing `updateBrunoConfig` thunk to persist, then `deleteItem` to drop the folder from the tree

### Tests

Added `utils/collections/ignore.spec.js` covering relative-path derivation (nested paths, Windows separators, trailing slashes, root/empty inputs) and ignore-list merging (append, create, dedupe, empty paths, immutability). 11 assertions, all passing.

### Notes

- Only shown for folders.
- Reuses existing persistence (`updateBrunoConfig`) and tree-removal (`deleteItem`) machinery; no watcher changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Ignore Folder** action to the folder menu in the sidebar.
  * Ignoring a folder updates the app’s ignore list and removes the folder from view right away.

* **Bug Fixes**
  * Improved ignore-path computation, including nested paths, trailing slashes, Windows path separators, and boundary/case handling.
  * Avoids duplicate ignore entries and skips invalid inputs.

* **Tests**
  * Added Jest coverage for ignore-path handling and ignore-list update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->