### PR TITLE
feat: Add line continuation character option to Shell code generator.

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -386,7 +386,7 @@ class CodeEditor extends React.Component {
     }
 
     if (this.props.mode !== prevProps.mode) {
-      this.editor.setOption('mode', this.props.mode);
+      this.addOverlay();
     }
 
     if (this.props.readOnly !== prevProps.readOnly && this.editor) {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -36,9 +36,10 @@ const CodeView = ({ language, item }) => {
       language,
       item,
       collection,
-      shouldInterpolate: generateCodePrefs.shouldInterpolate
+      shouldInterpolate: generateCodePrefs.shouldInterpolate,
+      lineContinuationChar: generateCodePrefs.lineContinuationChar
     });
-  }, [language, item, collection, generateCodePrefs.shouldInterpolate]);
+  }, [language, item, collection, generateCodePrefs.shouldInterpolate, generateCodePrefs.lineContinuationChar]);
 
   return (
     <StyledWrapper>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeViewToolbar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeViewToolbar/StyledWrapper.js
@@ -94,6 +94,14 @@ const StyledWrapper = styled.div`
   }
 
   .right-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+
+    .continuation-select .native-select {
+      min-width: 170px;
+    }
+
     .interpolate-checkbox {
       display: flex;
       align-items: center;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeViewToolbar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeViewToolbar/index.js
@@ -102,6 +102,7 @@ const CodeViewToolbar = () => {
                 value={generateCodePrefs.lineContinuationChar}
                 onChange={handleLineContinuationChange}
                 title="Line continuation character"
+                aria-label="Line continuation character"
               >
                 <option value={'\\'}>{'\\'} (Unix/macOS)</option>
                 <option value="^">^ (Windows cmd)</option>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeViewToolbar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeViewToolbar/index.js
@@ -54,6 +54,12 @@ const CodeViewToolbar = () => {
     }));
   };
 
+  const handleLineContinuationChange = (e) => {
+    dispatch(updateGenerateCode({
+      lineContinuationChar: e.target.value
+    }));
+  };
+
   return (
     <StyledWrapper>
       <div className="toolbar">
@@ -89,6 +95,22 @@ const CodeViewToolbar = () => {
         </div>
 
         <div className="right-controls">
+          {generateCodePrefs.mainLanguage === 'Shell' && (
+            <div className="select-wrapper continuation-select">
+              <select
+                className="native-select"
+                value={generateCodePrefs.lineContinuationChar}
+                onChange={handleLineContinuationChange}
+                title="Line continuation character"
+              >
+                <option value={'\\'}>{'\\'} (Unix/macOS)</option>
+                <option value="^">^ (Windows cmd)</option>
+                <option value="`">` (PowerShell)</option>
+              </select>
+              <IconChevronDown size={16} className="select-arrow" />
+            </div>
+          )}
+
           <label className="interpolate-checkbox">
             <input
               type="checkbox"

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -31,7 +31,16 @@ const addCurlAuthFlags = (curlCommand, auth) => {
   return curlCommand;
 };
 
-const generateSnippet = ({ language, item, collection, shouldInterpolate = false }) => {
+// package httpsnippet's shell clients (curl/httpie/wget) hardcode `\` as the
+// multiline join character. There is no option to override it upstream.
+// Swap it on the rendered text for cmd (^) / PowerShell (`) snippets.
+const applyLineContinuation = (text, lineContinuationChar) => {
+  if (!lineContinuationChar || lineContinuationChar === '\\') return text;
+
+  return text.split(' \\\n').join(` ${lineContinuationChar}\n`);
+};
+
+const generateSnippet = ({ language, item, collection, shouldInterpolate = false, lineContinuationChar = '\\' }) => {
   try {
     // Get HTTPSnippet dynamically so mocks can be applied in tests
     const { HTTPSnippet } = require('httpsnippet');
@@ -108,7 +117,13 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
     }
 
     // Restore `{{var}}` placeholders that buildHar hashed during processing.
-    return unhash(result);
+    result = unhash(result);
+
+    if (language.target === 'shell') {
+      result = applyLineContinuation(result, lineContinuationChar);
+    }
+
+    return result;
   } catch (error) {
     console.error('Error generating code snippet:', error);
     return 'Error generating code snippet';

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -1311,3 +1311,47 @@ describe('generateSnippet – pre-encode URL before HAR (HTTPSnippet validator r
     expect(result).not.toBe('Error generating code snippet');
   });
 });
