### PR TITLE
(size/L)feat:Added the option for bruno version edit in the collection overview

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/StyledWrapper.js
@@ -39,6 +39,15 @@ const StyledWrapper = styled.div`
       }
     }
 
+    &.version {
+      background-color: ${(props) => rgba(props.theme.colors.text.yellow, 0.1)};
+      border: 1px solid ${(props) => rgba(props.theme.colors.text.yellow, 0.1)};
+
+      svg {
+        color: ${(props) => props.theme.colors.text.yellow};
+      }
+    }
+
     &.generate-docs {
       background-color: ${(props) => rgba(props.theme.accents.primary, 0.08)};
       border: 1px solid ${(props) => rgba(props.theme.accents.primary, 0.09)};

--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
@@ -59,7 +59,7 @@ const Info = ({ collection }) => {
                 {collectionVersion
                   ? <span className="text-muted" data-testid="info-version-value">{collectionVersion}</span>
                   : <span className="text-muted italic" data-testid="info-version-value">Not Set</span>}
-                <span className="group-hover:underline text-link" data-testid="info-version-change">Change</span>
+                <span className="group-hover:underline text-link" data-testid="info-version-change">change</span>
               </div>
             </div>
           </div>

--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { getTotalRequestCountInCollection } from 'utils/collections/';
-import { IconFolder, IconWorld, IconApi, IconShare, IconBook } from '@tabler/icons';
-import { areItemsLoading, getItemsLoadStats } from 'utils/collections/index';
+import { IconFolder, IconWorld, IconApi, IconShare, IconBook, IconTag } from '@tabler/icons';
+import { areItemsLoading, getItemsLoadStats, getCollectionVersion } from 'utils/collections/index';
 import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import ShareCollection from 'components/ShareCollection/index';
 import GenerateDocumentation from 'components/Sidebar/Collections/Collection/GenerateDocumentation';
+import ChangeCollectionVersion from 'components/Sidebar/Collections/Collection/ChangeCollectionVersion';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import StyledWrapper from './StyledWrapper';
 import Migration from '../Migration';
@@ -18,6 +19,9 @@ const Info = ({ collection }) => {
   const { loading: itemsLoadingCount, total: totalItems } = getItemsLoadStats(collection);
   const [showShareCollectionModal, toggleShowShareCollectionModal] = useState(false);
   const [showGenerateDocumentationModal, setShowGenerateDocumentationModal] = useState(false);
+  const [showChangeVersionModal, setShowChangeVersionModal] = useState(false);
+
+  const collectionVersion = getCollectionVersion(collection);
 
   const globalEnvironments = useSelector((state) => state.globalEnvironments.globalEnvironments);
 
@@ -44,6 +48,22 @@ const Info = ({ collection }) => {
               </div>
             </div>
           </div>
+
+          <div className="flex items-start group cursor-pointer" onClick={() => setShowChangeVersionModal(true)} data-testid="info-version-row">
+            <div className="icon-box version flex-shrink-0 p-3 rounded-lg">
+              <IconTag className="w-5 h-5" stroke={1.5} />
+            </div>
+            <div className="ml-4 h-full flex flex-col justify-start">
+              <div className="font-medium h-fit my-auto">Version</div>
+              <div className="flex items-center gap-2">
+                {collectionVersion
+                  ? <span className="text-muted" data-testid="info-version-value">{collectionVersion}</span>
+                  : <span className="text-muted italic" data-testid="info-version-value">Not Set</span>}
+                <span className="group-hover:underline text-link" data-testid="info-version-change">Change</span>
+              </div>
+            </div>
+          </div>
+          {showChangeVersionModal && <ChangeCollectionVersion collectionUid={collection.uid} onClose={() => setShowChangeVersionModal(false)} />}
 
           {/* Environments Row */}
           <div className="flex items-start">

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/StyledWrapper.js
@@ -8,7 +8,7 @@ export const ModalTitle = styled.div`
 `;
 
 const StyledWrapper = styled.div`
