### PR TITLE
fix(request-panel)/websocket and grpc tooltip overflow fixed in request panel

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/StyledWrapper.js
@@ -35,50 +35,6 @@ const Wrapper = styled.div`
     top: 1px;
   }
 
-  .infotip {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-  }
-
-  .infotip:hover .infotip-text {
-    visibility: visible;
-    opacity: 1;
-  }
-
-  .infotip-text {
-    visibility: hidden;
-    width: auto;
-    background-color: ${(props) => props.theme.background.surface2};
-    color: ${(props) => props.theme.text};
-    text-align: center;
-    border-radius: 4px;
-    padding: 4px 8px;
-    position: absolute;
-    z-index: 1;
-    bottom: 34px;
-    left: 50%;
-    transform: translateX(-50%);
-    opacity: 0;
-    transition: opacity 0.3s;
-    white-space: nowrap;
-  }
-
-  .infotip-text::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-left: -4px;
-    border-width: 4px;
-    border-style: solid;
-    border-color: ${(props) => props.theme.background.surface2} transparent transparent transparent;
-  }
-
-  .shortcut {
-    font-size: 0.625rem;
-  }
-
   @keyframes pulse {
     0% {
       opacity: 0.4;

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -395,6 +395,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
         >
           <div
             className="flex items-center"
+            data-testid="save-request-button"
             onClick={(e) => {
               e.stopPropagation();
               if (!item.draft) return;

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -26,6 +26,7 @@ import useReflectionManagement from 'hooks/useReflectionManagement/index';
 import useProtoFileManagement from 'hooks/useProtoFileManagement/index';
 import MethodDropdown from './MethodDropdown';
 import ProtoFileDropdown from './ProtoFileDropdown';
+import ToolHint from 'components/ToolHint';
 
 const STREAMING_METHOD_TYPES = ['client-streaming', 'server-streaming', 'bidi-streaming'];
 const CLIENT_STREAMING_METHOD_TYPES = ['client-streaming', 'bidi-streaming'];
@@ -336,71 +337,86 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
           onProtoFileLoad={handleProtoFileLoad}
         />
 
-        <div
-          className="infotip"
-          onClick={(e) => {
-            e.stopPropagation();
-            if (isReflectionMode) {
-              handleReflection(url, true);
-            } else if (protoFilePath) {
-              handleProtoFileLoad(protoFilePath, true);
-            } else {
-              toast.error('No proto file selected');
-            }
-          }}
+        <ToolHint
+          text={isReflectionMode ? 'Refresh server reflection' : 'Refresh proto file methods'}
+          toolhintId="grpc-refresh-methods"
+          place="top"
+          positionStrategy="fixed"
         >
-          <IconRefresh
-            color={theme.requestTabs.icon.color}
-            strokeWidth={1.5}
-            size={20}
-            className={`${(isReflectionMode ? reflectionManagement.isLoadingMethods : protoFileManagement.isLoadingMethods) ? 'animate-spin' : 'cursor-pointer'}`}
-            data-testid="refresh-methods-icon"
-          />
-          <span className="infotip-text text-xs">
-            {isReflectionMode ? 'Refresh server reflection' : 'Refresh proto file methods'}
-          </span>
-        </div>
+          <div
+            className="flex items-center"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (isReflectionMode) {
+                handleReflection(url, true);
+              } else if (protoFilePath) {
+                handleProtoFileLoad(protoFilePath, true);
+              } else {
+                toast.error('No proto file selected');
+              }
+            }}
+          >
+            <IconRefresh
+              color={theme.requestTabs.icon.color}
+              strokeWidth={1.5}
+              size={20}
+              className={`${(isReflectionMode ? reflectionManagement.isLoadingMethods : protoFileManagement.isLoadingMethods) ? 'animate-spin' : 'cursor-pointer'}`}
+              data-testid="refresh-methods-icon"
+            />
+          </div>
+        </ToolHint>
 
-        <div
-          className="infotip"
-          onClick={(e) => {
-            e.stopPropagation();
-            handleGrpcurl(url);
-          }}
+        <ToolHint
+          text="Generate grpcurl command"
+          toolhintId="grpc-generate-grpcurl"
+          place="top"
+          positionStrategy="fixed"
         >
-          <IconCode
-            color={theme.requestTabs.icon.color}
-            strokeWidth={1.5}
-            size={20}
-          />
-          <span className="infotip-text text-xs">Generate grpcurl command</span>
-        </div>
+          <div
+            className="flex items-center cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleGrpcurl(url);
+            }}
+          >
+            <IconCode
+              color={theme.requestTabs.icon.color}
+              strokeWidth={1.5}
+              size={20}
+            />
+          </div>
+        </ToolHint>
 
-        <div
-          className="infotip"
-          onClick={(e) => {
-            e.stopPropagation();
-            if (!item.draft) return;
-            onSave();
-          }}
+        <ToolHint
+          text={`Save (${saveShortcut})`}
+          toolhintId="grpc-save-request"
+          place="top"
+          positionStrategy="fixed"
         >
-          <IconDeviceFloppy
-            color={item.draft ? theme.draftColor : theme.requestTabs.icon.color}
-            strokeWidth={1.5}
-            size={20}
-            className={`${item.draft ? 'cursor-pointer' : 'cursor-default'}`}
-          />
-          <span className="infotip-text text-xs">
-            Save <span className="shortcut">({saveShortcut})</span>
-          </span>
-        </div>
+          <div
+            className="flex items-center"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!item.draft) return;
+              onSave();
+            }}
+          >
+            <IconDeviceFloppy
+              color={item.draft ? theme.draftColor : theme.requestTabs.icon.color}
+              strokeWidth={1.5}
+              size={20}
+              className={`${item.draft ? 'cursor-pointer' : 'cursor-default'}`}
+            />
+          </div>
+        </ToolHint>
 
         {isConnectionActive && isStreamingMethod && (
           <div className="connection-controls relative flex items-center h-full gap-3">
-            <div className="infotip" onClick={handleCancelConnection} data-testid="grpc-cancel-connection-button">
-              <IconX color={theme.requestTabs.icon.color} strokeWidth={1.5} size={20} className="cursor-pointer" />
-              <span className="infotip-text text-xs">Cancel</span>
-            </div>
+            <ToolHint text="Cancel" toolhintId="grpc-cancel-connection" place="top" positionStrategy="fixed">
+              <div className="flex items-center" onClick={handleCancelConnection} data-testid="grpc-cancel-connection-button">
+                <IconX color={theme.requestTabs.icon.color} strokeWidth={1.5} size={20} className="cursor-pointer" />
+              </div>
+            </ToolHint>
 
             {isClientStreamingMethod && (
               <div onClick={handleEndConnection} data-testid="grpc-end-connection-button">

--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/StyledWrapper.js
@@ -10,50 +10,6 @@ const Wrapper = styled.div`
     min-width: 0;
   }
 
