### PR TITLE
fix(import) - Handle pm.sendRequest promise chain in postman to bruno import

### DIFF
--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -148,6 +148,59 @@ const transformBody = (j, requestOptions) => {
   });
 };
 
+// Postman response methods/props -> Bruno (axios-shaped) response equivalents.
+// Used both for callback bodies and for promise-chain .then() handlers.
+const responsePropertyMap = {
+  json: 'data',
+  text: 'data',
+  code: 'status',
+  status: 'statusText'
+};
+
+/**
+ * Rewrite Postman response property references (response.json(), response.code, ...)
+ * to their Bruno equivalents (response.data, response.status, ...) within a body.
+ * @param {Object} j - jscodeshift API
+ * @param {Object} body - AST node to search within (block statement or expression)
+ * @param {string} responseVarName - Identifier name bound to the response object
+ */
+const transformResponseProperties = (j, body, responseVarName) => {
+  j(body).find(j.MemberExpression, {
+    object: {
+      type: 'Identifier',
+      name: responseVarName
+    }
+  }).forEach((memberPath) => {
+    const property = memberPath.node.property;
+
+    // Handle property access
+    if (property.type === 'Identifier' && responsePropertyMap[property.name]) {
+      const bruProperty = responsePropertyMap[property.name];
+      if (bruProperty) {
+        // Check if memberPath is part of a CallExpression
+        const parentPath = memberPath.parent;
+        if (parentPath && parentPath.node.type === 'CallExpression' && parentPath.node.callee === memberPath.node) {
+          // Replace the entire CallExpression with a property access
+          j(parentPath).replaceWith(
+            j.memberExpression(
+              j.identifier(responseVarName),
+              j.identifier(bruProperty)
+            )
+          );
+        } else {
+          // Regular property access replacement
+          j(memberPath).replaceWith(
+            j.memberExpression(
+              j.identifier(responseVarName),
+              j.identifier(bruProperty)
+            )
+          );
+        }
+      }
+    }
+  });
+};
+
 /**
  * Transform callback function to Bruno format
  * @param {Object} j - jscodeshift API
@@ -171,49 +224,8 @@ const transformCallback = (j, callback) => {
     errorVarName = params[0].name;
   }
 
-  // Define translations for callback response properties
-  const responsePropertyMap = {
-    json: 'data',
-    text: 'data',
-    code: 'status',
-    status: 'statusText'
-  };
-
   // Process the callback body to transform response property references
-  j(callbackBody).find(j.MemberExpression, {
-    object: {
-      type: 'Identifier',
-      name: responseVarName
-    }
-  }).forEach((memberPath) => {
-    const property = memberPath.node.property;
-
-    // Handle property access
-    if (property.type === 'Identifier' && responsePropertyMap[property.name]) {
-      const bruProperty = responsePropertyMap[property.name];
-      if (bruProperty) {
-        // Check if memberPath is part of a CallExpression
-        const parentPath = memberPath.parent;
-        if (parentPath && parentPath.node.type === 'CallExpression') {
-          // Replace the entire CallExpression with a property access
-          j(parentPath).replaceWith(
-            j.memberExpression(
-              j.identifier(responseVarName),
-              j.identifier(bruProperty)
-            )
-          );
-        } else {
-          // Regular property access replacement
-          j(memberPath).replaceWith(
-            j.memberExpression(
-              j.identifier(responseVarName),
-              j.identifier(bruProperty)
-            )
-          );
-        }
-      }
-    }
-  });
+  transformResponseProperties(j, callbackBody, responseVarName);
 
   // Create the callback block
   return j.functionExpression(
@@ -221,6 +233,80 @@ const transformCallback = (j, callback) => {
     [j.identifier(errorVarName), j.identifier(responseVarName)],
     j.blockStatement(callbackBody.body)
   );
+};
+
+// Promise-chain methods that can follow pm.sendRequest(...).
+const PROMISE_CHAIN_METHODS = new Set(['then', 'catch', 'finally']);
+
+/**
+ * Given a call NodePath, return the next `.then/.catch/.finally(...)` link that
+ * chains off it, or null if the chain ends here. A link is only recognised when
+ * our call is the object of a promise-method member that is itself being called
+ * (e.g. `<call>.then(...)`), not when the call is merely an argument elsewhere.
+ * @param {Object} callPath - NodePath of a CallExpression in the chain
+ * @returns {{ callPath: Object, methodName: string } | null}
+ */
+const nextPromiseChainLink = (callPath) => {
+  const memberPath = callPath.parent;
+  if (!memberPath || !memberPath.value || memberPath.value.type !== 'MemberExpression') return null;
+  // Ensure our call is the object being chained on (not e.g. an argument)
+  if (memberPath.value.object !== callPath.value) return null;
+
+  const property = memberPath.value.property;
+  const methodName = property && (property.name || property.value);
+  if (!PROMISE_CHAIN_METHODS.has(methodName)) return null;
+
+  const outerCallPath = memberPath.parent;
+  if (!outerCallPath || !outerCallPath.value || outerCallPath.value.type !== 'CallExpression') return null;
+  if (outerCallPath.value.callee !== memberPath.value) return null;
+
+  return { callPath: outerCallPath, methodName };
+};
+
+/**
+ * Walk the promise chain that follows a pm.sendRequest(...) call, e.g.
+ *   pm.sendRequest(cfg).then(res => ...).catch(err => ...)
+ *
+ * @param {Object} sendRequestCallPath - NodePath of the pm.sendRequest(...) CallExpression
+ * @returns {{ isChain: boolean, outermostPath: Object, thenHandlers: Array }}
+ */
+const collectPromiseChain = (sendRequestCallPath) => {
+  const thenHandlers = [];
+  let current = sendRequestCallPath;
+  let isChain = false;
+
+  for (let link = nextPromiseChainLink(current); link; link = nextPromiseChainLink(current)) {
+    isChain = true;
+
+    // The onFulfilled handler receives the response object; .then(onFulfilled, onRejected)
+    if (link.methodName === 'then') {
+      const handler = link.callPath.value.arguments[0];
+      if (handler) thenHandlers.push(handler);
+    }
+
+    current = link.callPath;
+  }
+
+  return { isChain, outermostPath: current, thenHandlers };
+};
+
+/**
+ * Translate the response references inside a promise-chain .then() handler,
+ * preserving the handler's original shape (arrow/function, param name).
+ * @param {Object} j - jscodeshift API
+ * @param {Object} handler - The onFulfilled handler node
+ */
+const transformPromiseHandler = (j, handler) => {
+  if (!handler || (handler.type !== 'FunctionExpression' && handler.type !== 'ArrowFunctionExpression')) return;
+
+  const params = handler.params;
+  // The first parameter is bound to the response object
+  if (!params.length || params[0].type !== 'Identifier') return;
+
+  // Root the search at the handler (not handler.body): for concise arrow bodies
+  // like `res => res.json()` the body itself is the node being replaced, and it
+  // needs a parent path within the searched collection.
+  transformResponseProperties(j, handler, params[0].name);
 };
 
 /**
@@ -265,6 +351,26 @@ const findAndTransformVariableDeclaration = (j, root, variableName, visited = ne
   return transformedConfig;
 };
 
+const FUNCTION_NODE_TYPES = new Set(['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression']);
+
+/**
+ * Mark the function that encloses this path as async, so an `await` we add on
+ * the sendRequest call is syntactically valid (e.g. when the call sits inside a
+ * forEach callback, a named helper, a pm.test body, or another .then handler).
+ * @param {Object} path - NodePath of the pm.sendRequest MemberExpression
+ */
+const markEnclosingFunctionAsync = (path) => {
+  let current = path.parent;
+  while (current) {
+    const node = current.value;
+    if (node && FUNCTION_NODE_TYPES.has(node.type)) {
+      node.async = true;
+      return;
+    }
+    current = current.parent;
+  }
+};
+
 const sendRequestTransformer = (path, j) => {
   const callExpr = path.parent.value;
   if (callExpr.type !== 'CallExpression') return;
@@ -296,6 +402,34 @@ const sendRequestTransformer = (path, j) => {
     findAndTransformVariableDeclaration(j, root, variableName);
   }
 
+  // Handle promise-based usage: pm.sendRequest(cfg).then(...).catch(...)
+  // bru.sendRequest returns a promise resolving to an axios-shaped response, so
+  // the chain works as-is once the response references are translated and the
+  // whole chain (not just the inner call) is awaited.
+  const chain = collectPromiseChain(path.parent);
+  if (chain.isChain) {
+    // Translate response references (res.json() -> res.data, ...) in each .then handler
+    chain.thenHandlers.forEach((handler) => transformPromiseHandler(j, handler));
+
+    // Await the entire chain once, unless the caller already awaited it.
+    const outermostPath = chain.outermostPath;
+    const alreadyAwaited = outermostPath.parent
+      && outermostPath.parent.value
+      && outermostPath.parent.value.type === 'AwaitExpression';
+    if (!alreadyAwaited) {
+      // Ensure the enclosing function is async before adding the await.
+      markEnclosingFunctionAsync(path);
+      j(outermostPath).replaceWith(j.awaitExpression(outermostPath.value));
+    }
+
+    // Replace only the inner call with bru.sendRequest(...); the .then/.catch
+    // chain wrapping it is preserved by the surrounding AST.
+    return j.callExpression(
+      j.identifier('bru.sendRequest'),
+      args
+    );
+  }
+
   // Create the callback block and promise chain if there's a callback
   if (callback) {
     const transformedCallback = transformCallback(j, callback);
@@ -311,7 +445,10 @@ const sendRequestTransformer = (path, j) => {
       transformedCallback ? [requestOptions, transformedCallback] : [requestOptions]
     );
 
-    return wasAwaited ? sendRequestCall : j.awaitExpression(sendRequestCall);
+    if (wasAwaited) return sendRequestCall;
+    // Ensure the enclosing function is async before adding the await.
+    markEnclosingFunctionAsync(path);
+    return j.awaitExpression(sendRequestCall);
   }
 
   // If there's no callback, just transform to await bru.sendRequest
@@ -320,7 +457,10 @@ const sendRequestTransformer = (path, j) => {
     [requestOptions]
   );
 
-  return wasAwaited ? sendRequestCall : j.awaitExpression(sendRequestCall);
+  if (wasAwaited) return sendRequestCall;
+  // Ensure the enclosing function is async before adding the await.
+  markEnclosingFunctionAsync(path);
+  return j.awaitExpression(sendRequestCall);
 };
 
 export default sendRequestTransformer;

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -158,19 +158,52 @@ const responsePropertyMap = {
 };
 
 /**
+ * When a nested function between `memberPath` and `handlerFn` re-binds
+ * `responseVarName` as a parameter. Such member expressions reference a
+ * different (shadowing) response object — e.g. a reused `res` param in an inner
+ * `.then` or an unrelated fetch callback — and must not be rewritten here; they
+ * are handled when their own handler is transformed. Member expressions that
+ * merely close over the handler's response (no re-binding) are not shadowed.
+ * @param {Object} memberPath - NodePath of the candidate MemberExpression
+ * @param {string} responseVarName - Identifier name bound to the response object
+ * @param {Object} handlerFn - The active handler function node (the scope boundary)
+ * @returns {boolean}
+ */
+const isShadowedByNestedHandler = (memberPath, responseVarName, handlerFn) => {
+  let current = memberPath.parent;
+  while (current) {
+    const node = current.value;
+    if (node && FUNCTION_NODE_TYPES.has(node.type)) {
+      if (node === handlerFn) return false; // reached the active handler; same binding
+      const params = node.params || [];
+      if (params.some((p) => p.type === 'Identifier' && p.name === responseVarName)) {
+        return true; // inner function re-binds the name -> different response object
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+};
+
+/**
  * Rewrite Postman response property references (response.json(), response.code, ...)
  * to their Bruno equivalents (response.data, response.status, ...) within a body.
  * @param {Object} j - jscodeshift API
  * @param {Object} body - AST node to search within (block statement or expression)
  * @param {string} responseVarName - Identifier name bound to the response object
+ * @param {Object} handlerFn - The active handler function node; replacements are
+ *   scoped to it so nested callbacks that re-bind `responseVarName` are skipped
+ *   (prevents double-transforming, e.g. code->status then status->statusText)
  */
-const transformResponseProperties = (j, body, responseVarName) => {
+const transformResponseProperties = (j, body, responseVarName, handlerFn) => {
   j(body).find(j.MemberExpression, {
     object: {
       type: 'Identifier',
       name: responseVarName
     }
   }).forEach((memberPath) => {
+    if (isShadowedByNestedHandler(memberPath, responseVarName, handlerFn)) return;
+
     const property = memberPath.node.property;
 
     // Handle property access
@@ -225,7 +258,7 @@ const transformCallback = (j, callback) => {
   }
 
   // Process the callback body to transform response property references
-  transformResponseProperties(j, callbackBody, responseVarName);
+  transformResponseProperties(j, callbackBody, responseVarName, callback);
 
   // Create the callback block
   return j.functionExpression(
@@ -306,7 +339,7 @@ const transformPromiseHandler = (j, handler) => {
   // Root the search at the handler (not handler.body): for concise arrow bodies
   // like `res => res.json()` the body itself is the node being replaced, and it
   // needs a parent path within the searched collection.
-  transformResponseProperties(j, handler, params[0].name);
+  transformResponseProperties(j, handler, params[0].name, handler);
 };
 
 /**

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -686,6 +686,100 @@ describe('Send Request Translation', () => {
     });
   });
 
+  describe('Promise-based (.then/.catch) chains', () => {
+    it('should translate a .then().catch().finally() chain', () => {
+      const code = `
+        pm.sendRequest({
+            url: 'https://echo.usebruno.com',
+            method: 'GET'
+        })
+        .then((response) => {
+            console.log(response.json());
+        })
+        .catch((error) => {
+            console.log(error);
+        })
+        .finally(() => {
+            console.log('done');
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({
+            url: 'https://echo.usebruno.com',
+            method: 'GET'
+        })
+        .then((response) => {
+            console.log(response.data);
+        })
+        .catch((error) => {
+            console.log(error);
+        })
+        .finally(() => {
+            console.log('done');
+        });
+      `);
+    });
+
+    it('should handle nested .then() chains', () => {
+      const code = `
+        pm.sendRequest({
+            url: 'https://echo.usebruno.com',
+            method: 'GET'
+        })
+        .then((response) => {
+            return response.json();
+        })
+        .then((data) => {
+            console.log(data);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({
+            url: 'https://echo.usebruno.com',
+            method: 'GET'
+        })
+        .then((response) => {
+            return response.data;
+        })
+        .then((data) => {
+            console.log(data);
+        });
+      `);
+    });
+
+    it('should translate a sendRequest nested inside a .then and make that handler async', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com/users/1' })
+        .then((userRes) => {
+            const userId = userRes.json().id;
+            return pm.sendRequest({ url: 'https://echo.usebruno.com/posts' })
+                .then((postsRes) => {
+                    console.log(postsRes.json());
+                });
+        })
+        .catch((error) => {
+            console.log(error);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com/users/1' })
+        .then(async userRes => {
+            const userId = userRes.data.id;
+            return await bru.sendRequest({ url: 'https://echo.usebruno.com/posts' })
+                .then((postsRes) => {
+                    console.log(postsRes.data);
+                });
+        })
+        .catch((error) => {
+            console.log(error);
+        });
+      `);
+    });
+  });
+
   describe('requestConfig variables', () => {
     it('requestConfig passed as a variable', () => {
       const code = `

--- a/tests/import/postman/fixtures/postman-sendrequest-promise-chains.json
+++ b/tests/import/postman/fixtures/postman-sendrequest-promise-chains.json
@@ -1,0 +1,107 @@
+{
+  "info": {
+    "name": "SendRequest Promise Chains",
+    "description": "pm.sendRequest promise-chain translation coverage for Postman-to-Bruno import.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Promise Then Catch Finally",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.sendRequest({ url: 'https://jsonplaceholder.typicode.com/posts/1' })",
+              "  .then((response) => {",
+              "    console.log(response.json());",
+              "  })",
+              "  .catch((error) => {",
+              "    console.log(error);",
+              "  })",
+              "  .finally(() => {",
+              "    console.log('done');",
+              "  });"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://jsonplaceholder.typicode.com/posts/1",
+          "protocol": "https",
+          "host": ["jsonplaceholder", "typicode", "com"],
+          "path": ["posts", "1"]
+        }
+      }
+    },
+    {
+      "name": "Nested Then Chains",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.sendRequest({ url: 'https://jsonplaceholder.typicode.com/posts/1' })",
+              "  .then((response) => response.json())",
+              "  .then((data) => {",
+              "    console.log(data.title);",
+              "  })",
+              "  .catch((error) => {",
+              "    console.log(error);",
+              "  });"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://jsonplaceholder.typicode.com/posts/1",
+          "protocol": "https",
+          "host": ["jsonplaceholder", "typicode", "com"],
+          "path": ["posts", "1"]
+        }
+      }
+    },
+    {
+      "name": "SendRequest Inside SendRequest",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.sendRequest({ url: 'https://jsonplaceholder.typicode.com/users/1' })",
+              "  .then((userRes) => {",
+              "    const userId = userRes.json().id;",
+              "    return pm.sendRequest({ url: `https://jsonplaceholder.typicode.com/users/${userId}/posts` })",
+              "      .then((postsRes) => {",
+              "        console.log(postsRes.json());",
+              "      });",
+              "  })",
+              "  .catch((error) => {",
+              "    console.log(error);",
+              "  });"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://jsonplaceholder.typicode.com/users/1",
+          "protocol": "https",
+          "host": ["jsonplaceholder", "typicode", "com"],
+          "path": ["users", "1"]
+        }
+      }
+    }
+  ]
+}

--- a/tests/import/postman/import-sendrequest-promise-chains.spec.ts
+++ b/tests/import/postman/import-sendrequest-promise-chains.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+import * as fs from 'fs';
+import { closeAllCollections, importCollection } from '../../utils/page';
+
+// End-to-end coverage for the Postman -> Bruno pm.sendRequest() promise-chain
+// translation fix. Importing writes the translated scripts to disk (YAML), so we
+// read the generated request files and assert the chains were translated:
+//   - the whole chain is awaited (not just the inner call)
+//   - response.json()/.code map to response.data/.status inside .then handlers
+//   - .catch/.finally handlers and nested chains are preserved
+//   - a nested sendRequest inside a .then makes that handler async
+test.describe('Import Postman Collection - pm.sendRequest promise chains', () => {
+  const collectionName = 'SendRequest Promise Chains';
+
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('translates pm.sendRequest promise chains during import', async ({ page, createTmpDir }) => {
+    const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-sendrequest-promise-chains.json');
+    const collectionDir = await createTmpDir('postman-sendrequest-promise-chains');
+
+    await importCollection(page, postmanFile, collectionDir, { expectedCollectionName: collectionName });
+
+    const readRequestFile = (requestName: string) =>
+      fs.readFileSync(path.join(collectionDir, collectionName, `${requestName}.yml`), 'utf8');
+
+    await test.step('translates a .then().catch().finally() chain and awaits the whole chain', () => {
+      const content = readRequestFile('Promise Then Catch Finally');
+
+      // Whole chain is awaited, not just the inner call: `await bru.sendRequest(...)` then `.then`
+      expect(content).toContain('await bru.sendRequest({ url: \'https://jsonplaceholder.typicode.com/posts/1\' })');
+      expect(content).toContain('.then((response) => {');
+      // response.json() -> response.data inside the .then handler
+      expect(content).toContain('console.log(response.data);');
+      // .catch and .finally handlers survive untouched
+      expect(content).toContain('.catch((error) => {');
+      expect(content).toContain('.finally(() => {');
+      expect(content).toContain('console.log(\'done\');');
+
+      // The Postman API and its response methods must be gone
+      expect(content).not.toContain('pm.sendRequest');
+      expect(content).not.toContain('response.json()');
+      // The buggy form (await wrapping only the inner call) must not appear
+      expect(content).not.toContain('(await bru.sendRequest');
+    });
+
+    await test.step('handles nested .then() chains with a concise arrow body', () => {
+      const content = readRequestFile('Nested Then Chains');
+
+      expect(content).toContain('await bru.sendRequest({ url: \'https://jsonplaceholder.typicode.com/posts/1\' })');
+      // concise arrow body: response.json() -> response.data
+      expect(content).toContain('.then((response) => response.data)');
+      // second .then in the chain is preserved
+      expect(content).toContain('.then((data) => {');
+      expect(content).toContain('console.log(data.title);');
+      expect(content).toContain('.catch((error) => {');
+
+      expect(content).not.toContain('pm.sendRequest');
+      expect(content).not.toContain('response.json()');
+      expect(content).not.toContain('(await bru.sendRequest');
+    });
+
+    await test.step('translates a sendRequest nested inside a .then and makes that handler async', () => {
+      const content = readRequestFile('SendRequest Inside SendRequest');
+
+      // Outer chain awaited
+      expect(content).toContain('await bru.sendRequest({ url: \'https://jsonplaceholder.typicode.com/users/1\' })');
+      // The .then handler that contains a nested awaited sendRequest becomes async
+      expect(content).toContain('.then(async userRes => {');
+      // Response remapping in the outer handler
+      expect(content).toContain('const userId = userRes.data.id;');
+      // Inner sendRequest chain is awaited via `return await`
+      expect(content).toContain('return await bru.sendRequest(');
+      // Response remapping in the inner handler
+      expect(content).toContain('console.log(postsRes.data);');
+      expect(content).toContain('.catch((error) => {');
+
+      expect(content).not.toContain('pm.sendRequest');
+      expect(content).not.toContain('.json()');
+    });
+  });
+});


### PR DESCRIPTION
BRU-3117

### Description

Adds Postman → Bruno translation for promise-based pm.sendRequest() usage. Previously only the callback form was handled; .then()/.catch()/.finally() chains were emitted unchanged and broke at runtime after import.

Translate pm.sendRequest(...).then().catch().finally() chains to await bru.sendRequest(...).then()..., awaiting the whole chain.
Remap response refs in .then() handlers (res.json()→res.data, res.code→res.status, etc.).
Handle nested .then() chains, nested sendRequest inside .then(), already-awaited chains, and chains assigned to variables.
Mark the nearest enclosing function async so added awaits are valid; existing callback/await behavior unchanged.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import translation for `pm.sendRequest()` promise chains, including `.then()`, `.catch()`, and `.finally()` flows.
  * More consistent conversion of response property access (e.g., `response.json()` → Bruno-style response data/status fields).
  * Better handling of nested promise chains and nested `sendRequest` calls, with correct `async/await` insertion and no double-`await`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->