### PR TITLE
fix:cmd+w now works for transient tabs

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -591,11 +591,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
                 setShowConfirmClose(false);
               })
               .catch((err) => {
-                if (!err) {
-                  setShowConfirmClose(false);
-                } else {
-                  console.log('err', err);
-                }
+                console.log('err', err);
               });
           }}
         />

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -581,7 +581,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
             const useFileSave = collection.fileMode || item.type === 'js';
             const savePromise = useFileSave
               ? dispatch(saveFile(item?.draft?.raw ?? item?.raw, item.uid, collection.uid))
-              : dispatch(saveRequest(item.uid, collection.uid));
+              : dispatch(saveRequest(item.uid, collection.uid, false, true));
 
             savePromise
               .then(() => {
@@ -591,7 +591,11 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
                 setShowConfirmClose(false);
               })
               .catch((err) => {
-                console.log('err', err);
+                if (!err) {
+                  setShowConfirmClose(false);
+                } else {
+                  console.log('err', err);
+                }
               });
           }}
         />

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -579,16 +579,17 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
           }}
           onSaveAndClose={() => {
             const useFileSave = collection.fileMode || item.type === 'js';
+            let savePromise;
 
-            if (!useFileSave && isItemTransientRequest(item)) {
+            if (useFileSave) {
+              savePromise = dispatch(saveFile(item?.draft?.raw ?? item?.raw, item.uid, collection.uid));
+            } else if (isItemTransientRequest(item)) {
               dispatch(addSaveTransientRequestModal({ item, collection, closeAfterSave: true }));
               setShowConfirmClose(false);
               return;
+            } else {
+              savePromise = dispatch(saveRequest(item.uid, collection.uid));
             }
-
-            const savePromise = useFileSave
-              ? dispatch(saveFile(item?.draft?.raw ?? item?.raw, item.uid, collection.uid))
-              : dispatch(saveRequest(item.uid, collection.uid));
 
             savePromise
               .then(() => {

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import { makeTabPermanent, syncTabUid } from 'providers/ReduxStore/slices/tabs';
 import { saveRequest, saveCollectionRoot, saveFolderRoot, saveEnvironment, saveCollectionSettings, closeTabs, saveFile } from 'providers/ReduxStore/slices/collections/actions';
 import useKeybinding from 'hooks/useKeybinding';
-import { deleteRequestDraft, deleteCollectionDraft, deleteFolderDraft, clearEnvironmentsDraft } from 'providers/ReduxStore/slices/collections';
+import { deleteRequestDraft, deleteCollectionDraft, deleteFolderDraft, clearEnvironmentsDraft, addSaveTransientRequestModal } from 'providers/ReduxStore/slices/collections';
 import { clearGlobalEnvironmentDraft } from 'providers/ReduxStore/slices/global-environments';
 import { saveGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import { useTheme } from 'providers/Theme';
@@ -579,9 +579,16 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
           }}
           onSaveAndClose={() => {
             const useFileSave = collection.fileMode || item.type === 'js';
+
+            if (!useFileSave && isItemTransientRequest(item)) {
+              dispatch(addSaveTransientRequestModal({ item, collection, closeAfterSave: true }));
+              setShowConfirmClose(false);
+              return;
+            }
+
             const savePromise = useFileSave
               ? dispatch(saveFile(item?.draft?.raw ?? item?.raw, item.uid, collection.uid))
-              : dispatch(saveRequest(item.uid, collection.uid, false, true));
+              : dispatch(saveRequest(item.uid, collection.uid));
 
             savePromise
               .then(() => {

--- a/packages/bruno-app/src/components/SaveTransientRequest/Container/index.js
+++ b/packages/bruno-app/src/components/SaveTransientRequest/Container/index.js
@@ -52,6 +52,7 @@ const SaveTransientRequestContainer = () => {
           item={modalToOpen.item}
           collection={modalToOpen.collection}
           isOpen={true}
+          closeAfterSave={modalToOpen.closeAfterSave}
         />
       );
     }

--- a/packages/bruno-app/src/components/SaveTransientRequest/index.js
+++ b/packages/bruno-app/src/components/SaveTransientRequest/index.js
@@ -25,7 +25,7 @@ import { uuid } from 'utils/common';
 import { formatIpcError } from 'utils/common/error';
 import get from 'lodash/get';
 
-const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOpen = false, onClose }) => {
+const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOpen = false, onClose, closeAfterSave = false }) => {
   const dispatch = useDispatch();
 
   const latestCollection = useSelector((state) =>
@@ -243,15 +243,17 @@ const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOp
         sourceFormat
       });
 
-      dispatch(
-        insertTaskIntoQueue({
-          uid: uuid(),
-          type: 'OPEN_REQUEST',
-          collectionUid: targetCollection.uid,
-          itemPathname: targetPathname,
-          preview: false
-        })
-      );
+      if (!closeAfterSave) {
+        dispatch(
+          insertTaskIntoQueue({
+            uid: uuid(),
+            type: 'OPEN_REQUEST',
+            collectionUid: targetCollection.uid,
+            itemPathname: targetPathname,
+            preview: false
+          })
+        );
+      }
 
       dispatch(closeTabs({ tabUids: [item.uid] }));
 

--- a/packages/bruno-app/src/pages/Bruno/index.js
+++ b/packages/bruno-app/src/pages/Bruno/index.js
@@ -74,6 +74,7 @@ const TransientRequestModalsRenderer = ({ modals }) => {
         item={modals[0].item}
         collection={modals[0].collection}
         isOpen={true}
+        closeAfterSave={modals[0].closeAfterSave}
       />
     );
   }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -158,7 +158,7 @@ export const renameCollection = (newName, collectionUid) => (dispatch, getState)
   });
 };
 
