### PR TITLE
fix(graphql):tool tip icon follows consistent font size

### DIFF
--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -342,6 +342,45 @@ const GlobalStyle = createGlobalStyle`
     font-size: ${(props) => props.theme.font.size.xs};
     color: ${(props) => props.theme.text};
   }
+  
+  .CodeMirror-info {
+    padding: 4px 8px !important;
+    background-color: ${(props) => props.theme.infoTip.bg} !important;
+    border: 1px solid ${(props) => props.theme.infoTip.border} !important;
+    box-shadow: ${(props) => props.theme.infoTip.boxShadow} !important;
+    border-radius: ${(props) => props.theme.border.radius.sm} !important;
+    color: ${(props) => props.theme.text} !important;
+    font-size: ${(props) => props.theme.font.size.xs} !important;
+    max-width: 320px !important;
+    max-height: 240px !important;
+  }
+
+  .CodeMirror-info .CodeMirror-info-header > .type-name,
+  .CodeMirror-info .CodeMirror-info-header > .field-name,
+  .CodeMirror-info .CodeMirror-info-header > .arg-name,
+  .CodeMirror-info .CodeMirror-info-header > .directive-name,
+  .CodeMirror-info .CodeMirror-info-header > .enum-value {
+    font-size: ${(props) => props.theme.font.size.sm} !important;
+  }
+
+  /*
+   * Header/type-name/field-name/etc render as <a> tags (codemirror-graphql wires an onClick
+   * handler onto every one of them), so they don't just inherit .CodeMirror-info's color —
+   * graphiql.min.css's generic "a { color: hsl(var(--color-primary)) }" link rule can win
+   * depending on stylesheet load order. Set colors explicitly instead of relying on inheritance.
+   */
+  .CodeMirror-info a {
+    color: ${(props) => props.theme.text} !important;
+  }
+
+  .CodeMirror-info .type-name-pill,
+  .CodeMirror-info .info-description {
+    color: ${(props) => props.theme.colors.text.muted} !important;
+  }
+
+  .CodeMirror-info .info-description a {
+    color: ${(props) => props.theme.textLink} !important;
+  }
 
   .CodeMirror-lint-message-warning {
     color: ${(props) => props.theme.status.warning.text};

--- a/packages/bruno-app/src/styles/globals.css
+++ b/packages/bruno-app/src/styles/globals.css
@@ -131,15 +131,10 @@
 }
 
 
-.CodeMirror-info,
 .CodeMirror-lint-tooltip {
   --px-12: 8px !important;
 }
 
-.CodeMirror-info {
-  max-width: 320px;
-  max-height: 240px;
-}
 
 .CodeMirror-lint-tooltip {
   max-width: 320px;

--- a/packages/bruno-app/src/styles/globals.css
+++ b/packages/bruno-app/src/styles/globals.css
@@ -47,8 +47,8 @@
   --font-family-mono: 'Fira Code', monospace;
   --font-size-hint: .75rem;
   --font-size-inline-code: .8125rem;
-  --font-size-body: 1rem; 
-  --font-size-h4: 1.125rem;
+  --font-size-body: .8125rem; 
+  --font-size-h4: 0.875rem;
   --font-size-h3: 1.375rem;
   --font-size-h2: 1.8125rem;
   --font-weight-regular: 400;
@@ -98,8 +98,8 @@
   --font-family-mono: 'Fira Code', monospace;
   --font-size-hint: .75rem;
   --font-size-inline-code: .8125rem;
-  --font-size-body: 1rem; 
-  --font-size-h4: 1.125rem;
+  --font-size-body: 0.8125rem; 
+  --font-size-h4: 0.875rem;
   --font-size-h3: 1.375rem;
   --font-size-h2: 1.8125rem;
   --font-weight-regular: 400;
@@ -128,6 +128,21 @@
 .CodeMirror-dialog {
   --px-4: 0px !important;
   --px-12: 2px !important;
+}
+
+
+.CodeMirror-info,
+.CodeMirror-lint-tooltip {
+  --px-12: 8px !important;
+}
+
+.CodeMirror-info {
+  max-width: 320px;
+  max-height: 240px;
+}
+
+.CodeMirror-lint-tooltip {
+  max-width: 320px;
 }
 
 .CodeMirror-hints {


### PR DESCRIPTION
### Description
[JIRA](https://usebruno.atlassian.net/browse/BRU-3691)
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

GraphQL hover-info tooltips (.CodeMirror-info) rendered --font-size-body: 1rem and --font-size-h4: 1.125rem  making annotation popups render noticeably larger (18px heading, 16px body) than the rest of the app's UI and the ~13px editor code they annotate. The popup box  was also oversized relative to other hover tooltips in the app, made changes to make it consistent with the overall app.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
<img width="508" height="317" alt="Screenshot 2026-07-06 at 1 44 35 PM" src="https://github.com/user-attachments/assets/0f5a5dc8-d6bf-4caa-b747-d2141878b246" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced base typography sizing for the GraphiQL/CodeMirror interface, including body and heading text.
  * Updated CodeMirror tooltip and info-panel styling to improve readability and spacing (padding, theme-consistent colors, rounded corners, and constrained max width/height).
  * Added targeted link styling within the CodeMirror info panel to prevent conflicting global link styles and keep the layout consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->