### PR TITLE
fix: prevent collection search crash

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -59,6 +59,10 @@ export const flattenItems = (items = []) => {
 
   const flatten = (itms, flattened) => {
     each(itms, (i) => {
+      if (!i) {
+        return;
+      }
+
       flattened.push(i);
 
       if (i.items && i.items.length) {

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
+import { flattenItems, mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -84,6 +84,25 @@ describe('transformRequestToSaveToFilesystem', () => {
 
     expect(transformed.request.params[0].annotations).toEqual([{ name: 'param-note', value: 'keep me' }]);
     expect(transformed.request.headers[0].annotations).toEqual([{ name: 'header-note', value: 'keep me' }]);
+  });
+});
+
+describe('flattenItems', () => {
+  it('skips empty entries while flattening nested collection items', () => {
+    const request = { type: 'http-request', name: 'List Users', request: {} };
+    const folder = {
+      type: 'folder',
+      name: 'Users',
+      items: [
+        undefined,
+        request
+      ]
+    };
+
+    expect(flattenItems([null, folder])).toEqual([
+      folder,
+      request
+    ]);
   });
 });
 


### PR DESCRIPTION
### Description

This PR prevents collection item flattening from crashing when the collection tree contains empty entries. Search flows depend on `flattenItems`, so invalid entries should be skipped instead of causing the app error boundary to render.

Fixes #8504

Validation:

- `npm run lint -- packages/bruno-app/src/utils/collections/index.js packages/bruno-app/src/utils/collections/index.spec.js`
- `npm run test --workspace=packages/bruno-app -- src/utils/collections/index.spec.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list flattening so empty or invalid entries are safely ignored instead of causing incorrect nested results.
  * Added coverage for nested item lists to ensure only valid folders and requests are returned in the expected order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->