### PR TITLE
test(OpenWorkspace): Automation script for Open workspace

### DIFF
--- a/tests/utils/page/toast.ts
+++ b/tests/utils/page/toast.ts
@@ -1,0 +1,9 @@
+import { Page } from '../../../playwright';
+
+/**
+ * Toast (react-hot-toast) locators, parameterised by message.
+ */
+export const buildToastLocators = (page: Page) => ({
+  byMessage: (message: string) => page.getByText(message),
+  confirmTextContent: (text: string) => page.getByText(text, { exact: true })
+});

--- a/tests/utils/page/workspace/open-workspace.ts
+++ b/tests/utils/page/workspace/open-workspace.ts
@@ -3,12 +3,8 @@ import { ElectronApplication, Page, test } from '../../../../playwright';
 import { buildCommonLocators } from '../locators';
 import { buildTitleBarLocators } from '../title-bar';
 
-export const initUserDataPath = path.join(__dirname, '../../../workspace/create-workspace/init-user-data');
+export const initUserDataPath = path.join(__dirname, '../../../workspace/open-workspace/init-user-data');
 export const WORKSPACE_NAME = 'my-workspace';
-
-export const buildOpenWorkspaceLocators = (page: Page) => ({
-  confirmTextContent: () => page.getByText('Workspace opened successfully', { exact: true })
-});
 
 type OpenWorkspaceDialogOptions = {
   canceled: boolean;

--- a/tests/utils/page/workspace/open-workspace.ts
+++ b/tests/utils/page/workspace/open-workspace.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import { ElectronApplication, Page, test } from '../../../../playwright';
+import { buildCommonLocators } from '../locators';
+import { buildTitleBarLocators } from '../title-bar';
+
+export const initUserDataPath = path.join(__dirname, '../../../workspace/create-workspace/init-user-data');
+export const WORKSPACE_NAME = 'my-workspace';
+
+export const buildOpenWorkspaceLocators = (page: Page) => ({
+  confirmTextContent: () => page.getByText('Workspace opened successfully', { exact: true })
+});
+
+type OpenWorkspaceDialogOptions = {
+  canceled: boolean;
+  filePaths: string[];
+};
+
+export const stubElectronOpenDialog = async (
+  app: ElectronApplication,
+  options: OpenWorkspaceDialogOptions
+) => {
+  await app.evaluate(({ dialog }, { canceled, filePaths }) => {
+    (dialog as { showOpenDialog: typeof dialog.showOpenDialog }).showOpenDialog = () =>
+      Promise.resolve({ canceled, filePaths });
+  }, options);
+};
+
+export const triggerOpenWorkspaceFromMenu = async (page: Page) => {
+  const commLocators = buildCommonLocators(page);
+  const titleBarLocators = buildTitleBarLocators(page);
+  await test.step('Open Workspace from My Workspace menu', async () => {
+    await titleBarLocators.workspaceMenuTrigger().click();
+    await commLocators.dropdown.item('Open workspace').click();
+  });
+};
+
+type OpenWorkspaceOptions = OpenWorkspaceDialogOptions & {
+  app: ElectronApplication;
+};
+
+export const openWorkspaceFromMenu = async (page: Page, opts: OpenWorkspaceOptions) => {
+  await stubElectronOpenDialog(opts.app, { canceled: opts.canceled, filePaths: opts.filePaths });
+  await triggerOpenWorkspaceFromMenu(page);
+};

--- a/tests/workspace/open-workspace/init-user-data/preferences.json
+++ b/tests/workspace/open-workspace/init-user-data/preferences.json
@@ -1,0 +1,11 @@
+{
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    },
+    "general": {
+      "defaultLocation": "{{wsLocation}}"
+    }
+  }
+}

--- a/tests/workspace/open-workspace/open-workspace.spec.ts
+++ b/tests/workspace/open-workspace/open-workspace.spec.ts
@@ -3,11 +3,11 @@ import { expect, test } from '../../../playwright';
 import { createWorkspace, switchWorkspace, waitForReadyPage } from '../../utils/page';
 import {
   WORKSPACE_NAME,
-  buildOpenWorkspaceLocators,
   initUserDataPath,
   openWorkspaceFromMenu
 } from '../../utils/page/workspace/open-workspace';
 import { buildTitleBarLocators } from '../../utils/page/title-bar';
