### PR TITLE
fix(request-panel)/fixed overflow size column issue on first load

### DIFF
--- a/packages/bruno-app/src/hooks/useResizableColumns/index.js
+++ b/packages/bruno-app/src/hooks/useResizableColumns/index.js
@@ -35,62 +35,79 @@ const getSeparatorPositions = (widths) => {
   return positions;
 };
 
-const scaleWidthsToTotal = (widths, targetTotal, minColWidth) => {
-  const n = widths.length;
+// Container too narrow for everyone to get minColWidth — split evenly instead
+// (columns clip instead of overflow).
+const distributeEqually = (count, total) => {
+  const each = Math.floor(total / count);
+  return [
+    ...Array(count - 1).fill(each),
+    total - each * (count - 1)
+  ];
+};
 
-  // When the container is too narrow to satisfy minColWidth for every column,
-  // fall back to equal distribution so the total stays exact (columns clip instead of overflow).
-  if (targetTotal < minColWidth * n) {
-    const each = Math.floor(targetTotal / n);
-    const last = targetTotal - each * (n - 1);
-    return [...Array(n - 1).fill(each), last];
-  }
-
-  const result = new Array(n).fill(null);
+// Pins any column that would shrink below minColWidth, then re-checks the
+// rest (pinning one column shifts the math for the others). Returns the
+// pinned widths plus what's left for the caller to hand out.
+const pinColumnsAtMinimum = (widths, targetTotal, minColWidth) => {
+  const result = Array(widths.length).fill(null);
   let remainingIdx = widths.map((_, i) => i);
   let remainingTotal = targetTotal;
 
-  while (remainingIdx.length > 0) {
-    const remainingWidthsSum = remainingIdx.reduce((s, i) => s + widths[i], 0);
-    const factor = remainingTotal / remainingWidthsSum;
+  while (true) {
+    const remainingWidth = remainingIdx.reduce((sum, i) => sum + widths[i], 0);
+    const scale = remainingTotal / remainingWidth;
 
-    const stillRemaining = [];
-    let anyPinned = false;
+    const nextRemaining = [];
     for (const i of remainingIdx) {
-      if (widths[i] * factor < minColWidth) {
+      if (widths[i] * scale < minColWidth) {
         result[i] = minColWidth;
         remainingTotal -= minColWidth;
-        anyPinned = true;
       } else {
-        stillRemaining.push(i);
+        nextRemaining.push(i);
       }
     }
 
-    remainingIdx = stillRemaining;
-    if (!anyPinned) break;
-  }
-
-  if (remainingIdx.length > 0) {
-    const unpinnedWidthsSum = remainingIdx.reduce((sum, colIndex) => sum + widths[colIndex], 0);
-    const exactShares = remainingIdx.map((colIndex) => (widths[colIndex] / unpinnedWidthsSum) * remainingTotal);
-    const flooredShares = exactShares.map((share) => Math.floor(share));
-    const leftoverPixels = remainingTotal - flooredShares.reduce((sum, w) => sum + w, 0);
-
-    // Columns ranked by how much they lost to flooring (largest first) — these
-    // are the ones that get a leftover pixel, one each, until none are left.
-    const columnsByLargestRemainder = exactShares
-      .map((share, position) => ({ position, remainder: share - flooredShares[position] }))
-      .sort((a, b) => b.remainder - a.remainder);
-
-    const bonusPixel = new Array(remainingIdx.length).fill(0);
-    for (let pixel = 0; pixel < leftoverPixels; pixel++) {
-      bonusPixel[columnsByLargestRemainder[pixel].position] = 1;
+    if (nextRemaining.length === remainingIdx.length) {
+      return { result, remainingIdx, remainingTotal };
     }
-
-    remainingIdx.forEach((colIndex, position) => {
-      result[colIndex] = flooredShares[position] + bonusPixel[position];
-    });
+    remainingIdx = nextRemaining;
   }
+};
+
+// Largest remainder method: scales proportionally, floors each share, then
+// gives the leftover whole pixels to whoever rounded down the most, so the
+// sum always hits `total` exactly, with no single column eating the error.
+const scaleAndRound = (widths, total) => {
+  const widthSum = widths.reduce((a, b) => a + b, 0);
+  const exact = widths.map((w) => (w / widthSum) * total);
+  const rounded = exact.map(Math.floor);
+  const leftover = total - rounded.reduce((a, b) => a + b, 0);
+
+  exact
+    .map((value, i) => ({ i, remainder: value - rounded[i] }))
+    .sort((a, b) => b.remainder - a.remainder)
+    .slice(0, leftover)
+    .forEach(({ i }) => rounded[i]++);
+
+  return rounded;
+};
+
+const scaleWidthsToTotal = (widths, targetTotal, minColWidth) => {
+  if (targetTotal < minColWidth * widths.length) {
+    return distributeEqually(widths.length, targetTotal);
+  }
+
+  const { result, remainingIdx, remainingTotal }
+    = pinColumnsAtMinimum(widths, targetTotal, minColWidth);
+
+  const scaled = scaleAndRound(
+    remainingIdx.map((i) => widths[i]),
+    remainingTotal
+  );
+
+  remainingIdx.forEach((colIndex, i) => {
+    result[colIndex] = scaled[i];
+  });
 
   return result;
 };

--- a/packages/bruno-app/src/hooks/useResizableColumns/index.js
+++ b/packages/bruno-app/src/hooks/useResizableColumns/index.js
@@ -57,8 +57,7 @@ const scaleWidthsToTotal = (widths, targetTotal, minColWidth) => {
     const stillRemaining = [];
     let anyPinned = false;
     for (const i of remainingIdx) {
-      const scaled = widths[i] * factor;
-      if (scaled < minColWidth) {
+      if (widths[i] * factor < minColWidth) {
         result[i] = minColWidth;
         remainingTotal -= minColWidth;
         anyPinned = true;
@@ -71,19 +70,25 @@ const scaleWidthsToTotal = (widths, targetTotal, minColWidth) => {
     if (!anyPinned) break;
   }
 
-  // Distribute whatever's left proportionally among the unpinned columns;
-  // the last one absorbs the rounding remainder so the total is always exact.
   if (remainingIdx.length > 0) {
-    const remainingWidthsSum = remainingIdx.reduce((s, i) => s + widths[i], 0);
-    let allocated = 0;
-    remainingIdx.forEach((i, idx) => {
-      if (idx === remainingIdx.length - 1) {
-        result[i] = remainingTotal - allocated;
-        return;
-      }
-      const w = Math.round((widths[i] / remainingWidthsSum) * remainingTotal);
-      result[i] = w;
-      allocated += w;
+    const unpinnedWidthsSum = remainingIdx.reduce((sum, colIndex) => sum + widths[colIndex], 0);
+    const exactShares = remainingIdx.map((colIndex) => (widths[colIndex] / unpinnedWidthsSum) * remainingTotal);
+    const flooredShares = exactShares.map((share) => Math.floor(share));
+    const leftoverPixels = remainingTotal - flooredShares.reduce((sum, w) => sum + w, 0);
+
+    // Columns ranked by how much they lost to flooring (largest first) — these
+    // are the ones that get a leftover pixel, one each, until none are left.
+    const columnsByLargestRemainder = exactShares
+      .map((share, position) => ({ position, remainder: share - flooredShares[position] }))
+      .sort((a, b) => b.remainder - a.remainder);
+
+    const bonusPixel = new Array(remainingIdx.length).fill(0);
+    for (let pixel = 0; pixel < leftoverPixels; pixel++) {
+      bonusPixel[columnsByLargestRemainder[pixel].position] = 1;
+    }
+
+    remainingIdx.forEach((colIndex, position) => {
+      result[colIndex] = flooredShares[position] + bonusPixel[position];
     });
   }
 

--- a/packages/bruno-app/src/hooks/useResizableColumns/index.js
+++ b/packages/bruno-app/src/hooks/useResizableColumns/index.js
@@ -36,19 +36,58 @@ const getSeparatorPositions = (widths) => {
 };
 
 const scaleWidthsToTotal = (widths, targetTotal, minColWidth) => {
+  const n = widths.length;
+
   // When the container is too narrow to satisfy minColWidth for every column,
   // fall back to equal distribution so the total stays exact (columns clip instead of overflow).
-  if (targetTotal < minColWidth * widths.length) {
-    const each = Math.floor(targetTotal / widths.length);
-    const last = targetTotal - each * (widths.length - 1);
-    return [...Array(widths.length - 1).fill(each), last];
+  if (targetTotal < minColWidth * n) {
+    const each = Math.floor(targetTotal / n);
+    const last = targetTotal - each * (n - 1);
+    return [...Array(n - 1).fill(each), last];
   }
 
-  const currentTotal = widths.reduce((s, w) => s + w, 0);
-  const factor = targetTotal / currentTotal;
-  const next = widths.slice(0, -1).map((w) => Math.max(minColWidth, Math.round(w * factor)));
-  const last = Math.max(minColWidth, targetTotal - next.reduce((s, w) => s + w, 0));
-  return [...next, last];
+  const result = new Array(n).fill(null);
+  let remainingIdx = widths.map((_, i) => i);
+  let remainingTotal = targetTotal;
+
+  while (remainingIdx.length > 0) {
+    const remainingWidthsSum = remainingIdx.reduce((s, i) => s + widths[i], 0);
+    const factor = remainingTotal / remainingWidthsSum;
+
+    const stillRemaining = [];
+    let anyPinned = false;
+    for (const i of remainingIdx) {
+      const scaled = widths[i] * factor;
+      if (scaled < minColWidth) {
+        result[i] = minColWidth;
+        remainingTotal -= minColWidth;
+        anyPinned = true;
+      } else {
+        stillRemaining.push(i);
+      }
+    }
+
+    remainingIdx = stillRemaining;
+    if (!anyPinned) break;
+  }
+
+  // Distribute whatever's left proportionally among the unpinned columns;
+  // the last one absorbs the rounding remainder so the total is always exact.
+  if (remainingIdx.length > 0) {
+    const remainingWidthsSum = remainingIdx.reduce((s, i) => s + widths[i], 0);
+    let allocated = 0;
+    remainingIdx.forEach((i, idx) => {
+      if (idx === remainingIdx.length - 1) {
+        result[i] = remainingTotal - allocated;
+        return;
+      }
+      const w = Math.round((widths[i] / remainingWidthsSum) * remainingTotal);
+      result[i] = w;
+      allocated += w;
+    });
+  }
+
+  return result;
 };
 
 export function useResizableColumns({ defaultWidths, initialWidths = null, minColWidth = 60, onResizeEnd = null }) {

--- a/packages/bruno-app/src/hooks/useResizableColumns/index.spec.js
+++ b/packages/bruno-app/src/hooks/useResizableColumns/index.spec.js
@@ -138,6 +138,55 @@ describe('useResizableColumns', () => {
     });
   });
 
+  describe('scaling invariants (regression: Devtools network tab "Size" column overflow)', () => {
+    const NETWORK_TAB_WIDTHS = [80, 70, 180, 300, 110, 100, 80];
+
+    const assertNoOverflowAndRespectsMin = (widths, minColWidth) => {
+      setup({ defaultWidths: widths, minColWidth });
+
+      const from = minColWidth * widths.length;
+      const to = Math.ceil(widths.reduce((s, w) => s + w, 0) * 1.5);
+      // Step by at least 2px: the hook itself treats a <=1px delta as noise
+      // and skips recomputing (see the ResizeObserver callback in index.js),
+      // which is unrelated to the scaling algorithm under test here.
+      const step = Math.max(2, Math.floor((to - from) / 200));
+
+      for (let target = from; target <= to; target += step) {
+        act(() => { triggerResize(target); });
+
+        const total = hookValue.colWidths.reduce((s, w) => s + w, 0);
+        const minVal = Math.min(...hookValue.colWidths);
+
+        expect(total).toBe(target);
+        expect(minVal).toBeGreaterThanOrEqual(minColWidth);
+      }
+    };
+
+    it('never overflows or dips under minColWidth across a sweep of container widths (real network-tab columns)', () => {
+      assertNoOverflowAndRespectsMin(NETWORK_TAB_WIDTHS, 60);
+    });
+
+    it('never overflows or dips under minColWidth across a sweep of container widths (generic columns)', () => {
+      assertNoOverflowAndRespectsMin(DEFAULT_WIDTHS, MIN_COL_WIDTH);
+    });
+
+    it('exact reproduction: shrinking to 380px (below minColWidth*7=420) still clips instead of overflowing', () => {
+      setup({ defaultWidths: NETWORK_TAB_WIDTHS, minColWidth: 60 });
+
+      act(() => { triggerResize(380); });
+
+      const total = hookValue.colWidths.reduce((s, w) => s + w, 0);
+      expect(total).toBe(380);
+    });
+
+    it('handles evenly-weighted columns without rounding pile-up pushing a column under minColWidth', () => {
+      // With naive per-column Math.round(), 4 equal-weight columns at this
+      // exact target used to round 3 columns up to minColWidth and leave the
+      // 4th short of it.
+      assertNoOverflowAndRespectsMin([20, 20, 20, 20], 10);
+    });
+  });
+
   describe('drag resize', () => {
     beforeEach(() => {
       setup();


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3775)
## Network tab "Size" column disappears behind the Request Details panel.
In Devtools → Network, resizing the Request Details panel wide enough caused the last column ("Size") in the request list table to vanish — it rendered clipped off, appearing to sit underneath the details panel. Happened reliably on first open (and again after close/reopen) once the panel was dragged near its max width.

### Root cause
`scaleWidthsToTotal()` (in `hooks/useResizableColumns/index.js`) is responsible for shrinking the 7 table columns so they always sum to exactly the available container width. Its old logic:

1. Scale every column proportionally to the target width.
2. Clamp any column below `minColWidth` (60px) up to `minColWidth`.
3. Give the last column whatever's left over.

The bug: when several small columns get clamped up to `minColWidth` independently, their floors alone can already exceed the container's actual width — before the "leftover" for the last column is even computed. Example, with the real column weights `[80, 70, 180, 300, 110, 100, 80]` shrunk to a 420px container:

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Fix

Reworked `scaleWidthsToTotal()` into a two-step algorithm:

1. Scale columns proportionally, pinning any column that would fall below `minColWidth` and recalculating the remaining space.
2. Round to whole pixels by distributing leftover pixels to the columns with the largest fractional remainders, ensuring the total matches the container width.

This guarantees:
- Widths always sum to the container width.
- No column goes below `minColWidth`.
- Existing proportional resize behavior is preserved when no clamping is needed.

- Added regression tests for the reported 380px/420px cases and a container-width sweep.
- Verified the existing proportional resize test continues to pass.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column resizing so column widths always total exactly to the container width.
  * Enhanced minimum column width enforcement to prevent overflow and invalid sizing in tight edge cases.

* **Tests**
  * Added regression tests covering exact-total width invariants and minimum-width constraints across a range of resize scenarios, including real-world column sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->