### PR TITLE
feat(workspaces): dispatch closeAiSidebar action on workspace switch

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -24,6 +24,7 @@ import { openConsole, closeConsole, setActiveTab as setActiveDevToolsTab, TAB_ID
 import { normalizePath } from 'utils/common/path';
 import { hydrateTabs, getActiveTabFromSnapshot, hydrateSnapshotLookups } from 'utils/snapshot';
 import toast from 'react-hot-toast';
+import { closeAiSidebar } from '../chat';
 
 const { ipcRenderer } = window;
 let snapshotHydrationTimer = null;
@@ -571,10 +572,10 @@ export const loadWorkspaceApiSpecs = (workspaceUid) => {
 
 export const switchWorkspace = (workspaceUid) => {
   return async (dispatch, getState) => {
+    dispatch(closeAiSidebar());
     clearSnapshotHydrationTimeout();
     dispatch(setSnapshotReady(false));
     dispatch(clearSnapshotHydrationSession());
-
     try {
       dispatch(setActiveWorkspace(workspaceUid));
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.spec.js
@@ -1,0 +1,116 @@
+jest.mock('@usebruno/schema', () => ({
+  collectionSchema: { validate: () => Promise.resolve() },
+  environmentSchema: { validate: () => Promise.resolve() },
+  itemSchema: { validate: () => Promise.resolve() }
+}));
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+import { configureStore } from '@reduxjs/toolkit';
+import workspacesReducer from './index';
+import collectionsReducer from '../collections';
+import chatReducer, { openAiSidebar } from '../chat';
+import appReducer from '../app';
+import tabsReducer from '../tabs';
+import globalEnvironmentsReducer from '../global-environments';
+
+const WS_A = 'workspace-a';
+const WS_B = 'workspace-b';
+const SCRATCH_A = 'scratch-a';
+const SCRATCH_B = 'scratch-b';
+
+const makeScratchCollection = (uid) => ({
+  uid,
+  pathname: `/tmp/${uid}`,
+  name: 'Scratch',
+  items: [],
+  brunoConfig: { version: '1', name: 'Scratch', type: 'collection' },
+  mountStatus: 'mounted'
+});
+
+const makeWorkspace = (uid, scratchUid) => ({
+  uid,
+  name: uid,
+  pathname: null,
+  collections: [],
+  scratchCollectionUid: scratchUid
+});
+
+const mockIpcInvoke = (channel) => {
+  if (channel === 'renderer:snapshot:get') {
+    return Promise.resolve(null);
+  }
+  if (channel === 'renderer:get-global-environments') {
+    return Promise.resolve({ globalEnvironments: [], activeGlobalEnvironmentUid: null });
+  }
+  return Promise.resolve(null);
+};
+
+const createStore = ({ activeWorkspaceUid = WS_A } = {}) => {
+  const preloadedState = {
+    workspaces: {
+      activeWorkspaceUid,
+      workspaces: [makeWorkspace(WS_A, SCRATCH_A), makeWorkspace(WS_B, SCRATCH_B)]
+    },
+    collections: {
+      collections: [makeScratchCollection(SCRATCH_A), makeScratchCollection(SCRATCH_B)],
+      collectionSortOrder: 'default',
+      activeConnections: [],
+      tempDirectories: {},
+      saveTransientRequestModals: []
+    },
+    chat: { isOpen: false, chats: {} },
+    app: {
+      snapshotReady: true,
+      snapshotHydration: {
+        workspaceUid: null,
+        pendingCollectionPathnames: [],
+        activeCollectionPathname: null,
+        startedAt: null
+      },
+      preferences: { cache: { file: { enabled: false } } }
+    },
+    tabs: { tabs: [], activeTabUid: null, recentlyClosedTabs: [] },
+    globalEnvironments: {
+      globalEnvironments: [],
+      activeGlobalEnvironmentUid: null,
+      globalEnvironmentDraft: null,
+      _scriptGlobalEnvBaseline: null
+    }
+  };
+
+  return configureStore({
+    reducer: {
+      workspaces: workspacesReducer,
+      collections: collectionsReducer,
+      chat: chatReducer,
+      app: appReducer,
+      tabs: tabsReducer,
+      globalEnvironments: globalEnvironmentsReducer
+    },
+    preloadedState
+  });
+};
+
+describe('switchWorkspace', () => {
+  let switchWorkspace;
+
+  beforeAll(async () => {
+    window.ipcRenderer = { invoke: jest.fn(mockIpcInvoke) };
+    ({ switchWorkspace } = await import('./actions'));
+  });
+
+  it('closes the AI sidebar when switching workspaces', async () => {
+    const store = createStore();
+    store.dispatch(openAiSidebar());
+    expect(store.getState().chat.isOpen).toBe(true);
+
+    await store.dispatch(switchWorkspace(WS_B));
+
+    expect(store.getState().chat.isOpen).toBe(false);
+    expect(store.getState().workspaces.activeWorkspaceUid).toBe(WS_B);
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.spec.js
@@ -9,6 +9,8 @@ jest.mock('react-hot-toast', () => ({
   error: jest.fn()
 }));
 
+import os from 'os';
+import path from 'path';
 import { configureStore } from '@reduxjs/toolkit';
 import workspacesReducer from './index';
 import collectionsReducer from '../collections';
@@ -24,7 +26,7 @@ const SCRATCH_B = 'scratch-b';
 
 const makeScratchCollection = (uid) => ({
   uid,
-  pathname: `/tmp/${uid}`,
+  pathname: path.join(os.tmpdir(), uid),
   name: 'Scratch',
   items: [],
   brunoConfig: { version: '1', name: 'Scratch', type: 'collection' },


### PR DESCRIPTION
### Description

Added a call to `closeAiSidebar` in the `switchWorkspace` action to ensure the AI sidebar is closed when switching workspaces, improving user experience and interface consistency.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switching workspaces now automatically closes the AI sidebar to keep the interface consistent.
  * Workspace switching continues to update the active workspace selection as expected.
* **Tests**
  * Added Jest coverage to verify workspace switching closes the AI sidebar and updates the active workspace correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->