### PR TITLE
fix(mount): show requests that failed to load in the collection overview

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
@@ -17,7 +17,6 @@ const toRelativePathname = (pathname, collectionPathname) => {
 const RequestsNotLoaded = ({ collection }) => {
   const dispatch = useDispatch();
   const tabs = useSelector((state) => state.tabs.tabs);
-  const flattenedItems = flattenItems(collection.items);
 
   const itemsFailedLoading = useMemo(() => {
     return flattenItems(collection.items)?.filter((item) => {
@@ -69,17 +68,15 @@ const RequestsNotLoaded = ({ collection }) => {
           </tr>
         </thead>
         <tbody>
-          {flattenedItems?.map((item, index) => (
-            item?.partial && !item?.loading ? (
-              <tr key={index} className="cursor-pointer" onClick={handleRequestClick(item)}>
-                <td className="py-1.5 px-3">
-                  {toRelativePathname(item?.pathname, collection?.pathname)}
-                </td>
-                <td className="py-1.5 px-3">
-                  {item?.size?.toFixed?.(2)}&nbsp;MB
-                </td>
-              </tr>
-            ) : null
+          {itemsFailedLoading?.map((item, index) => (
+            <tr key={index} className="cursor-pointer" onClick={handleRequestClick(item)}>
+              <td className="py-1.5 px-3">
+                {toRelativePathname(item?.pathname, collection?.pathname)}
+              </td>
+              <td className="py-1.5 px-3">
+                {item?.size?.toFixed?.(2)}&nbsp;MB
+              </td>
+            </tr>
           ))}
         </tbody>
       </table>

--- a/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
@@ -69,7 +69,7 @@ const RequestsNotLoaded = ({ collection }) => {
         </thead>
         <tbody>
           {itemsFailedLoading?.map((item, index) => (
-            <tr key={index} className="cursor-pointer" onClick={handleRequestClick(item)}>
+            <tr key={item?.pathname} className="cursor-pointer" onClick={handleRequestClick(item)}>
               <td className="py-1.5 px-3">
                 {toRelativePathname(item?.pathname, collection?.pathname)}
               </td>

--- a/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
@@ -6,10 +6,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import { isItemARequest, itemIsOpenedInTabs } from 'utils/tabs/index';
 import { getDefaultRequestPaneTab } from 'utils/collections/index';
 import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
+import { normalizePath } from 'utils/common/path';
 
 const toRelativePathname = (pathname, collectionPathname) => {
-  if (pathname && collectionPathname && pathname.startsWith(collectionPathname)) {
-    return pathname.slice(collectionPathname.length + 1);
+  if (!pathname || !collectionPathname) return pathname;
+  const normalizedPathname = normalizePath(pathname);
+  const normalizedCollection = normalizePath(collectionPathname);
+  if (normalizedPathname.toLowerCase().startsWith(normalizedCollection.toLowerCase())) {
+    return normalizedPathname.slice(normalizedCollection.length + 1);
   }
   return pathname;
 };
@@ -20,11 +24,11 @@ const RequestsNotLoaded = ({ collection }) => {
 
   const itemsFailedLoading = useMemo(() => {
     return flattenItems(collection.items)?.filter((item) => {
-      return (item?.partial && !item.loading) || (item?.error);
-    });
+      return (item?.partial && !item?.loading) || item?.error;
+    }) ?? [];
   }, [collection.items]);
 
-  if (!itemsFailedLoading?.length) {
+  if (!itemsFailedLoading.length) {
     return null;
   }
 
@@ -68,13 +72,13 @@ const RequestsNotLoaded = ({ collection }) => {
           </tr>
         </thead>
         <tbody>
-          {itemsFailedLoading?.map((item, index) => (
+          {itemsFailedLoading.map((item) => (
             <tr key={item?.pathname} className="cursor-pointer" onClick={handleRequestClick(item)}>
               <td className="py-1.5 px-3">
                 {toRelativePathname(item?.pathname, collection?.pathname)}
               </td>
               <td className="py-1.5 px-3">
-                {item?.size?.toFixed?.(2)}&nbsp;MB
+                {item?.size ? `${item.size?.toFixed?.(2)} MB` : '-'}
               </td>
             </tr>
           ))}

--- a/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { flattenItems } from 'utils/collections';
 import { IconAlertTriangle } from '@tabler/icons';
 import StyledWrapper from './StyledWrapper';
@@ -7,11 +7,23 @@ import { isItemARequest, itemIsOpenedInTabs } from 'utils/tabs/index';
 import { getDefaultRequestPaneTab } from 'utils/collections/index';
 import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
 
+const toRelativePathname = (pathname, collectionPathname) => {
+  if (pathname && collectionPathname && pathname.startsWith(collectionPathname)) {
+    return pathname.slice(collectionPathname.length + 1);
+  }
+  return pathname;
+};
+
 const RequestsNotLoaded = ({ collection }) => {
   const dispatch = useDispatch();
   const tabs = useSelector((state) => state.tabs.tabs);
   const flattenedItems = flattenItems(collection.items);
-  const itemsFailedLoading = flattenedItems?.filter((item) => item?.partial && !item?.loading);
+
+  const itemsFailedLoading = useMemo(() => {
+    return flattenItems(collection.items)?.filter((item) => {
+      return (item?.partial && !item.loading) || (item?.error);
+    });
+  }, [collection.items]);
 
   if (!itemsFailedLoading?.length) {
     return null;
@@ -61,7 +73,7 @@ const RequestsNotLoaded = ({ collection }) => {
             item?.partial && !item?.loading ? (
               <tr key={index} className="cursor-pointer" onClick={handleRequestClick(item)}>
                 <td className="py-1.5 px-3">
-                  {item?.pathname?.split(`${collection?.pathname}/`)?.[1]}
+                  {toRelativePathname(item?.pathname, collection?.pathname)}
                 </td>
                 <td className="py-1.5 px-3">
                   {item?.size?.toFixed?.(2)}&nbsp;MB

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/file-mode.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/file-mode.spec.js
@@ -259,3 +259,104 @@ describe('collectionChangeFileEvent — raw content', () => {
     expect(item.draft.request.url).toBe('https://example.com/locally-edited');
   });
 });
+
+describe('collectionChangeFileEvent — failed parse', () => {
+  const makeFailedFileEvent = ({ raw = 'meta {\n  name: user_info', message = 'unexpected token' } = {}) => ({
+    file: {
+      meta: {
+        collectionUid: COLLECTION_UID,
+        pathname: '/coll/user_info.bru',
+        name: 'user_info.bru'
+      },
+      data: {
+        uid: ITEM_UID,
+        name: 'user_info',
+        type: 'http-request',
+        raw
+      },
+      partial: true,
+      loading: false,
+      size: 0,
+      error: { message }
+    }
+  });
+
+  const makeSuccessFileEvent = ({ raw, request = makeRequest(), seq = 1 } = {}) => ({
+    file: {
+      meta: {
+        collectionUid: COLLECTION_UID,
+        pathname: '/coll/user_info.bru',
+        name: 'user_info.bru'
+      },
+      data: {
+        uid: ITEM_UID,
+        name: 'user_info',
+        type: 'http-request',
+        seq,
+        raw,
+        request
+      },
+      size: 0.001
+    }
+  });
+
+  test('flags the item as not-loaded and preserves the last-good request', () => {
+    const state = reducer(makeInitialState(), collectionChangeFileEvent(makeFailedFileEvent()));
+
+    const item = state.collections[0].items[0];
+    expect(item.partial).toBe(true);
+    expect(item.loading).toBe(false);
+    expect(item.error).toEqual({ message: 'unexpected token' });
+    // the last-good parsed request must survive an invalid edit
+    expect(item.request).toEqual(makeRequest());
+  });
+
+  test('does not wipe a user draft on a failed parse', () => {
+    let state = makeInitialState({ fileMode: true });
+    state = reducer(
+      state,
+      updateFileContent({ collectionUid: COLLECTION_UID, itemUid: ITEM_UID, content: 'unsaved edit' })
+    );
+
+    state = reducer(state, collectionChangeFileEvent(makeFailedFileEvent()));
+
+    const item = state.collections[0].items[0];
+    expect(item.draft).not.toBeNull();
+    expect(item.draft.raw).toBe('unsaved edit');
+  });
+
+  test('clears the not-loaded flags when a subsequent valid save arrives', () => {
+    let state = reducer(makeInitialState(), collectionChangeFileEvent(makeFailedFileEvent()));
+    expect(state.collections[0].items[0].partial).toBe(true);
+
+    const fixedRaw = 'meta {\n  name: user_info\n}';
+    state = reducer(
+      state,
+      collectionChangeFileEvent(makeSuccessFileEvent({ raw: fixedRaw, request: makeRequest({ url: 'https://example.com/fixed' }) }))
+    );
+
+    const item = state.collections[0].items[0];
+    expect(item.partial).toBeFalsy();
+    expect(item.error).toBeFalsy();
+    expect(item.raw).toBe(fixedRaw);
+    expect(item.request.url).toBe('https://example.com/fixed');
+  });
+
+  test('recovers an item that mounted with an empty request (corrupted from the start)', () => {
+    const state0 = makeInitialState({ item: { request: {}, partial: true, error: { message: 'bad' }, loading: false } });
+
+    const fixedRaw = 'meta {\n  name: user_info\n}\n\nget {\n  url: https://example.com/recovered\n}';
+    const state = reducer(
+      state0,
+      collectionChangeFileEvent(
+        makeSuccessFileEvent({ raw: fixedRaw, request: makeRequest({ url: 'https://example.com/recovered' }) })
+      )
+    );
+
+    const item = state.collections[0].items[0];
+    expect(item.partial).toBeFalsy();
+    expect(item.error).toBeFalsy();
+    expect(item.request.url).toBe('https://example.com/recovered');
+    expect(item.raw).toBe(fixedRaw);
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/file-mode.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/file-mode.spec.js
@@ -300,15 +300,14 @@ describe('collectionChangeFileEvent — failed parse', () => {
     }
   });
 
-  test('flags the item as not-loaded and preserves the last-good request', () => {
+  test('flags the item as not-loaded and keeps the raw content', () => {
     const state = reducer(makeInitialState(), collectionChangeFileEvent(makeFailedFileEvent()));
 
     const item = state.collections[0].items[0];
     expect(item.partial).toBe(true);
     expect(item.loading).toBe(false);
     expect(item.error).toEqual({ message: 'unexpected token' });
-    // the last-good parsed request must survive an invalid edit
-    expect(item.request).toEqual(makeRequest());
+    expect(item.raw).toBe('meta {\n  name: user_info');
   });
 
   test('does not wipe a user draft on a failed parse', () => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -2988,12 +2988,8 @@ export const collectionsSlice = createSlice({
         if (item) {
           item.partial = file.partial;
           item.error = file.error;
-
-          if (file.partial || file.error) {
-            item.raw = file.data.raw;
-            item.size = file.size;
-            item.loading = file.loading;
-          } else if (areItemsTheSameExceptSeqUpdate(item, file.data)) {
+          item.loading = file.loading;
+          if (areItemsTheSameExceptSeqUpdate(item, file.data)) {
             // whenever a user attempts to sort a req within the same folder
             // the seq is updated, but everything else remains the same
             // we don't want to lose the draft in this case
@@ -3017,7 +3013,7 @@ export const collectionsSlice = createSlice({
             item.filename = file.meta.name;
             item.pathname = file.meta.pathname;
             item.raw = file.data.raw;
-
+            item.size = file.size;
             // Only clear draft if it matches the file content
             // This preserves characters typed during autosave
             // The raw comparison is guarded so an undefined === undefined match

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -2986,10 +2986,17 @@ export const collectionsSlice = createSlice({
         const item = findItemInCollection(collection, file.data.uid);
 
         if (item) {
-          // whenever a user attempts to sort a req within the same folder
-          // the seq is updated, but everything else remains the same
-          // we don't want to lose the draft in this case
-          if (areItemsTheSameExceptSeqUpdate(item, file.data)) {
+          item.partial = file.partial;
+          item.error = file.error;
+
+          if (file.partial || file.error) {
+            item.raw = file.data.raw;
+            item.size = file.size;
+            item.loading = file.loading;
+          } else if (areItemsTheSameExceptSeqUpdate(item, file.data)) {
+            // whenever a user attempts to sort a req within the same folder
+            // the seq is updated, but everything else remains the same
+            // we don't want to lose the draft in this case
             item.seq = file.data.seq;
             item.raw = file.data.raw;
             if (item?.draft) {

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1118,8 +1118,14 @@ export const areItemsTheSameExceptSeqUpdate = (_item1, _item2) => {
   delete item2.draft;
 
   // get projection of both items
-  item1 = transformRequestToSaveToFilesystem(item1);
-  item2 = transformRequestToSaveToFilesystem(item2);
+  // a partial/unparseable item has no comparable request projection; treat it as
+  // changed so callers fall back to a full update instead of throwing
+  try {
+    item1 = transformRequestToSaveToFilesystem(item1);
+    item2 = transformRequestToSaveToFilesystem(item2);
+  } catch (err) {
+    return false;
+  }
 
   // delete uids from both items
   deleteUidsInItem(item1);

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -352,7 +352,19 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
         hydrateRequestWithUuid(file.data, pathname);
         win.webContents.send('main:collection-tree-updated', 'addFile', file);
       } catch (error) {
-        console.error(error);
+        file.data = {
+          name: path.basename(pathname),
+          type: 'http-request'
+        };
+        file.error = {
+          message: error?.message
+        };
+        file.partial = true;
+        file.loading = false;
+        file.size = sizeInMB(fileStats?.size);
+        file.data.raw = content;
+        hydrateRequestWithUuid(file.data, pathname);
+        win.webContents.send('main:collection-tree-updated', 'addFile', file);
       } finally {
         watcher.markFileAsProcessed(win, collectionUid, pathname);
       }
@@ -561,17 +573,19 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
 
   const format = getCollectionFormat(collectionPath);
   if (hasRequestExtension(pathname, format)) {
-    try {
-      const file = {
-        meta: {
-          collectionUid,
-          pathname,
-          name: path.basename(pathname)
-        }
-      };
+    const file = {
+      meta: {
+        collectionUid,
+        pathname,
+        name: path.basename(pathname)
+      }
+    };
 
-      const content = fs.readFileSync(pathname, 'utf8');
-      const fileStats = fs.statSync(pathname);
+    let content;
+    let fileStats;
+    try {
+      content = fs.readFileSync(pathname, 'utf8');
+      fileStats = fs.statSync(pathname);
 
       if (fileStats.size >= MAX_FILE_SIZE && format === 'bru') {
         // redacted parse — do not write the redacted data through to the cache
@@ -586,7 +600,19 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       hydrateRequestWithUuid(file.data, pathname);
       win.webContents.send('main:collection-tree-updated', 'change', file);
     } catch (err) {
-      console.error(err);
+      file.data = {
+        name: path.basename(pathname),
+        type: 'http-request'
+      };
+      file.error = {
+        message: err?.message
+      };
+      file.partial = true;
+      file.loading = false;
+      file.size = sizeInMB(fileStats?.size);
+      file.data.raw = content;
+      hydrateRequestWithUuid(file.data, pathname);
+      win.webContents.send('main:collection-tree-updated', 'change', file);
     }
   }
 };

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -609,8 +609,8 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       };
       file.partial = true;
       file.loading = false;
-      file.size = sizeInMB(fileStats?.size);
-      file.data.raw = content;
+      file.size = sizeInMB(fileStats?.size ?? 0);
+      file.data.raw = content ?? '';
       hydrateRequestWithUuid(file.data, pathname);
       win.webContents.send('main:collection-tree-updated', 'change', file);
     }

--- a/packages/bruno-electron/src/services/mount/manager.js
+++ b/packages/bruno-electron/src/services/mount/manager.js
@@ -189,7 +189,7 @@ class MountManager {
         const result = parsed.get(e.relativePath);
         if (!result) continue;
         if (result.error) {
-          entry.state.set(e.relativePath, { data: result.data, error: result.error });
+          entry.state.set(e.relativePath, { data: result.data, error: result.error, raw: result.raw });
           continue;
         }
         entry.state.set(e.relativePath, { data: result.data, raw: result.raw });

--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -130,7 +130,7 @@ const buildRequestNode = (absolutePath, basename, entry, uidOverrides, uidFor) =
     settings: data.settings,
     examples: data.examples,
     raw: entry.raw ?? null,
-    size: sizeInMB(entry?.raw?.length ?? 0),
+    size: sizeInMB(entry.raw ? Buffer.byteLength(entry.raw, 'utf8') : 0),
     filename: basename,
     pathname: absolutePath,
     draft: null,

--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -5,6 +5,7 @@ const {
   uidForSeed,
   defaultClassify
 } = require('../../utils/mount');
+const { sizeInMB } = require('../../utils/filesystem');
 
 const REQUEST_EXT_RE = /\.(bru|yml|yaml)$/i;
 const stripExt = (basename) => basename.replace(REQUEST_EXT_RE, '');
@@ -129,6 +130,7 @@ const buildRequestNode = (absolutePath, basename, entry, uidOverrides, uidFor) =
     settings: data.settings,
     examples: data.examples,
     raw: entry.raw ?? null,
+    size: sizeInMB(entry?.raw?.length ?? 0),
     filename: basename,
     pathname: absolutePath,
     draft: null,

--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -126,7 +126,7 @@ const buildRequestNode = (absolutePath, basename, entry, uidOverrides, uidFor) =
     type: data.type || 'http-request',
     seq: data.seq,
     tags: data.tags,
-    request: data.request,
+    request: data.request || {},
     settings: data.settings,
     examples: data.examples,
     raw: entry.raw ?? null,


### PR DESCRIPTION
### Problem

When a request file fails to parse, it should appear in the **"Following requests were not loaded"** table in the collection overview. In several cases it didn't:

- **Mount v1 (legacy):** the synchronous add path and the change path only `console.error`'d the parse failure and never emitted the item to the renderer, so the failed request silently disappeared from the tree.
- **Mount v2:** reconcile dropped `raw` for errored items, so their size couldn't be derived.
- **Windows:** the table computed the relative pathname by splitting on a hardcoded `/`, which never matches Windows `\` paths — so the Pathname column rendered blank.

### Changes

- `app/collection-watcher.js`: both the synchronous add path and the change path now emit a partial item (`error`, `partial`, `size`, `raw`) on parse failure, matching the async worker path.
- `services/mount/manager.js`: forward `raw` for errored items during reconcile.
- `services/mount/tree-builder.js`: derive item `size` from `raw` and set it for every item.
- `components/CollectionSettings/Overview/RequestsNotLoaded`: compute the relative pathname separator-agnostically (fixes the blank Pathname on Windows) and include errored items.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “not loaded” requests view to include error-flagged items.
  * Made the Pathname column show a consistent relative path.
  * Failed HTTP request files are now retained, with correct partial/error UI state.
  * Error cases now preserve original raw content, and request node sizes are computed more reliably.
  * The collections reducer now correctly syncs partial/loading/error/raw/size for seq updates and failed parses.
  * Request comparison is now resilient to transformation failures.
* **Tests**
  * Added reducer tests for “failed parse” collection file-change handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->