### PR TITLE
fix(workspaces): switch to default workspace on close so header shows correct name

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/CollectionHeader/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionHeader/index.js
@@ -555,7 +555,7 @@ const CollectionHeader = ({ collection, isScratchCollection }) => {
                 appendTo={() => document.body}
                 icon={(
                   <button className="switcher-trigger">
-                    <span className={classNames('switcher-name', { 'scratch-collection': isScratchCollection })}>{displayName}</span>
+                    <span data-testid="workspace-switcher-name" className={classNames('switcher-name', { 'scratch-collection': isScratchCollection })}>{displayName}</span>
                     <IconChevronDown size={14} strokeWidth={1.5} className="chevron" />
                   </button>
                 )}
@@ -620,7 +620,7 @@ const CollectionHeader = ({ collection, isScratchCollection }) => {
               placement="bottom-start"
               onCreate={onWorkspaceActionsCreate}
               appendTo={() => document.body}
-              icon={<IconDots size={18} strokeWidth={1.5} className="workspace-actions-trigger" />}
+              icon={<IconDots size={18} strokeWidth={1.5} data-testid="workspace-actions-trigger" className="workspace-actions-trigger" />}
             >
               <div className="dropdown-item" onClick={handleRenameWorkspaceClick}>
                 <div className="dropdown-icon">

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -995,7 +995,20 @@ export const closeWorkspaceAction = (workspaceUid) => {
       }
 
       await ipcRenderer.invoke('renderer:close-workspace', workspace.pathname);
+
+      if (workspace.scratchCollectionUid) {
+        dispatch(removeCollection({ collectionUid: workspace.scratchCollectionUid }));
+      }
+
+      const wasActive = getState().workspaces.activeWorkspaceUid === workspaceUid;
       dispatch(removeWorkspace(workspaceUid));
+
+      if (wasActive) {
+        const defaultWorkspace = getState().workspaces.workspaces.find((w) => w.type === 'default');
+        if (defaultWorkspace) {
+          await dispatch(switchWorkspace(defaultWorkspace.uid));
+        }
+      }
     } catch (error) {
       toast.error(error.message || 'Failed to close workspace');
       throw error;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/closeWorkspaceAction.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/closeWorkspaceAction.spec.js
@@ -1,0 +1,94 @@
+jest.mock('nanoid', () => ({
+  customAlphabet: () => () => 'mock-uid'
+}));
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), success: jest.fn() }
+}));
+
+const DEFAULT_WORKSPACE = { uid: 'default', name: 'My Workspace', type: 'default', pathname: '/default' };
+
+let closeWorkspaceAction;
+let removeWorkspace;
+let removeCollection;
+
+beforeAll(() => {
+  window.ipcRenderer = { invoke: jest.fn().mockResolvedValue(true) };
+  ({ closeWorkspaceAction } = require('providers/ReduxStore/slices/workspaces/actions'));
+  ({ removeWorkspace } = require('providers/ReduxStore/slices/workspaces'));
+  ({ removeCollection } = require('providers/ReduxStore/slices/collections'));
+});
+
+beforeEach(() => {
+  window.ipcRenderer.invoke.mockClear();
+});
+
+const run = async ({ closing, activeWorkspaceUid }) => {
+  const state = {
+    workspaces: {
+      activeWorkspaceUid,
+      workspaces: [DEFAULT_WORKSPACE, closing]
+    }
+  };
+  const dispatch = jest.fn();
+  const getState = jest.fn(() => state);
+
+  await closeWorkspaceAction(closing.uid)(dispatch, getState);
+
+  const dispatched = dispatch.mock.calls.map((c) => c[0]);
+  const thunks = dispatched.filter((a) => typeof a === 'function');
+  return { dispatch, dispatched, thunks };
+};
+
+describe('closeWorkspaceAction', () => {
+  it('closes the workspace on disk via ipc using its pathname', async () => {
+    const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team', scratchCollectionUid: 'scratch-1' };
+    await run({ closing, activeWorkspaceUid: 'ws-1' });
+
+    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith('renderer:close-workspace', '/team');
+  });
+
+  it('removes the workspace scratch collection when one is mounted', async () => {
+    const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team', scratchCollectionUid: 'scratch-1' };
+    const { dispatch } = await run({ closing, activeWorkspaceUid: 'ws-1' });
+
+    expect(dispatch).toHaveBeenCalledWith(removeCollection({ collectionUid: 'scratch-1' }));
+  });
+
+  it('does not remove a scratch collection when the workspace has none', async () => {
+    const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team' };
+    const { dispatched } = await run({ closing, activeWorkspaceUid: 'ws-1' });
+
+    expect(dispatched).not.toContainEqual(removeCollection({ collectionUid: undefined }));
+  });
+
+  it('removes the workspace from state', async () => {
+    const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team', scratchCollectionUid: 'scratch-1' };
+    const { dispatch } = await run({ closing, activeWorkspaceUid: 'ws-1' });
+
+    expect(dispatch).toHaveBeenCalledWith(removeWorkspace('ws-1'));
+  });
+
+  it('switches to the default workspace when the closed workspace was active', async () => {
+    const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team', scratchCollectionUid: 'scratch-1' };
+    const { thunks } = await run({ closing, activeWorkspaceUid: 'ws-1' });
+
+    expect(thunks).toHaveLength(1);
+  });
+
+  it('does not switch workspaces when the closed workspace was not active', async () => {
+    const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team', scratchCollectionUid: 'scratch-1' };
+    const { thunks } = await run({ closing, activeWorkspaceUid: 'default' });
+
+    expect(thunks).toHaveLength(0);
+  });
+
+  it('throws when the workspace does not exist', async () => {
+    const dispatch = jest.fn();
+    const getState = jest.fn(() => ({ workspaces: { activeWorkspaceUid: 'default', workspaces: [DEFAULT_WORKSPACE] } }));
+
+    await expect(closeWorkspaceAction('missing')(dispatch, getState)).rejects.toThrow('Workspace not found');
+    expect(window.ipcRenderer.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/closeWorkspaceAction.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/closeWorkspaceAction.spec.js
@@ -10,13 +10,16 @@ jest.mock('react-hot-toast', () => ({
 const DEFAULT_WORKSPACE = { uid: 'default', name: 'My Workspace', type: 'default', pathname: '/default' };
 
 let closeWorkspaceAction;
+let workspacesReducer;
 let removeWorkspace;
 let removeCollection;
 
 beforeAll(() => {
   window.ipcRenderer = { invoke: jest.fn().mockResolvedValue(true) };
   ({ closeWorkspaceAction } = require('providers/ReduxStore/slices/workspaces/actions'));
-  ({ removeWorkspace } = require('providers/ReduxStore/slices/workspaces'));
+  const workspacesModule = require('providers/ReduxStore/slices/workspaces');
+  workspacesReducer = workspacesModule.default;
+  ({ removeWorkspace } = workspacesModule);
   ({ removeCollection } = require('providers/ReduxStore/slices/collections'));
 });
 
@@ -24,21 +27,29 @@ beforeEach(() => {
   window.ipcRenderer.invoke.mockClear();
 });
 
+const typeOf = (actionCreator) => actionCreator({}).type;
+
 const run = async ({ closing, activeWorkspaceUid }) => {
-  const state = {
-    workspaces: {
-      activeWorkspaceUid,
-      workspaces: [DEFAULT_WORKSPACE, closing]
+  let workspaces = { activeWorkspaceUid, workspaces: [DEFAULT_WORKSPACE, closing] };
+
+  const dispatched = [];
+  const thunks = [];
+  const dispatch = jest.fn((action) => {
+    dispatched.push(action);
+    if (typeof action === 'function') {
+      thunks.push(action);
+      return undefined;
     }
-  };
-  const dispatch = jest.fn();
-  const getState = jest.fn(() => state);
+    if (typeof action?.type === 'string' && action.type.startsWith('workspaces/')) {
+      workspaces = workspacesReducer(workspaces, action);
+    }
+    return action;
+  });
+  const getState = jest.fn(() => ({ workspaces }));
 
   await closeWorkspaceAction(closing.uid)(dispatch, getState);
 
-  const dispatched = dispatch.mock.calls.map((c) => c[0]);
-  const thunks = dispatched.filter((a) => typeof a === 'function');
-  return { dispatch, dispatched, thunks };
+  return { dispatch, dispatched, thunks, finalWorkspaces: () => workspaces };
 };
 
 describe('closeWorkspaceAction', () => {
@@ -56,32 +67,41 @@ describe('closeWorkspaceAction', () => {
     expect(dispatch).toHaveBeenCalledWith(removeCollection({ collectionUid: 'scratch-1' }));
   });
 
-  it('does not remove a scratch collection when the workspace has none', async () => {
+  it('does not remove any scratch collection when the workspace has none', async () => {
     const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team' };
     const { dispatched } = await run({ closing, activeWorkspaceUid: 'ws-1' });
 
-    expect(dispatched).not.toContainEqual(removeCollection({ collectionUid: undefined }));
+    expect(dispatched.some((a) => a?.type === typeOf(removeCollection))).toBe(false);
   });
 
   it('removes the workspace from state', async () => {
     const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team', scratchCollectionUid: 'scratch-1' };
-    const { dispatch } = await run({ closing, activeWorkspaceUid: 'ws-1' });
+    const { dispatch, finalWorkspaces } = await run({ closing, activeWorkspaceUid: 'ws-1' });
 
     expect(dispatch).toHaveBeenCalledWith(removeWorkspace('ws-1'));
+    expect(finalWorkspaces().workspaces.find((w) => w.uid === 'ws-1')).toBeUndefined();
   });
 
   it('switches to the default workspace when the closed workspace was active', async () => {
     const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team', scratchCollectionUid: 'scratch-1' };
-    const { thunks } = await run({ closing, activeWorkspaceUid: 'ws-1' });
+    const { dispatched, thunks, finalWorkspaces } = await run({ closing, activeWorkspaceUid: 'ws-1' });
 
     expect(thunks).toHaveLength(1);
+
+    const removeIdx = dispatched.findIndex((a) => a?.type === typeOf(removeWorkspace));
+    const thunkIdx = dispatched.findIndex((a) => typeof a === 'function');
+    expect(removeIdx).toBeGreaterThanOrEqual(0);
+    expect(thunkIdx).toBeGreaterThan(removeIdx);
+
+    expect(finalWorkspaces().activeWorkspaceUid).toBe('default');
   });
 
   it('does not switch workspaces when the closed workspace was not active', async () => {
     const closing = { uid: 'ws-1', name: 'Team WS', type: 'local', pathname: '/team', scratchCollectionUid: 'scratch-1' };
-    const { thunks } = await run({ closing, activeWorkspaceUid: 'default' });
+    const { thunks, finalWorkspaces } = await run({ closing, activeWorkspaceUid: 'default' });
 
     expect(thunks).toHaveLength(0);
+    expect(finalWorkspaces().activeWorkspaceUid).toBe('default');
   });
 
   it('throws when the workspace does not exist', async () => {

--- a/tests/workspace/close-workspace-returns-to-default.spec.ts
+++ b/tests/workspace/close-workspace-returns-to-default.spec.ts
@@ -15,7 +15,7 @@ const WORKSPACE_YML_WORKSPACEB = [
   ''
 ].join('\n');
 
-test.describe('Close workspace returns to default workspace (BRU-3663)', () => {
+test.describe('Close workspace returns to default workspace', () => {
   test('closing the active workspace shows "My Workspace" (not "Scratch") and restores its collections', async ({
     launchElectronApp,
     createTmpDir

--- a/tests/workspace/close-workspace-returns-to-default.spec.ts
+++ b/tests/workspace/close-workspace-returns-to-default.spec.ts
@@ -1,0 +1,72 @@
+import path from 'path';
+import fs from 'fs';
+import { test, expect, closeElectronApp } from '../../playwright';
+import { createCollection, waitForReadyPage } from '../utils/page';
+import { buildCommonLocators } from '../utils/page/locators';
+
+const WORKSPACE_YML_WORKSPACEB = [
+  'opencollection: 1.0.0',
+  'info:',
+  '  name: WorkspaceB',
+  '  type: workspace',
+  'collections:',
+  'specs: []',
+  'docs: \'\'',
+  ''
+].join('\n');
+
+test.describe('Close workspace returns to default workspace (BRU-3663)', () => {
+  test('closing the active workspace shows "My Workspace" (not "Scratch") and restores its collections', async ({
+    launchElectronApp,
+    createTmpDir
+  }) => {
+    const userDataPath = await createTmpDir('close-workspace-bru3663');
+    const colAPath = await createTmpDir('col-a');
+    const workspaceBPath = await createTmpDir('workspace-b');
+    fs.writeFileSync(path.join(workspaceBPath, 'workspace.yml'), WORKSPACE_YML_WORKSPACEB);
+
+    let app;
+    try {
+      app = await launchElectronApp({ userDataPath });
+      const page = await waitForReadyPage(app);
+      const locators = buildCommonLocators(page);
+      const switcherName = page.locator('.switcher-name').first();
+
+      await test.step('Default workspace is "My Workspace" with a collection ColA', async () => {
+        await expect(page.getByTestId('workspace-name')).toHaveText('My Workspace', { timeout: 10000 });
+        await createCollection(page, 'ColA', colAPath);
+        await expect(locators.sidebar.collection('ColA')).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step('Stub open-dialog and switch to WorkspaceB', async () => {
+        await app.evaluate(
+          ({ dialog }, targetPath: string) => {
+            (dialog as { showOpenDialog: typeof dialog.showOpenDialog }).showOpenDialog = () =>
+              Promise.resolve({ canceled: false, filePaths: [targetPath] });
+          },
+          workspaceBPath
+        );
+        await page.getByTestId('workspace-menu').click();
+        await page.locator('.dropdown-item').filter({ hasText: 'Open workspace' }).click();
+        await expect(page.getByTestId('workspace-name')).toHaveText('WorkspaceB', { timeout: 10000 });
+        await expect(switcherName).toHaveText('WorkspaceB', { timeout: 10000 });
+      });
+
+      await test.step('Close WorkspaceB via the workspace-actions ellipsis', async () => {
+        await expect(page.locator('.workspace-actions-trigger')).toBeVisible({ timeout: 10000 });
+        await page.locator('.workspace-actions-trigger').click();
+        await locators.dropdown.item('Close').click();
+        await expect(locators.modal.byTitle('Close Workspace')).toBeVisible({ timeout: 5000 });
+        await locators.modal.button('Close').click();
+      });
+
+      await test.step('App returns to My Workspace, never shows "Scratch", and ColA reloads', async () => {
+        await expect(page.getByTestId('workspace-name')).toHaveText('My Workspace', { timeout: 10000 });
+        await expect(locators.sidebar.collection('ColA')).toBeVisible({ timeout: 10000 });
+        await expect(switcherName).not.toHaveText('Scratch');
+      });
+    } finally {
+      if (app) await closeElectronApp(app);
+    }
+  });
+});

--- a/tests/workspace/close-workspace-returns-to-default.spec.ts
+++ b/tests/workspace/close-workspace-returns-to-default.spec.ts
@@ -30,7 +30,8 @@ test.describe('Close workspace returns to default workspace', () => {
       app = await launchElectronApp({ userDataPath });
       const page = await waitForReadyPage(app);
       const locators = buildCommonLocators(page);
-      const switcherName = page.locator('.switcher-name').first();
+      const switcherName = page.getByTestId('workspace-switcher-name');
+      const workspaceActionsTrigger = page.getByTestId('workspace-actions-trigger');
 
       await test.step('Default workspace is "My Workspace" with a collection ColA', async () => {
         await expect(page.getByTestId('workspace-name')).toHaveText('My Workspace', { timeout: 10000 });
@@ -47,14 +48,14 @@ test.describe('Close workspace returns to default workspace', () => {
           workspaceBPath
         );
         await page.getByTestId('workspace-menu').click();
-        await page.locator('.dropdown-item').filter({ hasText: 'Open workspace' }).click();
+        await locators.dropdown.item('Open workspace').click();
         await expect(page.getByTestId('workspace-name')).toHaveText('WorkspaceB', { timeout: 10000 });
         await expect(switcherName).toHaveText('WorkspaceB', { timeout: 10000 });
       });
 
       await test.step('Close WorkspaceB via the workspace-actions ellipsis', async () => {
-        await expect(page.locator('.workspace-actions-trigger')).toBeVisible({ timeout: 10000 });
-        await page.locator('.workspace-actions-trigger').click();
+        await expect(workspaceActionsTrigger).toBeVisible({ timeout: 10000 });
+        await workspaceActionsTrigger.click();
         await locators.dropdown.item('Close').click();
         await expect(locators.modal.byTitle('Close Workspace')).toBeVisible({ timeout: 5000 });
         await locators.modal.button('Close').click();

--- a/tests/workspace/close-workspace-returns-to-default.spec.ts
+++ b/tests/workspace/close-workspace-returns-to-default.spec.ts
@@ -20,7 +20,7 @@ test.describe('Close workspace returns to default workspace', () => {
     launchElectronApp,
     createTmpDir
   }) => {
-    const userDataPath = await createTmpDir('close-workspace-bru3663');
+    const userDataPath = await createTmpDir('close-workspace');
     const colAPath = await createTmpDir('col-a');
     const workspaceBPath = await createTmpDir('workspace-b');
     fs.writeFileSync(path.join(workspaceBPath, 'workspace.yml'), WORKSPACE_YML_WORKSPACEB);


### PR DESCRIPTION
### Description
[BRU3663](https://usebruno.atlassian.net/browse/BRU-3663)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Closing a workspace now also cleans up its scratch collection in the app state (when present).
  * If the closed workspace was the active one, the app now switches back to the default workspace.
  * More resilient behavior when a workspace ID can’t be found, avoiding unnecessary IPC calls.
* **Tests**
  * Added Jest coverage for workspace close behavior (scratch cleanup, active-workspace switching, and error handling).
  * Added an end-to-end Playwright test to confirm returning to the default workspace and restoring collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->