### PR TITLE
fix(import): linting issue in Import fails for gRPC request without URL in exported collection

### DIFF
--- a/tests/import/bruno/fixtures/bruno-grpc-request-missing-url.json
+++ b/tests/import/bruno/fixtures/bruno-grpc-request-missing-url.json
@@ -1,51 +1,48 @@
 {
-    "name": "GRPC Collection",
-    "version": "1",
-    "items": [
-        {
-            "type": "grpc",
-            "name": "grpc request without url",
-            "filename": "request-without-url.bru",
-            "seq": 2,
-            "settings": {},
-            "tags": [],
-            "examples": [],
-            "request": {
-                "method": "",
-                "headers": [],
-                "body": {
-                    "mode": "grpc",
-                    "formUrlEncoded": [],
-                    "multipartForm": [],
-                    "file": [],
-                    "grpc": [
-                        {
-                            "name": "message 1",
-                            "content": "{}"
-                        }
-                    ]
-                },
-                "script": {},
-                "vars": {},
-                "assertions": [],
-                "tests": "",
-                "docs": "",
-                "auth": {
-                    "mode": "none"
-                }
+  "name": "GRPC Collection",
+  "version": "1",
+  "items": [
+    {
+      "type": "grpc",
+      "name": "grpc request without url",
+      "filename": "request-without-url.bru",
+      "seq": 2,
+      "settings": {},
+      "tags": [],
+      "examples": [],
+      "request": {
+        "method": "",
+        "headers": [],
+        "body": {
+          "mode": "grpc",
+          "formUrlEncoded": [],
+          "multipartForm": [],
+          "file": [],
+          "grpc": [
+            {
+              "name": "message 1",
+              "content": "{}"
             }
+          ]
+        },
+        "script": {},
+        "vars": {},
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": {
+          "mode": "none"
         }
-    ],
-    "environments": [],
-    "brunoConfig": {
-        "version": "1",
-        "name": "GRPC Collection",
-        "type": "collection",
-        "ignore": [
-            "node_modules",
-            ".git"
-        ],
-        "size": 0,
-        "filesCount": 0
+      }
     }
+  ],
+  "environments": [],
+  "brunoConfig": {
+    "version": "1",
+    "name": "GRPC Collection",
+    "type": "collection",
+    "ignore": ["node_modules", ".git"],
+    "size": 0,
+    "filesCount": 0
+  }
 }

--- a/tests/import/bruno/fixtures/bruno-http-example-request-missing-url.json
+++ b/tests/import/bruno/fixtures/bruno-http-example-request-missing-url.json
@@ -1,83 +1,80 @@
 {
-    "name": "HTTP Example Collection",
-    "version": "1",
-    "items": [
+  "name": "HTTP Example Collection",
+  "version": "1",
+  "items": [
+    {
+      "type": "http",
+      "name": "http example request without url",
+      "filename": "request-with-example.bru",
+      "seq": 1,
+      "settings": {},
+      "tags": [],
+      "examples": [
         {
-            "type": "http",
-            "name": "http example request without url",
-            "filename": "request-with-example.bru",
-            "seq": 1,
-            "settings": {},
-            "tags": [],
-            "examples": [
-                {
-                    "uid": "ex0011223344556677889",
-                    "itemUid": "it0011223344556677889",
-                    "name": "Http request example response",
-                    "description": "Example whose request has no url",
-                    "type": "http",
-                    "request": {
-                        "method": "GET",
-                        "headers": [],
-                        "params": [],
-                        "body": {
-                            "mode": "none"
-                        }
-                    },
-                    "response": {
-                        "status": 200,
-                        "statusText": "OK",
-                        "headers": [
-                            {
-                                "uid": "hd0011223344556677889",
-                                "name": "content-type",
-                                "value": "application/json",
-                                "enabled": true
-                            }
-                        ],
-                        "body": {
-                            "type": "json",
-                            "content": "{\n  \"message\": \"hello\"\n}"
-                        }
-                    }
-                }
-            ],
-            "request": {
-                "method": "GET",
-                "headers": [],
-                "url": "",
-                "params": [],
-                "body": {
-                    "mode": "none",
-                    "json": null,
-                    "text": null,
-                    "xml": null,
-                    "sparql": null,
-                    "formUrlEncoded": [],
-                    "multipartForm": [],
-                    "file": []
-                },
-                "script": {},
-                "vars": {},
-                "assertions": [],
-                "tests": "",
-                "docs": "",
-                "auth": {
-                    "mode": "none"
-                }
+          "uid": "ex0011223344556677889",
+          "itemUid": "it0011223344556677889",
+          "name": "Http request example response",
+          "description": "Example whose request has no url",
+          "type": "http",
+          "request": {
+            "method": "GET",
+            "headers": [],
+            "params": [],
+            "body": {
+              "mode": "none"
             }
+          },
+          "response": {
+            "status": 200,
+            "statusText": "OK",
+            "headers": [
+              {
+                "uid": "hd0011223344556677889",
+                "name": "content-type",
+                "value": "application/json",
+                "enabled": true
+              }
+            ],
+            "body": {
+              "type": "json",
+              "content": "{\n  \"message\": \"hello\"\n}"
+            }
+          }
         }
-    ],
-    "environments": [],
-    "brunoConfig": {
-        "version": "1",
-        "name": "HTTP Example Collection",
-        "type": "collection",
-        "ignore": [
-            "node_modules",
-            ".git"
-        ],
-        "size": 0,
-        "filesCount": 0
+      ],
+      "request": {
+        "method": "GET",
+        "headers": [],
+        "url": "",
+        "params": [],
+        "body": {
+          "mode": "none",
+          "json": null,
+          "text": null,
+          "xml": null,
+          "sparql": null,
+          "formUrlEncoded": [],
+          "multipartForm": [],
+          "file": []
+        },
+        "script": {},
+        "vars": {},
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": {
+          "mode": "none"
+        }
+      }
     }
+  ],
+  "environments": [],
+  "brunoConfig": {
+    "version": "1",
+    "name": "HTTP Example Collection",
+    "type": "collection",
+    "ignore": ["node_modules", ".git"],
+    "size": 0,
+    "filesCount": 0
+  }
 }

--- a/tests/import/bruno/fixtures/bruno-http-request-missing-url.json
+++ b/tests/import/bruno/fixtures/bruno-http-request-missing-url.json
@@ -1,50 +1,47 @@
 {
-    "name": "HTTP Collection",
-    "version": "1",
-    "items": [
-        {
-            "type": "http",
-            "name": "http request without url",
-            "filename": "request-without-url.bru",
-            "seq": 2,
-            "settings": {},
-            "tags": [],
-            "examples": [],
-            "request": {
-                "method": "GET",
-                "headers": [],
-                "params": [],
-                "body": {
-                    "mode": "none",
-                    "json": null,
-                    "text": null,
-                    "xml": null,
-                    "sparql": null,
-                    "formUrlEncoded": [],
-                    "multipartForm": [],
-                    "file": []
-                },
-                "script": {},
-                "vars": {},
-                "assertions": [],
-                "tests": "",
-                "docs": "",
-                "auth": {
-                    "mode": "none"
-                }
-            }
+  "name": "HTTP Collection",
+  "version": "1",
+  "items": [
+    {
+      "type": "http",
+      "name": "http request without url",
+      "filename": "request-without-url.bru",
+      "seq": 2,
+      "settings": {},
+      "tags": [],
+      "examples": [],
+      "request": {
+        "method": "GET",
+        "headers": [],
+        "params": [],
+        "body": {
+          "mode": "none",
+          "json": null,
+          "text": null,
+          "xml": null,
+          "sparql": null,
+          "formUrlEncoded": [],
+          "multipartForm": [],
+          "file": []
+        },
+        "script": {},
+        "vars": {},
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": {
+          "mode": "none"
         }
-    ],
-    "environments": [],
-    "brunoConfig": {
-        "version": "1",
-        "name": "HTTP Collection",
-        "type": "collection",
-        "ignore": [
-            "node_modules",
-            ".git"
-        ],
-        "size": 0,
-        "filesCount": 0
+      }
     }
+  ],
+  "environments": [],
+  "brunoConfig": {
+    "version": "1",
+    "name": "HTTP Collection",
+    "type": "collection",
+    "ignore": ["node_modules", ".git"],
+    "size": 0,
+    "filesCount": 0
+  }
 }


### PR DESCRIPTION
### Description

Fixed linting issue in the json files

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted several Bruno import fixture JSON files for consistent indentation and layout.
  * Adjusted array and object formatting, including condensing some arrays into single-line form.
  * No functional request content or example data was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->