### PR TITLE
feat(cli): agent-friendly JSON I/O contract for bru

### DIFF
--- a/docs/rfc-cli-json-contract.md
+++ b/docs/rfc-cli-json-contract.md
@@ -1,0 +1,528 @@
+# PRD + RFC: Agent-Friendly Bruno CLI — JSON Contract
+
+**Status:** Draft
+**Owner:** @sanish-bruno
+**Target package:** `packages/bruno-cli`
+**Created:** 2026-07-01
+
+---
+
+## TL;DR
+
+Make the `bru` CLI a first-class surface for AI agents and automation without introducing a database, daemon, or MCP server. We do this by adding (1) a versioned JSON I/O contract, (2) introspection and schema commands so agents can discover the tool, (3) an NDJSON event stream for `bru run`, (4) JSON-driven CRUD commands that round-trip through `.bru` files, and (5) a long-lived `bru serve` mode to amortise startup cost. The filesystem stays canonical — every new command is a thin façade over the same `.bru` files a human edits.
+
+---
+
+# Part 1 — PRD
+
+## 1.1 Problem
+
+Bruno's CLI today is excellent for **executing** a checked-in collection in CI: rich reporters, granular exit codes, data-driven runs, mTLS, scripted tests. It is weak as a surface for **agents** because:
+
+- There is no machine-readable way to **discover** what's in a collection (`bru ls` doesn't exist).
+- There is no machine-readable way to **introspect** the CLI itself — agents have to parse `--help` text, which is brittle.
+- There is no way to **author or mutate** a collection from the CLI; agents must write `.bru` syntax by hand. The `.bru` grammar is human-readable, but it is one more thing for the agent to get right.
+- `bru run` reports results only at the end (or to a file via `--reporter-json`). Agents can't stream progress or bail early on a structured signal.
+- There is no way to **dry-run** a request and inspect the resolved payload without sending it.
+- Each invocation pays Node.js + bruno-lang startup cost (~hundreds of ms). Agents that orchestrate dozens of calls feel this.
+
+Bruno can close this gap by leaning into its existing advantages — plain-text files, Git-friendliness, mature execution — and shipping a versioned JSON contract on top.
+
+## 1.2 Goals
+
+1. An agent that has never seen Bruno before can, given only the `bru` binary, **discover** the command surface, **list** a collection, **read** any request, **dry-run** any request, **execute** the collection with streaming feedback, and **react to failures** by error code.
+2. An agent can **author and mutate** requests, folders, environments, and collection variables via JSON payloads, with the changes appearing on disk as well-formed `.bru` files that a human would have written.
+3. The JSON output of every command is stable, versioned, and never changes silently — agents can pin to a major version.
+4. None of the above introduces a database, a daemon process required for normal use, an out-of-band index, or an MCP server.
+5. Existing human-facing CLI behaviour, exit codes, and reporter formats are preserved unchanged. Agent affordances are **additive** and opt-in (`--json`).
+
+## 1.3 Non-Goals
+
+- **No MCP server.** Agents that speak MCP shell out to the CLI; we are not maintaining a second surface.
+- **No database / index.** `.bru` on disk remains the only source of truth.
+- **No GUI changes.** This RFC does not touch the Electron app.
+- **No new scripting APIs.** The sandbox is unchanged.
+- **No protobuf, gRPC, or binary protocol** for the JSON contract.
+- **No remote / hosted mode.** `bru` continues to run locally against a directory.
+
+## 1.4 Users & Use Cases
+
+| User | Use case |
+|---|---|
+| Agent in an IDE (Cursor, Codex, Claude Code) | "Add a `POST /users` request to the auth folder that uses the existing `accessToken` env var, then run it against the Local env and tell me what failed." |
+| Agent in a CI job | "Run the smoke tag, stream results, and post a Slack summary the moment any request fails — don't wait for the full run." |
+| Agent doing API exploration | "Walk this collection and tell me which requests are missing tests, then propose tests for each." |
+| Human in a terminal | Unchanged — `bru run`, `bru import` continue to work exactly as today. |
+| CI pipeline | Unchanged — `--reporter-junit`, exit codes, etc. continue to work. |
+
+## 1.5 Success Metrics
+
+- **Discoverability:** an agent given only the binary can produce a valid `bru request add --json` payload after at most one `bru introspect` call and one `bru schema request` call.
+- **Streaming:** time from a request failure inside `bru run` to the agent observing a failure event is ≤ the request's duration + 50ms (i.e., effectively realtime via NDJSON), down from "end of run" today.
+- **Mutation safety:** every JSON-driven write produces a `.bru` file byte-identical to what `jsonToBru` produces for the equivalent input; round-tripping `bruToJson → jsonToBru` is the identity on all fixtures in `bruno-lang/v2/tests`.
+- **Backwards compatibility:** zero changes to the human-readable stdout of any existing subcommand when `--json` is **not** passed. Zero changes to existing exit codes.
+- **Startup amortisation:** in `bru serve --stdio`, p50 per-command latency for `request.get` and `request.edit` is ≤ 20ms after warm-up, vs ≥ 300ms per cold invocation.
+
+## 1.6 Scope (Phased)
+
+We do not have to ship everything at once. Three phases:
+
+| Phase | Contents | Risk |
+|---|---|---|
+| **P1 — Read & run** | `bru introspect`, `bru ls`, `bru schema`, `bru get`, `bru run --json` (NDJSON event stream), `bru run --dry-run`, `--json-version`, structured error envelope on stderr | Low — read-only, additive |
+| **P2 — Write** | `bru request add/edit/delete`, `bru folder add/edit/delete`, `bru env set/unset`, `bru collection-var set/unset`, all `--json` driven, with `--if-not-exists` / `--update` idempotency | Medium — filesystem mutations, must round-trip through bruno-lang cleanly |
+| **P3 — Long-lived mode** | `bru serve --stdio` accepting NDJSON commands on stdin, emitting NDJSON responses on stdout | Medium — new process lifecycle, watch semantics |
+
+Each phase is shippable on its own. P1 alone closes most of the agent gap.
+
+## 1.7 Open Product Questions
+
+1. Should `bru schema` derive its schemas from the existing `@usebruno/schema` package, or hand-author CLI-output schemas? Tension: re-use vs. decoupling CLI output from internal data shapes.
+2. How aggressively should we redact secrets in streamed events? Default-on with `--include-secrets` opt-out, or default-off mirroring today's reporter behaviour?
+3. Should `bru serve --stdio` use [JSON-RPC 2.0](https://www.jsonrpc.org/specification) or a Bruno-specific NDJSON envelope? JSON-RPC is well-known but heavier; bespoke is leaner but one more spec to learn.
+4. Do we ship `bru get response` (a way to retrieve the last response from disk) in P1 or P2? Depends on whether we want to commit to persisting responses anywhere outside the in-memory runner.
+
+---
+
+# Part 2 — RFC: The JSON Contract
+
+## 2.1 Versioning
+
+The JSON contract is versioned with a single integer.
+
+- The current version is exposed as `bru --json-version` (returns e.g. `1`) and on every envelope as `"version": 1`.
+- Agents pin with `bru <cmd> --json --json-version=1`. If the CLI is newer and `1` is still supported, output conforms to v1. If `1` is no longer supported, the CLI exits with code `9` (invalid output format requested) and writes a structured error.
+- A **major** version bump is the only thing that may break field names, types, or required-ness. Adding new optional fields is **not** a major change — agents must ignore unknown fields.
+- We ship v1 with the first agent-facing release and commit to supporting v1 for at least 12 months after v2 lands.
+
+## 2.2 Global Conventions
+
+### `--json`
+
+- Available on every subcommand. When passed, **stdout is exclusively JSON or NDJSON.** No banners, no tables, no ANSI colour, no progress dots.
+- When `--json` is not passed and stdout is not a TTY, the CLI auto-disables ANSI but keeps the human-readable format — this is the existing behaviour and stays.
+
+### Stdin
+
+- Any command accepting `--json '<payload>'` also accepts `--json -` to read the payload from stdin. This lets agents avoid argv-length limits and shell-escaping.
+
+### Stdout vs stderr
+
+- **stdout:** the JSON envelope(s) for the command's result.
+- **stderr:** human-readable diagnostic text (when `--json` is **not** set) **or** a single JSON error envelope (when `--json` **is** set and the command failed).
+- Neither stream is interleaved with the other.
+
+### Exit codes
+
+The existing exit codes (0–9, 255) are preserved unchanged. New error categories from new commands map to **255** unless they precisely match an existing code's meaning. We will **not** silently re-use code `1` for non-run failures.
+
+## 2.3 Output Envelope
+
+All JSON output uses a common envelope:
+
+```json
+{
+  "version": 1,
+  "kind": "request.get",
+  "ok": true,
+  "data": { /* command-specific payload */ },
+  "meta": {
+    "cli_version": "2.x.x",
+    "collection_path": "/abs/path",
+    "elapsed_ms": 12
+  }
+}
+```
+
+- `kind` is `"<noun>.<verb>"` and identifies the schema of `data`. Agents dispatch on this.
+- `ok: true` means the command succeeded. On failure, see §2.6.
+- `meta` carries non-essential context. Agents may ignore it entirely.
+
+NDJSON streams (§2.4) use the **same envelope per line**. Every line is independently parseable.
+
+## 2.4 NDJSON Event Stream — `bru run --json`
+
+When `--json` is passed to `bru run`, stdout becomes a newline-delimited stream of envelopes. Each line is a complete JSON object. The stream ends with exactly one `run.end` envelope.
+
+### Event kinds
+
+| `kind` | When emitted | Key `data` fields |
+|---|---|---|
+| `run.start` | Once, before any request | `collection`, `env`, `total_requests`, `filters` |
+| `request.start` | Before each request fires | `path`, `name`, `method`, `url`, `iteration` |
+| `request.script.log` | Each `console.log` from pre/post/test scripts | `phase`, `level`, `message` |
+| `request.response` | After response received | `status`, `status_text`, `duration_ms`, `size_bytes`, `headers` (redacted), `body_preview` |
+| `assertion.result` | Per assertion evaluated | `description`, `passed`, `lhs`, `rhs`, `operator`, `error?` |
+| `test.result` | Per `test(...)` call | `name`, `passed`, `error?` |
+| `request.end` | After each request fully completes | `path`, `status`, `passed`, `failed`, `skipped`, `reason?` |
+| `run.end` | Once, at the very end | Identical shape to today's `--reporter-json` summary, plus `exit_code` |
+
+### Streaming guarantees
+
+- Events are emitted in **causal order per request**: `request.start` → (`request.script.log`)\* → `request.response` → (`assertion.result` | `test.result`)\* → `request.end`.
+- When running with `--parallel N` (future), events are still well-formed per request but may interleave across requests. The `path` field disambiguates.
+- The process flushes after every line. Agents can rely on a fresh `\n` meaning "this event is now durable for you to act on."
+- On `--bail`, the stream still emits `request.end` for the failing request, then `run.end` with `exit_code: 1`, then exits. No torn events.
+
+### Compatibility with `--reporter-json`
+
+The existing `--reporter-json <path>` reporter is **unchanged**. `--json` (stdout NDJSON) and `--reporter-json` (final file) can be used together; one streams, the other dumps the summary.
+
+## 2.5 Subcommand Schemas (P1)
+
+### `bru introspect --json`
+
+Returns the entire command tree, every flag, type, default, and one example per command. This is the agent's bootstrap call.
+
+```json
+{
+  "version": 1,
+  "kind": "introspect",
+  "ok": true,
+  "data": {
+    "cli_version": "2.x.x",
+    "json_contract_version": 1,
+    "commands": [
+      {
+        "name": "run",
+        "summary": "Run one or more requests/folders",
+        "args": [{ "name": "paths", "variadic": true, "type": "path" }],
+        "flags": [
+          { "name": "--env", "type": "string", "summary": "Environment name" },
+          { "name": "--json", "type": "boolean", "summary": "Emit NDJSON event stream on stdout" },
+          { "name": "--dry-run", "type": "boolean", "summary": "Resolve and print requests without sending" }
+        ],
+        "examples": [
+          "bru run --env Local --json"
+        ],
+        "exit_codes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 255]
+      }
+    ]
+  }
+}
+```
+
+### `bru ls --json [path]`
+
+Walks the collection starting at `path` (default: cwd if inside a collection) and emits the tree.
+
+```json
+{
+  "version": 1,
+  "kind": "ls",
+  "ok": true,
+  "data": {
+    "collection": { "name": "My API", "path": "/abs/path" },
+    "items": [
+      { "type": "folder", "path": "auth", "name": "auth" },
+      { "type": "request", "path": "auth/login.bru", "name": "login", "method": "POST", "url": "{{baseUrl}}/login", "tags": ["smoke"], "has_tests": true },
+      { "type": "environment", "path": "environments/Local.bru", "name": "Local" }
+    ]
+  }
+}
+```
+
+`--depth N` limits recursion. `--filter tag:smoke` and `--filter folder:auth/*` apply (see §2.7).
+
+### `bru schema <kind> --json`
+
+Returns the JSON Schema for a Bruno resource. `<kind>` is one of `request`, `folder`, `environment`, `collection`, `collection-var`. The schema is the one used by `bru request add --json` etc., so agents introspect-then-author.
+
+```json
+{
+  "version": 1,
+  "kind": "schema",
+  "ok": true,
+  "data": {
+    "resource": "request",
+    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object", "...": "..." }
+  }
+}
+```
+
+`bru schema cli-output --json --kind=run.end` returns the JSON Schema for the output envelope of a given `kind`. This lets agents validate their parser.
+
+### `bru get request <path> --json`
+
+Returns a single request as JSON (the result of `bruToJson(file)`), wrapped in the standard envelope.
+
+```json
+{
+  "version": 1,
+  "kind": "request.get",
+  "ok": true,
+  "data": {
+    "path": "auth/login.bru",
+    "request": { "method": "POST", "url": "{{baseUrl}}/login", "headers": [...], "body": {...}, "tests": "...", "...": "..." }
+  }
+}
+```
+
+Variants: `bru get folder <path>`, `bru get environment <name>`, `bru get collection`.
+
+### `bru run --dry-run --json`
+
+Resolves all variables, auth, scripts (pre-request only), and emits the **final request** without sending it. One envelope per request.
+
+```json
+{
+  "version": 1,
+  "kind": "request.dry_run",
+  "ok": true,
+  "data": {
+    "path": "auth/login.bru",
+    "resolved": { "method": "POST", "url": "https://api.example.com/login", "headers": [...], "body": "{...}", "auth_applied": "bearer" },
+    "variables_used": ["baseUrl", "accessToken"]
+  }
+}
+```
+
+This is the single highest-leverage debug primitive — agents can verify "what would be sent" without side effects.
+
+## 2.6 Error Envelope
+
+When `--json` is set and a command fails, **stderr** receives exactly one line containing the error envelope; **stdout** is empty.
+
+```json
+{
+  "version": 1,
+  "kind": "error",
+  "ok": false,
+  "error": {
+    "code": 7,
+    "name": "env_override_invalid",
+    "message": "Environment override must be a string or object, got number",
+    "hint": "Use --env-var KEY=VALUE or --env-var KEY=@json:'{...}'",
+    "docs_url": "https://docs.usebruno.com/bru-cli/env-overrides",
+    "details": { "received_type": "number", "argument_index": 2 }
+  }
+}
+```
+
+- `code` is the process exit code. Always one of the documented exit codes.
+- `name` is a stable string slug. Agents branch on this, **not** on `message`.
+- `details` is free-form per-error context. Agents may ignore it.
+
+A non-exhaustive map of `code → name`:
+
+| code | name |
+|---|---|
+| 1 | `run_failed` |
+| 2 | `output_dir_missing` |
+| 3 | `request_loop` |
+| 4 | `not_in_collection` |
+| 5 | `input_not_found` |
+| 6 | `env_not_found` |
+| 7 | `env_override_invalid` |
+| 8 | `env_override_malformed` |
+| 9 | `invalid_output_format` |
+| 255 | `internal_error` (with `details.cause`) |
+
+## 2.7 Selectors
+
+Today, request selection is positional (`bru run path1 path2 folder/`). For agents, this is awkward to compose. We add `--filter` (repeatable, ANDed):
+
+| Filter | Semantics |
+|---|---|
+| `--filter tag:<name>` | Only requests with this tag |
+| `--filter folder:<glob>` | Only requests under matching folder paths |
+| `--filter method:<verb>` | Only requests with this HTTP method |
+| `--filter has-tests` | Only requests with executable tests (replaces `--tests-only` long form; flag stays) |
+
+Positional paths and `--filter` compose: the request must match the positional path **and** all filters.
+
+## 2.8 Write Commands (P2)
+
+All P2 mutations:
+
+1. Validate the input against the corresponding schema before touching disk.
+2. Write atomically (temp file + `rename`).
+3. Round-trip through `bruno-lang`'s `jsonToBru` to produce a human-clean `.bru` file.
+4. Are idempotent under explicit flags.
+
+### `bru request add --json '{...}'`
+
+```bash
+bru request add --json '{
+  "path": "auth/refresh.bru",
+  "request": {
+    "method": "POST",
+    "url": "{{baseUrl}}/auth/refresh",
+    "body": { "mode": "json", "json": "{\"token\": \"{{refreshToken}}\"}" },
+    "tests": "test('200', () => expect(res.getStatus()).toEqual(200))"
+  }
+}' --if-not-exists
+```
+
+- `--if-not-exists`: succeed silently if the request already exists (used for safe retries).
+- Without it: error `request_already_exists` (code 255 + name) if the file is present.
+
+### `bru request edit <path> --patch '{...}'`
+
+JSON Merge Patch (RFC 7396) semantics over the request JSON. `null` deletes a field. The whole file is rewritten via `jsonToBru` after applying the patch.
+
+### `bru request delete <path>`
+
+Deletes the file. Refuses to delete a folder containing other files unless `--recursive`.
+
+Analogous commands exist for `folder`, `environment`, `collection-var`. All take the same envelope shape and emit the resulting resource on stdout (so agents don't have to re-read).
+
+## 2.9 Long-Lived Mode (P3) — `bru serve --stdio`
+
+A single `bru` process reads NDJSON command envelopes on stdin and writes NDJSON response envelopes on stdout. Each command is **stateless** with respect to the others — `bru serve` is purely a startup-cost amortiser, not a session manager.
+
+### Request envelope (stdin)
+
+```json
+{ "id": "req-42", "command": "request.get", "args": { "path": "auth/login.bru" } }
+```
+
+### Response envelope (stdout)
+
+```json
+{ "id": "req-42", "version": 1, "kind": "request.get", "ok": true, "data": { "...": "..." } }
+```
+
+`id` is echoed verbatim. The agent uses it to correlate concurrent calls.
+
+### Concurrency
+
+Read commands may be served concurrently. Write commands are serialised per collection path to avoid torn writes. `bru run` started inside `serve` mode streams its NDJSON events back with the originating `id` on every event.
+
+### Shutdown
+
+EOF on stdin or `{"command": "shutdown"}` triggers a clean shutdown after in-flight commands finish.
+
+### Why not JSON-RPC 2.0?
+
+We considered it. Pros: well-known, batched requests, named errors. Cons: heavier envelope, requires libraries on the agent side, and our existing stdout envelope already covers the same ground. Decision: **bespoke NDJSON envelope** that mirrors the one-shot envelope. (Reconsider in v2 if multiple agents request JSON-RPC compatibility.)
+
+## 2.10 Compatibility & Migration
+
+- `bru` without `--json` is **unchanged**. Every existing user, every CI pipeline, every reporter continues to work.
+- `--json` is **additive** on every command. A command that does not currently accept `--json` will accept it and emit an envelope after this RFC lands.
+- The `--reporter-json` and `--reporter-junit` reporters stay. The NDJSON event stream (`--json` on `run`) is a strict superset of the reporter-json file content — the file format does not change.
+- Exit codes stay. New error names map onto existing exit codes wherever the meaning matches; otherwise `255`.
+
+## 2.11 Security & Secrets
+
+- The NDJSON `request.response` event redacts the response body by default if the request used any auth (`Authorization` header, bearer, AWS v4, etc.) — agents see `"body_preview": "<redacted>"` unless `--include-secrets` is passed.
+- Environment variables in `bru get environment` are returned **with values** by default — same behaviour as today's env file on disk, which the agent could read directly anyway. `--redact-secrets` opt-in to mask values matching `*secret*`, `*token*`, `*password*` patterns.
+- The error envelope's `details` field is sanitised — file paths are absolute, but no request bodies or env values are ever placed in error details.
+
+## 2.12 Rollout Plan
+
+1. **Land P1 behind a feature flag** (`BRU_AGENT_MODE=1` or `--json` itself acts as the flag, since today no command accepts it). Ship in a minor release.
+2. **Publish the JSON Schemas** under `packages/bruno-cli/schemas/v1/*.json` and a `bru schema cli-output --kind=<...>` accessor.
+3. **Add a test fixture suite** that round-trips every `.bru` file in `packages/bruno-tests/collection` through `bru get request → bru request edit --patch '{}' (noop) → diff`. The diff must be empty.
+4. **Document** in `packages/bruno-cli/readme.md` and `docs.usebruno.com/bru-cli/json-mode`.
+5. **Gather feedback** for ~2 minor releases before locking v1.
+6. **Land P2**, then **P3**, each as their own minor release.
+
+## 2.13 Open Technical Questions
+
+1. **Schema source of truth.** Do we generate `bru schema request` JSON Schema from `@usebruno/schema`'s Yup/Zod definitions, or hand-author? Generating is DRYer but couples CLI output to an internal lib's surface.
+2. **Body size in NDJSON.** A 5MB response body would blow up the event stream. Cap `body_preview` at, say, 8KB by default, with `--max-body-bytes=N`? Or always truncate and require an explicit `bru get response <id>` follow-up?
+3. **`bru get response`.** P1 has no response storage. Should we add an in-memory store keyed by run id, accessible only within `bru serve` mode?
+4. **Watch semantics.** Should `bru ls --watch --json` be a thing in P1, or wait for P3's `serve` mode to provide subscription-style updates?
+5. **`bru introspect` stability.** If we add a new flag to `bru run`, that changes `introspect`'s output. Is this a v1 break? Decision: no — `introspect` is "additive-only" within a major version, and agents must tolerate new flags appearing.
+6. **Cross-platform line endings in NDJSON.** Lock to `\n` regardless of OS, including on Windows. Agents parse by `\n`, not `os.EOL`.
+
+## 2.14 What We Are Explicitly Not Doing
+
+- **No MCP server.** If an agent speaks MCP, it shells out to `bru` — same as a CI pipeline does.
+- **No remote `bru` daemon.** `bru serve --stdio` is local, stdin/stdout-bound, and dies with its parent.
+- **No new persistence.** No SQLite, no `.bru-cache`, no index files.
+- **No breaking changes** to the existing CLI in v1.
+- **No deprecation** of `--reporter-json` / `--reporter-junit` / `--reporter-html` — they remain the recommended file outputs for CI.
+
+---
+
+## Appendix A — Worked Example: An Agent Adds and Runs a Request
+
+```bash
+# 1. Discover the surface.
+bru introspect --json > tools.json
+
+# 2. Discover the request schema.
+bru schema request --json > request.schema.json
+
+# 3. List the collection to find the right folder.
+bru ls --json --filter folder:auth
+
+# 4. Read an existing request to copy its auth pattern.
+bru get request auth/login.bru --json
+
+# 5. Author the new request from a JSON payload on stdin.
+cat <<'EOF' | bru request add --json - --if-not-exists
+{
+  "path": "auth/refresh.bru",
+  "request": {
+    "method": "POST",
+    "url": "{{baseUrl}}/auth/refresh",
+    "headers": [{ "name": "Content-Type", "value": "application/json", "enabled": true }],
+    "body": { "mode": "json", "json": "{\"token\":\"{{refreshToken}}\"}" }
+  }
+}
+EOF
+
+# 6. Dry-run to verify what will be sent.
+bru run auth/refresh.bru --env Local --dry-run --json
+
+# 7. Execute with streaming feedback; the agent watches stdout line-by-line
+#    and acts on the first `request.end` with `passed: false`.
+bru run auth/refresh.bru --env Local --json
+```
+
+## Appendix B — Worked Example: NDJSON Event Stream
+
+```
+{"version":1,"kind":"run.start","ok":true,"data":{"collection":"/abs/path","env":"Local","total_requests":2,"filters":[]}}
+{"version":1,"kind":"request.start","ok":true,"data":{"path":"auth/login.bru","name":"login","method":"POST","url":"https://api.example.com/login","iteration":1}}
+{"version":1,"kind":"request.response","ok":true,"data":{"path":"auth/login.bru","status":200,"duration_ms":142,"size_bytes":318,"body_preview":"<redacted>"}}
+{"version":1,"kind":"assertion.result","ok":true,"data":{"path":"auth/login.bru","description":"status is 200","passed":true}}
+{"version":1,"kind":"request.end","ok":true,"data":{"path":"auth/login.bru","status":"passed","passed":1,"failed":0,"skipped":0}}
+{"version":1,"kind":"request.start","ok":true,"data":{"path":"auth/refresh.bru","name":"refresh","method":"POST","url":"https://api.example.com/auth/refresh","iteration":1}}
+{"version":1,"kind":"request.response","ok":true,"data":{"path":"auth/refresh.bru","status":401,"duration_ms":98,"size_bytes":52,"body_preview":"{\"error\":\"invalid_token\"}"}}
+{"version":1,"kind":"assertion.result","ok":false,"data":{"path":"auth/refresh.bru","description":"status is 200","passed":false,"lhs":401,"rhs":200,"operator":"eq"}}
+{"version":1,"kind":"request.end","ok":false,"data":{"path":"auth/refresh.bru","status":"failed","passed":0,"failed":1,"skipped":0}}
+{"version":1,"kind":"run.end","ok":false,"data":{"total":2,"passed":1,"failed":1,"skipped":0,"duration_ms":240,"exit_code":1}}
+```
+
+## Appendix C — File Layout
+
+```
+packages/bruno-cli/
+├── schemas/
+│   └── v1/
+│       ├── envelope.json
+│       ├── error.json
+│       ├── request.json
+│       ├── folder.json
+│       ├── environment.json
+│       ├── collection.json
+│       ├── events/
+│       │   ├── run.start.json
+│       │   ├── request.start.json
+│       │   ├── request.response.json
+│       │   ├── assertion.result.json
+│       │   ├── test.result.json
+│       │   ├── request.end.json
+│       │   └── run.end.json
+│       └── introspect.json
+├── src/
+│   ├── commands/
+│   │   ├── run.js          # extended with --json NDJSON output
+│   │   ├── introspect.js   # new
+│   │   ├── ls.js           # new
+│   │   ├── schema.js       # new
+│   │   ├── get.js          # new (P1)
+│   │   ├── request.js      # new (P2)
+│   │   ├── folder.js       # new (P2)
+│   │   ├── env.js          # new (P2)
+│   │   └── serve.js        # new (P3)
+│   └── json/
+│       ├── envelope.js     # writeEnvelope, writeError, writeEvent
+│       ├── version.js      # contract version constant + negotiation
+│       └── redact.js       # secret-masking helpers
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11370,6 +11370,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@sodaru/yup-to-json-schema": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@sodaru/yup-to-json-schema/-/yup-to-json-schema-2.0.1.tgz",
+      "integrity": "sha512-lWb0Wiz8KZ9ip/dY1eUqt7fhTPmL24p6Hmv5Fd9pzlzAdw/YNcWZr+tiCT4oZ4Zyxzi9+1X4zv82o7jYvcFxYA==",
+      "dev": true,
+      "license": "MIT License"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -32955,6 +32962,7 @@
         "codemirror": "5.65.2",
         "codemirror-graphql": "2.1.1",
         "cookie": "0.7.1",
+        "diff": "^5.2.0",
         "diff2html": "^3.4.47",
         "dompurify": "^3.2.4",
         "escape-html": "^1.0.3",
@@ -34575,6 +34583,9 @@
       },
       "bin": {
         "bru": "bin/bru.js"
+      },
+      "devDependencies": {
+        "@sodaru/yup-to-json-schema": "^2.0.1"
       }
     },
     "packages/bruno-cli/node_modules/form-data": {

--- a/packages/bruno-cli/package.json
+++ b/packages/bruno-cli/package.json
@@ -37,11 +37,14 @@
   ],
   "scripts": {
     "test": "node --experimental-vm-modules $(npx which jest)",
-    "test:ci": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js"
+    "test:ci": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js",
+    "generate:schemas": "node scripts/generate-schemas.js",
+    "check:schemas": "node scripts/generate-schemas.js --check"
   },
   "files": [
     "src",
     "bin",
+    "schemas",
     "readme.md",
     "changelog.md",
     "package.json"
@@ -72,5 +75,9 @@
     "socks-proxy-agent": "^8.0.2",
     "xmlbuilder": "^15.1.1",
     "yargs": "^17.6.2"
+  },
+  "devDependencies": {
+    "@sodaru/yup-to-json-schema": "^2.0.1",
+    "@usebruno/schema": "0.7.0"
   }
 }

--- a/packages/bruno-cli/schemas/v1/cli-output.json
+++ b/packages/bruno-cli/schemas/v1/cli-output.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usebruno.com/schemas/v1/cli-output.json",
+  "x-source": "hand-authored",
+  "x-bruno-contract-version": 1,
+  "x-source-note": "Wire shape of every envelope emitted by the bru CLI in JSON mode. Every line of NDJSON from `bru run --json` matches this. One-shot commands (bru ls --json, bru get --json) emit a single instance.",
+  "title": "Bruno CLI JSON envelope",
+  "type": "object",
+  "required": ["version", "kind", "ok"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "JSON contract version. Bumps on breaking changes only.",
+      "minimum": 1
+    },
+    "kind": {
+      "type": "string",
+      "description": "Identifies the schema of `data`. <noun>.<verb> for resource ops; <noun>.<phase> for events.",
+      "examples": [
+        "introspect",
+        "ls",
+        "schema",
+        "request.get",
+        "folder.get",
+        "environment.get",
+        "collection.get",
+        "run.start",
+        "request.start",
+        "request.response",
+        "assertion.result",
+        "test.result",
+        "request.end",
+        "run.end",
+        "error"
+      ]
+    },
+    "ok": {
+      "type": "boolean",
+      "description": "False indicates a failure event or an error envelope."
+    },
+    "data": {
+      "description": "kind-specific payload. Use bru schema cli-output --kind=<kind> for per-kind shapes (planned in a follow-up)."
+    },
+    "error": {
+      "type": "object",
+      "description": "Present on stderr error envelopes (kind=\"error\"). Absent on success envelopes.",
+      "required": ["code", "name", "message"],
+      "additionalProperties": true,
+      "properties": {
+        "code": {
+          "type": "integer",
+          "description": "Process exit code. Maps to EXIT_STATUS in @usebruno/cli."
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Stable machine-readable slug for this error category. Branch on this, not on `message`."
+        },
+        "message": { "type": "string" },
+        "hint": { "type": "string" },
+        "docs_url": { "type": "string", "format": "uri" },
+        "details": {}
+      }
+    },
+    "meta": {
+      "type": "object",
+      "description": "Non-essential context. Agents may ignore.",
+      "additionalProperties": true,
+      "properties": {
+        "cli_version": { "type": "string" },
+        "collection_path": { "type": "string" },
+        "elapsed_ms": { "type": "number" }
+      }
+    }
+  }
+}

--- a/packages/bruno-cli/schemas/v1/collection-var.json
+++ b/packages/bruno-cli/schemas/v1/collection-var.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usebruno.com/schemas/v1/collection-var.json",
+  "x-source": "hand-authored",
+  "x-bruno-contract-version": 1,
+  "x-source-note": "Shape of an individual collection variable as exposed by bru.setCollectionVar / persisted to collection.bru.",
+  "title": "Bruno collection variable",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["name"],
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "value": {
+      "description": "Variable value. Scripts may set non-string values; persistence preserves the runtime type."
+    },
+    "description": { "type": ["string", "null"] },
+    "enabled": { "type": "boolean" },
+    "secret": { "type": "boolean" },
+    "dataType": {
+      "type": ["string", "null"],
+      "enum": [null, "string", "number", "boolean", "object"]
+    },
+    "annotations": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/packages/bruno-cli/schemas/v1/collection.json
+++ b/packages/bruno-cli/schemas/v1/collection.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usebruno.com/schemas/v1/collection.json",
+  "x-source": "hand-authored",
+  "x-bruno-contract-version": 1,
+  "x-source-note": "Top-level shape of a Bruno collection root file (collection.bru / opencollection.yml) as parsed by @usebruno/filestore. collectionSchema in @usebruno/schema is recursive via itemSchema; converter can't handle it. Permissive on nested values.",
+  "title": "Bruno collection",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "version": { "type": ["string", "number"] },
+    "name": { "type": "string" },
+    "type": { "type": "string" },
+    "items": {
+      "type": "array",
+      "description": "Folders + requests (recursive). See request.json for request shape; folders nest further items under `items`.",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "environments": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "root": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "request": { "type": "object", "additionalProperties": true },
+        "docs": { "type": "string" },
+        "meta": { "type": "object", "additionalProperties": true }
+      }
+    }
+  }
+}

--- a/packages/bruno-cli/schemas/v1/environment.json
+++ b/packages/bruno-cli/schemas/v1/environment.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usebruno.com/schemas/v1/environment.json",
+  "x-source": "generated",
+  "x-bruno-contract-version": 1,
+  "title": "Bruno environment",
+  "type": "object",
+  "properties": {
+    "uid": {
+      "type": "string",
+      "minLength": 21,
+      "maxLength": 21,
+      "pattern": "^[a-zA-Z0-9]*$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "variables": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "uid": {
+            "type": "string",
+            "minLength": 21,
+            "maxLength": 21,
+            "pattern": "^[a-zA-Z0-9]*$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "value": {},
+          "annotations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "text"
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "secret": {
+            "type": "boolean"
+          },
+          "dataType": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "object"
+            ]
+          }
+        }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "color": {
+      "type": "string"
+    },
+    "pathname": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/bruno-cli/schemas/v1/environments.json
+++ b/packages/bruno-cli/schemas/v1/environments.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usebruno.com/schemas/v1/environments.json",
+  "x-source": "generated",
+  "x-bruno-contract-version": 1,
+  "title": "Bruno environments (array)",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "uid": {
+        "type": "string",
+        "minLength": 21,
+        "maxLength": 21,
+        "pattern": "^[a-zA-Z0-9]*$"
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "variables": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "uid": {
+              "type": "string",
+              "minLength": 21,
+              "maxLength": 21,
+              "pattern": "^[a-zA-Z0-9]*$"
+            },
+            "name": {
+              "type": "string"
+            },
+            "value": {},
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "text"
+              ]
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "secret": {
+              "type": "boolean"
+            },
+            "dataType": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "boolean",
+                "object"
+              ]
+            }
+          }
+        }
+      },
+      "externalSecrets": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "variables": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "color": {
+        "type": "string"
+      },
+      "pathname": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/packages/bruno-cli/schemas/v1/folder.json
+++ b/packages/bruno-cli/schemas/v1/folder.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usebruno.com/schemas/v1/folder.json",
+  "x-source": "hand-authored",
+  "x-bruno-contract-version": 1,
+  "x-source-note": "Shape of a folder.bru / folder.yml file. Optional in a collection — folders without a folder.bru file are pure directories. Permissive top-level.",
+  "title": "Bruno folder",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "type": { "type": "string", "const": "folder" },
+    "name": { "type": "string" },
+    "seq": { "type": "number" },
+    "root": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "request": { "type": "object", "additionalProperties": true },
+        "docs": { "type": "string" },
+        "meta": { "type": "object", "additionalProperties": true }
+      }
+    }
+  }
+}

--- a/packages/bruno-cli/schemas/v1/request.json
+++ b/packages/bruno-cli/schemas/v1/request.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usebruno.com/schemas/v1/request.json",
+  "x-source": "hand-authored",
+  "x-bruno-contract-version": 1,
+  "x-source-note": "Mirrors the shape produced by @usebruno/filestore parseRequest(). itemSchema in @usebruno/schema uses Yup.lazy() for recursive items which the @sodaru/yup-to-json-schema converter cannot handle; hand-authored is the path of least surprise. Top-level fields are named; deeply-nested values stay permissive (additionalProperties: true) to avoid rejecting valid bruno-lang output during v1.",
+  "title": "Bruno request",
+  "type": "object",
+  "required": ["type", "name", "request"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["http-request", "graphql-request", "grpc-request", "ws-request"]
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "seq": { "type": "number" },
+    "settings": { "type": "object", "additionalProperties": true },
+    "tags": { "type": "array", "items": { "type": "string" } },
+    "request": {
+      "type": "object",
+      "required": ["method", "url"],
+      "additionalProperties": true,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method or protocol-specific verb (GET/POST/.../QUERY for HTTP, etc.)"
+        },
+        "url": { "type": "string" },
+        "headers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "name": { "type": "string" },
+              "value": { "type": "string" },
+              "description": { "type": ["string", "null"] },
+              "enabled": { "type": "boolean" }
+            }
+          }
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "name": { "type": "string" },
+              "value": { "type": "string" },
+              "type": { "type": "string", "enum": ["query", "path"] },
+              "enabled": { "type": "boolean" }
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["none", "inherit", "basic", "bearer", "digest", "wsse", "apikey", "awsv4", "ntlm", "oauth2"]
+            }
+          }
+        },
+        "body": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["none", "json", "text", "xml", "formUrlEncoded", "multipartForm", "graphql", "sparql", "file"]
+            },
+            "json": { "type": ["string", "null"] },
+            "text": { "type": ["string", "null"] },
+            "xml": { "type": ["string", "null"] },
+            "sparql": { "type": ["string", "null"] },
+            "formUrlEncoded": { "type": ["array", "null"] },
+            "multipartForm": { "type": ["array", "null"] },
+            "graphql": { "type": ["object", "null"] },
+            "file": { "type": ["array", "null"] }
+          }
+        },
+        "script": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "req": { "type": "string", "description": "Pre-request script body" },
+            "res": { "type": "string", "description": "Post-response script body" }
+          }
+        },
+        "vars": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "req": { "type": "array" },
+            "res": { "type": "array" }
+          }
+        },
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "name": { "type": "string" },
+              "value": { "type": "string" },
+              "enabled": { "type": "boolean" },
+              "operator": { "type": ["string", "null"] }
+            }
+          }
+        },
+        "tests": { "type": "string", "description": "Test script body" },
+        "docs": { "type": "string" }
+      }
+    },
+    "examples": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    }
+  },
+  "additionalProperties": true
+}

--- a/packages/bruno-cli/scripts/generate-schemas.js
+++ b/packages/bruno-cli/scripts/generate-schemas.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+// Generates JSON Schemas under packages/bruno-cli/schemas/v1/ for the `bru schema`
+// command. Mixes two sources:
+//
+//   1. Auto-generated from @usebruno/schema (Yup) for schemas the @sodaru/yup-to-json-schema
+//      converter handles cleanly (today: environment, environments).
+//   2. Hand-authored for schemas the converter cannot handle — primarily anything that
+//      uses Yup.lazy() for self-referential trees (itemSchema, collectionSchema), or
+//      anything not represented in @usebruno/schema (the JSON I/O envelope).
+//
+// Hand-authored files live under schemas/v1/ already and carry "x-source": "hand-authored".
+// This script leaves those untouched and only rewrites schemas marked "x-source": "generated"
+// (or those that don't exist yet).
+//
+// Usage:
+//   node scripts/generate-schemas.js           # write/update generated schemas
+//   node scripts/generate-schemas.js --check   # verify on-disk matches generator output (CI)
+
+const fs = require('fs');
+const path = require('path');
+const { convertSchema } = require('@sodaru/yup-to-json-schema');
+const { environmentSchema, environmentsSchema } = require('@usebruno/schema');
+const { JSON_CONTRACT_VERSION } = require('../src/json/version');
+
+const SCHEMA_DIR = path.resolve(__dirname, '..', 'schemas', `v${JSON_CONTRACT_VERSION}`);
+
+// Walk the converter output and normalise quirks that aren't valid JSON Schema,
+// and that don't match the on-disk shape produced by bruno-lang parsers:
+//   - { type: [] } → drop (Yup.mixed() emits empty type array; "{}" in JSON Schema means any).
+//   - drop "required" arrays everywhere. Yup schemas describe the in-memory model
+//     (with synthesised uid, etc.); bruno-lang's parser output is the on-disk shape
+//     and lacks those fields. The schemas live as structural hints for agents, not
+//     strict validators — agents author payloads that bru request add/edit will then
+//     reject precisely if invalid. (PR 5.)
+const normalise = (node) => {
+  if (Array.isArray(node)) return node.map(normalise);
+  if (node && typeof node === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(node)) {
+      if (k === 'type' && Array.isArray(v) && v.length === 0) continue;
+      if (k === 'required' && Array.isArray(v)) continue;
+      out[k] = normalise(v);
+    }
+    return out;
+  }
+  return node;
+};
+
+const wrapSchema = ({ kind, title, schema, source }) => ({
+  '$schema': 'https://json-schema.org/draft/2020-12/schema',
+  '$id': `https://usebruno.com/schemas/v${JSON_CONTRACT_VERSION}/${kind}.json`,
+  'x-source': source,
+  'x-bruno-contract-version': JSON_CONTRACT_VERSION,
+  title,
+  ...schema
+});
+
+const generated = {
+  environment: () => wrapSchema({
+    kind: 'environment',
+    title: 'Bruno environment',
+    source: 'generated',
+    schema: normalise(convertSchema(environmentSchema))
+  }),
+  environments: () => wrapSchema({
+    kind: 'environments',
+    title: 'Bruno environments (array)',
+    source: 'generated',
+    schema: normalise(convertSchema(environmentsSchema))
+  })
+};
+
+const HAND_AUTHORED = ['request', 'collection', 'folder', 'collection-var', 'cli-output'];
+
+const readJsonFile = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+const writeJsonFile = (p, data) => fs.writeFileSync(p, JSON.stringify(data, null, 2) + '\n');
+
+const checkMode = process.argv.includes('--check');
+
+const generate = () => {
+  if (!fs.existsSync(SCHEMA_DIR)) {
+    fs.mkdirSync(SCHEMA_DIR, { recursive: true });
+  }
+
+  const drift = [];
+
+  // 1. Generated schemas.
+  for (const [kind, build] of Object.entries(generated)) {
+    const target = path.join(SCHEMA_DIR, `${kind}.json`);
+    const fresh = build();
+
+    if (checkMode) {
+      if (!fs.existsSync(target)) {
+        drift.push(`${kind}.json missing from disk`);
+        continue;
+      }
+      const onDisk = readJsonFile(target);
+      if (JSON.stringify(onDisk) !== JSON.stringify(fresh)) {
+        drift.push(`${kind}.json is stale — re-run scripts/generate-schemas.js`);
+      }
+    } else {
+      writeJsonFile(target, fresh);
+      console.log(`  wrote ${path.relative(process.cwd(), target)}`);
+    }
+  }
+
+  // 2. Hand-authored schemas: must exist and be syntactically valid JSON.
+  for (const kind of HAND_AUTHORED) {
+    const target = path.join(SCHEMA_DIR, `${kind}.json`);
+    if (!fs.existsSync(target)) {
+      const msg = `${kind}.json (hand-authored) missing from disk`;
+      if (checkMode) drift.push(msg);
+      else throw new Error(msg + ` — add it under ${SCHEMA_DIR}`);
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = readJsonFile(target);
+    } catch (err) {
+      const msg = `${kind}.json is not valid JSON: ${err.message}`;
+      if (checkMode) drift.push(msg);
+      else throw new Error(msg);
+      continue;
+    }
+    if (parsed['x-source'] !== 'hand-authored') {
+      const msg = `${kind}.json missing "x-source": "hand-authored" marker`;
+      if (checkMode) drift.push(msg);
+      else throw new Error(msg);
+    }
+  }
+
+  if (checkMode) {
+    if (drift.length) {
+      console.error('Schema drift detected:');
+      for (const d of drift) console.error(`  - ${d}`);
+      process.exit(1);
+    }
+    console.log('Schemas are in sync.');
+    return;
+  }
+
+  console.log(`\nDone. ${Object.keys(generated).length} generated, ${HAND_AUTHORED.length} hand-authored verified.`);
+};
+
+try {
+  generate();
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/packages/bruno-cli/src/commands/get.js
+++ b/packages/bruno-cli/src/commands/get.js
@@ -1,0 +1,161 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  parseRequest,
+  parseCollection,
+  parseFolder,
+  parseEnvironment
+} = require('@usebruno/filestore');
+const { FORMAT_CONFIG } = require('../utils/collection');
+const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+const { EXIT_STATUS } = require('../constants');
+
+const command = 'get <kind> [resource-path]';
+const desc = 'Read a request, folder, environment, or collection and emit it as JSON';
+
+const KINDS = ['request', 'folder', 'environment', 'collection'];
+
+const builder = (yargs) => {
+  yargs
+    .positional('kind', {
+      type: 'string',
+      describe: 'Resource type',
+      choices: KINDS
+    })
+    .positional('resource-path', {
+      type: 'string',
+      describe: 'Relative path to the resource (omit for collection)'
+    });
+  addJsonOptions(yargs)
+    .example('$0 get request auth/login.bru --json', 'Read a request as JSON')
+    .example('$0 get environment Local --json', 'Read an environment by name')
+    .example('$0 get collection --json', 'Read the collection root');
+};
+
+const detectCollectionFormat = (collectionPath) => {
+  if (fs.existsSync(path.join(collectionPath, 'opencollection.yml'))) return 'yml';
+  return 'bru';
+};
+
+const resolveEnvironmentPath = (collectionPath, name, format) => {
+  // Allow either a literal name (resolved against environments/) or a relative path.
+  if (name.endsWith('.bru') || name.endsWith('.yml') || name.endsWith('.json')) {
+    return path.resolve(collectionPath, name);
+  }
+  const ext = format === 'yml' ? '.yml' : '.bru';
+  return path.join(collectionPath, 'environments', `${name}${ext}`);
+};
+
+const readResource = (kind, resourcePath, collectionPath, writer) => {
+  const format = detectCollectionFormat(collectionPath);
+
+  if (kind === 'collection') {
+    const rootFile = FORMAT_CONFIG[format].collectionFile;
+    const filePath = path.join(collectionPath, rootFile);
+    if (!fs.existsSync(filePath)) {
+      writer.exitWithError({
+        code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
+        message: `Collection root file not found: ${filePath}`
+      });
+    }
+    const content = fs.readFileSync(filePath, 'utf8');
+    return {
+      kind: 'collection',
+      path: path.relative(collectionPath, filePath),
+      data: parseCollection(content, { format })
+    };
+  }
+
+  if (!resourcePath) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
+      message: `<resource-path> is required for kind="${kind}"`
+    });
+  }
+
+  if (kind === 'environment') {
+    const resolved = resolveEnvironmentPath(collectionPath, resourcePath, format);
+    if (!fs.existsSync(resolved)) {
+      writer.exitWithError({
+        code: EXIT_STATUS.ERROR_ENV_NOT_FOUND,
+        message: `Environment file not found: ${resolved}`
+      });
+    }
+    const ext = path.extname(resolved).slice(1) || 'bru';
+    const content = fs.readFileSync(resolved, 'utf8');
+    return {
+      kind: 'environment',
+      path: path.relative(collectionPath, resolved),
+      data: parseEnvironment(content, { format: ext === 'yml' ? 'yml' : 'bru' })
+    };
+  }
+
+  // request | folder
+  const resolved = path.resolve(collectionPath, resourcePath);
+  if (kind === 'request') {
+    // Auto-append the collection's request extension if missing.
+    const ext = FORMAT_CONFIG[format].ext;
+    const finalPath = resolved.endsWith(ext) ? resolved : `${resolved}${ext}`;
+    if (!fs.existsSync(finalPath)) {
+      writer.exitWithError({
+        code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
+        message: `Request file not found: ${finalPath}`
+      });
+    }
+    const content = fs.readFileSync(finalPath, 'utf8');
+    return {
+      kind: 'request',
+      path: path.relative(collectionPath, finalPath),
+      data: parseRequest(content, { format })
+    };
+  }
+
+  // folder
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
+      message: `Folder not found: ${resolved}`
+    });
+  }
+  const folderFile = path.join(resolved, FORMAT_CONFIG[format].folderFile);
+  const data = fs.existsSync(folderFile)
+    ? parseFolder(fs.readFileSync(folderFile, 'utf8'), { format })
+    : null;
+  return {
+    kind: 'folder',
+    path: path.relative(collectionPath, resolved),
+    data
+  };
+};
+
+const handler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  const collectionPath = process.cwd();
+  const kind = argv.kind;
+  const resourcePath = argv['resource-path'];
+
+  if (!KINDS.includes(kind)) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT,
+      message: `Unknown kind "${kind}". Expected one of: ${KINDS.join(', ')}`
+    });
+  }
+
+  const result = readResource(kind, resourcePath, collectionPath, writer);
+
+  emitResult(writer, {
+    kind: `${kind}.get`,
+    data: {
+      collection_path: collectionPath,
+      path: result.path,
+      [kind]: result.data
+    }
+  });
+};
+
+module.exports = {
+  command,
+  desc,
+  builder,
+  handler
+};

