### PR TITLE
fix(converters): add missing auth mappings on postman export, add additional parameters mapping on postman import

### DIFF
--- a/packages/bruno-converters/src/common/index.js
+++ b/packages/bruno-converters/src/common/index.js
@@ -29,6 +29,13 @@ export const safeStringifyJSON = (obj, indent = false) => {
   }
 };
 
+export const ensureString = (value, fallback = '') => {
+  if (value == null || value === '') return fallback;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
 export const isItemARequest = (item) => {
   return item.hasOwnProperty('request') && ['http-request', 'graphql-request'].includes(item.type) && !item.items;
 };

--- a/packages/bruno-converters/src/common/index.js
+++ b/packages/bruno-converters/src/common/index.js
@@ -29,13 +29,6 @@ export const safeStringifyJSON = (obj, indent = false) => {
   }
 };
 
-export const ensureString = (value, fallback = '') => {
-  if (value == null || value === '') return fallback;
-  if (typeof value === 'string') return value;
-  if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
-};
-
 export const isItemARequest = (item) => {
   return item.hasOwnProperty('request') && ['http-request', 'graphql-request'].includes(item.type) && !item.items;
 };

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -1,6 +1,7 @@
 import map from 'lodash/map';
-import { deleteSecretsInEnvs, deleteUidsInEnvs, deleteUidsInItems, ensureString, isItemARequest } from '../common';
+import { deleteSecretsInEnvs, deleteUidsInEnvs, deleteUidsInItems, isItemARequest } from '../common';
 import translateBruToPostman from '../utils/bruno-to-postman-translator';
+import { toDisplayString as ensureString } from '@usebruno/common/utils';
 
 const isItemAFolder = (item) => item.type === 'folder';
 
@@ -626,7 +627,10 @@ export const brunoToPostman = (collection) => {
         // 3. Bruno's `tokenPlacement` ('header'/'url') maps to Postman's `addTokenTo`, where the query case
         //    is represented as 'queryParams' (not 'url').
         // 4. Postman-only keys (`useBrowser`, `code_verifier`) have no Bruno equivalent, so
-        //    they are not produced here.
+        //    they are not produced here. Postman lets you enable `useBrowser` ("Authorize using
+        //    browser") per collection/folder/request. In Bruno, using the system browser is a
+        //    global preference (`request.oauth2.useSystemBrowser`) applied to all OAuth2 requests
+        //    and cannot be scoped per collection/folder/request.
         // 5. Bruno's `additionalParameters` (authorization/token/refresh) map to Postman's
         //    `authRequestParams`/`tokenRequestParams`/`refreshRequestParams`, with `sendIn`
         //    ('headers'/'queryparams'/'body') mapped to `send_as` ('request_header'/'request_url'/'request_body').

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -422,6 +422,11 @@ export const brunoToPostman = (collection) => {
               key: 'value',
               value: itemAuth.apikey?.value || '',
               type: 'string'
+            },
+            {
+              key: 'in',
+              value: itemAuth.apikey?.placement === 'queryparams' ? 'query' : 'header',
+              type: 'string'
             }
           ]
         };

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -378,16 +378,19 @@ export const brunoToPostman = (collection) => {
     }
   };
 
