### PR TITLE
Add keymap binding to run Prettify on request text

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/RequestBody/RequestBodyMode/index.js
@@ -19,6 +19,7 @@ import { updateRequestBody } from 'providers/ReduxStore/slices/collections/index
 import { toastError } from 'utils/common/error';
 import { prettifyJsonString } from 'utils/common/index';
 import xmlFormat from 'xml-formatter';
+import useKeybinding from 'hooks/useKeybinding';
 
 const DEFAULT_MODES = [
   {
@@ -90,6 +91,11 @@ const RequestBodyMode = ({ item, collection }) => {
       }
     }
   };
+
+  useKeybinding('prettify', () => {
+    onPrettify();
+    return false;
+  }, { deps: [body, bodyMode] });
 
   const menuItems = useMemo(() => {
     return DEFAULT_MODES.map((group) => ({

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -38,7 +38,8 @@ export const KEY_BINDING_SECTIONS = [
     heading: 'Requests',
     bindings: {
       sendRequest: { mac: 'command+bind+enter', windows: 'ctrl+bind+enter', name: 'Send Request' }, // D
-      changeLayout: { mac: 'command+bind+j', windows: 'ctrl+bind+j', name: 'Change Orientation' } // D
+      changeLayout: { mac: 'command+bind+j', windows: 'ctrl+bind+j', name: 'Change Orientation' }, // D
+      prettify: { mac: 'alt+bind+shift+bind+f', windows: 'alt+bind+shift+bind+f', name: 'Prettify' } // D
     }
   },
   {


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Added Prettify button keyboard shortcut in response to this ticket:
https://github.com/usebruno/bruno/issues/1578

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new keyboard shortcut to prettify request bodies from the request editor.
  * The shortcut is available on both macOS and Windows for faster formatting of JSON/XML content.
* **Bug Fixes**
  * Updated shortcut handling so the prettify action stays in sync when the request body or its mode changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->