-  .infotip {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-  }
-
-  .infotip:hover .infotiptext {
-    visibility: visible;
-    opacity: 1;
-  }
-
-  .infotiptext {
-    visibility: hidden;
-    width: auto;
-    background-color: ${(props) => props.theme.background.surface2};
-    color: ${(props) => props.theme.text};
-    text-align: center;
-    border-radius: 4px;
-    padding: 4px 8px;
-    position: absolute;
-    z-index: 1;
-    bottom: 34px;
-    left: 50%;
-    transform: translateX(-50%);
-    opacity: 0;
-    transition: opacity 0.3s;
-    white-space: nowrap;
-  }
-
-  .infotiptext::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-left: -4px;
-    border-width: 4px;
-    border-style: solid;
-    border-color: ${(props) => props.theme.background.surface2} transparent transparent transparent;
-  }
-
-  .shortcut {
-    font-size: 0.625rem;
-  }
-
 `;
 
 export default Wrapper;

--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -418,6 +418,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
             <ToolHint text="Generate Code" toolhintId="http-generate-code" place="top" positionStrategy="fixed">
               <div
                 className="flex items-center"
+                data-testid="generate-code-button"
                 onClick={(e) => {
                   handleGenerateCode(e);
                 }}
@@ -428,6 +429,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
             <ToolHint text={`Save (${saveShortcut})`} toolhintId="http-save-request" place="top" positionStrategy="fixed">
               <div
                 className="flex items-center"
+                data-testid="save-request-button"
                 onClick={(e) => {
                   e.stopPropagation();
                   if (!hasChanges) return;

--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -23,6 +23,7 @@ import { isMacOS } from 'utils/common/platform';
 import { hasRequestChanges } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import GenerateCodeItem from 'components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index';
+import ToolHint from 'components/ToolHint';
 import toast from 'react-hot-toast';
 
 const QueryUrl = ({ item, collection, handleRun }) => {
@@ -414,35 +415,33 @@ const QueryUrl = ({ item, collection, handleRun }) => {
             showNewlineArrow={true}
           />
           <div className="flex items-center h-full mx-2 gap-3" id="request-actions">
-            <div
-              title="Generate Code"
-              className="infotip"
-              onClick={(e) => {
-                handleGenerateCode(e);
-              }}
-            >
-              <IconCode color={theme.requestTabs.icon.color} strokeWidth={1.5} size={20} className="cursor-pointer" />
-              <span className="infotiptext text-xs">Generate Code</span>
-            </div>
-            <div
-              title="Save Request"
-              className="infotip"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (!hasChanges) return;
-                onSave();
-              }}
-            >
-              <IconDeviceFloppy
-                color={hasChanges ? theme.draftColor : theme.requestTabs.icon.color}
-                strokeWidth={1.5}
-                size={20}
-                className={`${hasChanges ? 'cursor-pointer' : 'cursor-default'}`}
-              />
-              <span className="infotiptext text-xs">
-                Save <span className="shortcut">({saveShortcut})</span>
-              </span>
-            </div>
+            <ToolHint text="Generate Code" toolhintId="http-generate-code" place="top" positionStrategy="fixed">
+              <div
+                className="flex items-center"
+                onClick={(e) => {
+                  handleGenerateCode(e);
+                }}
+              >
+                <IconCode color={theme.requestTabs.icon.color} strokeWidth={1.5} size={20} className="cursor-pointer" />
+              </div>
+            </ToolHint>
+            <ToolHint text={`Save (${saveShortcut})`} toolhintId="http-save-request" place="top" positionStrategy="fixed">
+              <div
+                className="flex items-center"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!hasChanges) return;
+                  onSave();
+                }}
+              >
+                <IconDeviceFloppy
+                  color={hasChanges ? theme.draftColor : theme.requestTabs.icon.color}
+                  strokeWidth={1.5}
+                  size={20}
+                  className={`${hasChanges ? 'cursor-pointer' : 'cursor-default'}`}
+                />
+              </div>
+            </ToolHint>
           </div>
         </div>
       </div>

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/StyledWrapper.js
@@ -48,58 +48,6 @@ const StyledWrapper = styled.div`
     }
   }
 