+import { buildToastLocators } from '../../utils/page/toast';
 
 test.describe('Open Workspace', () => {
   test('TC-3213: Verify that clicking the cancel button closes the dialog on open workspace', { tag: '@sanity' }, async ({
@@ -39,7 +39,7 @@ test.describe('Open Workspace', () => {
       templateVars: { wsLocation }
     });
     const page = await waitForReadyPage(app);
-    const locators = buildOpenWorkspaceLocators(page);
+    const toastLocators = buildToastLocators(page);
     const titleBarLocators = buildTitleBarLocators(page);
 
     await test.step('Create a workspace and switch back to My Workspace', async () => {
@@ -53,7 +53,7 @@ test.describe('Open Workspace', () => {
     });
 
     await test.step('Verify workspace opened successfully', async () => {
-      await expect(locators.confirmTextContent()).toBeVisible();
+      await expect(toastLocators.confirmTextContent('Workspace opened successfully')).toBeVisible();
       await expect(titleBarLocators.activeWorkspaceName()).toHaveText(WORKSPACE_NAME);
     });
   });

--- a/tests/workspace/open-workspace/open-workspace.spec.ts
+++ b/tests/workspace/open-workspace/open-workspace.spec.ts
@@ -1,38 +1,60 @@
-import type { ElectronApplication } from '@playwright/test';
+import path from 'path';
 import { expect, test } from '../../../playwright';
-import { buildCommonLocators, waitForReadyPage } from '../../utils/page';
+import { createWorkspace, switchWorkspace, waitForReadyPage } from '../../utils/page';
+import {
+  WORKSPACE_NAME,
+  buildOpenWorkspaceLocators,
+  initUserDataPath,
+  openWorkspaceFromMenu
+} from '../../utils/page/workspace/open-workspace';
+import { buildTitleBarLocators } from '../../utils/page/title-bar';
 
 test.describe('Open Workspace', () => {
-  test('click on cancel button, should just close the dialog', async ({
+  test('TC-3213: Verify that clicking the cancel button closes the dialog on open workspace', { tag: '@sanity' }, async ({
     launchElectronApp,
     createTmpDir
   }) => {
     const userDataPath = await createTmpDir('open-workspace-cancel');
-
-    let app: ElectronApplication = await launchElectronApp({ userDataPath });
+    const app = await launchElectronApp({ userDataPath });
     const page = await waitForReadyPage(app);
-    const locators = buildCommonLocators(page);
+    const titleBarLocators = buildTitleBarLocators(page);
+    const initialWorkspaceName = await titleBarLocators.activeWorkspaceName().textContent();
 
-    const initialWorkspaceName = await page
-      .getByTestId('workspace-name')
-      .textContent();
-
-    await app.evaluate(({ dialog }) => {
-      (
-        dialog as { showOpenDialog: typeof dialog.showOpenDialog }
-      ).showOpenDialog = () =>
-        Promise.resolve({ canceled: true, filePaths: [] });
+    await test.step('Open workspace dialog and click on cancel', async () => {
+      await openWorkspaceFromMenu(page, { app, canceled: true, filePaths: [] });
     });
 
-    await test.step('Open the workspace menu and click "Open workspace"', async () => {
-      await page.getByTestId('workspace-menu').click();
-      await locators.dropdown.item('Open workspace').click();
-    });
-
-    await test.step('Workspace unchanged after canceling the dialog', async () => {
+    await test.step('Verify the active workspace remains unchanged', async () => {
       expect(initialWorkspaceName).not.toBeNull();
-      const workspaceName = initialWorkspaceName as string;
-      await expect(page.getByTestId('workspace-name')).toHaveText(workspaceName);
+      await expect(titleBarLocators.activeWorkspaceName()).toHaveText(initialWorkspaceName as string);
+    });
+  });
+
+  test('TC-1011: Verify the open Workspace from the device', { tag: '@sanity' }, async ({ launchElectronApp, createTmpDir }) => {
+    const wsLocation = await createTmpDir('ws-location');
+    const userDataPath = await createTmpDir('open-workspace');
+    const app = await launchElectronApp({
+      initUserDataPath,
+      userDataPath,
+      templateVars: { wsLocation }
+    });
+    const page = await waitForReadyPage(app);
+    const locators = buildOpenWorkspaceLocators(page);
+    const titleBarLocators = buildTitleBarLocators(page);
+
+    await test.step('Create a workspace and switch back to My Workspace', async () => {
+      await createWorkspace(page, WORKSPACE_NAME);
+      await switchWorkspace(page, 'My Workspace');
+    });
+
+    const workspacePath = path.join(wsLocation, WORKSPACE_NAME);
+    await test.step('Open the workspace from the device', async () => {
+      await openWorkspaceFromMenu(page, { app, canceled: false, filePaths: [workspacePath] });
+    });
+
+    await test.step('Verify workspace opened successfully', async () => {
+      await expect(locators.confirmTextContent()).toBeVisible();
+      await expect(titleBarLocators.activeWorkspaceName()).toHaveText(WORKSPACE_NAME);
     });
   });
 });


### PR DESCRIPTION
https://usebruno.atlassian.net/browse/BRU-3627

### Description
This JIRA ticket is about adding the sanity test cases automation script for Open workspace


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for opening workspaces.
  * Verified canceling the workspace picker leaves the active workspace unchanged.
  * Added coverage confirming a workspace opens successfully, displays a confirmation message, and updates the active workspace name.
  * Improved test reliability through consistent workspace setup and dialog handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->