### PR TITLE
Fix/flaky test chrome sandbox path (THIS IS A CI/CD PIPELINE TEST PR )

### DIFF
--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Install npm dependencies
         run: |
           npm ci --legacy-peer-deps
-          sudo chown root /home/runner/work/bruno/bruno/node_modules/electron/dist/chrome-sandbox
-          sudo chmod 4755 /home/runner/work/bruno/bruno/node_modules/electron/dist/chrome-sandbox
+          sudo chown root node_modules/electron/dist/chrome-sandbox
+          sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
 
       - name: Install test collection dependencies
         run: npm ci --prefix packages/bruno-tests/collection

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
@@ -5,6 +5,8 @@ import { cloneDeep, find, get } from 'lodash';
 import { IconLoader2, IconX } from '@tabler/icons';
 import { interpolate } from '@usebruno/common';
 import { fetchOauth2Credentials, clearOauth2Cache, refreshOauth2Credentials, cancelOauth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress } from 'providers/ReduxStore/slices/collections/actions';
+import { responseReceived } from 'providers/ReduxStore/slices/collections';
+import { updateResponsePaneTab } from 'providers/ReduxStore/slices/tabs';
 import { getAllVariables } from 'utils/collections/index';
 import Button from 'ui/Button';
 
@@ -41,6 +43,25 @@ const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, c
   const credentialsData = find(collection?.oauth2Credentials, (creds) => creds?.url == interpolatedAccessTokenUrl && creds?.collectionUid == collectionUid && creds?.credentialsId == credentialsId);
   const creds = credentialsData?.credentials || {};
 
+  const showOauth2Error = (errorMessage) => {
+    dispatch(
+      responseReceived({
+        itemUid: item.uid,
+        collectionUid,
+        response: {
+          error: errorMessage,
+          status: null,
+          headers: {},
+          data: null,
+          dataBuffer: null,
+          size: 0,
+          duration: 0
+        }
+      })
+    );
+    dispatch(updateResponsePaneTab({ uid: item.uid, responsePaneTab: 'response' }));
+  };
+
   const handleFetchOauth2Credentials = async () => {
     let requestCopy = cloneDeep(request);
     requestCopy.oauth2 = requestCopy?.auth.oauth2;
@@ -59,6 +80,7 @@ const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, c
         const errorMessage = result?.error || 'No access token received from authorization server';
         console.error(errorMessage);
         toast.error(errorMessage);
+        showOauth2Error(errorMessage);
         return;
       }
 
@@ -70,7 +92,9 @@ const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, c
       if (error?.message && error.message.includes('cancelled by user')) {
         return;
       }
-      toast.error(error?.message || 'An error occurred while fetching token!');
+      const errorMessage = error?.message || 'An error occurred while fetching token!';
+      toast.error(errorMessage);
+      showOauth2Error(errorMessage);
     } finally {
       toggleFetchingToken(false);
       toggleFetchingAuthorizationCode(false);
@@ -97,6 +121,7 @@ const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, c
         const errorMessage = result?.error || 'No access token received from authorization server';
         console.error(errorMessage);
         toast.error(errorMessage);
+        showOauth2Error(errorMessage);
         return;
       }
 
