### PR TITLE
fix(e2e-test): update runner to run on self-hosted instances

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -54,7 +54,10 @@ jobs:
   e2e-test:
     name: Playwright E2E Tests (macOS)
     timeout-minutes: 240
-    runs-on: macos-latest
+    runs-on: 
+      - macOS
+      - self-hosted
+      - e2e
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
### Description

Run e2e on the larger mac instances instead to run with 2 workers instead of 1 in the github shared runner setup (e2e taking 2 hours) 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the macOS end-to-end test setup to run on a dedicated self-hosted environment.
  * This may improve test stability and consistency for macOS validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->