### PR TITLE
test(auth): fix modified-indicator inherit spec test

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcRequestPane/GrpcAuth/GrpcAuthMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcRequestPane/GrpcAuth/GrpcAuthMode/index.js
@@ -61,14 +61,14 @@ const GrpcAuthMode = ({ item, collection }) => {
 
   return (
     <StyledWrapper>
-      <div className="inline-flex items-center cursor-pointer auth-mode-selector">
+      <div className="inline-flex items-center cursor-pointer auth-mode-selector" data-testid="auth-mode-selector">
         <MenuDropdown
           items={menuItems}
           placement="bottom-end"
           selectedItemId={authMode}
           showTickMark={true}
         >
-          <div className="flex items-center justify-center auth-mode-label select-none">
+          <div className="flex items-center justify-center auth-mode-label select-none" data-testid="auth-mode-label">
             {humanizeRequestAuthMode(authMode)} <IconCaretDown className="caret ml-1" size={14} strokeWidth={2} />
           </div>
         </MenuDropdown>

--- a/packages/bruno-app/src/components/RequestPane/WSRequestPane/WSAuth/WSAuthMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WSRequestPane/WSAuth/WSAuthMode/index.js
@@ -54,14 +54,14 @@ const WSAuthMode = ({ item, collection }) => {
 
   return (
     <StyledWrapper>
-      <div className="inline-flex items-center cursor-pointer auth-mode-selector">
+      <div className="inline-flex items-center cursor-pointer auth-mode-selector" data-testid="auth-mode-selector">
         <MenuDropdown
           items={menuItems}
           placement="bottom-end"
           selectedItemId={authMode}
           showTickMark={true}
         >
-          <div className="flex items-center justify-center auth-mode-label select-none">
+          <div className="flex items-center justify-center auth-mode-label select-none" data-testid="auth-mode-label">
             {humanizeRequestAuthMode(authMode)} <IconCaretDown className="caret ml-1" size={14} strokeWidth={2} />
           </div>
         </MenuDropdown>

--- a/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
+++ b/tests/auth/auth-mode/folder-no-auth-stops-inheritance.spec.ts
@@ -6,7 +6,6 @@ import {
   createFolder,
   createRequest,
   openRequest,
-  saveRequest,
   selectAuthMode,
   selectRequestPaneTab,
   selectResponsePaneTab,
@@ -53,7 +52,7 @@ test('Request inherits No Auth from the folder — collection Bearer Token is ov
     await openRequest(page, collectionName, requestName);
     await selectRequestPaneTab(page, 'Auth');
     await selectAuthMode(page, AUTH_MODE_LABELS.INHERIT);
-    await saveRequest(page);
+    await expect(locators.auth.modeSelector()).toContainText(AUTH_MODE_LABELS.INHERIT);
   });
 
   await test.step('Send the request and open the Timeline tab', async () => {

--- a/tests/auth/auth-mode/modified-indicator-for-auth.spec.ts
+++ b/tests/auth/auth-mode/modified-indicator-for-auth.spec.ts
@@ -96,12 +96,11 @@ test.describe('Modified indicator for auth tab', () => {
         await page.getByRole('button', { name: 'Save' }).click();
       });
 
-      await test.step(`Create a ${protocol} request inside folder-1 and set auth type for the request as Inherit`, async () => {
+      await test.step(`Create a ${protocol} request inside folder-1 (auth defaults to Inherit)`, async () => {
         await createRequest(page, requestName, 'folder-1', { inFolder: true, requestType, url });
         await openRequest(page, collectionName, requestName);
         await selectRequestPaneTab(page, 'Auth');
-        await selectAuthMode(page, AUTH_MODE_LABELS.INHERIT);
-        await saveRequest(page);
+        await expect(locators.auth.modeSelector()).toContainText(AUTH_MODE_LABELS.INHERIT);
       });
 
       await test.step(`Verify the ${protocol} request Auth tab shows the status dot (inheriting Basic Auth from folder-1)`, async () => {


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for auth mode behavior in request panes, including inherited folder auth and status indicators.
  * Adjusted test flows to rely on default inherited auth behavior and verify the auth mode selector state before further assertions.
* **Bug Fixes**
  * Improved UI test reliability by adding dedicated `data-testid` attributes to auth mode selector controls in both gRPC and WebSocket request views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->