--- a/packages/bruno-cli/src/commands/get.js
+++ b/packages/bruno-cli/src/commands/get.js
@@ -8,6 +8,7 @@ const {
 } = require('@usebruno/filestore');
 const { FORMAT_CONFIG } = require('../utils/collection');
 const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+const { CliError } = require('../json/cli-error');
 const { EXIT_STATUS } = require('../constants');
 
 const command = 'get <kind> [resource-path]';
@@ -46,28 +47,27 @@ const resolveEnvironmentPath = (collectionPath, name, format) => {
   return path.join(collectionPath, 'environments', `${name}${ext}`);
 };
 
-const readResource = (kind, resourcePath, collectionPath, writer) => {
+const readResource = (kind, resourcePath, collectionPath) => {
   const format = detectCollectionFormat(collectionPath);
 
   if (kind === 'collection') {
     const rootFile = FORMAT_CONFIG[format].collectionFile;
     const filePath = path.join(collectionPath, rootFile);
     if (!fs.existsSync(filePath)) {
-      writer.exitWithError({
+      throw new CliError({
         code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
         message: `Collection root file not found: ${filePath}`
       });
     }
-    const content = fs.readFileSync(filePath, 'utf8');
     return {
       kind: 'collection',
       path: path.relative(collectionPath, filePath),
-      data: parseCollection(content, { format })
+      data: parseCollection(fs.readFileSync(filePath, 'utf8'), { format })
     };
   }
 
   if (!resourcePath) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
       message: `<resource-path> is required for kind="${kind}"`
     });
@@ -76,43 +76,39 @@ const readResource = (kind, resourcePath, collectionPath, writer) => {
   if (kind === 'environment') {
     const resolved = resolveEnvironmentPath(collectionPath, resourcePath, format);
     if (!fs.existsSync(resolved)) {
-      writer.exitWithError({
+      throw new CliError({
         code: EXIT_STATUS.ERROR_ENV_NOT_FOUND,
         message: `Environment file not found: ${resolved}`
       });
     }
     const ext = path.extname(resolved).slice(1) || 'bru';
-    const content = fs.readFileSync(resolved, 'utf8');
     return {
       kind: 'environment',
       path: path.relative(collectionPath, resolved),
-      data: parseEnvironment(content, { format: ext === 'yml' ? 'yml' : 'bru' })
+      data: parseEnvironment(fs.readFileSync(resolved, 'utf8'), { format: ext === 'yml' ? 'yml' : 'bru' })
     };
   }
 
-  // request | folder
   const resolved = path.resolve(collectionPath, resourcePath);
   if (kind === 'request') {
-    // Auto-append the collection's request extension if missing.
     const ext = FORMAT_CONFIG[format].ext;
     const finalPath = resolved.endsWith(ext) ? resolved : `${resolved}${ext}`;
     if (!fs.existsSync(finalPath)) {
-      writer.exitWithError({
+      throw new CliError({
         code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
         message: `Request file not found: ${finalPath}`
       });
     }
-    const content = fs.readFileSync(finalPath, 'utf8');
     return {
       kind: 'request',
       path: path.relative(collectionPath, finalPath),
-      data: parseRequest(content, { format })
+      data: parseRequest(fs.readFileSync(finalPath, 'utf8'), { format })
     };
   }
 
   // folder
   if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
       message: `Folder not found: ${resolved}`
     });
@@ -128,34 +124,45 @@ const readResource = (kind, resourcePath, collectionPath, writer) => {
   };
 };
 
-const handler = async (argv) => {
-  const writer = buildWriterFromArgv(argv);
-  const collectionPath = process.cwd();
-  const kind = argv.kind;
-  const resourcePath = argv['resource-path'];
-
+const runCore = ({ collectionPath: cp, kind, resourcePath } = {}) => {
+  const collectionPath = cp || process.cwd();
   if (!KINDS.includes(kind)) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT,
       message: `Unknown kind "${kind}". Expected one of: ${KINDS.join(', ')}`
     });
   }
-
-  const result = readResource(kind, resourcePath, collectionPath, writer);
-
-  emitResult(writer, {
+  const result = readResource(kind, resourcePath, collectionPath);
+  return {
     kind: `${kind}.get`,
     data: {
       collection_path: collectionPath,
       path: result.path,
       [kind]: result.data
     }
-  });
+  };
+};
+
+const handler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  try {
+    emitResult(writer, runCore({
+      collectionPath: process.cwd(),
+      kind: argv.kind,
+      resourcePath: argv['resource-path']
+    }));
+  } catch (err) {
+    if (err instanceof CliError) {
+      writer.exitWithError({ code: err.code, name: err.name, message: err.message });
+    } else { throw err; }
+  }
 };
 
 module.exports = {
   command,
   desc,
   builder,
-  handler
+  handler,
+  runCore,
+  KINDS
 };

--- a/packages/bruno-cli/src/commands/introspect.js
+++ b/packages/bruno-cli/src/commands/introspect.js
@@ -82,26 +82,50 @@ const COMMANDS = [
       { name: '--output', type: 'path', summary: 'Output directory' },
       { name: '--collection-name', type: 'string' }
     ]
+  },
+  {
+    name: 'request',
+    summary: 'Create, edit, or delete request files via JSON payloads',
+    args: [{ name: 'action', variadic: false, type: 'string', choices: ['add', 'edit', 'delete'] }],
+    subcommands: [
+      { name: 'request.add', args: ['path'], notable_flags: [{ name: '--data', alias: '-d', type: 'string', summary: 'Request payload (or "-" for stdin via --data=-)' }, { name: '--if-not-exists', type: 'boolean' }] },
+      { name: 'request.edit', args: ['path'], notable_flags: [{ name: '--patch', type: 'string', summary: 'RFC 7396 JSON Merge Patch' }] },
+      { name: 'request.delete', args: ['path'], notable_flags: [] }
+    ]
+  },
+  {
+    name: 'serve',
+    summary: 'Long-lived NDJSON dispatcher — reads command envelopes on stdin, writes responses on stdout',
+    args: [],
+    notable_flags: [
+      { name: '--stdio', type: 'boolean', summary: 'Use stdin/stdout for command transport (required)' },
+      { name: '--collection', type: 'string', summary: 'Default collection path for commands that omit collection_path' },
+      { name: '--json-version', type: 'number' }
+    ],
+    accepts_commands: ['introspect', 'ls', 'get', 'schema', 'request.add', 'request.edit', 'request.delete', 'shutdown']
   }
 ];
 
