### PR TITLE
fix(bruno-response): normalize response header name lookup to be case-insensitive

### DIFF
--- a/packages/bruno-js/src/bruno-response.js
+++ b/packages/bruno-js/src/bruno-response.js
@@ -32,7 +32,8 @@ class BrunoResponse {
   }
 
   getHeader(name) {
-    return this.res && this.res.headers ? this.res.headers[name] : null;
+    let lowerName = name?.toLowerCase();
+    return this.res && this.res.headers ? this.res.headers[lowerName] : null;
   }
 
   getHeaders() {

--- a/packages/bruno-js/src/bruno-response.js
+++ b/packages/bruno-js/src/bruno-response.js
@@ -32,8 +32,10 @@ class BrunoResponse {
   }
 
   getHeader(name) {
-    let lowerName = name?.toLowerCase();
-    return this.res && this.res.headers ? this.res.headers[lowerName] : null;
+    if (typeof name !== 'string' || !this.res?.headers) {
+      return null;
+    }
+    return this.res.headers[name.toLowerCase()];
   }
 
   getHeaders() {

--- a/packages/bruno-js/tests/bruno-response-get-header.spec.js
+++ b/packages/bruno-js/tests/bruno-response-get-header.spec.js
@@ -1,0 +1,36 @@
+const BrunoResponse = require('../src/bruno-response');
+
+describe('BrunoResponse getHeader (case-insensitive lookup)', () => {
+  const createRes = () => ({
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'no-cache',
+      'x-request-id': 'abc-123',
+      'set-cookie': ['a=1', 'b=2'],
+      'content-length': '512'
+    },
+    data: {}
+  });
+
+  it('looks up headers case-insensitively', () => {
+    const res = new BrunoResponse(createRes());
+    expect(res.getHeader('Content-Type')).toBe('application/json');
+    expect(res.getHeader('CONTENT-TYPE')).toBe('application/json');
+    expect(res.getHeader('Cache-Control')).toBe('no-cache');
+    expect(res.getHeader('X-Request-Id')).toBe('abc-123');
+    expect(res.getHeader('X-REQUEST-ID')).toBe('abc-123');
+    expect(res.getHeader('Content-Length')).toBe('512');
+  });
+
+  it('returns array-valued headers as-is', () => {
+    const res = new BrunoResponse(createRes());
+    expect(res.getHeader('Set-Cookie')).toEqual(['a=1', 'b=2']);
+  });
+
+  it('returns undefined for a missing header', () => {
+    const res = new BrunoResponse(createRes());
+    expect(res.getHeader('X-Does-Not-Exist')).toBeUndefined();
+  });
+});

--- a/packages/bruno-js/tests/bruno-response-get-header.spec.js
+++ b/packages/bruno-js/tests/bruno-response-get-header.spec.js
@@ -1,7 +1,7 @@
 const BrunoResponse = require('../src/bruno-response');
 
 describe('BrunoResponse getHeader (case-insensitive lookup)', () => {
-  const createRes = () => ({
+  const mockResponse = {
     status: 200,
     statusText: 'OK',
     headers: {
@@ -12,10 +12,10 @@ describe('BrunoResponse getHeader (case-insensitive lookup)', () => {
       'content-length': '512'
     },
     data: {}
-  });
+  };
 
   it('looks up headers case-insensitively', () => {
-    const res = new BrunoResponse(createRes());
+    const res = new BrunoResponse(mockResponse);
     expect(res.getHeader('Content-Type')).toBe('application/json');
     expect(res.getHeader('CONTENT-TYPE')).toBe('application/json');
     expect(res.getHeader('Cache-Control')).toBe('no-cache');
@@ -25,17 +25,17 @@ describe('BrunoResponse getHeader (case-insensitive lookup)', () => {
   });
 
   it('returns array-valued headers as-is', () => {
-    const res = new BrunoResponse(createRes());
+    const res = new BrunoResponse(mockResponse);
     expect(res.getHeader('Set-Cookie')).toEqual(['a=1', 'b=2']);
   });
 
   it('returns undefined for a missing header', () => {
-    const res = new BrunoResponse(createRes());
+    const res = new BrunoResponse(mockResponse);
     expect(res.getHeader('X-Does-Not-Exist')).toBeUndefined();
   });
 
   it('returns null for non-string name', () => {
-    const res = new BrunoResponse(createRes());
+    const res = new BrunoResponse(mockResponse);
     expect(res.getHeader(null)).toBeNull();
     expect(res.getHeader(undefined)).toBeNull();
     expect(res.getHeader(123)).toBeNull();

--- a/packages/bruno-js/tests/bruno-response-get-header.spec.js
+++ b/packages/bruno-js/tests/bruno-response-get-header.spec.js
@@ -33,4 +33,11 @@ describe('BrunoResponse getHeader (case-insensitive lookup)', () => {
     const res = new BrunoResponse(createRes());
     expect(res.getHeader('X-Does-Not-Exist')).toBeUndefined();
   });
+
+  it('returns null for non-string name', () => {
+    const res = new BrunoResponse(createRes());
+    expect(res.getHeader(null)).toBeNull();
+    expect(res.getHeader(undefined)).toBeNull();
+    expect(res.getHeader(123)).toBeNull();
+  });
 });


### PR DESCRIPTION
BRU-2763

Fixes: #1412

### Description

res.getHeader(name) is now case-insensitive, ensuring header lookups work regardless of casing. This aligns Bruno's behavior with Postman's pm.response.headers.get().

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Header lookups are now case-insensitive by normalizing header names before retrieving values, returning consistent results across different casing.
  * Non-string header name inputs now return `null` instead of producing an unexpected value.

* **Tests**
  * Added coverage for mixed-case header queries, array-valued headers (for example, `set-cookie`), missing headers, and non-string inputs to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->