-  const generateAuth = (itemAuth) => {
+  const generateAuth = (itemAuth, isCollection) => {
     switch (itemAuth?.mode) {
+      case 'inherit': return undefined;
       case 'bearer':
         return {
           type: 'bearer',
-          bearer: {
-            key: 'token',
-            value: itemAuth.bearer?.token || '',
-            type: 'string'
-          }
+          bearer: [
+            {
+              key: 'token',
+              value: itemAuth.bearer?.token || '',
+              type: 'string'
+            }
+          ]
         };
       case 'basic': {
         return {
@@ -438,8 +441,319 @@ export const brunoToPostman = (collection) => {
           ]
         };
       }
-      default: {
+      case 'awsv4': {
         return {
+          type: 'awsv4',
+          awsv4: [
+            {
+              key: 'sessionToken',
+              value: itemAuth.awsv4?.sessionToken || '',
+              type: 'string'
+            },
+            {
+              key: 'service',
+              value: itemAuth.awsv4?.service || '',
+              type: 'string'
+            },
+            {
+              key: 'region',
+              value: itemAuth.awsv4?.region || '',
+              type: 'string'
+            },
+            {
+              key: 'secretKey',
+              value: itemAuth.awsv4?.secretAccessKey || '',
+              type: 'string'
+            },
+            {
+              key: 'accessKey',
+              value: itemAuth.awsv4?.accessKeyId || '',
+              type: 'string'
+            }
+          ]
+        };
+      }
+      case 'digest': {
+        // Note on Bruno <-> Postman differences:
+        // 1. Bruno and Postman share the same `username`/`password` fields, so they map directly.
+        // 2. Postman-only keys (`algorithm`, `nonce`, `nonceCount`, `realm`, `qop`, `cnonce`, `opaque`)
+        //    have no Bruno equivalent, so they are omitted here.
+        return {
+          type: 'digest',
+          digest: [
+            {
+              key: 'password',
+              value: itemAuth.digest?.password || '',
+              type: 'string'
+            },
+            {
+              key: 'username',
+              value: itemAuth.digest?.username || '',
+              type: 'string'
+            }
+          ]
+        };
+      }
+      case 'ntlm': {
+        // Note on Bruno <-> Postman differences:
+        // 1. Bruno and Postman share the same `username`/`password`/`domain` fields, so they map directly.
+        // 2. Postman-only keys (`workstation`) have no Bruno equivalent, so they are omitted here.
+        return {
+          type: 'ntlm',
+          ntlm: [
+            {
+              key: 'username',
+              value: itemAuth.ntlm?.username || '',
+              type: 'string'
+            },
+            {
+              key: 'password',
+              value: itemAuth.ntlm?.password || '',
+              type: 'string'
+            },
+            {
+              key: 'domain',
+              value: itemAuth.ntlm?.domain || '',
+              type: 'string'
+            }
+          ]
+        };
+      }
+      case 'oauth1': {
+        // Note on Bruno <-> Postman differences:
+        // 1. Bruno's `placement` supports 'header'/'query'/'body', but Postman only has the boolean
+        //    `addParamsToHeader`. We map 'query' -> false and everything else (including 'body') -> true.
+        // 2. Postman-only keys (`addEmptyParamsToSign`, `disableHeaderEncoding`) have no Bruno equivalent,
+        //    so they are omitted here.
+        // 3. `privateKey` is only relevant for RSA signature methods, so it is exported only when the
+        //    signature method is an RSA type (`RSA-SHA1`/`RSA-SHA256`/`RSA-SHA512`).
+        //    When Bruno's `privateKeyType` is 'file', `privateKey` holds a relative file path (not the PEM
+        //    content). Postman expects the inline PEM string and has no file concept, and export runs in the
+        //    browser with no filesystem access, so the file cannot be resolved here. We export an empty
+        //    `privateKey` in file mode to avoid leaking a path that Postman couldn't use anyway.
+        //    Text-mode keys export correctly.
+        const oauth1 = itemAuth.oauth1 || {};
+        const signatureMethod = oauth1.signatureMethod || 'HMAC-SHA1';
+        const isRsa = signatureMethod.startsWith('RSA-');
+        const privateKey = oauth1.privateKeyType === 'file' ? '' : (oauth1.privateKey || '');
+        return {
+          type: 'oauth1',
+          oauth1: [
+            {
+              key: 'consumerKey',
+              value: oauth1.consumerKey || '',
+              type: 'string'
+            },
+            {
+              key: 'consumerSecret',
+              value: oauth1.consumerSecret || '',
+              type: 'string'
+            },
+            {
+              key: 'token',
+              value: oauth1.accessToken || '',
+              type: 'string'
+            },
+            {
+              key: 'tokenSecret',
+              value: oauth1.accessTokenSecret || '',
+              type: 'string'
+            },
+            {
+              key: 'signatureMethod',
+              value: signatureMethod,
+              type: 'string'
+            },
+            ...(isRsa ? [{
+              key: 'privateKey',
+              value: privateKey,
+              type: 'string'
+            }] : []),
+            {
+              key: 'callback',
+              value: oauth1.callbackUrl || '',
+              type: 'string'
+            },
+            {
+              key: 'verifier',
+              value: oauth1.verifier || '',
+              type: 'string'
+            },
+            {
+              key: 'timestamp',
+              value: oauth1.timestamp || '',
+              type: 'string'
+            },
+            {
+              key: 'nonce',
+              value: oauth1.nonce || '',
+              type: 'string'
+            },
+            {
+              key: 'version',
+              value: oauth1.version || '1.0',
+              type: 'string'
+            },
+            {
+              key: 'realm',
+              value: oauth1.realm || '',
+              type: 'string'
+            },
+            {
+              key: 'addParamsToHeader',
+              value: oauth1.placement === 'query' ? false : true,
+              type: 'boolean'
+            },
+            {
+              key: 'includeBodyHash',
+              value: oauth1.includeBodyHash || false,
+              type: 'boolean'
+            }
+          ]
+        };
+      }
+      case 'oauth2': {
+        // Note on Bruno <-> Postman differences:
+        // 1. Bruno's `grantType` maps to Postman's `grant_type`. Bruno's `authorization_code` with
+        //    `pkce: true` becomes Postman's `authorization_code_with_pkce`; `password` becomes
+        //    `password_credentials`; the rest keep the same value.
+        // 2. Bruno-only fields (`autoRefreshToken`(not exposed by postman as part of export), `autoFetchToken`, `tokenSource`) have no Postman equivalent, so they are omitted here.
+        // 3. Bruno's `tokenPlacement` ('header'/'url') maps to Postman's `addTokenTo`, where the query case
+        //    is represented as 'queryParams' (not 'url').
+        // 4. Postman-only keys (`useBrowser`, `code_verifier`) have no Bruno equivalent, so
+        //    they are not produced here.
+        // 5. Bruno's `additionalParameters` (authorization/token/refresh) map to Postman's
+        //    `authRequestParams`/`tokenRequestParams`/`refreshRequestParams`, with `sendIn`
+        //    ('headers'/'queryparams'/'body') mapped to `send_as` ('request_header'/'request_url'/'request_body').
+        const oauth2 = itemAuth.oauth2 || {};
+
+        // Maps a Bruno additional-parameters array to Postman's request-params format
+        const sendInToSendAs = { headers: 'request_header', queryparams: 'request_url', body: 'request_body' };
+        const mapAdditionalParams = (params) => (params || []).map((param) => ({
+          key: param.name || '',
+          value: param.value || '',
+          enabled: param.enabled !== false,
+          send_as: sendInToSendAs[param.sendIn] || 'request_header'
+        }));
+
+        const grantTypeMap = {
+          authorization_code: oauth2.pkce ? 'authorization_code_with_pkce' : 'authorization_code',
+          password: 'password_credentials',
+          client_credentials: 'client_credentials',
+          implicit: 'implicit'
+        };
+        const grantType = grantTypeMap[oauth2.grantType] || 'client_credentials';
+        // Empty/null values are filtered out below, so keys can be listed unconditionally.
+        const oauth2Params = [
+          {
+            key: 'grant_type',
+            value: grantType,
+            type: 'string'
+          },
+          {
+            key: 'accessTokenUrl',
+            value: oauth2.accessTokenUrl,
+            type: 'string'
+          },
+          {
+            key: 'refreshTokenUrl',
+            value: oauth2.refreshTokenUrl,
+            type: 'string'
+          },
+          {
+            key: 'clientId',
+            value: oauth2.clientId,
+            type: 'string'
+          },
+          {
+            key: 'clientSecret',
+            value: oauth2.clientSecret,
+            type: 'string'
+          },
+          {
+            key: 'scope',
+            value: oauth2.scope,
+            type: 'string'
+          },
+          {
+            key: 'state',
+            value: oauth2.state,
+            type: 'string'
+          },
+          {
+            key: 'tokenName',
+            value: oauth2.credentialsId,
+            type: 'string'
+          },
+          {
+            key: 'addTokenTo',
+            value: oauth2.tokenPlacement === 'header' ? 'header' : 'queryParams',
+            type: 'string'
+          },
+          {
+            key: 'headerPrefix',
+            // use tokenQueryKey when postman supports queryParams customization
+            value: oauth2.tokenHeaderPrefix,
+            type: 'string'
+          },
+          {
+            key: 'client_authentication',
+            value: oauth2.credentialsPlacement === 'body' ? 'body' : '',
+            type: 'string'
+          },
+          {
+            key: 'authUrl',
+            value: oauth2.authorizationUrl,
+            type: 'string'
+          },
+          {
+            key: 'redirect_uri',
+            value: oauth2.callbackUrl,
+            type: 'string'
+          },
+          {
+            key: 'username',
+            value: oauth2.username,
+            type: 'string'
+          },
+          {
+            key: 'password',
+            value: oauth2.password,
+            type: 'string'
+          }
+        ].filter((param) => param.value !== null && param.value !== undefined && param.value !== '');
+
+        // Additional parameters (authorization/token/refresh) — only emitted when present
+        const additionalParameters = oauth2.additionalParameters || {};
+        if (additionalParameters.authorization?.length) {
+          oauth2Params.push({
+            key: 'authRequestParams',
+            value: mapAdditionalParams(additionalParameters.authorization),
+            type: 'any'
+          });
+        }
+        if (additionalParameters.token?.length) {
+          oauth2Params.push({
+            key: 'tokenRequestParams',
+            value: mapAdditionalParams(additionalParameters.token),
+            type: 'any'
+          });
+        }
+        if (additionalParameters.refresh?.length) {
+          oauth2Params.push({
+            key: 'refreshRequestParams',
+            value: mapAdditionalParams(additionalParameters.refresh),
+            type: 'any'
+          });
+        }
+
+        return {
+          type: 'oauth2',
+          oauth2: oauth2Params
+        };
+      }
+      default: {
+        return isCollection ? undefined : {
           type: 'noauth'
         };
       }
@@ -454,7 +768,7 @@ export const brunoToPostman = (collection) => {
     const requestObject = {
       method: itemRequest.method || 'GET',
       header: generateHeaders(itemRequest.headers),
-      auth: generateAuth(itemRequest.auth),
+      auth: generateAuth(itemRequest.auth, false),
       description: itemRequest.docs || '',
       // We sanitize the URL to make sure it's in the right format before passing it to the transformUrl func. This means changing backslashes to forward slashes and reducing multiple slashes to a single one, except in the protocol part.
       url: transformUrl(sanitizeUrl(itemRequest.url || ''), itemRequest.params || [])
@@ -607,6 +921,7 @@ export const brunoToPostman = (collection) => {
   collectionToExport.info = generateInfoSection();
   collectionToExport.item = generateItemSection(collection.items);
   collectionToExport.variable = generateCollectionVars(collection);
+  collectionToExport.auth = generateAuth(collection.root?.request?.auth, true);
   const collectionEvents = generateEventSection(collection.root);
   if (collectionEvents.length) {
     collectionToExport.event = collectionEvents;

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -1,5 +1,5 @@
 import map from 'lodash/map';
-import { deleteSecretsInEnvs, deleteUidsInEnvs, deleteUidsInItems, isItemARequest } from '../common';
+import { deleteSecretsInEnvs, deleteUidsInEnvs, deleteUidsInItems, ensureString, isItemARequest } from '../common';
 import translateBruToPostman from '../utils/bruno-to-postman-translator';
 
 const isItemAFolder = (item) => item.type === 'folder';
@@ -387,7 +387,7 @@ export const brunoToPostman = (collection) => {
           bearer: [
             {
               key: 'token',
-              value: itemAuth.bearer?.token || '',
+              value: ensureString(itemAuth.bearer?.token),
               type: 'string'
             }
           ]
@@ -398,12 +398,12 @@ export const brunoToPostman = (collection) => {
           basic: [
             {
               key: 'password',
-              value: itemAuth.basic?.password || '',
+              value: ensureString(itemAuth.basic?.password),
               type: 'string'
             },
             {
               key: 'username',
-              value: itemAuth.basic?.username || '',
+              value: ensureString(itemAuth.basic?.username),
               type: 'string'
             }
           ]
@@ -415,12 +415,12 @@ export const brunoToPostman = (collection) => {
           apikey: [
             {
               key: 'key',
-              value: itemAuth.apikey?.key || '',
+              value: ensureString(itemAuth.apikey?.key),
               type: 'string'
             },
             {
               key: 'value',
-              value: itemAuth.apikey?.value || '',
+              value: ensureString(itemAuth.apikey?.value),
               type: 'string'
             },
             {
@@ -435,13 +435,13 @@ export const brunoToPostman = (collection) => {
         return {
           type: 'edgegrid',
           edgegrid: [
-            { key: 'accessToken', value: itemAuth.akamaiEdgegrid?.accessToken || '', type: 'string' },
-            { key: 'clientToken', value: itemAuth.akamaiEdgegrid?.clientToken || '', type: 'string' },
-            { key: 'clientSecret', value: itemAuth.akamaiEdgegrid?.clientSecret || '', type: 'string' },
-            { key: 'baseURL', value: itemAuth.akamaiEdgegrid?.baseURL || '', type: 'string' },
-            { key: 'nonce', value: itemAuth.akamaiEdgegrid?.nonce || '', type: 'string' },
-            { key: 'timestamp', value: itemAuth.akamaiEdgegrid?.timestamp || '', type: 'string' },
-            { key: 'headersToSign', value: itemAuth.akamaiEdgegrid?.headersToSign || '', type: 'string' },
+            { key: 'accessToken', value: ensureString(itemAuth.akamaiEdgegrid?.accessToken), type: 'string' },
+            { key: 'clientToken', value: ensureString(itemAuth.akamaiEdgegrid?.clientToken), type: 'string' },
+            { key: 'clientSecret', value: ensureString(itemAuth.akamaiEdgegrid?.clientSecret), type: 'string' },
+            { key: 'baseURL', value: ensureString(itemAuth.akamaiEdgegrid?.baseURL), type: 'string' },
+            { key: 'nonce', value: ensureString(itemAuth.akamaiEdgegrid?.nonce), type: 'string' },
+            { key: 'timestamp', value: ensureString(itemAuth.akamaiEdgegrid?.timestamp), type: 'string' },
+            { key: 'headersToSign', value: ensureString(itemAuth.akamaiEdgegrid?.headersToSign), type: 'string' },
             { key: 'maxBodySize', value: itemAuth.akamaiEdgegrid?.maxBodySize ?? '', type: 'string' }
           ]
         };
@@ -452,27 +452,27 @@ export const brunoToPostman = (collection) => {
           awsv4: [
             {
               key: 'sessionToken',
-              value: itemAuth.awsv4?.sessionToken || '',
+              value: ensureString(itemAuth.awsv4?.sessionToken),
               type: 'string'
             },
             {
               key: 'service',
-              value: itemAuth.awsv4?.service || '',
+              value: ensureString(itemAuth.awsv4?.service),
               type: 'string'
             },
             {
               key: 'region',
-              value: itemAuth.awsv4?.region || '',
+              value: ensureString(itemAuth.awsv4?.region),
               type: 'string'
             },
             {
               key: 'secretKey',
-              value: itemAuth.awsv4?.secretAccessKey || '',
+              value: ensureString(itemAuth.awsv4?.secretAccessKey),
               type: 'string'
             },
             {
               key: 'accessKey',
-              value: itemAuth.awsv4?.accessKeyId || '',
+              value: ensureString(itemAuth.awsv4?.accessKeyId),
               type: 'string'
             }
           ]
@@ -488,12 +488,12 @@ export const brunoToPostman = (collection) => {
           digest: [
             {
               key: 'password',
-              value: itemAuth.digest?.password || '',
+              value: ensureString(itemAuth.digest?.password),
               type: 'string'
             },
             {
               key: 'username',
-              value: itemAuth.digest?.username || '',
+              value: ensureString(itemAuth.digest?.username),
               type: 'string'
             }
           ]
@@ -508,17 +508,17 @@ export const brunoToPostman = (collection) => {
           ntlm: [
             {
               key: 'username',
-              value: itemAuth.ntlm?.username || '',
+              value: ensureString(itemAuth.ntlm?.username),
               type: 'string'
             },
             {
               key: 'password',
-              value: itemAuth.ntlm?.password || '',
+              value: ensureString(itemAuth.ntlm?.password),
               type: 'string'
             },
             {
               key: 'domain',
-              value: itemAuth.ntlm?.domain || '',
+              value: ensureString(itemAuth.ntlm?.domain),
               type: 'string'
             }
           ]
@@ -538,30 +538,30 @@ export const brunoToPostman = (collection) => {
         //    `privateKey` in file mode to avoid leaking a path that Postman couldn't use anyway.
         //    Text-mode keys export correctly.
         const oauth1 = itemAuth.oauth1 || {};
-        const signatureMethod = oauth1.signatureMethod || 'HMAC-SHA1';
+        const signatureMethod = ensureString(oauth1.signatureMethod, 'HMAC-SHA1');
         const isRsa = signatureMethod.startsWith('RSA-');
-        const privateKey = oauth1.privateKeyType === 'file' ? '' : (oauth1.privateKey || '');
+        const privateKey = oauth1.privateKeyType === 'file' ? '' : ensureString(oauth1.privateKey);
         return {
           type: 'oauth1',
           oauth1: [
             {
               key: 'consumerKey',
-              value: oauth1.consumerKey || '',
+              value: ensureString(oauth1.consumerKey),
               type: 'string'
             },
             {
               key: 'consumerSecret',
-              value: oauth1.consumerSecret || '',
+              value: ensureString(oauth1.consumerSecret),
               type: 'string'
             },
             {
               key: 'token',
-              value: oauth1.accessToken || '',
+              value: ensureString(oauth1.accessToken),
               type: 'string'
             },
             {
               key: 'tokenSecret',
-              value: oauth1.accessTokenSecret || '',
+              value: ensureString(oauth1.accessTokenSecret),
               type: 'string'
             },
             {
@@ -576,32 +576,32 @@ export const brunoToPostman = (collection) => {
             }] : []),
             {
               key: 'callback',
-              value: oauth1.callbackUrl || '',
+              value: ensureString(oauth1.callbackUrl),
               type: 'string'
             },
             {
               key: 'verifier',
-              value: oauth1.verifier || '',
+              value: ensureString(oauth1.verifier),
               type: 'string'
             },
             {
               key: 'timestamp',
-              value: oauth1.timestamp || '',
+              value: ensureString(oauth1.timestamp),
               type: 'string'
             },
             {
               key: 'nonce',
-              value: oauth1.nonce || '',
+              value: ensureString(oauth1.nonce),
               type: 'string'
             },
             {
               key: 'version',
-              value: oauth1.version || '1.0',
+              value: ensureString(oauth1.version, '1.0'),
               type: 'string'
             },
             {
               key: 'realm',
-              value: oauth1.realm || '',
+              value: ensureString(oauth1.realm),
               type: 'string'
             },
             {
@@ -635,8 +635,8 @@ export const brunoToPostman = (collection) => {
         // Maps a Bruno additional-parameters array to Postman's request-params format
         const sendInToSendAs = { headers: 'request_header', queryparams: 'request_url', body: 'request_body' };
         const mapAdditionalParams = (params) => (params || []).map((param) => ({
-          key: param.name || '',
-          value: param.value || '',
+          key: ensureString(param.name),
+          value: ensureString(param.value),
           enabled: param.enabled !== false,
           send_as: sendInToSendAs[param.sendIn] || 'request_header'
         }));
@@ -657,48 +657,48 @@ export const brunoToPostman = (collection) => {
           },
           {
             key: 'accessTokenUrl',
-            value: oauth2.accessTokenUrl,
+            value: ensureString(oauth2.accessTokenUrl),
             type: 'string'
           },
           {
             key: 'refreshTokenUrl',
-            value: oauth2.refreshTokenUrl,
+            value: ensureString(oauth2.refreshTokenUrl),
             type: 'string'
           },
           {
             key: 'clientId',
-            value: oauth2.clientId,
+            value: ensureString(oauth2.clientId),
             type: 'string'
           },
           {
             key: 'clientSecret',
-            value: oauth2.clientSecret,
+            value: ensureString(oauth2.clientSecret),
             type: 'string'
           },
           {
             key: 'scope',
-            value: oauth2.scope,
+            value: ensureString(oauth2.scope),
             type: 'string'
           },
           {
             key: 'state',
-            value: oauth2.state,
+            value: ensureString(oauth2.state),
             type: 'string'
           },
           {
             key: 'tokenName',
-            value: oauth2.credentialsId,
+            value: ensureString(oauth2.credentialsId),
             type: 'string'
           },
           {
             key: 'addTokenTo',
-            value: oauth2.tokenPlacement === 'header' ? 'header' : 'queryParams',
+            value: oauth2.tokenPlacement === 'url' ? 'queryParams' : 'header',
             type: 'string'
           },
           {
             key: 'headerPrefix',
             // use tokenQueryKey when postman supports queryParams customization
-            value: oauth2.tokenHeaderPrefix,
+            value: ensureString(oauth2.tokenHeaderPrefix),
             type: 'string'
           },
           {
@@ -708,22 +708,22 @@ export const brunoToPostman = (collection) => {
           },
           {
             key: 'authUrl',
-            value: oauth2.authorizationUrl,
+            value: ensureString(oauth2.authorizationUrl),
             type: 'string'
           },
           {
             key: 'redirect_uri',
-            value: oauth2.callbackUrl,
+            value: ensureString(oauth2.callbackUrl),
             type: 'string'
           },
           {
             key: 'username',
-            value: oauth2.username,
+            value: ensureString(oauth2.username),
             type: 'string'
           },
           {
             key: 'password',
-            value: oauth2.password,
+            value: ensureString(oauth2.password),
             type: 'string'
           }
         ].filter((param) => param.value !== null && param.value !== undefined && param.value !== '');
@@ -892,9 +892,11 @@ export const brunoToPostman = (collection) => {
 
       if (item.type === 'folder') {
         const folderEvents = generateEventSection(item);
+        const folderAuth = generateAuth(item.root?.request?.auth, false);
         return {
           name: item.name || 'Untitled Folder',
           item: generateItemSection(item.items),
+          ...(folderAuth ? { auth: folderAuth } : {}),
           ...(folderEvents.length ? { event: folderEvents } : {})
         };
       } else if (isItemARequest(item)) {

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -703,7 +703,7 @@ export const brunoToPostman = (collection) => {
           },
           {
             key: 'client_authentication',
-            value: oauth2.credentialsPlacement === 'body' ? 'body' : '',
+            value: oauth2.credentialsPlacement === 'body' ? 'body' : 'header',
             type: 'string'
           },
           {

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -344,11 +344,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
       };
 
       const postmanGrantType = findValueUsingKey('grant_type');
-      // Postman omits `grant_type` when exporting a plain authorization_code auth. Infer it from the
-      // presence of authUrl/redirect_uri so it isn't misclassified as the client_credentials default.
-      const hasAuthCodeFields = !!(findValueUsingKey('authUrl') || findValueUsingKey('redirect_uri'));
-      const effectiveGrantType = postmanGrantType || (hasAuthCodeFields ? 'authorization_code' : '');
-      const targetGrantType = oauth2GrantTypeMaps[effectiveGrantType] || 'client_credentials'; // Default
+      const targetGrantType = oauth2GrantTypeMaps[postmanGrantType] || 'client_credentials'; // Default
 
       // Maps Postman's request-params arrays to Bruno's `additionalParameters`, converting `send_as`
       // ('request_header'/'request_url'/'request_body') to Bruno's `sendIn` ('headers'/'queryparams'/'body').
@@ -393,7 +389,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
         credentialsId: findValueUsingKey('tokenName')
       };
 
-      switch (effectiveGrantType) {
+      switch (targetGrantType) {
         case 'authorization_code':
           requestObject.auth.oauth2 = {
             ...baseOAuth2Config,
@@ -428,7 +424,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
           };
           break;
         default:
-          console.warn('Unexpected OAuth2 grant type after mapping:', effectiveGrantType);
+          console.warn('Unexpected OAuth2 grant type after mapping:', targetGrantType);
           requestObject.auth.oauth2 = baseOAuth2Config; // Fallback to default which is Client Credentials
           break;
       }

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -20,6 +20,7 @@ const AUTH_TYPES = Object.freeze({
   OAUTH2: 'oauth2',
   EDGEGRID: 'edgegrid',
   NOAUTH: 'noauth',
+  NTLM: 'ntlm',
   NONE: 'none'
 });
 
@@ -302,6 +303,15 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
         maxBodySize: ensureMaxBodySize(authValues.maxBodySize)
       };
       break;
+    case AUTH_TYPES.NTLM:
+      // Postman's `workstation` field has no Bruno equivalent, so it is dropped here.
+      requestObject.auth.ntlm = {
+        username: ensureString(authValues.username),
+        password: ensureString(authValues.password),
+        domain: ensureString(authValues.domain)
+      };
+      break;
+
     case AUTH_TYPES.OAUTH1:
       requestObject.auth.oauth1 = {
         consumerKey: ensureString(authValues.consumerKey),
@@ -475,7 +485,8 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
               apikey: null,
               oauth1: null,
               oauth2: null,
-              digest: null
+              digest: null,
+              ntlm: null
             },
             headers: [],
             script: {},
@@ -542,7 +553,8 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
               apikey: null,
               oauth1: null,
               oauth2: null,
-              digest: null
+              digest: null,
+              ntlm: null
             },
             headers: [],
             params: [],
@@ -1019,7 +1031,8 @@ const importPostmanV2Collection = async (collection, { useWorkers = false }) => 
           apikey: null,
           oauth1: null,
           oauth2: null,
-          digest: null
+          digest: null,
+          ntlm: null
         },
         headers: [],
         script: {},

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -389,7 +389,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
         credentialsId: findValueUsingKey('tokenName')
       };
 
-      switch (targetGrantType) {
+      switch (postmanGrantType) {
         case 'authorization_code':
           requestObject.auth.oauth2 = {
             ...baseOAuth2Config,

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -334,10 +334,41 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
       };
 
       const postmanGrantType = findValueUsingKey('grant_type');
-      const targetGrantType = oauth2GrantTypeMaps[postmanGrantType] || 'client_credentials'; // Default
+      // Postman omits `grant_type` when exporting a plain authorization_code auth. Infer it from the
+      // presence of authUrl/redirect_uri so it isn't misclassified as the client_credentials default.
+      const hasAuthCodeFields = !!(findValueUsingKey('authUrl') || findValueUsingKey('redirect_uri'));
+      const effectiveGrantType = postmanGrantType || (hasAuthCodeFields ? 'authorization_code' : '');
+      const targetGrantType = oauth2GrantTypeMaps[effectiveGrantType] || 'client_credentials'; // Default
+
+      // Maps Postman's request-params arrays to Bruno's `additionalParameters`, converting `send_as`
+      // ('request_header'/'request_url'/'request_body') to Bruno's `sendIn` ('headers'/'queryparams'/'body').
+      const sendAsToSendIn = { request_header: 'headers', request_url: 'queryparams', request_body: 'body' };
+      const mapRequestParams = (params) => (Array.isArray(params) ? params : []).map((param) => ({
+        name: ensureString(param.key),
+        value: ensureString(param.value),
+        sendIn: sendAsToSendIn[param.send_as] || 'headers',
+        enabled: param.enabled !== false
+      }));
+      const additionalParameters = {};
+      if (Array.isArray(authValues.authRequestParams)) {
+        additionalParameters.authorization = mapRequestParams(authValues.authRequestParams);
+      }
+      if (Array.isArray(authValues.tokenRequestParams)) {
+        additionalParameters.token = mapRequestParams(authValues.tokenRequestParams);
+      }
+      if (Array.isArray(authValues.refreshRequestParams)) {
+        additionalParameters.refresh = mapRequestParams(authValues.refreshRequestParams);
+      }
+      const hasAdditionalParameters = Object.keys(additionalParameters).length > 0;
+      // The schema requires an `authorization` array for the authorization_code grant, so ensure it
+      // exists when any additional params are attached to this grant type.
+      if (hasAdditionalParameters && targetGrantType === 'authorization_code' && !additionalParameters.authorization) {
+        additionalParameters.authorization = [];
+      }
 
       // Common properties for all OAuth2 grant types
       const baseOAuth2Config = {
+        ...(hasAdditionalParameters ? { additionalParameters } : {}),
         grantType: targetGrantType,
         accessTokenUrl: findValueUsingKey('accessTokenUrl'),
         refreshTokenUrl: findValueUsingKey('refreshTokenUrl'),
@@ -348,10 +379,11 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
         tokenPlacement: findValueUsingKey('addTokenTo') === 'header' ? 'header' : 'url',
         tokenHeaderPrefix: findValueUsingKey('headerPrefix'),
         tokenQueryKey: 'access_token',
-        credentialsPlacement: findValueUsingKey('client_authentication') === 'body' ? 'body' : 'basic_auth_header'
+        credentialsPlacement: findValueUsingKey('client_authentication') === 'body' ? 'body' : 'basic_auth_header',
+        credentialsId: findValueUsingKey('tokenName')
       };
 
-      switch (postmanGrantType) {
+      switch (effectiveGrantType) {
         case 'authorization_code':
           requestObject.auth.oauth2 = {
             ...baseOAuth2Config,
@@ -386,7 +418,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
           };
           break;
         default:
-          console.warn('Unexpected OAuth2 grant type after mapping:', targetGrantType);
+          console.warn('Unexpected OAuth2 grant type after mapping:', effectiveGrantType);
           requestObject.auth.oauth2 = baseOAuth2Config; // Fallback to default which is Client Credentials
           break;
       }

--- a/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
+++ b/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
@@ -426,8 +426,11 @@ describe('brunoToPostman auth export', () => {
   });
 
   it('should return noauth for a null or undefined auth object', () => {
-    const result = brunoToPostman(makeRequestWithAuth(null));
-    expect(result.item[0].request.auth).toEqual({ type: 'noauth' });
+    const resultNull = brunoToPostman(makeRequestWithAuth(null));
+    expect(resultNull.item[0].request.auth).toEqual({ type: 'noauth' });
+
+    const resultUndefined = brunoToPostman(makeRequestWithAuth(undefined));
+    expect(resultUndefined.item[0].request.auth).toEqual({ type: 'noauth' });
   });
 
   it('should export bearer auth as an array (Postman v2.1 schema)', () => {

--- a/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
+++ b/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
@@ -837,6 +837,42 @@ describe('brunoToPostman auth export', () => {
       expect(result.auth).toBeUndefined();
     });
   });
+
+  describe('folder-level auth', () => {
+    const makeFolderWithAuth = (auth) => ({
+      items: [
+        {
+          type: 'folder',
+          name: 'Test Folder',
+          root: { request: { auth } },
+          items: []
+        }
+      ]
+    });
+
+    it('should export folder-level auth from root.request.auth', () => {
+      const result = brunoToPostman(
+        makeFolderWithAuth({ mode: 'bearer', bearer: { token: 'folder-token' } })
+      );
+      expect(result.item[0].auth).toEqual({
+        type: 'bearer',
+        bearer: [
+          { key: 'token', value: 'folder-token', type: 'string' }
+        ]
+      });
+    });
+
+    it('should omit folder auth for inherit mode so Postman falls back to the parent', () => {
+      const result = brunoToPostman(makeFolderWithAuth({ mode: 'inherit' }));
+      expect(result.item[0].auth).toBeUndefined();
+      expect(result.item[0]).not.toHaveProperty('auth');
+    });
+
+    it('should export explicit noauth for a folder set to none (no auth, do not inherit)', () => {
+      const result = brunoToPostman(makeFolderWithAuth({ mode: 'none' }));
+      expect(result.item[0].auth).toEqual({ type: 'noauth' });
+    });
+  });
 });
 
 describe('brunoToPostman multipartForm handling', () => {

--- a/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
+++ b/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
@@ -403,124 +403,438 @@ describe('brunoToPostman null checks and fallbacks', () => {
     const result = brunoToPostman(simpleCollection);
     expect(result.item[0].item).toEqual([]);
   });
+});
 
-  it('should handle null or undefined auth object', () => {
-    const simpleCollection = {
-      items: [
-        {
-          name: 'Test Request',
-          type: 'http-request',
-          request: {
-            method: 'GET',
-            url: 'https://example.com',
-            auth: null
-          }
+describe('brunoToPostman auth export', () => {
+  const makeRequestWithAuth = (auth) => ({
+    items: [
+      {
+        name: 'Test Request',
+        type: 'http-request',
+        request: {
+          method: 'GET',
+          url: 'https://example.com',
+          auth
         }
-      ]
-    };
+      }
+    ]
+  });
 
-    const result = brunoToPostman(simpleCollection);
+  it('should omit auth (undefined) for inherit mode so Postman falls back to the parent', () => {
+    const result = brunoToPostman(makeRequestWithAuth({ mode: 'inherit' }));
+    expect(result.item[0].request.auth).toBeUndefined();
+  });
+
+  it('should return noauth for a null or undefined auth object', () => {
+    const result = brunoToPostman(makeRequestWithAuth(null));
     expect(result.item[0].request.auth).toEqual({ type: 'noauth' });
   });
 
-  it('should handle missing token in bearer auth', () => {
-    const simpleCollection = {
-      items: [
-        {
-          name: 'Test Request',
-          type: 'http-request',
-          request: {
-            method: 'GET',
-            url: 'https://example.com',
-            auth: {
-              mode: 'bearer',
-              bearer: { token: null }
-            }
-          }
-        }
-      ]
-    };
-
-    const result = brunoToPostman(simpleCollection);
+  it('should export bearer auth as an array (Postman v2.1 schema)', () => {
+    const result = brunoToPostman(makeRequestWithAuth({
+      mode: 'bearer',
+      bearer: { token: 'my-token' }
+    }));
     expect(result.item[0].request.auth).toEqual({
       type: 'bearer',
-      bearer: {
-        key: 'token',
-        value: '',
-        type: 'string'
-      }
+      bearer: [
+        { key: 'token', value: 'my-token', type: 'string' }
+      ]
+    });
+  });
+
+  it('should handle missing token in bearer auth', () => {
+    const result = brunoToPostman(makeRequestWithAuth({
+      mode: 'bearer',
+      bearer: { token: null }
+    }));
+    expect(result.item[0].request.auth).toEqual({
+      type: 'bearer',
+      bearer: [
+        { key: 'token', value: '', type: 'string' }
+      ]
+    });
+  });
+
+  it('should export basic auth (password then username)', () => {
+    const result = brunoToPostman(makeRequestWithAuth({
+      mode: 'basic',
+      basic: { username: 'user', password: 'pass' }
+    }));
+    expect(result.item[0].request.auth).toEqual({
+      type: 'basic',
+      basic: [
+        { key: 'password', value: 'pass', type: 'string' },
+        { key: 'username', value: 'user', type: 'string' }
+      ]
     });
   });
 
   it('should handle missing username/password in basic auth', () => {
-    const simpleCollection = {
-      items: [
-        {
-          name: 'Test Request',
-          type: 'http-request',
-          request: {
-            method: 'GET',
-            url: 'https://example.com',
-            auth: {
-              mode: 'basic',
-              basic: { username: null, password: undefined }
-            }
-          }
-        }
-      ]
-    };
-
-    const result = brunoToPostman(simpleCollection);
+    const result = brunoToPostman(makeRequestWithAuth({
+      mode: 'basic',
+      basic: { username: null, password: undefined }
+    }));
     expect(result.item[0].request.auth).toEqual({
       type: 'basic',
       basic: [
-        {
-          key: 'password',
-          value: '',
-          type: 'string'
-        },
-        {
-          key: 'username',
-          value: '',
-          type: 'string'
-        }
+        { key: 'password', value: '', type: 'string' },
+        { key: 'username', value: '', type: 'string' }
       ]
     });
   });
 
-  it('should handle missing key/value in apikey auth', () => {
-    const simpleCollection = {
-      items: [
-        {
-          name: 'Test Request',
-          type: 'http-request',
-          request: {
-            method: 'GET',
-            url: 'https://example.com',
-            auth: {
-              mode: 'apikey',
-              apikey: { key: null, value: undefined }
-            }
+  it('should export awsv4 auth mapping Bruno field names to Postman', () => {
+    const result = brunoToPostman(makeRequestWithAuth({
+      mode: 'awsv4',
+      awsv4: {
+        accessKeyId: 'AKIA',
+        secretAccessKey: 'secret',
+        sessionToken: 'session',
+        service: 's3',
+        region: 'us-east-1'
+      }
+    }));
+    expect(result.item[0].request.auth).toEqual({
+      type: 'awsv4',
+      awsv4: [
+        { key: 'sessionToken', value: 'session', type: 'string' },
+        { key: 'service', value: 's3', type: 'string' },
+        { key: 'region', value: 'us-east-1', type: 'string' },
+        { key: 'secretKey', value: 'secret', type: 'string' },
+        { key: 'accessKey', value: 'AKIA', type: 'string' }
+      ]
+    });
+  });
+
+  it('should export digest auth (only username/password, Postman-only keys dropped)', () => {
+    const result = brunoToPostman(makeRequestWithAuth({
+      mode: 'digest',
+      digest: { username: 'user', password: 'pass' }
+    }));
+    expect(result.item[0].request.auth).toEqual({
+      type: 'digest',
+      digest: [
+        { key: 'password', value: 'pass', type: 'string' },
+        { key: 'username', value: 'user', type: 'string' }
+      ]
+    });
+  });
+
+  it('should export ntlm auth (username/password/domain)', () => {
+    const result = brunoToPostman(makeRequestWithAuth({
+      mode: 'ntlm',
+      ntlm: { username: 'user', password: 'pass', domain: 'CORP' }
+    }));
+    expect(result.item[0].request.auth).toEqual({
+      type: 'ntlm',
+      ntlm: [
+        { key: 'username', value: 'user', type: 'string' },
+        { key: 'password', value: 'pass', type: 'string' },
+        { key: 'domain', value: 'CORP', type: 'string' }
+      ]
+    });
+  });
+
+  describe('oauth1', () => {
+    it('should export oauth1 with HMAC signature (no privateKey emitted)', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth1',
+        oauth1: {
+          consumerKey: 'ck',
+          consumerSecret: 'cs',
+          accessToken: 'at',
+          accessTokenSecret: 'ats',
+          signatureMethod: 'HMAC-SHA1',
+          callbackUrl: 'https://cb',
+          verifier: 'v',
+          timestamp: '123',
+          nonce: 'n',
+          version: '1.0',
+          realm: 'r',
+          placement: 'header'
+        }
+      }));
+      expect(result.item[0].request.auth).toEqual({
+        type: 'oauth1',
+        oauth1: [
+          { key: 'consumerKey', value: 'ck', type: 'string' },
+          { key: 'consumerSecret', value: 'cs', type: 'string' },
+          { key: 'token', value: 'at', type: 'string' },
+          { key: 'tokenSecret', value: 'ats', type: 'string' },
+          { key: 'signatureMethod', value: 'HMAC-SHA1', type: 'string' },
+          { key: 'callback', value: 'https://cb', type: 'string' },
+          { key: 'verifier', value: 'v', type: 'string' },
+          { key: 'timestamp', value: '123', type: 'string' },
+          { key: 'nonce', value: 'n', type: 'string' },
+          { key: 'version', value: '1.0', type: 'string' },
+          { key: 'realm', value: 'r', type: 'string' },
+          { key: 'addParamsToHeader', value: true, type: 'boolean' },
+          { key: 'includeBodyHash', value: false, type: 'boolean' }
+        ]
+      });
+    });
+
+    it('should emit privateKey for RSA signature methods', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth1',
+        oauth1: {
+          signatureMethod: 'RSA-SHA256',
+          privateKeyType: 'text',
+          privateKey: '-----BEGIN PRIVATE KEY-----'
+        }
+      }));
+      const oauth1 = result.item[0].request.auth.oauth1;
+      expect(oauth1).toContainEqual({
+        key: 'privateKey',
+        value: '-----BEGIN PRIVATE KEY-----',
+        type: 'string'
+      });
+    });
+
+    it('should export an empty privateKey when RSA key is file-backed (no FS access on export)', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth1',
+        oauth1: {
+          signatureMethod: 'RSA-SHA1',
+          privateKeyType: 'file',
+          privateKey: './keys/private.pem'
+        }
+      }));
+      const oauth1 = result.item[0].request.auth.oauth1;
+      expect(oauth1).toContainEqual({ key: 'privateKey', value: '', type: 'string' });
+    });
+
+    it('should set addParamsToHeader=false when placement is query', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth1',
+        oauth1: { placement: 'query' }
+      }));
+      const oauth1 = result.item[0].request.auth.oauth1;
+      expect(oauth1).toContainEqual({ key: 'addParamsToHeader', value: false, type: 'boolean' });
+    });
+  });
+
+  describe('oauth2', () => {
+    it('should export authorization_code grant with pkce and map all fields', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth2',
+        oauth2: {
+          grantType: 'authorization_code',
+          pkce: true,
+          accessTokenUrl: 'https://token',
+          refreshTokenUrl: 'https://refresh',
+          authorizationUrl: 'https://auth',
+          callbackUrl: 'https://callback',
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+          scope: 'read write',
+          state: 'xyz',
+          credentialsId: 'my-token',
+          tokenPlacement: 'header',
+          tokenHeaderPrefix: 'Bearer',
+          credentialsPlacement: 'body',
+          username: 'user',
+          password: 'pass'
+        }
+      }));
+      expect(result.item[0].request.auth).toEqual({
+        type: 'oauth2',
+        oauth2: [
+          { key: 'grant_type', value: 'authorization_code_with_pkce', type: 'string' },
+          { key: 'accessTokenUrl', value: 'https://token', type: 'string' },
+          { key: 'refreshTokenUrl', value: 'https://refresh', type: 'string' },
+          { key: 'clientId', value: 'client-id', type: 'string' },
+          { key: 'clientSecret', value: 'client-secret', type: 'string' },
+          { key: 'scope', value: 'read write', type: 'string' },
+          { key: 'state', value: 'xyz', type: 'string' },
+          { key: 'tokenName', value: 'my-token', type: 'string' },
+          { key: 'addTokenTo', value: 'header', type: 'string' },
+          { key: 'headerPrefix', value: 'Bearer', type: 'string' },
+          { key: 'client_authentication', value: 'body', type: 'string' },
+          { key: 'authUrl', value: 'https://auth', type: 'string' },
+          { key: 'redirect_uri', value: 'https://callback', type: 'string' },
+          { key: 'username', value: 'user', type: 'string' },
+          { key: 'password', value: 'pass', type: 'string' }
+        ]
+      });
+    });
+
+    it('should map grant types (password -> password_credentials, authorization_code without pkce)', () => {
+      const passwordResult = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth2',
+        oauth2: { grantType: 'password' }
+      }));
+      expect(passwordResult.item[0].request.auth.oauth2).toContainEqual({
+        key: 'grant_type', value: 'password_credentials', type: 'string'
+      });
+
+      const authCodeResult = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth2',
+        oauth2: { grantType: 'authorization_code', pkce: false }
+      }));
+      expect(authCodeResult.item[0].request.auth.oauth2).toContainEqual({
+        key: 'grant_type', value: 'authorization_code', type: 'string'
+      });
+    });
+
+    it('should default unknown grant type to client_credentials and map url token placement to queryParams', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth2',
+        oauth2: { tokenPlacement: 'url' }
+      }));
+      const oauth2 = result.item[0].request.auth.oauth2;
+      expect(oauth2).toContainEqual({ key: 'grant_type', value: 'client_credentials', type: 'string' });
+      expect(oauth2).toContainEqual({ key: 'addTokenTo', value: 'queryParams', type: 'string' });
+    });
+
+    it('should filter out empty/null/undefined values from oauth2 params', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth2',
+        oauth2: {
+          grantType: 'client_credentials',
+          clientId: 'client-id',
+          clientSecret: '',
+          scope: null,
+          state: undefined
+        }
+      }));
+      const keys = result.item[0].request.auth.oauth2.map((p) => p.key);
+      expect(keys).toContain('clientId');
+      expect(keys).not.toContain('clientSecret');
+      expect(keys).not.toContain('scope');
+      expect(keys).not.toContain('state');
+    });
+
+    it('should map additionalParameters to request-params with send_as translation', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth2',
+        oauth2: {
+          grantType: 'authorization_code',
+          additionalParameters: {
+            authorization: [{ name: 'a', value: 'av', enabled: true, sendIn: 'headers' }],
+            token: [{ name: 't', value: 'tv', enabled: false, sendIn: 'queryparams' }],
+            refresh: [{ name: 'r', value: 'rv', enabled: true, sendIn: 'body' }]
           }
         }
-      ]
-    };
+      }));
+      const oauth2 = result.item[0].request.auth.oauth2;
+      expect(oauth2).toContainEqual({
+        key: 'authRequestParams',
+        value: [{ key: 'a', value: 'av', enabled: true, send_as: 'request_header' }],
+        type: 'any'
+      });
+      expect(oauth2).toContainEqual({
+        key: 'tokenRequestParams',
+        value: [{ key: 't', value: 'tv', enabled: false, send_as: 'request_url' }],
+        type: 'any'
+      });
+      expect(oauth2).toContainEqual({
+        key: 'refreshRequestParams',
+        value: [{ key: 'r', value: 'rv', enabled: true, send_as: 'request_body' }],
+        type: 'any'
+      });
+    });
 
