### PR TITLE
fix:url truncates in docs

### DIFF
--- a/packages/bruno-app/src/components/MarkDown/index.jsx
+++ b/packages/bruno-app/src/components/MarkDown/index.jsx
@@ -3,38 +3,9 @@ import * as MarkdownItReplaceLink from 'markdown-it-replace-link';
 import StyledWrapper from './StyledWrapper';
 import React from 'react';
 import { isValidUrl } from 'utils/url/index';
-import { extendUrlWithBalancedParentheses } from 'utils/codemirror/linkAware';
+import { patchLinkifyToExtendUrls } from 'utils/linkify';
 import DOMPurify from 'dompurify';
 import { useMemo } from 'react';
-
-function extendMatch(match, text) {
-  const extended = extendUrlWithBalancedParentheses(match.raw, text, match.lastIndex);
-  const addedSuffix = extended.url.slice(match.raw.length);
-  if (!addedSuffix) return match;
-
-  match.raw += addedSuffix;
-  match.url += addedSuffix;
-  match.text += addedSuffix;
-  match.lastIndex = extended.lastIndex;
-
-  return match;
-}
-
-function patchLinkifyToExtendUrls(md) {
-  const originalMatchAtStart = md.linkify.matchAtStart.bind(md.linkify);
-  md.linkify.matchAtStart = (text) => {
-    const match = originalMatchAtStart(text);
-    return match ? extendMatch(match, text) : match;
-  };
-
-  const originalMatch = md.linkify.match.bind(md.linkify);
-  md.linkify.match = (text) => {
-    const matches = originalMatch(text);
-    return matches ? matches.map((match) => extendMatch(match, text)) : matches;
-  };
-
-  return md;
-}
 
 const Markdown = ({ collectionPath, onDoubleClick, content, allowHtml = true }) => {
   const md = useMemo(() => {

--- a/packages/bruno-app/src/components/MarkDown/index.jsx
+++ b/packages/bruno-app/src/components/MarkDown/index.jsx
@@ -3,18 +3,50 @@ import * as MarkdownItReplaceLink from 'markdown-it-replace-link';
 import StyledWrapper from './StyledWrapper';
 import React from 'react';
 import { isValidUrl } from 'utils/url/index';
+import { extendUrlWithBalancedParentheses } from 'utils/codemirror/linkAware';
 import DOMPurify from 'dompurify';
 import { useMemo } from 'react';
 
-const Markdown = ({ collectionPath, onDoubleClick, content, allowHtml = true }) => {
-  const markdownItOptions = {
-    html: allowHtml,
-    breaks: true,
-    linkify: true,
-    replaceLink: function (link, env) {
-      return link.replace(/^\./, collectionPath);
-    }
+function extendMatch(match, text) {
+  const extended = extendUrlWithBalancedParentheses(match.raw, text, match.lastIndex);
+  const addedSuffix = extended.url.slice(match.raw.length);
+  if (!addedSuffix) return match;
+
+  match.raw += addedSuffix;
+  match.url += addedSuffix;
+  match.text += addedSuffix;
+  match.lastIndex = extended.lastIndex;
+
+  return match;
+}
+
+function patchLinkifyToExtendUrls(md) {
+  const originalMatchAtStart = md.linkify.matchAtStart.bind(md.linkify);
+  md.linkify.matchAtStart = (text) => {
+    const match = originalMatchAtStart(text);
+    return match ? extendMatch(match, text) : match;
   };
+
+  const originalMatch = md.linkify.match.bind(md.linkify);
+  md.linkify.match = (text) => {
+    const matches = originalMatch(text);
+    return matches ? matches.map((match) => extendMatch(match, text)) : matches;
+  };
+
+  return md;
+}
+
+const Markdown = ({ collectionPath, onDoubleClick, content, allowHtml = true }) => {
+  const md = useMemo(() => {
+    const instance = new MarkdownIt({
+      html: allowHtml,
+      breaks: true,
+      linkify: true,
+      replaceLink: (link) => link.replace(/^\./, collectionPath)
+    }).use(MarkdownItReplaceLink);
+
+    return patchLinkifyToExtendUrls(instance);
+  }, [allowHtml, collectionPath]);
 
   const handleOnClick = (event) => {
     const target = event.target;
@@ -34,7 +66,6 @@ const Markdown = ({ collectionPath, onDoubleClick, content, allowHtml = true }) 
     }
   };
 
-  const md = new MarkdownIt(markdownItOptions).use(MarkdownItReplaceLink);
   const htmlFromMarkdown = useMemo(() => md.render(content || ''), [content, collectionPath, allowHtml]);
   const cleanHTML = useMemo(() => DOMPurify.sanitize(htmlFromMarkdown), [htmlFromMarkdown]);
 

--- a/packages/bruno-app/src/utils/linkify/index.js
+++ b/packages/bruno-app/src/utils/linkify/index.js
@@ -1,0 +1,30 @@
+import { extendUrlWithBalancedParentheses } from 'utils/codemirror/linkAware';
+
+export function extendMatch(match, text) {
+  const extended = extendUrlWithBalancedParentheses(match.raw, text, match.lastIndex);
+  const addedSuffix = extended.url.slice(match.raw.length);
+  if (!addedSuffix) return match;
+
+  match.raw += addedSuffix;
+  match.url += addedSuffix;
+  match.text += addedSuffix;
+  match.lastIndex = extended.lastIndex;
+
+  return match;
+}
+
+export function patchLinkifyToExtendUrls(md) {
+  const originalMatchAtStart = md.linkify.matchAtStart.bind(md.linkify);
+  md.linkify.matchAtStart = (text) => {
+    const match = originalMatchAtStart(text);
+    return match ? extendMatch(match, text) : match;
+  };
+
+  const originalMatch = md.linkify.match.bind(md.linkify);
+  md.linkify.match = (text) => {
+    const matches = originalMatch(text);
+    return matches ? matches.map((match) => extendMatch(match, text)) : matches;
+  };
+
+  return md;
+}

--- a/packages/bruno-app/src/utils/linkify/index.spec.js
+++ b/packages/bruno-app/src/utils/linkify/index.spec.js
@@ -1,0 +1,115 @@
+import { extendMatch, patchLinkifyToExtendUrls } from './index';
+
+describe('Linkify Utils - extendMatch', () => {
+  it('should leave the match unchanged when parentheses are already balanced', () => {
+    const url = 'https://example.com/path?q=(a)';
+    const text = `${url} end`;
+    const match = { raw: url, url, text: url, lastIndex: url.length };
+
+    const result = extendMatch(match, text);
+
+    expect(result.raw).toBe(url);
+    expect(result.url).toBe(url);
+    expect(result.text).toBe(url);
+    expect(result.lastIndex).toBe(url.length);
+  });
+
+  it('should extend raw, url, text and lastIndex to balance nested parentheses', () => {
+    const url = 'https://example.com?_g=(a:!(),b:(c:d';
+    const text = 'https://example.com?_g=(a:!(),b:(c:d))&_a=(e) end';
+    const fullUrl = 'https://example.com?_g=(a:!(),b:(c:d))&_a=(e)';
+    const match = { raw: url, url, text: url, lastIndex: url.length };
+
+    const result = extendMatch(match, text);
+
+    expect(result.raw).toBe(fullUrl);
+    expect(result.url).toBe(fullUrl);
+    expect(result.text).toBe(fullUrl);
+    expect(result.lastIndex).toBe(fullUrl.length);
+  });
+
+  it('should mutate and return the same match object it was given', () => {
+    const url = 'https://example.com?_g=(a';
+    const text = 'https://example.com?_g=(a) end';
+    const match = { raw: url, url, text: url, lastIndex: url.length };
+
+    const result = extendMatch(match, text);
+
+    expect(result).toBe(match);
+  });
+
+  it('should stop extending at whitespace', () => {
+    const url = 'https://example.com?q=(a';
+    const text = 'https://example.com?q=(a ) end';
+    const match = { raw: url, url, text: url, lastIndex: url.length };
+
+    const result = extendMatch(match, text);
+
+    expect(result.url).toBe(url);
+    expect(result.lastIndex).toBe(url.length);
+  });
+});
+
+describe('Linkify Utils - patchLinkifyToExtendUrls', () => {
+  const buildMarkdownItLike = ({ matchAtStartResult, matchResults }) => ({
+    linkify: {
+      matchAtStart: jest.fn().mockReturnValue(matchAtStartResult),
+      match: jest.fn().mockReturnValue(matchResults)
+    }
+  });
+
+  it('should return the same markdown-it instance it was given', () => {
+    const md = buildMarkdownItLike({ matchAtStartResult: null, matchResults: null });
+
+    const result = patchLinkifyToExtendUrls(md);
+
+    expect(result).toBe(md);
+  });
+
+  it('should extend matches returned by linkify.matchAtStart', () => {
+    const url = 'https://example.com?_g=(a:!(),b:(c:d';
+    const text = 'https://example.com?_g=(a:!(),b:(c:d))&_a=(e) end';
+    const fullUrl = 'https://example.com?_g=(a:!(),b:(c:d))&_a=(e)';
+    const originalMatch = { raw: url, url, text: url, lastIndex: url.length };
+    const md = buildMarkdownItLike({ matchAtStartResult: originalMatch, matchResults: null });
+
+    patchLinkifyToExtendUrls(md);
+    const result = md.linkify.matchAtStart(text);
+
+    expect(result.url).toBe(fullUrl);
+  });
+
+  it('should return null from matchAtStart when there is no match', () => {
+    const md = buildMarkdownItLike({ matchAtStartResult: null, matchResults: null });
+
+    patchLinkifyToExtendUrls(md);
+
+    expect(md.linkify.matchAtStart('no urls here')).toBeNull();
+  });
+
+  it('should extend every match returned by linkify.match', () => {
+    const url1 = 'https://example.com/path?q=(a)';
+    const url2 = 'https://example.com?_g=(a:!(),b:(c:d';
+    const text = `${url1} https://example.com?_g=(a:!(),b:(c:d))&_a=(e) end`;
+    const fullUrl2 = 'https://example.com?_g=(a:!(),b:(c:d))&_a=(e)';
+    const matches = [
+      { raw: url1, url: url1, text: url1, lastIndex: url1.length },
+      { raw: url2, url: url2, text: url2, lastIndex: text.indexOf(url2) + url2.length }
+    ];
+    const md = buildMarkdownItLike({ matchAtStartResult: null, matchResults: matches });
+
+    patchLinkifyToExtendUrls(md);
+    const result = md.linkify.match(text);
+
+    expect(result[0].url).toBe(url1);
+    expect(result[1].url).toBe(fullUrl2);
+  });
+
+  it('should return null from match when there are no matches', () => {
+    const md = buildMarkdownItLike({ matchAtStartResult: null, matchResults: null });
+
+    patchLinkifyToExtendUrls(md);
+
+    expect(md.linkify.match('no urls here')).toBeNull();
+  });
+});


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

[JIRA](https://usebruno.atlassian.net/browse/BRU-2944)

Links containing parentheses (e.g. dashboard URLs) were being cut off early by markdown-it's link detection. Reuses the existing paren-balancing fix from the CodeMirror editor (#7406) to resolve this.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
<img width="1200" height="591" alt="image" src="https://github.com/user-attachments/assets/ecd3c0ea-1f97-40bd-8a46-3ba42bdf7951" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown links now handle URLs with balanced parentheses more reliably, improving how some links are rendered and clicked.
* **Bug Fixes**
  * Improved Markdown rendering consistency by reusing the same parser setup during display.
  * Fixed link detection so generated links are more accurately extended before being shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->