### PR TITLE
fix(mount): persist raw file content in file-index for file mode

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -35,6 +35,7 @@ const FILE_DERIVED_REQUEST_FIELDS = [
   'request',
   'settings',
   'examples',
+  'raw',
   'filename',
   'pathname',
   'partial',

--- a/packages/bruno-electron/src/services/mount/file-index.js
+++ b/packages/bruno-electron/src/services/mount/file-index.js
@@ -27,6 +27,13 @@ const MIGRATIONS = [
       ) WITHOUT ROWID;
       CREATE INDEX IF NOT EXISTS idx_collection_path ON file_index_entries(collection_path);
     `
+  },
+  {
+    version: 2,
+    up: `
+      ALTER TABLE file_index_entries ADD COLUMN raw TEXT;
+      UPDATE file_index_entries SET mtime = 0, hash = '';
+    `
   }
 ];
 
@@ -102,12 +109,12 @@ class FileIndex {
   entries(collectionPath) {
     const root = normalize(collectionPath);
     const rows = this.#db.all(
-      'SELECT relative_path AS relativePath, data FROM file_index_entries WHERE collection_path = ?',
+      'SELECT relative_path AS relativePath, data, raw FROM file_index_entries WHERE collection_path = ?',
       root
     );
     const map = new Map();
     for (const row of rows) {
-      map.set(row.relativePath, { data: JSON.parse(row.data) });
+      map.set(row.relativePath, { data: JSON.parse(row.data), raw: row.raw });
     }
     return map;
   }
@@ -125,23 +132,25 @@ class FileIndex {
       return;
     }
 
-    const { mtime, hash, data } = entry;
+    const { mtime, hash, data, raw } = entry;
     const id = idForAbsolutePath(path.join(root, relativePath));
     this.#db.run(
       `
-      INSERT INTO file_index_entries (collection_path, relative_path, id, mtime, hash, data)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO file_index_entries (collection_path, relative_path, id, mtime, hash, data, raw)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(collection_path, relative_path) DO UPDATE SET
         mtime = excluded.mtime,
         hash = excluded.hash,
-        data = excluded.data
+        data = excluded.data,
+        raw = excluded.raw
     `,
       root,
       relativePath,
       id,
       mtime,
       hash,
-      JSON.stringify(data)
+      JSON.stringify(data),
+      raw ?? null
     );
   }
 
@@ -155,6 +164,7 @@ class FileIndex {
       relativePath,
       mtime: stat.mtimeNs,
       hash: hashFile(absolutePath),
+      raw: fs.readFileSync(absolutePath, 'utf8'),
       data
     });
   }

--- a/packages/bruno-electron/src/services/mount/file-index.js
+++ b/packages/bruno-electron/src/services/mount/file-index.js
@@ -33,9 +33,14 @@ const MIGRATIONS = [
     up: `
       ALTER TABLE file_index_entries ADD COLUMN raw TEXT;
       UPDATE file_index_entries SET mtime = 0, hash = '';
+      ALTER TABLE file_index_entries ADD COLUMN created_at INTEGER;
+      ALTER TABLE file_index_entries ADD COLUMN updated_at INTEGER;
+      UPDATE file_index_entries SET created_at = unixepoch(), updated_at = unixepoch();
     `
   }
 ];
+
+// TODO: Check for trigger (ON UPDATE) and then see if we can use that to update updated_at
 
 class FileIndex {
   #db;
@@ -136,13 +141,14 @@ class FileIndex {
     const id = idForAbsolutePath(path.join(root, relativePath));
     this.#db.run(
       `
-      INSERT INTO file_index_entries (collection_path, relative_path, id, mtime, hash, data, raw)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO file_index_entries (collection_path, relative_path, id, mtime, hash, data, raw, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, unixepoch(), unixepoch())
       ON CONFLICT(collection_path, relative_path) DO UPDATE SET
         mtime = excluded.mtime,
         hash = excluded.hash,
         data = excluded.data,
-        raw = excluded.raw
+        raw = excluded.raw,
+        updated_at = unixepoch()
     `,
       root,
       relativePath,

--- a/packages/bruno-electron/src/services/mount/manager.js
+++ b/packages/bruno-electron/src/services/mount/manager.js
@@ -192,13 +192,14 @@ class MountManager {
           entry.state.set(e.relativePath, { data: result.data, error: result.error });
           continue;
         }
-        entry.state.set(e.relativePath, { data: result.data });
+        entry.state.set(e.relativePath, { data: result.data, raw: result.raw });
         this.#getIndex().stage(entry.collectionPath, {
           op: 'add',
           relativePath: e.relativePath,
           mtime: result.mtime,
           hash: result.hash,
-          data: result.data
+          data: result.data,
+          raw: result.raw
         });
       }
       for (const e of removed) {

--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -128,6 +128,7 @@ const buildRequestNode = (absolutePath, basename, entry, uidOverrides, uidFor) =
     request: data.request,
     settings: data.settings,
     examples: data.examples,
+    raw: entry.raw ?? null,
     filename: basename,
     pathname: absolutePath,
     draft: null,

--- a/packages/bruno-electron/src/services/pool/jobs/parse-file.js
+++ b/packages/bruno-electron/src/services/pool/jobs/parse-file.js
@@ -69,10 +69,10 @@ const parseFile = ({ collectionPath, relativePath, format, type }) => {
   const content = buf.toString('utf8');
   try {
     const data = parseContent(content, format, type, buf.length);
-    return { relativePath, mtime, hash, data, format, type };
+    return { relativePath, mtime, hash, data, format, type, raw: content };
   } catch (err) {
     const data = format === 'bru' && type === 'request' ? extractBruMeta(content) : {};
-    return { relativePath, mtime, hash, data, format, type, partial: true, error: { message: err.message, stack: err.stack } };
+    return { relativePath, mtime, hash, data, format, type, raw: content, partial: true, error: { message: err.message, stack: err.stack } };
   }
 };
 


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3762)

In file mode, request nodes were not carrying their raw file content, leaving the `raw` field empty. This change persists the original file content through the mount pipeline so it is available on request nodes.

### Changes

- **parse-file job**: return the raw file `content` as `raw` alongside the parsed data.
- **file-index**: add a `raw TEXT` column (schema migration v2) and read/write it in `entries()`, `stage()`, and the on-disk read path. The migration forces a re-index of existing entries (`mtime = 0, hash = ''`) so the column gets populated.
- **mount manager**: propagate `raw` when updating in-memory state and staging index entries.
- **tree-builder**: include `raw` on request nodes (defaulting to `null`).
- **collections slice**: add `raw` to `FILE_DERIVED_REQUEST_FIELDS` so it is treated as a file-derived field.

### How to test

1. Open a collection in file mode.
2. Verify request nodes now carry their raw file content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end preservation of original raw request/file text, alongside parsed content, across mounting, indexing, and request tree building.
  * File index now stores and returns raw content so views can access it for accurate editing and review.

* **Bug Fixes**
  * Improved reload/merge behavior to ensure raw request content is retained instead of being dropped when items are updated or reloaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->