-    const result = brunoToPostman(simpleCollection);
-    expect(result.item[0].request.auth).toEqual({
-      type: 'apikey',
-      apikey: [
-        {
-          key: 'key',
-          value: '',
-          type: 'string'
+    it('should not emit request-params keys when additionalParameters are absent', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'oauth2',
+        oauth2: { grantType: 'client_credentials' }
+      }));
+      const keys = result.item[0].request.auth.oauth2.map((p) => p.key);
+      expect(keys).not.toContain('authRequestParams');
+      expect(keys).not.toContain('tokenRequestParams');
+      expect(keys).not.toContain('refreshRequestParams');
+    });
+  });
+
+  describe('apikey', () => {
+    it('should map queryparams placement to in: query', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'apikey',
+        apikey: { key: 'X-API-Key', value: 'secret', placement: 'queryparams' }
+      }));
+      expect(result.item[0].request.auth).toEqual({
+        type: 'apikey',
+        apikey: [
+          { key: 'key', value: 'X-API-Key', type: 'string' },
+          { key: 'value', value: 'secret', type: 'string' },
+          { key: 'in', value: 'query', type: 'string' }
+        ]
+      });
+    });
+
+    it('should map header placement to in: header', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'apikey',
+        apikey: { key: 'X-API-Key', value: 'secret', placement: 'header' }
+      }));
+      expect(result.item[0].request.auth.apikey).toContainEqual({ key: 'in', value: 'header', type: 'string' });
+    });
+
+    it('should default to in: header when placement is missing', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'apikey',
+        apikey: { key: 'X-API-Key', value: 'secret' }
+      }));
+      expect(result.item[0].request.auth.apikey).toContainEqual({ key: 'in', value: 'header', type: 'string' });
+    });
+
+    it('should handle missing key/value in apikey auth', () => {
+      const result = brunoToPostman(makeRequestWithAuth({
+        mode: 'apikey',
+        apikey: { key: null, value: undefined }
+      }));
+      expect(result.item[0].request.auth).toEqual({
+        type: 'apikey',
+        apikey: [
+          { key: 'key', value: '', type: 'string' },
+          { key: 'value', value: '', type: 'string' },
+          { key: 'in', value: 'header', type: 'string' }
+        ]
+      });
+    });
+  });
+
+  describe('default / noauth', () => {
+    it('should return noauth for a request with an unknown/none auth mode', () => {
+      const result = brunoToPostman(makeRequestWithAuth({ mode: 'none' }));
+      expect(result.item[0].request.auth).toEqual({ type: 'noauth' });
+    });
+  });
+
+  describe('collection-level auth', () => {
+    it('should export collection-level auth from root.request.auth', () => {
+      const collection = {
+        root: {
+          request: {
+            auth: { mode: 'bearer', bearer: { token: 'collection-token' } }
+          }
         },
-        {
-          key: 'value',
-          value: '',
-          type: 'string'
-        }
-      ]
+        items: []
+      };
+      const result = brunoToPostman(collection);
+      expect(result.auth).toEqual({
+        type: 'bearer',
+        bearer: [
+          { key: 'token', value: 'collection-token', type: 'string' }
+        ]
+      });
+    });
+
+    it('should leave collection auth undefined (not noauth) when the collection has no auth', () => {
+      const collection = { items: [] };
+      const result = brunoToPostman(collection);
+      expect(result.auth).toBeUndefined();
+    });
+
+    it('should leave collection auth undefined for inherit mode', () => {
+      const collection = {
+        root: { request: { auth: { mode: 'inherit' } } },
+        items: []
+      };
+      const result = brunoToPostman(collection);
+      expect(result.auth).toBeUndefined();
     });
   });
 });

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/collection-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/collection-auth.spec.js
@@ -40,7 +40,8 @@ describe('Collection Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -100,7 +101,8 @@ describe('Collection Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -154,7 +156,8 @@ describe('Collection Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -214,7 +217,8 @@ describe('Collection Authentication', () => {
       },
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -278,7 +282,8 @@ describe('Collection Authentication', () => {
       digest: {
         username: 'digest auth',
         password: 'digest auth'
-      }
+      },
+      ntlm: null
     });
   });
   it('should handle missing auth values when auth.type exists', async () => {
@@ -325,7 +330,8 @@ describe('Collection Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -372,7 +378,8 @@ describe('Collection Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 });

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/folder-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/folder-auth.spec.js
@@ -59,7 +59,8 @@ describe('Folder Authentication', () => {
       apikey: null,
       oauth2: null,
       digest: null,
-      oauth1: null
+      oauth1: null,
+      ntlm: null
     });
   });
 