+
+describe('generateSnippet – line continuation char against real httpsnippet output', () => {
+  const baseCollection = { root: { request: { auth: { mode: 'none' }, headers: [] } } };
+
+  const item = {
+    uid: 'real-shell-req',
+    request: {
+      method: 'GET',
+      url: 'https://example.com/api',
+      headers: [{ name: 'X-Api-Key', value: 'abc123', enabled: true }],
+      body: { mode: 'none' },
+      auth: { mode: 'none' }
+    }
+  };
+
+  let savedHTTPSnippet;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const utilsCollections = require('utils/collections/index');
+    utilsCollections.getTreePathFromCollectionToItem.mockImplementation(() => []);
+    utilsCollections.getAllVariables.mockReturnValue({});
+
+    savedHTTPSnippet = require('httpsnippet').HTTPSnippet;
+    require('httpsnippet').HTTPSnippet = jest.requireActual('httpsnippet').HTTPSnippet;
+  });
+
+  afterEach(() => {
+    require('httpsnippet').HTTPSnippet = savedHTTPSnippet;
+  });
+
+  it.each([
+    ['curl', { target: 'shell', client: 'curl' }],
+    ['wget', { target: 'shell', client: 'wget' }],
+    ['httpie', { target: 'shell', client: 'httpie' }]
+  ])('%s: real output contains \\ continuation and caret swap applies', (_client, language) => {
+    const defaultResult = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    const cmdResult = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false, lineContinuationChar: '^' });
+
+    expect(defaultResult).toContain(' \\\n');
+    expect(cmdResult).not.toContain(' \\\n');
+    expect(cmdResult).toContain(' ^\n');
+  });
+});

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -866,11 +866,18 @@ describe('generateSnippet – line continuation character', () => {
 
   const multilineSnippet = 'curl --request GET \\\n  --url https://example.com/api \\\n  --header \'Accept: application/json\'';
 
+  let savedHTTPSnippet;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    savedHTTPSnippet = require('httpsnippet').HTTPSnippet;
     require('httpsnippet').HTTPSnippet = jest.fn().mockImplementation(() => ({
       convert: jest.fn(() => multilineSnippet)
     }));
+  });
+
+  afterEach(() => {
+    require('httpsnippet').HTTPSnippet = savedHTTPSnippet;
   });
 
   it('leaves the backslash continuation untouched by default', () => {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -851,6 +851,59 @@ describe('generateSnippet – digest and NTLM auth curl export', () => {
   });
 });
 