-export const saveRequest = (itemUid, collectionUid, silent = false, closeAfterSave = false) => (dispatch, getState) => {
+export const saveRequest = (itemUid, collectionUid, silent = false) => (dispatch, getState) => {
   const state = getState();
   const collection = findCollectionByUid(state.collections.collections, collectionUid);
   const tempDirectory = state.collections.tempDirectories?.[collectionUid];
@@ -175,7 +175,7 @@ export const saveRequest = (itemUid, collectionUid, silent = false, closeAfterSa
 
     const isTransient = tempDirectory && item.pathname.startsWith(tempDirectory);
     if (isTransient) {
-      dispatch(addSaveTransientRequestModal({ item, collection, closeAfterSave }));
+      dispatch(addSaveTransientRequestModal({ item, collection }));
       return reject();
     }
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -158,7 +158,7 @@ export const renameCollection = (newName, collectionUid) => (dispatch, getState)
   });
 };
 
-export const saveRequest = (itemUid, collectionUid, silent = false) => (dispatch, getState) => {
+export const saveRequest = (itemUid, collectionUid, silent = false, closeAfterSave = false) => (dispatch, getState) => {
   const state = getState();
   const collection = findCollectionByUid(state.collections.collections, collectionUid);
   const tempDirectory = state.collections.tempDirectories?.[collectionUid];
@@ -175,7 +175,7 @@ export const saveRequest = (itemUid, collectionUid, silent = false) => (dispatch
 
     const isTransient = tempDirectory && item.pathname.startsWith(tempDirectory);
     if (isTransient) {
-      dispatch(addSaveTransientRequestModal({ item, collection }));
+      dispatch(addSaveTransientRequestModal({ item, collection, closeAfterSave }));
       return reject();
     }
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -3929,11 +3929,11 @@ export const collectionsSlice = createSlice({
       state.tempDirectories[action.payload.collectionUid] = action.payload.pathname;
     },
     addSaveTransientRequestModal: (state, action) => {
-      const { item, collection } = action.payload;
+      const { item, collection, closeAfterSave = false } = action.payload;
       // Avoid duplicates - check if this item is already in the array
       const exists = state.saveTransientRequestModals.some((modal) => modal.item.uid === item.uid);
       if (!exists) {
-        state.saveTransientRequestModals.push({ item, collection });
+        state.saveTransientRequestModals.push({ item, collection, closeAfterSave });
       }
     },
     removeSaveTransientRequestModal: (state, action) => {

--- a/tests/shortcuts/tabs-actions.spec.ts
+++ b/tests/shortcuts/tabs-actions.spec.ts
@@ -240,6 +240,10 @@ test.describe('Shortcut Keys - BOUND_ACTIONS', () => {
         await expect(
           page.locator('.request-tab').filter({ has: page.getByText('Transient Close Test', { exact: true }) })
         ).not.toBeVisible();
+
+        // Open the saved request from the sidebar and verify the URL was persisted correctly
+        await openRequest(page, collectionName, 'Transient Close Test');
+        await expect(page.locator('#request-url .CodeMirror-line')).toContainText('http://localhost:8081/ping');
       });
     });
 

--- a/tests/shortcuts/tabs-actions.spec.ts
+++ b/tests/shortcuts/tabs-actions.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../../playwright';
-import { closeAllCollections } from '../utils/page';
+import { closeAllCollections, createTransientRequest, fillRequestUrl } from '../utils/page';
 import {
   closePreferencesTab,
   closeTabByName,
@@ -186,6 +186,60 @@ test.describe('Shortcut Keys - BOUND_ACTIONS', () => {
         await expect(modal).toBeVisible({ timeout: 3000 });
         await modal.getByRole('button', { name: 'Don\'t Save' }).click();
         await expect(collectionTab).not.toBeVisible({ timeout: 3000 });
+      });
+
+      test('Close transient request (Shift+X): saves to collection and closes tab without reopening', async ({ pageWithUserData: page }) => {
+        // Count tabs already open before we start
+        const initialTabCount = await page.locator('.request-tab').count();
+
+        // Create a new transient HTTP request — it opens as "Untitled X" and is NOT in the sidebar
+        await createTransientRequest(page, { requestType: 'HTTP' });
+
+        // One new tab should be open and active
+        await expect(page.locator('.request-tab')).toHaveCount(initialTabCount + 1);
+        const transientTab = page.locator('.request-tab.active');
+        await expect(transientTab).toContainText('Untitled');
+
+        // Type a URL so the request has an unsaved change (creates a draft, shows the dot indicator)
+        await fillRequestUrl(page, 'http://localhost:8081/ping');
+        await expect(transientTab.locator('.has-changes-icon')).toBeVisible();
+
+        // Press Shift+X (closeTab remapped in beforeEach)
+        await pressShortcut(page, 'Shift', 'KeyX');
+
+        // "Unsaved changes" dialog should appear
+        const unsavedModal = page.locator('.bruno-modal-card').filter({ has: page.getByText('Unsaved changes', { exact: true }) });
+        await expect(unsavedModal).toBeVisible({ timeout: 3000 });
+
+        // Click "Save" — this should dismiss this dialog and open the Save Request picker
+        await unsavedModal.getByRole('button', { name: 'Save', exact: true }).click();
+
+        // The save flow modal appears. In workspaces with a scratch collection it first shows
+        // "Select Collection" so the user can pick a target — handle that automatically.
+        const saveFlowModal = page.locator('.bruno-modal-card');
+        await expect(saveFlowModal.filter({ hasText: /Save Request|Select Collection/ })).toBeVisible({ timeout: 5000 });
+
+        if (await saveFlowModal.filter({ hasText: 'Select Collection' }).isVisible()) {
+          // Pick kb-collection from the list so the form advances to "Save Request"
+          await saveFlowModal.locator('.collection-item-name').filter({ hasText: collectionName }).click();
+          await expect(saveFlowModal.filter({ hasText: 'Save Request' })).toBeVisible({ timeout: 5000 });
+        }
+
+        // Give the request a name and confirm
+        const saveModal = saveFlowModal.filter({ hasText: 'Save Request' });
+        const nameInput = saveModal.locator('#request-name');
+        await nameInput.clear();
+        await nameInput.fill('Transient Close Test');
+        await saveModal.getByRole('button', { name: 'Save' }).click();
+
+        // After saving, the tab count must return to the initial count:
+        // the transient tab closed AND no new tab was reopened for the saved request
+        await expect(page.locator('.request-tab')).toHaveCount(initialTabCount, { timeout: 5000 });
+
+        // Double-check: no tab named "Transient Close Test" is visible
+        await expect(
+          page.locator('.request-tab').filter({ has: page.getByText('Transient Close Test', { exact: true }) })
+        ).not.toBeVisible();
       });
     });
 

--- a/tests/shortcuts/tabs-actions.spec.ts
+++ b/tests/shortcuts/tabs-actions.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from '../../playwright';
-import { closeAllCollections, createTransientRequest, fillRequestUrl } from '../utils/page';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createTransientRequest,
+  fillRequestUrl,
+  saveTransientViaModal
+} from '../utils/page';
 import {
   closePreferencesTab,
   closeTabByName,
@@ -189,61 +195,43 @@ test.describe('Shortcut Keys - BOUND_ACTIONS', () => {
       });
 
       test('Close transient request (Shift+X): saves to collection and closes tab without reopening', async ({ pageWithUserData: page }) => {
-        // Count tabs already open before we start
-        const initialTabCount = await page.locator('.request-tab').count();
+        const locators = buildCommonLocators(page);
+        const transientUrl = 'http://localhost:8081/ping';
+        const savedRequestName = 'Transient Close Test';
+        let initialTabCount = 0;
 
-        // Create a new transient HTTP request — it opens as "Untitled X" and is NOT in the sidebar
-        await createTransientRequest(page, { requestType: 'HTTP' });
+        await test.step('Create a transient request with an unsaved URL', async () => {
+          initialTabCount = await locators.tabs.allRequestTabs().count();
 
-        // One new tab should be open and active
-        await expect(page.locator('.request-tab')).toHaveCount(initialTabCount + 1);
-        const transientTab = page.locator('.request-tab.active');
-        await expect(transientTab).toContainText('Untitled');
+          // A transient request opens as "Untitled X" and is NOT in the sidebar
+          await createTransientRequest(page, { requestType: 'HTTP' });
+          await expect(locators.tabs.allRequestTabs()).toHaveCount(initialTabCount + 1);
+          await expect(locators.tabs.activeRequestTab()).toContainText('Untitled');
 
-        // Type a URL so the request has an unsaved change (creates a draft, shows the dot indicator)
-        await fillRequestUrl(page, 'http://localhost:8081/ping');
-        await expect(transientTab.locator('.has-changes-icon')).toBeVisible();
+          // Typing a URL creates a draft, shown by the dot indicator on the tab
+          await fillRequestUrl(page, transientUrl);
+          await expect(locators.tabs.draftIndicator()).toBeVisible();
+        });
 
-        // Press Shift+X (closeTab remapped in beforeEach)
-        await pressShortcut(page, 'Shift', 'KeyX');
+        await test.step('Close the tab (Shift+X) and pick Save in the unsaved-changes prompt', async () => {
+          await pressShortcut(page, 'Shift', 'KeyX');
+          await expect(locators.modal.byTitle('Unsaved changes')).toBeVisible({ timeout: 3000 });
+          await locators.modal.button('Save').click();
+        });
 
-        // "Unsaved changes" dialog should appear
-        const unsavedModal = page.locator('.bruno-modal-card').filter({ has: page.getByText('Unsaved changes', { exact: true }) });
-        await expect(unsavedModal).toBeVisible({ timeout: 3000 });
+        await test.step('Save the transient request into the collection', async () => {
+          await saveTransientViaModal(page, savedRequestName, { collectionName });
+        });
 
-        // Click "Save" — this should dismiss this dialog and open the Save Request picker
-        await unsavedModal.getByRole('button', { name: 'Save', exact: true }).click();
+        await test.step('Tab closes and the saved request is not reopened', async () => {
+          await expect(locators.tabs.allRequestTabs()).toHaveCount(initialTabCount, { timeout: 5000 });
+          await expect(locators.tabs.requestTab(savedRequestName)).toHaveCount(0);
+        });
 
-        // The save flow modal appears. In workspaces with a scratch collection it first shows
-        // "Select Collection" so the user can pick a target — handle that automatically.
-        const saveFlowModal = page.locator('.bruno-modal-card');
-        await expect(saveFlowModal.filter({ hasText: /Save Request|Select Collection/ })).toBeVisible({ timeout: 5000 });
-
-        if (await saveFlowModal.filter({ hasText: 'Select Collection' }).isVisible()) {
-          // Pick kb-collection from the list so the form advances to "Save Request"
-          await saveFlowModal.locator('.collection-item-name').filter({ hasText: collectionName }).click();
-          await expect(saveFlowModal.filter({ hasText: 'Save Request' })).toBeVisible({ timeout: 5000 });
-        }
-
-        // Give the request a name and confirm
-        const saveModal = saveFlowModal.filter({ hasText: 'Save Request' });
-        const nameInput = saveModal.locator('#request-name');
-        await nameInput.clear();
-        await nameInput.fill('Transient Close Test');
-        await saveModal.getByRole('button', { name: 'Save' }).click();
-
-        // After saving, the tab count must return to the initial count:
-        // the transient tab closed AND no new tab was reopened for the saved request
-        await expect(page.locator('.request-tab')).toHaveCount(initialTabCount, { timeout: 5000 });
-
-        // Double-check: no tab named "Transient Close Test" is visible
-        await expect(
-          page.locator('.request-tab').filter({ has: page.getByText('Transient Close Test', { exact: true }) })
-        ).not.toBeVisible();
-
-        // Open the saved request from the sidebar and verify the URL was persisted correctly
-        await openRequest(page, collectionName, 'Transient Close Test');
-        await expect(page.locator('#request-url .CodeMirror-line')).toContainText('http://localhost:8081/ping');
+        await test.step('Saved request keeps the URL typed before saving', async () => {
+          await openRequest(page, collectionName, savedRequestName);
+          await expect(locators.request.urlLine()).toContainText(transientUrl);
+        });
       });
     });
 

