### PR TITLE
fix(graphql): reduce GraphQL annotation tooltip font size

### DIFF
--- a/packages/bruno-app/src/styles/globals.css
+++ b/packages/bruno-app/src/styles/globals.css
@@ -125,6 +125,20 @@
   --session-header-height: 51px
 }
 
+/*
+ * GraphQL annotation tooltips (.CodeMirror-info) share the GraphiQL font-size
+ * design tokens above, which are sized for editor chrome (body 16px, headings
+ * up to 29px). That makes the hover tooltips render ~50% larger than the code
+ * font. Scope smaller sizes to the tooltip only so the rest of the GraphiQL
+ * container is unaffected. See usebruno/bruno#8431.
+ */
+.CodeMirror-info {
+  --font-size-body: 0.8125rem !important;
+  --font-size-h4: 0.875rem !important;
+  --font-size-h3: 0.9375rem !important;
+  --font-size-h2: 1rem !important;
+}
+
 .CodeMirror-dialog {
   --px-4: 0px !important;
   --px-12: 2px !important;


### PR DESCRIPTION
### Description

GraphQL annotation tooltips (the `.CodeMirror-info` popovers shown on hover in the GraphQL query editor) render their heading at 18px and body at 16px — roughly 50% larger than the surrounding code font (~13px), as reported in #8431.

**Root cause:** `packages/bruno-app/src/styles/globals.css` defines the GraphiQL design-token variables (`--font-size-body: 1rem`/16px, `--font-size-h4: 1.125rem`/18px, `--font-size-h3`, `--font-size-h2`) on a selector list shared by both `.graphiql-container` and `.CodeMirror-info`. The `codemirror-graphql` info addon sizes the tooltip heading from `--font-size-h4` and the body from `--font-size-body`, so the tooltip inherits the editor-chrome sizes. The reported 18px/16px map exactly to those two tokens.

**Fix:** add a rule scoped to `.CodeMirror-info` only that overrides those font-size tokens to values proportional to the code font (body `0.8125rem`, matching `--font-size-inline-code`; headings slightly larger). `!important` on the custom-property declarations ensures the override wins the cascade regardless of stylesheet import order. Because the tooltip element is not a descendant of `.graphiql-container`, the editor chrome is unaffected. This mirrors the file's existing per-selector overrides (`.CodeMirror-dialog`, `.CodeMirror-hints`).

Scope: single file, one new CSS rule block, no logic change.

Closes #8431

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** — the linked issue #8431 contains the before screenshot; this is a CSS token change and the after state is the tooltip text scaled down to match the code font.
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** — links #8431.

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted GraphQL tooltip text sizing so annotation popups now match the surrounding editor more closely.
  * Improved readability of tooltip content by using smaller, consistent typography settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->