+describe('generateSnippet – line continuation character', () => {
+  const baseCollection = { root: { request: { auth: { mode: 'none' }, headers: [] } } };
+  const item = {
+    uid: 'continuation-req',
+    request: {
+      method: 'GET',
+      url: 'https://example.com/api',
+      headers: [],
+      body: { mode: 'none' },
+      auth: { mode: 'none' }
+    }
+  };
+
+  const multilineSnippet = 'curl --request GET \\\n  --url https://example.com/api \\\n  --header \'Accept: application/json\'';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    require('httpsnippet').HTTPSnippet = jest.fn().mockImplementation(() => ({
+      convert: jest.fn(() => multilineSnippet)
+    }));
+  });
+
+  it('leaves the backslash continuation untouched by default', () => {
+    const language = { target: 'shell', client: 'curl' };
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toBe(multilineSnippet);
+  });
+
+  it('swaps to the caret continuation for Windows cmd', () => {
+    const language = { target: 'shell', client: 'curl' };
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false, lineContinuationChar: '^' });
+    expect(result).toBe('curl --request GET ^\n  --url https://example.com/api ^\n  --header \'Accept: application/json\'');
+  });
+
+  it('swaps to the backtick continuation for PowerShell', () => {
+    const language = { target: 'shell', client: 'curl' };
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false, lineContinuationChar: '`' });
+    expect(result).toBe('curl --request GET `\n  --url https://example.com/api `\n  --header \'Accept: application/json\'');
+  });
+
+  it('applies to other shell clients (wget/httpie), not just curl', () => {
+    const language = { target: 'shell', client: 'httpie' };
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false, lineContinuationChar: '^' });
+    expect(result).toBe('curl --request GET ^\n  --url https://example.com/api ^\n  --header \'Accept: application/json\'');
+  });
+
+  it('does not affect non-shell targets', () => {
+    const language = { target: 'javascript', client: 'fetch' };
+    const result = generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false, lineContinuationChar: '^' });
+    expect(result).toBe(multilineSnippet);
+  });
+});
+
 describe('generateSnippet – encodeUrl setting', () => {
   const language = { target: 'shell', client: 'curl' };
   const baseCollection = { root: { request: { auth: { mode: 'none' }, headers: [] } } };

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -79,7 +79,8 @@ const initialState = {
   generateCode: {
     mainLanguage: 'Shell',
     library: 'curl',
-    shouldInterpolate: true
+    shouldInterpolate: true,
+    lineContinuationChar: '\\'
   },
   cookies: [],
   taskQueue: [],

--- a/packages/bruno-app/src/utils/codegenerator/targets.js
+++ b/packages/bruno-app/src/utils/codegenerator/targets.js
@@ -1,21 +1,32 @@
 import { targets } from 'httpsnippet';
 
+// Maps httpsnippet target keys to CodeMirror mode identifiers.
+// Shell mode is not imported, and JSON-LD fallback mis-parses
+// backtick continuation chars, corrupting syntax colors.
+// Other targets keep their previous behaviour.
+const TARGET_CM_MODE = {
+  shell: 'text/plain'
+};
+
 export const getLanguages = () => {
   const allLanguages = [];
   for (const target of Object.values(targets)) {
     const { key, title } = target.info;
     const clients = Object.keys(target.clientsById);
+    const language = TARGET_CM_MODE[key];
     const languages
       = (clients.length === 1)
         ? [{
             name: title,
             target: key,
-            client: clients[0]
+            client: clients[0],
+            language
           }]
         : clients.map((client) => ({
             name: `${title}-${client}`,
             target: key,
-            client
+            client,
+            language
           }));
     allLanguages.push(...languages);
 


### PR DESCRIPTION
### Description

After `httpsnippet` generates the snippet, a lightweight string transform swaps the hardcoded  `\` + newline pattern with the user's chosen character. This is isolated to shell target only and is a no-op when the default `\` is selected.

## Why do this help?

`httpsnippet` assume that shell line continuation character is `\` for all shells, but that is not the case for PowerShell or even Windows cmd, where the correct character is the backtick (`` ` ``) and caret (`^`), respectively.


## Notes
Please, note that I disabled code syntax highlighting on shell commands since backtick and and caret broke it, but I think that it's a CodeMirror bug, since backtick and caret character in Shell commands are valid.

See this SS:

<img width="803" height="592" alt="image" src="https://github.com/user-attachments/assets/1489c9e1-22b5-4260-819a-81e97a6b8b98" />


## Screenshots

<img width="799" height="592" alt="image" src="https://github.com/user-attachments/assets/012c1e67-ca33-4d58-80c9-d354473ee5e9" />

<img width="800" height="590" alt="image" src="https://github.com/user-attachments/assets/84a04338-9cbb-4f54-84dc-3ac00fad32e7" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a line-continuation character selector for generated Shell commands (Unix/macOS `\`, Windows cmd `^`, PowerShell `` ` ``).
  * Generated shell snippets now use the selected continuation style.
* **Bug Fixes**
  * Improved shell snippet formatting to swap continuation characters correctly (non-shell output remains unchanged).
  * Enhanced code editor mode handling to keep highlighting and the variables overlay consistent when switching modes.
* **Tests**
  * Added Jest coverage verifying continuation behavior across multiple shell clients and non-shell targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->