-  .infotip {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-  }
-
-  .infotip:hover .infotip-text {
-    visibility: visible;
-    opacity: 1;
-  }
-
-  .infotip-text {
-    visibility: hidden;
-    width: auto;
-    background-color: ${(props) => props.theme.background.surface2};
-    color: ${(props) => props.theme.text};
-    text-align: center;
-    border-radius: 4px;
-    padding: 4px 8px;
-    position: absolute;
-    z-index: 1;
-    bottom: 34px;
-    left: 50%;
-    transform: translateX(-50%);
-    opacity: 0;
-    transition: opacity 0.3s;
-    white-space: nowrap;
-  }
-
-  .infotip-text::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-left: -4px;
-    border-width: 4px;
-    border-style: solid;
-    border-color: ${(props) => props.theme.background.surface2} transparent transparent transparent;
-  }
-
-  .shortcut {
-    font-size: 0.625rem;
-  }
-
-  .connection-controls {
-    .infotip {
-      &:hover {
-        background-color: color-mix(in srgb, ${(props) => props.theme.colors.text.danger} 6%, transparent);
-      }
-    }
-  }
-
 `;
 
 export default StyledWrapper;

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
@@ -12,6 +12,7 @@ import { isMacOS } from 'utils/common/platform';
 import { hasRequestChanges } from 'utils/collections';
 import { closeWsConnection, getWsConnectionStatus } from 'utils/network/index';
 import StyledWrapper from './StyledWrapper';
+import ToolHint from 'components/ToolHint';
 import { interpolateUrl } from 'utils/url';
 import { getAllVariables } from 'utils/collections';
 import useDebounce from 'hooks/useDebounce';
@@ -140,52 +141,53 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
             item={item}
           />
           <div className="flex items-center h-full cursor-pointer gap-3 mx-3">
-            <div
-              className="infotip"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (!hasChanges) return;
-                onSave();
-              }}
-            >
-              <IconDeviceFloppy
-                color={hasChanges ? theme.draftColor : theme.requestTabs.icon.color}
-                strokeWidth={1.5}
-                size={20}
-                className={`${hasChanges ? 'cursor-pointer' : 'cursor-default'}`}
-              />
-              <span className="infotip-text text-xs">
-                Save <span className="shortcut">({saveShortcut})</span>
-              </span>
-            </div>
+            <ToolHint text={`Save (${saveShortcut})`} toolhintId="ws-save-request" place="top" positionStrategy="fixed">
+              <div
+                className="flex items-center"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!hasChanges) return;
+                  onSave();
+                }}
+              >
+                <IconDeviceFloppy
+                  color={hasChanges ? theme.draftColor : theme.requestTabs.icon.color}
+                  strokeWidth={1.5}
+                  size={20}
+                  className={`${hasChanges ? 'cursor-pointer' : 'cursor-default'}`}
+                />
+              </div>
+            </ToolHint>
 
             {connectionStatus === 'connected' && (
               <div className="connection-controls relative flex items-center h-full">
-                <div className="infotip" onClick={(e) => handleDisconnect(e, true)}>
-                  <IconPlugConnectedX
-                    color={theme.colors.text.danger}
-                    strokeWidth={1.5}
-                    size={20}
-                    className="cursor-pointer"
-                  />
-                  <span className="infotip-text text-xs">Close Connection</span>
-                </div>
+                <ToolHint text="Close Connection" toolhintId="ws-close-connection" place="top" positionStrategy="fixed">
+                  <div className="flex items-center" onClick={(e) => handleDisconnect(e, true)}>
+                    <IconPlugConnectedX
+                      color={theme.colors.text.danger}
+                      strokeWidth={1.5}
+                      size={20}
+                      className="cursor-pointer"
+                    />
+                  </div>
+                </ToolHint>
               </div>
             )}
 
             {connectionStatus !== 'connected' && (
               <div className="connection-controls relative flex items-center h-full">
-                <div className="infotip" onClick={handleConnect}>
-                  <IconPlugConnected
-                    className={classnames('cursor-pointer', {
-                      'animate-pulse': connectionStatus === CONNECTION_STATUS.CONNECTING
-                    })}
-                    color={theme.colors.text.green}
-                    strokeWidth={1.5}
-                    size={20}
-                  />
-                  <span className="infotip-text text-xs">Connect</span>
-                </div>
+                <ToolHint text="Connect" toolhintId="ws-connect" place="top" positionStrategy="fixed">
+                  <div className="flex items-center" onClick={handleConnect}>
+                    <IconPlugConnected
+                      className={classnames('cursor-pointer', {
+                        'animate-pulse': connectionStatus === CONNECTION_STATUS.CONNECTING
+                      })}
+                      color={theme.colors.text.green}
+                      strokeWidth={1.5}
+                      size={20}
+                    />
+                  </div>
+                </ToolHint>
               </div>
             )}
           </div>

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
@@ -144,6 +144,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
             <ToolHint text={`Save (${saveShortcut})`} toolhintId="ws-save-request" place="top" positionStrategy="fixed">
               <div
                 className="flex items-center"
+                data-testid="save-request-button"
                 onClick={(e) => {
                   e.stopPropagation();
                   if (!hasChanges) return;
@@ -162,7 +163,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
             {connectionStatus === 'connected' && (
               <div className="connection-controls relative flex items-center h-full">
                 <ToolHint text="Close Connection" toolhintId="ws-close-connection" place="top" positionStrategy="fixed">
-                  <div className="flex items-center" onClick={(e) => handleDisconnect(e, true)}>
+                  <div className="flex items-center" onClick={(e) => handleDisconnect(e, true)} data-testid="ws-disconnect-button">
                     <IconPlugConnectedX
                       color={theme.colors.text.danger}
                       strokeWidth={1.5}
@@ -177,7 +178,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
             {connectionStatus !== 'connected' && (
               <div className="connection-controls relative flex items-center h-full">
                 <ToolHint text="Connect" toolhintId="ws-connect" place="top" positionStrategy="fixed">
-                  <div className="flex items-center" onClick={handleConnect}>
+                  <div className="flex items-center" onClick={handleConnect} data-testid="ws-connect-button">
                     <IconPlugConnected
                       className={classnames('cursor-pointer', {
                         'animate-pulse': connectionStatus === CONNECTION_STATUS.CONNECTING

--- a/tests/collection/create/create-collection.spec.ts
+++ b/tests/collection/create/create-collection.spec.ts
@@ -65,12 +65,12 @@ test.describe('Create collection', () => {
     // Set the URL
     await page.locator('#request-url .CodeMirror').click();
     await page.locator('#request-url').locator('textarea').fill('http://localhost:8081');
-    await page.locator('#request-actions').getByTitle('Save Request').click();
+    await page.locator('#request-actions').getByTestId('save-request-button').click();
 
     // Send a request
     await page.locator('#request-url .CodeMirror').click();
     await page.locator('#request-url').locator('textarea').fill('/ping');
-    await page.locator('#request-actions').getByTitle('Save Request').click();
+    await page.locator('#request-actions').getByTestId('save-request-button').click();
     await page.getByTestId('send-arrow-icon').click();
 
     // Verify the response

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -230,7 +230,7 @@ const createUntitledRequest = async (
     if (url) {
       await page.locator('#request-url .CodeMirror').click();
       await page.locator('#request-url textarea').fill(url);
-      await page.locator('#request-actions').getByTitle('Save Request').click();
+      await page.locator('#request-actions').getByTestId('save-request-button').click();
       await page.waitForTimeout(200);
     }
 

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -10,9 +10,7 @@ export const buildCommonLocators = (page: Page) => ({
   },
   preferences: buildPreferencesLocators(page),
   ai: buildAiPreferencesLocators(page),
-  saveButton: () => page
-    .locator('.infotip')
-    .filter({ hasText: /^Save/ }),
+  saveButton: () => page.getByTestId('save-request-button'),
   openPreferences: () => page.getByRole('button', { name: 'Open Preferences' }),
   sidebar: {
     collectionsContainer: () => page.getByTestId('collections'),
@@ -166,7 +164,7 @@ export const buildCommonLocators = (page: Page) => ({
     newRequestUrl: () => page.locator('#new-request-url .CodeMirror'),
     requestNameInput: () => page.getByPlaceholder('Request Name'),
     requestTestId: () => page.getByTestId('request-name'),
-    generateCodeButton: () => page.locator('#request-actions .infotip').first(),
+    generateCodeButton: () => page.getByTestId('generate-code-button'),
     bodyModeSelector: () => page.getByTestId('request-body-mode-selector'),
     bodyEditor: () => page.getByTestId('request-body-editor'),
     bodyVariableToken: (name: string) =>
@@ -346,16 +344,8 @@ export const buildCommonLocators = (page: Page) => ({
 export const buildWebsocketCommonLocators = (page: Page) => ({
   ...buildCommonLocators(page),
   connectionControls: {
-    connect: () =>
-      page
-        .locator('div.connection-controls')
-        .locator('.infotip')
-        .filter({ hasText: /^Connect$/ }),
-    disconnect: () =>
-      page
-        .locator('div.connection-controls')
-        .locator('.infotip')
-        .filter({ hasText: /^Close Connection$/ })
+    connect: () => page.getByTestId('ws-connect-button'),
+    disconnect: () => page.getByTestId('ws-disconnect-button')
   },
   messages: () => page.locator('.ws-message'),
   message: {


### PR DESCRIPTION
### Description
[JIRA](https://usebruno.atlassian.net/browse/BRU-3792)

Tooltips on the URL bar action icons (Save, Connect, Generate Code, Generate grpcurl, etc.) were being clipped and appeared to render under the request pane in WebSocket, gRPC, and HTTP requests.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

## Fix
 
Replaced the custom `.infotip` tooltips with the existing `ToolHint` component (built on `react-tooltip`) in all three URL bars.
 
`ToolHint` renders through a **portal to `document.body`** at `z-index: 9999` with `positionStrategy="fixed"`, so no ancestor `overflow-hidden` wrapper can clip it. Removed the now-dead `.infotip` CSS from the three `StyledWrapper` files.
 
## Scope
 
- `RequestPane/QueryUrl` (HTTP) — Generate Code, Save
- `RequestPane/WsQueryUrl` (WebSocket) — Save, Connect, Close Connection
- `RequestPane/GrpcQueryUrl` (gRPC) — Refresh methods, Generate grpcurl, Save, Cancel


| BEFORE  | AFTER  |
| :--- | :--- |
| <img width="320" height="221" alt="image" src="https://github.com/user-attachments/assets/287b9646-40c8-4f8d-af4e-6754d0b44278" /> | <img width="712" height="403" alt="image" src="https://github.com/user-attachments/assets/492e27b1-484b-44e8-a1b2-37815753bb3b" /> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized request action hints by replacing multiple inline tooltips with a consistent, shared hint component across gRPC, HTTP, and WebSocket controls.
  * Refreshed hint/shortcut styling and ensured actions like Generate Code, Save, Connect, Close Connection, and related streaming controls behave the same for the user.

* **Testing**
  * Updated end-to-end test flows and locators to rely on stable UI test IDs for saving and related request actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->