-  width: 100%;
+  max-width: 100%;
   .subheader {
     margin-bottom: 0.5rem;
     color: ${(props) => props.theme.colors.text.muted};
@@ -55,6 +55,7 @@ const StyledWrapper = styled.div`
       font-weight: 400;
       font-size: ${(props) => props.theme.font.size.sm};
       line-height: 20px;
+      overflow-wrap: anywhere;
 
       .unset {
         font-family: inherit;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/StyledWrapper.js
@@ -1,0 +1,145 @@
+import styled from 'styled-components';
+
+export const ModalTitle = styled.div`
+  color: ${(props) => props.theme.colors.text.subtext2};
+  font-weight: 600;
+  font-size: ${(props) => props.theme.font.size.base};
+  line-height: 18px;
+`;
+
+const StyledWrapper = styled.div`
+  width: 100%;
+  .subheader {
+    margin-bottom: 0.5rem;
+    color: ${(props) => props.theme.colors.text.muted};
+    font-weight: 400;
+    font-size: ${(props) => props.theme.font.size.base};
+    line-height: 18px;
+
+    .collection-name {
+      color: ${(props) => props.theme.text};
+      font-weight: 600;
+    }
+  }
+
+  .version-card {
+    width: 100%;
+    border: 1px solid ${(props) => props.theme.border.border1};
+    border-radius: ${(props) => props.theme.border.radius.md};
+    overflow: hidden;
+
+    .version-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 1rem;
+      padding: 1rem;
+    }
+
+    .version-col {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .col-label {
+      color: ${(props) => props.theme.text};
+      font-weight: 500;
+      font-size: ${(props) => props.theme.font.size.base};
+      line-height: 20px;
+    }
+
+    .current-value {
+      color: ${(props) => props.theme.text};
+      font-weight: 400;
+      font-size: ${(props) => props.theme.font.size.sm};
+      line-height: 20px;
+
+      .unset {
+        font-family: inherit;
+        font-style: italic;
+      }
+    }
+
+    .arrow {
+      align-self: center;
+      color: ${(props) => props.theme.colors.text.muted};
+      flex-shrink: 0;
+    }
+
+    .input-wrap {
+      position: relative;
+
+      .textbox {
+        padding-right: 2.25rem;
+        color: ${(props) => props.theme.text};
+        font-weight: 400;
+        font-size: ${(props) => props.theme.font.size.sm};
+        line-height: 20px;
+      }
+
+      .copy-btn {
+        position: absolute;
+        top: 50%;
+        right: 0.5rem;
+        transform: translateY(-50%);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.25rem;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        color: ${(props) => props.theme.colors.text.muted};
+
+        &:hover:not(:disabled) {
+          color: ${(props) => props.theme.text};
+        }
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: default;
+        }
+      }
+    }
+  }
+
+  .preview {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0.625rem 1rem;
+    border-top: 1px solid ${(props) => props.theme.border.border1};
+    background-color: ${(props) => props.theme.background.mantle};
+    color: ${(props) => props.theme.text};
+    font-weight: 400;
+    font-size: ${(props) => props.theme.font.size.sm};
+    line-height: 20px;
+
+    strong {
+      font-weight: 700;
+    }
+
+    .old {
+      color: ${(props) => props.theme.colors.text.danger};
+      font-weight: 700;
+      word-break: break-all;
+    }
+
+    .new {
+      font-family: monospace;
+      color: ${(props) => props.theme.colors.text.green};
+      font-weight: 700;
+      word-break: break-all;
+    }
+
+    .preview-arrow {
+      color: ${(props) => props.theme.colors.text.muted};
+      flex-shrink: 0;
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
@@ -1,0 +1,141 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { IconArrowRight, IconCopy, IconCheck, IconAlertTriangle } from '@tabler/icons';
+
+import Modal from 'components/Modal';
+import Portal from 'components/Portal';
+import { findCollectionByUid, getCollectionVersion, isOpenCollectionFormat } from 'utils/collections/index';
+import { saveCollectionVersion } from 'providers/ReduxStore/slices/collections/actions';
+import StyledWrapper, { ModalTitle } from './StyledWrapper';
+
+const CollectionNotFound = ({ onClose }) => (
+  <Portal>
+    <Modal size="sm" title="Change Collection Version" confirmText="Close" handleConfirm={onClose} hideCancel>
+      <StyledWrapper className="w-[480px]">
+        <div className="flex items-center gap-2 text-warning">
+          <IconAlertTriangle size={16} className="shrink-0" />
+          <span>Collection not found. It may have been deleted or is no longer available.</span>
+        </div>
+      </StyledWrapper>
+    </Modal>
+  </Portal>
+);
+
+const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
+  const dispatch = useDispatch();
+  const inputRef = useRef(null);
+  const collection = useSelector((state) => findCollectionByUid(state.collections.collections, collectionUid));
+
+  const currentVersion = getCollectionVersion(collection);
+  const isYml = isOpenCollectionFormat(collection);
+  const targetKey = isYml ? 'info.version' : 'collectionVersion';
+  const targetFile = isYml ? 'opencollection.yml' : 'bruno.json';
+  const [newVersion, setNewVersion] = useState(currentVersion);
+  const [isSaving, setIsSaving] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, []);
+
+  const trimmedVersion = newVersion.trim();
+  const canSubmit = useMemo(
+    () => trimmedVersion.length > 0 && trimmedVersion !== currentVersion,
+    [trimmedVersion, currentVersion]
+  );
+
+  const handleConfirm = () => {
+    if (!canSubmit || isSaving) return;
+    setIsSaving(true);
+    dispatch(saveCollectionVersion(collectionUid, trimmedVersion))
+      .then(() => onClose())
+      .catch(() => setIsSaving(false));
+  };
+
+  const handleCopy = () => {
+    if (!trimmedVersion) return;
+    navigator.clipboard?.writeText(trimmedVersion);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  if (!collection) {
+    return <CollectionNotFound onClose={onClose} />;
+  }
+
+  return (
+    <Portal>
+      <Modal
+        size="md"
+        title="Change Collection Version"
+        customHeader={<ModalTitle>Change Collection Version</ModalTitle>}
+        confirmText={isSaving ? 'Updating...' : 'Update Version'}
+        cancelText="Cancel"
+        handleConfirm={handleConfirm}
+        handleCancel={onClose}
+        confirmDisabled={!canSubmit || isSaving}
+        dataTestId="change-version"
+      >
+        <StyledWrapper className="w-[560px]">
+          <div className="subheader" data-testid="change-version-collection">
+            Collection: <span className="collection-name">{collection.name}</span>
+          </div>
+
+          <div className="version-card">
+            <div className="version-row">
+              <div className="version-col">
+                <div className="col-label">Current Version</div>
+                <div className="current-value" data-testid="change-version-current">
+                  {currentVersion || <span className="unset">Not Set</span>}
+                </div>
+              </div>
+
+              <IconArrowRight size={18} className="arrow" stroke={1.5} />
+
+              <div className="version-col">
+                <div className="col-label">New Version</div>
+                <div className="input-wrap">
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    className="textbox w-full"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck="false"
+                    placeholder="e.g. 1.0.0"
+                    value={newVersion}
+                    onChange={(e) => setNewVersion(e.target.value)}
+                    data-testid="change-version-input"
+                  />
+                  <button
+                    type="button"
+                    className="copy-btn"
+                    aria-label={copied ? 'Copied' : 'Copy version'}
+                    onClick={handleCopy}
+                    disabled={!trimmedVersion}
+                    data-testid="change-version-copy"
+                  >
+                    {copied ? <IconCheck size={15} stroke={1.5} /> : <IconCopy size={15} stroke={1.5} />}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <p className="preview m-0" data-testid="change-version-preview">
+              Updates <strong>{targetKey}</strong> in {targetFile} from{' '}
+              <span className="old">{currentVersion || '(none)'}</span>
+              <IconArrowRight size={13} className="preview-arrow" stroke={1.5} />
+              <span className="new">{trimmedVersion || '…'}</span>
+            </p>
+          </div>
+        </StyledWrapper>
+      </Modal>
+    </Portal>
+  );
+};
+
+export default ChangeCollectionVersion;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
@@ -56,10 +56,12 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
   };
 
   const handleCopy = () => {
-    if (!trimmedVersion) return;
-    navigator.clipboard?.writeText(trimmedVersion);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    if (!trimmedVersion || !navigator.clipboard) return;
+    navigator.clipboard.writeText(trimmedVersion)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }).catch(() => {});
   };
 
   if (!collection) {
@@ -70,7 +72,6 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
     <Portal>
       <Modal
         size="md"
-        title="Change Collection Version"
         customHeader={<ModalTitle>Change Collection Version</ModalTitle>}
         confirmText={isSaving ? 'Updating...' : 'Update Version'}
         cancelText="Cancel"
@@ -106,7 +107,8 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
                     autoCorrect="off"
                     autoCapitalize="off"
                     spellCheck="false"
-                    placeholder="e.g. 1.0.0"
+                    placeholder="e.g. v1.0.0"
+                    maxLength={50}
                     value={newVersion}
                     onChange={(e) => setNewVersion(e.target.value)}
                     data-testid="change-version-input"

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.spec.js
@@ -1,0 +1,121 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+import ChangeCollectionVersion from './index';
+
+const mockSaveCollectionVersion = jest.fn();
+
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  saveCollectionVersion: (collectionUid, version) => {
+    mockSaveCollectionVersion(collectionUid, version);
+    return () => Promise.resolve();
+  }
+}));
+
+jest.mock('components/Portal', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>
+}));
+
+jest.mock('./StyledWrapper', () => ({
+  __esModule: true,
+  default: ({ children, className }) => <div className={className}>{children}</div>
+}));
+
+jest.mock('components/Modal', () => ({
+  __esModule: true,
+  default: (props) => (
+    <div data-testid="mock-modal">
+      <div data-testid="modal-title">{props.title}</div>
+      {props.children}
+      <button
+        data-testid="change-version-submit-btn"
+        disabled={props.confirmDisabled}
+        onClick={props.handleConfirm}
+      >
+        {props.confirmText}
+      </button>
+    </div>
+  )
+}));
+
+const buildCollection = (overrides = {}) => ({
+  uid: 'collection-1',
+  name: 'Bruno-Testbench',
+  pathname: '/tmp/bruno-testbench',
+  brunoConfig: { opencollection: '1.0.0', name: 'Bruno-Testbench', version: 'v1.0.0' },
+  ...overrides
+});
+
+const renderModal = (collection, onClose = jest.fn()) => {
+  const collections = collection ? [collection] : [];
+  const slice = createSlice({ name: 'collections', initialState: { collections }, reducers: {} });
+  const store = configureStore({ reducer: { collections: slice.reducer } });
+  const utils = render(
+    <Provider store={store}>
+      <ChangeCollectionVersion collectionUid="collection-1" onClose={onClose} />
+    </Provider>
+  );
+  return { ...utils, onClose };
+};
+
+beforeEach(() => {
+  mockSaveCollectionVersion.mockClear();
+});
+
+describe('ChangeCollectionVersion', () => {
+  it('lets you save only when the new version is different from the current one', () => {
+    renderModal(buildCollection());
+    const submit = screen.getByTestId('change-version-submit-btn');
+    const input = screen.getByTestId('change-version-input');
+
+    expect(submit).toBeDisabled();
+    fireEvent.change(input, { target: { value: '2' } });
+    expect(submit).toBeEnabled();
+    fireEvent.change(input, { target: { value: 'v1.0.0' } });
+    expect(submit).toBeDisabled();
+  });
+
+  it('does not let you save an empty or blank version', () => {
+    renderModal(buildCollection());
+    fireEvent.change(screen.getByTestId('change-version-input'), { target: { value: '   ' } });
+    expect(screen.getByTestId('change-version-submit-btn')).toBeDisabled();
+  });
+
+  it('removes extra spaces around the version before saving, then closes', async () => {
+    const { onClose } = renderModal(buildCollection());
+
+    fireEvent.change(screen.getByTestId('change-version-input'), { target: { value: '  2.0.0  ' } });
+    fireEvent.click(screen.getByTestId('change-version-submit-btn'));
+
+    expect(mockSaveCollectionVersion).toHaveBeenCalledWith('collection-1', '2.0.0');
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('for a bru collection, the preview mentions bruno.json and collectionVersion', () => {
+    renderModal(buildCollection({ brunoConfig: { version: '1', name: 'Legacy', type: 'collection' } }));
+    fireEvent.change(screen.getByTestId('change-version-input'), { target: { value: '2' } });
+
+    const preview = screen.getByTestId('change-version-preview');
+    expect(preview).toHaveTextContent('collectionVersion');
+    expect(preview).toHaveTextContent('bruno.json');
+    expect(preview).not.toHaveTextContent('info.version');
+  });
+
+  it('shows "1" for a yml collection that has no version yet', () => {
+    renderModal(buildCollection({ brunoConfig: { opencollection: '1.0.0', name: 'Bruno-Testbench' } }));
+
+    expect(screen.getByTestId('change-version-current')).toHaveTextContent('1');
+    expect(screen.getByTestId('change-version-input')).toHaveValue('1');
+  });
+
+  it('shows a "Collection not found" message when the collection is missing', () => {
+    renderModal(null);
+
+    expect(screen.getByTestId('modal-title')).toHaveTextContent('Change Collection Version');
+    expect(screen.getByText(/Collection not found/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('change-version-input')).not.toBeInTheDocument();
+  });
+});

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.spec.js
@@ -78,6 +78,11 @@ describe('ChangeCollectionVersion', () => {
     expect(submit).toBeDisabled();
   });
 
+  it('limits the version input at 50 characters', () => {
+    renderModal(buildCollection());
+    expect(screen.getByTestId('change-version-input')).toHaveAttribute('maxlength', '50');
+  });
+
   it('does not let you save an empty or blank version', () => {
     renderModal(buildCollection());
     fireEvent.change(screen.getByTestId('change-version-input'), { target: { value: '   ' } });

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.spec.js
@@ -109,11 +109,11 @@ describe('ChangeCollectionVersion', () => {
     expect(preview).not.toHaveTextContent('info.version');
   });
 
-  it('shows "1" for a yml collection that has no version yet', () => {
+  it('shows "Not Set" for a yml collection that has no version yet', () => {
     renderModal(buildCollection({ brunoConfig: { opencollection: '1.0.0', name: 'Bruno-Testbench' } }));
 
-    expect(screen.getByTestId('change-version-current')).toHaveTextContent('1');
-    expect(screen.getByTestId('change-version-input')).toHaveValue('1');
+    expect(screen.getByTestId('change-version-current')).toHaveTextContent('Not Set');
+    expect(screen.getByTestId('change-version-input')).toHaveValue('');
   });
 
   it('shows a "Collection not found" message when the collection is missing', () => {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.js
@@ -10,7 +10,9 @@ const CollectionVersionInfo = ({ name, version, folderCount = 0, requestCount = 
         <span className="collection-name" data-testid="collection-name">{name}</span>
         {version ? (
           <span className="version-value" data-testid="version-value">{`Version: ${version}`}</span>
-        ) : null}
+        ) : (
+          <span className="version-value unset" data-testid="version-value">Not Set</span>
+        )}
       </div>
       <p className="version-summary" data-testid="version-summary">
         <span>{`${folderCount} ${folderLabel}`}</span>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.js
@@ -8,11 +8,7 @@ const CollectionVersionInfo = ({ name, version, folderCount = 0, requestCount = 
     <div className="version-info" data-testid="version-info">
       <div className="version-line">
         <span className="collection-name" data-testid="collection-name">{name}</span>
-        {version ? (
-          <span className="version-value" data-testid="version-value">{`Version: ${version}`}</span>
-        ) : (
-          <span className="version-value unset" data-testid="version-value">Not Set</span>
-        )}
+        <span className="version-value" data-testid="version-value">{`Version: ${version || 'Not Set'}`}</span>
       </div>
       <p className="version-summary" data-testid="version-summary">
         <span>{`${folderCount} ${folderLabel}`}</span>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/CollectionVersionInfo/index.spec.js
@@ -14,9 +14,9 @@ describe('CollectionVersionInfo', () => {
     expect(screen.getByTestId('version-value')).toHaveTextContent('Version: 2.3-beta');
   });
 
-  it('omits the version when the collection has none', () => {
+  it('shows "Not Set" when the collection has no version', () => {
     render(<CollectionVersionInfo name="API" />);
-    expect(screen.queryByTestId('version-value')).not.toBeInTheDocument();
+    expect(screen.getByTestId('version-value')).toHaveTextContent('Not Set');
   });
 
   it('renders folder and request counts and pluralizes them', () => {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
@@ -44,6 +44,10 @@ const StyledWrapper = styled.div`
           white-space: nowrap;
         }
 
+        .version-value.unset {
+          font-style: italic;
+        }
+
         .version-summary {
           display: flex;
           align-items: center;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -13,7 +13,7 @@ import StyledWrapper from './StyledWrapper';
 import CollectionVersionInfo from './CollectionVersionInfo';
 import EnvironmentSelectionList from './EnvironmentSelectionList';
 import { useApp } from 'providers/App';
-import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsLoading, sortItemsBySidebarOrder, getCollectionItemCounts } from 'utils/collections/index';
+import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsLoading, sortItemsBySidebarOrder, getCollectionItemCounts, getCollectionVersion } from 'utils/collections/index';
 import { brunoToOpenCollection } from '@usebruno/converters';
 import { sanitizeName } from 'utils/common/regex';
 import { escapeHtml } from 'utils/response';
@@ -76,8 +76,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
     [collection]
   );
 
-  // The collection's current version (read-only here); formatted for display below.
-  const currentVersion = collection?.version;
+  const currentVersion = getCollectionVersion(collection);
 
   // Folder + request counts, computed from the collection tree (recursively).
   const { folderCount, requestCount } = useMemo(

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -325,13 +325,11 @@ export const saveCollectionVersion = (collectionUid, version) => (dispatch, getS
 
     const updatedVersion = typeof version === 'string' ? version.trim() : '';
 
-    const isYml = Boolean(collection.brunoConfig?.opencollection);
-    const versionKey = isYml ? 'version' : 'collectionVersion';
     const brunoConfigToSave = { ...(collection.brunoConfig || {}) };
     if (updatedVersion) {
-      brunoConfigToSave[versionKey] = updatedVersion;
+      brunoConfigToSave.version = updatedVersion;
     } else {
-      delete brunoConfigToSave[versionKey];
+      delete brunoConfigToSave.version;
     }
 
     const { ipcRenderer } = window;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -44,6 +44,7 @@ import {
   responseReceived,
   updateLastAction,
   setCollectionSecurityConfig,
+  updateCollectionVersion as _updateCollectionVersion,
   collectionAddOauth2CredentialsByUrl,
   collectionClearOauth2CredentialsByUrlAndCredentialsId,
   initRunRequestEvent,
@@ -308,6 +309,42 @@ export const saveCollectionRoot = (collectionUid) => (dispatch, getState) => {
       .then(resolve)
       .catch((err) => {
         toast.error('Failed to save collection settings!');
+        reject(err);
+      });
+  });
+};
+
+export const saveCollectionVersion = (collectionUid, version) => (dispatch, getState) => {
+  const state = getState();
+  const collection = findCollectionByUid(state.collections.collections, collectionUid);
+
+  return new Promise((resolve, reject) => {
+    if (!collection) {
+      return reject(new Error('Collection not found'));
+    }
+
+    const updatedVersion = typeof version === 'string' ? version.trim() : '';
+
+    const isYml = Boolean(collection.brunoConfig?.opencollection);
+    const versionKey = isYml ? 'version' : 'collectionVersion';
+    const brunoConfigToSave = { ...(collection.brunoConfig || {}) };
+    if (updatedVersion) {
+      brunoConfigToSave[versionKey] = updatedVersion;
+    } else {
+      delete brunoConfigToSave[versionKey];
+    }
+
+    const { ipcRenderer } = window;
+
+    ipcRenderer
+      .invoke('renderer:update-bruno-config', brunoConfigToSave, collection.pathname, collection.root)
+      .then(() => {
+        dispatch(_updateCollectionVersion({ collectionUid, version: updatedVersion }));
+        toast.success('Collection version updated');
+      })
+      .then(resolve)
+      .catch((err) => {
+        toast.error('Failed to update collection version');
         reject(err);
       });
   });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -287,6 +287,25 @@ export const collectionsSlice = createSlice({
         collection.securityConfig = action.payload.securityConfig;
       }
     },
+    updateCollectionVersion: (state, action) => {
+      const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
+      if (collection) {
+        const version = action.payload.version;
+        const versionKey = collection.brunoConfig?.opencollection ? 'version' : 'collectionVersion';
+        const applyVersion = (target) => {
+          if (!target) return;
+          if (version) {
+            target[versionKey] = version;
+          } else {
+            delete target[versionKey];
+          }
+        };
+        collection.brunoConfig = collection.brunoConfig || {};
+        applyVersion(collection.brunoConfig);
+        // Keep any unsaved brunoConfig draft in sync so a later settings-save can't wipe it.
+        applyVersion(collection.draft?.brunoConfig);
+      }
+    },
     brunoConfigUpdateEvent: (state, action) => {
       const { collectionUid, brunoConfig } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
@@ -3046,7 +3065,7 @@ export const collectionsSlice = createSlice({
               // Persist the selection to the UI state snapshot
               const { ipcRenderer } = window;
               if (ipcRenderer) {
-                const extension = collection?.brunoConfig?.version === '1' ? 'bru' : 'yml';
+                const extension = collection?.brunoConfig?.opencollection ? 'yml' : 'bru';
                 const environmentPath = environment?.pathname
                   || (environment?.name && collection?.pathname
                     ? path.join(collection.pathname, 'environments', `${environment.name}.${extension}`)
@@ -3889,6 +3908,7 @@ export const {
   updateCollectionLoadingState,
   collectionLoadedFromTree,
   setCollectionSecurityConfig,
+  updateCollectionVersion,
   brunoConfigUpdateEvent,
   renameCollection,
   removeCollection,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -291,13 +291,12 @@ export const collectionsSlice = createSlice({
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
       if (collection) {
         const version = action.payload.version;
-        const versionKey = collection.brunoConfig?.opencollection ? 'version' : 'collectionVersion';
         const applyVersion = (target) => {
           if (!target) return;
           if (version) {
-            target[versionKey] = version;
+            target.version = version;
           } else {
-            delete target[versionKey];
+            delete target.version;
           }
         };
         collection.brunoConfig = collection.brunoConfig || {};

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1258,17 +1258,7 @@ const getPathParams = (item) => {
 
 export const isOpenCollectionFormat = (collection) => Boolean(collection?.brunoConfig?.opencollection);
 
-export const getCollectionVersion = (collection) => {
-  const brunoConfig = collection?.brunoConfig;
-  if (!brunoConfig) return '';
-  if (isOpenCollectionFormat(collection)) {
-    // yml: the user version is info.version (brunoConfig.version). When the file has none,
-    // default to '1' (mirroring the schema version) so a yml collection always shows a version.
-    return brunoConfig.version || '1';
-  }
-  // bru: only the explicit collectionVersion; an existing bru collection without one shows "Not Set".
-  return brunoConfig.collectionVersion || '';
-};
+export const getCollectionVersion = (collection) => collection?.brunoConfig?.version || '';
 
 export const getTotalRequestCountInCollection = (collection) => {
   let count = 0;

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1256,6 +1256,20 @@ const getPathParams = (item) => {
   return pathParams;
 };
 
+export const isOpenCollectionFormat = (collection) => Boolean(collection?.brunoConfig?.opencollection);
+
+export const getCollectionVersion = (collection) => {
+  const brunoConfig = collection?.brunoConfig;
+  if (!brunoConfig) return '';
+  if (isOpenCollectionFormat(collection)) {
+    // yml: the user version is info.version (brunoConfig.version). When the file has none,
+    // default to '1' (mirroring the schema version) so a yml collection always shows a version.
+    return brunoConfig.version || '1';
+  }
+  // bru: only the explicit collectionVersion; an existing bru collection without one shows "Not Set".
+  return brunoConfig.collectionVersion || '';
+};
+
 export const getTotalRequestCountInCollection = (collection) => {
   let count = 0;
   each(collection.items, (item) => {

--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -93,7 +93,15 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
     }
   };
 
-  const config = toOpenCollectionConfig(collection.brunoConfig as BrunoConfig);
+  const brunoConfig = collection.brunoConfig as BrunoConfig | undefined;
+
+  const isOpenCollectionFormat = Boolean(brunoConfig?.opencollection);
+  const collectionVersion = isOpenCollectionFormat ? brunoConfig?.version : brunoConfig?.collectionVersion;
+  if (openCollection.info && collectionVersion != null && collectionVersion !== '') {
+    openCollection.info.version = String(collectionVersion);
+  }
+
+  const config = toOpenCollectionConfig(brunoConfig);
   if (config) {
     openCollection.config = config;
   }
@@ -150,11 +158,11 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
     presets?: BrunoPresets;
   } = {};
 
-  if ((collection.brunoConfig as BrunoConfig)?.ignore?.length) {
-    brunoExtension.ignore = (collection.brunoConfig as BrunoConfig).ignore;
+  if (brunoConfig?.ignore?.length) {
+    brunoExtension.ignore = brunoConfig.ignore;
   }
 
-  const presets = (collection.brunoConfig as BrunoConfig)?.presets;
+  const presets = brunoConfig?.presets;
   if (presets?.requestType || presets?.requestUrl) {
     brunoExtension.presets = {};
     if (presets.requestType) {

--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -88,8 +88,7 @@ const hasRequestDefaults = (root: BrunoCollectionRoot | undefined): boolean => {
 export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollection => {
   const brunoConfig = collection.brunoConfig as BrunoConfig | undefined;
 
-  const isOpenCollectionFormat = Boolean(brunoConfig?.opencollection);
-  const collectionVersion = isOpenCollectionFormat ? brunoConfig?.version : brunoConfig?.collectionVersion;
+  const collectionVersion = brunoConfig?.version;
   const hasCollectionVersion = collectionVersion != null && collectionVersion !== '';
 
   const openCollection: OpenCollection = {

--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -86,20 +86,19 @@ const hasRequestDefaults = (root: BrunoCollectionRoot | undefined): boolean => {
 };
 
 export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollection => {
-  const openCollection: OpenCollection = {
-    opencollection: '1.0.0',
-    info: {
-      name: collection.name || 'Untitled Collection'
-    }
-  };
-
   const brunoConfig = collection.brunoConfig as BrunoConfig | undefined;
 
   const isOpenCollectionFormat = Boolean(brunoConfig?.opencollection);
   const collectionVersion = isOpenCollectionFormat ? brunoConfig?.version : brunoConfig?.collectionVersion;
-  if (openCollection.info && collectionVersion != null && collectionVersion !== '') {
-    openCollection.info.version = String(collectionVersion);
-  }
+  const hasCollectionVersion = collectionVersion != null && collectionVersion !== '';
+
+  const openCollection: OpenCollection = {
+    opencollection: '1.0.0',
+    info: {
+      name: collection.name || 'Untitled Collection',
+      ...(hasCollectionVersion ? { version: String(collectionVersion) } : {})
+    }
+  };
 
   const config = toOpenCollectionConfig(brunoConfig);
   if (config) {

--- a/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
+++ b/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
@@ -17,14 +17,13 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
     : ['node_modules', '.git'];
 
   const brunoConfig: BrunoConfig = {
-    version: '1',
     name: oc.info?.name || 'Untitled Collection',
     type: 'collection',
     ignore: ignoreList
   };
 
   if (oc.info?.version != null && oc.info.version !== '') {
-    brunoConfig.collectionVersion = String(oc.info.version);
+    brunoConfig.version = String(oc.info.version);
   }
 
   if (brunoExtension?.presets?.requestType || brunoExtension?.presets?.requestUrl) {

--- a/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
+++ b/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
@@ -23,6 +23,10 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
     ignore: ignoreList
   };
 
+  if (oc.info?.version != null && oc.info.version !== '') {
+    brunoConfig.collectionVersion = String(oc.info.version);
+  }
+
   if (brunoExtension?.presets?.requestType || brunoExtension?.presets?.requestUrl) {
     brunoConfig.presets = {};
     if (brunoExtension.presets.requestType) {

--- a/packages/bruno-converters/src/opencollection/types.ts
+++ b/packages/bruno-converters/src/opencollection/types.ts
@@ -175,8 +175,6 @@ export interface BrunoPresets {
 
 export interface BrunoConfig {
   version?: string;
-  // bru only: the user-facing collection version (bruno.json key, sibling of the marker).
-  collectionVersion?: string;
   // present only for OpenCollection (yml) collections; its presence marks the format.
   opencollection?: string;
   name?: string;

--- a/packages/bruno-converters/src/opencollection/types.ts
+++ b/packages/bruno-converters/src/opencollection/types.ts
@@ -175,6 +175,10 @@ export interface BrunoPresets {
 
 export interface BrunoConfig {
   version?: string;
+  // bru only: the user-facing collection version (bruno.json key, sibling of the marker).
+  collectionVersion?: string;
+  // present only for OpenCollection (yml) collections; its presence marks the format.
+  opencollection?: string;
   name?: string;
   type?: string;
   ignore?: string[];

--- a/packages/bruno-converters/tests/opencollection/collection-version.spec.js
+++ b/packages/bruno-converters/tests/opencollection/collection-version.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from '@jest/globals';
+import { brunoToOpenCollection } from '../../src/opencollection/bruno-to-opencollection';
+import { openCollectionToBruno } from '../../src/opencollection/opencollection-to-bruno';
+
+describe('openCollectionToBruno (import): keeps the collection version', () => {
+  it('keeps the version as-is when importing', () => {
+    const { brunoConfig } = openCollectionToBruno({ opencollection: '1.0.0', info: { name: 'API', version: 'v2.3.4' } });
+    expect(brunoConfig.collectionVersion).toBe('v2.3.4');
+  });
+
+  it('turns a number version into text (2 becomes "2")', () => {
+    const { brunoConfig } = openCollectionToBruno({ opencollection: '1.0.0', info: { name: 'API', version: 2 } });
+    expect(brunoConfig.collectionVersion).toBe('2');
+  });
+
+  it('has no version when the imported file has none', () => {
+    const { brunoConfig } = openCollectionToBruno({ opencollection: '1.0.0', info: { name: 'API' } });
+    expect(brunoConfig.collectionVersion).toBeUndefined();
+  });
+});
+
+describe('brunoToOpenCollection (export): writes the collection version', () => {
+  it('uses the bru version (collectionVersion) for a bru collection', () => {
+    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: { version: '1', collectionVersion: 'v2.3.4' }, items: [] });
+    expect(oc.info.version).toBe('v2.3.4');
+  });
+
+  it('uses the yml version (info.version) for a yml collection', () => {
+    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: { opencollection: '1.0.0', version: 'v9.9' }, items: [] });
+    expect(oc.info.version).toBe('v9.9');
+  });
+
+  it('writes no version when the collection has none', () => {
+    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: {}, items: [] });
+    expect(oc.info.version).toBeUndefined();
+  });
+});
+
+describe('collection version: export then import keeps it the same', () => {
+  it('keeps the same version after exporting and importing again', () => {
+    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: { collectionVersion: '1.2.3-beta' }, items: [] });
+    const { brunoConfig } = openCollectionToBruno(oc);
+    expect(brunoConfig.collectionVersion).toBe('1.2.3-beta');
+  });
+});

--- a/packages/bruno-converters/tests/opencollection/collection-version.spec.js
+++ b/packages/bruno-converters/tests/opencollection/collection-version.spec.js
@@ -5,27 +5,27 @@ import { openCollectionToBruno } from '../../src/opencollection/opencollection-t
 describe('openCollectionToBruno (import): keeps the collection version', () => {
   it('keeps the version as-is when importing', () => {
     const { brunoConfig } = openCollectionToBruno({ opencollection: '1.0.0', info: { name: 'API', version: 'v2.3.4' } });
-    expect(brunoConfig.collectionVersion).toBe('v2.3.4');
+    expect(brunoConfig.version).toBe('v2.3.4');
   });
 
   it('turns a number version into text (2 becomes "2")', () => {
     const { brunoConfig } = openCollectionToBruno({ opencollection: '1.0.0', info: { name: 'API', version: 2 } });
-    expect(brunoConfig.collectionVersion).toBe('2');
+    expect(brunoConfig.version).toBe('2');
   });
 
   it('has no version when the imported file has none', () => {
     const { brunoConfig } = openCollectionToBruno({ opencollection: '1.0.0', info: { name: 'API' } });
-    expect(brunoConfig.collectionVersion).toBeUndefined();
+    expect(brunoConfig.version).toBeUndefined();
   });
 });
 
 describe('brunoToOpenCollection (export): writes the collection version', () => {
-  it('uses the bru version (collectionVersion) for a bru collection', () => {
-    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: { version: '1', collectionVersion: 'v2.3.4' }, items: [] });
+  it('uses the agnostic version for a bru collection', () => {
+    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: { version: 'v2.3.4' }, items: [] });
     expect(oc.info.version).toBe('v2.3.4');
   });
 
-  it('uses the yml version (info.version) for a yml collection', () => {
+  it('uses the agnostic version for a yml collection', () => {
     const oc = brunoToOpenCollection({ name: 'API', brunoConfig: { opencollection: '1.0.0', version: 'v9.9' }, items: [] });
     expect(oc.info.version).toBe('v9.9');
   });
@@ -38,8 +38,8 @@ describe('brunoToOpenCollection (export): writes the collection version', () => 
 
 describe('collection version: export then import keeps it the same', () => {
   it('keeps the same version after exporting and importing again', () => {
-    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: { collectionVersion: '1.2.3-beta' }, items: [] });
+    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: { version: '1.2.3-beta' }, items: [] });
     const { brunoConfig } = openCollectionToBruno(oc);
-    expect(brunoConfig.collectionVersion).toBe('1.2.3-beta');
+    expect(brunoConfig.version).toBe('1.2.3-beta');
   });
 });

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -19,11 +19,7 @@ const registerScratchCollectionPath = (scratchPath) => {
 const configSchema = Yup.object({
   name: Yup.string().max(256, 'name must be 256 characters or less').required('name is required'),
   type: Yup.string().oneOf(['collection']).required('type is required'),
-  version: Yup.string().when('opencollection', {
-    is: (opencollection) => Boolean(opencollection),
-    then: Yup.string().notRequired(),
-    otherwise: Yup.string().oneOf(['1']).notRequired()
-  }),
+  version: Yup.string().notRequired(),
   // For YAML format collections (opencollection)
   opencollection: Yup.string().notRequired(),
   collectionVersion: Yup.string().notRequired(),

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -22,7 +22,6 @@ const configSchema = Yup.object({
   version: Yup.string().notRequired(),
   // For YAML format collections (opencollection)
   opencollection: Yup.string().notRequired(),
-  collectionVersion: Yup.string().notRequired(),
   // OpenAPI sync configuration (array, one entry per synced spec)
   openapi: Yup.array().of(
     Yup.object({

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -19,10 +19,14 @@ const registerScratchCollectionPath = (scratchPath) => {
 const configSchema = Yup.object({
   name: Yup.string().max(256, 'name must be 256 characters or less').required('name is required'),
   type: Yup.string().oneOf(['collection']).required('type is required'),
-  // For BRU format collections
-  version: Yup.string().oneOf(['1']).notRequired(),
+  version: Yup.string().when('opencollection', {
+    is: (opencollection) => Boolean(opencollection),
+    then: Yup.string().notRequired(),
+    otherwise: Yup.string().oneOf(['1']).notRequired()
+  }),
   // For YAML format collections (opencollection)
   opencollection: Yup.string().notRequired(),
+  collectionVersion: Yup.string().notRequired(),
   // OpenAPI sync configuration (array, one entry per synced spec)
   openapi: Yup.array().of(
     Yup.object({

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -2224,7 +2224,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
       const brunoConfig = {
         opencollection: '1.0.0',
-        version: '1',
         name: 'Scratch',
         type: 'collection',
         ignore: ['node_modules', '.git']

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -203,6 +203,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         const uid = generateUidBasedOnHash(dirPath);
         let brunoConfig = {
           version: '1',
+          collectionVersion: '1',
           name: collectionName,
           type: 'collection',
           ignore: ['node_modules', '.git']
@@ -214,9 +215,9 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               name: collectionName
             }
           };
-          // For YAML collections, set opencollection instead of version
           brunoConfig = {
             opencollection: '1.0.0',
+            version: '1',
             name: collectionName,
             type: 'collection',
             ignore: ['node_modules', '.git']
@@ -313,7 +314,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       brunoConfig.filesCount = filesCount;
 
       mainWindow.webContents.send('main:collection-opened', dirPath, uid, brunoConfig);
-      ipcMain.emit('main:collection-opened', mainWindow, dirPath, uid);
+      ipcMain.emit('main:collection-opened', mainWindow, dirPath, uid, brunoConfig);
     }
   );
 
@@ -1386,10 +1387,15 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           if (!brunoConfig) {
             brunoConfig = {
               version: '1',
+              collectionVersion: '1',
               name: collection.name,
               type: 'collection',
               ignore: ['node_modules', '.git']
             };
+          } else if (!brunoConfig.collectionVersion) {
+            // Imports create new collection files; default the user-facing version when the
+            // source didn't carry one (a present version, e.g. OpenCollection info.version, is kept).
+            brunoConfig.collectionVersion = '1';
           }
           if (brunoConfig.proxy) {
             brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
@@ -1413,6 +1419,12 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
         if (format === 'yml') {
           brunoConfig.opencollection = '1.0.0';
+          // For yml the user-facing version is info.version (brunoConfig.version); map the
+          // neutral collectionVersion onto it and keep collectionVersion out of the yaml.
+          if (brunoConfig.collectionVersion) {
+            brunoConfig.version = brunoConfig.collectionVersion;
+          }
+          delete brunoConfig.collectionVersion;
           const collectionContent = await stringifyCollection(coll.root, brunoConfig, { format });
           await writeFile(path.join(collectionPath, 'opencollection.yml'), collectionContent);
         } else if (format === 'bru') {
@@ -1692,7 +1704,22 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         const content = await stringifyJson(transformedBrunoConfig);
         await writeFile(brunoConfigPath, content);
       } else if (format === 'yml') {
-        const content = await stringifyCollection(collectionRoot, transformedBrunoConfig, { format });
+        // opencollection.yml holds both config AND the collection root. If the caller
+        // didn't supply a root (e.g. a config-only update before the tree finished
+        // loading), recover it from disk so request defaults/docs/scripts aren't wiped.
+        let rootToWrite = collectionRoot;
+        if (!rootToWrite) {
+          const ocYmlPath = path.join(collectionPath, 'opencollection.yml');
+          if (fs.existsSync(ocYmlPath)) {
+            try {
+              const existing = fs.readFileSync(ocYmlPath, 'utf8');
+              rootToWrite = parseCollection(existing, { format }).collectionRoot;
+            } catch (e) {
+              rootToWrite = collectionRoot;
+            }
+          }
+        }
+        const content = await stringifyCollection(rootToWrite, transformedBrunoConfig, { format });
         await writeFile(path.join(collectionPath, 'opencollection.yml'), content);
       } else {
         throw new Error(`Invalid collection format: ${format}`);
@@ -2202,6 +2229,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
       const brunoConfig = {
         opencollection: '1.0.0',
+        version: '1',
         name: 'Scratch',
         type: 'collection',
         ignore: ['node_modules', '.git']
@@ -2587,7 +2615,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         }
 
         let collectionName = 'Imported Collection';
-        let brunoConfig = { name: collectionName, version: '1', type: 'collection', ignore: ['node_modules', '.git'] };
+        let brunoConfig = { name: collectionName, version: '1', collectionVersion: '1', type: 'collection', ignore: ['node_modules', '.git'] };
         if (fs.existsSync(openCollectionYmlPath)) {
           try {
             const content = fs.readFileSync(openCollectionYmlPath, 'utf8');
@@ -2667,8 +2695,13 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       }
 
       const ymlBrunoConfig = { ...brunoConfig };
-      delete ymlBrunoConfig.version;
+      delete ymlBrunoConfig.version; // drop the bru format marker
       ymlBrunoConfig.opencollection = '1.0.0';
+      // Carry the user-facing version: bru's collectionVersion becomes yml's info.version.
+      if (ymlBrunoConfig.collectionVersion) {
+        ymlBrunoConfig.version = ymlBrunoConfig.collectionVersion;
+      }
+      delete ymlBrunoConfig.collectionVersion;
 
       const ocYmlPath = path.join(collectionPathname, 'opencollection.yml');
       const ymlCollectionContent = stringifyCollection(collectionRoot, ymlBrunoConfig, { format: 'yml' });

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1420,8 +1420,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           const bruJsonConfig = { ...brunoConfig, version: '1' };
           if (brunoConfig.version) {
             bruJsonConfig.collectionVersion = brunoConfig.version;
-          } else {
-            delete bruJsonConfig.collectionVersion;
           }
           const stringifiedBrunoConfig = await stringifyJson(bruJsonConfig);
           await writeFile(path.join(collectionPath, 'bruno.json'), stringifiedBrunoConfig);

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -76,7 +76,7 @@ const { getProcessEnvVars } = require('../store/process-env');
 const { getOAuth2TokenUsingAuthorizationCode, getOAuth2TokenUsingClientCredentials, getOAuth2TokenUsingPasswordCredentials, getOAuth2TokenUsingImplicitGrant, refreshOauth2Token } = require('../utils/oauth2');
 const { getCertsAndProxyConfig } = require('./network/cert-utils');
 const collectionWatcher = require('../app/collection-watcher');
-const { transformBrunoConfigBeforeSave } = require('../utils/transformBrunoConfig');
+const { transformBrunoConfigBeforeSave, transformBrunoConfigAfterRead } = require('../utils/transformBrunoConfig');
 const { REQUEST_TYPES } = require('../utils/constants');
 const { cancelOAuth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress } = require('../utils/oauth2-protocol-handler');
 const { findUniqueFolderName } = require('../utils/collection-import');
@@ -203,7 +203,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         const uid = generateUidBasedOnHash(dirPath);
         let brunoConfig = {
           version: '1',
-          collectionVersion: '1',
           name: collectionName,
           type: 'collection',
           ignore: ['node_modules', '.git']
@@ -217,7 +216,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           };
           brunoConfig = {
             opencollection: '1.0.0',
-            version: '1',
             name: collectionName,
             type: 'collection',
             ignore: ['node_modules', '.git']
@@ -233,12 +231,15 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
         await writeFile(path.join(dirPath, '.gitignore'), DEFAULT_GITIGNORE);
 
-        const { size, filesCount } = await getCollectionStats(dirPath);
-        brunoConfig.size = size;
-        brunoConfig.filesCount = filesCount;
+        let persistedConfig = await getCollectionConfigFile(dirPath);
+        persistedConfig = await transformBrunoConfigAfterRead(persistedConfig, dirPath);
 
-        mainWindow.webContents.send('main:collection-opened', dirPath, uid, brunoConfig);
-        ipcMain.emit('main:collection-opened', mainWindow, dirPath, uid, brunoConfig);
+        const { size, filesCount } = await getCollectionStats(dirPath);
+        persistedConfig.size = size;
+        persistedConfig.filesCount = filesCount;
+
+        mainWindow.webContents.send('main:collection-opened', dirPath, uid, persistedConfig);
+        ipcMain.emit('main:collection-opened', mainWindow, dirPath, uid, persistedConfig);
       } catch (error) {
         return Promise.reject(error);
       }
@@ -1386,16 +1387,10 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
           if (!brunoConfig) {
             brunoConfig = {
-              version: '1',
-              collectionVersion: '1',
               name: collection.name,
               type: 'collection',
               ignore: ['node_modules', '.git']
             };
-          } else if (!brunoConfig.collectionVersion) {
-            // Imports create new collection files; default the user-facing version when the
-            // source didn't carry one (a present version, e.g. OpenCollection info.version, is kept).
-            brunoConfig.collectionVersion = '1';
           }
           if (brunoConfig.proxy) {
             brunoConfig.proxy = transformProxyConfig(brunoConfig.proxy);
@@ -1419,16 +1414,16 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
         if (format === 'yml') {
           brunoConfig.opencollection = '1.0.0';
-          // For yml the user-facing version is info.version (brunoConfig.version); map the
-          // neutral collectionVersion onto it and keep collectionVersion out of the yaml.
-          if (brunoConfig.collectionVersion) {
-            brunoConfig.version = brunoConfig.collectionVersion;
-          }
-          delete brunoConfig.collectionVersion;
           const collectionContent = await stringifyCollection(coll.root, brunoConfig, { format });
           await writeFile(path.join(collectionPath, 'opencollection.yml'), collectionContent);
         } else if (format === 'bru') {
-          const stringifiedBrunoConfig = await stringifyJson(brunoConfig);
+          const bruJsonConfig = { ...brunoConfig, version: '1' };
+          if (brunoConfig.version) {
+            bruJsonConfig.collectionVersion = brunoConfig.version;
+          } else {
+            delete bruJsonConfig.collectionVersion;
+          }
+          const stringifiedBrunoConfig = await stringifyJson(bruJsonConfig);
           await writeFile(path.join(collectionPath, 'bruno.json'), stringifiedBrunoConfig);
 
           const collectionContent = await stringifyCollection(coll.root, brunoConfig, { format });
@@ -2615,7 +2610,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         }
 
         let collectionName = 'Imported Collection';
-        let brunoConfig = { name: collectionName, version: '1', collectionVersion: '1', type: 'collection', ignore: ['node_modules', '.git'] };
+        let brunoConfig = { name: collectionName, version: '1', type: 'collection', ignore: ['node_modules', '.git'] };
         if (fs.existsSync(openCollectionYmlPath)) {
           try {
             const content = fs.readFileSync(openCollectionYmlPath, 'utf8');
@@ -2651,6 +2646,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         }
 
         const uid = generateUidBasedOnHash(finalCollectionPath);
+        brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, finalCollectionPath);
         const { size, filesCount } = await getCollectionStats(finalCollectionPath);
         brunoConfig.size = size;
         brunoConfig.filesCount = filesCount;

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -87,14 +87,10 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
 
     if (!brunoConfig) {
       brunoConfig = {
-        version: '1',
-        collectionVersion: '1',
         name: collection.name,
         type: 'collection',
         ignore: ['node_modules', '.git']
       };
-    } else if (!brunoConfig.collectionVersion) {
-      brunoConfig.collectionVersion = '1';
     }
 
     if (brunoConfig.proxy) {
@@ -110,14 +106,17 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
   let brunoConfig = getBrunoJsonConfig(collection);
 
   if (format === 'yml') {
-    if (brunoConfig.collectionVersion) {
-      brunoConfig.version = brunoConfig.collectionVersion;
-    }
-    delete brunoConfig.collectionVersion;
+    brunoConfig.opencollection = '1.0.0';
     const collectionContent = await stringifyCollection(collection.root, brunoConfig, { format });
     await writeFile(path.join(collectionPath, 'opencollection.yml'), collectionContent);
   } else if (format === 'bru') {
-    const stringifiedBrunoConfig = await stringifyJson(brunoConfig);
+    const bruJsonConfig = { ...brunoConfig, version: '1' };
+    if (brunoConfig.version) {
+      bruJsonConfig.collectionVersion = brunoConfig.version;
+    } else {
+      delete bruJsonConfig.collectionVersion;
+    }
+    const stringifiedBrunoConfig = await stringifyJson(bruJsonConfig);
     await writeFile(path.join(collectionPath, 'bruno.json'), stringifiedBrunoConfig);
 
     const collectionContent = await stringifyCollection(collection.root, brunoConfig, { format });

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -88,10 +88,13 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
     if (!brunoConfig) {
       brunoConfig = {
         version: '1',
+        collectionVersion: '1',
         name: collection.name,
         type: 'collection',
         ignore: ['node_modules', '.git']
       };
+    } else if (!brunoConfig.collectionVersion) {
+      brunoConfig.collectionVersion = '1';
     }
 
     if (brunoConfig.proxy) {
@@ -107,6 +110,10 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
   let brunoConfig = getBrunoJsonConfig(collection);
 
   if (format === 'yml') {
+    if (brunoConfig.collectionVersion) {
+      brunoConfig.version = brunoConfig.collectionVersion;
+    }
+    delete brunoConfig.collectionVersion;
     const collectionContent = await stringifyCollection(collection.root, brunoConfig, { format });
     await writeFile(path.join(collectionPath, 'opencollection.yml'), collectionContent);
   } else if (format === 'bru') {

--- a/packages/bruno-electron/src/utils/transformBrunoConfig.js
+++ b/packages/bruno-electron/src/utils/transformBrunoConfig.js
@@ -3,6 +3,16 @@ const { isFile, isDirectory } = require('./filesystem');
 const { transformProxyConfig } = require('@usebruno/requests');
 
 function transformBrunoConfigBeforeSave(brunoConfig) {
+  if (brunoConfig && !brunoConfig.opencollection) {
+    const userVersion = brunoConfig.version;
+    brunoConfig.version = '1'; // bru schema marker
+    if (userVersion) {
+      brunoConfig.collectionVersion = userVersion;
+    } else {
+      delete brunoConfig.collectionVersion;
+    }
+  }
+
   // remove exists from importPaths and protoFiles
   if (brunoConfig.protobuf?.importPaths) {
     brunoConfig.protobuf.importPaths = brunoConfig.protobuf.importPaths.map((importPath) => {
@@ -33,6 +43,15 @@ function transformBrunoConfigBeforeSave(brunoConfig) {
 }
 
 async function transformBrunoConfigAfterRead(brunoConfig, collectionPathname) {
+  if (brunoConfig && !brunoConfig.opencollection) {
+    if (brunoConfig.collectionVersion) {
+      brunoConfig.version = brunoConfig.collectionVersion;
+    } else {
+      delete brunoConfig.version;
+    }
+    delete brunoConfig.collectionVersion;
+  }
+
   // add exists to importPaths and protoFiles by checking actual file/directory existence
   if (brunoConfig.protobuf?.importPaths) {
     brunoConfig.protobuf.importPaths = await Promise.all(brunoConfig.protobuf.importPaths.map(async (importPath) => {

--- a/packages/bruno-filestore/src/formats/yml/parseCollection.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseCollection.spec.ts
@@ -51,3 +51,20 @@ request:
     expect(reqVars[5]).toMatchObject({ name: 'cfg', value: 'not-json', dataType: 'object' });
   });
 });
+
+describe('parseCollection — reading the collection version', () => {
+  it('reads the version from the file as text', () => {
+    const { brunoConfig } = parseCollection('opencollection: "1.0.0"\ninfo:\n  name: c\n  version: v1.0.0\n');
+    expect(brunoConfig.version).toBe('v1.0.0');
+  });
+
+  it('turns a number version into text (2 becomes "2")', () => {
+    const { brunoConfig } = parseCollection('opencollection: "1.0.0"\ninfo:\n  name: c\n  version: 2\n');
+    expect(brunoConfig.version).toBe('2');
+  });
+
+  it('has no version when the file does not have one', () => {
+    const { brunoConfig } = parseCollection('opencollection: "1.0.0"\ninfo:\n  name: c\n');
+    expect(brunoConfig.version).toBeUndefined();
+  });
+});

--- a/packages/bruno-filestore/src/formats/yml/parseCollection.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseCollection.ts
@@ -26,6 +26,10 @@ const parseCollection = (ymlString: string): ParsedCollection => {
       ignore: []
     };
 
+    if (oc.info?.version != null && oc.info.version !== '') {
+      brunoConfig.version = ensureString(oc.info.version, '');
+    }
+
     const brunoExtension = (oc.extensions as any)?.bruno;
     if (brunoExtension?.ignore && Array.isArray(brunoExtension.ignore)) {
       brunoConfig.ignore = brunoExtension.ignore;

--- a/packages/bruno-filestore/src/formats/yml/stringifyCollection.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyCollection.spec.ts
@@ -47,3 +47,31 @@ describe('stringifyCollection — typed request.variables', () => {
     expect(reqVars[4].dataType).toBeUndefined();
   });
 });
+
+describe('stringifyCollection — writing the collection version', () => {
+  const baseRoot = {
+    meta: null,
+    request: { headers: [], auth: { mode: 'none' }, script: { req: null, res: null }, tests: null, vars: { req: [], res: [] } },
+    docs: null
+  } as any;
+
+  it('writes the version as-is and reads back the same value', () => {
+    const yml = stringifyCollection(baseRoot, { name: 'c', version: '2' });
+    expect(yml).toMatch(/version:\s*['"]?2['"]?/);
+    expect(parseCollection(yml).brunoConfig.version).toBe('2');
+  });
+
+  it('writes no version when the collection has none', () => {
+    const yml = stringifyCollection(baseRoot, { name: 'c' });
+    expect(parseCollection(yml).brunoConfig.version).toBeUndefined();
+  });
+
+  it('accepts any version text — there is no check on the format', () => {
+    // The version is free-form: users can set whatever they like. Each of these should be
+    // saved and read back exactly the same, without changing the format or rejecting it.
+    ['v1.0.0', '2', '1.2.3-beta', '2024.01.15', 'release-2024-Q3', 'anything-goes'].forEach((version) => {
+      const yml = stringifyCollection(baseRoot, { name: 'c', version });
+      expect(parseCollection(yml).brunoConfig.version).toBe(version);
+    });
+  });
+});

--- a/packages/bruno-filestore/src/formats/yml/stringifyCollection.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyCollection.ts
@@ -73,6 +73,10 @@ const stringifyCollection = (collectionRoot: any, brunoConfig: any): string => {
       name: brunoConfig.name || 'Untitled Collection'
     };
 
+    if (brunoConfig.version != null && brunoConfig.version !== '') {
+      oc.info.version = String(brunoConfig.version);
+    }
+
     // collection config
     if (hasCollectionConfig(brunoConfig)) {
       oc.config = {};

--- a/tests/collection/change-version-bru/change-version-bru.spec.ts
+++ b/tests/collection/change-version-bru/change-version-bru.spec.ts
@@ -47,4 +47,17 @@ test.describe('Change Collection Version (bru collection)', () => {
         .toMatchObject({ version: '1', collectionVersion: 'v2.3.4' });
     });
   });
+
+  test('limits the version input at 50 characters', async ({ pageWithUserData: page }) => {
+    await openCollectionSettings(page, COLLECTION_NAME);
+    await selectCollectionPaneTab(page, 'overview');
+    await page.getByTestId('info-version-change').click();
+
+    const input = page.getByTestId('change-version-input');
+    await expect(input).toHaveAttribute('maxlength', '50');
+
+    await input.fill('');
+    await input.pressSequentially('9'.repeat(55));
+    await expect(input).toHaveValue('9'.repeat(50));
+  });
 });

--- a/tests/collection/change-version-bru/change-version-bru.spec.ts
+++ b/tests/collection/change-version-bru/change-version-bru.spec.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, openCollectionSettings, selectCollectionPaneTab } from '../../utils/page';
+
+const COLLECTION_NAME = 'BruVersionTest';
+
+test.describe('Change Collection Version (bru collection)', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('a bru collection with no version shows "Not Set", and saving writes it to bruno.json', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    const collectionPath = collectionFixturePath!;
+    const brunoJsonPath = path.join(collectionPath, 'bruno.json');
+
+    await test.step('the collection has no version yet (only the internal "1" marker)', async () => {
+      const config = JSON.parse(fs.readFileSync(brunoJsonPath, 'utf-8'));
+      expect(config.collectionVersion).toBeUndefined();
+      expect(config.version).toBe('1'); // the format marker is untouched
+    });
+
+    await test.step('the overview shows the version as "Not Set"', async () => {
+      await openCollectionSettings(page, COLLECTION_NAME);
+      await selectCollectionPaneTab(page, 'overview');
+      await expect(page.getByTestId('info-version-value')).toHaveText('Not Set');
+    });
+
+    await test.step('a new version can be set in the popup', async () => {
+      await page.getByTestId('info-version-change').click();
+      await expect(page.getByTestId('change-version-current')).toHaveText('Not Set');
+      await expect(page.getByTestId('change-version-input')).toHaveValue('');
+
+      await page.getByTestId('change-version-input').fill('v2.3.4');
+      await page.getByTestId('change-version-submit-btn').click();
+      await expect(page.getByText('Collection version updated')).toBeVisible();
+    });
+
+    await test.step('the screen shows the new version and bruno.json now has it (the "1" marker stays)', async () => {
+      await expect(page.getByTestId('info-version-value')).toHaveText('v2.3.4');
+
+      await expect
+        .poll(async () => JSON.parse(fs.readFileSync(brunoJsonPath, 'utf-8')), { timeout: 5000 })
+        .toMatchObject({ version: '1', collectionVersion: 'v2.3.4' });
+    });
+  });
+});

--- a/tests/collection/change-version-bru/fixtures/collection/bruno.json
+++ b/tests/collection/change-version-bru/fixtures/collection/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "BruVersionTest",
+  "type": "collection"
+}

--- a/tests/collection/change-version-bru/init-user-data/preferences.json
+++ b/tests/collection/change-version-bru/init-user-data/preferences.json
@@ -1,0 +1,10 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": ["{{collectionPath}}"],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/collection/change-version-bru/init-user-data/preferences.json
+++ b/tests/collection/change-version-bru/init-user-data/preferences.json
@@ -1,10 +1,3 @@
 {
-  "maximized": false,
-  "lastOpenedCollections": ["{{collectionPath}}"],
-  "preferences": {
-    "onboarding": {
-      "hasLaunchedBefore": true,
-      "hasSeenWelcomeModal": true
-    }
-  }
+  "lastOpenedCollections": ["{{collectionPath}}"]
 }

--- a/tests/collection/change-version/change-version.spec.ts
+++ b/tests/collection/change-version/change-version.spec.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, openCollectionSettings, selectCollectionPaneTab } from '../../utils/page';
+
+const COLLECTION_NAME = 'VersionEditTest';
+
+test.describe('Change Collection Version (yml collection)', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('changing the version updates the yml file and the screen', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    const collectionPath = collectionFixturePath!;
+    const ymlPath = path.join(collectionPath, 'opencollection.yml');
+
+    await test.step('the collection starts at version 1.0.0 on disk', async () => {
+      expect(fs.readFileSync(ymlPath, 'utf-8')).toMatch(/version:\s*["']?1\.0\.0["']?/);
+    });
+
+    await test.step('open the collection overview and read the current version', async () => {
+      await openCollectionSettings(page, COLLECTION_NAME);
+      await selectCollectionPaneTab(page, 'overview');
+      await expect(page.getByTestId('info-version-value')).toHaveText('1.0.0');
+    });
+
+    await test.step('open the Change Collection Version modal', async () => {
+      await page.getByTestId('info-version-change').click();
+      await expect(page.getByTestId('change-version-current')).toHaveText('1.0.0');
+      await expect(page.getByTestId('change-version-input')).toHaveValue('1.0.0');
+    });
+
+    await test.step('the Update button stays off until the version is changed', async () => {
+      const submit = page.getByTestId('change-version-submit-btn');
+      await expect(submit).toBeDisabled();
+      await page.getByTestId('change-version-input').fill('2.0.0');
+      await expect(submit).toBeEnabled();
+    });
+
+    await test.step('the preview shows the old version changing to the new one', async () => {
+      const preview = page.getByTestId('change-version-preview');
+      await expect(preview).toContainText('info.version');
+      await expect(preview.locator('.old')).toHaveText('1.0.0');
+      await expect(preview.locator('.new')).toHaveText('2.0.0');
+    });
+
+    await test.step('saving updates both the file on disk and the screen', async () => {
+      await page.getByTestId('change-version-submit-btn').click();
+      await expect(page.getByText('Collection version updated')).toBeVisible();
+      await expect(page.getByTestId('info-version-value')).toHaveText('2.0.0');
+
+      await expect
+        .poll(async () => fs.readFileSync(ymlPath, 'utf-8'), { timeout: 5000 })
+        .toMatch(/version:\s*["']?2\.0\.0["']?/);
+    });
+  });
+});

--- a/tests/collection/change-version/fixtures/collection/opencollection.yml
+++ b/tests/collection/change-version/fixtures/collection/opencollection.yml
@@ -1,0 +1,4 @@
+opencollection: "1.0.0"
+info:
+  name: VersionEditTest
+  version: 1.0.0

--- a/tests/collection/change-version/init-user-data/preferences.json
+++ b/tests/collection/change-version/init-user-data/preferences.json
@@ -1,0 +1,10 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": ["{{collectionPath}}"],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/collection/create/create-collection.spec.ts
+++ b/tests/collection/create/create-collection.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, createCollection, createRequest } from '../../utils/page';
+import { closeAllCollections, createCollection, createRequest, openCollectionSettings, selectCollectionPaneTab } from '../../utils/page';
 
 test.describe('Create collection', () => {
   test.afterEach(async ({ page }) => {
@@ -75,5 +75,14 @@ test.describe('Create collection', () => {
 
     // Verify the response
     await expect(page.getByRole('main')).toContainText('200 OK');
+  });
+
+  test('a newly created collection has no version set (shows "Not Set")', async ({ page, createTmpDir }) => {
+    const collectionName = 'versioned-collection';
+    await createCollection(page, collectionName, await createTmpDir(collectionName));
+
+    await openCollectionSettings(page, collectionName);
+    await selectCollectionPaneTab(page, 'overview');
+    await expect(page.getByTestId('info-version-value')).toHaveText('Not Set');
   });
 });

--- a/tests/collection/generate-docs/fixtures/collection/bruno.json
+++ b/tests/collection/generate-docs/fixtures/collection/bruno.json
@@ -1,5 +1,6 @@
 {
   "version": "1",
+  "collectionVersion": "2.5",
   "name": "GenerateDocsOrder",
   "type": "collection"
 }

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -178,8 +178,8 @@ test.describe('Generate Documentation', () => {
 
     await expect(locators.generateDocs.collectionName()).toHaveText(COLLECTION_NAME);
 
-    // The version is shown exactly as the collection sets it.
-    await expect(locators.generateDocs.versionValue()).toHaveText('Version: 1');
+    // The user-facing collection version (bruno.json `collectionVersion`), not the schema `version`.
+    await expect(locators.generateDocs.versionValue()).toHaveText('Version: 2.5');
 
     // The fixture has 2 folders (Zoo, Aviary) and 5 requests (Lion, Bear, Parrot,
     // ReqAlpha, ReqBeta), counted recursively across the whole tree.

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -164,7 +164,7 @@ test.describe('Generate Documentation', () => {
     await expect(modal).toBeHidden();
   });
 
-  test('shows the collection name alongside the raw collection version', async ({
+  test('shows the current collection version verbatim, consistent with the settings page', async ({
     pageWithUserData: page
   }) => {
     const locators = buildCommonLocators(page);

--- a/tests/collection/migrate-to-yml/fixtures/collection/bruno.json
+++ b/tests/collection/migrate-to-yml/fixtures/collection/bruno.json
@@ -2,6 +2,7 @@
   "version": "1",
   "name": "migration-test",
   "type": "collection",
+  "collectionVersion": "v9.9.9",
   "ignore": [
     "node_modules",
     ".git"

--- a/tests/collection/migrate-to-yml/migrate-to-yml.spec.ts
+++ b/tests/collection/migrate-to-yml/migrate-to-yml.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import jsyaml from 'js-yaml';
 import { test, expect } from '../../../playwright';
 import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
 
@@ -81,6 +82,9 @@ test.describe('Migrate collection from bru to yml format', () => {
       const ocContent = fs.readFileSync(path.join(collectionPath, 'opencollection.yml'), 'utf8');
       expect(ocContent).toContain('opencollection');
       expect(ocContent).toContain('migration-test');
+
+      const oc = jsyaml.load(ocContent) as { info?: { version?: string } };
+      expect(oc.info?.version).toBe('v9.9.9');
     });
 
     await test.step('Verify request yml files preserve data', async () => {


### PR DESCRIPTION
### Description
A collection has no visible, editable version in the Bruno UI. yml (opencollection) collections define info.version in their schema, but Bruno never reads, displays, or lets users set it. .bru collections have no collection-version field at all (bruno.json carries only the bru schema version). Users can't see what version a collection is at, or set one, in either format.

Proposed Solution
Add a Version section to the collection Overview page (Collection Settings → Overview) for both formats:

Display the current collection version. yml reads info.version; .bru reads a new collectionVersion field in bruno.json, added after the existing version field (which remains the bru schema version). Collections that have never set a version show "Not set".

A “Change” text button opens the Change Collection Version modal: the current version, a free-form New Version text field, and a preview line ("Updates info.version in collection YAML" for yml / "Updates collectionVersion in bruno.json" for .bru, from <old> → <new>). Update Version saves.

New collections default the version to 1 (yml info.version and .bru collectionVersion both default to "1"). Existing collections are not auto-migrated; the value is written only when the user sets one.

https://usebruno.atlassian.net/browse/BRU-2545

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

<img width="2634" height="1214" alt="image" src="https://github.com/user-attachments/assets/209e85e8-73a2-4e0a-af9b-65f78959ecad" />

<img width="2774" height="1160" alt="image" src="https://github.com/user-attachments/assets/9dad5596-325a-4eae-ab2f-f9c65eb01f8a" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a “Version” row to collection settings with a “Change Collection Version” popup, including live preview and copy-to-clipboard.

* **Bug Fixes**
  * Improved version persistence and round-tripping between BRU and YAML collections.
  * Consistent handling of unset versions (“Not Set”), plus whitespace trimming, 50-character max, and correct display/update of user-facing version values.

* **Tests**
  * Added/updated unit and end-to-end tests for editing, submit enable/disable behavior, previews, and BRU↔YAML conversion/migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->