### PR TITLE
fix: open custom response links externally

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/HtmlPreview.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/HtmlPreview.js
@@ -3,6 +3,7 @@ import { escapeHtml } from 'utils/response/index';
 
 const HtmlPreview = React.memo(({ data, baseUrl }) => {
   const webviewContainerRef = useRef(null);
+  const webviewRef = useRef(null);
   const [isDragging, setIsDragging] = useState(false);
 
   useEffect(() => {
@@ -30,6 +31,37 @@ const HtmlPreview = React.memo(({ data, baseUrl }) => {
     return () => mutationObserver.disconnect();
   }, []);
 
+  useEffect(() => {
+    const webview = webviewRef.current;
+    if (!webview) return;
+
+    const openExternalUrl = (url) => {
+      if (/^https?:\/\//.test(url)) {
+        window.ipcRenderer.openExternal(url);
+      }
+    };
+
+    const handleNavigation = (event) => {
+      if (/^https?:\/\//.test(event.url)) {
+        event.preventDefault();
+        openExternalUrl(event.url);
+      }
+    };
+
+    const handleNewWindow = (event) => {
+      event.preventDefault();
+      openExternalUrl(event.url);
+    };
+
+    webview.addEventListener('will-navigate', handleNavigation);
+    webview.addEventListener('new-window', handleNewWindow);
+
+    return () => {
+      webview.removeEventListener('will-navigate', handleNavigation);
+      webview.removeEventListener('new-window', handleNewWindow);
+    };
+  }, []);
+
   const renderHtmlPreview = (data, baseUrl, isDragging, webviewContainerRef) => {
     const htmlContent = data.includes('<head>')
       ? data.replace('<head>', `<head><base href="${escapeHtml(baseUrl)}">`)
@@ -44,6 +76,8 @@ const HtmlPreview = React.memo(({ data, baseUrl }) => {
         style={dragStyles}
       >
         <webview
+          ref={webviewRef}
+          data-testid="html-response-preview"
           src={`data:text/html; charset=utf-8,${encodeURIComponent(htmlContent)}`}
           webpreferences="disableDialogs=true, javascript=yes"
           className="h-full bg-white"

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/HtmlPreview.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/HtmlPreview.spec.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import HtmlPreview from './HtmlPreview';
+
+const dispatchWebviewUrlEvent = (webview, eventName, url) => {
+  const event = new Event(eventName, { cancelable: true });
+  Object.defineProperty(event, 'url', { value: url });
+  webview.dispatchEvent(event);
+  return event;
+};
+
+describe('HtmlPreview', () => {
+  beforeEach(() => {
+    window.ipcRenderer = {
+      openExternal: jest.fn()
+    };
+  });
+
+  it('opens navigated http links in the default browser', () => {
+    const { getByTestId } = render(<HtmlPreview data={'<a href="https://example.com">Example</a>'} baseUrl="https://base.example" />);
+    const webview = getByTestId('html-response-preview');
+
+    const event = dispatchWebviewUrlEvent(webview, 'will-navigate', 'https://example.com');
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(window.ipcRenderer.openExternal).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('opens new-window http links in the default browser', () => {
+    const { getByTestId } = render(<HtmlPreview data={'<a target="_blank" href="https://example.com">Example</a>'} baseUrl="https://base.example" />);
+    const webview = getByTestId('html-response-preview');
+
+    const event = dispatchWebviewUrlEvent(webview, 'new-window', 'https://example.com');
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(window.ipcRenderer.openExternal).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('does not open non-http links externally', () => {
+    const { getByTestId } = render(<HtmlPreview data={'<a href="data:text/plain,test">Example</a>'} baseUrl="https://base.example" />);
+    const webview = getByTestId('html-response-preview');
+
+    const event = dispatchWebviewUrlEvent(webview, 'will-navigate', 'data:text/plain,test');
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(window.ipcRenderer.openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-app/src/components/ResponsePane/ResponseDownload/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseDownload/index.js
@@ -5,8 +5,50 @@ import get from 'lodash/get';
 import { IconDownload } from '@tabler/icons';
 import classnames from 'classnames';
 import ActionIcon from 'ui/ActionIcon/index';
+import { formatResponse } from 'utils/common';
 
-const ResponseDownload = forwardRef(({ item, children }, ref) => {
+const FORMAT_CONTENT_TYPES = {
+  json: 'application/json',
+  html: 'text/html',
+  xml: 'application/xml',
+  javascript: 'application/javascript',
+  raw: 'text/plain',
+  hex: 'text/plain',
+  base64: 'text/plain'
+};
+
+export const getResponseText = (selectedTab, selectedFormat, data, dataBuffer) => {
+  if (selectedTab === 'preview') {
+    return typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+  }
+
+  if (selectedFormat && data && dataBuffer) {
+    return formatResponse(data, dataBuffer, selectedFormat, null);
+  }
+
+  return typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+};
+
+export const getDownloadResponse = ({ response, selectedFormat, selectedTab, data, dataBuffer }) => {
+  if (!selectedFormat || !dataBuffer) {
+    return response;
+  }
+
+  const responseText = getResponseText(selectedTab, selectedFormat, data, dataBuffer);
+
+  return {
+    ...response,
+    data: responseText,
+    dataBuffer: Buffer.from(responseText).toString('base64'),
+    size: Buffer.byteLength(responseText),
+    headers: {
+      ...response.headers,
+      'content-type': FORMAT_CONTENT_TYPES[selectedFormat] || 'text/plain'
+    }
+  };
+};
+
+const ResponseDownload = forwardRef(({ item, children, selectedFormat, selectedTab, data, dataBuffer }, ref) => {
   const { ipcRenderer } = window;
   const response = item.response || {};
   const isDisabled = !response.dataBuffer || response.stream?.running;
@@ -23,7 +65,7 @@ const ResponseDownload = forwardRef(({ item, children }, ref) => {
     }
     return new Promise((resolve, reject) => {
       ipcRenderer
-        .invoke('renderer:save-response-to-file', response, item?.requestSent?.url, item.pathname)
+        .invoke('renderer:save-response-to-file', getDownloadResponse({ response, selectedFormat, selectedTab, data, dataBuffer }), item?.requestSent?.url, item.pathname)
         .then((result) => {
           if (result && result.success) {
             toast.success('Response downloaded to file');

--- a/packages/bruno-app/src/components/ResponsePane/ResponseDownload/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseDownload/index.spec.js
@@ -1,0 +1,78 @@
+jest.mock('utils/common', () => ({
+  formatResponse: (data, dataBuffer, selectedFormat) => {
+    if (selectedFormat === 'base64') {
+      return dataBuffer;
+    }
+
+    if (selectedFormat === 'json') {
+      return JSON.stringify(data, null, 2);
+    }
+
+    return typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+  }
+}));
+
+import { getDownloadResponse } from './index';
+
+describe('ResponseDownload', () => {
+  it('builds a download response from the selected Base64 format', () => {
+    const response = {
+      data: 'pong',
+      dataBuffer: Buffer.from('pong').toString('base64'),
+      headers: {
+        'content-type': 'text/plain'
+      },
+      size: 4
+    };
+
+    const downloadResponse = getDownloadResponse({
+      response,
+      selectedFormat: 'base64',
+      selectedTab: 'editor',
+      data: 'pong',
+      dataBuffer: response.dataBuffer
+    });
+
+    expect(downloadResponse.data).toBe('cG9uZw==');
+    expect(Buffer.from(downloadResponse.dataBuffer, 'base64').toString()).toBe('cG9uZw==');
+    expect(downloadResponse.headers['content-type']).toBe('text/plain');
+  });
+
+  it('builds a download response from the selected JSON format', () => {
+    const response = {
+      data: { hello: 'bruno' },
+      dataBuffer: Buffer.from('{"hello":"bruno"}').toString('base64'),
+      headers: {
+        'content-type': 'application/json'
+      }
+    };
+
+    const downloadResponse = getDownloadResponse({
+      response,
+      selectedFormat: 'json',
+      selectedTab: 'editor',
+      data: response.data,
+      dataBuffer: response.dataBuffer
+    });
+
+    expect(downloadResponse.data).toContain('"hello": "bruno"');
+    expect(downloadResponse.headers['content-type']).toBe('application/json');
+  });
+
+  it('keeps the original response when no format is selected', () => {
+    const response = {
+      data: 'pong',
+      dataBuffer: Buffer.from('pong').toString('base64')
+    };
+
+    const downloadResponse = getDownloadResponse({
+      response,
+      selectedFormat: null,
+      selectedTab: 'editor',
+      data: 'pong',
+      dataBuffer: response.dataBuffer
+    });
+
+    expect(downloadResponse).toBe(response);
+  });
+});

--- a/packages/bruno-app/src/components/ResponsePane/ResponsePaneActions/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponsePaneActions/index.js
@@ -163,7 +163,14 @@ const ResponsePaneActions = ({ item, collection, responseSize, selectedFormat, s
           dataBuffer={dataBuffer}
         />
         {item.type !== 'graphql-request' && <ResponseBookmark ref={bookmarkButtonRef} item={item} collection={collection} responseSize={responseSize} />}
-        <ResponseDownload ref={downloadButtonRef} item={item} />
+        <ResponseDownload
+          ref={downloadButtonRef}
+          item={item}
+          selectedFormat={selectedFormat}
+          selectedTab={selectedTab}
+          data={data}
+          dataBuffer={dataBuffer}
+        />
         <ResponseClear ref={clearButtonRef} item={item} collection={collection} />
         <ResponseLayoutToggle ref={layoutToggleButtonRef} />
       </div>


### PR DESCRIPTION
### Description

This PR makes links in custom HTML previews open in your normal browser, instead of inside Bruno.

It also makes downloaded responses use the format you currently selected, the same way copying a response already does.

Fixes #8548

### Validation

- [x] `npm run test --workspace=packages/bruno-app -- HtmlPreview.spec.js ResponseDownload/index.spec.js`
- [x] `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Downloaded responses now respect the selected response format and preview mode, including formatted text, JSON, and base64 output.
  * HTML previews now open external links in the system browser instead of navigating inside the preview.

* **Bug Fixes**
  * Improved handling of preview link clicks and new-window events.
  * External links in HTML previews now behave consistently for secure web URLs.

* **Tests**
  * Added coverage for HTML preview link behavior and formatted response downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->