### PR TITLE
ci(benchmarks): disable auto runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,8 +6,9 @@ on:
         description: 'Update baseline with current results instead of comparing'
         type: boolean
         default: false
-  pull_request:
-    branches: [main, 'release/v*']
+  # Temporarily disabled - re-enable by uncommenting
+  # pull_request:
+  #   branches: [main, 'release/v*']
 
 jobs:
   benchmark:


### PR DESCRIPTION
### Description

disable benchmarks from auto running for now

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily paused automatic benchmark runs for pull requests; benchmarks can still be started manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->