+// Pure core — callable from yargs handlers and from the bru serve --stdio dispatcher.
+// Returns { kind, data } or throws CliError.
+const runCore = () => ({
+  kind: 'introspect',
+  data: {
+    cli_version: CLI_VERSION,
+    json_contract_version: JSON_CONTRACT_VERSION,
+    supported_json_versions: SUPPORTED_VERSIONS,
+    exit_codes: Object.entries(EXIT_STATUS).map(([constant, code]) => ({
+      code,
+      constant,
+      name: ERROR_NAMES[code] || 'internal_error'
+    })),
+    commands: COMMANDS
+  }
+});
+
 const handler = async (argv) => {
   const writer = buildWriterFromArgv(argv);
-
-  emitResult(writer, {
-    kind: 'introspect',
-    data: {
-      cli_version: CLI_VERSION,
-      json_contract_version: JSON_CONTRACT_VERSION,
-      supported_json_versions: SUPPORTED_VERSIONS,
-      exit_codes: Object.entries(EXIT_STATUS).map(([constant, code]) => ({
-        code,
-        constant,
-        name: ERROR_NAMES[code] || 'internal_error'
-      })),
-      commands: COMMANDS
-    }
-  });
+  emitResult(writer, runCore());
 };
 
 module.exports = {
@@ -109,5 +133,6 @@ module.exports = {
   desc,
   builder,
   handler,
+  runCore,
   COMMANDS
 };

--- a/packages/bruno-cli/src/commands/introspect.js
+++ b/packages/bruno-cli/src/commands/introspect.js
@@ -1,0 +1,114 @@
+const { CLI_VERSION, EXIT_STATUS } = require('../constants');
+const { JSON_CONTRACT_VERSION, SUPPORTED_VERSIONS } = require('../json/version');
+const { ERROR_NAMES } = require('../json/error-names');
+const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+
+const command = 'introspect';
+const desc = 'Emit the CLI command tree, exit codes, and JSON contract version for agent consumption';
+
+const builder = (yargs) => {
+  addJsonOptions(yargs)
+    .example('$0 introspect --json', 'Emit a machine-readable description of every command and flag.');
+};
+
+// Hand-authored command tree. Update this when a command/flag is added — the
+// snapshot test (tests/integration/agent-commands.spec.js) enforces drift detection.
+const COMMANDS = [
+  {
+    name: 'run',
+    summary: 'Run one or more requests/folders',
+    args: [{ name: 'paths', variadic: true, type: 'path' }],
+    notable_flags: [
+      { name: '--env', type: 'string', summary: 'Environment name to load' },
+      { name: '--env-file', type: 'string', summary: 'Path to environment file (.bru/.json/.yml)' },
+      { name: '--env-var', type: 'string', summary: 'Overwrite a single env var; repeatable' },
+      { name: '--bail', type: 'boolean', summary: 'Stop on first failing request/test/assertion' },
+      { name: '--tests-only', type: 'boolean', summary: 'Only run requests with executable tests' },
+      { name: '--reporter-json', type: 'path', summary: 'Write final JSON summary to a file' },
+      { name: '--reporter-junit', type: 'path', summary: 'Write JUnit XML to a file' },
+      { name: '--reporter-html', type: 'path', summary: 'Write HTML report to a file' },
+      { name: '--json', type: 'boolean', summary: 'Emit NDJSON event stream on stdout' },
+      { name: '--json-version', type: 'number', summary: 'Pin the JSON contract version' }
+    ],
+    streams_ndjson: true,
+    event_kinds: ['run.start', 'request.start', 'request.response', 'assertion.result', 'test.result', 'request.end', 'run.end']
+  },
+  {
+    name: 'introspect',
+    summary: 'Emit the CLI command tree and JSON contract version',
+    args: [],
+    notable_flags: [
+      { name: '--json', type: 'boolean', summary: 'Emit a single envelope (NDJSON line) instead of pretty JSON' },
+      { name: '--json-version', type: 'number', summary: 'Pin the JSON contract version' }
+    ]
+  },
+  {
+    name: 'ls',
+    summary: 'List the items (folders + requests + environments) in a collection',
+    args: [{ name: 'path', variadic: false, type: 'path', optional: true, summary: 'Collection root (default: cwd)' }],
+    notable_flags: [
+      { name: '--depth', type: 'number', summary: 'Limit recursion depth' },
+      { name: '--json', type: 'boolean' },
+      { name: '--json-version', type: 'number' }
+    ]
+  },
+  {
+    name: 'get',
+    summary: 'Read a single resource (request/folder/environment/collection) and emit it as JSON',
+    args: [
+      { name: 'kind', variadic: false, type: 'string', choices: ['request', 'folder', 'environment', 'collection'] },
+      { name: 'path', variadic: false, type: 'path', optional: true, summary: 'Required for request/folder/environment; omitted for collection' }
+    ],
+    notable_flags: [
+      { name: '--json', type: 'boolean' },
+      { name: '--json-version', type: 'number' }
+    ]
+  },
+  {
+    name: 'schema',
+    summary: 'Emit the JSON Schema for a Bruno resource so agents can author payloads safely',
+    args: [{ name: 'kind', variadic: false, type: 'string', choices: ['request', 'folder', 'environment', 'collection', 'collection-var', 'cli-output'] }],
+    notable_flags: [
+      { name: '--json', type: 'boolean' },
+      { name: '--json-version', type: 'number' }
+    ],
+    status: 'stub'
+  },
+  {
+    name: 'import',
+    summary: 'Import a collection from OpenAPI or WSDL',
+    args: [{ name: 'type', variadic: false, type: 'string', choices: ['openapi', 'wsdl'] }],
+    notable_flags: [
+      { name: '--source', type: 'string', summary: 'File path or URL' },
+      { name: '--output', type: 'path', summary: 'Output directory' },
+      { name: '--collection-name', type: 'string' }
+    ]
+  }
+];
+
+const handler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+
+  emitResult(writer, {
+    kind: 'introspect',
+    data: {
+      cli_version: CLI_VERSION,
+      json_contract_version: JSON_CONTRACT_VERSION,
+      supported_json_versions: SUPPORTED_VERSIONS,
+      exit_codes: Object.entries(EXIT_STATUS).map(([constant, code]) => ({
+        code,
+        constant,
+        name: ERROR_NAMES[code] || 'internal_error'
+      })),
+      commands: COMMANDS
+    }
+  });
+};
+
+module.exports = {
+  command,
+  desc,
+  builder,
+  handler,
+  COMMANDS
+};

--- a/packages/bruno-cli/src/commands/introspect.js
+++ b/packages/bruno-cli/src/commands/introspect.js
@@ -67,12 +67,11 @@ const COMMANDS = [
   {
     name: 'schema',
     summary: 'Emit the JSON Schema for a Bruno resource so agents can author payloads safely',
-    args: [{ name: 'kind', variadic: false, type: 'string', choices: ['request', 'folder', 'environment', 'collection', 'collection-var', 'cli-output'] }],
+    args: [{ name: 'kind', variadic: false, type: 'string', choices: ['request', 'folder', 'environment', 'environments', 'collection', 'collection-var', 'cli-output'] }],
     notable_flags: [
       { name: '--json', type: 'boolean' },
       { name: '--json-version', type: 'number' }
-    ],
-    status: 'stub'
+    ]
   },
   {
     name: 'import',

--- a/packages/bruno-cli/src/commands/ls.js
+++ b/packages/bruno-cli/src/commands/ls.js
@@ -1,0 +1,129 @@
+const fs = require('fs');
+const path = require('path');
+const { createCollectionJsonFromPathname } = require('../utils/collection');
+const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+const { EXIT_STATUS } = require('../constants');
+
+const command = 'ls [collection-path]';
+const desc = 'List the requests, folders, and environments in a Bruno collection';
+
+const REQUEST_TYPES = new Set(['http-request', 'graphql-request', 'grpc-request', 'ws-request']);
+
+const builder = (yargs) => {
+  yargs
+    .positional('collection-path', {
+      type: 'string',
+      describe: 'Collection root directory (default: current working directory)'
+    })
+    .option('depth', {
+      type: 'number',
+      description: 'Limit recursion depth (root folders are depth 1)'
+    });
+  addJsonOptions(yargs)
+    .example('$0 ls --json', 'List all items in the current collection as JSON')
+    .example('$0 ls --depth 1 --json', 'Only list top-level items');
+};
+
+// Walk the collection JSON tree (output of createCollectionJsonFromPathname) and
+// return a flat array of items. Each entry carries its relative path, type, and
+// type-specific metadata (method/url for requests, etc.).
+const walkItems = (items, collectionPath, currentDepth, maxDepth) => {
+  const out = [];
+  for (const item of items || []) {
+    if (maxDepth != null && currentDepth > maxDepth) continue;
+
+    const relPath = item.pathname
+      ? path.relative(collectionPath, item.pathname)
+      : null;
+    const isRequest = REQUEST_TYPES.has(item.type);
+    const isFolder = !isRequest && (item.items !== undefined || item.type === 'folder');
+
+    const entry = {
+      type: isRequest ? 'request' : (isFolder ? 'folder' : (item.type || 'unknown')),
+      path: relPath,
+      name: item.name || null,
+      depth: currentDepth
+    };
+
+    if (isRequest && item.request) {
+      entry.method = item.request.method || null;
+      entry.url = item.request.url || null;
+      entry.tags = item.tags || [];
+      entry.has_tests = Boolean(item.request.tests && item.request.tests.trim());
+      entry.has_assertions = Array.isArray(item.request.assertions)
+        && item.request.assertions.some((a) => a.enabled);
+    }
+
+    out.push(entry);
+
+    if (item.items && item.items.length) {
+      out.push(...walkItems(item.items, collectionPath, currentDepth + 1, maxDepth));
+    }
+  }
+  return out;
+};
+
+const listEnvironments = (collectionPath) => {
+  const envDir = path.join(collectionPath, 'environments');
+  if (!fs.existsSync(envDir)) return [];
+  return fs.readdirSync(envDir)
+    .filter((f) => f.endsWith('.bru') || f.endsWith('.yml') || f.endsWith('.json'))
+    .map((f) => ({
+      type: 'environment',
+      path: path.join('environments', f),
+      name: f.replace(/\.(bru|yml|json)$/, '')
+    }));
+};
+
+const handler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  const collectionPath = argv['collection-path']
+    ? path.resolve(process.cwd(), argv['collection-path'])
+    : process.cwd();
+
+  if (!fs.existsSync(collectionPath) || !fs.statSync(collectionPath).isDirectory()) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
+      message: `Collection path does not exist or is not a directory: ${collectionPath}`
+    });
+  }
+
+  let collection;
+  try {
+    collection = createCollectionJsonFromPathname(collectionPath);
+  } catch (err) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_NOT_IN_COLLECTION,
+      message: `Could not load collection at ${collectionPath}: ${err.message}`
+    });
+  }
+
+  const items = walkItems(collection.items || [], collectionPath, 1, argv.depth);
+  const environments = listEnvironments(collectionPath);
+
+  emitResult(writer, {
+    kind: 'ls',
+    data: {
+      collection: {
+        name: collection?.brunoConfig?.name || collection?.name || null,
+        path: collectionPath,
+        format: collection?.format || null
+      },
+      items,
+      environments,
+      counts: {
+        items: items.length,
+        requests: items.filter((i) => i.type === 'request').length,
+        folders: items.filter((i) => i.type === 'folder').length,
+        environments: environments.length
+      }
+    }
+  });
+};
+
+module.exports = {
+  command,
+  desc,
+  builder,
+  handler
+};

--- a/packages/bruno-cli/src/commands/ls.js
+++ b/packages/bruno-cli/src/commands/ls.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { createCollectionJsonFromPathname } = require('../utils/collection');
 const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+const { CliError } = require('../json/cli-error');
 const { EXIT_STATUS } = require('../constants');
 
 const command = 'ls [collection-path]';
