### PR TITLE
fix(ai): render AI assist popup via portal to prevent clipping by response pane

### DIFF
--- a/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
@@ -34,16 +34,15 @@ const StyledWrapper = styled.div`
     }
   }
 
-  .ai-assist-popup {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
-    width: 360px;
-    background: ${(props) => props.theme.bg};
-    border: 1px solid ${(props) => props.theme.input.border};
-    border-radius: ${(props) => props.theme.border.radius.md};
-    overflow: hidden;
-  }
+`;
+
+// Tippy renders the popup into document.body, outside StyledWrapper's subtree.
+export const PopupWrapper = styled.div`
+  width: 360px;
+  background: ${(props) => props.theme.bg};
+  border: 1px solid ${(props) => props.theme.input.border};
+  border-radius: ${(props) => props.theme.border.radius.md};
+  overflow: hidden;
 
   .popup-header {
     display: flex;

--- a/packages/bruno-app/src/components/AIAssist/index.js
+++ b/packages/bruno-app/src/components/AIAssist/index.js
@@ -1,9 +1,10 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import get from 'lodash/get';
+import Tippy from '@tippyjs/react';
 import { IconStars, IconX, IconArrowBackUp, IconPlayerStop } from '@tabler/icons';
 import { aiGenerateScript, stopAiGeneration } from 'utils/ai';
-import StyledWrapper from './StyledWrapper';
+import StyledWrapper, { PopupWrapper } from './StyledWrapper';
 
 const SUGGESTIONS = {
   'tests': [
@@ -65,12 +66,28 @@ const AIAssist = ({ scriptType, currentScript, requestContext, docsContext, vari
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [generated, setGenerated] = useState(null);
-  const buttonRef = useRef(null);
   const streamIdRef = useRef(null);
+  const tippyRef = useRef(null);
 
-  const focusOnMount = useCallback((el) => {
-    el?.focus();
-  }, []);
+  // Focus the prompt textarea when coming back from preview
+  useEffect(() => {
+    if (isOpen && generated == null) {
+      tippyRef.current?.popper?.querySelector('.popup-input')?.focus();
+    }
+  }, [isOpen, generated]);
+
+  // handle Escape key to close the popup
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        tippyRef.current?.hide();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [isOpen]);
 
   const preferences = useSelector((state) => state.app.preferences);
   const isAiEnabled = get(preferences, 'ai.enabled', false);
@@ -80,27 +97,8 @@ const AIAssist = ({ scriptType, currentScript, requestContext, docsContext, vari
   const previewLabel = PREVIEW_LABELS[scriptType] || 'Preview · replaces current script';
 
   const close = useCallback(() => {
-    setIsOpen(false);
-    setError(null);
+    tippyRef.current?.hide();
   }, []);
-
-  const attachPopup = useCallback((el) => {
-    if (!el) return undefined;
-    const onDocMouseDown = (e) => {
-      if (!el.contains(e.target) && !buttonRef.current?.contains(e.target)) {
-        close();
-      }
-    };
-    const onKey = (e) => {
-      if (e.key === 'Escape') close();
-    };
-    document.addEventListener('mousedown', onDocMouseDown);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onDocMouseDown);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [close]);
 
   const handleGenerate = useCallback(
     async (overridePrompt) => {
@@ -167,120 +165,136 @@ const AIAssist = ({ scriptType, currentScript, requestContext, docsContext, vari
 
   return (
     <StyledWrapper>
-      <button
-        ref={buttonRef}
-        className={`ai-assist-trigger ${isOpen ? 'open' : ''}`}
-        onClick={() => setIsOpen((v) => !v)}
-        title={title}
-        type="button"
-        aria-label={title}
-      >
-        <IconStars size={14} strokeWidth={1.75} />
-      </button>
+      <Tippy
+        interactive
+        trigger="click"
+        placement="bottom-end"
+        arrow={false}
+        animation={false}
+        maxWidth="none"
+        appendTo={() => document.body}
+        onCreate={(instance) => (tippyRef.current = instance)}
+        onShow={(instance) => {
+          setIsOpen(true);
+          // rAF so the popup content is in the DOM
+          requestAnimationFrame(() => instance.popper?.querySelector('.popup-input')?.focus());
+        }}
+        onHide={() => {
+          setIsOpen(false);
+          setError(null);
+        }}
+        render={(attrs) => (
+          <PopupWrapper className="ai-assist-popup" role="dialog" aria-label={title} tabIndex={-1} {...attrs}>
+            <div className="popup-header">
+              <span className="popup-title">
+                <IconStars size={12} strokeWidth={1.75} />
+                {title}
+              </span>
+              <button className="popup-close" onClick={close} type="button" aria-label="Close">
+                <IconX size={14} />
+              </button>
+            </div>
 
-      {isOpen && (
-        <div ref={attachPopup} className="ai-assist-popup" role="dialog" aria-label={title}>
-          <div className="popup-header">
-            <span className="popup-title">
-              <IconStars size={12} strokeWidth={1.75} />
-              {title}
-            </span>
-            <button className="popup-close" onClick={close} type="button" aria-label="Close">
-              <IconX size={14} />
-            </button>
-          </div>
+            {generated == null ? (
+              <>
+                <div className="popup-body">
+                  <textarea
+                    className="popup-input"
+                    value={prompt}
+                    onChange={(e) => setPrompt(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        handleGenerate();
+                      }
+                    }}
+                    placeholder="Describe what you want to generate..."
+                    rows={3}
+                    disabled={isLoading}
+                  />
 
-          {generated == null ? (
-            <>
-              <div className="popup-body">
-                <textarea
-                  ref={focusOnMount}
-                  className="popup-input"
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      handleGenerate();
-                    }
-                  }}
-                  placeholder="Describe what you want to generate..."
-                  rows={3}
-                  disabled={isLoading}
-                />
+                  {!isLoading && !prompt && suggestions.length > 0 && (
+                    <div className="popup-suggestions">
+                      {suggestions.map((s) => (
+                        <button
+                          key={s.label}
+                          className="suggestion-chip"
+                          type="button"
+                          onClick={() => handleGenerate(s.prompt)}
+                          disabled={isLoading}
+                        >
+                          {s.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
 
-                {!isLoading && !prompt && suggestions.length > 0 && (
-                  <div className="popup-suggestions">
-                    {suggestions.map((s) => (
-                      <button
-                        key={s.label}
-                        className="suggestion-chip"
-                        type="button"
-                        onClick={() => handleGenerate(s.prompt)}
-                        disabled={isLoading}
-                      >
-                        {s.label}
-                      </button>
-                    ))}
-                  </div>
-                )}
-
-                {error && <div className="popup-error">{error}</div>}
-              </div>
-
-              <div className="popup-footer">
-                {isLoading ? (
-                  <span className="popup-loading">
-                    <span className="loading-spinner" />
-                    Generating...
-                  </span>
-                ) : (
-                  <span className="popup-hint">Enter to generate · Shift+Enter for newline</span>
-                )}
-                {isLoading ? (
-                  <button
-                    className="btn-stop"
-                    type="button"
-                    onClick={handleStop}
-                    title="Stop generating"
-                  >
-                    <IconPlayerStop size={12} /> Stop
-                  </button>
-                ) : (
-                  <button
-                    className="btn-generate"
-                    type="button"
-                    onClick={() => handleGenerate()}
-                    disabled={!prompt.trim()}
-                  >
-                    Generate
-                  </button>
-                )}
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="popup-body">
-                <div className="preview-section">
-                  <span className="preview-label">{previewLabel}</span>
-                  <pre className="preview-code">{generated}</pre>
+                  {error && <div className="popup-error">{error}</div>}
                 </div>
-              </div>
 
-              <div className="popup-footer">
-                <button className="btn-secondary" type="button" onClick={handleBackToPrompt}>
-                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                    <IconArrowBackUp size={12} /> Back
-                  </span>
-                </button>
-                <button className="btn-generate" type="button" onClick={handleApply}>
-                  Apply
-                </button>
-              </div>
-            </>
-          )}
-        </div>
-      )}
+                <div className="popup-footer">
+                  {isLoading ? (
+                    <span className="popup-loading">
+                      <span className="loading-spinner" />
+                      Generating...
+                    </span>
+                  ) : (
+                    <span className="popup-hint">Enter to generate · Shift+Enter for newline</span>
+                  )}
+                  {isLoading ? (
+                    <button
+                      className="btn-stop"
+                      type="button"
+                      onClick={handleStop}
+                      title="Stop generating"
+                    >
+                      <IconPlayerStop size={12} /> Stop
+                    </button>
+                  ) : (
+                    <button
+                      className="btn-generate"
+                      type="button"
+                      onClick={() => handleGenerate()}
+                      disabled={!prompt.trim()}
+                    >
+                      Generate
+                    </button>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="popup-body">
+                  <div className="preview-section">
+                    <span className="preview-label">{previewLabel}</span>
+                    <pre className="preview-code">{generated}</pre>
+                  </div>
+                </div>
+
+                <div className="popup-footer">
+                  <button className="btn-secondary" type="button" onClick={handleBackToPrompt}>
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                      <IconArrowBackUp size={12} /> Back
+                    </span>
+                  </button>
+                  <button className="btn-generate" type="button" onClick={handleApply}>
+                    Apply
+                  </button>
+                </div>
+              </>
+            )}
+          </PopupWrapper>
+        )}
+      >
+        <button
+          className={`ai-assist-trigger ${isOpen ? 'open' : ''}`}
+          title={title}
+          type="button"
+          aria-label={title}
+        >
+          <IconStars size={14} strokeWidth={1.75} />
+        </button>
+      </Tippy>
     </StyledWrapper>
   );
 };

--- a/packages/bruno-app/src/components/AIAssist/index.spec.js
+++ b/packages/bruno-app/src/components/AIAssist/index.spec.js
@@ -105,6 +105,15 @@ describe('AIAssist', () => {
       expect(screen.queryByRole('dialog', { name: 'Generate Tests' })).not.toBeInTheDocument();
     });
 
+    it('renders the popup into document.body as a portal', () => {
+      renderAIAssist();
+      openPopup();
+      const dialog = screen.getByRole('dialog', { name: 'Generate Tests' });
+      const tippyRoot = dialog.closest('[data-tippy-root]');
+      expect(tippyRoot).not.toBeNull();
+      expect(tippyRoot.parentElement).toBe(document.body);
+    });
+
     it('closes the popup when Escape is pressed', () => {
       renderAIAssist();
       openPopup();


### PR DESCRIPTION

### Description

Fixes an issue where the AI Assist Popup was clipped or appeared below by the response tab when using the horizontal layout. The Popup now correctly appears above the terminal, ensuring the complete AI-generated output remains visible across all AI-enabled tabs.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3670)

#### Screenshot of the fix
<img width="1218" height="788" alt="Screenshot 2026-07-02 at 12 51 38 PM" src="https://github.com/user-attachments/assets/3b344860-c1a2-41d7-a8d3-a03260778490" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The AI Assist popup now opens as a floating dialog and renders correctly outside the main panel.
  * Keyboard behavior is improved, including automatic focus when opened and closing with Escape.

* **Bug Fixes**
  * Fixed popup styling so it displays consistently when rendered in the page body.
  * Improved popup lifecycle behavior when switching between the prompt and preview states.

* **Tests**
  * Added coverage to confirm the popup is rendered in the expected location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->