### PR TITLE
fix(bruno-js): expose __dirname and __filename to node-vm scripts

### DIFF
--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -68,6 +68,14 @@ async function runScriptInNodeVm({
 
     const vmFilename = resolveVmFilename(scriptPath, collectionPath);
 
+    // Expose Node's CommonJS module globals to the top-level user script,
+    // mirroring what cjs-loader already provides to require()d modules. This
+    // lets scripts resolve files relative to their .bru request file /
+    // collection directory, e.g.
+    // fs.readFileSync(path.join(__dirname, './template.hbs')).
+    scriptContext.__filename = vmFilename;
+    scriptContext.__dirname = path.dirname(vmFilename);
+
     // Execute the script in the isolated context
     const wrappedScript = wrapScriptInClosure(script, SANDBOX.NODEVM);
     let compiledScript;

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -1195,4 +1195,64 @@ describe('node-vm sandbox', () => {
       expect(context.bru.setVar).toHaveBeenCalledWith('result', 'a,b');
     });
   });
+
+  describe('__dirname / __filename globals', () => {
+    it('should expose __dirname and __filename to the top-level script', async () => {
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const script = `
+        bru.setVar('dirname', __dirname);
+        bru.setVar('filename', __filename);
+      `;
+
+      const scriptPath = path.join(collectionPath, 'requests', 'get-users.bru');
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {}, scriptPath });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('filename', scriptPath);
+      expect(context.bru.setVar).toHaveBeenCalledWith('dirname', path.dirname(scriptPath));
+    });
+
+    it('should fall back to the collection directory when scriptPath is not provided', async () => {
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const script = `
+        bru.setVar('dirname', __dirname);
+        bru.setVar('filename', __filename);
+      `;
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('filename', path.join(collectionPath, 'script.js'));
+      expect(context.bru.setVar).toHaveBeenCalledWith('dirname', collectionPath);
+    });
+
+    it('should let a script read a file relative to __dirname', async () => {
+      fs.writeFileSync(path.join(collectionPath, 'template.hbs'), 'Hello {{name}}');
+
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const script = `
+        const fs = require('fs');
+        const path = require('path');
+        const template = fs.readFileSync(path.join(__dirname, './template.hbs'), 'utf-8');
+        bru.setVar('template', template);
+      `;
+
+      const scriptPath = path.join(collectionPath, 'read-template.bru');
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {}, scriptPath });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('template', 'Hello {{name}}');
+    });
+  });
 });


### PR DESCRIPTION
### Description

Scripts running in Bruno's developer (`node-vm`) sandbox threw `ReferenceError: __dirname is not defined` when a script referenced `__dirname` or `__filename` — for example when loading a file relative to the collection:

```js
const fs = require('fs');
const path = require('path');
const template = fs.readFileSync(path.join(__dirname, './template.hbs'), 'utf-8');
```

Node's CommonJS module globals `__dirname` / `__filename` were already provided to every `require()`d CJS module by the sandbox's `cjs-loader`, but they were never injected into the top-level user script context.

This change injects `__filename` and `__dirname` into the node-vm script context, resolved from the request's `.bru` file / collection directory via the already-computed `resolveVmFilename(scriptPath, collectionPath)`. Scripts can now resolve paths relative to their location, matching Node semantics and the behavior users expect.

**Scope note:** this applies to the developer (`node-vm`) sandbox, where filesystem access via `require('fs')` is available. The safe (QuickJS) sandbox intentionally restricts filesystem access, so `__dirname` there has no filesystem use case and is left unchanged.

Added regression tests in `packages/bruno-js/src/sandbox/node-vm/index.spec.js` covering `__dirname`/`__filename` resolution with an explicit script path, the fallback to the collection directory when no script path is provided, and reading a file relative to `__dirname`.

Closes #8390

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** (n/a — no UI change)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `__dirname` and `__filename` inside sandboxed scripts, making it easier to reference files relative to a request or collection path.
  * Improved file resolution behavior when a script path is provided or omitted.
* **Bug Fixes**
  * Enabled sandboxed scripts to read nearby files more reliably using relative paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->