@@ -104,7 +129,9 @@ const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, c
     } catch (error) {
       console.error(error);
       toggleRefreshingToken(false);
-      toast.error(error?.message || 'An error occurred while refreshing token!');
+      const errorMessage = error?.message || 'An error occurred while refreshing token!';
+      toast.error(errorMessage);
+      showOauth2Error(errorMessage);
     }
   };
 

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
@@ -8,6 +8,7 @@ import { fetchOauth2Credentials, clearOauth2Cache, refreshOauth2Credentials, can
 import { responseReceived } from 'providers/ReduxStore/slices/collections';
 import { updateResponsePaneTab } from 'providers/ReduxStore/slices/tabs';
 import { getAllVariables } from 'utils/collections/index';
+import { formatIpcError } from 'utils/common/error';
 import Button from 'ui/Button';
 
 const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, credentialsId }) => {
@@ -92,7 +93,7 @@ const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, c
       if (error?.message && error.message.includes('cancelled by user')) {
         return;
       }
-      const errorMessage = error?.message || 'An error occurred while fetching token!';
+      const errorMessage = formatIpcError(error) || 'An error occurred while fetching token!';
       toast.error(errorMessage);
       showOauth2Error(errorMessage);
     } finally {
@@ -129,7 +130,7 @@ const Oauth2ActionButtons = ({ item, request, collection, url: accessTokenUrl, c
     } catch (error) {
       console.error(error);
       toggleRefreshingToken(false);
-      const errorMessage = error?.message || 'An error occurred while refreshing token!';
+      const errorMessage = formatIpcError(error) || 'An error occurred while refreshing token!';
       toast.error(errorMessage);
       showOauth2Error(errorMessage);
     }

--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-system-browser.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-system-browser.js
@@ -1,7 +1,7 @@
 const { shell } = require('electron');
 const { registerOauth2AuthorizationRequest, rejectOauth2AuthorizationRequest } = require('../../utils/oauth2-protocol-handler');
 
-const authorizeUserInSystemBrowser = ({ authorizeUrl, callbackUrl, grantType = 'authorization_code' }) => {
+const authorizeUserInSystemBrowser = ({ authorizeUrl, callbackUrl, grantType = 'authorization_code', expectedState = null }) => {
   return new Promise((resolve, reject) => {
     // Replace callback URL in authorization URL
     const authorizationUrlObj = new URL(authorizeUrl);
@@ -51,7 +51,7 @@ const authorizeUserInSystemBrowser = ({ authorizeUrl, callbackUrl, grantType = '
       reject(error);
     };
 
-    registerOauth2AuthorizationRequest(wrappedResolve, wrappedReject, debugInfo);
+    registerOauth2AuthorizationRequest(wrappedResolve, wrappedReject, debugInfo, expectedState);
 
     // Open system browser
     shell.openExternal(modifiedAuthorizeUrl).catch((error) => {

--- a/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
+++ b/packages/bruno-electron/src/ipc/network/authorize-user-in-window.js
@@ -11,7 +11,7 @@ const matchesCallbackUrl = (url, callbackUrl) => {
     && (url.searchParams.has('code') || url.hash.length > 1);
 };
 
-const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session, additionalHeaders = {}, grantType = 'authorization_code' }) => {
+const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session, additionalHeaders = {}, grantType = 'authorization_code', expectedState = null }) => {
   return new Promise(async (resolve, reject) => {
     let finalUrl = null;
     let debugInfo = {
@@ -202,6 +202,22 @@ const authorizeUserInWindow = ({ authorizeUrl, callbackUrl, session, additionalH
 
       if (finalUrl) {
         try {
+          // Validate the state parameter to protect against CSRF / authorization
+          // code injection. The returned state must match the cryptographically
+          // random state issued when the flow was initiated.
+          if (expectedState) {
+            const finalUrlObj = new URL(finalUrl);
+            const returnedState
+              = finalUrlObj.searchParams.get('state')
+                || (finalUrlObj.hash ? new URLSearchParams(finalUrlObj.hash.substring(1)).get('state') : null);
+
+            if (returnedState !== expectedState) {
+              return reject(
+                new Error('OAuth2 state mismatch: the returned state does not match the issued state. Aborting to prevent authorization code injection.')
+              );
+            }
+          }
+
           // Handle different grant types differently
           if (grantType === 'implicit') {
             // For implicit flow, tokens are in the URL hash fragment

--- a/packages/bruno-electron/src/utils/oauth2-protocol-handler.js
+++ b/packages/bruno-electron/src/utils/oauth2-protocol-handler.js
@@ -1,6 +1,6 @@
 let oauth2AuthorizationRequest = null;
 
-const registerOauth2AuthorizationRequest = (resolve, reject, debugInfo = null) => {
+const registerOauth2AuthorizationRequest = (resolve, reject, debugInfo = null, expectedState = null) => {
   // Cancel any existing pending request
   if (oauth2AuthorizationRequest) {
     oauth2AuthorizationRequest.reject(new Error('Authorization cancelled: new request started'));
@@ -10,6 +10,7 @@ const registerOauth2AuthorizationRequest = (resolve, reject, debugInfo = null) =
     resolve,
     reject,
     debugInfo,
+    expectedState,
     timestamp: Date.now()
   };
 };
@@ -78,6 +79,23 @@ const handleOauth2ProtocolUrl = (url) => {
       };
       rejectOauth2AuthorizationRequest(new Error(JSON.stringify(errorData)));
       return;
+    }
+
+    // Validate the state parameter to protect against CSRF / authorization code
+    // injection. The returned state must match the cryptographically random state
+    // issued when the flow was initiated.
+    const expectedState = oauth2AuthorizationRequest?.expectedState;
+    if (expectedState) {
+      const returnedState
+        = urlObj.searchParams.get('state')
+          || (urlObj.hash ? new URLSearchParams(urlObj.hash.substring(1)).get('state') : null);
+
+      if (returnedState !== expectedState) {
+        rejectOauth2AuthorizationRequest(
+          new Error('OAuth2 state mismatch: the returned state does not match the issued state. Aborting to prevent authorization code injection.')
+        );
+        return;
+      }
     }
 
     // Check if this is an implicit grant (tokens in hash fragment)

--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -973,5 +973,6 @@ module.exports = {
   refreshOauth2Token,
   generateCodeVerifier,
   generateCodeChallenge,
+  generateState,
   updateCollectionOauth2Credentials
 };

--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -308,6 +308,10 @@ const getOAuth2AuthorizationCode = (request, codeChallenge, collectionUid) => {
     const { callbackUrl, clientId, authorizationUrl, scope, state, pkce, accessTokenUrl, additionalParameters } = oauth2;
     const useSystemBrowser = preferencesUtil.shouldUseSystemBrowser();
     const effectiveCallbackUrl = callbackUrl && callbackUrl.length ? callbackUrl : BRUNO_OAUTH2_CALLBACK_URL;
+    // Always append a cryptographically random nonce to the user-configured state
+    // (or generate a fully random one when none is set). The state is validated when
+    // the callback is received to prevent authorization code injection / CSRF.
+    const effectiveState = generateState({ userState: state });
 
     const authorizationUrlWithQueryParams = new URL(authorizationUrl);
     authorizationUrlWithQueryParams.searchParams.append('response_type', 'code');
@@ -324,8 +328,8 @@ const getOAuth2AuthorizationCode = (request, codeChallenge, collectionUid) => {
       authorizationUrlWithQueryParams.searchParams.append('code_challenge', codeChallenge);
       authorizationUrlWithQueryParams.searchParams.append('code_challenge_method', 'S256');
     }
-    if (state) {
-      authorizationUrlWithQueryParams.searchParams.append('state', state);
+    if (effectiveState) {
+      authorizationUrlWithQueryParams.searchParams.append('state', effectiveState);
     }
     if (additionalParameters?.authorization?.length) {
       additionalParameters.authorization.forEach((param) => {
@@ -344,6 +348,7 @@ const getOAuth2AuthorizationCode = (request, codeChallenge, collectionUid) => {
         authorizeUrl,
         callbackUrl: effectiveCallbackUrl,
         session: oauth2Store.getSessionIdOfCollection({ collectionUid, url: accessTokenUrl }),
+        expectedState: effectiveState,
         additionalHeaders: getAdditionalHeaders(additionalParameters?.authorization)
       });
       resolve({ authorizationCode, debugInfo });
@@ -707,6 +712,16 @@ const generateCodeVerifier = () => {
   return crypto.randomBytes(22).toString('hex');
 };
 
+// Generate a cryptographically random state value used to protect OAuth2
+// authorization flows against CSRF / authorization code injection.
+const generateState = ({ userState }) => {
+  let cryptographicallyRandomString = crypto.randomBytes(16).toString('hex');
+  if (userState && userState.length) {
+    return userState + cryptographicallyRandomString;
+  }
+  return cryptographicallyRandomString;
+};
+
 const generateCodeChallenge = (codeVerifier) => {
   const hash = crypto.createHash('sha256');
   hash.update(codeVerifier);
@@ -760,6 +775,9 @@ const getOAuth2TokenUsingImplicitGrant = async ({ request, collectionUid, forceF
   } = oauth2;
   const useSystemBrowser = preferencesUtil.shouldUseSystemBrowser();
   const effectiveCallbackUrl = callbackUrl && callbackUrl.length ? callbackUrl : BRUNO_OAUTH2_CALLBACK_URL;
+  // Use the user-configured state if present, otherwise generate a cryptographically
+  // random one. The state is validated when the callback is received to prevent CSRF.
+  const effectiveState = generateState({ userState: state });
 
   // Validate required fields
   if (!authorizationUrl) {
@@ -844,8 +862,8 @@ const getOAuth2TokenUsingImplicitGrant = async ({ request, collectionUid, forceF
   if (scope) {
     authorizationUrlWithQueryParams.searchParams.append('scope', scope);
   }
-  if (state) {
-    authorizationUrlWithQueryParams.searchParams.append('state', state);
+  if (effectiveState) {
+    authorizationUrlWithQueryParams.searchParams.append('state', effectiveState);
   }
   if (additionalParameters?.authorization?.length) {
     additionalParameters.authorization.forEach((param) => {
@@ -866,6 +884,7 @@ const getOAuth2TokenUsingImplicitGrant = async ({ request, collectionUid, forceF
       callbackUrl: effectiveCallbackUrl,
       session: oauth2Store.getSessionIdOfCollection({ collectionUid, url: authorizationUrl }),
       grantType: 'implicit',
+      expectedState: effectiveState,
       additionalHeaders: getAdditionalHeaders(additionalParameters?.authorization)
     });
 

--- a/packages/bruno-electron/tests/utils/oauth2-protocol-handler.spec.js
+++ b/packages/bruno-electron/tests/utils/oauth2-protocol-handler.spec.js
@@ -81,6 +81,19 @@ describe('handleOauth2ProtocolUrl - state validation', () => {
         expect.objectContaining({ message: expect.stringContaining('state mismatch') })
       );
     });
+
+    it('should reject when no hash state is returned but one was expected', () => {
+      registerOauth2AuthorizationRequest(resolve, reject, null, 'expected-state');
+
+      handleOauth2ProtocolUrl(
+        'bruno://oauth2/callback#access_token=token-abc&token_type=bearer'
+      );
+
+      expect(resolve).not.toHaveBeenCalled();
+      expect(reject).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('state mismatch') })
+      );
+    });
   });
 
   describe('when no expected state was registered (backward compatibility)', () => {

--- a/packages/bruno-electron/tests/utils/oauth2-protocol-handler.spec.js
+++ b/packages/bruno-electron/tests/utils/oauth2-protocol-handler.spec.js
@@ -1,0 +1,109 @@
+const {
+  registerOauth2AuthorizationRequest,
+  handleOauth2ProtocolUrl,
+  cancelOAuth2AuthorizationRequest,
+  isOauth2AuthorizationRequestInProgress
+} = require('../../src/utils/oauth2-protocol-handler');
+
+describe('handleOauth2ProtocolUrl - state validation', () => {
+  let resolve;
+  let reject;
+
+  beforeEach(() => {
+    resolve = jest.fn();
+    reject = jest.fn();
+  });
+
+  afterEach(() => {
+    // Clear any pending request between tests
+    if (isOauth2AuthorizationRequestInProgress()) {
+      cancelOAuth2AuthorizationRequest();
+    }
+    jest.clearAllMocks();
+  });
+
+  describe('authorization code flow (state in query params)', () => {
+    it('should resolve with the code when the returned state matches', () => {
+      registerOauth2AuthorizationRequest(resolve, reject, null, 'expected-state');
+
+      handleOauth2ProtocolUrl('bruno://oauth2/callback?code=auth-code-123&state=expected-state');
+
+      expect(resolve).toHaveBeenCalledWith('auth-code-123');
+      expect(reject).not.toHaveBeenCalled();
+    });
+
+    it('should reject when the returned state does not match', () => {
+      registerOauth2AuthorizationRequest(resolve, reject, null, 'expected-state');
+
+      handleOauth2ProtocolUrl('bruno://oauth2/callback?code=auth-code-123&state=attacker-state');
+
+      expect(resolve).not.toHaveBeenCalled();
+      expect(reject).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('state mismatch') })
+      );
+    });
+
+    it('should reject when no state is returned but one was expected', () => {
+      registerOauth2AuthorizationRequest(resolve, reject, null, 'expected-state');
+
+      handleOauth2ProtocolUrl('bruno://oauth2/callback?code=auth-code-123');
+
+      expect(resolve).not.toHaveBeenCalled();
+      expect(reject).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('state mismatch') })
+      );
+    });
+  });
+
+  describe('implicit flow (state in hash fragment)', () => {
+    it('should resolve with tokens when the returned state matches', () => {
+      registerOauth2AuthorizationRequest(resolve, reject, null, 'expected-state');
+
+      handleOauth2ProtocolUrl(
+        'bruno://oauth2/callback#access_token=token-abc&token_type=bearer&state=expected-state'
+      );
+
+      expect(resolve).toHaveBeenCalledWith(
+        expect.objectContaining({ access_token: 'token-abc' })
+      );
+      expect(reject).not.toHaveBeenCalled();
+    });
+
+    it('should reject when the hash state does not match', () => {
+      registerOauth2AuthorizationRequest(resolve, reject, null, 'expected-state');
+
+      handleOauth2ProtocolUrl(
+        'bruno://oauth2/callback#access_token=token-abc&token_type=bearer&state=attacker-state'
+      );
+
+      expect(resolve).not.toHaveBeenCalled();
+      expect(reject).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('state mismatch') })
+      );
+    });
+  });
+
+  describe('when no expected state was registered (backward compatibility)', () => {
+    it('should resolve without validating state', () => {
+      registerOauth2AuthorizationRequest(resolve, reject, null, null);
+
+      handleOauth2ProtocolUrl('bruno://oauth2/callback?code=auth-code-123');
+
+      expect(resolve).toHaveBeenCalledWith('auth-code-123');
+      expect(reject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error responses are handled before state validation', () => {
+    it('should reject with the provider error even if state is absent', () => {
+      registerOauth2AuthorizationRequest(resolve, reject, null, 'expected-state');
+
+      handleOauth2ProtocolUrl('bruno://oauth2/callback?error=access_denied');
+
+      expect(resolve).not.toHaveBeenCalled();
+      expect(reject).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('Authorization Failed') })
+      );
+    });
+  });
+});

--- a/tests/auth/oauth2/fixtures/collection/Authorization Code.bru
+++ b/tests/auth/oauth2/fixtures/collection/Authorization Code.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Authorization Code
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{localhost}}/ping
+  body: none
+  auth: oauth2
+}
+
+auth:oauth2 {
+  grant_type: authorization_code
+  callback_url: bruno://app/oauth2/callback
+  authorization_url: {{localhost}}/api/auth/oauth2/authorization_code/authorize
+  access_token_url: {{localhost}}/api/auth/oauth2/authorization_code/token
+  refresh_token_url:
+  client_id: client_id_1
+  client_secret: client_secret_1
+  scope: read
+  state:
+  pkce: false
+  credentials_placement: body
+  credentials_id: credentials
+  token_placement: header
+  token_header_prefix: Bearer
+  auto_fetch_token: true
+  auto_refresh_token: false
+}

--- a/tests/auth/oauth2/fixtures/collection/Implicit.bru
+++ b/tests/auth/oauth2/fixtures/collection/Implicit.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Implicit
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{localhost}}/ping
+  body: none
+  auth: oauth2
+}
+
+auth:oauth2 {
+  grant_type: implicit
+  callback_url: bruno://app/oauth2/callback
+  authorization_url: {{localhost}}/api/auth/oauth2/authorization_code/authorize
+  client_id: client_id_1
+  scope: read
+  state:
+  credentials_id: credentials
+  token_placement: header
+  token_header_prefix: Bearer
+  auto_fetch_token: true
+}

--- a/tests/auth/oauth2/fixtures/collection/User Supplied State.bru
+++ b/tests/auth/oauth2/fixtures/collection/User Supplied State.bru
@@ -1,0 +1,30 @@
+meta {
+  name: User Supplied State
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{localhost}}/ping
+  body: none
+  auth: oauth2
+}
+
+auth:oauth2 {
+  grant_type: authorization_code
+  callback_url: bruno://app/oauth2/callback
+  authorization_url: {{localhost}}/api/auth/oauth2/authorization_code/authorize
+  access_token_url: {{localhost}}/api/auth/oauth2/authorization_code/token
+  refresh_token_url:
+  client_id: client_id_1
+  client_secret: client_secret_1
+  scope: read
+  state: brunoUserState
+  pkce: false
+  credentials_placement: body
+  credentials_id: credentials
+  token_placement: header
+  token_header_prefix: Bearer
+  auto_fetch_token: true
+  auto_refresh_token: false
+}

--- a/tests/auth/oauth2/fixtures/collection/bruno.json
+++ b/tests/auth/oauth2/fixtures/collection/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "oauth2-state",
+  "type": "collection"
+}

--- a/tests/auth/oauth2/fixtures/collection/environments/Local.bru
+++ b/tests/auth/oauth2/fixtures/collection/environments/Local.bru
@@ -1,0 +1,3 @@
+vars {
+  localhost: http://localhost:8081
+}

--- a/tests/auth/oauth2/init-user-data/preferences.json
+++ b/tests/auth/oauth2/init-user-data/preferences.json
@@ -1,0 +1,15 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": ["{{collectionPath}}"],
+  "preferences": {
+    "request": {
+      "oauth2": {
+        "useSystemBrowser": true
+      }
+    },
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/auth/oauth2/oauth2-state-validation.spec.ts
+++ b/tests/auth/oauth2/oauth2-state-validation.spec.ts
@@ -33,7 +33,7 @@ const PROVIDER_AUTH_CODE = 'provider-auth-code';
 const PROVIDER_ACCESS_TOKEN = 'provider-access-token';
 const WRONG_STATE = 'not-the-issued-state';
 const STATE_MISMATCH_ERROR
-  = 'Error invoking remote method \'renderer:fetch-oauth2-credentials\': Error: OAuth2 state mismatch: the returned state does not match the issued state. Aborting to prevent authorization code injection.';
+  = 'OAuth2 state mismatch: the returned state does not match the issued state. Aborting to prevent authorization code injection.';
 
 test.beforeAll(async () => {
   const response = await fetch(`${TESTBENCH}/ping`);
@@ -41,8 +41,8 @@ test.beforeAll(async () => {
   expect(await response.text()).toBe('pong');
 });
 
-/** Register an auth code with the testbench by hitting the captured authorization URL. */
-const registerAuthCodeWithTestbench = async (authorizationUrl: string): Promise<string> => {
+/** Obtain a valid auth code issued by the testbench by hitting the captured authorization URL. */
+const fetchAuthCodeFromTestbench = async (authorizationUrl: string): Promise<string> => {
   const response = await fetch(authorizationUrl);
   expect(response.ok, 'testbench authorize should respond').toBeTruthy();
   const html = await response.text();
@@ -141,7 +141,7 @@ const getCallbackParams = (callbackUrl: string, style: CallbackStyle = 'query') 
   };
 };
 
-test.describe.serial('OAuth2 callback state validation', () => {
+test.describe('OAuth2 callback state validation', () => {
   test('authorization code: rejects callback when returned state does not match issued state', async ({ restartApp }) => {
     const app = await restartApp();
     const page = await waitForReadyPage(app);
@@ -149,7 +149,6 @@ test.describe.serial('OAuth2 callback state validation', () => {
     await installCallbackCapture(app);
     await clickGetAccessToken(page, 'Authorization Code');
     await waitForAuthorizationStarted(app);
-    // await page.pause();
 
     const issuedState = await getIssuedState(app);
     const callbackUrl = `${CALLBACK}?code=${PROVIDER_AUTH_CODE}&state=${WRONG_STATE}`;
@@ -165,12 +164,11 @@ test.describe.serial('OAuth2 callback state validation', () => {
     expect(code).toBe(PROVIDER_AUTH_CODE);
 
     await expect(
-      page.getByTestId('response-pane').getByText(STATE_MISMATCH_ERROR)
-    ).toBeVisible({ timeout: 15_000 });
-    await expect(
       page.getByRole('status').filter({ hasText: STATE_MISMATCH_ERROR })
     ).toBeVisible({ timeout: 15_000 });
-    // await page.pause();
+    await expect(
+      page.getByTestId('response-pane').getByText(STATE_MISMATCH_ERROR)
+    ).toBeVisible({ timeout: 15_000 });
   });
 
   test('implicit grant: rejects callback when returned state does not match issued state', async ({ restartApp }) => {
@@ -194,14 +192,12 @@ test.describe.serial('OAuth2 callback state validation', () => {
     expect(returnedState).toBe(WRONG_STATE);
     expect(returnedState).not.toBe(issuedState);
     expect(access_token).toBe(PROVIDER_ACCESS_TOKEN);
-
-    await expect(
-      page.getByTestId('response-pane').getByText(STATE_MISMATCH_ERROR)
-    ).toBeVisible({ timeout: 15_000 });
     await expect(
       page.getByRole('status').filter({ hasText: STATE_MISMATCH_ERROR })
     ).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText('Token fetched successfully!')).not.toBeVisible();
+    await expect(
+      page.getByTestId('response-pane').getByText(STATE_MISMATCH_ERROR)
+    ).toBeVisible({ timeout: 15_000 });
   });
 
   test('authorization code: accepts callback when returned state matches issued state', async ({ restartApp }) => {
@@ -213,11 +209,10 @@ test.describe.serial('OAuth2 callback state validation', () => {
 
     await clickGetAccessToken(page, 'Authorization Code');
     await waitForAuthorizationStarted(app);
-
     const authUrl = await getCapturedAuthUrl(app);
     expect(authUrl).toBeTruthy();
     const issuedState = await getIssuedState(app);
-    const authCode = await registerAuthCodeWithTestbench(authUrl as string);
+    const authCode = await fetchAuthCodeFromTestbench(authUrl as string);
     const callbackUrl = `${CALLBACK}?code=${authCode}&state=${encodeURIComponent(issuedState)}`;
 
     await fireCallback(app, callbackUrl);

--- a/tests/auth/oauth2/oauth2-state-validation.spec.ts
+++ b/tests/auth/oauth2/oauth2-state-validation.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * E2E tests for OAuth2 callback `state` validation (authorization code + implicit grant).
+ *
+ * Bruno issues `state` on the authorization URL when the flow starts. The callback must
+ * return that same `state`. These tests compare issued vs returned `state` — the
+ * authorization code / access token values are arbitrary provider payloads.
+ *
+ * `shell.openExternal` is stubbed so no real browser opens; the authorization URL is
+ * captured to obtain the issued state. Callbacks are delivered via the real
+ * `second-instance` protocol handler — the same path the OS uses for
+ * `bruno://app/oauth2/callback` deep links. A wrapped `second-instance` listener
+ * records the URL Bruno actually receives.
+ *
+ * Oracles:
+ *   - authorization code: callback URI + error/success toast + bruno-tests token endpoint
+ *   - implicit grant: callback URI + error/success toast (no token exchange POST)
+ *
+ * Requires the bruno-tests server (`packages/bruno-tests`, default port 8081).
+ *
+ * Fixtures (auto-loaded by Playwright):
+ *   - fixtures/collection  → oauth2-state collection (Authorization Code + Implicit requests)
+ *   - init-user-data         → preloads collection, enables system-browser OAuth2 mode
+ */
+
+import type { ElectronApplication } from 'playwright';
+import { test, expect, waitForReadyPage } from '../../../playwright';
+import { openRequest, selectRequestPaneTab, selectEnvironment } from '../../utils/page';
+
+const COLLECTION = 'oauth2-state';
+const TESTBENCH = 'http://localhost:8081';
+const CALLBACK = 'bruno://app/oauth2/callback';
+const PROVIDER_AUTH_CODE = 'provider-auth-code';
+const PROVIDER_ACCESS_TOKEN = 'provider-access-token';
+const WRONG_STATE = 'not-the-issued-state';
+const STATE_MISMATCH_ERROR
+  = 'Error invoking remote method \'renderer:fetch-oauth2-credentials\': Error: OAuth2 state mismatch: the returned state does not match the issued state. Aborting to prevent authorization code injection.';
+
+test.beforeAll(async () => {
+  const response = await fetch(`${TESTBENCH}/ping`);
+  expect(response.ok, `bruno-tests server should be running at ${TESTBENCH}`).toBeTruthy();
+  expect(await response.text()).toBe('pong');
+});
+
+/** Register an auth code with the testbench by hitting the captured authorization URL. */
+const registerAuthCodeWithTestbench = async (authorizationUrl: string): Promise<string> => {
+  const response = await fetch(authorizationUrl);
+  expect(response.ok, 'testbench authorize should respond').toBeTruthy();
+  const html = await response.text();
+  const match = html.match(/bruno:\/\/app\/oauth2\/callback\?code=([a-f0-9]+)/);
+  expect(match, 'authorize response should embed a callback code').toBeTruthy();
+  return match![1];
+};
+
+/** Fire a deep-link callback through the real protocol handler (cross-platform path). */
+const fireCallback = (app: ElectronApplication, url: string) =>
+  app.evaluate(({ app: electronApp }, callbackUrl) => {
+    electronApp.emit('second-instance', {}, [callbackUrl]);
+  }, url);
+
+/**
+ * Wrap the real `second-instance` listener so callback URLs are recorded when Bruno
+ * receives them — same argv path as `getAppProtocolUrlFromArgv` in index.js.
+ */
+const installCallbackCapture = (app: ElectronApplication) =>
+  app.evaluate(({ app: electronApp }) => {
+    (globalThis as any).__brunoCapturedCallbackUrl = null;
+
+    const listeners = electronApp.listeners('second-instance') as Array<
+      (event: unknown, commandLine: string[]) => void
+    >;
+
+    electronApp.removeAllListeners('second-instance');
+
+    for (const listener of listeners) {
+      electronApp.on('second-instance', (event, commandLine) => {
+        const url = commandLine?.find((arg) => arg?.startsWith('bruno://'));
+        if (url) {
+          (globalThis as any).__brunoCapturedCallbackUrl = url;
+        }
+        listener.call(electronApp, event, commandLine);
+      });
+    }
+  });
+
+const getCapturedCallbackUrl = (app: ElectronApplication): Promise<string | null> =>
+  app.evaluate(() => (globalThis as any).__brunoCapturedCallbackUrl ?? null);
+
+// This block stubs Electron's shell.openExternal inside the Bruno app
+// so the OAuth2 test can intercept the authorization URL
+// instead of opening a real browser.
+const stubOpenExternal = (app: ElectronApplication) =>
+  app.evaluate(({ shell }) => {
+    (globalThis as any).__brunoCapturedAuthUrl = null;
+    shell.openExternal = async (url: string) => {
+      (globalThis as any).__brunoCapturedAuthUrl = url;
+    };
+  });
+
+const getCapturedAuthUrl = (app: ElectronApplication): Promise<string | null> =>
+  app.evaluate(() => (globalThis as any).__brunoCapturedAuthUrl ?? null);
+
+const waitForAuthorizationStarted = async (app: ElectronApplication) => {
+  await expect.poll(() => getCapturedAuthUrl(app), { timeout: 15_000 }).toBeTruthy();
+};
+
+type CallbackStyle = 'query' | 'hash';
+
+const stateFromAuthorizationUrl = (url: string) => new URL(url).searchParams.get('state');
+
+/** `state` Bruno sent on the authorization URL (stored internally as expectedState). */
+const getIssuedState = async (app: ElectronApplication): Promise<string> => {
+  const authUrl = await getCapturedAuthUrl(app);
+  expect(authUrl, 'authorization URL should have been opened').toBeTruthy();
+  const state = stateFromAuthorizationUrl(authUrl as string);
+  expect(state, 'issued state should be present on the authorization URL').toBeTruthy();
+  expect(state).toMatch(/^[0-9a-f]{32}$/);
+  return state as string;
+};
+
+const clickGetAccessToken = async (page: Parameters<typeof openRequest>[0], requestName: string) => {
+  await openRequest(page, COLLECTION, requestName);
+  await selectEnvironment(page, 'Local', 'collection');
+  await selectRequestPaneTab(page, 'Auth');
+  await page.getByRole('button', { name: 'Get Access Token' }).click();
+};
+
+const getCallbackParams = (callbackUrl: string, style: CallbackStyle = 'query') => {
+  const url = new URL(callbackUrl);
+  if (style === 'hash') {
+    const hashParams = new URLSearchParams(url.hash.slice(1));
+    return {
+      state: hashParams.get('state'),
+      code: null,
+      access_token: hashParams.get('access_token')
+    };
+  }
+  return {
+    state: url.searchParams.get('state'),
+    code: url.searchParams.get('code'),
+    access_token: null
+  };
+};
+
+test.describe.serial('OAuth2 callback state validation', () => {
+  test('authorization code: rejects callback when returned state does not match issued state', async ({ restartApp }) => {
+    const app = await restartApp();
+    const page = await waitForReadyPage(app);
+    await stubOpenExternal(app);
+    await installCallbackCapture(app);
+    await clickGetAccessToken(page, 'Authorization Code');
+    await waitForAuthorizationStarted(app);
+    // await page.pause();
+
+    const issuedState = await getIssuedState(app);
+    const callbackUrl = `${CALLBACK}?code=${PROVIDER_AUTH_CODE}&state=${WRONG_STATE}`;
+
+    await fireCallback(app, callbackUrl);
+
+    const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+    expect(receivedCallbackUrl).toBe(callbackUrl);
+
+    const { state: returnedState, code } = getCallbackParams(receivedCallbackUrl as string);
+    expect(returnedState).toBe(WRONG_STATE);
+    expect(returnedState).not.toBe(issuedState);
+    expect(code).toBe(PROVIDER_AUTH_CODE);
+
+    await expect(
+      page.getByTestId('response-pane').getByText(STATE_MISMATCH_ERROR)
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByRole('status').filter({ hasText: STATE_MISMATCH_ERROR })
+    ).toBeVisible({ timeout: 15_000 });
+    // await page.pause();
+  });
+
+  test('implicit grant: rejects callback when returned state does not match issued state', async ({ restartApp }) => {
+    const app = await restartApp();
+    const page = await waitForReadyPage(app);
+    await stubOpenExternal(app);
+    await installCallbackCapture(app);
+
+    await clickGetAccessToken(page, 'Implicit');
+    await waitForAuthorizationStarted(app);
+
+    const issuedState = await getIssuedState(app);
+    const callbackUrl = `${CALLBACK}#access_token=${PROVIDER_ACCESS_TOKEN}&token_type=Bearer&state=${WRONG_STATE}`;
+
+    await fireCallback(app, callbackUrl);
+
+    const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+    expect(receivedCallbackUrl).toBe(callbackUrl);
+
+    const { state: returnedState, access_token } = getCallbackParams(receivedCallbackUrl as string, 'hash');
+    expect(returnedState).toBe(WRONG_STATE);
+    expect(returnedState).not.toBe(issuedState);
+    expect(access_token).toBe(PROVIDER_ACCESS_TOKEN);
+
+    await expect(
+      page.getByTestId('response-pane').getByText(STATE_MISMATCH_ERROR)
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByRole('status').filter({ hasText: STATE_MISMATCH_ERROR })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('Token fetched successfully!')).not.toBeVisible();
+  });
+
+  test('authorization code: accepts callback when returned state matches issued state', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+    const app = await restartApp();
+    const page = await waitForReadyPage(app);
+    await stubOpenExternal(app);
+    await installCallbackCapture(app);
+
+    await clickGetAccessToken(page, 'Authorization Code');
+    await waitForAuthorizationStarted(app);
+
+    const authUrl = await getCapturedAuthUrl(app);
+    expect(authUrl).toBeTruthy();
+    const issuedState = await getIssuedState(app);
+    const authCode = await registerAuthCodeWithTestbench(authUrl as string);
+    const callbackUrl = `${CALLBACK}?code=${authCode}&state=${encodeURIComponent(issuedState)}`;
+
+    await fireCallback(app, callbackUrl);
+
+    const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+    expect(receivedCallbackUrl).toBe(callbackUrl);
+
+    const { state: returnedState, code } = getCallbackParams(receivedCallbackUrl as string);
+    expect(returnedState).toBe(issuedState);
+    expect(code).toBe(authCode);
+
+    await expect(page.getByText('Token fetched successfully!')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('implicit grant: accepts callback when returned state matches issued state', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+    const app = await restartApp();
+    const page = await waitForReadyPage(app);
+    await stubOpenExternal(app);
+    await installCallbackCapture(app);
+
+    await clickGetAccessToken(page, 'Implicit');
+    await waitForAuthorizationStarted(app);
+
+    const issuedState = await getIssuedState(app);
+    const callbackUrl
+      = `${CALLBACK}#access_token=${PROVIDER_ACCESS_TOKEN}&token_type=Bearer&expires_in=3600&state=${encodeURIComponent(issuedState)}`;
+
+    await fireCallback(app, callbackUrl);
+
+    const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+    expect(receivedCallbackUrl).toBe(callbackUrl);
+
+    const { state: returnedState, access_token } = getCallbackParams(receivedCallbackUrl as string, 'hash');
+    expect(returnedState).toBe(issuedState);
+    expect(access_token).toBe(PROVIDER_ACCESS_TOKEN);
+
+    await expect(page.getByText('Token fetched successfully!')).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/tests/auth/oauth2/oauth2-state-validation.spec.ts
+++ b/tests/auth/oauth2/oauth2-state-validation.spec.ts
@@ -107,13 +107,18 @@ type CallbackStyle = 'query' | 'hash';
 
 const stateFromAuthorizationUrl = (url: string) => new URL(url).searchParams.get('state');
 
+// Bruno always appends a cryptographically random nonce (crypto.randomBytes(16) → 32 hex
+// chars) to the state — whether the user configured one or not (see generateState in
+// oauth2.js). So the issued state is at least that nonce length.
+const STATE_NONCE_HEX_LENGTH = 32;
+
 /** `state` Bruno sent on the authorization URL (stored internally as expectedState). */
 const getIssuedState = async (app: ElectronApplication): Promise<string> => {
   const authUrl = await getCapturedAuthUrl(app);
   expect(authUrl, 'authorization URL should have been opened').toBeTruthy();
   const state = stateFromAuthorizationUrl(authUrl as string);
   expect(state, 'issued state should be present on the authorization URL').toBeTruthy();
-  expect(state).toMatch(/^[0-9a-f]{32}$/);
+  expect((state as string).length).toBeGreaterThanOrEqual(STATE_NONCE_HEX_LENGTH);
   return state as string;
 };
 
@@ -249,6 +254,40 @@ test.describe('OAuth2 callback state validation', () => {
     const { state: returnedState, access_token } = getCallbackParams(receivedCallbackUrl as string, 'hash');
     expect(returnedState).toBe(issuedState);
     expect(access_token).toBe(PROVIDER_ACCESS_TOKEN);
+
+    await expect(page.getByText('Token fetched successfully!')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('authorization code (user-supplied state): issues userState + nonce and accepts matching callback', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+    const USER_STATE = 'brunoUserState';
+    const app = await restartApp();
+    const page = await waitForReadyPage(app);
+    await stubOpenExternal(app);
+    await installCallbackCapture(app);
+
+    await clickGetAccessToken(page, 'User Supplied State');
+    await waitForAuthorizationStarted(app);
+    const authUrl = await getCapturedAuthUrl(app);
+    expect(authUrl).toBeTruthy();
+
+    const issuedState = await getIssuedState(app);
+    // Bruno appends a nonce — the issued state must be `userState + <32 hex>`, not the raw input.
+    expect(issuedState.startsWith(USER_STATE)).toBeTruthy();
+    expect(issuedState).not.toBe(USER_STATE);
+    expect(issuedState.slice(USER_STATE.length)).toMatch(/^[0-9a-f]{32}$/);
+
+    const authCode = await fetchAuthCodeFromTestbench(authUrl as string);
+    const callbackUrl = `${CALLBACK}?code=${authCode}&state=${encodeURIComponent(issuedState)}`;
+
+    await fireCallback(app, callbackUrl);
+
+    const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+    expect(receivedCallbackUrl).toBe(callbackUrl);
+
+    const { state: returnedState, code } = getCallbackParams(receivedCallbackUrl as string);
+    expect(returnedState).toBe(issuedState);
+    expect(code).toBe(authCode);
 
     await expect(page.getByText('Token fetched successfully!')).toBeVisible({ timeout: 15_000 });
   });

--- a/tests/auth/oauth2/oauth2-state-validation.spec.ts
+++ b/tests/auth/oauth2/oauth2-state-validation.spec.ts
@@ -46,9 +46,12 @@ const fetchAuthCodeFromTestbench = async (authorizationUrl: string): Promise<str
   const response = await fetch(authorizationUrl);
   expect(response.ok, 'testbench authorize should respond').toBeTruthy();
   const html = await response.text();
-  const match = html.match(/bruno:\/\/app\/oauth2\/callback\?code=([a-f0-9]+)/);
-  expect(match, 'authorize response should embed a callback code').toBeTruthy();
-  return match![1];
+  const callbackMatch = html.match(/bruno:\/\/app\/oauth2\/callback\?[^\s"'`<]+/);
+  expect(callbackMatch, 'authorize response should embed a callback url').toBeTruthy();
+  const callbackUrl = new URL(callbackMatch![0]);
+  const code = callbackUrl.searchParams.get('code');
+  expect(code, 'authorize response should embed a callback code').toBeTruthy();
+  return code as string;
 };
 
 /** Fire a deep-link callback through the real protocol handler (cross-platform path). */
@@ -65,21 +68,12 @@ const installCallbackCapture = (app: ElectronApplication) =>
   app.evaluate(({ app: electronApp }) => {
     (globalThis as any).__brunoCapturedCallbackUrl = null;
 
-    const listeners = electronApp.listeners('second-instance') as Array<
-      (event: unknown, commandLine: string[]) => void
-    >;
-
-    electronApp.removeAllListeners('second-instance');
-
-    for (const listener of listeners) {
-      electronApp.on('second-instance', (event, commandLine) => {
-        const url = commandLine?.find((arg) => arg?.startsWith('bruno://'));
-        if (url) {
-          (globalThis as any).__brunoCapturedCallbackUrl = url;
-        }
-        listener.call(electronApp, event, commandLine);
-      });
-    }
+    electronApp.prependListener('second-instance', (_event, commandLine) => {
+      const url = commandLine?.find((arg) => arg?.startsWith('bruno://'));
+      if (url) {
+        (globalThis as any).__brunoCapturedCallbackUrl = url;
+      }
+    });
   });
 
 const getCapturedCallbackUrl = (app: ElectronApplication): Promise<string | null> =>


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth2 sign-in now validates callback state values to better protect authorization flows.
  * User-supplied state is now preserved alongside a generated secure state value.

* **Bug Fixes**
  * OAuth2 errors now appear in the response pane as well as in toast messages, making failures easier to see and debug.
  * Authorization responses now handle state mismatches more reliably across browser and in-app flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->