--- a/tests/utils/page/file-mode.ts
+++ b/tests/utils/page/file-mode.ts
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import { Page, test } from '../../../playwright';
+import { expect, Page, test } from '../../../playwright';
 
 const findShortcut = process.platform === 'darwin' ? 'Meta+f' : 'Control+f';
 
@@ -16,6 +16,9 @@ export const buildFileModeLocators = (page: Page) => ({
   },
   transientSaveModal: {
     card: () => page.getByTestId('save-transient-request-modal'),
+    title: () => page.getByTestId('save-transient-request-modal').locator('.bruno-modal-header-title'),
+    collectionOption: (collectionName: string) =>
+      page.getByTestId('save-transient-request-modal').locator('.collection-item').filter({ hasText: collectionName }),
     nameInput: () => page.getByTestId('save-transient-request-name'),
     saveButton: () => page.getByTestId('save-transient-request-submit')
   }
@@ -75,11 +78,23 @@ export const setFileModeRaw = async (page: Page, content: string) => {
   });
 };
 
-// Fill and submit the transient "Save Request" modal.
-export const saveTransientViaModal = async (page: Page, requestName: string) => {
+// Fill and submit the transient "Save Request" modal. When the active collection is a scratch
+// collection the modal opens on a "Select Collection" step first; pass `collectionName` to pick
+// the target and advance to the name form.
+export const saveTransientViaModal = async (
+  page: Page,
+  requestName: string,
+  options: { collectionName?: string } = {}
+) => {
   await test.step(`Save transient request as "${requestName}"`, async () => {
     const { transientSaveModal } = buildFileModeLocators(page);
     await transientSaveModal.card().waitFor({ state: 'visible' });
+
+    if (options.collectionName && (await transientSaveModal.title().textContent()) === 'Select Collection') {
+      await transientSaveModal.collectionOption(options.collectionName).click();
+      await expect(transientSaveModal.nameInput()).toBeVisible();
+    }
+
     await transientSaveModal.nameInput().fill(requestName);
     await transientSaveModal.saveButton().click();
   });

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -48,6 +48,7 @@ export const buildCommonLocators = (page: Page) => ({
     tippyItem: (text: string) => page.locator('.tippy-box .dropdown-item').filter({ hasText: text })
   },
   tabs: {
+    allRequestTabs: () => page.locator('.request-tab'),
     requestTab: (requestName: string) => page.locator('.request-tab .tab-label').filter({ hasText: requestName }),
     folderTab: (folderName: string) => page.locator('.request-tab .tab-label').filter({ hasText: folderName }),
     collectionSettingsTab: () =>


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3623)

Pressing Cmd+W on a transient request showed the Save picker but the tab didn't close after saving. Threaded a closeAfterSave flag through the save flow so the tab closes correctly without reopening.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optionally closing the transient request tab after saving the request, preventing it from reopening.
  * Newly created transient HTTP requests now use standard default settings.
* **Bug Fixes**
  * Improved the close-and-save workflow for transient requests to follow the modal’s intended behavior.
* **Tests**
  * Added an end-to-end test covering the transient close shortcut, saving via the unsaved-changes modal (including collection selection), and verifying the saved request content matches the draft.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->