@@ -123,7 +124,8 @@ describe('Folder Authentication', () => {
       apikey: null,
       oauth2: null,
       digest: null,
-      oauth1: null
+      oauth1: null,
+      ntlm: null
     });
   });
 
@@ -187,7 +189,8 @@ describe('Folder Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -243,7 +246,8 @@ describe('Folder Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -304,7 +308,8 @@ describe('Folder Authentication', () => {
       apikey: { key: 'apikey', value: 'apikey', placement: 'header' },
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -370,7 +375,8 @@ describe('Folder Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: { username: 'digest user', password: 'digest pass' }
+      digest: { username: 'digest user', password: 'digest pass' },
+      ntlm: null
     });
   });
 
@@ -423,7 +429,8 @@ describe('Folder Authentication', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 });

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
@@ -413,7 +413,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
 
     // Request should inherit auth mode
@@ -425,7 +426,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -470,7 +472,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -516,7 +519,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
 
     // Request should inherit auth mode
@@ -528,7 +532,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -573,7 +578,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
 
     // Request auth should default to 'none'
@@ -585,7 +591,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -635,7 +642,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
 
     // Request should inherit auth mode
@@ -647,7 +655,8 @@ describe('postman-collection', () => {
       apikey: null,
       oauth1: null,
       oauth2: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -1452,7 +1461,8 @@ const expectedOutput = {
               apikey: null,
               oauth1: null,
               oauth2: null,
-              digest: null
+              digest: null,
+              ntlm: null
             },
             headers: [],
             params: [],
@@ -1482,7 +1492,8 @@ const expectedOutput = {
             apikey: null,
             oauth1: null,
             oauth2: null,
-            digest: null
+            digest: null,
+            ntlm: null
           },
           headers: [],
           script: {},
@@ -1507,7 +1518,8 @@ const expectedOutput = {
           apikey: null,
           oauth1: null,
           oauth2: null,
-          digest: null
+          digest: null,
+          ntlm: null
         },
         headers: [],
         params: [],
@@ -1538,7 +1550,8 @@ const expectedOutput = {
         apikey: null,
         oauth1: null,
         oauth2: null,
-        digest: null
+        digest: null,
+        ntlm: null
       },
       headers: [],
       script: {},

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/process-auth.spec.js
@@ -13,7 +13,8 @@ describe('processAuth', () => {
         apikey: null,
         oauth1: null,
         oauth2: null,
-        digest: null
+        digest: null,
+        ntlm: null
       }
     };
   });
