### PR TITLE
fix(ai): prevent AI preferences panel clipping and enforce min-height…

### DIFF
--- a/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
@@ -105,6 +105,7 @@ export const PopupWrapper = styled.div`
     background: ${(props) => props.theme.input.bg};
     color: ${(props) => props.theme.text};
     resize: vertical;
+    min-height: calc(3 * 1.4em + 18px);
     outline: none;
     transition: border-color 0.15s ease;
 

--- a/packages/bruno-app/src/components/Preferences/AI/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/AI/StyledWrapper.js
@@ -41,6 +41,8 @@ const StyledWrapper = styled.div`
     display: flex;
     flex-direction: column;
     min-height: 0;
+    overflow-y: auto;
+    padding-bottom: 2rem;
   }
 
   .ai-master {


### PR DESCRIPTION
[JIRA](https://usebruno.atlassian.net/browse/BRU-3730)

### Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Issue 1: Preference - AI - clipping at the bottom
<img width="1591" height="1091" alt="Screenshot 2026-07-06 164243-20260706-111243" src="https://github.com/user-attachments/assets/c3cf320d-30af-4e66-a71d-fa723253130b" />

Issue 2: Generate test ai panel
<img width="440" height="288" alt="Screenshot 2026-07-06 at 5 29 20 PM" src="https://github.com/user-attachments/assets/d17c1584-a067-49a6-a183-540ac304701a" />

