### PR TITLE
fix(ai-assist): prevent double border and gap shift on AI generate bu…

### DIFF
--- a/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
@@ -5,6 +5,9 @@ const StyledWrapper = styled.div`
   top: 6px;
   right: 6px;
   z-index: 10;
+  background: ${(props) => props.theme.bg};
+  border: 1px solid ${(props) => props.theme.input.border};
+  border-radius: ${(props) => props.theme.border.radius.sm};
 
   .ai-assist-trigger {
     display: inline-flex;
@@ -13,11 +16,11 @@ const StyledWrapper = styled.div`
     width: 24px;
     height: 24px;
     border-radius: ${(props) => props.theme.border.radius.sm};
-    border: 1px solid transparent;
+    border: none;
     background: transparent;
     color: ${(props) => props.theme.colors.text.muted};
     cursor: pointer;
-    transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+    transition: color 0.15s ease, background-color 0.15s ease;
     opacity: 0.7;
 
     &:hover,
@@ -25,7 +28,6 @@ const StyledWrapper = styled.div`
       opacity: 1;
       color: ${(props) => props.theme.colors.accent};
       background: ${(props) => props.theme.colors.accent}10;
-      border-color: ${(props) => props.theme.input.border};
     }
 
     &:focus-visible {


### PR DESCRIPTION

[JIRA](https://usebruno.atlassian.net/browse/BRU-3748)
### Description

#### Problem
The AI Generate button becomes hidden when the response pane is expanded, making it inaccessible to users.


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the AI Assist trigger and wrapper styling to better match the current theme.
  * Improved background, border, and corner styling for a cleaner look.
  * Simplified hover and open-state behavior by refining visual transitions and removing border changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->