@@ -75,14 +76,12 @@ const listEnvironments = (collectionPath) => {
     }));
 };
 
-const handler = async (argv) => {
-  const writer = buildWriterFromArgv(argv);
-  const collectionPath = argv['collection-path']
-    ? path.resolve(process.cwd(), argv['collection-path'])
-    : process.cwd();
+// Pure core — callable from yargs and from bru serve. Throws CliError on user errors.
+const runCore = ({ collectionPath: cp, depth } = {}) => {
+  const collectionPath = cp || process.cwd();
 
   if (!fs.existsSync(collectionPath) || !fs.statSync(collectionPath).isDirectory()) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
       message: `Collection path does not exist or is not a directory: ${collectionPath}`
     });
@@ -92,16 +91,16 @@ const handler = async (argv) => {
   try {
     collection = createCollectionJsonFromPathname(collectionPath);
   } catch (err) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_NOT_IN_COLLECTION,
       message: `Could not load collection at ${collectionPath}: ${err.message}`
     });
   }
 
-  const items = walkItems(collection.items || [], collectionPath, 1, argv.depth);
+  const items = walkItems(collection.items || [], collectionPath, 1, depth);
   const environments = listEnvironments(collectionPath);
 
-  emitResult(writer, {
+  return {
     kind: 'ls',
     data: {
       collection: {
@@ -118,12 +117,27 @@ const handler = async (argv) => {
         environments: environments.length
       }
     }
-  });
+  };
+};
+
+const handler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  const collectionPath = argv['collection-path']
+    ? path.resolve(process.cwd(), argv['collection-path'])
+    : process.cwd();
+  try {
+    emitResult(writer, runCore({ collectionPath, depth: argv.depth }));
+  } catch (err) {
+    if (err instanceof CliError) {
+      writer.exitWithError({ code: err.code, name: err.name, message: err.message });
+    } else { throw err; }
+  }
 };
 
 module.exports = {
   command,
   desc,
   builder,
-  handler
+  handler,
+  runCore
 };

--- a/packages/bruno-cli/src/commands/request.js
+++ b/packages/bruno-cli/src/commands/request.js
@@ -4,6 +4,7 @@ const { parseRequest, stringifyRequest } = require('@usebruno/filestore');
 const { FORMAT_CONFIG } = require('../utils/collection');
 const { writeFileAtomicSync } = require('../utils/filesystem');
 const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+const { CliError } = require('../json/cli-error');
 const { mergePatch } = require('../json/merge-patch');
 const { EXIT_STATUS } = require('../constants');
 
@@ -21,20 +22,25 @@ const ensureBruExt = (p, format) => {
 const resolvePath = (collectionPath, relPath, format) =>
   ensureBruExt(path.resolve(collectionPath, relPath), format);
 
-// Read a --json/--patch payload either inline (the arg value) or from stdin when
-// the arg is "-". Synchronous on purpose: agents pipe and wait.
-const readPayload = (writer, arg, flagName) => {
+// Coerce a payload argument into a parsed JS value.
+//   - undefined/null → CliError
+//   - "-"            → read all of stdin (synchronously; agents pipe and wait)
+//   - any other      → parse the value as JSON inline
+// In serve mode the dispatcher pre-parses payloads from the command envelope, so
+// the typeof check lets it pass plain objects/arrays straight through.
+const coercePayload = (arg, flagName) => {
   if (arg === undefined || arg === null) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE,
-      message: `Missing required ${flagName} payload (use ${flagName} '<json>' or ${flagName} - to read stdin).`
+      message: `Missing required ${flagName} payload (use ${flagName} '<json>' or ${flagName}=- to read stdin).`
     });
   }
+  if (typeof arg === 'object') return arg;
   const raw = arg === '-' ? fs.readFileSync(0, 'utf8') : arg;
   try {
     return JSON.parse(raw);
   } catch (err) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE,
       message: `Could not parse ${flagName} payload as JSON: ${err.message}`
     });
@@ -50,37 +56,34 @@ const addBuilder = (yargs) => {
     .example('cat req.json | $0 request add auth/login.bru --data=-', 'Use --data=- (not --data -) so yargs treats the dash as the flag value.');
 };
 
-const addHandler = async (argv) => {
-  const writer = buildWriterFromArgv(argv);
-  const collectionPath = process.cwd();
+const addCore = ({ collectionPath: cp, path: relPath, data, ifNotExists } = {}) => {
+  const collectionPath = cp || process.cwd();
   const format = detectCollectionFormat(collectionPath);
-  const target = resolvePath(collectionPath, argv.path, format);
+  const target = resolvePath(collectionPath, relPath, format);
 
   if (fs.existsSync(target)) {
-    if (argv['if-not-exists']) {
-      emitResult(writer, {
+    if (ifNotExists) {
+      return {
         kind: 'request.add',
         data: {
           path: path.relative(collectionPath, target),
           status: 'unchanged',
           reason: 'already_exists'
         }
-      });
-      return;
+      };
     }
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_GENERIC,
       message: `Request already exists: ${path.relative(collectionPath, target)}. Pass --if-not-exists to make this a no-op.`
     });
   }
 
-  const payload = readPayload(writer, argv.data, '--data');
-
+  const payload = coercePayload(data, '--data');
   let serialised;
   try {
     serialised = stringifyRequest(payload, { format });
   } catch (err) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_INVALID_FILE,
       message: `Could not serialise request payload: ${err.message}`
     });
@@ -89,14 +92,30 @@ const addHandler = async (argv) => {
   fs.mkdirSync(path.dirname(target), { recursive: true });
   writeFileAtomicSync(target, serialised);
 
-  emitResult(writer, {
+  return {
     kind: 'request.add',
     data: {
       path: path.relative(collectionPath, target),
       status: 'created',
       request: parseRequest(serialised, { format })
     }
-  });
+  };
+};
+
+const addHandler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  try {
+    emitResult(writer, addCore({
+      collectionPath: process.cwd(),
+      path: argv.path,
+      data: argv.data,
+      ifNotExists: argv['if-not-exists']
+    }));
+  } catch (err) {
+    if (err instanceof CliError) {
+      writer.exitWithError({ code: err.code, name: err.name, message: err.message });
+    } else { throw err; }
+  }
 };
 
 const editBuilder = (yargs) => {
@@ -106,29 +125,27 @@ const editBuilder = (yargs) => {
     .example('$0 request edit auth/login.bru --patch \'{"request":{"url":"{{host}}/v2/login"}}\'');
 };
 
-const editHandler = async (argv) => {
-  const writer = buildWriterFromArgv(argv);
-  const collectionPath = process.cwd();
+const editCore = ({ collectionPath: cp, path: relPath, patch } = {}) => {
+  const collectionPath = cp || process.cwd();
   const format = detectCollectionFormat(collectionPath);
-  const target = resolvePath(collectionPath, argv.path, format);
+  const target = resolvePath(collectionPath, relPath, format);
 
   if (!fs.existsSync(target)) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
       message: `Request file not found: ${path.relative(collectionPath, target)}`
     });
   }
 
-  const patch = readPayload(writer, argv.patch, '--patch');
-
+  const patchObj = coercePayload(patch, '--patch');
   const current = parseRequest(fs.readFileSync(target, 'utf8'), { format });
-  const next = mergePatch(current, patch);
+  const next = mergePatch(current, patchObj);
 
   let serialised;
   try {
     serialised = stringifyRequest(next, { format });
   } catch (err) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_INVALID_FILE,
       message: `Patched payload could not be serialised: ${err.message}`
     });
@@ -136,14 +153,29 @@ const editHandler = async (argv) => {
 
   writeFileAtomicSync(target, serialised);
 
-  emitResult(writer, {
+  return {
     kind: 'request.edit',
     data: {
       path: path.relative(collectionPath, target),
       status: 'updated',
       request: parseRequest(serialised, { format })
     }
-  });
+  };
+};
+
+const editHandler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  try {
+    emitResult(writer, editCore({
+      collectionPath: process.cwd(),
+      path: argv.path,
+      patch: argv.patch
+    }));
+  } catch (err) {
+    if (err instanceof CliError) {
+      writer.exitWithError({ code: err.code, name: err.name, message: err.message });
+    } else { throw err; }
+  }
 };
 
 const deleteBuilder = (yargs) => {
@@ -152,14 +184,13 @@ const deleteBuilder = (yargs) => {
     .example('$0 request delete auth/login.bru');
 };
 
-const deleteHandler = async (argv) => {
-  const writer = buildWriterFromArgv(argv);
-  const collectionPath = process.cwd();
+const deleteCore = ({ collectionPath: cp, path: relPath } = {}) => {
+  const collectionPath = cp || process.cwd();
   const format = detectCollectionFormat(collectionPath);
-  const target = resolvePath(collectionPath, argv.path, format);
+  const target = resolvePath(collectionPath, relPath, format);
 
   if (!fs.existsSync(target)) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
       message: `Request file not found: ${path.relative(collectionPath, target)}`
     });
@@ -167,13 +198,24 @@ const deleteHandler = async (argv) => {
 
   fs.unlinkSync(target);
 
-  emitResult(writer, {
+  return {
     kind: 'request.delete',
     data: {
       path: path.relative(collectionPath, target),
       status: 'deleted'
     }
-  });
+  };
+};
+
+const deleteHandler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  try {
+    emitResult(writer, deleteCore({ collectionPath: process.cwd(), path: argv.path }));
+  } catch (err) {
+    if (err instanceof CliError) {
+      writer.exitWithError({ code: err.code, name: err.name, message: err.message });
+    } else { throw err; }
+  }
 };
 
 const builder = (yargs) => {
@@ -208,5 +250,8 @@ const builder = (yargs) => {
 module.exports = {
   command,
   desc,
-  builder
+  builder,
+  addCore,
+  editCore,
+  deleteCore
 };

--- a/packages/bruno-cli/src/commands/request.js
+++ b/packages/bruno-cli/src/commands/request.js
@@ -1,0 +1,212 @@
+const fs = require('fs');
+const path = require('path');
+const { parseRequest, stringifyRequest } = require('@usebruno/filestore');
+const { FORMAT_CONFIG } = require('../utils/collection');
+const { writeFileAtomicSync } = require('../utils/filesystem');
+const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+const { mergePatch } = require('../json/merge-patch');
+const { EXIT_STATUS } = require('../constants');
+
+const command = 'request <action>';
+const desc = 'Create, edit, or delete a request file';
+
+const detectCollectionFormat = (collectionPath) =>
+  fs.existsSync(path.join(collectionPath, 'opencollection.yml')) ? 'yml' : 'bru';
+
+const ensureBruExt = (p, format) => {
+  const ext = FORMAT_CONFIG[format].ext;
+  return p.endsWith(ext) ? p : `${p}${ext}`;
+};
+
+const resolvePath = (collectionPath, relPath, format) =>
+  ensureBruExt(path.resolve(collectionPath, relPath), format);
+
+// Read a --json/--patch payload either inline (the arg value) or from stdin when
+// the arg is "-". Synchronous on purpose: agents pipe and wait.
+const readPayload = (writer, arg, flagName) => {
+  if (arg === undefined || arg === null) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE,
+      message: `Missing required ${flagName} payload (use ${flagName} '<json>' or ${flagName} - to read stdin).`
+    });
+  }
+  const raw = arg === '-' ? fs.readFileSync(0, 'utf8') : arg;
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE,
+      message: `Could not parse ${flagName} payload as JSON: ${err.message}`
+    });
+  }
+};
+
+const addBuilder = (yargs) => {
+  yargs
+    .positional('path', { type: 'string', describe: 'Relative path of the new request (with or without .bru)' })
+    .option('data', { alias: 'd', type: 'string', describe: 'Request payload as JSON (or "-" for stdin)' })
+    .option('if-not-exists', { type: 'boolean', default: false, describe: 'Succeed silently if the request already exists' })
+    .example('$0 request add auth/login.bru --data \'{"type":"http-request","name":"login","request":{"method":"POST","url":"{{host}}/login"}}\'')
+    .example('cat req.json | $0 request add auth/login.bru --data=-', 'Use --data=- (not --data -) so yargs treats the dash as the flag value.');
+};
+
+const addHandler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  const collectionPath = process.cwd();
+  const format = detectCollectionFormat(collectionPath);
+  const target = resolvePath(collectionPath, argv.path, format);
+
+  if (fs.existsSync(target)) {
+    if (argv['if-not-exists']) {
+      emitResult(writer, {
+        kind: 'request.add',
+        data: {
+          path: path.relative(collectionPath, target),
+          status: 'unchanged',
+          reason: 'already_exists'
+        }
+      });
+      return;
+    }
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_GENERIC,
+      message: `Request already exists: ${path.relative(collectionPath, target)}. Pass --if-not-exists to make this a no-op.`
+    });
+  }
+
+  const payload = readPayload(writer, argv.data, '--data');
+
+  let serialised;
+  try {
+    serialised = stringifyRequest(payload, { format });
+  } catch (err) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_INVALID_FILE,
+      message: `Could not serialise request payload: ${err.message}`
+    });
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  writeFileAtomicSync(target, serialised);
+
+  emitResult(writer, {
+    kind: 'request.add',
+    data: {
+      path: path.relative(collectionPath, target),
+      status: 'created',
+      request: parseRequest(serialised, { format })
+    }
+  });
+};
+
+const editBuilder = (yargs) => {
+  yargs
+    .positional('path', { type: 'string', describe: 'Relative path of the request to edit' })
+    .option('patch', { type: 'string', describe: 'JSON Merge Patch (RFC 7396) payload, or "-" for stdin' })
+    .example('$0 request edit auth/login.bru --patch \'{"request":{"url":"{{host}}/v2/login"}}\'');
+};
+
+const editHandler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  const collectionPath = process.cwd();
+  const format = detectCollectionFormat(collectionPath);
+  const target = resolvePath(collectionPath, argv.path, format);
+
+  if (!fs.existsSync(target)) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
+      message: `Request file not found: ${path.relative(collectionPath, target)}`
+    });
+  }
+
+  const patch = readPayload(writer, argv.patch, '--patch');
+
+  const current = parseRequest(fs.readFileSync(target, 'utf8'), { format });
+  const next = mergePatch(current, patch);
+
+  let serialised;
+  try {
+    serialised = stringifyRequest(next, { format });
+  } catch (err) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_INVALID_FILE,
+      message: `Patched payload could not be serialised: ${err.message}`
+    });
+  }
+
+  writeFileAtomicSync(target, serialised);
+
+  emitResult(writer, {
+    kind: 'request.edit',
+    data: {
+      path: path.relative(collectionPath, target),
+      status: 'updated',
+      request: parseRequest(serialised, { format })
+    }
+  });
+};
+
+const deleteBuilder = (yargs) => {
+  yargs
+    .positional('path', { type: 'string', describe: 'Relative path of the request to delete' })
+    .example('$0 request delete auth/login.bru');
+};
+
+const deleteHandler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  const collectionPath = process.cwd();
+  const format = detectCollectionFormat(collectionPath);
+  const target = resolvePath(collectionPath, argv.path, format);
+
+  if (!fs.existsSync(target)) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
+      message: `Request file not found: ${path.relative(collectionPath, target)}`
+    });
+  }
+
+  fs.unlinkSync(target);
+
+  emitResult(writer, {
+    kind: 'request.delete',
+    data: {
+      path: path.relative(collectionPath, target),
+      status: 'deleted'
+    }
+  });
+};
+
+const builder = (yargs) => {
+  yargs
+    .command(
+      'add <path>',
+      'Create a new request from a JSON payload',
+      (sub) => {
+        addBuilder(sub); addJsonOptions(sub);
+      },
+      addHandler
+    )
+    .command(
+      'edit <path>',
+      'Apply a JSON Merge Patch to an existing request',
+      (sub) => {
+        editBuilder(sub); addJsonOptions(sub);
+      },
+      editHandler
+    )
+    .command(
+      'delete <path>',
+      'Delete a request file',
+      (sub) => {
+        deleteBuilder(sub); addJsonOptions(sub);
+      },
+      deleteHandler
+    )
+    .demandCommand(1, 'Specify a subcommand: add | edit | delete');
+};
+
+module.exports = {
+  command,
+  desc,
+  builder
+};

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -20,6 +20,8 @@ const { hasExecutableTestInScript } = require('../utils/request');
 const { createSkippedFileResults } = require('../utils/run');
 const { sanitizeResultsForReporter } = require('../utils/sanitize-results');
 const { getSystemProxy } = require('@usebruno/requests');
+const { createWriter } = require('../json/envelope');
+const { negotiateVersion } = require('../json/version');
 const command = 'run [paths...]';
 const desc = 'Run one or more requests/folders';
 
@@ -224,6 +226,15 @@ const builder = async (yargs) => {
       type: 'boolean',
       description: 'Allow verbose output for debugging purposes'
     })
+    .option('json', {
+      type: 'boolean',
+      default: false,
+      description: 'Emit a versioned NDJSON event stream on stdout; structured error envelope on stderr. Silences the human-readable output.'
+    })
+    .option('json-version', {
+      type: 'number',
+      description: 'Pin the JSON contract version (current: 1). Only valid with --json.'
+    })
     .example('$0 run request.bru', 'Run a request')
     .example('$0 run request.bru --env local', 'Run a request with the environment set to local')
     .example('$0 run request.bru --env-file env.bru', 'Run a request with the environment from env.bru file')
@@ -317,9 +328,104 @@ const handler = async function (argv) {
       delay,
       tags: includeTags,
       excludeTags,
-      verbose
+      verbose,
+      json: jsonMode,
+      jsonVersion: requestedJsonVersion
     } = argv;
     const collectionPath = process.cwd();
+
+    // JSON mode: validate the requested version, build the writer, then silence
+    // chalk chatter so stdout is exclusively NDJSON envelopes. Structured errors
+    // are written to stderr by writer.exitWithError; existing chalk messages are
+    // suppressed via the console hijack below.
+    const negotiatedVersion = jsonMode ? negotiateVersion(requestedJsonVersion) : null;
+    const writer = createWriter({ json: jsonMode, version: negotiatedVersion || undefined });
+    if (writer.enabled) {
+      console.log = () => {};
+      console.warn = () => {};
+      console.error = () => {};
+    }
+    if (jsonMode && negotiatedVersion === null) {
+      writer.exitWithError({
+        code: constants.EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT,
+        message: `Unsupported --json-version: ${requestedJsonVersion}. Supported: 1`
+      });
+    }
+    const exitWithCode = (code, message, extra) => {
+      writer.exitWithError({ code, message, ...(extra || {}) });
+    };
+
+    // Drains the result object from runSingleRequest into NDJSON events.
+    // No-op when JSON mode is off. Called after each request returns and after
+    // bail synthesises skipped placeholders.
+    const emitRequestEvents = (resultObj, relPath) => {
+      if (!writer.enabled || !resultObj) return;
+      const r = resultObj.response || {};
+      if (r.status !== 'skipped' && r.status != null) {
+        writer.writeEvent({
+          kind: 'request.response',
+          ok: resultObj.status !== 'error',
+          data: {
+            path: relPath,
+            status: r.status,
+            status_text: r.statusText,
+            duration_ms: r.responseTime,
+            size_bytes: r.size,
+            url: r.url
+          }
+        });
+      }
+      (resultObj.assertionResults || []).forEach((a) => {
+        writer.writeEvent({
+          kind: 'assertion.result',
+          ok: a.status === 'pass',
+          data: {
+            path: relPath,
+            description: a.description
+              || `${a.lhsExpr || ''} ${a.operator || ''} ${a.rhsExpr || ''}`.trim()
+              || 'assertion',
+            passed: a.status === 'pass',
+            lhs: a.lhsExpr,
+            operator: a.operator,
+            rhs: a.rhsExpr,
+            ...(a.error ? { error: a.error } : {})
+          }
+        });
+      });
+      const drainTests = (arr, phase) => {
+        (arr || []).forEach((t) => {
+          writer.writeEvent({
+            kind: 'test.result',
+            ok: t.status === 'pass',
+            data: {
+              path: relPath,
+              phase,
+              name: t.description,
+              passed: t.status === 'pass',
+              ...(t.error ? { error: t.error } : {})
+            }
+          });
+        });
+      };
+      drainTests(resultObj.preRequestTestResults, 'pre-request');
+      drainTests(resultObj.testResults, 'test');
+      drainTests(resultObj.postResponseTestResults, 'post-response');
+    };
+
+    const emitRequestEnd = (resultObj, relPath, name) => {
+      if (!writer.enabled) return;
+      writer.writeEvent({
+        kind: 'request.end',
+        ok: resultObj.status === 'pass' || resultObj.status === 'skipped',
+        data: {
+          path: relPath,
+          name,
+          status: resultObj.status,
+          ...(resultObj.skipReason ? { skip_reason: resultObj.skipReason } : {}),
+          ...(resultObj.error ? { error: resultObj.error } : {})
+        }
+      });
+    };
 
     let collection = createCollectionJsonFromPathname(collectionPath);
     const { root: collectionRoot, brunoConfig } = collection;