@@ -247,6 +248,69 @@ describe('processAuth', () => {
     });
   });
 
+  it('should handle ntlm auth', () => {
+    const auth = {
+      type: 'ntlm',
+      ntlm: {
+        username: 'testuser',
+        password: 'testpass',
+        domain: 'testdomain'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('ntlm');
+    expect(requestObject.auth.ntlm).toEqual({
+      username: 'testuser',
+      password: 'testpass',
+      domain: 'testdomain'
+    });
+  });
+
+  it('should handle ntlm auth with v2.1 array format', () => {
+    const auth = {
+      type: 'ntlm',
+      ntlm: [
+        { key: 'username', value: 'testuser', type: 'string' },
+        { key: 'password', value: 'testpass', type: 'string' },
+        { key: 'domain', value: 'testdomain', type: 'string' }
+      ]
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('ntlm');
+    expect(requestObject.auth.ntlm).toEqual({
+      username: 'testuser',
+      password: 'testpass',
+      domain: 'testdomain'
+    });
+  });
+
+  it('should handle ntlm auth with missing values', () => {
+    const auth = {
+      type: 'ntlm',
+      ntlm: {}
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('ntlm');
+    expect(requestObject.auth.ntlm).toEqual({
+      username: '',
+      password: '',
+      domain: ''
+    });
+  });
+
+  it('should handle ntlm auth with missing ntlm key', () => {
+    const auth = {
+      type: 'ntlm'
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('ntlm');
+    expect(requestObject.auth.ntlm).toEqual({
+      username: '',
+      password: '',
+      domain: ''
+    });
+  });
+
   it('should handle oauth2 auth with authorization_code grant type', () => {
     const auth = {
       type: 'oauth2',
@@ -261,7 +325,8 @@ describe('processAuth', () => {
         scope: 'test-scope',
         state: 'test-state',
         addTokenTo: 'header',
-        client_authentication: 'body'
+        client_authentication: 'body',
+        tokenName: 'test-token-name'
       }
     };
     processAuth(auth, requestObject);
@@ -280,7 +345,8 @@ describe('processAuth', () => {
       tokenPlacement: 'header',
       tokenHeaderPrefix: '',
       tokenQueryKey: 'access_token',
-      credentialsPlacement: 'body'
+      credentialsPlacement: 'body',
+      credentialsId: 'test-token-name'
     });
   });
 
@@ -298,7 +364,8 @@ describe('processAuth', () => {
         scope: 'test-scope',
         state: 'test-state',
         addTokenTo: 'header',
-        client_authentication: 'body'
+        client_authentication: 'body',
+        tokenName: 'test-token-name'
       }
     };
     processAuth(auth, requestObject);
@@ -316,7 +383,8 @@ describe('processAuth', () => {
       tokenPlacement: 'header',
       tokenHeaderPrefix: '',
       tokenQueryKey: 'access_token',
-      credentialsPlacement: 'body'
+      credentialsPlacement: 'body',
+      credentialsId: 'test-token-name'
     });
   });
 
@@ -332,7 +400,8 @@ describe('processAuth', () => {
         scope: 'test-scope',
         state: 'test-state',
         addTokenTo: 'header',
-        client_authentication: 'body'
+        client_authentication: 'body',
+        tokenName: 'test-token-name'
       }
     };
     processAuth(auth, requestObject);
@@ -348,7 +417,8 @@ describe('processAuth', () => {
       tokenPlacement: 'header',
       tokenHeaderPrefix: '',
       tokenQueryKey: 'access_token',
-      credentialsPlacement: 'body'
+      credentialsPlacement: 'body',
+      credentialsId: 'test-token-name'
     });
   });
 
@@ -370,7 +440,8 @@ describe('processAuth', () => {
       tokenPlacement: 'url',
       tokenHeaderPrefix: '',
       tokenQueryKey: 'access_token',
-      credentialsPlacement: 'basic_auth_header'
+      credentialsPlacement: 'basic_auth_header',
+      credentialsId: ''
     });
   });
 
