### PR TITLE
test(converters): add round trip tests for Postman <-> Bruno converters

### DIFF
--- a/packages/bruno-converters/tests/common/diff-kind.js
+++ b/packages/bruno-converters/tests/common/diff-kind.js
@@ -7,7 +7,7 @@
 //   KEY_MISSING_IN_ROUNDTRIP -> a field present in the original was dropped on round-trip
 //   KEY_ONLY_IN_ROUNDTRIP    -> a field absent in the original was added on round-trip
 //   VALUE_MISMATCH           -> a field exists on both sides but its value differs
-const DiffKind = Object.freeze({
+export const DiffKind = Object.freeze({
   NODE_ONLY_IN_ORIGINAL: 'node-only-in-original',
   NODE_ONLY_IN_ROUNDTRIP: 'node-only-in-roundtrip',
   TYPE_MISMATCH: 'type-mismatch',
@@ -15,5 +15,3 @@ const DiffKind = Object.freeze({
   KEY_ONLY_IN_ROUNDTRIP: 'key-only-in-roundtrip',
   VALUE_MISMATCH: 'value-mismatch'
 });
-
-module.exports = { DiffKind };

--- a/packages/bruno-converters/tests/common/diff-kind.js
+++ b/packages/bruno-converters/tests/common/diff-kind.js
@@ -1,0 +1,19 @@
+// Kinds of structural diff produced when comparing two collections during a round-trip test
+// (e.g. Postman -> Bruno -> Postman).
+//
+//   NODE_ONLY_IN_ORIGINAL    -> a node exists only in the original collection
+//   NODE_ONLY_IN_ROUNDTRIP   -> a node exists only in the round-tripped collection
+//   TYPE_MISMATCH            -> the node exists on both sides but its type differs
+//   KEY_MISSING_IN_ROUNDTRIP -> a field present in the original was dropped on round-trip
+//   KEY_ONLY_IN_ROUNDTRIP    -> a field absent in the original was added on round-trip
+//   VALUE_MISMATCH           -> a field exists on both sides but its value differs
+const DiffKind = Object.freeze({
+  NODE_ONLY_IN_ORIGINAL: 'node-only-in-original',
+  NODE_ONLY_IN_ROUNDTRIP: 'node-only-in-roundtrip',
+  TYPE_MISMATCH: 'type-mismatch',
+  KEY_MISSING_IN_ROUNDTRIP: 'key-missing-in-roundtrip',
+  KEY_ONLY_IN_ROUNDTRIP: 'key-only-in-roundtrip',
+  VALUE_MISMATCH: 'value-mismatch'
+});
+
+module.exports = { DiffKind };

--- a/packages/bruno-converters/tests/postman/round-trip/README.md
+++ b/packages/bruno-converters/tests/postman/round-trip/README.md
@@ -1,0 +1,153 @@
+# Round-trip conversion tests
+
+This directory tests conversion **fidelity** by sending a real collection through both converters and
+comparing the result against the input:
+
+```
+Postman export ──postmanToBruno──▶ Bruno collection ──brunoToPostman──▶ Postman export
+     (input)                                                              (output)
+        └──────────────────── compared, subtree by subtree ──────────────────┘
+```
+
+Currently only the **auth** subtree is covered ([`auth.spec.js`](./auth.spec.js)), but the harness is
+built so other subtrees (body, headers, scripts, params, …) can be added as sibling files with no new
+plumbing. See [Extending](#extending) below.
+
+---
+
+## Why round-trip, and why this direction
+
+The per-converter unit specs (`process-auth`, `request-auth`, `bruno-to-postman`, …) each exercise
+**one** converter in isolation and assert a hand-written expected object. That has two blind spots:
+
+1. **Asymmetry between the two converters** — a field renamed on import (`tokenName` → `credentialsId`)
+   but not renamed back on export is invisible to a one-sided test. A round-trip is the only thing that
+   exercises both mappings against each other.
+2. **Circular expectations** — a hand-written "expected" object is only as correct as the author's
+   reading of the converter. If you misread it, the test encodes the misreading.
+
+We focus on **Postman → Bruno → Postman** (not Bruno → Postman → Bruno) because that is the direction
+where a **real exported `.postman_collection.json`** is the input. Real exports carry the exact key
+names, the full v2.1 array-backed auth format, and even fields Bruno doesn't model — ground truth that
+a hand-built object can't reproduce.
+
+---
+
+## Why the fixture approach
+
+Tests are **data-driven off the files in [`fixtures/`](./fixtures)**. Every `*.postman_collection.json`
+is discovered automatically and run through the round-trip. This is deliberate:
+
+- **No hand-written expected values.** The input fixture's own auth is the source of truth — the test
+  asserts the output equals the input (minus documented exceptions), so adding coverage is "drop a
+  file", not "write an expectation".
+- **Real-world shape.** Fixtures are actual Postman exports, so they include the quirks (omitted
+  defaults, extra keys, ordering) that synthetic objects miss.
+
+### Extending
+
+- **More auth coverage:** export a collection of the desired auth type from Postman, drop it into
+  `fixtures/`. It's picked up automatically. A new whitelist entry is only needed if it exercises a
+  field Bruno doesn't model yet (see below).
+- **Another subtree** (e.g. body): add `body.spec.js` alongside `auth.spec.js`, reusing the same
+  fixtures. Factor the shared "walk + diff by node path" logic the way [`compare-auth.js`](./compare-auth.js)
+  does for auth, keeping each subtree's normalization rules in its own module.
+
+---
+
+## The whitelist and its categories
+
+Comparison is **strict**: any difference in the auth subtree fails the test. Differences that are
+expected today are recorded in `AUTH_ROUNDTRIP_WHITELIST` in [`auth.spec.js`](./auth.spec.js), each
+tagged with a `category`. The category is the whole point — it separates "bug we haven't fixed" from
+"working as intended":
+
+| Category | Meaning | Trend | Action |
+| --- | --- | --- | --- |
+| **`feature-gap`** | Bruno has no field to hold this Postman value, so it's dropped on import. | **Should shrink** as Bruno adds support. | **This is the list to focus on.** Each entry is a concrete, user-visible data loss. |
+| **`normalization`** | Intentional, semantically-lossless transformation. | **Permanent** — will never reach zero. | Leave alone. Documents *why* the round-trip isn't byte-identical. |
+
+**Where to focus: the `feature-gap` count.** It's the number of Postman auth capabilities Bruno can't
+represent. Driving it down is real product work; when a gap is filled, delete its whitelist entry and
+the test stays green. The `normalization` entries are not a backlog — they're the documented contract
+of what round-tripping intentionally changes.
+
+### The two flavors of `normalization`
+
+- **Grant-scoped pruning** (oauth2): Bruno stores grant-type-specific fields, so a field unused by the
+  grant (`authUrl` on a `client_credentials` grant, `username` on anything but `password`) is dropped.
+  These entries carry a `grantType` list and are accepted **only** for grants that don't use the field —
+  so the *same* drop on a grant that *does* use it (e.g. `authUrl` on `authorization_code`) still fails.
+  That keeps the exception tight instead of blanket-allowing the field to vanish.
+- **Default materialization**: Postman omits a field and relies on a default; Bruno stores it
+  explicitly and re-emits it (apikey `in: header`, oauth1 `version`). Whitelisted only where **Bruno's
+  default equals Postman's default**, so materializing it changes nothing semantically.
+
+### Whitelist entry matching
+
+Each entry matches a diff on `(fixture, node, authType, key, kind)`:
+
+- `fixture` and `node` accept `'*'` — a field-level gap that recurs across many requests/fixtures is
+  **one wildcard entry**, not dozens of near-duplicates.
+- `grantType` (oauth2, optional) restricts an entry to specific grant types (grant-scoped pruning).
+- Matching is **value-agnostic** (`kind` + `key`, never the value) so a whitelisted field tolerates any
+  value — we're asserting "this field is *expected* to differ", not pinning a specific value.
+
+---
+
+## Comparison mechanics (`compare-auth.js`)
+
+### `stableStringify`
+
+Auth values are compared by a **canonical stringification** — object keys sorted, array order
+preserved — rather than by `JSON.stringify` or reference equality. Two reasons:
+
+1. **Key order is not semantic.** Postman and Bruno emit auth params in different orders; a plain
+   string compare would flag every reorder as a diff. Sorting keys makes the compare structural.
+2. **Nested values must compare by content.** The oauth2 `additionalParameters` arrays
+   (`authRequestParams` / `tokenRequestParams` / `refreshRequestParams`) are arrays of objects. We need
+   deep, order-insensitive-on-keys but order-*sensitive*-on-arrays comparison, which `stableStringify`
+   gives: object keys are sorted (order-insensitive), array element order is preserved (array order *is*
+   semantic for these params).
+
+### `normalizeAuth` — array-backed → map
+
+Postman's v2.1 auth is an array of `{key, value, type}`. We collapse it to a plain `{key: value}` map so
+that (a) param ordering doesn't matter and (b) the `type` tag (always `'string'`/`'any'`, never
+semantically meaningful) doesn't create false diffs. Missing auth normalizes to `null` so "no auth"
+compares equal on both sides.
+
+### `absent === ""` collapse
+
+An absent key and an empty-string value are treated as **equal**. Postman treats a missing auth param as
+unset, and `brunoToPostman` drops empty params on export — so `state: ""` disappearing on round-trip is a
+lossless no-op, not a diff. Collapsing this structurally (rather than whitelisting each empty field)
+keeps the whitelist focused on real differences and avoids churn when a fixture's empty fields change.
+Confirmed safe: Postman's importer defaults any missing auth param, so omitting empties never errors.
+
+### `grantType` on oauth2 diffs
+
+Each oauth2 diff is tagged with the node's grant type (from the original, falling back to the
+round-tripped side). This is what lets grant-scoped-pruning whitelist entries be conditional — the diff
+carries enough context to say "dropped `authUrl`, and this was a `client_credentials` grant, so it's
+fine."
+
+### Node-path walk
+
+`collectAuthNodes` walks the whole collection — collection-level auth, folder-level auth, and
+request-level auth — keying each by a stable path (`collection`, `collection/Folder`,
+`collection/Folder/Request`). Comparison is per-node by path, so a request that gains or loses auth, or
+inherits differently, is caught rather than averaged away.
+
+---
+
+## Running
+
+```bash
+# from packages/bruno-converters
+npx jest tests/postman/round-trip/auth.spec.js
+```
+
+On failure, each un-whitelisted diff prints a readable line — `DROPPED` (Bruno lost a field),
+`ADDED` (Bruno emitted a field Postman didn't), or `CHANGED` (value differs) — so you can tell at a
+glance whether it's a new feature gap to whitelist or a real regression to fix.

--- a/packages/bruno-converters/tests/postman/round-trip/README.md
+++ b/packages/bruno-converters/tests/postman/round-trip/README.md
@@ -113,9 +113,8 @@ preserved — rather than by `JSON.stringify` or reference equality. Two reasons
 ### `normalizeAuth` — array-backed → map
 
 Postman's v2.1 auth is an array of `{key, value, type}`. We collapse it to a plain `{key: value}` map so
-that (a) param ordering doesn't matter and (b) the `type` tag (always `'string'`/`'any'`, never
-semantically meaningful) doesn't create false diffs. Missing auth normalizes to `null` so "no auth"
-compares equal on both sides.
+that (a) param ordering doesn't matter and (b) the `type` tag is ignored because it is not semantically meaningful. 
+Missing auth normalizes to `null` so "no auth" compares equal on both sides.
 
 ### `absent === ""` collapse
 

--- a/packages/bruno-converters/tests/postman/round-trip/auth.spec.js
+++ b/packages/bruno-converters/tests/postman/round-trip/auth.spec.js
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import path from 'path';
+import postmanToBruno from '../../../src/postman/postman-to-bruno';
+import brunoToPostman from '../../../src/postman/bruno-to-postman';
+import { diffAuthNodes } from './compare-auth';
+
+/**
+ * Round-trip auth fidelity: Postman -> Bruno -> Postman.
+ *
+ * Every real Postman export in ./fixtures is imported to Bruno and exported back to Postman; the
+ * auth subtree of the result is compared against the auth subtree of the original export. This is
+ * the direction where a real-world Postman file matters, because the *input* shape then matches
+ * exactly what Postman emits (real key names, extra keys, v2.1 array format) instead of an
+ * approximation hand-written in a test.
+ *
+ * Comparison is STRICT: any difference in the auth subtree is a failure. Some differences are
+ * expected today. Those are recorded in AUTH_ROUNDTRIP_WHITELIST below with a category:
+ *   - category 'feature-gap'     -> Bruno can't represent this Postman field yet; SHOULD shrink as
+ *                                   gaps are filled. This is the number to drive toward zero.
+ *   - category 'normalization'   -> intentional & permanent (default materialization, grant-scoped
+ *                                   pruning); will NOT shrink.
+ * (Empty-value differences are handled structurally in compare-auth.js — absent == "" — and never
+ * reach the whitelist.)
+ *
+ * Whitelist entry matching:
+ *   - fixture / node accept the literal value or '*' (wildcard) so a field-level gap that recurs
+ *     across many nodes/fixtures is one entry, not dozens.
+ *   - grantType (oauth2 only, optional): the diff is accepted ONLY when the node's grant type is in
+ *     this list. This is how grant-scoped pruning is bounded — dropping authUrl is fine for
+ *     client_credentials, but the SAME drop on an authorization_code grant is a real failure.
+ *   - matching is value-agnostic (kind + key), so a whitelisted field tolerates any value.
+ *
+ * To add coverage: drop another *.postman_collection.json into ./fixtures — it is picked up
+ * automatically. New whitelist entries are only needed if it exercises an unmodelled field.
+ */
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+// Shape: { fixture, node, authType, key, kind, category, reason, grantType? }
+// fixture/node support '*'. grantType (array) restricts an oauth2 entry to those grant types.
+const AUTH_ROUNDTRIP_WHITELIST = [
+  // --- feature-gap: Bruno does not model these Postman fields yet (drive this list to zero) ---
+  // oauth1: Bruno models currently don't support the following.
+  { fixture: '*', node: '*', authType: 'oauth1', key: 'addEmptyParamsToSign', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no oauth1 addEmptyParamsToSign field' },
+  { fixture: '*', node: '*', authType: 'oauth1', key: 'disableHeaderEncoding', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no oauth1 disableHeaderEncoding field' },
+  // digest: Bruno models only support username/password; the rest of Postman's digest params are dropped.
+  { fixture: '*', node: '*', authType: 'digest', key: 'algorithm', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest algorithm field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'nonce', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest nonce field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'nonceCount', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest nonceCount field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'realm', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest realm field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'qop', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest qop field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'clientNonce', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest client nonce field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'opaque', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest opaque field' },
+  // ntlm: Bruno models support username/password/domain only.
+  { fixture: '*', node: '*', authType: 'ntlm', key: 'workstation', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no ntlm workstation field' },
+  // oauth2: Bruno models currently don't support the following.
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'useBrowser', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no oauth2 useBrowser field' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'code_verifier', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no oauth2 code_verifier (PKCE) field' },
+
+  // --- normalization: grant-scoped pruning (accepted ONLY for grants that don't use the field) ---
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'authUrl', kind: 'key-missing-in-roundtrip', grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'authorizationUrl is unused by client_credentials/password grants, so Bruno drops it' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'redirect_uri', kind: 'key-missing-in-roundtrip', grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'callbackUrl is unused by client_credentials/password grants, so Bruno drops it' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'username', kind: 'key-missing-in-roundtrip', grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'username is used only by the password grant, so Bruno drops it elsewhere' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'password', kind: 'key-missing-in-roundtrip', grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'password is used only by the password grant, so Bruno drops it elsewhere' },
+
+  // --- normalization: default materialization (Postman omits, defaults it; Bruno emits explicitly) ---
+  { fixture: '*', node: '*', authType: 'apikey', key: 'in', kind: 'key-only-in-roundtrip', category: 'normalization', reason: 'Postman defaults apikey placement to header when omitted; Bruno emits it' },
+  { fixture: '*', node: '*', authType: 'oauth1', key: 'version', kind: 'key-only-in-roundtrip', category: 'normalization', reason: 'Bruno materializes default version=1.0 (== Postman default)' }
+];
+
+const readJson = (file) => JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, file), 'utf8'));
+
+const matchesField = (w, v) => w === '*' || w === v;
+
+const isWhitelisted = (fixture, diff) =>
+  AUTH_ROUNDTRIP_WHITELIST.some(
+    (w) =>
+      matchesField(w.fixture, fixture)
+      && matchesField(w.node, diff.node)
+      && (w.authType ?? null) === (diff.authType ?? null)
+      && (w.key ?? null) === (diff.key ?? null)
+      && w.kind === diff.kind
+      && (!w.grantType || (diff.grantType != null && w.grantType.includes(diff.grantType)))
+  );
+
+const fixtureFiles = fs.readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.postman_collection.json'));
+
+// Readable one-liner for each diff, used in the failure message.
+const formatDiff = (d) => {
+  const loc = `[${d.node}]${d.key ? ` ${d.authType}.${d.key}` : d.authType ? ` (${d.authType})` : ''}`;
+  switch (d.kind) {
+    case 'key-missing-in-roundtrip':
+      return `${loc} DROPPED on round-trip (original=${JSON.stringify(d.original)})`;
+    case 'key-only-in-roundtrip':
+      return `${loc} ADDED on round-trip (roundtrip=${JSON.stringify(d.roundTripped)})`;
+    case 'value-mismatch':
+      return `${loc} CHANGED original=${JSON.stringify(d.original)} roundtrip=${JSON.stringify(d.roundTripped)}`;
+    case 'type-mismatch':
+      return `${loc} TYPE CHANGED original=${JSON.stringify(d.original)} roundtrip=${JSON.stringify(d.roundTripped)}`;
+    default:
+      return `${loc} ${d.kind}`;
+  }
+};
+
+describe('auth round-trip (Postman -> Bruno -> Postman)', () => {
+  it.each(fixtureFiles)('preserves the auth subtree of %s', async (fixture) => {
+    const original = readJson(fixture);
+    const { collection } = await postmanToBruno(original);
+    const roundTripped = brunoToPostman(collection);
+
+    const allDiffs = diffAuthNodes(original, roundTripped);
+    const unexpected = allDiffs.filter((d) => !isWhitelisted(fixture, d));
+
+    if (unexpected.length) {
+      // Surface a human-readable summary alongside Jest's structured dump.
+      console.log(`\n[${fixture}] ${unexpected.length} un-whitelisted auth diff(s):`);
+      unexpected.forEach((d) => console.log('  ' + formatDiff(d)));
+    }
+
+    expect(unexpected).toEqual([]);
+  });
+});

--- a/packages/bruno-converters/tests/postman/round-trip/auth.spec.js
+++ b/packages/bruno-converters/tests/postman/round-trip/auth.spec.js
@@ -3,6 +3,7 @@ import path from 'path';
 import postmanToBruno from '../../../src/postman/postman-to-bruno';
 import brunoToPostman from '../../../src/postman/bruno-to-postman';
 import { diffAuthNodes } from './compare-auth';
+import { DiffKind } from '../../common/diff-kind';
 
 /**
  * Round-trip auth fidelity: Postman -> Bruno -> Postman.
@@ -41,31 +42,32 @@ const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 const AUTH_ROUNDTRIP_WHITELIST = [
   // --- feature-gap: Bruno does not model these Postman fields yet (drive this list to zero) ---
   // oauth1: Bruno models currently don't support the following.
-  { fixture: '*', node: '*', authType: 'oauth1', key: 'addEmptyParamsToSign', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no oauth1 addEmptyParamsToSign field' },
-  { fixture: '*', node: '*', authType: 'oauth1', key: 'disableHeaderEncoding', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no oauth1 disableHeaderEncoding field' },
+  { fixture: '*', node: '*', authType: 'oauth1', key: 'addEmptyParamsToSign', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth1 addEmptyParamsToSign field' },
+  { fixture: '*', node: '*', authType: 'oauth1', key: 'disableHeaderEncoding', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth1 disableHeaderEncoding field' },
   // digest: Bruno models only support username/password; the rest of Postman's digest params are dropped.
-  { fixture: '*', node: '*', authType: 'digest', key: 'algorithm', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest algorithm field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'nonce', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest nonce field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'nonceCount', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest nonceCount field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'realm', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest realm field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'qop', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest qop field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'clientNonce', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest client nonce field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'opaque', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no digest opaque field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'algorithm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest algorithm field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'nonce', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest nonce field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'nonceCount', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest nonceCount field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'realm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest realm field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'qop', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest qop field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'clientNonce', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest client nonce field' },
+  { fixture: '*', node: '*', authType: 'digest', key: 'opaque', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest opaque field' },
   // ntlm: Bruno models support username/password/domain only.
-  { fixture: '*', node: '*', authType: 'ntlm', key: 'workstation', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no ntlm workstation field' },
+  { fixture: '*', node: '*', authType: 'ntlm', key: 'workstation', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no ntlm workstation field' },
   // oauth2: Bruno models currently don't support the following.
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'useBrowser', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no oauth2 useBrowser field' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'code_verifier', kind: 'key-missing-in-roundtrip', category: 'feature-gap', reason: 'Bruno has no oauth2 code_verifier (PKCE) field' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'useBrowser', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 useBrowser field' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'code_verifier', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 code_verifier (PKCE) field' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'challengeAlgorithm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 code verifier - challenge algorithm' },
 
   // --- normalization: grant-scoped pruning (accepted ONLY for grants that don't use the field) ---
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'authUrl', kind: 'key-missing-in-roundtrip', grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'authorizationUrl is unused by client_credentials/password grants, so Bruno drops it' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'redirect_uri', kind: 'key-missing-in-roundtrip', grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'callbackUrl is unused by client_credentials/password grants, so Bruno drops it' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'username', kind: 'key-missing-in-roundtrip', grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'username is used only by the password grant, so Bruno drops it elsewhere' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'password', kind: 'key-missing-in-roundtrip', grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'password is used only by the password grant, so Bruno drops it elsewhere' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'authUrl', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'authorizationUrl is unused by client_credentials/password grants, so Bruno drops it' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'redirect_uri', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'callbackUrl is unused by client_credentials/password grants, so Bruno drops it' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'username', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'username is used only by the password grant, so Bruno drops it elsewhere' },
+  { fixture: '*', node: '*', authType: 'oauth2', key: 'password', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'password is used only by the password grant, so Bruno drops it elsewhere' },
 
   // --- normalization: default materialization (Postman omits, defaults it; Bruno emits explicitly) ---
-  { fixture: '*', node: '*', authType: 'apikey', key: 'in', kind: 'key-only-in-roundtrip', category: 'normalization', reason: 'Postman defaults apikey placement to header when omitted; Bruno emits it' },
-  { fixture: '*', node: '*', authType: 'oauth1', key: 'version', kind: 'key-only-in-roundtrip', category: 'normalization', reason: 'Bruno materializes default version=1.0 (== Postman default)' }
+  { fixture: '*', node: '*', authType: 'apikey', key: 'in', kind: DiffKind.KEY_ONLY_IN_ROUNDTRIP, category: 'normalization', reason: 'Postman defaults apikey placement to header when omitted; Bruno emits it' },
+  { fixture: '*', node: '*', authType: 'oauth1', key: 'version', kind: DiffKind.KEY_ONLY_IN_ROUNDTRIP, category: 'normalization', reason: 'Bruno materializes default version=1.0 (== Postman default)' }
 ];
 
 const readJson = (file) => JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, file), 'utf8'));
@@ -89,13 +91,13 @@ const fixtureFiles = fs.readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.pos
 const formatDiff = (d) => {
   const loc = `[${d.node}]${d.key ? ` ${d.authType}.${d.key}` : d.authType ? ` (${d.authType})` : ''}`;
   switch (d.kind) {
-    case 'key-missing-in-roundtrip':
+    case DiffKind.KEY_MISSING_IN_ROUNDTRIP:
       return `${loc} DROPPED on round-trip (original=${JSON.stringify(d.original)})`;
-    case 'key-only-in-roundtrip':
+    case DiffKind.KEY_ONLY_IN_ROUNDTRIP:
       return `${loc} ADDED on round-trip (roundtrip=${JSON.stringify(d.roundTripped)})`;
-    case 'value-mismatch':
+    case DiffKind.VALUE_MISMATCH:
       return `${loc} CHANGED original=${JSON.stringify(d.original)} roundtrip=${JSON.stringify(d.roundTripped)}`;
-    case 'type-mismatch':
+    case DiffKind.TYPE_MISMATCH:
       return `${loc} TYPE CHANGED original=${JSON.stringify(d.original)} roundtrip=${JSON.stringify(d.roundTripped)}`;
     default:
       return `${loc} ${d.kind}`;

--- a/packages/bruno-converters/tests/postman/round-trip/auth.spec.js
+++ b/packages/bruno-converters/tests/postman/round-trip/auth.spec.js
@@ -37,37 +37,50 @@ import { DiffKind } from '../../common/diff-kind';
 
 const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
+const AUTH_TYPES = Object.freeze({
+  BASIC: 'basic',
+  BEARER: 'bearer',
+  AWSV4: 'awsv4',
+  APIKEY: 'apikey',
+  DIGEST: 'digest',
+  NTLM: 'ntlm',
+  OAUTH1: 'oauth1',
+  OAUTH2: 'oauth2',
+  EDGEGRID: 'edgegrid',
+  NOAUTH: 'noauth'
+});
+
 // Shape: { fixture, node, authType, key, kind, category, reason, grantType? }
 // fixture/node support '*'. grantType (array) restricts an oauth2 entry to those grant types.
 const AUTH_ROUNDTRIP_WHITELIST = [
   // --- feature-gap: Bruno does not model these Postman fields yet (drive this list to zero) ---
   // oauth1: Bruno models currently don't support the following.
-  { fixture: '*', node: '*', authType: 'oauth1', key: 'addEmptyParamsToSign', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth1 addEmptyParamsToSign field' },
-  { fixture: '*', node: '*', authType: 'oauth1', key: 'disableHeaderEncoding', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth1 disableHeaderEncoding field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH1, key: 'addEmptyParamsToSign', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth1 addEmptyParamsToSign field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH1, key: 'disableHeaderEncoding', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth1 disableHeaderEncoding field' },
   // digest: Bruno models only support username/password; the rest of Postman's digest params are dropped.
-  { fixture: '*', node: '*', authType: 'digest', key: 'algorithm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest algorithm field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'nonce', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest nonce field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'nonceCount', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest nonceCount field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'realm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest realm field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'qop', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest qop field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'clientNonce', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest client nonce field' },
-  { fixture: '*', node: '*', authType: 'digest', key: 'opaque', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest opaque field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.DIGEST, key: 'algorithm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest algorithm field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.DIGEST, key: 'nonce', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest nonce field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.DIGEST, key: 'nonceCount', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest nonceCount field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.DIGEST, key: 'realm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest realm field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.DIGEST, key: 'qop', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest qop field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.DIGEST, key: 'clientNonce', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest client nonce field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.DIGEST, key: 'opaque', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no digest opaque field' },
   // ntlm: Bruno models support username/password/domain only.
-  { fixture: '*', node: '*', authType: 'ntlm', key: 'workstation', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no ntlm workstation field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.NTLM, key: 'workstation', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no ntlm workstation field' },
   // oauth2: Bruno models currently don't support the following.
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'useBrowser', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 useBrowser field' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'code_verifier', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 code_verifier (PKCE) field' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'challengeAlgorithm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 code verifier - challenge algorithm' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH2, key: 'useBrowser', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 useBrowser field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH2, key: 'code_verifier', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 code_verifier (PKCE) field' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH2, key: 'challengeAlgorithm', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, category: 'feature-gap', reason: 'Bruno has no oauth2 code verifier - challenge algorithm' },
 
   // --- normalization: grant-scoped pruning (accepted ONLY for grants that don't use the field) ---
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'authUrl', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'authorizationUrl is unused by client_credentials/password grants, so Bruno drops it' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'redirect_uri', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'callbackUrl is unused by client_credentials/password grants, so Bruno drops it' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'username', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'username is used only by the password grant, so Bruno drops it elsewhere' },
-  { fixture: '*', node: '*', authType: 'oauth2', key: 'password', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'password is used only by the password grant, so Bruno drops it elsewhere' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH2, key: 'authUrl', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'authorizationUrl is unused by client_credentials/password grants, so Bruno drops it' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH2, key: 'redirect_uri', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'password_credentials'], category: 'normalization', reason: 'callbackUrl is unused by client_credentials/password grants, so Bruno drops it' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH2, key: 'username', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'username is used only by the password grant, so Bruno drops it elsewhere' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH2, key: 'password', kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, grantType: ['client_credentials', 'authorization_code', 'authorization_code_with_pkce', 'implicit'], category: 'normalization', reason: 'password is used only by the password grant, so Bruno drops it elsewhere' },
 
   // --- normalization: default materialization (Postman omits, defaults it; Bruno emits explicitly) ---
-  { fixture: '*', node: '*', authType: 'apikey', key: 'in', kind: DiffKind.KEY_ONLY_IN_ROUNDTRIP, category: 'normalization', reason: 'Postman defaults apikey placement to header when omitted; Bruno emits it' },
-  { fixture: '*', node: '*', authType: 'oauth1', key: 'version', kind: DiffKind.KEY_ONLY_IN_ROUNDTRIP, category: 'normalization', reason: 'Bruno materializes default version=1.0 (== Postman default)' }
+  { fixture: '*', node: '*', authType: AUTH_TYPES.APIKEY, key: 'in', kind: DiffKind.KEY_ONLY_IN_ROUNDTRIP, category: 'normalization', reason: 'Postman defaults apikey placement to header when omitted; Bruno emits it' },
+  { fixture: '*', node: '*', authType: AUTH_TYPES.OAUTH1, key: 'version', kind: DiffKind.KEY_ONLY_IN_ROUNDTRIP, category: 'normalization', reason: 'Bruno materializes default version=1.0 (== Postman default)' }
 ];
 
 const readJson = (file) => JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, file), 'utf8'));

--- a/packages/bruno-converters/tests/postman/round-trip/compare-auth.js
+++ b/packages/bruno-converters/tests/postman/round-trip/compare-auth.js
@@ -1,4 +1,4 @@
-const { DiffKind } = require('../../common/diff-kind');
+import { DiffKind } from '../../common/diff-kind';
 
 // Canonical stringify (object keys sorted, array order preserved) so nested values like the
 // additional-params arrays (authRequestParams/tokenRequestParams/refreshRequestParams) are
@@ -40,7 +40,7 @@ const collectAuthNodes = (collection) => {
 
   const walk = (items, parentPath) => {
     (items || []).forEach((item, index) => {
-      const nodePath = `${parentPath}-{index}/${item.name}`;
+      const nodePath = `${parentPath}-${index}/${item.name}`;
       if (Array.isArray(item.item)) {
         // Folder: auth lives directly on the folder item.
         nodes[nodePath] = normalizeAuth(item.auth);
@@ -58,7 +58,7 @@ const collectAuthNodes = (collection) => {
 
 // Diff the auth subtree of two Postman collections (original vs round-tripped). Returns a flat
 // list of structured diffs. `kind` is one of the DiffKind values.
-const diffAuthNodes = (originalCollection, roundTrippedCollection) => {
+export const diffAuthNodes = (originalCollection, roundTrippedCollection) => {
   const original = collectAuthNodes(originalCollection);
   const roundtrip = collectAuthNodes(roundTrippedCollection);
   const paths = [...new Set([...Object.keys(original), ...Object.keys(roundtrip)])].sort();
@@ -114,5 +114,3 @@ const diffAuthNodes = (originalCollection, roundTrippedCollection) => {
   }
   return diffs;
 };
-
-module.exports = { stableStringify, normalizeAuth, collectAuthNodes, diffAuthNodes, DiffKind };

--- a/packages/bruno-converters/tests/postman/round-trip/compare-auth.js
+++ b/packages/bruno-converters/tests/postman/round-trip/compare-auth.js
@@ -1,3 +1,5 @@
+const { DiffKind } = require('../../common/diff-kind');
+
 // Canonical stringify (object keys sorted, array order preserved) so nested values like the
 // additional-params arrays (authRequestParams/tokenRequestParams/refreshRequestParams) are
 // compared structurally rather than by key order or reference.
@@ -55,9 +57,7 @@ const collectAuthNodes = (collection) => {
 };
 
 // Diff the auth subtree of two Postman collections (original vs round-tripped). Returns a flat
-// list of structured diffs. `kind` is one of:
-//   'node-only-in-original' | 'node-only-in-roundtrip' | 'type-mismatch'
-//   'key-missing-in-roundtrip' | 'key-only-in-roundtrip' | 'value-mismatch'
+// list of structured diffs. `kind` is one of the DiffKind values.
 const diffAuthNodes = (originalCollection, roundTrippedCollection) => {
   const original = collectAuthNodes(originalCollection);
   const roundtrip = collectAuthNodes(roundTrippedCollection);
@@ -69,11 +69,11 @@ const diffAuthNodes = (originalCollection, roundTrippedCollection) => {
     const b = roundtrip[nodePath];
 
     if (!(nodePath in original)) {
-      diffs.push({ node: nodePath, kind: 'node-only-in-roundtrip', authType: b?.type ?? null });
+      diffs.push({ node: nodePath, kind: DiffKind.NODE_ONLY_IN_ROUNDTRIP, authType: b?.type ?? null });
       continue;
     }
     if (!(nodePath in roundtrip)) {
-      diffs.push({ node: nodePath, kind: 'node-only-in-original', authType: a?.type ?? null });
+      diffs.push({ node: nodePath, kind: DiffKind.NODE_ONLY_IN_ORIGINAL, authType: a?.type ?? null });
       continue;
     }
 
@@ -81,7 +81,7 @@ const diffAuthNodes = (originalCollection, roundTrippedCollection) => {
     if (a === null && b === null) continue;
 
     if ((a?.type ?? null) !== (b?.type ?? null)) {
-      diffs.push({ node: nodePath, kind: 'type-mismatch', original: a?.type ?? null, roundTripped: b?.type ?? null });
+      diffs.push({ node: nodePath, kind: DiffKind.TYPE_MISMATCH, original: a?.type ?? null, roundTripped: b?.type ?? null });
       // Type differs; param-level comparison below would be noise, so skip it.
       continue;
     }
@@ -104,15 +104,15 @@ const diffAuthNodes = (originalCollection, roundTrippedCollection) => {
       const diff = { node: nodePath, authType: a.type, key };
       if (grantType !== undefined) diff.grantType = grantType;
       if (isEmpty(vA)) {
-        diffs.push({ ...diff, kind: 'key-only-in-roundtrip', roundTripped: vB });
+        diffs.push({ ...diff, kind: DiffKind.KEY_ONLY_IN_ROUNDTRIP, roundTripped: vB });
       } else if (isEmpty(vB)) {
-        diffs.push({ ...diff, kind: 'key-missing-in-roundtrip', original: vA });
+        diffs.push({ ...diff, kind: DiffKind.KEY_MISSING_IN_ROUNDTRIP, original: vA });
       } else if (stableStringify(vA) !== stableStringify(vB)) {
-        diffs.push({ ...diff, kind: 'value-mismatch', original: vA, roundTripped: vB });
+        diffs.push({ ...diff, kind: DiffKind.VALUE_MISMATCH, original: vA, roundTripped: vB });
       }
     }
   }
   return diffs;
 };
 
-module.exports = { stableStringify, normalizeAuth, collectAuthNodes, diffAuthNodes };
+module.exports = { stableStringify, normalizeAuth, collectAuthNodes, diffAuthNodes, DiffKind };

--- a/packages/bruno-converters/tests/postman/round-trip/compare-auth.js
+++ b/packages/bruno-converters/tests/postman/round-trip/compare-auth.js
@@ -1,0 +1,118 @@
+// Canonical stringify (object keys sorted, array order preserved) so nested values like the
+// additional-params arrays (authRequestParams/tokenRequestParams/refreshRequestParams) are
+// compared structurally rather than by key order or reference.
+const stableStringify = (v) => {
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(',')}]`;
+  if (v && typeof v === 'object') {
+    return `{${Object.keys(v).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(v[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(v);
+};
+
+// Normalize an auth object into { type, params: { key: value } }. Postman's v2.1 array-of-
+// {key,value,type} representation is collapsed into a plain map so param ordering and the `type`
+// tag (always 'string'/'any', not semantically meaningful) don't create false diffs. An absent
+// auth block normalizes to null so "no auth" compares equal on both sides.
+const normalizeAuth = (auth) => {
+  if (!auth || !auth.type) return null;
+  const result = { type: auth.type, params: {} };
+  const params = auth[auth.type];
+  if (Array.isArray(params)) {
+    for (const { key, value } of params) {
+      result.params[key] = value;
+    }
+  } else if (params && typeof params === 'object') {
+    result.params = { ...params };
+  }
+  return result;
+};
+
+// Walk a Postman collection and collect every auth-bearing node keyed by a stable path:
+//   'collection'                    -> collection-level auth
+//   'collection/Folder'             -> folder-level auth
+//   'collection/Folder/Request'     -> request-level auth
+// Nodes with no auth are still recorded (auth: null) so a node that gains/loses auth is caught.
+const collectAuthNodes = (collection) => {
+  const nodes = {};
+  nodes['collection'] = normalizeAuth(collection.auth);
+
+  const walk = (items, parentPath) => {
+    (items || []).forEach((item) => {
+      const nodePath = `${parentPath}/${item.name}`;
+      if (Array.isArray(item.item)) {
+        // Folder: auth lives directly on the folder item.
+        nodes[nodePath] = normalizeAuth(item.auth);
+        walk(item.item, nodePath);
+      } else {
+        // Request: auth lives on item.request.auth.
+        nodes[nodePath] = normalizeAuth(item.request && item.request.auth);
+      }
+    });
+  };
+
+  walk(collection.item, 'collection');
+  return nodes;
+};
+
+// Diff the auth subtree of two Postman collections (original vs round-tripped). Returns a flat
+// list of structured diffs. `kind` is one of:
+//   'node-only-in-original' | 'node-only-in-roundtrip' | 'type-mismatch'
+//   'key-missing-in-roundtrip' | 'key-only-in-roundtrip' | 'value-mismatch'
+const diffAuthNodes = (originalCollection, roundTrippedCollection) => {
+  const original = collectAuthNodes(originalCollection);
+  const roundtrip = collectAuthNodes(roundTrippedCollection);
+  const paths = [...new Set([...Object.keys(original), ...Object.keys(roundtrip)])].sort();
+
+  const diffs = [];
+  for (const nodePath of paths) {
+    const a = original[nodePath];
+    const b = roundtrip[nodePath];
+
+    if (!(nodePath in original)) {
+      diffs.push({ node: nodePath, kind: 'node-only-in-roundtrip', authType: b?.type ?? null });
+      continue;
+    }
+    if (!(nodePath in roundtrip)) {
+      diffs.push({ node: nodePath, kind: 'node-only-in-original', authType: a?.type ?? null });
+      continue;
+    }
+
+    // Both null (no auth on either side) -> identical.
+    if (a === null && b === null) continue;
+
+    if ((a?.type ?? null) !== (b?.type ?? null)) {
+      diffs.push({ node: nodePath, kind: 'type-mismatch', original: a?.type ?? null, roundTripped: b?.type ?? null });
+      // Type differs; param-level comparison below would be noise, so skip it.
+      continue;
+    }
+
+    const paramsA = a?.params || {};
+    const paramsB = b?.params || {};
+    // Grant type of the node (oauth2 only), taken from the original and falling back to the
+    // round-tripped side. Attached to every oauth2 diff so the whitelist can accept a dropped
+    // field ONLY for grant types that don't use it (grant-scoped pruning).
+    const grantType = a?.type === 'oauth2' ? (paramsA.grant_type ?? paramsB.grant_type ?? null) : undefined;
+    // An absent key and an empty-string value are equivalent: Postman treats a missing auth param
+    // as unset, and brunoToPostman drops empty params on export, so this is a lossless round-trip.
+    const isEmpty = (v) => v === undefined || v === '';
+
+    const keys = [...new Set([...Object.keys(paramsA), ...Object.keys(paramsB)])].sort();
+    for (const key of keys) {
+      const vA = paramsA[key];
+      const vB = paramsB[key];
+      if (isEmpty(vA) && isEmpty(vB)) continue; // absent == empty on both sides
+      const diff = { node: nodePath, authType: a.type, key };
+      if (grantType !== undefined) diff.grantType = grantType;
+      if (isEmpty(vA)) {
+        diffs.push({ ...diff, kind: 'key-only-in-roundtrip', roundTripped: vB });
+      } else if (isEmpty(vB)) {
+        diffs.push({ ...diff, kind: 'key-missing-in-roundtrip', original: vA });
+      } else if (stableStringify(vA) !== stableStringify(vB)) {
+        diffs.push({ ...diff, kind: 'value-mismatch', original: vA, roundTripped: vB });
+      }
+    }
+  }
+  return diffs;
+};
+
+module.exports = { stableStringify, normalizeAuth, collectAuthNodes, diffAuthNodes };

--- a/packages/bruno-converters/tests/postman/round-trip/compare-auth.js
+++ b/packages/bruno-converters/tests/postman/round-trip/compare-auth.js
@@ -37,8 +37,8 @@ const collectAuthNodes = (collection) => {
   nodes['collection'] = normalizeAuth(collection.auth);
 
   const walk = (items, parentPath) => {
-    (items || []).forEach((item) => {
-      const nodePath = `${parentPath}/${item.name}`;
+    (items || []).forEach((item, index) => {
+      const nodePath = `${parentPath}-{index}/${item.name}`;
       if (Array.isArray(item.item)) {
         // Folder: auth lives directly on the folder item.
         nodes[nodePath] = normalizeAuth(item.auth);

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/API Key.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/API Key.postman_collection.json
@@ -1,0 +1,108 @@
+{
+  "info": {
+    "_postman_id": "2b051f45-c2a9-444d-bac3-9aa91df14a0a",
+    "name": "API Key",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-2b051f45-c2a9-444d-bac3-9aa91df14a0a?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Inherited",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Own Auth",
+      "request": {
+        "auth": {
+          "type": "apikey",
+          "apikey": [
+            {
+              "key": "value",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "in",
+              "value": "query",
+              "type": "string"
+            },
+            {
+              "key": "key",
+              "value": "client-id",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      {
+        "key": "value",
+        "value": "{{client_id}}",
+        "type": "string"
+      },
+      {
+        "key": "key",
+        "value": "client-id",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/AWS.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/AWS.postman_collection.json
@@ -1,0 +1,133 @@
+{
+  "info": {
+    "_postman_id": "384fe6bf-31cb-4b5b-93cc-d1df944bf745",
+    "name": "AWS",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-384fe6bf-31cb-4b5b-93cc-d1df944bf745?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Inherit",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Own Auth",
+      "request": {
+        "auth": {
+          "type": "awsv4",
+          "awsv4": [
+            {
+              "key": "region",
+              "value": "us-east1",
+              "type": "string"
+            },
+            {
+              "key": "sessionToken",
+              "value": "sessionToken",
+              "type": "string"
+            },
+            {
+              "key": "service",
+              "value": "service_name",
+              "type": "string"
+            },
+            {
+              "key": "secretKey",
+              "value": "newSecretKey",
+              "type": "string"
+            },
+            {
+              "key": "accessKey",
+              "value": "newAccessKey",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "awsv4",
+    "awsv4": [
+      {
+        "key": "service",
+        "value": "serviceName",
+        "type": "string"
+      },
+      {
+        "key": "region",
+        "value": "us-west-1",
+        "type": "string"
+      },
+      {
+        "key": "sessionToken",
+        "value": "{{token}}",
+        "type": "string"
+      },
+      {
+        "key": "secretKey",
+        "value": "secret",
+        "type": "string"
+      },
+      {
+        "key": "accessKey",
+        "value": "accessKey",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Akamai EdgeGrid.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Akamai EdgeGrid.postman_collection.json
@@ -1,0 +1,153 @@
+{
+  "info": {
+    "_postman_id": "afdba147-a9d3-4c38-b25f-0997d67dd2d9",
+    "name": "Akamai EdgeGrid",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-afdba147-a9d3-4c38-b25f-0997d67dd2d9?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Inherit",
+      "request": {
+        "auth": {
+          "type": "ntlm",
+          "ntlm": [
+            {
+              "key": "password",
+              "value": "password",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "NTLM_USER_2",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Own Auth",
+      "request": {
+        "auth": {
+          "type": "edgegrid",
+          "edgegrid": [
+            {
+              "key": "clientSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "clientToken",
+              "value": "clientToken",
+              "type": "string"
+            },
+            {
+              "key": "accessToken",
+              "value": "accessToken",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "edgegrid",
+    "edgegrid": [
+      {
+        "key": "maxBodySize",
+        "value": 70,
+        "type": "number"
+      },
+      {
+        "key": "headersToSign",
+        "value": "Auth",
+        "type": "string"
+      },
+      {
+        "key": "baseURL",
+        "value": "http://localhost:4000",
+        "type": "string"
+      },
+      {
+        "key": "timestamp",
+        "value": "20260707T10:28:15+0000",
+        "type": "string"
+      },
+      {
+        "key": "nonce",
+        "value": "Nonce",
+        "type": "string"
+      },
+      {
+        "key": "clientSecret",
+        "value": "{{secret}}",
+        "type": "string"
+      },
+      {
+        "key": "clientToken",
+        "value": "{{client_token}}",
+        "type": "string"
+      },
+      {
+        "key": "accessToken",
+        "value": "{{accessToken}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Akamai EdgeGrid.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Akamai EdgeGrid.postman_collection.json
@@ -10,21 +10,6 @@
     {
       "name": "Inherit",
       "request": {
-        "auth": {
-          "type": "ntlm",
-          "ntlm": [
-            {
-              "key": "password",
-              "value": "password",
-              "type": "string"
-            },
-            {
-              "key": "username",
-              "value": "NTLM_USER_2",
-              "type": "string"
-            }
-          ]
-        },
         "method": "GET",
         "header": [],
         "url": {

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Basic Auth Folder.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Basic Auth Folder.postman_collection.json
@@ -1,0 +1,343 @@
+{
+  "info": {
+    "_postman_id": "447ee40d-9414-4569-a8f6-5b74aadcc0f2",
+    "name": "Basic Auth",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-447ee40d-9414-4569-a8f6-5b74aadcc0f2?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Inherited Folder",
+      "item": [
+        {
+          "name": "Inherited",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "health"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Own Auth",
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "password",
+                  "value": "johndoefolder",
+                  "type": "string"
+                },
+                {
+                  "key": "username",
+                  "value": "john-custom-folder",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "health"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Own Auth folder",
+      "item": [
+        {
+          "name": "Inherited",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "health"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Own Auth",
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "password",
+                  "value": "leaf-pass",
+                  "type": "string"
+                },
+                {
+                  "key": "username",
+                  "value": "folder-leaf",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "health"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "auth": {
+        "type": "basic",
+        "basic": [
+          {
+            "key": "password",
+            "value": "folder-pass",
+            "type": "string"
+          },
+          {
+            "key": "username",
+            "value": "Folder-user",
+            "type": "string"
+          }
+        ]
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "No Auth",
+      "item": [
+        {
+          "name": "Inherited",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "health"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Own Auth",
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "password",
+                  "value": "leaf-pass2",
+                  "type": "string"
+                },
+                {
+                  "key": "username",
+                  "value": "folder-leaf",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "health"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "auth": {
+        "type": "noauth"
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "packages": {},
+            "requests": {},
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Inherited",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Own Auth",
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "johndoe1",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "john-custom",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "basic",
+    "basic": [
+      {
+        "key": "password",
+        "value": "johnm",
+        "type": "string"
+      },
+      {
+        "key": "username",
+        "value": "john",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Basic Auth.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Basic Auth.postman_collection.json
@@ -1,0 +1,103 @@
+{
+  "info": {
+    "_postman_id": "447ee40d-9414-4569-a8f6-5b74aadcc0f2",
+    "name": "Basic Auth",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-447ee40d-9414-4569-a8f6-5b74aadcc0f2?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Inherited",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Own Auth",
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "password",
+              "value": "johndoe1",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "john-custom",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "basic",
+    "basic": [
+      {
+        "key": "password",
+        "value": "johnm",
+        "type": "string"
+      },
+      {
+        "key": "username",
+        "value": "john",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Bearer.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Bearer.postman_collection.json
@@ -1,0 +1,115 @@
+{
+  "info": {
+    "_postman_id": "8c5f7e2f-01c8-46d6-b5c3-b9355748d126",
+    "name": "Bearer",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-8c5f7e2f-01c8-46d6-b5c3-b9355748d126?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Inherited",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Own Auth",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}-new",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "No Auth",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Digest.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Digest.postman_collection.json
@@ -1,0 +1,132 @@
+{
+  "info": {
+    "_postman_id": "429aca26-42a7-472a-bc41-a1fad336956f",
+    "name": "Digest",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-429aca26-42a7-472a-bc41-a1fad336956f?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Own auth",
+      "request": {
+        "auth": {
+          "type": "digest",
+          "digest": [
+            {
+              "key": "password",
+              "value": "plain_password",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "test",
+              "type": "string"
+            },
+            {
+              "key": "algorithm",
+              "value": "MD5",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Inherited",
+      "request": {
+        "method": "GET",
+        "header": []
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "digest",
+    "digest": [
+      {
+        "key": "opaque",
+        "value": "opaque",
+        "type": "string"
+      },
+      {
+        "key": "clientNonce",
+        "value": "0af11b",
+        "type": "string"
+      },
+      {
+        "key": "nonceCount",
+        "value": "1",
+        "type": "string"
+      },
+      {
+        "key": "qop",
+        "value": "auth-int",
+        "type": "string"
+      },
+      {
+        "key": "nonce",
+        "value": "Nonce",
+        "type": "string"
+      },
+      {
+        "key": "realm",
+        "value": "testrealm@example.com",
+        "type": "string"
+      },
+      {
+        "key": "password",
+        "value": "{{password}}",
+        "type": "string"
+      },
+      {
+        "key": "username",
+        "value": "username",
+        "type": "string"
+      },
+      {
+        "key": "algorithm",
+        "value": "MD5",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/NTLM.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/NTLM.postman_collection.json
@@ -1,0 +1,113 @@
+{
+  "info": {
+    "_postman_id": "68dee704-cc87-496a-9715-6e60158709dd",
+    "name": "NTLM",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-68dee704-cc87-496a-9715-6e60158709dd?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Inherited",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Own Auth",
+      "request": {
+        "auth": {
+          "type": "ntlm",
+          "ntlm": [
+            {
+              "key": "password",
+              "value": "password",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "NTLM_USER_2",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "ntlm",
+    "ntlm": [
+      {
+        "key": "workstation",
+        "value": "my-pc",
+        "type": "string"
+      },
+      {
+        "key": "domain",
+        "value": "example.com",
+        "type": "string"
+      },
+      {
+        "key": "password",
+        "value": "pass",
+        "type": "string"
+      },
+      {
+        "key": "username",
+        "value": "NTLM_user",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Oauth1.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Oauth1.postman_collection.json
@@ -1,0 +1,837 @@
+{
+  "info": {
+    "_postman_id": "1305cc95-5259-4020-89d1-6b5c04bd978e",
+    "name": "Oauth1",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-1305cc95-5259-4020-89d1-6b5c04bd978e?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "type 1",
+      "request": {
+        "auth": {
+          "type": "oauth1",
+          "oauth1": [
+            {
+              "key": "addEmptyParamsToSign",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "includeBodyHash",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "realm",
+              "value": "realm",
+              "type": "string"
+            },
+            {
+              "key": "nonce",
+              "value": "nonce",
+              "type": "string"
+            },
+            {
+              "key": "timestamp",
+              "value": "timestamp",
+              "type": "string"
+            },
+            {
+              "key": "verifier",
+              "value": "verifier",
+              "type": "string"
+            },
+            {
+              "key": "callback",
+              "value": "url",
+              "type": "string"
+            },
+            {
+              "key": "tokenSecret",
+              "value": "tokensecret",
+              "type": "string"
+            },
+            {
+              "key": "token",
+              "value": "token",
+              "type": "string"
+            },
+            {
+              "key": "consumerSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "consumerKey",
+              "value": "key",
+              "type": "string"
+            },
+            {
+              "key": "addParamsToHeader",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "signatureMethod",
+              "value": "HMAC-SHA1",
+              "type": "string"
+            },
+            {
+              "key": "version",
+              "value": "1.0",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "type 2",
+      "request": {
+        "auth": {
+          "type": "oauth1",
+          "oauth1": [
+            {
+              "key": "disableHeaderEncoding",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "signatureMethod",
+              "value": "HMAC-SHA256",
+              "type": "string"
+            },
+            {
+              "key": "addEmptyParamsToSign",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "includeBodyHash",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "realm",
+              "value": "realm",
+              "type": "string"
+            },
+            {
+              "key": "nonce",
+              "value": "nonce",
+              "type": "string"
+            },
+            {
+              "key": "timestamp",
+              "value": "timestamp",
+              "type": "string"
+            },
+            {
+              "key": "verifier",
+              "value": "verifier",
+              "type": "string"
+            },
+            {
+              "key": "callback",
+              "value": "url",
+              "type": "string"
+            },
+            {
+              "key": "tokenSecret",
+              "value": "tokensecret",
+              "type": "string"
+            },
+            {
+              "key": "token",
+              "value": "token",
+              "type": "string"
+            },
+            {
+              "key": "consumerSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "consumerKey",
+              "value": "key",
+              "type": "string"
+            },
+            {
+              "key": "addParamsToHeader",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "version",
+              "value": "1.0",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "type 3",
+      "request": {
+        "auth": {
+          "type": "oauth1",
+          "oauth1": [
+            {
+              "key": "addParamsToHeader",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "signatureMethod",
+              "value": "HMAC-SHA512",
+              "type": "string"
+            },
+            {
+              "key": "addEmptyParamsToSign",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "includeBodyHash",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "realm",
+              "value": "realm",
+              "type": "string"
+            },
+            {
+              "key": "nonce",
+              "value": "nonce",
+              "type": "string"
+            },
+            {
+              "key": "timestamp",
+              "value": "timestamp",
+              "type": "string"
+            },
+            {
+              "key": "verifier",
+              "value": "verifier",
+              "type": "string"
+            },
+            {
+              "key": "callback",
+              "value": "url",
+              "type": "string"
+            },
+            {
+              "key": "tokenSecret",
+              "value": "tokensecret",
+              "type": "string"
+            },
+            {
+              "key": "token",
+              "value": "token",
+              "type": "string"
+            },
+            {
+              "key": "consumerSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "consumerKey",
+              "value": "key",
+              "type": "string"
+            },
+            {
+              "key": "version",
+              "value": "1.0",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "type 4",
+      "request": {
+        "auth": {
+          "type": "oauth1",
+          "oauth1": [
+            {
+              "key": "signatureMethod",
+              "value": "PLAINTEXT",
+              "type": "string"
+            },
+            {
+              "key": "disableHeaderEncoding",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "addEmptyParamsToSign",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "includeBodyHash",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "realm",
+              "value": "realm",
+              "type": "string"
+            },
+            {
+              "key": "nonce",
+              "value": "nonce",
+              "type": "string"
+            },
+            {
+              "key": "timestamp",
+              "value": "timestamp",
+              "type": "string"
+            },
+            {
+              "key": "verifier",
+              "value": "verifier",
+              "type": "string"
+            },
+            {
+              "key": "callback",
+              "value": "url",
+              "type": "string"
+            },
+            {
+              "key": "tokenSecret",
+              "value": "tokensecret",
+              "type": "string"
+            },
+            {
+              "key": "token",
+              "value": "token",
+              "type": "string"
+            },
+            {
+              "key": "consumerSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "consumerKey",
+              "value": "key",
+              "type": "string"
+            },
+            {
+              "key": "addParamsToHeader",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "version",
+              "value": "1.0",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "type5",
+      "request": {
+        "auth": {
+          "type": "oauth1",
+          "oauth1": [
+            {
+              "key": "privateKey",
+              "value": "-----BEGIN CERTIFICATE-----\nTest Certificate\n-----END CERTIFICATE-----\n-----BEGIN PRIVATE KEY-----\nTest Private key\n-----END PRIVATE KEY-----",
+              "type": "string"
+            },
+            {
+              "key": "signatureMethod",
+              "value": "RSA-SHA1",
+              "type": "string"
+            },
+            {
+              "key": "disableHeaderEncoding",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "addEmptyParamsToSign",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "includeBodyHash",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "realm",
+              "value": "realm",
+              "type": "string"
+            },
+            {
+              "key": "nonce",
+              "value": "nonce",
+              "type": "string"
+            },
+            {
+              "key": "timestamp",
+              "value": "timestamp",
+              "type": "string"
+            },
+            {
+              "key": "verifier",
+              "value": "verifier",
+              "type": "string"
+            },
+            {
+              "key": "callback",
+              "value": "url",
+              "type": "string"
+            },
+            {
+              "key": "tokenSecret",
+              "value": "tokensecret",
+              "type": "string"
+            },
+            {
+              "key": "token",
+              "value": "token",
+              "type": "string"
+            },
+            {
+              "key": "consumerSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "consumerKey",
+              "value": "key",
+              "type": "string"
+            },
+            {
+              "key": "addParamsToHeader",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "version",
+              "value": "1.0",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "type6",
+      "request": {
+        "auth": {
+          "type": "oauth1",
+          "oauth1": [
+            {
+              "key": "privateKey",
+              "value": "-----BEGIN CERTIFICATE-----\nTest Certificate\n-----END CERTIFICATE-----\n-----BEGIN PRIVATE KEY-----\nTest Private key\n-----END PRIVATE KEY-----",
+              "type": "string"
+            },
+            {
+              "key": "signatureMethod",
+              "value": "RSA-SHA256",
+              "type": "string"
+            },
+            {
+              "key": "disableHeaderEncoding",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "addEmptyParamsToSign",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "includeBodyHash",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "realm",
+              "value": "realm",
+              "type": "string"
+            },
+            {
+              "key": "nonce",
+              "value": "nonce",
+              "type": "string"
+            },
+            {
+              "key": "timestamp",
+              "value": "timestamp",
+              "type": "string"
+            },
+            {
+              "key": "verifier",
+              "value": "verifier",
+              "type": "string"
+            },
+            {
+              "key": "callback",
+              "value": "url",
+              "type": "string"
+            },
+            {
+              "key": "tokenSecret",
+              "value": "tokensecret",
+              "type": "string"
+            },
+            {
+              "key": "token",
+              "value": "token",
+              "type": "string"
+            },
+            {
+              "key": "consumerSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "consumerKey",
+              "value": "key",
+              "type": "string"
+            },
+            {
+              "key": "addParamsToHeader",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "version",
+              "value": "1.0",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "type7",
+      "request": {
+        "auth": {
+          "type": "oauth1",
+          "oauth1": [
+            {
+              "key": "privateKey",
+              "value": "-----BEGIN CERTIFICATE-----\nTest Certificate\n-----END CERTIFICATE-----\n-----BEGIN PRIVATE KEY-----\nTest Private key\n-----END PRIVATE KEY-----",
+              "type": "string"
+            },
+            {
+              "key": "signatureMethod",
+              "value": "RSA-SHA512",
+              "type": "string"
+            },
+            {
+              "key": "disableHeaderEncoding",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "addEmptyParamsToSign",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "includeBodyHash",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "realm",
+              "value": "realm",
+              "type": "string"
+            },
+            {
+              "key": "nonce",
+              "value": "nonce",
+              "type": "string"
+            },
+            {
+              "key": "timestamp",
+              "value": "timestamp",
+              "type": "string"
+            },
+            {
+              "key": "verifier",
+              "value": "verifier",
+              "type": "string"
+            },
+            {
+              "key": "callback",
+              "value": "url",
+              "type": "string"
+            },
+            {
+              "key": "tokenSecret",
+              "value": "tokensecret",
+              "type": "string"
+            },
+            {
+              "key": "token",
+              "value": "token",
+              "type": "string"
+            },
+            {
+              "key": "consumerSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "consumerKey",
+              "value": "key",
+              "type": "string"
+            },
+            {
+              "key": "addParamsToHeader",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "version",
+              "value": "1.0",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Optional values",
+      "request": {
+        "auth": {
+          "type": "oauth1",
+          "oauth1": [
+            {
+              "key": "addEmptyParamsToSign",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "includeBodyHash",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "realm",
+              "value": "",
+              "type": "string"
+            },
+            {
+              "key": "version",
+              "value": "",
+              "type": "string"
+            },
+            {
+              "key": "nonce",
+              "value": "",
+              "type": "string"
+            },
+            {
+              "key": "timestamp",
+              "value": "",
+              "type": "string"
+            },
+            {
+              "key": "privateKey",
+              "value": "-----BEGIN CERTIFICATE-----\nTest Certificate\n-----END CERTIFICATE-----\n-----BEGIN PRIVATE KEY-----\nTest Private key\n-----END PRIVATE KEY-----",
+              "type": "string"
+            },
+            {
+              "key": "signatureMethod",
+              "value": "RSA-SHA512",
+              "type": "string"
+            },
+            {
+              "key": "disableHeaderEncoding",
+              "value": true,
+              "type": "boolean"
+            },
+            {
+              "key": "verifier",
+              "value": "verifier",
+              "type": "string"
+            },
+            {
+              "key": "callback",
+              "value": "url",
+              "type": "string"
+            },
+            {
+              "key": "tokenSecret",
+              "value": "tokensecret",
+              "type": "string"
+            },
+            {
+              "key": "token",
+              "value": "token",
+              "type": "string"
+            },
+            {
+              "key": "consumerSecret",
+              "value": "secret",
+              "type": "string"
+            },
+            {
+              "key": "consumerKey",
+              "value": "key",
+              "type": "string"
+            },
+            {
+              "key": "addParamsToHeader",
+              "value": true,
+              "type": "boolean"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ]
+}

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Oauth2.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Oauth2.postman_collection.json
@@ -650,6 +650,16 @@
           "type": "oauth2",
           "oauth2": [
             {
+              "key": "code_verifier",
+              "value": "asfajhfkasjfjkasfkjsabjkabgjksabgjkasgjlabglajsglba",
+              "type": "string"
+            },
+            {
+              "key": "challengeAlgorithm",
+              "value": "plain",
+              "type": "string"
+            },
+            {
               "key": "grant_type",
               "value": "authorization_code_with_pkce",
               "type": "string"

--- a/packages/bruno-converters/tests/postman/round-trip/fixtures/Oauth2.postman_collection.json
+++ b/packages/bruno-converters/tests/postman/round-trip/fixtures/Oauth2.postman_collection.json
@@ -1,0 +1,1303 @@
+{
+  "info": {
+    "_postman_id": "bfd86e56-743f-4f19-8c04-d8782454b817",
+    "name": "Oauth2",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "56331529",
+    "_collection_link": "https://go.postman.co/collection/56331529-bfd86e56-743f-4f19-8c04-d8782454b817?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "Client Creds",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "grant_type",
+              "value": "client_credentials",
+              "type": "string"
+            },
+            {
+              "key": "redirect_uri",
+              "value": "https://api.example.com/authorize",
+              "type": "string"
+            },
+            {
+              "key": "refreshTokenUrl",
+              "value": "https://api.example.com/refresh",
+              "type": "string"
+            },
+            {
+              "key": "client_authentication",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "scope:scope1,scope:scope2",
+              "type": "string"
+            },
+            {
+              "key": "clientSecret",
+              "value": "{{client_secret}}",
+              "type": "string"
+            },
+            {
+              "key": "clientId",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "https://api.example.com/access",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "cc-tname",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "Bearer",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "useBrowser",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "refreshRequestParams",
+              "value": [
+                {
+                  "key": "refreshKey",
+                  "value": "refreshValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "refreshKey1",
+                  "value": "refreshValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "refreshKey2",
+                  "value": "refreshValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [
+                {
+                  "key": "tokenKey",
+                  "value": "tokenValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "tokenKey1",
+                  "value": "tokenValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "tokenKey2",
+                  "value": "tokenValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "authRequestParams",
+              "value": [
+                {
+                  "key": "authKey",
+                  "value": "authValue",
+                  "enabled": true,
+                  "send_as": "request_url"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "state",
+              "value": "state",
+              "type": "string"
+            },
+            {
+              "key": "authUrl",
+              "value": "https://stripe.com/authorize",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Implicit",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "client_authentication",
+              "value": "body",
+              "type": "string"
+            },
+            {
+              "key": "state",
+              "value": "customState",
+              "type": "string"
+            },
+            {
+              "key": "authUrl",
+              "value": "https://api.example.com/authorize",
+              "type": "string"
+            },
+            {
+              "key": "redirect_uri",
+              "value": "https://api.example.com/callback",
+              "type": "string"
+            },
+            {
+              "key": "grant_type",
+              "value": "implicit",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "CustomBearer",
+              "type": "string"
+            },
+            {
+              "key": "refreshTokenUrl",
+              "value": "https://api.example.com/refresh",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "scope:scope1,scope:scope2",
+              "type": "string"
+            },
+            {
+              "key": "clientSecret",
+              "value": "{{client_secret}}",
+              "type": "string"
+            },
+            {
+              "key": "clientId",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "https://api.example.com/access",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "cc-tname",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "useBrowser",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "refreshRequestParams",
+              "value": [
+                {
+                  "key": "refreshKey",
+                  "value": "refreshValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "refreshKey1",
+                  "value": "refreshValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "refreshKey2",
+                  "value": "refreshValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [
+                {
+                  "key": "tokenKey",
+                  "value": "tokenValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "tokenKey1",
+                  "value": "tokenValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "tokenKey2",
+                  "value": "tokenValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "authRequestParams",
+              "value": [
+                {
+                  "key": "authKey",
+                  "value": "authValue",
+                  "enabled": true,
+                  "send_as": "request_url"
+                }
+              ],
+              "type": "any"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Auth Code",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "headerPrefix",
+              "value": "Bearer",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "queryParams",
+              "type": "string"
+            },
+            {
+              "key": "client_authentication",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "grant_type",
+              "value": "authorization_code",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{password}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{username}}",
+              "type": "string"
+            },
+            {
+              "key": "state",
+              "value": "customState",
+              "type": "string"
+            },
+            {
+              "key": "authUrl",
+              "value": "https://api.example.com/authorize",
+              "type": "string"
+            },
+            {
+              "key": "redirect_uri",
+              "value": "https://api.example.com/callback",
+              "type": "string"
+            },
+            {
+              "key": "refreshTokenUrl",
+              "value": "https://api.example.com/refresh",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "scope:scope1,scope:scope2",
+              "type": "string"
+            },
+            {
+              "key": "clientSecret",
+              "value": "{{client_secret}}",
+              "type": "string"
+            },
+            {
+              "key": "clientId",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "https://api.example.com/access",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "cc-tname",
+              "type": "string"
+            },
+            {
+              "key": "useBrowser",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "refreshRequestParams",
+              "value": [
+                {
+                  "key": "refreshKey",
+                  "value": "refreshValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "refreshKey1",
+                  "value": "refreshValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "refreshKey2",
+                  "value": "refreshValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [
+                {
+                  "key": "tokenKey",
+                  "value": "tokenValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "tokenKey1",
+                  "value": "tokenValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "tokenKey2",
+                  "value": "tokenValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "authRequestParams",
+              "value": [
+                {
+                  "key": "authKey",
+                  "value": "authValue",
+                  "enabled": true,
+                  "send_as": "request_url"
+                }
+              ],
+              "type": "any"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "password",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "password",
+              "value": "{{password}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{username}}",
+              "type": "string"
+            },
+            {
+              "key": "grant_type",
+              "value": "password_credentials",
+              "type": "string"
+            },
+            {
+              "key": "client_authentication",
+              "value": "body",
+              "type": "string"
+            },
+            {
+              "key": "state",
+              "value": "customState",
+              "type": "string"
+            },
+            {
+              "key": "authUrl",
+              "value": "https://api.example.com/authorize",
+              "type": "string"
+            },
+            {
+              "key": "redirect_uri",
+              "value": "https://api.example.com/callback",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "CustomBearer",
+              "type": "string"
+            },
+            {
+              "key": "refreshTokenUrl",
+              "value": "https://api.example.com/refresh",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "scope:scope1,scope:scope2",
+              "type": "string"
+            },
+            {
+              "key": "clientSecret",
+              "value": "{{client_secret}}",
+              "type": "string"
+            },
+            {
+              "key": "clientId",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "https://api.example.com/access",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "cc-tname",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "useBrowser",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "refreshRequestParams",
+              "value": [
+                {
+                  "key": "refreshKey",
+                  "value": "refreshValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "refreshKey1",
+                  "value": "refreshValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "refreshKey2",
+                  "value": "refreshValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [
+                {
+                  "key": "tokenKey",
+                  "value": "tokenValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "tokenKey1",
+                  "value": "tokenValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "tokenKey2",
+                  "value": "tokenValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "authRequestParams",
+              "value": [
+                {
+                  "key": "authKey",
+                  "value": "authValue",
+                  "enabled": true,
+                  "send_as": "request_url"
+                }
+              ],
+              "type": "any"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "PKCE",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "grant_type",
+              "value": "authorization_code_with_pkce",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "Bearer",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "queryParams",
+              "type": "string"
+            },
+            {
+              "key": "client_authentication",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{password}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{username}}",
+              "type": "string"
+            },
+            {
+              "key": "state",
+              "value": "customState",
+              "type": "string"
+            },
+            {
+              "key": "authUrl",
+              "value": "https://api.example.com/authorize",
+              "type": "string"
+            },
+            {
+              "key": "redirect_uri",
+              "value": "https://api.example.com/callback",
+              "type": "string"
+            },
+            {
+              "key": "refreshTokenUrl",
+              "value": "https://api.example.com/refresh",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "scope:scope1,scope:scope2",
+              "type": "string"
+            },
+            {
+              "key": "clientSecret",
+              "value": "{{client_secret}}",
+              "type": "string"
+            },
+            {
+              "key": "clientId",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "https://api.example.com/access",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "cc-tname",
+              "type": "string"
+            },
+            {
+              "key": "useBrowser",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "refreshRequestParams",
+              "value": [
+                {
+                  "key": "refreshKey",
+                  "value": "refreshValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "refreshKey1",
+                  "value": "refreshValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "refreshKey2",
+                  "value": "refreshValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [
+                {
+                  "key": "tokenKey",
+                  "value": "tokenValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "tokenKey1",
+                  "value": "tokenValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "tokenKey2",
+                  "value": "tokenValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "authRequestParams",
+              "value": [
+                {
+                  "key": "authKey",
+                  "value": "authValue",
+                  "enabled": true,
+                  "send_as": "request_url"
+                }
+              ],
+              "type": "any"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Implicit from PKCE",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "grant_type",
+              "value": "implicit",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "Bearer",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "queryParams",
+              "type": "string"
+            },
+            {
+              "key": "client_authentication",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{password}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{username}}",
+              "type": "string"
+            },
+            {
+              "key": "state",
+              "value": "customState",
+              "type": "string"
+            },
+            {
+              "key": "authUrl",
+              "value": "https://api.example.com/authorize",
+              "type": "string"
+            },
+            {
+              "key": "redirect_uri",
+              "value": "https://api.example.com/callback",
+              "type": "string"
+            },
+            {
+              "key": "refreshTokenUrl",
+              "value": "https://api.example.com/refresh",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "scope:scope1,scope:scope2",
+              "type": "string"
+            },
+            {
+              "key": "clientSecret",
+              "value": "{{client_secret}}",
+              "type": "string"
+            },
+            {
+              "key": "clientId",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "https://api.example.com/access",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "cc-tname",
+              "type": "string"
+            },
+            {
+              "key": "useBrowser",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "refreshRequestParams",
+              "value": [
+                {
+                  "key": "refreshKey",
+                  "value": "refreshValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "refreshKey1",
+                  "value": "refreshValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "refreshKey2",
+                  "value": "refreshValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [
+                {
+                  "key": "tokenKey",
+                  "value": "tokenValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "tokenKey1",
+                  "value": "tokenValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "tokenKey2",
+                  "value": "tokenValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "authRequestParams",
+              "value": [
+                {
+                  "key": "authKey",
+                  "value": "authValue",
+                  "enabled": true,
+                  "send_as": "request_url"
+                }
+              ],
+              "type": "any"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Client Creds from PKCE",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "grant_type",
+              "value": "client_credentials",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "Bearer",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "queryParams",
+              "type": "string"
+            },
+            {
+              "key": "client_authentication",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{password}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{username}}",
+              "type": "string"
+            },
+            {
+              "key": "state",
+              "value": "customState",
+              "type": "string"
+            },
+            {
+              "key": "authUrl",
+              "value": "https://api.example.com/authorize",
+              "type": "string"
+            },
+            {
+              "key": "redirect_uri",
+              "value": "https://api.example.com/callback",
+              "type": "string"
+            },
+            {
+              "key": "refreshTokenUrl",
+              "value": "https://api.example.com/refresh",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "scope:scope1,scope:scope2",
+              "type": "string"
+            },
+            {
+              "key": "clientSecret",
+              "value": "{{client_secret}}",
+              "type": "string"
+            },
+            {
+              "key": "clientId",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "https://api.example.com/access",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "cc-tname",
+              "type": "string"
+            },
+            {
+              "key": "useBrowser",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "refreshRequestParams",
+              "value": [
+                {
+                  "key": "refreshKey",
+                  "value": "refreshValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "refreshKey1",
+                  "value": "refreshValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "refreshKey2",
+                  "value": "refreshValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [
+                {
+                  "key": "tokenKey",
+                  "value": "tokenValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "tokenKey1",
+                  "value": "tokenValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "tokenKey2",
+                  "value": "tokenValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "authRequestParams",
+              "value": [
+                {
+                  "key": "authKey",
+                  "value": "authValue",
+                  "enabled": true,
+                  "send_as": "request_url"
+                }
+              ],
+              "type": "any"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Password from PKCE",
+      "request": {
+        "auth": {
+          "type": "oauth2",
+          "oauth2": [
+            {
+              "key": "grant_type",
+              "value": "password_credentials",
+              "type": "string"
+            },
+            {
+              "key": "headerPrefix",
+              "value": "Bearer",
+              "type": "string"
+            },
+            {
+              "key": "addTokenTo",
+              "value": "queryParams",
+              "type": "string"
+            },
+            {
+              "key": "client_authentication",
+              "value": "header",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{password}}",
+              "type": "string"
+            },
+            {
+              "key": "username",
+              "value": "{{username}}",
+              "type": "string"
+            },
+            {
+              "key": "state",
+              "value": "customState",
+              "type": "string"
+            },
+            {
+              "key": "authUrl",
+              "value": "https://api.example.com/authorize",
+              "type": "string"
+            },
+            {
+              "key": "redirect_uri",
+              "value": "https://api.example.com/callback",
+              "type": "string"
+            },
+            {
+              "key": "refreshTokenUrl",
+              "value": "https://api.example.com/refresh",
+              "type": "string"
+            },
+            {
+              "key": "scope",
+              "value": "scope:scope1,scope:scope2",
+              "type": "string"
+            },
+            {
+              "key": "clientSecret",
+              "value": "{{client_secret}}",
+              "type": "string"
+            },
+            {
+              "key": "clientId",
+              "value": "{{client_id}}",
+              "type": "string"
+            },
+            {
+              "key": "accessTokenUrl",
+              "value": "https://api.example.com/access",
+              "type": "string"
+            },
+            {
+              "key": "tokenName",
+              "value": "cc-tname",
+              "type": "string"
+            },
+            {
+              "key": "useBrowser",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "key": "refreshRequestParams",
+              "value": [
+                {
+                  "key": "refreshKey",
+                  "value": "refreshValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "refreshKey1",
+                  "value": "refreshValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "refreshKey2",
+                  "value": "refreshValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "tokenRequestParams",
+              "value": [
+                {
+                  "key": "tokenKey",
+                  "value": "tokenValue",
+                  "enabled": true,
+                  "send_as": "request_body"
+                },
+                {
+                  "key": "tokenKey1",
+                  "value": "tokenValue1",
+                  "enabled": true,
+                  "send_as": "request_url"
+                },
+                {
+                  "key": "tokenKey2",
+                  "value": "tokenValue2",
+                  "enabled": true,
+                  "send_as": "request_header"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "key": "authRequestParams",
+              "value": [
+                {
+                  "key": "authKey",
+                  "value": "authValue",
+                  "enabled": true,
+                  "send_as": "request_url"
+                }
+              ],
+              "type": "any"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/health",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}


### PR DESCRIPTION
### Description

This PR adds a fixture based round trip test suite to validate auth settings in postman-Bruno converters. Added a harness that is extendable to other settings with a whitelist to accommodate current gaps in the converters.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded authentication round-trip validation across additional auth types (basic, bearer, digest, NTLM, API key, AWS, EdgeGrid, OAuth1, OAuth2), including inheritance and override scenarios.
* **Bug Fixes**
  * Enhanced fidelity checking with deterministic auth diffing and strict comparison rules (including oauth2 grant-type-aware diff handling and absent/empty equivalence).
* **Documentation**
  * Added/updated end-to-end guidance for the auth round-trip harness, coverage scope, and whitelist behavior.
* **Tests**
  * Introduced a Jest auth round-trip spec with new diff utilities and additional Postman fixture collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->