### PR TITLE
Added the fix for bottom spacing and also AiAssits can have default 4…

### DIFF
--- a/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
@@ -107,7 +107,7 @@ export const PopupWrapper = styled.div`
     background: ${(props) => props.theme.input.bg};
     color: ${(props) => props.theme.text};
     resize: vertical;
-    min-height: calc(3 * 1.4em + 18px);
+    min-height: calc(4 * 1.4em + 18px);
     outline: none;
     transition: border-color 0.15s ease;
 

--- a/packages/bruno-app/src/components/Preferences/AI/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/AI/StyledWrapper.js
@@ -40,6 +40,7 @@ const StyledWrapper = styled.div`
   .ai-tab-panel {
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
     padding-bottom: 2rem;

--- a/packages/bruno-app/src/components/Preferences/AI/index.js
+++ b/packages/bruno-app/src/components/Preferences/AI/index.js
@@ -286,7 +286,7 @@ const AI = () => {
   }, [status, formik.values.providers, formik.values.models, formik.values.openaiCompatibleEndpoints]);
 
   return (
-    <StyledWrapper className="w-full flex flex-col text-xs min-h-0 max-h-[calc(100%-30px)]">
+    <StyledWrapper className="w-full flex flex-col text-xs self-start max-h-full">
       <div className="section-header">AI</div>
 
       <div className="ai-tabs flex items-center" role="tablist" aria-label="AI preferences">

--- a/packages/bruno-app/src/components/Preferences/AI/index.js
+++ b/packages/bruno-app/src/components/Preferences/AI/index.js
@@ -286,7 +286,7 @@ const AI = () => {
   }, [status, formik.values.providers, formik.values.models, formik.values.openaiCompatibleEndpoints]);
 
   return (
-    <StyledWrapper className="w-full flex flex-col text-xs self-start max-h-full">
+    <StyledWrapper className="w-full flex flex-col text-xs self-stretch min-h-0">
       <div className="section-header">AI</div>
 
       <div className="ai-tabs flex items-center" role="tablist" aria-label="AI preferences">

--- a/packages/bruno-app/src/components/Preferences/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/StyledWrapper.js
@@ -38,10 +38,12 @@ const StyledWrapper = styled.div`
   }
 
   section.tab-panel {
-    max-height: calc(100% - 55px);
+    min-height: 0;
+    max-height: 100%;
     overflow-y: auto;
     flex-grow: 1;
     padding: 12px;
+    padding-bottom: 0;
   }
 
   input[type="checkbox"],


### PR DESCRIPTION

[JIRA](https://usebruno.atlassian.net/browse/BRU-3793)

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout and scrolling behavior in AI preferences so tab panels fit more reliably within the available space.
  * Updated AI popup input styling to be taller by default for more comfortable multi-line entry.
  * Refined tab panel sizing rules to better participate in flex layouts and use full available height without cramped content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->