@@ -391,7 +462,8 @@ describe('processAuth', () => {
       tokenPlacement: 'url',
       tokenHeaderPrefix: '',
       tokenQueryKey: 'access_token',
-      credentialsPlacement: 'basic_auth_header'
+      credentialsPlacement: 'basic_auth_header',
+      credentialsId: ''
     });
   });
 
@@ -409,7 +481,8 @@ describe('processAuth', () => {
         scope: 'test-scope',
         state: 'test-state',
         addTokenTo: 'header',
-        client_authentication: 'body'
+        client_authentication: 'body',
+        tokenName: 'test-token-name'
       }
     };
     processAuth(auth, requestObject);
@@ -428,7 +501,8 @@ describe('processAuth', () => {
       tokenPlacement: 'header',
       tokenHeaderPrefix: '',
       tokenQueryKey: 'access_token',
-      credentialsPlacement: 'body'
+      credentialsPlacement: 'body',
+      credentialsId: 'test-token-name'
     });
   });
 
@@ -448,7 +522,8 @@ describe('processAuth', () => {
         addTokenTo: 'header',
         tokenHeaderPrefix: 'Bearer',
         tokenQueryKey: '',
-        client_authentication: 'body'
+        client_authentication: 'body',
+        tokenName: 'test-token-name'
       }
     };
     processAuth(auth, requestObject);
