### PR TITLE
Version edit modal minor UI fixes

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/StyledWrapper.js
@@ -2,6 +2,19 @@ import styled from 'styled-components';
 import { rgba } from 'polished';
 
 const StyledWrapper = styled.div`
+  .version-value-wrap {
+    display: flex;
+    min-width: 0;
+    max-width: 220px;
+  }
+
+  .version-value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .icon-box {
     &.location {
       background-color: ${(props) => rgba(props.theme.textLink, 0.08)};

--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { getTotalRequestCountInCollection } from 'utils/collections/';
 import { IconFolder, IconWorld, IconApi, IconShare, IconBook, IconTag } from '@tabler/icons';
 import { areItemsLoading, getItemsLoadStats, getCollectionVersion } from 'utils/collections/index';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import ShareCollection from 'components/ShareCollection/index';
 import GenerateDocumentation from 'components/Sidebar/Collections/Collection/GenerateDocumentation';
 import ChangeCollectionVersion from 'components/Sidebar/Collections/Collection/ChangeCollectionVersion';
+import ToolHint from 'components/ToolHint';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import StyledWrapper from './StyledWrapper';
 import Migration from '../Migration';
@@ -20,8 +21,16 @@ const Info = ({ collection }) => {
   const [showShareCollectionModal, toggleShowShareCollectionModal] = useState(false);
   const [showGenerateDocumentationModal, setShowGenerateDocumentationModal] = useState(false);
   const [showChangeVersionModal, setShowChangeVersionModal] = useState(false);
+  const [isVersionOverflowing, setIsVersionOverflowing] = useState(false);
 
   const collectionVersion = getCollectionVersion(collection);
+
+  const versionRef = useRef(null);
+
+  const handleVersionHover = () => {
+    const el = versionRef.current;
+    if (el) setIsVersionOverflowing(el.scrollWidth > el.clientWidth);
+  };
 
   const globalEnvironments = useSelector((state) => state.globalEnvironments.globalEnvironments);
 
@@ -55,10 +64,28 @@ const Info = ({ collection }) => {
             </div>
             <div className="ml-4 h-full flex flex-col justify-start">
               <div className="font-medium h-fit my-auto">Version</div>
-              <div className="flex items-center gap-2">
-                {collectionVersion
-                  ? <span className="text-muted" data-testid="info-version-value">{collectionVersion}</span>
-                  : <span className="text-muted italic" data-testid="info-version-value">Not Set</span>}
+              <div className="flex flex-wrap items-center gap-2">
+                {collectionVersion ? (
+                  <ToolHint
+                    text={collectionVersion}
+                    toolhintId={`info-version-value-${collection.uid}`}
+                    hidden={!isVersionOverflowing}
+                    place="top"
+                    tooltipStyle={{ maxWidth: '320px', whiteSpace: 'normal', wordBreak: 'break-all' }}
+                    className="version-value-wrap"
+                  >
+                    <span
+                      ref={versionRef}
+                      className="text-muted version-value"
+                      onMouseEnter={handleVersionHover}
+                      data-testid="info-version-value"
+                    >
+                      {collectionVersion}
+                    </span>
+                  </ToolHint>
+                ) : (
+                  <span className="text-muted italic" data-testid="info-version-value">Not Set</span>
+                )}
                 <span className="group-hover:underline text-link" data-testid="info-version-change">change</span>
               </div>
             </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/StyledWrapper.js
@@ -127,6 +127,10 @@ const StyledWrapper = styled.div`
       color: ${(props) => props.theme.colors.text.danger};
       font-weight: 700;
       word-break: break-all;
+   
+      .not-set {
+        font-weight: 500;
+      }
     }
 
     .new {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
@@ -90,7 +90,7 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
               <div className="version-col">
                 <div className="col-label">Current Version</div>
                 <div className="current-value" data-testid="change-version-current">
-                  {currentVersion || <span className="unset">Not Set</span>}
+                  {currentVersion || <span className="text-muted italic">Not Set</span>}
                 </div>
               </div>
 
@@ -129,7 +129,7 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
 
             <p className="preview m-0" data-testid="change-version-preview">
               Updates <strong>{targetKey}</strong> in {targetFile} from{' '}
-              <span className="old">{currentVersion || '(none)'}</span>
+              <span className="old">{currentVersion || <span className="text-muted italic not-set">(Not Set)</span>}</span>
               <IconArrowRight size={13} className="preview-arrow" stroke={1.5} />
               <span className="new">{trimmedVersion || '…'}</span>
             </p>


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Issues Resolved
When collection version is not set and when I click on change in Overview, in the modal preview, it is displayed as “(none)-> “ instead of “Not Set->”

 Collection version is truncated in Overview page when it has more characters.

https://usebruno.atlassian.net/browse/BRU-2545

<img width="1678" height="976" alt="image" src="https://github.com/user-attachments/assets/b6385594-81c4-4f56-9888-3cdf9126fead" />

<img width="1814" height="862" alt="image" src="https://github.com/user-attachments/assets/23be5305-cd2d-41a2-a97e-b5c3731c4a73" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved version display behavior to keep long text on one line and neatly truncated when needed.
  * Added hover tooltips for version values when the text overflows its container.
  * Updated empty version states to show a clearer “Not Set” label in both settings and version-change views.

* **Style**
  * Refined spacing and emphasis for version-related preview text to improve readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->