### PR TITLE
CDN docs url change

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -18,7 +18,7 @@ import { brunoToOpenCollection } from '@usebruno/converters';
 import { sanitizeName } from 'utils/common/regex';
 import { escapeHtml } from 'utils/response';
 
-const CDN_BASE_URL = 'https://cdn.opencollection.com';
+const CDN_BASE_URL = 'https://cdn.usebruno.com';
 
 const FEATURES = [
   'Standalone HTML file - no server required',
@@ -36,8 +36,8 @@ const buildHtmlDocument = (collectionName, escapedYamlContent) => `<!DOCTYPE htm
         body { margin: 0; padding: 0; }
         #opencollection-container { width: 100vw; height: 100vh; }
     </style>
-    <link rel="stylesheet" href="${CDN_BASE_URL}/docs.css">
-    <script src="${CDN_BASE_URL}/docs.js"></script>
+    <link rel="stylesheet" href="${CDN_BASE_URL}/docs/index.css">
+    <script src="${CDN_BASE_URL}/docs/index.js"></script>
 </head>
 <body>
     <div id="opencollection-container"></div>


### PR DESCRIPTION
### Description
Problem
The standalone renderer will be served from cdn.usebruno.com/docs/index.js + index.css (using index under the /docs/ prefix rather than repeating the name as docs.js). Two source changes are needed to make the emitted asset and the consumer agree on the new naming.

Proposed Solution
opencollection / oc-docs — in vite.config.standalone.ts, change the standalone build output names:

UMD fileName: docs.js → index.js

CSS assetFileNames: docs.css → index.css

ES fileName: docs.esm.js → index.esm.js for consistency

bruno / bruno-app — in the Generate Documentation component:

CDN_BASE_URL: https://cdn.opencollection.com → https://cdn.usebruno.com

template refs: ${CDN_BASE_URL}/docs.css → ${CDN_BASE_URL}/docs/index.css, ${CDN_BASE_URL}/docs.js → ${CDN_BASE_URL}/docs/index.js

https://usebruno.atlassian.net/browse/BRU-3709
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated documentation pages to load assets from the new CDN location.
  * Standalone HTML documentation now uses the correct stylesheet and script paths, improving loading reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->