### PR TITLE
fix:env configure remains visible

### DIFF
--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
@@ -267,6 +267,7 @@ const EnvironmentSelector = ({ collection }) => {
           onCreate={(ref) => (dropdownTippyRef.current = ref)}
           icon={<DropdownTrigger collectionEnv={activeCollectionEnvironment} globalEnv={activeGlobalEnvironment} />}
           placement="bottom-end"
+          popperOptions={{ strategy: 'fixed' }}
         >
           {/* Tab Headers */}
           <div className="tab-header flex pt-3 pb-2 px-3">


### PR DESCRIPTION
### Description
[JIRA](https://usebruno.atlassian.net/browse/BRU-3675)

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
The dropdown was getting cut off by its container when the terminal panel was open and there were environments to make the list tall. This hid the Configure button at the bottom. Fixed by making the dropdown position itself relative to the whole window instead of its container
#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
<img width="1261" height="754" alt="image" src="https://github.com/user-attachments/assets/d340d4c2-d363-4190-acd0-a9b0640224cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the environment selector dropdown’s positioning behavior for more consistent placement on the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->