@@ -466,8 +541,101 @@ describe('processAuth', () => {
       tokenPlacement: 'header',
       tokenHeaderPrefix: '',
       tokenQueryKey: 'access_token',
-      credentialsPlacement: 'body'
+      credentialsPlacement: 'body',
+      credentialsId: 'test-token-name'
     });
+  });
+
+  it('should map oauth2 additionalParameters for authorization/token/refresh with send_as placements', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'authorization_code',
+        authUrl: 'https://auth.example.com',
+        redirect_uri: 'https://callback.example.com',
+        accessTokenUrl: 'https://token.example.com',
+        clientId: 'test-client-id',
+        authRequestParams: [{ key: 'audience', value: 'https://api.example.com', send_as: 'request_url', enabled: true }],
+        tokenRequestParams: [{ key: 'resource', value: 'res-1', send_as: 'request_body' }],
+        refreshRequestParams: [{ key: 'x-refresh', value: 'r-1', send_as: 'request_header', enabled: false }]
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.mode).toBe('oauth2');
+    expect(requestObject.auth.oauth2.additionalParameters).toEqual({
+      authorization: [{ name: 'audience', value: 'https://api.example.com', sendIn: 'queryparams', enabled: true }],
+      token: [{ name: 'resource', value: 'res-1', sendIn: 'body', enabled: true }],
+      refresh: [{ name: 'x-refresh', value: 'r-1', sendIn: 'headers', enabled: false }]
+    });
+  });
+
+  it('should default additionalParameters sendIn to headers and enabled to true when unspecified', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'client_credentials',
+        accessTokenUrl: 'https://token.example.com',
+        tokenRequestParams: [
+          { key: 'a', value: '1' }, // no send_as, no enabled
+          { key: 'b', value: '2', send_as: 'unknown_placement' } // unrecognized send_as
+        ]
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.oauth2.additionalParameters).toEqual({
+      token: [
+        { name: 'a', value: '1', sendIn: 'headers', enabled: true },
+        { name: 'b', value: '2', sendIn: 'headers', enabled: true }
+      ]
+    });
+  });
+
+  it('should only include the additionalParameters keys that are present in the auth', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'client_credentials',
+        accessTokenUrl: 'https://token.example.com',
+        tokenRequestParams: [{ key: 'scope_extra', value: 'x', send_as: 'request_body' }]
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.oauth2.additionalParameters).toEqual({
+      token: [{ name: 'scope_extra', value: 'x', sendIn: 'body', enabled: true }]
+    });
+    expect(requestObject.auth.oauth2.additionalParameters).not.toHaveProperty('authorization');
+    expect(requestObject.auth.oauth2.additionalParameters).not.toHaveProperty('refresh');
+  });
+
+  it('should inject an empty authorization array for authorization_code grant when only other params are present', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'authorization_code_with_pkce',
+        authUrl: 'https://auth.example.com',
+        redirect_uri: 'https://callback.example.com',
+        accessTokenUrl: 'https://token.example.com',
+        tokenRequestParams: [{ key: 'foo', value: 'bar', send_as: 'request_header' }]
+      }
+    };
+    processAuth(auth, requestObject);
+    // targetGrantType maps to 'authorization_code', whose schema requires an authorization array
+    expect(requestObject.auth.oauth2.additionalParameters).toEqual({
+      token: [{ name: 'foo', value: 'bar', sendIn: 'headers', enabled: true }],
+      authorization: []
+    });
+  });
+
+  it('should omit additionalParameters entirely when no request-param arrays are present', () => {
+    const auth = {
+      type: 'oauth2',
+      oauth2: {
+        grant_type: 'client_credentials',
+        accessTokenUrl: 'https://token.example.com'
+      }
+    };
+    processAuth(auth, requestObject);
+    expect(requestObject.auth.oauth2).not.toHaveProperty('additionalParameters');
   });
 
   it('should handle auth object with undefined type', () => {

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/request-auth.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/request-auth.spec.js
@@ -39,7 +39,8 @@ describe('Request Authentication', () => {
       apikey: null,
       oauth2: null,
       oauth1: null,
-      digest: null
+      digest: null,
+      ntlm: null
     });
   });
 