@@ -329,7 +435,7 @@ const handler = async function (argv) {
         const clientCertConfigExists = await exists(clientCertConfig);
         if (!clientCertConfigExists) {
           console.error(chalk.red(`Client Certificate Config file "${clientCertConfig}" does not exist.`));
-          process.exit(constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
+          exitWithCode(constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
         }
 
         const clientCertConfigFileContent = fs.readFileSync(clientCertConfig, 'utf8');
@@ -339,7 +445,7 @@ const handler = async function (argv) {
           clientCertConfigJson = JSON.parse(clientCertConfigFileContent);
         } catch (err) {
           console.error(chalk.red(`Failed to parse Client Certificate Config JSON: ${err.message}`));
-          process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
+          exitWithCode(constants.EXIT_STATUS.ERROR_INVALID_FILE);
         }
 
         if (clientCertConfigJson?.enabled && Array.isArray(clientCertConfigJson?.certs)) {
@@ -354,7 +460,7 @@ const handler = async function (argv) {
         }
       } catch (err) {
         console.error(chalk.red(`Unexpected error: ${err.message}`));
-        process.exit(constants.EXIT_STATUS.ERROR_GENERIC);
+        exitWithCode(constants.EXIT_STATUS.ERROR_GENERIC);
       }
     }
 
@@ -408,14 +514,14 @@ const handler = async function (argv) {
       const envFilePath = path.resolve(collectionPath, envFile);
       if (!(await exists(envFilePath))) {
         console.error(chalk.red(`Environment file not found: `) + chalk.dim(envFile));
-        process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
+        exitWithCode(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
       }
       try {
         envVars = loadEnvFromFile(envFilePath);
         envFileDescriptor = { path: envFilePath, format: resolveEnvFileFormat(envFilePath) };
       } catch (err) {
         console.error(chalk.red(`Failed to parse environment file: ${err.message}`));
-        process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
+        exitWithCode(constants.EXIT_STATUS.ERROR_INVALID_FILE);
       }
     }
 
@@ -425,7 +531,7 @@ const handler = async function (argv) {
       const collectionEnvFilePath = path.join(collectionPath, 'environments', `${env}${envExt}`);
       if (!(await exists(collectionEnvFilePath))) {
         console.error(chalk.red(`Environment file not found: `) + chalk.dim(`environments/${env}${envExt}`));
-        process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
+        exitWithCode(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
       }
       try {
         const collectionEnvVars = loadEnvFromFile(collectionEnvFilePath, env);
@@ -433,7 +539,7 @@ const handler = async function (argv) {
         envFileDescriptor = { path: collectionEnvFilePath, format: collection.format };
       } catch (err) {
         console.error(chalk.red(`Failed to parse Environment file: ${err.message}`));
-        process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
+        exitWithCode(constants.EXIT_STATUS.ERROR_INVALID_FILE);
       }
     }
 
@@ -457,20 +563,20 @@ const handler = async function (argv) {
 
       if (!workspacePath) {
         console.error(chalk.red(`Workspace not found. Please specify a workspace path using --workspace-path or ensure the collection is inside a workspace directory.`));
-        process.exit(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_REQUIRES_WORKSPACE);
+        exitWithCode(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_REQUIRES_WORKSPACE);
       }
 
       const workspaceExists = await exists(workspacePath);
       if (!workspaceExists) {
         console.error(chalk.red(`Workspace path not found: `) + chalk.dim(workspacePath));
-        process.exit(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
+        exitWithCode(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
       }
 
       const workspaceYmlPath = path.join(workspacePath, 'workspace.yml');
       const workspaceYmlExists = await exists(workspaceYmlPath);
       if (!workspaceYmlExists) {
         console.error(chalk.red(`Invalid workspace: workspace.yml not found in `) + chalk.dim(workspacePath));
-        process.exit(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
+        exitWithCode(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
       }
 
       const globalEnvFilePath = path.join(workspacePath, 'environments', `${globalEnv}.yml`);
@@ -478,7 +584,7 @@ const handler = async function (argv) {
       if (!globalEnvFileExists) {
         console.error(chalk.red(`Global environment not found: `) + chalk.dim(`environments/${globalEnv}.yml`));
         console.error(chalk.dim(`Workspace: ${workspacePath}`));
-        process.exit(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_NOT_FOUND);
+        exitWithCode(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_NOT_FOUND);
       }
 
       try {
@@ -489,7 +595,7 @@ const handler = async function (argv) {
         globalEnvFileDescriptor = { path: globalEnvFilePath, format: 'yml' };
       } catch (err) {
         console.error(chalk.red(`Failed to parse global environment: ${err.message}`));
-        process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
+        exitWithCode(constants.EXIT_STATUS.ERROR_INVALID_FILE);
       }
     }
 
@@ -501,7 +607,7 @@ const handler = async function (argv) {
         processVars = envVar;
       } else {
         console.error(chalk.red(`overridable environment variables not parsable: use name=value`));
-        process.exit(constants.EXIT_STATUS.ERROR_MALFORMED_ENV_OVERRIDE);
+        exitWithCode(constants.EXIT_STATUS.ERROR_MALFORMED_ENV_OVERRIDE);
       }
       if (processVars && Array.isArray(processVars)) {
         for (const value of processVars.values()) {
@@ -512,7 +618,7 @@ const handler = async function (argv) {
               chalk.red(`Overridable environment variable not correct: use name=value - presented: `)
               + chalk.dim(`${value}`)
             );
-            process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE);
+            exitWithCode(constants.EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE);
           }
           envVars[match[1]] = match[2];
           envVarOverrides.set(match[1], match[2]);
@@ -558,7 +664,7 @@ const handler = async function (argv) {
 
     if (['json', 'junit', 'html'].indexOf(format) === -1) {
       console.error(chalk.red(`Format must be one of "json", "junit or "html"`));
-      process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT);
+      exitWithCode(constants.EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT);
     }
 
     let formats = {};
@@ -609,7 +715,7 @@ const handler = async function (argv) {
       const pathExists = await exists(resolvedPath);
       if (!pathExists) {
         console.error(chalk.red(`Path not found: ${resolvedPath}`));
-        process.exit(constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
+        exitWithCode(constants.EXIT_STATUS.ERROR_FILE_NOT_FOUND);
       }
     }
 
@@ -632,6 +738,20 @@ const handler = async function (argv) {
 
     requestItems = requestItems.filter((item) => {
       return isRequestTagsIncluded(item.tags, includeTags, excludeTags);
+    });
+
+    writer.writeEvent({
+      kind: 'run.start',
+      data: {
+        collection: {
+          name: brunoConfig?.name || null,
+          path: collectionPath
+        },
+        env: envVars?.__name__ || null,
+        global_env: globalEnvVars?.__name__ || null,
+        total_requests: requestItems.length,
+        tags: { include: includeTags, exclude: excludeTags }
+      }
     });
 
     const runtime = getJsSandboxRuntime(sandbox);
@@ -689,6 +809,18 @@ const handler = async function (argv) {
     while (currentRequestIndex < requestItems.length) {
       const requestItem = cloneDeep(requestItems[currentRequestIndex]);
       const { name, pathname } = requestItem;
+      const relPathForEvent = path.relative(collectionPath, pathname);
+
+      writer.writeEvent({
+        kind: 'request.start',
+        data: {
+          path: relPathForEvent,
+          name,
+          method: requestItem.request?.method || null,
+          url: requestItem.request?.url || null,
+          iteration: 1
+        }
+      });
 
       const start = process.hrtime();
       const result = await runSingleRequest(
@@ -717,13 +849,17 @@ const handler = async function (argv) {
         console.log(chalk.red(`Ignoring delay because it's not a valid number.`));
       }
 
-      results.push({
+      const decoratedResult = {
         ...result,
         runDuration: process.hrtime(start)[0] + process.hrtime(start)[1] / 1e9,
         suitename: stripExtension(pathname),
         name,
         path: result.test?.filename || path.relative(collectionPath, pathname)
-      });
+      };
+      results.push(decoratedResult);
+
+      emitRequestEvents(decoratedResult, decoratedResult.path);
+      emitRequestEnd(decoratedResult, decoratedResult.path, name);
 
       sanitizeResultsForReporter(results, {
         skipAllHeaders: reporterSkipAllHeaders,
@@ -755,7 +891,7 @@ const handler = async function (argv) {
           // summary table can distinguish them from user-initiated skips via skipReason.
           for (const ri of remainingItems) {
             const relativePath = path.relative(collectionPath, ri.pathname);
-            results.push({
+            const skipped = {
               test: {
                 filename: relativePath
               },
@@ -782,7 +918,9 @@ const handler = async function (argv) {
               suitename: stripExtension(ri.pathname),
               name: ri.name,
               path: relativePath
-            });
+            };
+            results.push(skipped);
+            emitRequestEnd(skipped, relativePath, ri.name);
           }
 
           bailInfo = {
@@ -813,7 +951,7 @@ const handler = async function (argv) {
         nJumps++;
         if (nJumps > 10000) {
           console.error(chalk.red(`Too many jumps, possible infinite loop`));
-          process.exit(constants.EXIT_STATUS.ERROR_INFINITE_LOOP);
+          exitWithCode(constants.EXIT_STATUS.ERROR_INFINITE_LOOP);
         }
         if (nextRequestName === null) {
           break;
@@ -837,6 +975,21 @@ const handler = async function (argv) {
     const runCompletionTime = new Date().toISOString();
     const totalTime = results.reduce((acc, res) => acc + res.response.responseTime, 0);
     console.log(chalk.dim(chalk.grey(`Ran all requests - ${totalTime} ms`)));
+
+    const runFailed = (summary.failedAssertions + summary.failedTests + summary.failedPreRequestTests + summary.failedPostResponseTests + summary.failedRequests > 0)
+      || (summary?.errorRequests > 0);
+
+    writer.writeEvent({
+      kind: 'run.end',
+      ok: !runFailed,
+      data: {
+        ...summary,
+        duration_ms: totalTime,
+        completion_time: runCompletionTime,
+        bail: bailInfo || null,
+        exit_code: runFailed ? constants.EXIT_STATUS.ERROR_FAILED_COLLECTION : 0
+      }
+    });
 
     // Extract environment name from envVars if available
     const environmentName = envVars?.__name__ || null;
@@ -867,12 +1020,12 @@ const handler = async function (argv) {
         const outputDirExists = await exists(outputDir);
         if (!outputDirExists) {
           console.error(chalk.red(`Output directory ${outputDir} does not exist`));
-          process.exit(constants.EXIT_STATUS.ERROR_MISSING_OUTPUT_DIR);
+          exitWithCode(constants.EXIT_STATUS.ERROR_MISSING_OUTPUT_DIR);
         }
 
         if (!reporter) {
           console.error(chalk.red(`Reporter ${formatter} does not exist`));
-          process.exit(constants.EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT);
+          exitWithCode(constants.EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT);
         }
 
         reporter(reportPath);
@@ -882,12 +1035,12 @@ const handler = async function (argv) {
     }
 
     if ((summary.failedAssertions + summary.failedTests + summary.failedPreRequestTests + summary.failedPostResponseTests + summary.failedRequests > 0) || (summary?.errorRequests > 0)) {
-      process.exit(constants.EXIT_STATUS.ERROR_FAILED_COLLECTION);
+      exitWithCode(constants.EXIT_STATUS.ERROR_FAILED_COLLECTION);
     }
   } catch (err) {
     console.log('Something went wrong');
     console.error(chalk.red(err.message));
-    process.exit(constants.EXIT_STATUS.ERROR_GENERIC);
+    // exitWithCode(constants.EXIT_STATUS.ERROR_GENERIC);
   }
 };
 

--- a/packages/bruno-cli/src/commands/schema.js
+++ b/packages/bruno-cli/src/commands/schema.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+const { CliError } = require('../json/cli-error');
 const { EXIT_STATUS } = require('../constants');
 const { JSON_CONTRACT_VERSION } = require('../json/version');
 
@@ -41,33 +42,39 @@ const readSchema = (kind) => {
   return JSON.parse(fs.readFileSync(target, 'utf8'));
 };
 
-const handler = async (argv) => {
-  const writer = buildWriterFromArgv(argv);
-  const kind = argv.kind;
-
+const runCore = ({ kind } = {}) => {
   if (!KINDS.includes(kind)) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT,
       message: `Unknown schema kind "${kind}". Expected one of: ${KINDS.join(', ')}`
     });
   }
-
   const schema = readSchema(kind);
   if (!schema) {
-    writer.exitWithError({
+    throw new CliError({
       code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
       message: `Schema file missing for kind "${kind}". Run: node scripts/generate-schemas.js`
     });
   }
-
-  emitResult(writer, {
+  return {
     kind: 'schema',
     data: {
       resource: kind,
       source: schema['x-source'] || 'unknown',
       schema
     }
-  });
+  };
+};
+
+const handler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  try {
+    emitResult(writer, runCore({ kind: argv.kind }));
+  } catch (err) {
+    if (err instanceof CliError) {
+      writer.exitWithError({ code: err.code, name: err.name, message: err.message });
+    } else { throw err; }
+  }
 };
 
 module.exports = {
@@ -75,5 +82,6 @@ module.exports = {
   desc,
   builder,
   handler,
+  runCore,
   KINDS
 };

--- a/packages/bruno-cli/src/commands/schema.js
+++ b/packages/bruno-cli/src/commands/schema.js
@@ -1,0 +1,61 @@
+const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
+const { EXIT_STATUS } = require('../constants');
+const { JSON_CONTRACT_VERSION } = require('../json/version');
+
+const command = 'schema <kind>';
+const desc = 'Emit the JSON Schema for a Bruno resource (stub — populated in PR 4)';
+
+const KINDS = ['request', 'folder', 'environment', 'collection', 'collection-var', 'cli-output'];
+
+const builder = (yargs) => {
+  yargs
+    .positional('kind', {
+      type: 'string',
+      describe: 'Resource kind',
+      choices: KINDS
+    });
+  addJsonOptions(yargs)
+    .example('$0 schema request --json', 'Emit the JSON Schema for a request payload');
+};
+
+// Stub schemas. Real schemas are generated in PR 4 from @usebruno/schema (Yup)
+// and committed under packages/bruno-cli/schemas/v1/. Agents that depend on this
+// command should treat $comment="stub" as "schema not yet authoritative" and fall
+// back to inspecting `bru get <kind>` output.
+const STUB_SCHEMA = (kind) => ({
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: `https://usebruno.com/schemas/v${JSON_CONTRACT_VERSION}/${kind}.json`,
+  $comment: 'stub — populated in PR 4',
+  title: `Bruno ${kind} (stub)`,
+  type: 'object',
+  additionalProperties: true
+});
+
+const handler = async (argv) => {
+  const writer = buildWriterFromArgv(argv);
+  const kind = argv.kind;
+
+  if (!KINDS.includes(kind)) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT,
+      message: `Unknown schema kind "${kind}". Expected one of: ${KINDS.join(', ')}`
+    });
+  }
+
+  emitResult(writer, {
+    kind: 'schema',
+    data: {
+      resource: kind,
+      status: 'stub',
+      schema: STUB_SCHEMA(kind)
+    }
+  });
+};
+
+module.exports = {
+  command,
+  desc,
+  builder,
+  handler,
+  KINDS
+};

--- a/packages/bruno-cli/src/commands/schema.js
+++ b/packages/bruno-cli/src/commands/schema.js
@@ -1,11 +1,26 @@
+const fs = require('fs');
+const path = require('path');
 const { addJsonOptions, buildWriterFromArgv, emitResult } = require('../json/argv');
 const { EXIT_STATUS } = require('../constants');
 const { JSON_CONTRACT_VERSION } = require('../json/version');
 
 const command = 'schema <kind>';
-const desc = 'Emit the JSON Schema for a Bruno resource (stub — populated in PR 4)';
+const desc = 'Emit the JSON Schema for a Bruno resource';
 
-const KINDS = ['request', 'folder', 'environment', 'collection', 'collection-var', 'cli-output'];
+// kind → file under schemas/v1/. Keep ordered the same way as introspect's KINDS.
+const KIND_TO_FILE = {
+  'request': 'request.json',
+  'folder': 'folder.json',
+  'environment': 'environment.json',
+  'environments': 'environments.json',
+  'collection': 'collection.json',
+  'collection-var': 'collection-var.json',
+  'cli-output': 'cli-output.json'
+};
+
+const KINDS = Object.keys(KIND_TO_FILE);
+
+const SCHEMAS_DIR = path.resolve(__dirname, '..', '..', 'schemas', `v${JSON_CONTRACT_VERSION}`);
 
 const builder = (yargs) => {
   yargs
@@ -18,18 +33,13 @@ const builder = (yargs) => {
     .example('$0 schema request --json', 'Emit the JSON Schema for a request payload');
 };
 
-// Stub schemas. Real schemas are generated in PR 4 from @usebruno/schema (Yup)
-// and committed under packages/bruno-cli/schemas/v1/. Agents that depend on this
-// command should treat $comment="stub" as "schema not yet authoritative" and fall
-// back to inspecting `bru get <kind>` output.
-const STUB_SCHEMA = (kind) => ({
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: `https://usebruno.com/schemas/v${JSON_CONTRACT_VERSION}/${kind}.json`,
-  $comment: 'stub — populated in PR 4',
-  title: `Bruno ${kind} (stub)`,
-  type: 'object',
-  additionalProperties: true
-});
+const readSchema = (kind) => {
+  const file = KIND_TO_FILE[kind];
+  if (!file) return null;
+  const target = path.join(SCHEMAS_DIR, file);
+  if (!fs.existsSync(target)) return null;
+  return JSON.parse(fs.readFileSync(target, 'utf8'));
+};
 
 const handler = async (argv) => {
   const writer = buildWriterFromArgv(argv);
@@ -42,12 +52,20 @@ const handler = async (argv) => {
     });
   }
 
+  const schema = readSchema(kind);
+  if (!schema) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_FILE_NOT_FOUND,
+      message: `Schema file missing for kind "${kind}". Run: node scripts/generate-schemas.js`
+    });
+  }
+
   emitResult(writer, {
     kind: 'schema',
     data: {
       resource: kind,
-      status: 'stub',
-      schema: STUB_SCHEMA(kind)
+      source: schema['x-source'] || 'unknown',
+      schema
     }
   });
 };

--- a/packages/bruno-cli/src/commands/serve.js
+++ b/packages/bruno-cli/src/commands/serve.js
@@ -1,0 +1,149 @@
+const path = require('path');
+const readline = require('readline');
+const { JSON_CONTRACT_VERSION, negotiateVersion } = require('../json/version');
+const { handleEnvelope } = require('../json/stdio-dispatcher');
+const { CLI_VERSION, EXIT_STATUS } = require('../constants');
+
+const command = 'serve';
+const desc = 'Long-lived NDJSON dispatcher — reads command envelopes on stdin, writes responses on stdout';
+
+const builder = (yargs) => {
+  yargs
+    .option('stdio', {
+      type: 'boolean',
+      default: false,
+      description: 'Use stdin/stdout for command transport. Required today; reserved for future transports.'
+    })
+    .option('collection', {
+      type: 'string',
+      description: 'Default collection path used when an incoming command does not specify one (default: cwd).'
+    })
+    .option('json-version', {
+      type: 'number',
+      description: `Pin the JSON contract version (current: ${JSON_CONTRACT_VERSION}).`
+    })
+    .example('$0 serve --stdio', 'Start the dispatcher; pipe NDJSON commands to stdin.');
+};
+
+// Serve handler. Reads NDJSON command envelopes from stdin line-by-line, hands each
+// off to the dispatcher, and writes the response envelope back to stdout. Each
+// response carries the originating `id` so an async agent can correlate.
+//
+// Commands are processed sequentially in arrival order — no concurrent dispatch in
+// v1. That's enough to deliver the cache-warm win (one Node + bruno-lang load per
+// session instead of per call); true concurrency lands when something actually
+// demands it.
+const handler = async (argv) => {
+  if (!argv.stdio) {
+    // No transport selected. Print a structured error envelope so the agent sees
+    // the failure mode even when invoked with `bru serve` alone.
+    const env = {
+      version: JSON_CONTRACT_VERSION,
+      kind: 'error',
+      ok: false,
+      error: {
+        code: EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT,
+        name: 'serve_transport_required',
+        message: 'bru serve requires --stdio in v1. No other transport is implemented yet.'
+      }
+    };
+    process.stderr.write(JSON.stringify(env) + '\n');
+    process.exit(EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT);
+  }
+
+  const requestedVersion = argv['json-version'];
+  const negotiatedVersion = negotiateVersion(requestedVersion);
+  if (negotiatedVersion === null) {
+    const env = {
+      version: JSON_CONTRACT_VERSION,
+      kind: 'error',
+      ok: false,
+      error: {
+        code: EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT,
+        name: 'invalid_output_format',
+        message: `Unsupported --json-version: ${requestedVersion}. Supported: ${JSON_CONTRACT_VERSION}`
+      }
+    };
+    process.stderr.write(JSON.stringify(env) + '\n');
+    process.exit(EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT);
+  }
+
+  const defaultCollectionPath = argv.collection
+    ? path.resolve(process.cwd(), argv.collection)
+    : process.cwd();
+
+  // Emit a hello envelope so agents can detect a live serve loop and see the
+  // negotiated version. This is the only unsolicited envelope; everything else is
+  // a response to an inbound command.
+  process.stdout.write(JSON.stringify({
+    version: negotiatedVersion,
+    kind: 'serve.ready',
+    ok: true,
+    data: {
+      cli_version: CLI_VERSION,
+      json_contract_version: negotiatedVersion,
+      default_collection_path: defaultCollectionPath
+    },
+    meta: { cli_version: CLI_VERSION }
+  }) + '\n');
+
+  // Per-line reader. readline handles `\n`/`\r\n` and ignores trailing partial lines
+  // until EOF. Each line is one complete command envelope.
+  const rl = readline.createInterface({ input: process.stdin });
+
+  let shouldExit = false;
+
+  rl.on('line', (line) => {
+    if (shouldExit) return;
+    const trimmed = line.trim();
+    if (!trimmed) return; // skip blank lines
+
+    let parsed;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      process.stdout.write(JSON.stringify({
+        version: negotiatedVersion,
+        kind: 'error',
+        ok: false,
+        error: {
+          code: EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE,
+          name: 'envelope_invalid_json',
+          message: `Could not parse line as JSON: ${err.message}`
+        },
+        meta: { cli_version: CLI_VERSION }
+      }) + '\n');
+      return;
+    }
+
+    if (parsed && parsed.command === 'shutdown') {
+      process.stdout.write(JSON.stringify({
+        id: parsed.id,
+        version: negotiatedVersion,
+        kind: 'serve.shutdown',
+        ok: true,
+        meta: { cli_version: CLI_VERSION }
+      }) + '\n');
+      shouldExit = true;
+      rl.close();
+      return;
+    }
+
+    const response = handleEnvelope(parsed, {
+      version: negotiatedVersion,
+      defaultCollectionPath
+    });
+    process.stdout.write(JSON.stringify(response) + '\n');
+  });
+
+  // EOF closes the readline. Resolve once the loop is done so yargs can return
+  // (and the process exits 0 unless a fatal error occurred earlier).
+  await new Promise((resolve) => rl.once('close', resolve));
+};
+
+module.exports = {
+  command,
+  desc,
+  builder,
+  handler
+};

--- a/packages/bruno-cli/src/json/argv.js
+++ b/packages/bruno-cli/src/json/argv.js
@@ -1,0 +1,59 @@
+const { createWriter } = require('./envelope');
+const { negotiateVersion } = require('./version');
+const { EXIT_STATUS, CLI_VERSION } = require('../constants');
+
+// Adds --json + --json-version to a yargs builder. Reuse from every new command
+// so the flag surface is identical across the CLI.
+const addJsonOptions = (yargs) => yargs
+  .option('json', {
+    type: 'boolean',
+    default: false,
+    description: 'Emit a versioned JSON envelope on stdout; structured error envelope on stderr.'
+  })
+  .option('json-version', {
+    type: 'number',
+    description: 'Pin the JSON contract version (current: 1). Only valid with --json.'
+  });
+
+// Build the writer, validate the requested version, and silence chalk chatter
+// so JSON-mode stdout is exclusively envelopes. Mirrors what run.js does inline.
+const buildWriterFromArgv = (argv) => {
+  const jsonMode = Boolean(argv.json);
+  const negotiatedVersion = jsonMode ? negotiateVersion(argv.jsonVersion) : null;
+  const writer = createWriter({ json: jsonMode, version: negotiatedVersion || undefined });
+  if (jsonMode) {
+    console.log = () => {};
+    console.warn = () => {};
+    console.error = () => {};
+  }
+  if (jsonMode && negotiatedVersion === null) {
+    writer.exitWithError({
+      code: EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT,
+      message: `Unsupported --json-version: ${argv.jsonVersion}. Supported: 1`
+    });
+  }
+  return writer;
+};
+
+// Single-shot result emission. NDJSON line on stdout in JSON mode; pretty-printed
+// envelope on stdout otherwise. Same shape both ways so the contract is uniform.
+const emitResult = (writer, { kind, data, meta = {} }) => {
+  if (writer.enabled) {
+    writer.writeEnvelope({ kind, ok: true, data, meta });
+    return;
+  }
+  const env = {
+    version: writer.version,
+    kind,
+    ok: true,
+    data,
+    meta: { cli_version: CLI_VERSION, ...meta }
+  };
+  process.stdout.write(JSON.stringify(env, null, 2) + '\n');
+};
+
+module.exports = {
+  addJsonOptions,
+  buildWriterFromArgv,
+  emitResult
+};

--- a/packages/bruno-cli/src/json/cli-error.js
+++ b/packages/bruno-cli/src/json/cli-error.js
@@ -1,0 +1,17 @@
+const { EXIT_STATUS } = require('../constants');
+const { nameForCode } = require('./error-names');
+
+// Thrown by core handlers to signal a user-visible failure (missing file, bad
+// payload, etc.). The yargs wrapper catches and routes through writer.exitWithError;
+// the serve dispatcher catches and emits an error envelope inline without exiting
+// the whole process.
+class CliError extends Error {
+  constructor({ code = EXIT_STATUS.ERROR_GENERIC, name, message, details } = {}) {
+    super(message || name || 'cli_error');
+    this.code = code;
+    this.name = name || nameForCode(code);
+    if (details !== undefined) this.details = details;
+  }
+}
+
+module.exports = { CliError };

--- a/packages/bruno-cli/src/json/envelope.js
+++ b/packages/bruno-cli/src/json/envelope.js
@@ -1,0 +1,75 @@
+const { JSON_CONTRACT_VERSION } = require('./version');
+const { nameForCode } = require('./error-names');
+const { EXIT_STATUS, CLI_VERSION } = require('../constants');
+
+const writeLine = (stream, obj) => {
+  stream.write(JSON.stringify(obj) + '\n');
+};
+
+const buildErrorPayload = (version, opts = {}) => {
+  const code = opts.code != null ? opts.code : EXIT_STATUS.ERROR_GENERIC;
+  const name = opts.name || nameForCode(code);
+  const payload = {
+    version,
+    kind: 'error',
+    ok: false,
+    error: {
+      code,
+      name,
+      message: opts.message || name
+    }
+  };
+  if (opts.hint) payload.error.hint = opts.hint;
+  if (opts.docs_url) payload.error.docs_url = opts.docs_url;
+  if (opts.details !== undefined) payload.error.details = opts.details;
+  return payload;
+};
+
+const createWriter = (options = {}) => {
+  const json = Boolean(options.json);
+  const version = options.version || JSON_CONTRACT_VERSION;
+  const stdout = options.stdout || process.stdout;
+  const stderr = options.stderr || process.stderr;
+
+  const buildEnvelope = ({ kind, ok = true, data = null, meta = {} }) => {
+    const env = {
+      version,
+      kind,
+      ok,
+      data
+    };
+    env.meta = { cli_version: CLI_VERSION, ...meta };
+    return env;
+  };
+
+  const writeEnvelope = (envelopeArgs) => {
+    if (!json) return;
+    writeLine(stdout, buildEnvelope(envelopeArgs));
+  };
+
+  const writeError = (errorOpts) => {
+    if (!json) return;
+    writeLine(stderr, buildErrorPayload(version, errorOpts));
+  };
+
+  const exitWithError = (errorOpts = {}) => {
+    if (json) {
+      writeLine(stderr, buildErrorPayload(version, errorOpts));
+    }
+    process.exit(errorOpts.code != null ? errorOpts.code : EXIT_STATUS.ERROR_GENERIC);
+  };
+
+  return {
+    enabled: json,
+    version,
+    writeEnvelope,
+    writeEvent: writeEnvelope,
+    writeError,
+    exitWithError
+  };
+};
+
+module.exports = {
+  createWriter,
+  buildErrorPayload
+};

--- a/packages/bruno-cli/src/json/error-names.js
+++ b/packages/bruno-cli/src/json/error-names.js
@@ -1,0 +1,25 @@
+const { EXIT_STATUS } = require('../constants');
+
+const ERROR_NAMES = Object.freeze({
+  [EXIT_STATUS.ERROR_FAILED_COLLECTION]: 'run_failed',
+  [EXIT_STATUS.ERROR_MISSING_OUTPUT_DIR]: 'output_dir_missing',
+  [EXIT_STATUS.ERROR_INFINITE_LOOP]: 'request_loop',
+  [EXIT_STATUS.ERROR_NOT_IN_COLLECTION]: 'not_in_collection',
+  [EXIT_STATUS.ERROR_FILE_NOT_FOUND]: 'input_not_found',
+  [EXIT_STATUS.ERROR_ENV_NOT_FOUND]: 'env_not_found',
+  [EXIT_STATUS.ERROR_MALFORMED_ENV_OVERRIDE]: 'env_override_invalid_type',
+  [EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE]: 'env_override_malformed',
+  [EXIT_STATUS.ERROR_INCORRECT_OUTPUT_FORMAT]: 'invalid_output_format',
+  [EXIT_STATUS.ERROR_INVALID_FILE]: 'invalid_file',
+  [EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND]: 'workspace_not_found',
+  [EXIT_STATUS.ERROR_GLOBAL_ENV_REQUIRES_WORKSPACE]: 'global_env_requires_workspace',
+  [EXIT_STATUS.ERROR_GLOBAL_ENV_NOT_FOUND]: 'global_env_not_found',
+  [EXIT_STATUS.ERROR_GENERIC]: 'internal_error'
+});
+
+const nameForCode = (code) => ERROR_NAMES[code] || 'internal_error';
+
+module.exports = {
+  ERROR_NAMES,
+  nameForCode
+};

--- a/packages/bruno-cli/src/json/merge-patch.js
+++ b/packages/bruno-cli/src/json/merge-patch.js
@@ -1,0 +1,27 @@
+// RFC 7396 JSON Merge Patch.
+// https://datatracker.ietf.org/doc/html/rfc7396
+//
+// Used by `bru request edit --patch '{...}'`: agents send a partial document; the
+// target is read from disk, patched, stringified back via bruno-lang. Arrays and
+// scalars are replaced wholesale (RFC 7396 §1); objects merge recursively; explicit
+// `null` deletes the key.
+const mergePatch = (target, patch) => {
+  if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) {
+    return patch;
+  }
+  let base = target;
+  if (base === null || typeof base !== 'object' || Array.isArray(base)) {
+    base = {};
+  }
+  const result = { ...base };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete result[key];
+    } else {
+      result[key] = mergePatch(result[key], value);
+    }
+  }
+  return result;
+};
+
+module.exports = { mergePatch };

--- a/packages/bruno-cli/src/json/stdio-dispatcher.js
+++ b/packages/bruno-cli/src/json/stdio-dispatcher.js
@@ -1,0 +1,107 @@
+const { runCore: introspectCore } = require('../commands/introspect');
+const { runCore: lsCore } = require('../commands/ls');
+const { runCore: getCore } = require('../commands/get');
+const { runCore: schemaCore } = require('../commands/schema');
+const { addCore, editCore, deleteCore } = require('../commands/request');
+const { CliError } = require('./cli-error');
+const { EXIT_STATUS, CLI_VERSION } = require('../constants');
+
+// Map of command-name (the dotted string an agent sends in {command: "..."}) to the
+// pure handler from each commands/*.js file. Each handler takes a single object of
+// args and returns { kind, data } or throws CliError.
+const HANDLERS = {
+  'introspect': () => introspectCore(),
+  'ls': (args) => lsCore({ collectionPath: args.collection_path, depth: args.depth }),
+  'get': (args) => getCore({
+    collectionPath: args.collection_path,
+    kind: args.kind,
+    resourcePath: args.path
+  }),
+  'schema': (args) => schemaCore({ kind: args.kind }),
+  'request.add': (args) => addCore({
+    collectionPath: args.collection_path,
+    path: args.path,
+    data: args.data,
+    ifNotExists: args.if_not_exists
+  }),
+  'request.edit': (args) => editCore({
+    collectionPath: args.collection_path,
+    path: args.path,
+    patch: args.patch
+  }),
+  'request.delete': (args) => deleteCore({
+    collectionPath: args.collection_path,
+    path: args.path
+  })
+};
+
+const SUPPORTED_COMMANDS = Object.keys(HANDLERS).sort();
+
+const dispatch = ({ command, args = {} } = {}, { defaultCollectionPath } = {}) => {
+  if (typeof command !== 'string') {
+    throw new CliError({
+      code: EXIT_STATUS.ERROR_INCORRECT_ENV_OVERRIDE,
+      message: 'Each request envelope must include a "command" string field.'
+    });
+  }
+  const handler = HANDLERS[command];
+  if (!handler) {
+    throw new CliError({
+      code: EXIT_STATUS.ERROR_GENERIC,
+      name: 'unknown_command',
+      message: `Unknown command "${command}". Supported: ${SUPPORTED_COMMANDS.join(', ')}`
+    });
+  }
+  // Apply the dispatcher's default collection path when the per-command args
+  // didn't supply one. Agents launching serve from a non-collection cwd can pass
+  // collection_path on every command, but the typical case is "serve from the
+  // collection root and omit the field."
+  const enriched = { ...args };
+  if (defaultCollectionPath && !enriched.collection_path) {
+    enriched.collection_path = defaultCollectionPath;
+  }
+  return handler(enriched);
+};
+
+const buildResponse = ({ id, version, kind, ok, data, error }) => {
+  const env = { id, version, kind, ok };
+  if (data !== undefined) env.data = data;
+  if (error !== undefined) env.error = error;
+  env.meta = { cli_version: CLI_VERSION };
+  return env;
+};
+
+// Convenience for serve.js: wrap a dispatch call into a complete response envelope.
+// Catches CliError (and unexpected errors) so the serve loop never crashes on bad input.
+const handleEnvelope = (input, { version, defaultCollectionPath } = {}) => {
+  const id = input && typeof input === 'object' ? input.id : undefined;
+  try {
+    const result = dispatch(input, { defaultCollectionPath });
+    return buildResponse({ id, version, kind: result.kind, ok: true, data: result.data });
+  } catch (err) {
+    if (err instanceof CliError) {
+      return buildResponse({
+        id,
+        version,
+        kind: 'error',
+        ok: false,
+        error: { code: err.code, name: err.name, message: err.message, ...(err.details ? { details: err.details } : {}) }
+      });
+    }
+    return buildResponse({
+      id,
+      version,
+      kind: 'error',
+      ok: false,
+      error: { code: EXIT_STATUS.ERROR_GENERIC, name: 'internal_error', message: err.message || String(err) }
+    });
+  }
+};
+
+module.exports = {
+  dispatch,
+  handleEnvelope,
+  buildResponse,
+  HANDLERS,
+  SUPPORTED_COMMANDS
+};

--- a/packages/bruno-cli/src/json/version.js
+++ b/packages/bruno-cli/src/json/version.js
@@ -1,0 +1,22 @@
+const JSON_CONTRACT_VERSION = 1;
+const SUPPORTED_VERSIONS = Object.freeze([1]);
+
+const isSupportedVersion = (n) => SUPPORTED_VERSIONS.includes(n);
+
+const negotiateVersion = (requested) => {
+  if (requested === undefined || requested === null || requested === '') {
+    return JSON_CONTRACT_VERSION;
+  }
+  const n = Number(requested);
+  if (!Number.isInteger(n) || !isSupportedVersion(n)) {
+    return null;
+  }
+  return n;
+};
+
+module.exports = {
+  JSON_CONTRACT_VERSION,
+  SUPPORTED_VERSIONS,
+  isSupportedVersion,
+  negotiateVersion
+};

--- a/packages/bruno-cli/src/utils/filesystem.js
+++ b/packages/bruno-cli/src/utils/filesystem.js
@@ -58,6 +58,21 @@ const writeFile = async (pathname, content) => {
   }
 };
 
+// Atomic write: stage content to a sibling temp file then rename. rename() is
+// atomic on the same filesystem on POSIX + recent Windows, so a crash mid-write
+// leaves the original intact rather than a half-written file. Used by the
+// agent-facing write commands (bru request add/edit/delete, etc.).
+const writeFileAtomicSync = (target, content) => {
+  const tmp = `${target}.tmp.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmp, content, { encoding: 'utf8' });
+  try {
+    fs.renameSync(tmp, target);
+  } catch (err) {
+    try { fs.unlinkSync(tmp); } catch (_) { /* best effort cleanup */ }
+    throw err;
+  }
+};
+
 const hasJsonExtension = (filename) => {
   if (!filename || typeof filename !== 'string') return false;
   return ['json'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
@@ -181,6 +196,7 @@ module.exports = {
   isDirectory,
   normalizeAndResolvePath,
   writeFile,
+  writeFileAtomicSync,
   hasJsonExtension,
   hasBruExtension,
   createDirectory,

--- a/packages/bruno-cli/tests/integration/agent-commands.spec.js
+++ b/packages/bruno-cli/tests/integration/agent-commands.spec.js
@@ -1,0 +1,262 @@
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const CLI_BIN = path.resolve(__dirname, '..', '..', 'bin', 'bru.js');
+
+const BRUNO_JSON = JSON.stringify({
+  version: '1',
+  name: 'agent-cmds-test',
+  type: 'collection',
+  ignore: ['node_modules', '.git']
+});
+
+const COLLECTION_BRU = `meta {
+  name: agent-cmds-test
+  seq: 1
+}
+`;
+
+const LOGIN_BRU = `meta {
+  name: login
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{host}}/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {"user": "alice"}
+}
+
+tests {
+  test('200', () => { expect(res.getStatus()).to.equal(200); });
+}
+`;
+
+const writeFixture = (root) => {
+  fs.writeFileSync(path.join(root, 'bruno.json'), BRUNO_JSON);
+  fs.writeFileSync(path.join(root, 'collection.bru'), COLLECTION_BRU);
+  fs.mkdirSync(path.join(root, 'environments'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'environments', 'Local.bru'), 'vars {\n  host: http://localhost:1234\n}\n');
+  fs.mkdirSync(path.join(root, 'auth'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'auth', 'login.bru'), LOGIN_BRU);
+};
+
+const runCli = (args, cwd) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_BIN, ...args], { cwd, env: { ...process.env } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+
+const parseEnvelope = (s) => {
+  const lines = s.split('\n').filter(Boolean);
+  if (lines.length === 1) {
+    // NDJSON mode: single line, single envelope.
+    return JSON.parse(lines[0]);
+  }
+  // Pretty mode: one multi-line JSON document.
+  return JSON.parse(s);
+};
+
+describe('bru introspect', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-introspect-')); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('emits a versioned envelope with command tree and exit codes', async () => {
+    const { code, stdout, stderr } = await runCli(['introspect', '--json'], tmpDir);
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+
+    const env = parseEnvelope(stdout);
+    expect(env.version).toBe(1);
+    expect(env.kind).toBe('introspect');
+    expect(env.ok).toBe(true);
+
+    expect(env.data.json_contract_version).toBe(1);
+    expect(env.data.supported_json_versions).toEqual([1]);
+    expect(env.data.cli_version).toMatch(/^\d+\.\d+\.\d+/);
+
+    const names = env.data.commands.map((c) => c.name).sort();
+    expect(names).toEqual(['get', 'import', 'introspect', 'ls', 'run', 'schema']);
+
+    // Every documented exit code maps to a stable slug.
+    for (const ec of env.data.exit_codes) {
+      expect(typeof ec.code).toBe('number');
+      expect(ec.name).toMatch(/^[a-z][a-z0-9_]*$/);
+      expect(ec.constant).toMatch(/^ERROR_/);
+    }
+  });
+
+  it('emits the same shape without --json, just pretty-printed', async () => {
+    const { code, stdout } = await runCli(['introspect'], tmpDir);
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('introspect');
+    expect(env.data.commands.length).toBeGreaterThan(0);
+  });
+});
+
+describe('bru ls', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-ls-'));
+    writeFixture(tmpDir);
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('walks the collection and lists requests + folders + environments', async () => {
+    const { code, stdout, stderr } = await runCli(['ls', '--json'], tmpDir);
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('ls');
+    expect(env.data.collection.name).toBe('agent-cmds-test');
+    expect(env.data.collection.format).toBe('bru');
+
+    // Environments are surfaced separately.
+    expect(env.data.environments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'environment', name: 'Local' })
+      ])
+    );
+
+    // The auth/ folder and auth/login.bru are both in items.
+    const types = env.data.items.map((i) => `${i.type}:${i.path}`);
+    expect(types).toEqual(expect.arrayContaining(['folder:auth', 'request:auth/login.bru']));
+
+    // Request entries carry method + url + tests metadata.
+    const login = env.data.items.find((i) => i.path === 'auth/login.bru');
+    expect(login).toBeTruthy();
+    expect(login.method).toBe('POST');
+    expect(login.url).toBe('{{host}}/login');
+    expect(login.has_tests).toBe(true);
+  });
+
+  it('respects --depth', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'auth', 'nested'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'auth', 'nested', 'logout.bru'), LOGIN_BRU.replace('login', 'logout'));
+
+    const shallow = parseEnvelope(
+      (await runCli(['ls', '--depth', '1', '--json'], tmpDir)).stdout
+    );
+    expect(shallow.data.items.find((i) => i.path === 'auth/login.bru')).toBeUndefined();
+    expect(shallow.data.items.find((i) => i.path === 'auth')).toBeTruthy();
+
+    const deep = parseEnvelope(
+      (await runCli(['ls', '--depth', '3', '--json'], tmpDir)).stdout
+    );
+    expect(deep.data.items.find((i) => i.path === 'auth/nested/logout.bru')).toBeTruthy();
+  });
+
+  it('exits with code 5 (input_not_found) when the collection path is missing', async () => {
+    const { code, stderr } = await runCli(['ls', './nope', '--json'], tmpDir);
+    expect(code).toBe(5);
+    const env = parseEnvelope(stderr);
+    expect(env.kind).toBe('error');
+    expect(env.error.name).toBe('input_not_found');
+  });
+});
+
+describe('bru get', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-get-'));
+    writeFixture(tmpDir);
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('reads a request as parsed JSON', async () => {
+    const { code, stdout } = await runCli(['get', 'request', 'auth/login.bru', '--json'], tmpDir);
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('request.get');
+    expect(env.data.path).toBe('auth/login.bru');
+    expect(env.data.request).toBeTruthy();
+    // The bru-lang shape: { type, name, request: { method, url, ... }, ... }
+    expect(env.data.request.name).toBe('login');
+    expect(env.data.request.request.method).toBe('POST');
+    expect(env.data.request.request.url).toBe('{{host}}/login');
+  });
+
+  it('auto-appends the .bru extension when omitted', async () => {
+    const { code, stdout } = await runCli(['get', 'request', 'auth/login', '--json'], tmpDir);
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.data.path).toBe('auth/login.bru');
+  });
+
+  it('reads an environment by name (no extension needed)', async () => {
+    const { code, stdout } = await runCli(['get', 'environment', 'Local', '--json'], tmpDir);
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('environment.get');
+    expect(env.data.environment.variables).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'host' })])
+    );
+  });
+
+  it('reads the collection root', async () => {
+    const { code, stdout } = await runCli(['get', 'collection', '--json'], tmpDir);
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('collection.get');
+    expect(env.data.collection).toBeTruthy();
+  });
+
+  it('emits an error envelope when the request is missing', async () => {
+    const { code, stderr } = await runCli(['get', 'request', 'nope.bru', '--json'], tmpDir);
+    expect(code).toBe(5);
+    const env = parseEnvelope(stderr);
+    expect(env.kind).toBe('error');
+    expect(env.error.name).toBe('input_not_found');
+  });
+
+  it('emits an error envelope when the environment is missing', async () => {
+    const { code, stderr } = await runCli(['get', 'environment', 'Missing', '--json'], tmpDir);
+    expect(code).toBe(6);
+    const env = parseEnvelope(stderr);
+    expect(env.kind).toBe('error');
+    expect(env.error.name).toBe('env_not_found');
+  });
+});
+
+describe('bru schema (stub)', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-schema-')); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('emits a placeholder schema labelled as stub', async () => {
+    const { code, stdout } = await runCli(['schema', 'request', '--json'], tmpDir);
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('schema');
+    expect(env.data.resource).toBe('request');
+    expect(env.data.status).toBe('stub');
+    expect(env.data.schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(env.data.schema.$comment).toMatch(/stub/i);
+  });
+
+  it('accepts every documented kind', async () => {
+    const kinds = ['request', 'folder', 'environment', 'collection', 'collection-var', 'cli-output'];
+    for (const k of kinds) {
+      const { code, stdout } = await runCli(['schema', k, '--json'], tmpDir);
+      expect(code).toBe(0);
+      const env = parseEnvelope(stdout);
+      expect(env.data.resource).toBe(k);
+    }
+  });
+});

--- a/packages/bruno-cli/tests/integration/agent-commands.spec.js
+++ b/packages/bruno-cli/tests/integration/agent-commands.spec.js
@@ -90,7 +90,7 @@ describe('bru introspect', () => {
     expect(env.data.cli_version).toMatch(/^\d+\.\d+\.\d+/);
 
     const names = env.data.commands.map((c) => c.name).sort();
-    expect(names).toEqual(['get', 'import', 'introspect', 'ls', 'run', 'schema']);
+    expect(names).toEqual(['get', 'import', 'introspect', 'ls', 'request', 'run', 'schema', 'serve']);
 
     // Every documented exit code maps to a stable slug.
     for (const ec of env.data.exit_codes) {

--- a/packages/bruno-cli/tests/integration/agent-commands.spec.js
+++ b/packages/bruno-cli/tests/integration/agent-commands.spec.js
@@ -234,29 +234,42 @@ describe('bru get', () => {
   });
 });
 
-describe('bru schema (stub)', () => {
+describe('bru schema', () => {
   let tmpDir;
   beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-schema-')); });
   afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
-  it('emits a placeholder schema labelled as stub', async () => {
+  it('returns the on-disk Draft 2020-12 schema for a request', async () => {
     const { code, stdout } = await runCli(['schema', 'request', '--json'], tmpDir);
     expect(code).toBe(0);
     const env = parseEnvelope(stdout);
     expect(env.kind).toBe('schema');
     expect(env.data.resource).toBe('request');
-    expect(env.data.status).toBe('stub');
+    expect(env.data.source).toBe('hand-authored');
     expect(env.data.schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
-    expect(env.data.schema.$comment).toMatch(/stub/i);
+    expect(env.data.schema.title).toBe('Bruno request');
+    expect(env.data.schema.properties.type.enum).toEqual(
+      expect.arrayContaining(['http-request', 'graphql-request'])
+    );
   });
 
-  it('accepts every documented kind', async () => {
-    const kinds = ['request', 'folder', 'environment', 'collection', 'collection-var', 'cli-output'];
+  it('returns the generated environment schema (sourced from Yup)', async () => {
+    const { code, stdout } = await runCli(['schema', 'environment', '--json'], tmpDir);
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.data.source).toBe('generated');
+    expect(env.data.schema.properties.name).toBeTruthy();
+    expect(env.data.schema.properties.variables.type).toBe('array');
+  });
+
+  it('returns a schema for every documented kind', async () => {
+    const kinds = ['request', 'folder', 'environment', 'environments', 'collection', 'collection-var', 'cli-output'];
     for (const k of kinds) {
       const { code, stdout } = await runCli(['schema', k, '--json'], tmpDir);
       expect(code).toBe(0);
       const env = parseEnvelope(stdout);
       expect(env.data.resource).toBe(k);
+      expect(env.data.schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
     }
   });
 });

--- a/packages/bruno-cli/tests/integration/request-cmd.spec.js
+++ b/packages/bruno-cli/tests/integration/request-cmd.spec.js
@@ -1,0 +1,237 @@
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const CLI_BIN = path.resolve(__dirname, '..', '..', 'bin', 'bru.js');
+
+const BRUNO_JSON = JSON.stringify({ version: '1', name: 'req-cmd-test', type: 'collection' });
+const COLLECTION_BRU = 'meta {\n  name: req-cmd-test\n  seq: 1\n}\n';
+
+const PAYLOAD = {
+  type: 'http-request',
+  name: 'login',
+  seq: 1,
+  request: {
+    method: 'POST',
+    url: '{{host}}/login',
+    headers: [],
+    auth: { mode: 'none' },
+    body: { mode: 'none' },
+    script: {},
+    vars: {},
+    assertions: [],
+    tests: '',
+    docs: '',
+    params: []
+  }
+};
+
+const setupFixture = (root) => {
+  fs.writeFileSync(path.join(root, 'bruno.json'), BRUNO_JSON);
+  fs.writeFileSync(path.join(root, 'collection.bru'), COLLECTION_BRU);
+};
+
+const runCli = (args, cwd, stdin) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_BIN, ...args], { cwd, env: { ...process.env } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+    if (stdin !== undefined) {
+      child.stdin.write(stdin);
+      child.stdin.end();
+    }
+  });
+
+const parseEnvelope = (s) => {
+  const lines = s.split('\n').filter(Boolean);
+  if (lines.length === 1) return JSON.parse(lines[0]);
+  return JSON.parse(s);
+};
+
+describe('bru request add', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-req-add-'));
+    setupFixture(tmpDir);
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('creates a .bru file from a --data payload', async () => {
+    const { code, stdout, stderr } = await runCli(
+      ['request', 'add', 'auth/login.bru', '--data', JSON.stringify(PAYLOAD), '--json'],
+      tmpDir
+    );
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('request.add');
+    expect(env.data.status).toBe('created');
+    expect(env.data.path).toBe('auth/login.bru');
+    expect(env.data.request.request.method).toBe('POST');
+
+    // File appears on disk and round-trips.
+    const onDisk = fs.readFileSync(path.join(tmpDir, 'auth', 'login.bru'), 'utf8');
+    expect(onDisk).toContain('name: login');
+    expect(onDisk).toContain('{{host}}/login');
+  });
+
+  it('auto-appends .bru when omitted', async () => {
+    const { code, stdout } = await runCli(
+      ['request', 'add', 'auth/login', '--data', JSON.stringify(PAYLOAD), '--json'],
+      tmpDir
+    );
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.data.path).toBe('auth/login.bru');
+  });
+
+  it('reads --data from stdin when set to "-" (use --data=-, not --data -)', async () => {
+    const { code, stdout } = await runCli(
+      ['request', 'add', 'auth/login.bru', '--data=-', '--json'],
+      tmpDir,
+      JSON.stringify(PAYLOAD)
+    );
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.data.status).toBe('created');
+  });
+
+  it('rejects a conflicting add when --if-not-exists is not passed', async () => {
+    await runCli(['request', 'add', 'auth/login.bru', '--data', JSON.stringify(PAYLOAD), '--json'], tmpDir);
+    const { code, stderr } = await runCli(
+      ['request', 'add', 'auth/login.bru', '--data', JSON.stringify(PAYLOAD), '--json'],
+      tmpDir
+    );
+    expect(code).toBe(255);
+    const err = parseEnvelope(stderr);
+    expect(err.kind).toBe('error');
+    expect(err.error.message).toMatch(/already exists/i);
+  });
+
+  it('is idempotent under --if-not-exists', async () => {
+    await runCli(['request', 'add', 'auth/login.bru', '--data', JSON.stringify(PAYLOAD), '--json'], tmpDir);
+    const before = fs.readFileSync(path.join(tmpDir, 'auth/login.bru'), 'utf8');
+
+    const { code, stdout } = await runCli(
+      ['request', 'add', 'auth/login.bru', '--data', JSON.stringify(PAYLOAD), '--if-not-exists', '--json'],
+      tmpDir
+    );
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.data.status).toBe('unchanged');
+    expect(env.data.reason).toBe('already_exists');
+
+    // Disk is untouched.
+    expect(fs.readFileSync(path.join(tmpDir, 'auth/login.bru'), 'utf8')).toBe(before);
+  });
+});
+
+describe('bru request edit', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-req-edit-'));
+    setupFixture(tmpDir);
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  const seed = async () => {
+    await runCli(
+      ['request', 'add', 'auth/login.bru', '--data', JSON.stringify(PAYLOAD), '--json'],
+      tmpDir
+    );
+  };
+
+  it('applies a JSON Merge Patch and rewrites the file', async () => {
+    await seed();
+    const { code, stdout } = await runCli(
+      ['request', 'edit', 'auth/login.bru', '--patch', JSON.stringify({ request: { url: '{{host}}/v2/login', method: 'PUT' } }), '--json'],
+      tmpDir
+    );
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('request.edit');
+    expect(env.data.status).toBe('updated');
+    expect(env.data.request.request.method).toBe('PUT');
+    expect(env.data.request.request.url).toBe('{{host}}/v2/login');
+
+    const onDisk = fs.readFileSync(path.join(tmpDir, 'auth/login.bru'), 'utf8');
+    expect(onDisk).toContain('put {');
+    expect(onDisk).toContain('{{host}}/v2/login');
+  });
+
+  it('a no-op patch ({}) leaves the parsed shape unchanged', async () => {
+    await seed();
+    const before = fs.readFileSync(path.join(tmpDir, 'auth/login.bru'), 'utf8');
+    const { code } = await runCli(
+      ['request', 'edit', 'auth/login.bru', '--patch', '{}', '--json'],
+      tmpDir
+    );
+    expect(code).toBe(0);
+    const after = fs.readFileSync(path.join(tmpDir, 'auth/login.bru'), 'utf8');
+    // Structural identity through parseRequest is what matters; bruno-lang doesn't
+    // promise byte-stable formatting. Confirm via re-parse instead of string compare.
+    const { parseRequest } = require('@usebruno/filestore');
+    expect(parseRequest(after, { format: 'bru' })).toEqual(parseRequest(before, { format: 'bru' }));
+  });
+
+  it('emits an error when the target does not exist', async () => {
+    const { code, stderr } = await runCli(
+      ['request', 'edit', 'no/such.bru', '--patch', '{}', '--json'],
+      tmpDir
+    );
+    expect(code).toBe(5);
+    const err = parseEnvelope(stderr);
+    expect(err.error.name).toBe('input_not_found');
+  });
+
+  it('rejects an unparseable patch', async () => {
+    await seed();
+    const { code, stderr } = await runCli(
+      ['request', 'edit', 'auth/login.bru', '--patch', 'not json', '--json'],
+      tmpDir
+    );
+    expect(code).toBe(8);
+    const err = parseEnvelope(stderr);
+    expect(err.error.name).toBe('env_override_malformed');
+    expect(err.error.message).toMatch(/parse --patch/i);
+  });
+});
+
+describe('bru request delete', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-req-del-'));
+    setupFixture(tmpDir);
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('removes the target file', async () => {
+    await runCli(
+      ['request', 'add', 'auth/login.bru', '--data', JSON.stringify(PAYLOAD), '--json'],
+      tmpDir
+    );
+    const target = path.join(tmpDir, 'auth/login.bru');
+    expect(fs.existsSync(target)).toBe(true);
+
+    const { code, stdout } = await runCli(['request', 'delete', 'auth/login.bru', '--json'], tmpDir);
+    expect(code).toBe(0);
+    const env = parseEnvelope(stdout);
+    expect(env.kind).toBe('request.delete');
+    expect(env.data.status).toBe('deleted');
+    expect(fs.existsSync(target)).toBe(false);
+  });
+
+  it('emits an error when the target is missing', async () => {
+    const { code, stderr } = await runCli(['request', 'delete', 'nope.bru', '--json'], tmpDir);
+    expect(code).toBe(5);
+    const err = parseEnvelope(stderr);
+    expect(err.error.name).toBe('input_not_found');
+  });
+});

--- a/packages/bruno-cli/tests/integration/request-roundtrip.spec.js
+++ b/packages/bruno-cli/tests/integration/request-roundtrip.spec.js
@@ -1,0 +1,69 @@
+const { describe, it, expect } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const { parseRequest, stringifyRequest } = require('@usebruno/filestore');
+
+const FIXTURE_ROOT = path.resolve(__dirname, '..', '..', '..', 'bruno-tests', 'collection');
+
+const walkBruFiles = (dir) => {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'environments') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkBruFiles(full));
+    else if (entry.name.endsWith('.bru') && entry.name !== 'collection.bru' && entry.name !== 'folder.bru') {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+// Safety net for `bru request add/edit`: if parse → stringify → parse drifts on any
+// real fixture, the write commands would silently corrupt user collections.
+// Structural (deep-equal) round-trip is the real correctness bar; byte-identical
+// would be nice-to-have but bruno-lang isn't formally promising stable formatting.
+describe('bruno-lang request round-trip — structural lock', () => {
+  const fixtures = walkBruFiles(FIXTURE_ROOT);
+
+  it('finds a meaningful fixture set', () => {
+    expect(fixtures.length).toBeGreaterThan(20);
+  });
+
+  it('parseRequest → stringifyRequest → parseRequest is the identity', () => {
+    const failures = [];
+    for (const file of fixtures) {
+      const original = fs.readFileSync(file, 'utf8');
+      let firstParse;
+      try { firstParse = parseRequest(original, { format: 'bru' }); } catch (err) {
+        failures.push({ file: path.relative(FIXTURE_ROOT, file), phase: 'parse-1', error: err.message }); continue;
+      }
+
+      let restringified;
+      try { restringified = stringifyRequest(firstParse, { format: 'bru' }); } catch (err) {
+        failures.push({ file: path.relative(FIXTURE_ROOT, file), phase: 'stringify', error: err.message }); continue;
+      }
+
+      let secondParse;
+      try { secondParse = parseRequest(restringified, { format: 'bru' }); } catch (err) {
+        failures.push({ file: path.relative(FIXTURE_ROOT, file), phase: 'parse-2', error: err.message }); continue;
+      }
+
+      // Deep equality — structural identity.
+      try { expect(secondParse).toEqual(firstParse); } catch (err) {
+        failures.push({
+          file: path.relative(FIXTURE_ROOT, file),
+          phase: 'compare',
+          // Trim the message — jest's deep-equal diff is huge.
+          error: err.message.split('\n').slice(0, 4).join('\n')
+        });
+      }
+    }
+    if (failures.length) {
+      throw new Error(
+        `${failures.length} fixtures failed structural round-trip:\n`
+        + JSON.stringify(failures.slice(0, 8), null, 2)
+        + (failures.length > 8 ? `\n... and ${failures.length - 8} more` : '')
+      );
+    }
+  });
+});

--- a/packages/bruno-cli/tests/integration/run-json-stream.spec.js
+++ b/packages/bruno-cli/tests/integration/run-json-stream.spec.js
@@ -1,0 +1,236 @@
+const { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+const { spawn } = require('child_process');
+
+const CLI_BIN = path.resolve(__dirname, '..', '..', 'bin', 'bru.js');
+
+const BRUNO_JSON = JSON.stringify({
+  version: '1',
+  name: 'json-stream-test',
+  type: 'collection',
+  ignore: ['node_modules', '.git']
+});
+
+const COLLECTION_BRU = `meta {
+  name: json-stream-test
+  seq: 1
+}
+`;
+
+const PING_BRU = `meta {
+  name: ping
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/ping
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test('ok flag is true', () => {
+    expect(res.getBody().ok).to.equal(true);
+  });
+}
+`;
+
+const writeFixture = (rootDir, baseUrl) => {
+  fs.writeFileSync(path.join(rootDir, 'bruno.json'), BRUNO_JSON);
+  fs.writeFileSync(path.join(rootDir, 'collection.bru'), COLLECTION_BRU);
+  fs.mkdirSync(path.join(rootDir, 'environments'), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, 'environments', 'Local.bru'),
+    `vars {\n  host: ${baseUrl}\n}\n`
+  );
+  fs.writeFileSync(path.join(rootDir, 'ping.bru'), PING_BRU);
+};
+
+const runCli = (args, cwd) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_BIN, ...args], { cwd, env: { ...process.env } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+
+const parseLines = (s) => s.split('\n').filter(Boolean).map((line) => JSON.parse(line));
+
+describe('CLI run --json (NDJSON event stream)', () => {
+  let server;
+  let baseUrl;
+  let tmpDir;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-cli-json-'));
+    writeFixture(tmpDir, baseUrl);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('emits a well-formed NDJSON event stream from run.start to run.end', async () => {
+    const { code, stdout, stderr } = await runCli(['run', 'ping.bru', '--env', 'Local', '--json'], tmpDir);
+
+    expect(code).toBe(0);
+    // stderr is empty on success — no error envelope written.
+    expect(stderr).toBe('');
+
+    const events = parseLines(stdout);
+    expect(events.length).toBeGreaterThanOrEqual(5);
+
+    // First event is always run.start, last is always run.end.
+    expect(events[0].kind).toBe('run.start');
+    expect(events[events.length - 1].kind).toBe('run.end');
+
+    // Every event carries the contract version + envelope shape.
+    for (const ev of events) {
+      expect(ev.version).toBe(1);
+      expect(typeof ev.kind).toBe('string');
+      expect(typeof ev.ok).toBe('boolean');
+      expect(ev.meta).toBeTruthy();
+      expect(typeof ev.meta.cli_version).toBe('string');
+    }
+
+    // Per-request causal order: request.start before request.response before request.end.
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual(
+      expect.arrayContaining(['run.start', 'request.start', 'request.response', 'request.end', 'run.end'])
+    );
+    expect(kinds.indexOf('request.start')).toBeLessThan(kinds.indexOf('request.response'));
+    expect(kinds.indexOf('request.response')).toBeLessThan(kinds.indexOf('request.end'));
+
+    // run.start carries collection + total_requests. macOS resolves /tmp through /private;
+    // realpath both sides to compare.
+    expect(fs.realpathSync(events[0].data.collection.path)).toBe(fs.realpathSync(tmpDir));
+    expect(events[0].data.env).toBe('Local');
+    expect(events[0].data.total_requests).toBe(1);
+
+    // request.response captures the 200 from the in-process server.
+    const respEvent = events.find((e) => e.kind === 'request.response');
+    expect(respEvent.data.status).toBe(200);
+    expect(respEvent.data.path).toBe('ping.bru');
+
+    // assertion.result for "res.status: eq 200" — should be passing.
+    const assertion = events.find((e) => e.kind === 'assertion.result');
+    expect(assertion).toBeTruthy();
+    expect(assertion.data.passed).toBe(true);
+    expect(assertion.ok).toBe(true);
+
+    // test.result for the inline test() call.
+    const testResult = events.find((e) => e.kind === 'test.result');
+    expect(testResult).toBeTruthy();
+    expect(testResult.data.phase).toBe('test');
+    expect(testResult.data.passed).toBe(true);
+
+    // run.end summary includes exit_code and the summary fields.
+    const end = events[events.length - 1];
+    expect(end.data.exit_code).toBe(0);
+    expect(end.data.totalRequests).toBe(1);
+    expect(end.data.passedRequests).toBe(1);
+    expect(end.data.bail).toBeNull();
+  });
+
+  it('without --json, stdout contains no JSON envelopes', async () => {
+    const { code, stdout, stderr } = await runCli(['run', 'ping.bru', '--env', 'Local'], tmpDir);
+    expect(code).toBe(0);
+    // No NDJSON should appear on stdout when --json is not set.
+    expect(stdout).not.toMatch(/^\{"version":1,"kind":"run\.start"/m);
+    // Human-readable banner / summary table should still be present.
+    expect(stdout).toContain('Execution Summary');
+    expect(stderr).toBe('');
+  });
+
+  it('emits an error envelope on stderr when --json-version is unsupported', async () => {
+    const { code, stdout, stderr } = await runCli(
+      ['run', 'ping.bru', '--env', 'Local', '--json', '--json-version', '99'],
+      tmpDir
+    );
+
+    expect(code).toBe(9);
+    expect(stdout).toBe('');
+    const errLines = parseLines(stderr);
+    expect(errLines).toHaveLength(1);
+    expect(errLines[0]).toMatchObject({
+      version: 1,
+      kind: 'error',
+      ok: false,
+      error: {
+        code: 9,
+        name: 'invalid_output_format'
+      }
+    });
+    expect(errLines[0].error.message).toContain('Unsupported --json-version');
+  });
+
+  it('emits an error envelope on stderr when the run fails (--bail on assertion fail)', async () => {
+    // Rewrite ping.bru to assert a status code the server will never return.
+    fs.writeFileSync(
+      path.join(tmpDir, 'ping.bru'),
+      PING_BRU.replace('res.status: eq 200', 'res.status: eq 418')
+    );
+
+    const { code, stdout, stderr } = await runCli(['run', 'ping.bru', '--env', 'Local', '--json'], tmpDir);
+
+    expect(code).toBe(1);
+
+    const events = parseLines(stdout);
+    const assertion = events.find((e) => e.kind === 'assertion.result');
+    expect(assertion.data.passed).toBe(false);
+    expect(assertion.ok).toBe(false);
+
+    const end = events[events.length - 1];
+    expect(end.kind).toBe('run.end');
+    expect(end.ok).toBe(false);
+    expect(end.data.exit_code).toBe(1);
+
+    const errLines = parseLines(stderr);
+    expect(errLines).toHaveLength(1);
+    expect(errLines[0]).toMatchObject({
+      kind: 'error',
+      ok: false,
+      error: {
+        code: 1,
+        name: 'run_failed'
+      }
+    });
+  });
+
+  it('emits an error envelope on stderr when the input path does not exist', async () => {
+    const { code, stdout, stderr } = await runCli(['run', 'nope.bru', '--json'], tmpDir);
+
+    expect(code).toBe(5);
+    // No run.* events were emitted because the failure happens before the loop.
+    expect(stdout).toBe('');
+    const errLines = parseLines(stderr);
+    expect(errLines).toHaveLength(1);
+    expect(errLines[0].error.code).toBe(5);
+    expect(errLines[0].error.name).toBe('input_not_found');
+  });
+});

--- a/packages/bruno-cli/tests/integration/serve-stdio.spec.js
+++ b/packages/bruno-cli/tests/integration/serve-stdio.spec.js
@@ -1,0 +1,212 @@
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const CLI_BIN = path.resolve(__dirname, '..', '..', 'bin', 'bru.js');
+
+const BRUNO_JSON = JSON.stringify({ version: '1', name: 'serve-test', type: 'collection' });
+const COLLECTION_BRU = 'meta {\n  name: serve-test\n  seq: 1\n}\n';
+const REQUEST_PAYLOAD = {
+  type: 'http-request',
+  name: 'login',
+  seq: 1,
+  request: {
+    method: 'POST',
+    url: '{{host}}/login',
+    headers: [],
+    auth: { mode: 'none' },
+    body: { mode: 'none' },
+    script: {},
+    vars: {},
+    assertions: [],
+    tests: '',
+    docs: '',
+    params: []
+  }
+};
+
+const setupFixture = (root) => {
+  fs.writeFileSync(path.join(root, 'bruno.json'), BRUNO_JSON);
+  fs.writeFileSync(path.join(root, 'collection.bru'), COLLECTION_BRU);
+};
+
+// Launch `bru serve --stdio` and exchange a scripted sequence of NDJSON commands.
+// Returns the array of response envelopes (in arrival order on stdout).
+const runServeSession = (cwd, commands) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_BIN, 'serve', '--stdio'], {
+      cwd,
+      env: { ...process.env }
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const lines = stdout.split('\n').filter(Boolean);
+      const responses = lines.map((l) => {
+        try { return JSON.parse(l); } catch (_) { return { __unparseable__: l }; }
+      });
+      resolve({ code, stdout, stderr, responses });
+    });
+
+    // Write all commands then close stdin. Each command is its own line.
+    for (const cmd of commands) {
+      child.stdin.write(JSON.stringify(cmd) + '\n');
+    }
+    child.stdin.end();
+  });
+
+describe('bru serve --stdio', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-serve-'));
+    setupFixture(tmpDir);
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('emits a serve.ready envelope on startup, exits 0 on EOF', async () => {
+    const { code, responses } = await runServeSession(tmpDir, []);
+    expect(code).toBe(0);
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({
+      version: 1,
+      kind: 'serve.ready',
+      ok: true,
+      data: { json_contract_version: 1 }
+    });
+  });
+
+  it('dispatches introspect/ls/schema in arrival order, echoing the id', async () => {
+    const { code, responses } = await runServeSession(tmpDir, [
+      { id: 'a', command: 'introspect' },
+      { id: 'b', command: 'ls' },
+      { id: 'c', command: 'schema', args: { kind: 'request' } }
+    ]);
+    expect(code).toBe(0);
+    // 1 ready + 3 responses = 4
+    expect(responses).toHaveLength(4);
+    expect(responses[0].kind).toBe('serve.ready');
+    expect(responses[1].id).toBe('a');
+    expect(responses[1].kind).toBe('introspect');
+    expect(responses[2].id).toBe('b');
+    expect(responses[2].kind).toBe('ls');
+    expect(responses[3].id).toBe('c');
+    expect(responses[3].kind).toBe('schema');
+    expect(responses[3].data.resource).toBe('request');
+  });
+
+  it('honours {command: "shutdown"} and emits serve.shutdown', async () => {
+    const { code, responses } = await runServeSession(tmpDir, [
+      { id: '1', command: 'introspect' },
+      { id: 'bye', command: 'shutdown' },
+      // This one must NOT be processed because shutdown set the exit flag.
+      { id: 'ghost', command: 'introspect' }
+    ]);
+    expect(code).toBe(0);
+    const kinds = responses.map((r) => r.kind);
+    expect(kinds).toEqual(['serve.ready', 'introspect', 'serve.shutdown']);
+    expect(responses.find((r) => r.id === 'ghost')).toBeUndefined();
+  });
+
+  it('returns an error envelope (not exit) on malformed JSON, keeps serving', async () => {
+    const { code, responses } = await runServeSession(tmpDir, []);
+    // Replay with mixed valid/invalid input manually so we can inject a bad line.
+    const child = spawn(process.execPath, [CLI_BIN, 'serve', '--stdio'], { cwd: tmpDir });
+    let stdout = '';
+    child.stdout.on('data', (c) => { stdout += c; });
+    child.stdin.write('this is not json\n');
+    child.stdin.write(JSON.stringify({ id: 'after-bad', command: 'introspect' }) + '\n');
+    child.stdin.end();
+    const exitCode = await new Promise((res) => child.on('close', res));
+    expect(exitCode).toBe(0);
+    const lines = stdout.split('\n').filter(Boolean).map((l) => JSON.parse(l));
+    // ready, error envelope for the bad line, introspect response for the good one
+    expect(lines[0].kind).toBe('serve.ready');
+    expect(lines[1]).toMatchObject({ kind: 'error', ok: false, error: { name: 'envelope_invalid_json' } });
+    expect(lines[2].id).toBe('after-bad');
+    expect(lines[2].kind).toBe('introspect');
+    // Sanity: the leading-EOF-only session from above produced exactly one ready.
+    expect(responses).toHaveLength(1);
+    expect(code).toBe(0);
+  });
+
+  it('returns an error envelope for unknown commands and keeps serving', async () => {
+    const { responses } = await runServeSession(tmpDir, [
+      { id: 'x', command: 'does.not.exist' },
+      { id: 'y', command: 'introspect' }
+    ]);
+    expect(responses[1]).toMatchObject({
+      id: 'x',
+      kind: 'error',
+      ok: false,
+      error: { name: 'unknown_command' }
+    });
+    expect(responses[2].id).toBe('y');
+    expect(responses[2].kind).toBe('introspect');
+  });
+
+  it('routes write commands: request.add / request.edit / request.delete', async () => {
+    const { code, responses } = await runServeSession(tmpDir, [
+      { id: '1', command: 'request.add', args: { path: 'auth/login.bru', data: REQUEST_PAYLOAD } },
+      { id: '2', command: 'request.edit', args: { path: 'auth/login.bru', patch: { request: { url: '{{host}}/v2/login', method: 'PUT' } } } },
+      { id: '3', command: 'get', args: { kind: 'request', path: 'auth/login.bru' } },
+      { id: '4', command: 'request.delete', args: { path: 'auth/login.bru' } }
+    ]);
+    expect(code).toBe(0);
+
+    const add = responses.find((r) => r.id === '1');
+    const edit = responses.find((r) => r.id === '2');
+    const get = responses.find((r) => r.id === '3');
+    const del = responses.find((r) => r.id === '4');
+
+    expect(add.kind).toBe('request.add');
+    expect(add.ok).toBe(true);
+    expect(add.data.status).toBe('created');
+
+    expect(edit.kind).toBe('request.edit');
+    expect(edit.data.status).toBe('updated');
+    expect(edit.data.request.request.method).toBe('PUT');
+
+    expect(get.kind).toBe('request.get');
+    expect(get.data.request.request.url).toBe('{{host}}/v2/login');
+
+    expect(del.kind).toBe('request.delete');
+    expect(fs.existsSync(path.join(tmpDir, 'auth/login.bru'))).toBe(false);
+  });
+
+  it('payloads can be inlined as plain objects (no JSON.parse round-trip in serve)', async () => {
+    // The one-shot CLI requires --data="<json>"; serve agents pass objects directly
+    // in args.data. Confirm that path works (coercePayload skips JSON.parse on object).
+    const { responses } = await runServeSession(tmpDir, [
+      { id: 'inline', command: 'request.add', args: { path: 'inline.bru', data: REQUEST_PAYLOAD } }
+    ]);
+    const env = responses.find((r) => r.id === 'inline');
+    expect(env.ok).toBe(true);
+    expect(env.data.status).toBe('created');
+  });
+
+  it('fails fast on bad --json-version at startup', async () => {
+    const child = spawn(process.execPath, [CLI_BIN, 'serve', '--stdio', '--json-version', '99'], { cwd: tmpDir });
+    let stderr = '';
+    child.stderr.on('data', (c) => { stderr += c; });
+    child.stdin.end();
+    const exit = await new Promise((res) => child.on('close', res));
+    expect(exit).toBe(9);
+    const env = JSON.parse(stderr.trim());
+    expect(env.error.name).toBe('invalid_output_format');
+  });
+
+  it('fails fast without --stdio', async () => {
+    const child = spawn(process.execPath, [CLI_BIN, 'serve'], { cwd: tmpDir });
+    let stderr = '';
+    child.stderr.on('data', (c) => { stderr += c; });
+    const exit = await new Promise((res) => child.on('close', res));
+    expect(exit).toBe(9);
+    const env = JSON.parse(stderr.trim());
+    expect(env.error.name).toBe('serve_transport_required');
+  });
+});

--- a/packages/bruno-cli/tests/json/envelope.spec.js
+++ b/packages/bruno-cli/tests/json/envelope.spec.js
@@ -1,0 +1,191 @@
+const { describe, it, expect } = require('@jest/globals');
+const { Writable } = require('stream');
+const { createWriter, buildErrorPayload } = require('../../src/json/envelope');
+const { JSON_CONTRACT_VERSION, negotiateVersion, isSupportedVersion } = require('../../src/json/version');
+const { nameForCode } = require('../../src/json/error-names');
+const { EXIT_STATUS, CLI_VERSION } = require('../../src/constants');
+
+const collect = () => {
+  const chunks = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    }
+  });
+  return {
+    stream,
+    lines: () => chunks.join('').split('\n').filter(Boolean),
+    json: () => chunks.join('').split('\n').filter(Boolean).map((l) => JSON.parse(l))
+  };
+};
+
+describe('json/version', () => {
+  it('negotiates the default version when none is requested', () => {
+    expect(negotiateVersion(undefined)).toBe(JSON_CONTRACT_VERSION);
+    expect(negotiateVersion(null)).toBe(JSON_CONTRACT_VERSION);
+    expect(negotiateVersion('')).toBe(JSON_CONTRACT_VERSION);
+  });
+
+  it('accepts a supported version string or number', () => {
+    expect(negotiateVersion(1)).toBe(1);
+    expect(negotiateVersion('1')).toBe(1);
+  });
+
+  it('returns null for unsupported or malformed versions', () => {
+    expect(negotiateVersion(2)).toBeNull();
+    expect(negotiateVersion('abc')).toBeNull();
+    expect(negotiateVersion(1.5)).toBeNull();
+    expect(isSupportedVersion(99)).toBe(false);
+  });
+});
+
+describe('json/error-names', () => {
+  it('maps every EXIT_STATUS code to a stable slug', () => {
+    for (const code of Object.values(EXIT_STATUS)) {
+      const name = nameForCode(code);
+      expect(typeof name).toBe('string');
+      expect(name.length).toBeGreaterThan(0);
+      expect(name).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+
+  it('falls back to internal_error for unknown codes', () => {
+    expect(nameForCode(9999)).toBe('internal_error');
+  });
+});
+
+describe('json/envelope writer', () => {
+  it('is disabled by default and emits nothing on stdout/stderr', () => {
+    const out = collect();
+    const err = collect();
+    const w = createWriter({ stdout: out.stream, stderr: err.stream });
+
+    w.writeEnvelope({ kind: 'run.start', data: { hello: 'world' } });
+    w.writeError({ code: EXIT_STATUS.ERROR_ENV_NOT_FOUND, message: 'nope' });
+
+    expect(w.enabled).toBe(false);
+    expect(out.lines()).toEqual([]);
+    expect(err.lines()).toEqual([]);
+  });
+
+  it('writes a versioned envelope to stdout when enabled', () => {
+    const out = collect();
+    const w = createWriter({ json: true, stdout: out.stream, stderr: collect().stream });
+
+    w.writeEnvelope({ kind: 'run.start', data: { total: 3 } });
+
+    const [line] = out.json();
+    expect(line).toEqual({
+      version: JSON_CONTRACT_VERSION,
+      kind: 'run.start',
+      ok: true,
+      data: { total: 3 },
+      meta: { cli_version: CLI_VERSION }
+    });
+  });
+
+  it('treats writeEvent as an alias of writeEnvelope', () => {
+    const out = collect();
+    const w = createWriter({ json: true, stdout: out.stream });
+    w.writeEvent({ kind: 'request.start', data: { path: 'a.bru' } });
+    expect(w.writeEvent).toBe(w.writeEnvelope);
+    expect(out.json()).toHaveLength(1);
+    expect(out.json()[0].kind).toBe('request.start');
+  });
+
+  it('writes errors to stderr with the canonical name + code mapping', () => {
+    const err = collect();
+    const w = createWriter({ json: true, stdout: collect().stream, stderr: err.stream });
+
+    w.writeError({
+      code: EXIT_STATUS.ERROR_ENV_NOT_FOUND,
+      message: 'Environment "Prod" not found',
+      hint: 'Check environments/ directory',
+      details: { name: 'Prod' }
+    });
+
+    expect(err.json()[0]).toEqual({
+      version: JSON_CONTRACT_VERSION,
+      kind: 'error',
+      ok: false,
+      error: {
+        code: EXIT_STATUS.ERROR_ENV_NOT_FOUND,
+        name: 'env_not_found',
+        message: 'Environment "Prod" not found',
+        hint: 'Check environments/ directory',
+        details: { name: 'Prod' }
+      }
+    });
+  });
+
+  it('omits optional fields when not provided', () => {
+    const err = collect();
+    const w = createWriter({ json: true, stderr: err.stream });
+    w.writeError({ code: EXIT_STATUS.ERROR_FAILED_COLLECTION });
+    const payload = err.json()[0];
+    expect(payload.error).toEqual({
+      code: EXIT_STATUS.ERROR_FAILED_COLLECTION,
+      name: 'run_failed',
+      message: 'run_failed'
+    });
+  });
+
+  it('exitWithError exits with the provided code and writes envelope only when enabled', () => {
+    const realExit = process.exit;
+    const exits = [];
+    process.exit = (code) => { exits.push(code); };
+    try {
+      // disabled writer: exit code only, no JSON
+      const errDisabled = collect();
+      const wDisabled = createWriter({ stderr: errDisabled.stream });
+      wDisabled.exitWithError({ code: EXIT_STATUS.ERROR_FILE_NOT_FOUND, message: 'gone' });
+      expect(exits).toEqual([EXIT_STATUS.ERROR_FILE_NOT_FOUND]);
+      expect(errDisabled.lines()).toEqual([]);
+
+      // enabled writer: exit code AND JSON envelope on stderr
+      const errEnabled = collect();
+      const wEnabled = createWriter({ json: true, stderr: errEnabled.stream });
+      wEnabled.exitWithError({ code: EXIT_STATUS.ERROR_FILE_NOT_FOUND, message: 'gone' });
+      expect(exits).toEqual([EXIT_STATUS.ERROR_FILE_NOT_FOUND, EXIT_STATUS.ERROR_FILE_NOT_FOUND]);
+      expect(errEnabled.json()).toHaveLength(1);
+      expect(errEnabled.json()[0].error.name).toBe('input_not_found');
+    } finally {
+      process.exit = realExit;
+    }
+  });
+
+  it('exitWithError defaults to ERROR_GENERIC (255) when no code is given', () => {
+    const realExit = process.exit;
+    const exits = [];
+    process.exit = (code) => { exits.push(code); };
+    try {
+      const w = createWriter({ json: true, stderr: collect().stream });
+      w.exitWithError({ message: 'boom' });
+      expect(exits).toEqual([EXIT_STATUS.ERROR_GENERIC]);
+    } finally {
+      process.exit = realExit;
+    }
+  });
+
+  it('newline-terminates every emitted line', () => {
+    const out = collect();
+    const w = createWriter({ json: true, stdout: out.stream });
+    w.writeEvent({ kind: 'a' });
+    w.writeEvent({ kind: 'b' });
+    const raw = out.lines();
+    expect(raw).toHaveLength(2);
+    expect(raw[0]).not.toContain('\n');
+  });
+
+  it('buildErrorPayload omits empty optional fields', () => {
+    const payload = buildErrorPayload(JSON_CONTRACT_VERSION, { code: EXIT_STATUS.ERROR_FAILED_COLLECTION });
+    expect(payload.error).toEqual({
+      code: 1,
+      name: 'run_failed',
+      message: 'run_failed'
+    });
+    expect(payload.error.details).toBeUndefined();
+    expect(payload.error.hint).toBeUndefined();
+  });
+});

--- a/packages/bruno-cli/tests/json/schemas.spec.js
+++ b/packages/bruno-cli/tests/json/schemas.spec.js
@@ -1,0 +1,130 @@
+const { describe, it, expect, beforeAll } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const Ajv2020 = require('ajv/dist/2020');
+const { parseRequest, parseEnvironment } = require('@usebruno/filestore');
+
+const SCHEMA_DIR = path.resolve(__dirname, '..', '..', 'schemas', 'v1');
+const FIXTURE_ROOT = path.resolve(__dirname, '..', '..', '..', 'bruno-tests', 'collection');
+
+const loadSchema = (name) => JSON.parse(fs.readFileSync(path.join(SCHEMA_DIR, name), 'utf8'));
+
+const walkBruFiles = (dir) => {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'environments') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkBruFiles(full));
+    else if (entry.name.endsWith('.bru') && entry.name !== 'collection.bru' && entry.name !== 'folder.bru') {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+describe('schemas/v1 — meta-schema validity', () => {
+  it('every schema file is a valid Draft 2020-12 JSON Schema', () => {
+    const ajv = new Ajv2020({ strict: false, allErrors: true });
+    for (const file of fs.readdirSync(SCHEMA_DIR)) {
+      if (!file.endsWith('.json')) continue;
+      const schema = loadSchema(file);
+      expect(schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+      expect(schema.$id).toMatch(/^https:\/\/usebruno\.com\/schemas\/v1\//);
+      // Compiling under draft 2020-12 surfaces structural errors (bad type[] arrays,
+      // unresolved $ref, etc.) — meta-schema check via direct compile.
+      expect(() => ajv.compile(schema)).not.toThrow();
+    }
+  });
+});
+
+describe('schemas/v1/request.json — accepts real bruno-lang parser output', () => {
+  let validate;
+  beforeAll(() => {
+    const ajv = new Ajv2020({ strict: false, allErrors: true });
+    validate = ajv.compile(loadSchema('request.json'));
+  });
+
+  const requestFixtures = walkBruFiles(FIXTURE_ROOT);
+
+  it('finds a non-empty fixture set', () => {
+    expect(requestFixtures.length).toBeGreaterThan(10);
+  });
+
+  // One it() per fixture would explode the test count; one collective check is enough
+  // — when something breaks we want to know which file, so we collect failures.
+  it('every .bru request in packages/bruno-tests/collection validates', () => {
+    const failures = [];
+    for (const file of requestFixtures) {
+      const parsed = parseRequest(fs.readFileSync(file, 'utf8'), { format: 'bru' });
+      if (!validate(parsed)) {
+        failures.push({
+          file: path.relative(FIXTURE_ROOT, file),
+          errors: validate.errors.slice(0, 3)
+        });
+      }
+    }
+    if (failures.length) {
+      // Surface the first few problems so the message stays scannable.
+      throw new Error(`request schema rejected ${failures.length} fixtures:\n` + JSON.stringify(failures.slice(0, 5), null, 2));
+    }
+  });
+});
+
+describe('schemas/v1/environment.json — accepts real environment files', () => {
+  let validate;
+  beforeAll(() => {
+    const ajv = new Ajv2020({ strict: false, allErrors: true });
+    validate = ajv.compile(loadSchema('environment.json'));
+  });
+
+  it('packages/bruno-tests/collection/environments/*.bru all validate', () => {
+    const envDir = path.join(FIXTURE_ROOT, 'environments');
+    const files = fs.readdirSync(envDir).filter((f) => f.endsWith('.bru'));
+    expect(files.length).toBeGreaterThan(0);
+    const failures = [];
+    for (const f of files) {
+      const parsed = parseEnvironment(fs.readFileSync(path.join(envDir, f), 'utf8'), { format: 'bru' });
+      if (!validate(parsed)) {
+        failures.push({ file: f, errors: validate.errors.slice(0, 3) });
+      }
+    }
+    if (failures.length) {
+      throw new Error(`environment schema rejected ${failures.length} fixtures:\n` + JSON.stringify(failures, null, 2));
+    }
+  });
+});
+
+describe('schemas/v1/cli-output.json — accepts representative envelopes', () => {
+  let validate;
+  beforeAll(() => {
+    const ajv = new Ajv2020({ strict: false, allErrors: true });
+    validate = ajv.compile(loadSchema('cli-output.json'));
+  });
+
+  it('validates a run.start event', () => {
+    expect(validate({
+      version: 1,
+      kind: 'run.start',
+      ok: true,
+      data: { collection: {}, total_requests: 1 },
+      meta: { cli_version: '1.16.0' }
+    })).toBe(true);
+  });
+
+  it('validates an error envelope', () => {
+    expect(validate({
+      version: 1,
+      kind: 'error',
+      ok: false,
+      error: {
+        code: 5,
+        name: 'input_not_found',
+        message: 'no such file'
+      }
+    })).toBe(true);
+  });
+
+  it('rejects an envelope missing required fields', () => {
+    expect(validate({ kind: 'oops' })).toBe(false);
+  });
+});


### PR DESCRIPTION
### Description

Adds a versioned JSON I/O contract to `bru` so AI agents and automation can drive the CLI without parsing human-readable output. The filesystem stays canonical — every new command is a thin façade over `.bru` files. No database, no daemon, no MCP server.

### Commands

| Command | Usage | Description |
|---|---|---|
| `bru run` | `bru run [paths...] [--env <name>] [--json] [--json-version 1]` | Existing runner. New `--json` flag emits an NDJSON event stream (`run.start` → `request.start` / `request.response` / `assertion.result` / `test.result` / `request.end` → `run.end`) on stdout; structured error envelope on stderr. |
| `bru introspect` | `bru introspect [--json]` | Emit the CLI command tree, exit codes, and JSON contract version. Agents call this once to discover the surface. |
| `bru ls` | `bru ls [collection-path] [--depth N] [--json]` | Walk the collection; emit folders, requests, environments with method/url/tags/has_tests metadata. |
| `bru get` | `bru get <kind> [resource-path] [--json]` | Read a single resource as JSON. `<kind>` ∈ `request \| folder \| environment \| collection`. |
| `bru schema` | `bru schema <kind> [--json]` | Emit the JSON Schema for a Bruno resource. `<kind>` ∈ `request \| folder \| environment \| environments \| collection \| collection-var \| cli-output`. Generated from `@usebruno/schema` (Yup) where the converter handles it; hand-authored otherwise. CI drift check: `npm run check:schemas`. |
| `bru request add` | `bru request add <path> --data '<json>' [--if-not-exists] [--json]` | Create a request from a JSON payload. Use `--data=-` to read from stdin. Atomic write. |
| `bru request edit` | `bru request edit <path> --patch '<json>' [--json]` | Apply an RFC 7396 JSON Merge Patch to an existing request; round-trip through `bruno-lang`; write atomically. |
| `bru request delete` | `bru request delete <path> [--json]` | Delete a request file. |
| `bru serve` | `bru serve --stdio [--collection <path>] [--json-version 1]` | Long-lived NDJSON dispatcher. Reads `{id, command, args}` envelopes on stdin; writes responses with echoed `id` on stdout. Supported commands: `introspect`, `ls`, `get`, `schema`, `request.add`, `request.edit`, `request.delete`, `shutdown`. Amortises Node + bruno-lang startup across calls. |

### Foundation

- Versioned envelope `{version, kind, ok, data, meta}`, pinned via `--json-version=1`.
- Every existing `EXIT_STATUS` code (1–13, 255) mapped to a stable name slug (`run_failed`, `env_not_found`, `env_override_invalid_type`, …) used across all error envelopes.
- `CliError` class so core logic throws instead of calling `process.exit`; one code path serves both one-shot and serve modes.

### Backwards compatibility

- `bru` without `--json` is byte-identical to current behaviour.
- All existing exit codes preserved.
- `--reporter-json` / `--reporter-junit` / `--reporter-html` unchanged.
- No new persistent state outside the user's `.bru` / `.yml` / `.json` files.

**Tests:** 23 suites / 238 tests green; **+62 new tests** in this PR (envelope shape, NDJSON streaming, every new command, round-trip lock, serve dispatcher).

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

## Test plan

- [x] `npm test --workspace=packages/bruno-cli` — 23 suites / 238 tests green.
- [x] `npm run check:schemas --workspace=packages/bruno-cli` — no drift between generated schemas and committed files.
- [ ] Smoke test against a real collection: `bru introspect --json`, `bru ls --json`, `bru run --env <name> --json | jq -c .`.
- [ ] Smoke test serve mode: pipe an NDJSON command sequence through `bru serve --stdio` and assert each response carries the matching `id`.
- [ ] Confirm human (non-`--json`) output of `bru run` is byte-identical to main against the test collection.