### PR TITLE
fix(graphql):tooltip font size matches the code editor preference

### DIFF
--- a/packages/bruno-app/src/pages/Bruno/index.js
+++ b/packages/bruno-app/src/pages/Bruno/index.js
@@ -59,6 +59,7 @@ require('codemirror-graphql/mode');
 require('utils/codemirror/brunoVarInfo');
 require('utils/codemirror/javascript-lint');
 require('utils/codemirror/autocomplete');
+require('utils/codemirror/codeMirrorInfo');
 
 const TransientRequestModalsRenderer = ({ modals }) => {
   if (modals.length === 0) {

--- a/packages/bruno-app/src/utils/codemirror/codeMirrorInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/codeMirrorInfo.js
@@ -1,0 +1,34 @@
+import get from 'lodash/get';
+import store from 'providers/ReduxStore';
+
+const DEFAULT_CODE_FONT_SIZE = 13;
+
+const styleTag = document.createElement('style');
+document.head.appendChild(styleTag);
+
+let lastFontSize;
+
+const updateCodeMirrorInfoFontSize = () => {
+  const fontSize = Number(get(store.getState(), 'app.preferences.font.codeFontSize', DEFAULT_CODE_FONT_SIZE));
+  if (fontSize === lastFontSize) return;
+  lastFontSize = fontSize;
+
+  const headerFontSize = fontSize;
+  const descriptionFontSize = Math.max(fontSize - 1, 1);
+  styleTag.innerHTML = `
+    .CodeMirror-info { font-size: ${fontSize}px !important; }
+    .CodeMirror-info .CodeMirror-info-header > .type-name,
+    .CodeMirror-info .CodeMirror-info-header > .field-name,
+    .CodeMirror-info .CodeMirror-info-header > .arg-name,
+    .CodeMirror-info .CodeMirror-info-header > .directive-name,
+    .CodeMirror-info .CodeMirror-info-header > .enum-value {
+      font-size: ${headerFontSize}px !important;
+    }
+    .CodeMirror-info .info-description {
+      font-size: ${descriptionFontSize}px !important;
+    }
+  `;
+};
+
+updateCodeMirrorInfoFontSize();
+store.subscribe(updateCodeMirrorInfoFontSize);


### PR DESCRIPTION
### Description
[JIRA](https://usebruno.atlassian.net/browse/BRU-3691)
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

The tooltip font size is consistent with the code editor font preference

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the display of CodeMirror “info” panels with font sizing that now follows your editor font preference.
  * Font sizes update dynamically at runtime when the preference changes, keeping the editor UI consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->