### PR TITLE
fix(scripts): expose __dirname and __filename in script sandboxes

### DIFF
--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -45,6 +45,13 @@ async function runScriptInNodeVm({
     // Build the script context with Bruno objects and globals
     const scriptContext = buildScriptContext(context, scriptingConfig);
 
+    // Inject CJS-like globals so scripts can use __dirname / __filename
+    // the way they did under the legacy vm2 sandbox (and the way the docs
+    // still document). __dirname is the collection root; __filename is the
+    // .bru/.yml source file when known.
+    scriptContext.__dirname = collectionPath;
+    scriptContext.__filename = scriptPath || undefined;
+
     // Create truly isolated context - scriptContext becomes the global object
     // Scripts can ONLY access what's explicitly in scriptContext
     const isolatedContext = vm.createContext(scriptContext);

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -1195,4 +1195,72 @@ describe('node-vm sandbox', () => {
       expect(context.bru.setVar).toHaveBeenCalledWith('result', 'a,b');
     });
   });
+
+  describe('top-level __dirname / __filename', () => {
+    it('should expose __dirname as the collection path', async () => {
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const script = `bru.setVar('result', __dirname)`;
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', collectionPath);
+    });
+
+    it('should expose __filename as the script path when provided', async () => {
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const scriptPath = '/some/path/to/req.bru';
+      const script = `bru.setVar('result', __filename)`;
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {}, scriptPath });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', scriptPath);
+    });
+
+    it('should leave __filename undefined when no scriptPath is provided', async () => {
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const script = `bru.setVar('result', typeof __filename)`;
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 'undefined');
+    });
+
+    it('should expose __dirname inside a require()\'d module too', async () => {
+      // Module reads __dirname at top-level (CJS module wrapper) and re-exports it.
+      fs.writeFileSync(
+        path.join(collectionPath, 'check-dirname.js'),
+        'module.exports = { dirname: typeof __dirname === "string" ? __dirname : null };'
+      );
+
+      const script = `
+        const mod = require('./check-dirname');
+        bru.setVar('fromCollection', __dirname);
+        bru.setVar('fromModule', mod.dirname);
+        bru.setVar('same', __dirname === mod.dirname);
+      `;
+
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('fromCollection', collectionPath);
+      expect(context.bru.setVar).toHaveBeenCalledWith('fromModule', collectionPath);
+      expect(context.bru.setVar).toHaveBeenCalledWith('same', true);
+    });
+  });
 });

--- a/packages/bruno-js/src/sandbox/quickjs/index.js
+++ b/packages/bruno-js/src/sandbox/quickjs/index.js
@@ -125,6 +125,16 @@ const executeQuickJsVmAsync = async ({ script: externalScript, context: external
     addLocalModuleLoaderShimToContext(vm, collectionPath);
     addPathShimToContext(vm);
 
+    // Mirror node-vm: expose __dirname/__filename so scripts can use them.
+    const dirnameHandle = vm.newString(collectionPath);
+    vm.setProp(vm.global, '__dirname', dirnameHandle);
+    dirnameHandle.dispose();
+    if (scriptPath) {
+      const filenameHandle = vm.newString(scriptPath);
+      vm.setProp(vm.global, '__filename', filenameHandle);
+      filenameHandle.dispose();
+    }
+
     await addLibraryShimsToContext(vm);
 
     test && __brunoTestResults && addTestShimToContext(vm, __brunoTestResults);


### PR DESCRIPTION
Scripts running inside Bruno's node-vm and QuickJS sandboxes could reference __dirname and __filename under the legacy vm2-based runtime, but the migration to node:vm direct (#6187) and the subsequent node-vm refactor (#7033) did not preserve that injection. The official docs at docs.usebruno.com/testing/script/external-libraries still document this pattern, and the community continues to use it (e.g. Discussion #385 Scriptmania examples).

Restore the behavior by setting __dirname = collectionPath and __filename = scriptPath on the script context, mirroring what the old sandbox provided. Adds tests covering the collection path exposure, script path exposure, undefined fallback when scriptPath is omitted, and module-level __dirname propagation.

### Description

This PR fixes a regression where Bruno script sandboxes (both `node-vm` and QuickJS) no longer expose the `__dirname` and `__filename` globals inside pre-request, post-response, and test scripts.

### Background

Scripts running under Bruno's legacy `vm2`-based sandbox could reference `__dirname` and `__filename` directly. That behavior was lost during the migration to `node:vm` (PR #6187) and the subsequent node-vm refactor (PR #7033). Neither PR preserved the injection.

This isn't a hidden compatibility quirk; it is documented first-party API. The official docs at `docs.usebruno.com/testing/script/external-libraries` show `__dirname` as the supported way to load files relative to the collection:

```js
const fs = require('fs');
const path = require('path');
const csvData = fs.readFileSync(path.join(__dirname, 'data.csv'), 'utf8');
```

The pattern is also widely used in the community (see Discussion #385: Scriptmania examples). Reports of breakage include #8390 ("Script __dirname is not defined": open against v3.5.0).

### Changes

- **`packages/bruno-js/src/sandbox/node-vm/index.js`**: before `vm.createContext(scriptContext)`, inject `__dirname = collectionPath` and `__filename = scriptPath || undefined` onto the script context, alongside the existing globals.
- **`packages/bruno-js/src/sandbox/quickjs/index.js`**: mirror the same behavior in the QuickJS sandbox via `vm.setProp(vm.global, '__dirname', ...)` and `vm.setProp(vm.global, '__filename', ...)`, matching the existing QuickJS shim style.
- **`packages/bruno-js/src/sandbox/node-vm/index.spec.js`**: add four tests covering:
  - `__dirname` resolves to the collection path
  - `__filename` resolves to the script path when provided
  - `__filename` is `undefined` when `scriptPath` is omitted
  - `__dirname` propagates correctly into `require()`'d modules

### Compatibility

- No public API changes; this only restores behavior that was previously documented and worked.
- `__filename` is intentionally left `undefined` (not a synthetic fallback) when no `scriptPath` is passed, to avoid giving scripts a misleading path. This matches Node's behavior when `__filename` is not in a module context.
- The QuickJS sandbox's synchronous `executeQuickJsVm` (used for `{{...}}` template interpolation) is intentionally not touched since `__dirname` has no meaningful value in that context.

### Testing

- `npm test` in `packages/bruno-js` passes: 602/603 total tests, with 1 pre-existing failure unrelated to this change.
- The 4 new tests in this PR all pass.

Closes #8390.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request** *(yes, Codey assisted with research, implementation, and the PR description)*
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** *(N/A this is a behavior-fix in a sandbox; reproducible with the code snippet from #8390)*
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** *(Links #8390)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox scripts now expose familiar Node-style path globals, including `__dirname` and `__filename` (when a script path is available).
  * CommonJS-style modules loaded inside the sandbox also preserve the correct `__dirname`.

* **Bug Fixes**
  * Improves path-based logic and related runtime context for scripts executed in the sandbox (including better stack-trace alignment).
  
* **Tests**
  * Added coverage to validate `__dirname`/`__filename` behavior for both top-level and module contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->