### PR TITLE
fix(lang): filter multipart multi file

### DIFF
--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -266,7 +266,7 @@ const mapPairListToKeyValPairsMultipart = (pairList = [], parseEnabled = true) =
     if (pair.value.startsWith('@file(') && pair.value.endsWith(')')) {
       let filestr = pair.value.replace(/^@file\(/, '').replace(/\)$/, '');
       pair.type = 'file';
-      pair.value = filestr.split('|');
+      pair.value = filestr.split('|').filter(Boolean);
     }
 
     return pair;

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -560,7 +560,7 @@ ${indentString(body.sparql)}
             }
 
             if (item.type === 'file') {
-              const filepaths = Array.isArray(item.value) ? item.value : [];
+              const filepaths = (Array.isArray(item.value) ? item.value : []).filter(Boolean);
               const filestr = filepaths.join('|');
 
               const value = `@file(${filestr})`;

--- a/packages/bruno-lang/v2/tests/bruToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/bruToJson.spec.js
@@ -485,5 +485,55 @@ body:multipart-form {
       const output = parser(input);
       expect(output).toEqual(expected);
     });
+
+    it('parses an empty multipart-form file value as an empty array', () => {
+      const input = `
+body:multipart-form {
+  file: @file()
+}
+`;
+
+      const expected = {
+        body: {
+          multipartForm: [
+            {
+              name: 'file',
+              value: [],
+              enabled: true,
+              type: 'file',
+              contentType: ''
+            }
+          ]
+        }
+      };
+
+      const output = parser(input);
+      expect(output).toEqual(expected);
+    });
+
+    it('drops empty entries when parsing multiple multipart-form file paths', () => {
+      const input = `
+body:multipart-form {
+  file: @file(a.txt||b.txt)
+}
+`;
+
+      const expected = {
+        body: {
+          multipartForm: [
+            {
+              name: 'file',
+              value: ['a.txt', 'b.txt'],
+              enabled: true,
+              type: 'file',
+              contentType: ''
+            }
+          ]
+        }
+      };
+
+      const output = parser(input);
+      expect(output).toEqual(expected);
+    });
   });
 });

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -54,6 +54,48 @@ describe('jsonToBru stringify', () => {
     });
   });
 
+  describe('body:multipart-form file values', () => {
+    it('stringifies an empty file value without a leading pipe', () => {
+      const input = {
+        body: {
+          multipartForm: [
+            {
+              name: 'file',
+              value: [],
+              enabled: true,
+              type: 'file',
+              contentType: ''
+            }
+          ]
+        }
+      };
+
+      const output = stringify(input);
+      expect(output).toContain('file: @file()');
+      expect(output).not.toContain('@file(|');
+    });
+
+    it('drops empty entries when stringifying multiple file paths', () => {
+      const input = {
+        body: {
+          multipartForm: [
+            {
+              name: 'file',
+              value: ['', '/path/to/file.csv'],
+              enabled: true,
+              type: 'file',
+              contentType: ''
+            }
+          ]
+        }
+      };
+
+      const output = stringify(input);
+      expect(output).toContain('file: @file(/path/to/file.csv)');
+      expect(output).not.toContain('@file(|');
+    });
+  });
+
   describe('multi-line values', () => {
     it('handles multi-line values in URL, headers, params, and vars', () => {
       const input = {


### PR DESCRIPTION
### Description

Fixes: https://github.com/usebruno/bruno/issues/8426

Removes empty slots from the `@file` construct during parsing and writing

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart `@file(...)` handling by filtering out empty/falsy entries when converting between representations.
  * Empty multipart file fields now serialize cleanly to `@file()` without extra separators or placeholders.
  * Multipart file lists that include blank segments now output only the valid file paths.

* **Tests**
  * Added Jest coverage for multipart `file` values, including `@file()` and `@file(a.txt||b.txt)` parsing, plus stringify output that omits empty segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->