### PR TITLE
chore(ci): skip benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   benchmark:
+    if: false
     name: Performance Benchmarks (${{ matrix.os }})
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Description

Added a condition to skip benchmark workflows.
We were not updating the baseline for benchmark and the job was consuming resources without giving us any valuable insights (for now). We will enable this once we have more clarity on baseline numbers.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled automated benchmark runs in the continuous integration workflow by hard-gating the benchmark job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->