### PR TITLE
fix(ai): align AI preference tab with theme styling

### DIFF
--- a/packages/bruno-app/src/components/Preferences/AI/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/AI/StyledWrapper.js
@@ -12,11 +12,10 @@ const StyledWrapper = styled.div`
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 7px 12px;
+    padding: 6px 0px;
+    margin-right: ${(props) => props.theme.tabs.marginRight};
     margin-bottom: -1px;
-    font-size: 12px;
-    font-weight: 500;
-    color: ${(props) => props.theme.colors.text.muted};
+    color: ${(props) => props.theme.colors.text.subtext0};
     background: transparent;
     border: none;
     border-bottom: 2px solid transparent;
@@ -24,12 +23,13 @@ const StyledWrapper = styled.div`
     transition: color 0.15s ease, border-color 0.15s ease;
 
     &:hover:not(.active) {
-      color: ${(props) => props.theme.text};
+      color: ${(props) => props.theme.tabs.active.color};
     }
 
     &.active {
-      color: ${(props) => props.theme.text};
-      border-bottom-color: ${(props) => props.theme.colors.accent};
+      color: ${(props) => props.theme.tabs.active.color};
+      font-weight: ${(props) => props.theme.tabs.active.fontWeight};
+      border-bottom-color: ${(props) => props.theme.tabs.active.border};
     }
 
     svg {

--- a/packages/bruno-app/src/components/Preferences/AI/index.js
+++ b/packages/bruno-app/src/components/Preferences/AI/index.js
@@ -289,7 +289,7 @@ const AI = () => {
     <StyledWrapper className="w-full flex flex-col text-xs min-h-0 max-h-[calc(100%-30px)]">
       <div className="section-header">AI</div>
 
-      <div className="ai-tabs flex items-center gap-1" role="tablist" aria-label="AI preferences">
+      <div className="ai-tabs flex items-center" role="tablist" aria-label="AI preferences">
         <button
           type="button"
           role="tab"


### PR DESCRIPTION
### Description

- Replace hardcoded color and spacing values in the AI preferences tab bar with shared theme tokens, matching the app-wide tab styling.
- Remove `gap-1` from the tab container since spacing now comes from StyledWrapper.

#### Screenshot
<img width="1222" height="700" alt="image" src="https://github.com/user-attachments/assets/0f4bff91-af88-4e03-ae19-3e920bb32f6b" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the AI preferences tabs with refreshed spacing, typography, and active/hover states to better match the current theme.
  * Adjusted tab layout spacing for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->