@@ -79,7 +80,8 @@ describe('Request Authentication', () => {
       apikey: null,
       oauth2: null,
       digest: null,
-      oauth1: null
+      oauth1: null,
+      ntlm: null
     });
   });
 
@@ -120,7 +122,8 @@ describe('Request Authentication', () => {
       apikey: null,
       oauth2: null,
       digest: null,
-      oauth1: null
+      oauth1: null,
+      ntlm: null
     });
   });
 
@@ -161,12 +164,12 @@ describe('Request Authentication', () => {
     // Check folder first
     expect(result.items[0].root.request.auth).toEqual({
       mode: 'inherit',
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
     // Then check request
     expect(result.items[0].items[0].request.auth).toEqual({
       mode: 'inherit',
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
   });
 
@@ -209,7 +212,8 @@ describe('Request Authentication', () => {
       apikey: null,
       oauth2: null,
       digest: null,
-      oauth1: null
+      oauth1: null,
+      ntlm: null
     });
   });
 
@@ -255,19 +259,19 @@ describe('Request Authentication', () => {
     // Check Folder Level 1
     expect(result.items[0].root.request.auth).toEqual({
       mode: 'inherit',
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
 
     // Check Folder Level 2
     expect(result.items[0].items[0].root.request.auth).toEqual({
       mode: 'inherit',
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
 
     // Check the Request
     expect(result.items[0].items[0].items[0].request.auth).toEqual({
       mode: 'inherit',
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
   });
 
@@ -318,19 +322,19 @@ describe('Request Authentication', () => {
       mode: 'bearer',
       basic: null,
       bearer: { token: 'folder1Token' }, // Explicitly set
-      awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
 
     // Check Folder Level 2
     expect(result.items[0].items[0].root.request.auth).toEqual({
       mode: 'inherit', // Inherits from Folder 1
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
 
     // Check the Request
     expect(result.items[0].items[0].items[0].request.auth).toEqual({
       mode: 'inherit', // Inherits from Folder 1
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
   });
 
@@ -376,6 +380,7 @@ describe('Request Authentication', () => {
       apikey: null,
       oauth2: null,
       digest: null,
+      ntlm: null,
       oauth1: {
         consumerKey: 'consumer_key',
         consumerSecret: 'consumer_secret',
@@ -565,19 +570,19 @@ describe('Request Authentication', () => {
     // Check Folder Level 1
     expect(result.items[0].root.request.auth).toEqual({
       mode: 'none', // Explicitly "No Auth"
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
 
     // Check Folder Level 2
     expect(result.items[0].items[0].root.request.auth).toEqual({
       mode: 'inherit', // Inherits from Folder 1
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
 
     // Check the Request
     expect(result.items[0].items[0].items[0].request.auth).toEqual({
       mode: 'inherit', // Inherits from Folder 1
-      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null
+      basic: null, bearer: null, awsv4: null, apikey: null, oauth2: null, digest: null, oauth1: null, ntlm: null
     });
   });
 


### PR DESCRIPTION
### Tickets Addressed

#### JIRA
Bruno to Postman Export: OAuth2, AWS, Digest, OAuth1 Auth Lost - BRU-3121
Postman Import: NTLM Auth Not Mapped - BRU-3114
Exporting Bruno collection to Postman format loses authentication settings - BRU-3680

#### Github
#8411 

### Description

Bruno to Postman converter currently loses auth settings for the following auth types - Bearer, OAuth2, OAuth1, AWS Signature V4, Digest, NTLM. Auth type - inherit when imported in postman is mapped to "No Auth".
Postman to Bruno converter currently doesnt parse "authRequestParams", "tokenRequestParams", and "refreshRequestParams". NTLM settings is also not processed.

This PR aims to fix the above issues and add sufficient unit test cases for the same. The round trip test case for Bruno to postman is added in this PR #8534 

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NTLM authentication support to Postman-to-Bruno conversion.
  * Enhanced auth conversion coverage across more modes, including OAuth1 signature handling and OAuth2 grant/additional-parameter mapping.

* **Bug Fixes**
  * Refined Bruno-to-Postman auth export to correctly represent inherit/noauth at request, folder, and collection levels.
  * Normalized credential value formatting and API key placement mapping for Postman compatibility.

* **Tests**
  * Expanded and reorganized auth test suites for both directions, updating expected auth shapes (including added null fields where applicable).

* **Chores**
  * Added a shared value-to-string normalizer for consistent auth serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->