### PR TITLE
feat(app): migrate ctx API to bru.ctx

### DIFF
--- a/packages/bruno-app/src/components/AIAssist/index.js
+++ b/packages/bruno-app/src/components/AIAssist/index.js
@@ -32,16 +32,16 @@ const SUGGESTIONS = {
     { label: 'Errors', prompt: 'Document common error responses and status codes' }
   ],
   'app-request': [
-    { label: 'Send button', prompt: 'Add a button that calls ctx.sendRequest() and displays the response status, headers, and pretty-printed body' },
-    { label: 'Form for body', prompt: 'Build a form whose fields override the request body, then send it with ctx.sendRequest({ variables }) and show the result' },
-    { label: 'Response viewer', prompt: 'Render ctx.response with collapsible JSON and a banner showing status and response time; update on ctx.onResponseUpdate' },
-    { label: 'Test results', prompt: 'List ctx.testResults and ctx.assertionResults with pass/fail badges; refresh on ctx.onResultsUpdate' }
+    { label: 'Send button', prompt: 'Add a button that calls bru.ctx.submitRequest() and displays the response status, headers, and pretty-printed body' },
+    { label: 'Form for body', prompt: 'Build a form whose fields override the request body, then send it with bru.ctx.submitRequest({ runtimeVariables }) and show the result' },
+    { label: 'Response viewer', prompt: 'Render bru.ctx.http.response with collapsible JSON and a banner showing status and response time; update on bru.ctx.http.onResponseChange' },
+    { label: 'Test results', prompt: 'List bru.ctx.tests and bru.ctx.assertions with pass/fail badges; refresh on bru.ctx.onTestsChange and bru.ctx.onAssertionsChange' }
   ],
   'app-collection': [
-    { label: 'Request list', prompt: 'List all requests from ctx.listRequests() with their method and url, and a Run button next to each that calls ctx.runRequest(pathname)' },
-    { label: 'Dashboard', prompt: 'Build a small dashboard that runs every request from ctx.listRequests() on load and shows status code, response time, and a pass/fail dot for each' },
-    { label: 'Form runner', prompt: 'Render a form, and on submit call ctx.runRequest(pathname, { variables }) for a chosen request and display the response' },
-    { label: 'Variables panel', prompt: 'Show ctx.variables in a table and allow editing values via ctx.setRuntimeVariable(key, value); react to ctx.onVariablesUpdate' }
+    { label: 'Request list', prompt: 'List all requests from bru.ctx.listRequests() with their method and url, and a Run button next to each that calls bru.ctx.runRequest(pathname)' },
+    { label: 'Dashboard', prompt: 'Build a small dashboard that runs every request from bru.ctx.listRequests() on load and shows status code, response time, and a pass/fail dot for each' },
+    { label: 'Form runner', prompt: 'Render a form, and on submit call bru.ctx.runRequest(pathname, { runtimeVariables }) for a chosen request and display the response' },
+    { label: 'Variables panel', prompt: 'Show bru.ctx.variables.resolved in a table and allow editing values via bru.ctx.variables.runtime.set(name, value); react to bru.ctx.onVariablesChange' }
   ]
 };
 

--- a/packages/bruno-app/src/components/AppView/index.js
+++ b/packages/bruno-app/src/components/AppView/index.js
@@ -27,7 +27,7 @@ import {
   useAppWebview
 } from './webview-bridge';
 
-// Request-level ctx bootstrap. Injected into the guest so window.ctx exists
+// Request-level ctx bootstrap. Injected into the guest so window.bru exists
 // before user scripts run.
 const REQUEST_CTX_BOOTSTRAP = `<script>
 (function () {
@@ -44,43 +44,53 @@ const REQUEST_CTX_BOOTSTRAP = `<script>
   }
 
   var ctx = {
-    theme: 'light',
-    response: null,
-    assertionResults: [],
-    testResults: [],
-    variables: {},
+    theme: { name: 'light', mode: 'light', config: {} },
+    assertions: [],
+    tests: [],
+    variables: {
+      resolved: {},
+      runtime: {
+        set: function (name, value) {
+          sendToHost({ type: 'setRuntimeVariable', key: String(name), value: value });
+        }
+      }
+    },
+    http: {
+      response: null,
+      onResponseChange: null
+    },
 
     // Called once when the host delivers the initial state. ctx data arrives
     // asynchronously AFTER page load, so apps must do their first render here
-    // (or in the granular on* callbacks), not at DOMContentLoaded.
+    // (or in the on*Change callbacks), not at DOMContentLoaded.
     onInit: null,
     onThemeChange: null,
-    onResponseUpdate: null,
-    onResultsUpdate: null,
-    onVariablesUpdate: null,
+    onAssertionsChange: null,
+    onTestsChange: null,
+    onVariablesChange: null,
 
-    sendRequest: function (overrides) {
+    submitRequest: function (options) {
       return new Promise(function (resolve, reject) {
         var requestId = ++nextRequestId;
         pending.set(requestId, { resolve: resolve, reject: reject });
-        sendToHost({ type: 'sendRequest', requestId: requestId, overrides: overrides || {} });
+        sendToHost({ type: 'sendRequest', requestId: requestId, options: options || {} });
       });
-    },
-    setRuntimeVariable: function (key, value) {
-      sendToHost({ type: 'setRuntimeVariable', key: String(key), value: value });
     },
     log: function () {
       var args = Array.prototype.slice.call(arguments);
       sendToHost({ type: 'log', args: args });
     }
   };
-  window.ctx = ctx;
+
+  var bru = { ctx: ctx };
+  window.bru = bru;
 
   function applyTheme(theme) {
-    ctx.theme = theme || 'light';
+    ctx.theme = theme || { name: 'light', mode: 'light', config: {} };
+    var mode = ctx.theme.mode || 'light';
     if (document.body) {
       document.body.classList.remove('light', 'dark');
-      document.body.classList.add(ctx.theme);
+      document.body.classList.add(mode);
     }
   }
 
@@ -89,14 +99,14 @@ const REQUEST_CTX_BOOTSTRAP = `<script>
     switch (msg.type) {
       case 'state':
         applyTheme(msg.theme);
-        ctx.response = msg.response || null;
-        ctx.assertionResults = msg.assertionResults || [];
-        ctx.testResults = msg.testResults || [];
-        ctx.variables = msg.variables || {};
+        ctx.http.response = msg.response || null;
+        ctx.assertions = msg.assertionResults || [];
+        ctx.tests = msg.testResults || [];
+        ctx.variables.resolved = msg.variables || {};
         if (!initialized) {
           initialized = true;
           if (typeof ctx.onInit === 'function') {
-            try { ctx.onInit(ctx); } catch (e) { sendToHost({ type: 'log', args: ['onInit error: ' + (e && e.message)] }); }
+            try { ctx.onInit(bru); } catch (e) { sendToHost({ type: 'log', args: ['onInit error: ' + (e && e.message)] }); }
           }
         }
         break;
@@ -105,19 +115,18 @@ const REQUEST_CTX_BOOTSTRAP = `<script>
         if (typeof ctx.onThemeChange === 'function') ctx.onThemeChange(ctx.theme);
         break;
       case 'responseUpdate':
-        ctx.response = msg.response || null;
-        if (typeof ctx.onResponseUpdate === 'function') ctx.onResponseUpdate(ctx.response);
+        ctx.http.response = msg.response || null;
+        if (typeof ctx.http.onResponseChange === 'function') ctx.http.onResponseChange(ctx.http.response);
         break;
       case 'results':
-        ctx.assertionResults = msg.assertionResults || [];
-        ctx.testResults = msg.testResults || [];
-        if (typeof ctx.onResultsUpdate === 'function') {
-          ctx.onResultsUpdate({ assertionResults: ctx.assertionResults, testResults: ctx.testResults });
-        }
+        ctx.assertions = msg.assertionResults || [];
+        ctx.tests = msg.testResults || [];
+        if (typeof ctx.onAssertionsChange === 'function') ctx.onAssertionsChange(ctx.assertions);
+        if (typeof ctx.onTestsChange === 'function') ctx.onTestsChange(ctx.tests);
         break;
       case 'variables':
-        ctx.variables = msg.variables || {};
-        if (typeof ctx.onVariablesUpdate === 'function') ctx.onVariablesUpdate(ctx.variables);
+        ctx.variables.resolved = msg.variables || {};
+        if (typeof ctx.onVariablesChange === 'function') ctx.onVariablesChange(ctx.variables);
         break;
       case 'response': {
         var entry = pending.get(msg.requestId);
@@ -154,8 +163,17 @@ const buildVariables = (collection) => {
 
 const AppView = ({ item, collection, code }) => {
   const dispatch = useDispatch();
-  const { displayedTheme } = useTheme();
+  const { displayedTheme, theme, themeVariantLight, themeVariantDark } = useTheme();
   const src = useMemo(() => toDataUrl(wrapHtml(REQUEST_CTX_BOOTSTRAP, code || '')), [code]);
+
+  const themePayload = useMemo(
+    () => ({
+      name: displayedTheme === 'light' ? themeVariantLight : themeVariantDark,
+      mode: displayedTheme,
+      config: theme
+    }),
+    [displayedTheme, theme, themeVariantLight, themeVariantDark]
+  );
 
   const environment = useMemo(
     () => findEnvironmentInCollection(collection, collection.activeEnvironmentUid),
@@ -170,29 +188,28 @@ const AppView = ({ item, collection, code }) => {
   // routing through a ref lets the callbacks call the *latest* pushToGuest without
   // creating a circular useCallback dependency. Without this, the request-id reply
   // (and error reply) close over the first-render no-op pushToGuest and the guest's
-  // ctx.sendRequest() promise never resolves.
+  // bru.ctx.submitRequest() promise never resolves.
   const pushToGuestRef = useRef(() => {});
 
   const handleSendRequest = useCallback(
-    async (requestId, overrides) => {
+    async (requestId, options) => {
       const push = pushToGuestRef.current;
       try {
         // Mint a requestUid and register the run so the main process emits its
         // test/assertion/script events against an id the store recognises — this
-        // is what makes ctx.testResults / ctx.assertionResults populate.
+        // is what makes ctx.tests / ctx.assertions populate.
         const requestUid = uuid();
         const requestItem = cloneDeep(item.draft || item);
         requestItem.requestUid = requestUid;
         dispatch(initRunRequestEvent({ requestUid, itemUid: item.uid, collectionUid: collection.uid }));
 
-        // Variable overrides: accept flat keys or { variables: {...} }.
-        const flatOverrides = overrides && typeof overrides === 'object' ? { ...overrides } : {};
-        const explicitVars = flatOverrides.variables;
-        delete flatOverrides.variables;
+        const runtimeOverrides
+          = options && typeof options.runtimeVariables === 'object' && options.runtimeVariables
+            ? options.runtimeVariables
+            : {};
         const mergedRuntime = {
           ...(collection.runtimeVariables || {}),
-          ...flatOverrides,
-          ...(explicitVars && typeof explicitVars === 'object' ? explicitVars : {})
+          ...runtimeOverrides
         };
 
         const result = await sendNetworkRequest(requestItem, collection, environment, mergedRuntime);
@@ -238,7 +255,7 @@ const AppView = ({ item, collection, code }) => {
         case 'ready':
           break;
         case 'sendRequest':
-          handleSendRequest(data.requestId, data.overrides);
+          handleSendRequest(data.requestId, data.options);
           break;
         case 'setRuntimeVariable':
           if (typeof data.key === 'string' && data.key.length) {
@@ -262,15 +279,15 @@ const AppView = ({ item, collection, code }) => {
   // are handled by the granular effects below; using a ref avoids re-firing
   // this effect (which would be a needless full re-broadcast).
   const stateRef = useRef();
-  stateRef.current = { theme: displayedTheme, response, assertionResults, testResults, variables };
+  stateRef.current = { theme: themePayload, response, assertionResults, testResults, variables };
   useEffect(() => {
     if (!domReady) return;
     pushToGuest({ type: 'state', ...stateRef.current });
   }, [domReady, pushToGuest]);
 
   useEffect(() => {
-    pushToGuest({ type: 'theme', theme: displayedTheme });
-  }, [displayedTheme, pushToGuest]);
+    pushToGuest({ type: 'theme', theme: themePayload });
+  }, [themePayload, pushToGuest]);
 
   useEffect(() => {
     pushToGuest({ type: 'responseUpdate', response });

--- a/packages/bruno-app/src/components/AppView/webview-bridge.js
+++ b/packages/bruno-app/src/components/AppView/webview-bridge.js
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  *   guest -> host  : console.log(SENTINEL + json), surfaced via 'console-message'
  *
  * Both the request-level AppView and the standalone CollectionApp use this — they
- * differ only in the bootstrap script (which builds window.ctx) and the message
+ * differ only in the bootstrap script (which builds window.bru) and the message
  * handler the host registers.
  */
 export const SENTINEL = '__BRUNO_APP_MSG__';
@@ -33,7 +33,7 @@ const FRAGMENT_STYLES = `<style>
 
 /**
  * Wrap user code into a guest document, injecting the host-supplied bootstrap
- * script as early as possible (right after <head>) so window.ctx exists before
+ * script as early as possible (right after <head>) so window.bru exists before
  * any user script runs. Full HTML documents have the bootstrap injected; bare
  * fragments are placed inside a minimal shell.
  */
@@ -114,7 +114,7 @@ export const useAppWebview = (onGuestMessage) => {
 
   // Outgoing messages sent before the guest is ready are queued and flushed by
   // the dom-ready effect below. This is critical for guest scripts that call
-  // promise-returning ctx APIs (e.g. ctx.listRequests) at parse time — the host
+  // promise-returning ctx APIs (e.g. bru.ctx.listRequests) at parse time — the host
   // receives the request via console-message before Electron's `dom-ready`
   // fires, and without a queue the reply gets dropped and the promise never
   // resolves.

--- a/packages/bruno-app/src/components/CollectionApp/index.js
+++ b/packages/bruno-app/src/components/CollectionApp/index.js
@@ -42,10 +42,10 @@ import {
  * the code prop changes.
  *
  * Collection ctx surface differs from the request-level AppView:
- *   shared:  theme, log, variables, setRuntimeVariable, onThemeChange, onVariablesUpdate
- *   added:   collection, listRequests(), runRequest(pathname, overrides?)
- *   dropped: sendRequest, response, assertionResults, testResults
- *             (and their on* hooks — they only make sense for one request)
+ *   shared:  theme, log, variables (.resolved / .runtime.set), onThemeChange, onVariablesChange
+ *   added:   collection, listRequests(), runRequest(pathname, options?), onCollectionChange
+ *   dropped: submitRequest, http.response, assertions, tests
+ *             (and their on*Change hooks — they only make sense for one request)
  */
 
 const COLLECTION_CTX_BOOTSTRAP = `<script>
@@ -71,36 +71,43 @@ const COLLECTION_CTX_BOOTSTRAP = `<script>
   }
 
   var ctx = {
-    theme: 'light',
-    variables: {},
+    theme: { name: 'light', mode: 'light', config: {} },
     collection: null,
+    variables: {
+      resolved: {},
+      runtime: {
+        set: function (name, value) {
+          sendToHost({ type: 'setRuntimeVariable', key: String(name), value: value });
+        }
+      }
+    },
 
     onInit: null,
     onThemeChange: null,
-    onVariablesUpdate: null,
-    onCollectionUpdate: null,
+    onVariablesChange: null,
+    onCollectionChange: null,
 
     listRequests: function () {
       return awaitReply('listRequests');
     },
-    runRequest: function (pathname, overrides) {
-      return awaitReply('runRequest', { pathname: String(pathname || ''), overrides: overrides || {} });
-    },
-    setRuntimeVariable: function (key, value) {
-      sendToHost({ type: 'setRuntimeVariable', key: String(key), value: value });
+    runRequest: function (pathname, options) {
+      return awaitReply('runRequest', { pathname: String(pathname || ''), options: options || {} });
     },
     log: function () {
       var args = Array.prototype.slice.call(arguments);
       sendToHost({ type: 'log', args: args });
     }
   };
-  window.ctx = ctx;
+
+  var bru = { ctx: ctx };
+  window.bru = bru;
 
   function applyTheme(theme) {
-    ctx.theme = theme || 'light';
+    ctx.theme = theme || { name: 'light', mode: 'light', config: {} };
+    var mode = ctx.theme.mode || 'light';
     if (document.body) {
       document.body.classList.remove('light', 'dark');
-      document.body.classList.add(ctx.theme);
+      document.body.classList.add(mode);
     }
   }
 
@@ -109,12 +116,12 @@ const COLLECTION_CTX_BOOTSTRAP = `<script>
     switch (msg.type) {
       case 'state':
         applyTheme(msg.theme);
-        ctx.variables = msg.variables || {};
+        ctx.variables.resolved = msg.variables || {};
         ctx.collection = msg.collection || null;
         if (!initialized) {
           initialized = true;
           if (typeof ctx.onInit === 'function') {
-            try { ctx.onInit(ctx); } catch (e) { sendToHost({ type: 'log', args: ['onInit error: ' + (e && e.message)] }); }
+            try { ctx.onInit(bru); } catch (e) { sendToHost({ type: 'log', args: ['onInit error: ' + (e && e.message)] }); }
           }
         }
         break;
@@ -123,12 +130,12 @@ const COLLECTION_CTX_BOOTSTRAP = `<script>
         if (typeof ctx.onThemeChange === 'function') ctx.onThemeChange(ctx.theme);
         break;
       case 'variables':
-        ctx.variables = msg.variables || {};
-        if (typeof ctx.onVariablesUpdate === 'function') ctx.onVariablesUpdate(ctx.variables);
+        ctx.variables.resolved = msg.variables || {};
+        if (typeof ctx.onVariablesChange === 'function') ctx.onVariablesChange(ctx.variables);
         break;
       case 'collection':
         ctx.collection = msg.collection || null;
-        if (typeof ctx.onCollectionUpdate === 'function') ctx.onCollectionUpdate(ctx.collection);
+        if (typeof ctx.onCollectionChange === 'function') ctx.onCollectionChange(ctx.collection);
         break;
       case 'reply': {
         var entry = pending.get(msg.replyId);
@@ -177,9 +184,18 @@ const listRequestSummaries = (collection) =>
 
 const CollectionApp = ({ item, collection }) => {
   const dispatch = useDispatch();
-  const { displayedTheme } = useTheme();
+  const { displayedTheme, theme, themeVariantLight, themeVariantDark } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
   const [view, setView] = useState('preview');
+
+  const themePayload = useMemo(
+    () => ({
+      name: displayedTheme === 'light' ? themeVariantLight : themeVariantDark,
+      mode: displayedTheme,
+      config: theme
+    }),
+    [displayedTheme, theme, themeVariantLight, themeVariantDark]
+  );
 
   const code = item.draft ? get(item, 'draft.app.code', '') : get(item, 'app.code', '');
 
@@ -216,7 +232,7 @@ const CollectionApp = ({ item, collection }) => {
   // overrides into runtime variables, sends, and dispatches responseReceived so the
   // request's normal Response pane updates too.
   const runRequestByPath = useCallback(
-    async (pathname, overrides) => {
+    async (pathname, options) => {
       const target = findItemInCollectionByPathname(collection, pathname);
       if (!target) {
         throw new Error(`Request not found: ${pathname}`);
@@ -232,13 +248,13 @@ const CollectionApp = ({ item, collection }) => {
         initRunRequestEvent({ requestUid, itemUid: target.uid, collectionUid: collection.uid })
       );
 
-      const flat = overrides && typeof overrides === 'object' ? { ...overrides } : {};
-      const explicit = flat.variables;
-      delete flat.variables;
+      const runtimeOverrides
+        = options && typeof options.runtimeVariables === 'object' && options.runtimeVariables
+          ? options.runtimeVariables
+          : {};
       const mergedRuntime = {
         ...(collection.runtimeVariables || {}),
-        ...flat,
-        ...(explicit && typeof explicit === 'object' ? explicit : {})
+        ...runtimeOverrides
       };
 
       const result = await sendNetworkRequest(requestItem, collection, environment, mergedRuntime);
@@ -301,7 +317,7 @@ const CollectionApp = ({ item, collection }) => {
         }
         case 'runRequest': {
           try {
-            const res = await runRequestByPath(data.pathname, data.overrides);
+            const res = await runRequestByPath(data.pathname, data.options);
             push({ type: 'reply', replyId: data.replyId, result: res });
           } catch (err) {
             push({ type: 'reply', replyId: data.replyId, error: err?.message || 'runRequest failed' });
@@ -319,15 +335,15 @@ const CollectionApp = ({ item, collection }) => {
   pushToGuestRef.current = pushToGuest;
 
   const stateRef = useRef();
-  stateRef.current = { theme: displayedTheme, variables, collection: collectionInfo };
+  stateRef.current = { theme: themePayload, variables, collection: collectionInfo };
   useEffect(() => {
     if (!domReady) return;
     pushToGuest({ type: 'state', ...stateRef.current });
   }, [domReady, pushToGuest]);
 
   useEffect(() => {
-    pushToGuest({ type: 'theme', theme: displayedTheme });
-  }, [displayedTheme, pushToGuest]);
+    pushToGuest({ type: 'theme', theme: themePayload });
+  }, [themePayload, pushToGuest]);
 
   useEffect(() => {
     pushToGuest({ type: 'variables', variables });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1831,7 +1831,7 @@ const DEFAULT_APP_STARTER = `<!DOCTYPE html>
   <script>
     const out = document.getElementById('out');
     document.getElementById('refresh').addEventListener('click', async () => {
-      const requests = await ctx.listRequests();
+      const requests = await bru.ctx.listRequests();
       out.textContent = requests.map(r => \`\${r.method || r.type}  \${r.name}\`).join('\\n') || '(no requests)';
     });
   </script>

--- a/packages/bruno-electron/src/ipc/ai/chat-prompts.js
+++ b/packages/bruno-electron/src/ipc/ai/chat-prompts.js
@@ -103,43 +103,44 @@ Post-response scripts run AFTER the response is received, before tests. Availabl
 
 An app is a self-contained HTML/CSS/JS document rendered inside a sandboxed <webview> in Bruno. The user's code is injected into the body of a generated HTML document at runtime. Plain HTML, CSS, and JavaScript only — no bundler, no module imports, no JSX. Output can be a bare HTML fragment or a full \`<html>\` document.
 
-Before any user script runs, the host provides a global \`window.ctx\`. The surface depends on where the app lives:
+Before any user script runs, the host provides a global \`window.bru\`; the app context lives under \`bru.ctx\`. The surface depends on where the app lives:
 
 ### Request-level app — the app you edit via read_content/write_content('app') is ALWAYS this kind
 \`\`\`js
-ctx.theme                // 'light' | 'dark' — also reflected as a class on document.body
-ctx.response             // { status, statusText, headers, data, size, duration, timeline } | null
-ctx.assertionResults     // array of assertion result objects
-ctx.testResults          // array of test result objects
-ctx.variables            // merged env + global + collection + runtime variables (read-only snapshot)
+bru.ctx.theme                 // { name, mode: 'light'|'dark', config } — also reflected as a class on document.body
+bru.ctx.http.response         // { status, statusText, headers, data, size, duration } | null
+bru.ctx.assertions            // array of assertion result objects
+bru.ctx.tests                 // array of test result objects
+bru.ctx.variables.resolved    // merged env + global + collection + runtime variables (read-only snapshot)
 
-ctx.sendRequest(overrides?)        // executes THIS request; returns Promise<response>; overrides may carry { variables: {...} }
-ctx.setRuntimeVariable(key, value) // persist a runtime variable on the collection
-ctx.log(...args)                   // forwarded to the Bruno devtools console
+bru.ctx.submitRequest(options?)          // executes THIS request; returns Promise<response>; options may carry { runtimeVariables: {...} }
+bru.ctx.variables.runtime.set(name, value) // persist a runtime variable on the collection
+bru.ctx.log(...args)                     // forwarded to the Bruno devtools console
 
-ctx.onInit              = (ctx) => { ... }   // called ONCE when the initial state arrives — do the first render here
-ctx.onThemeChange       = (theme) => { ... }
-ctx.onResponseUpdate    = (response) => { ... }
-ctx.onResultsUpdate     = ({ assertionResults, testResults }) => { ... }
-ctx.onVariablesUpdate   = (variables) => { ... }
+bru.ctx.onInit              = (bru) => { ... }   // called ONCE when the initial state arrives — do the first render here
+bru.ctx.onThemeChange       = (theme) => { ... }
+bru.ctx.http.onResponseChange = (response) => { ... }
+bru.ctx.onAssertionsChange  = (assertions) => { ... }
+bru.ctx.onTestsChange       = (tests) => { ... }
+bru.ctx.onVariablesChange   = (variables) => { ... }
 \`\`\`
 
 ### Collection-/folder-level app (edited from the collection's own app editor — mentioned here only so you can answer questions about it)
 \`\`\`js
-ctx.theme / ctx.variables / ctx.setRuntimeVariable / ctx.log / ctx.onInit   // as above
-ctx.collection                         // { name, pathname } | null
-ctx.listRequests()                     // Promise<Array<{ uid, name, pathname, type, method, url }>>
-ctx.runRequest(pathname, overrides?)   // run a request by pathname; returns Promise<response>
-ctx.onThemeChange / ctx.onVariablesUpdate / ctx.onCollectionUpdate
+bru.ctx.theme / bru.ctx.variables / bru.ctx.variables.runtime.set / bru.ctx.log / bru.ctx.onInit   // as above
+bru.ctx.collection                        // { name, pathname } | null
+bru.ctx.listRequests()                    // Promise<Array<{ uid, name, pathname, type, method, url }>>
+bru.ctx.runRequest(pathname, options?)    // run a request by pathname; returns Promise<response>
+bru.ctx.onThemeChange / bru.ctx.onVariablesChange / bru.ctx.onCollectionChange
 \`\`\`
-There is NO \`ctx.response\` / \`ctx.sendRequest\` / \`ctx.assertionResults\` / \`ctx.testResults\` at collection level. Reference requests by the \`pathname\` from \`ctx.listRequests()\`, not by name.
+There is NO \`bru.ctx.http\` / \`bru.ctx.submitRequest\` / \`bru.ctx.assertions\` / \`bru.ctx.tests\` at collection level. Reference requests by the \`pathname\` from \`bru.ctx.listRequests()\`, not by name.
 
 ## RULES
 1. Generate a single self-contained HTML document (inline styles and scripts are fine — no external CDN)
-2. Use ONLY the \`ctx\` APIs listed above for the app's level — do not invent \`ctx\` methods, do not use \`fetch\` to call the API directly, and do not rely on Bruno internals beyond \`ctx\`
-3. CRITICAL: ctx data (\`ctx.response\`, \`ctx.variables\`, \`ctx.collection\`, …) is delivered asynchronously AFTER the page loads — reading it at the top level or in \`DOMContentLoaded\` yields null/empty. Do the initial render inside \`ctx.onInit = (ctx) => { ... }\` and react to later changes via the \`on*\` callbacks
-4. Always handle loading and error states around \`ctx.sendRequest\` / \`ctx.runRequest\`; bind UI updates to the \`on*\` callbacks instead of polling
-5. Theme changes toggle a \`light\`/\`dark\` class on \`document.body\` — style both states
+2. Use ONLY the \`bru.ctx\` APIs listed above for the app's level — do not invent \`bru.ctx\` methods, do not use \`fetch\` to call the API directly, and do not rely on Bruno internals beyond \`bru.ctx\`
+3. CRITICAL: ctx data (\`bru.ctx.http.response\`, \`bru.ctx.variables.resolved\`, \`bru.ctx.collection\`, …) is delivered asynchronously AFTER the page loads — reading it at the top level or in \`DOMContentLoaded\` yields null/empty. Do the initial render inside \`bru.ctx.onInit = (bru) => { ... }\` and react to later changes via the \`on*Change\` callbacks
+4. Always handle loading and error states around \`bru.ctx.submitRequest\` / \`bru.ctx.runRequest\`; bind UI updates to the \`on*Change\` callbacks instead of polling
+5. Theme changes toggle a \`light\`/\`dark\` class on \`document.body\` (from \`bru.ctx.theme.mode\`) — style both states; \`bru.ctx.theme.config\` is the full resolved theme object
 6. Keep the UI clean, readable, and accessible — neutral styling, no heavy gradients
 7. Write the COMPLETE document when using write_content`
 };

--- a/packages/bruno-electron/src/ipc/ai/script-prompts.js
+++ b/packages/bruno-electron/src/ipc/ai/script-prompts.js
@@ -155,34 +155,35 @@ ${COMMON_OUTPUT_RULES}`,
 
 A Bruno App is a self-contained UI that runs inside a sandboxed <webview>. The user's code is injected into the body of a generated HTML document at runtime — it must be fully independent. Plain HTML, CSS, and JavaScript only. No bundler, no module imports, no JSX, no React import statements (React is allowed only if loaded inline via <script> tags + Babel from CDN). Output can be a bare HTML fragment or a full \`<html>\` document.
 
-Before any user script runs, a global \`window.ctx\` is provided by the host. For a request-level app, the ctx surface is:
+Before any user script runs, a global \`window.bru\` is provided by the host; the app context lives under \`bru.ctx\`. For a request-level app, the surface is:
 
 \`\`\`js
-ctx.theme                // 'light' | 'dark' — also reflected on document.body className
-ctx.response             // { status, statusText, headers, data, dataBuffer?, size, duration, timeline } | null
-ctx.assertionResults     // array of assertion result objects
-ctx.testResults          // array of test result objects
-ctx.variables            // merged env + global + collection + runtime variables (read-only snapshot)
+bru.ctx.theme                 // { name, mode: 'light'|'dark', config } — also reflected on document.body className
+bru.ctx.http.response         // { status, statusText, headers, data, size, duration } | null
+bru.ctx.assertions            // array of assertion result objects
+bru.ctx.tests                 // array of test result objects
+bru.ctx.variables.resolved    // merged env + global + collection + runtime variables (read-only snapshot)
 
-ctx.sendRequest(overrides?)        // returns Promise<response>; overrides may carry { variables: {...} }
-ctx.setRuntimeVariable(key, value) // persist a runtime variable on the collection
-ctx.log(...args)                   // forwarded to the Bruno devtools console
+bru.ctx.submitRequest(options?)          // returns Promise<response>; options may carry { runtimeVariables: {...} }
+bru.ctx.variables.runtime.set(name, value) // persist a runtime variable on the collection
+bru.ctx.log(...args)                     // forwarded to the Bruno devtools console
 
-ctx.onInit              = (ctx) => { ... }   // called ONCE when the initial state arrives — do the first render here
-ctx.onThemeChange       = (theme) => { ... }
-ctx.onResponseUpdate    = (response) => { ... }
-ctx.onResultsUpdate     = ({ assertionResults, testResults }) => { ... }
-ctx.onVariablesUpdate   = (variables) => { ... }
+bru.ctx.onInit              = (bru) => { ... }   // called ONCE when the initial state arrives — do the first render here
+bru.ctx.onThemeChange       = (theme) => { ... }
+bru.ctx.http.onResponseChange = (response) => { ... }
+bru.ctx.onAssertionsChange  = (assertions) => { ... }
+bru.ctx.onTestsChange       = (tests) => { ... }
+bru.ctx.onVariablesChange   = (variables) => { ... }
 \`\`\`
 
-Theme changes automatically add a \`light\` or \`dark\` class on \`document.body\` — style both states.
+Theme changes automatically add a \`light\` or \`dark\` class on \`document.body\` — style both states; \`bru.ctx.theme.config\` is the full resolved theme object
 
 ## Best Practices
 
-- CRITICAL: ctx data (\`ctx.response\`, \`ctx.variables\`, …) is delivered asynchronously AFTER the page loads. Reading it at the top level or in a \`DOMContentLoaded\` handler yields null/empty values. Do the initial render inside \`ctx.onInit\` and react to later changes via the granular \`on*\` callbacks.
-- Use modern JavaScript (async/await). Always handle loading and error states around \`ctx.sendRequest\`.
-- Bind UI updates to the \`on*\` callbacks so the app reacts to host updates without polling.
-- Do not rely on Bruno internals beyond \`ctx\`. Do not invent endpoints — the request URL/method is provided as HTTP Request Context.
+- CRITICAL: ctx data (\`bru.ctx.http.response\`, \`bru.ctx.variables.resolved\`, …) is delivered asynchronously AFTER the page loads. Reading it at the top level or in a \`DOMContentLoaded\` handler yields null/empty values. Do the initial render inside \`bru.ctx.onInit\` and react to later changes via the granular \`on*Change\` callbacks.
+- Use modern JavaScript (async/await). Always handle loading and error states around \`bru.ctx.submitRequest\`.
+- Bind UI updates to the \`on*Change\` callbacks so the app reacts to host updates without polling.
+- Do not rely on Bruno internals beyond \`bru.ctx\`. Do not invent endpoints — the request URL/method is provided as HTTP Request Context.
 - Keep CSS scoped to the app body; the webview is isolated but be a good guest.
 
 ## Output Rules
@@ -199,35 +200,35 @@ ${DECLINE_RULE}`,
 
 A Bruno App is a self-contained UI that runs inside a sandboxed <webview>. The user's code is injected into the body of a generated HTML document at runtime — it must be fully independent. Plain HTML, CSS, and JavaScript only. No bundler, no module imports, no JSX, no React import statements (React is allowed only if loaded inline via <script> tags + Babel from CDN). Output can be a bare HTML fragment or a full \`<html>\` document.
 
-Before any user script runs, a global \`window.ctx\` is provided by the host. For a collection-/folder-level app, the ctx surface is:
+Before any user script runs, a global \`window.bru\` is provided by the host; the app context lives under \`bru.ctx\`. For a collection-/folder-level app, the surface is:
 
 \`\`\`js
-ctx.theme               // 'light' | 'dark' — also reflected on document.body className
-ctx.variables           // merged env + global + collection + runtime variables (read-only snapshot)
-ctx.collection          // { name, pathname } | null
+bru.ctx.theme               // { name, mode: 'light'|'dark', config } — also reflected on document.body className
+bru.ctx.variables.resolved  // merged env + global + collection + runtime variables (read-only snapshot)
+bru.ctx.collection          // { name, pathname } | null
 
-ctx.listRequests()                     // returns Promise<Array<{ uid, name, pathname, type, method, url }>>
-ctx.runRequest(pathname, overrides?)   // runs a single request by its pathname; returns Promise<response>
-ctx.setRuntimeVariable(key, value)     // persist a runtime variable on the collection
-ctx.log(...args)                       // forwarded to the Bruno devtools console
+bru.ctx.listRequests()                    // returns Promise<Array<{ uid, name, pathname, type, method, url }>>
+bru.ctx.runRequest(pathname, options?)    // runs a single request by its pathname; returns Promise<response>
+bru.ctx.variables.runtime.set(name, value) // persist a runtime variable on the collection
+bru.ctx.log(...args)                      // forwarded to the Bruno devtools console
 
-ctx.onInit            = (ctx) => { ... }   // called ONCE when the initial state arrives — do the first render here
-ctx.onThemeChange     = (theme) => { ... }
-ctx.onVariablesUpdate = (variables) => { ... }
-ctx.onCollectionUpdate = (collection) => { ... }
+bru.ctx.onInit            = (bru) => { ... }   // called ONCE when the initial state arrives — do the first render here
+bru.ctx.onThemeChange     = (theme) => { ... }
+bru.ctx.onVariablesChange = (variables) => { ... }
+bru.ctx.onCollectionChange = (collection) => { ... }
 \`\`\`
 
-A collection-level app is NOT bound to a single request — use \`ctx.listRequests()\` to discover what is available and \`ctx.runRequest(pathname)\` to execute one. There is no \`ctx.response\` / \`ctx.sendRequest\` / \`ctx.assertionResults\` / \`ctx.testResults\` here — those exist only on request-level apps.
+A collection-level app is NOT bound to a single request — use \`bru.ctx.listRequests()\` to discover what is available and \`bru.ctx.runRequest(pathname)\` to execute one. There is no \`bru.ctx.http\` / \`bru.ctx.submitRequest\` / \`bru.ctx.assertions\` / \`bru.ctx.tests\` here — those exist only on request-level apps.
 
-Theme changes automatically add a \`light\` or \`dark\` class on \`document.body\` — style both states.
+Theme changes automatically add a \`light\` or \`dark\` class on \`document.body\` (from \`bru.ctx.theme.mode\`) — style both states; \`bru.ctx.theme.config\` is the full resolved theme object
 
 ## Best Practices
 
-- CRITICAL: ctx data (\`ctx.collection\`, \`ctx.variables\`, …) is delivered asynchronously AFTER the page loads. Reading it at the top level or in a \`DOMContentLoaded\` handler yields null/empty values. Do the initial render inside \`ctx.onInit\` and react to later changes via the granular \`on*\` callbacks. (\`ctx.listRequests()\` / \`ctx.runRequest()\` return promises and are safe to call any time.)
-- Use modern JavaScript (async/await). Always handle loading and error states around \`ctx.runRequest\` and \`ctx.listRequests\`.
-- Reference requests by the \`pathname\` returned from \`ctx.listRequests()\`, not by name — names can collide.
-- When Documentation Context lists the collection's requests, you may pre-populate the UI with those names, but always discover via \`ctx.listRequests()\` at runtime so the app stays in sync as requests are added or renamed.
-- Do not rely on Bruno internals beyond \`ctx\`.
+- CRITICAL: ctx data (\`bru.ctx.collection\`, \`bru.ctx.variables.resolved\`, …) is delivered asynchronously AFTER the page loads. Reading it at the top level or in a \`DOMContentLoaded\` handler yields null/empty values. Do the initial render inside \`bru.ctx.onInit\` and react to later changes via the granular \`on*Change\` callbacks. (\`bru.ctx.listRequests()\` / \`bru.ctx.runRequest()\` return promises and are safe to call any time.)
+- Use modern JavaScript (async/await). Always handle loading and error states around \`bru.ctx.runRequest\` and \`bru.ctx.listRequests\`.
+- Reference requests by the \`pathname\` returned from \`bru.ctx.listRequests()\`, not by name — names can collide.
+- When Documentation Context lists the collection's requests, you may pre-populate the UI with those names, but always discover via \`bru.ctx.listRequests()\` at runtime so the app stays in sync as requests are added or renamed.
+- Do not rely on Bruno internals beyond \`bru.ctx\`.
 
 ## Output Rules
 

--- a/tests/apps/apps-ctx-api.spec.ts
+++ b/tests/apps/apps-ctx-api.spec.ts
@@ -33,7 +33,7 @@ const guestEval = (electronApp: ElectronApplication, code: string) =>
 
 const waitForGuestReady = async (electronApp: ElectronApplication) => {
   await expect
-    .poll(async () => guestEval(electronApp, 'typeof window.ctx'), { timeout: 15000 })
+    .poll(async () => guestEval(electronApp, 'window.bru && typeof window.bru.ctx'), { timeout: 15000 })
     .toBe('object');
 };
 
@@ -45,9 +45,9 @@ const guestResult = (electronApp: ElectronApplication) =>
 const CTX_APP = `
 <div id="out" data-result="pending">pending</div>
 <script>
-  window.__send = function (overrides) {
+  window.__send = function (options) {
     document.getElementById('out').setAttribute('data-result', 'sending');
-    return ctx.sendRequest(overrides)
+    return bru.ctx.submitRequest(options)
       .then(function (res) {
         var d = res && res.data;
         if (typeof d === 'string') { try { d = JSON.parse(d); } catch (e) {} }
@@ -58,8 +58,8 @@ const CTX_APP = `
         document.getElementById('out').setAttribute('data-result', 'ERR:' + (e && e.message));
       });
   };
-  window.__setVar = function (k, v) { ctx.setRuntimeVariable(k, v); };
-  window.__log = function () { ctx.log('hello from app', 42); return 'logged'; };
+  window.__setVar = function (k, v) { bru.ctx.variables.runtime.set(k, v); };
+  window.__log = function () { bru.ctx.log('hello from app', 42); return 'logged'; };
 </script>`;
 
 // POST to the echo endpoint with a templated JSON body so an overridden `q`
@@ -93,25 +93,27 @@ test.describe('Apps - ctx API', () => {
     const raw = await guestEval(
       electronApp,
       `JSON.stringify({
-        ctx: typeof window.ctx,
-        sendRequest: typeof window.ctx.sendRequest,
-        setRuntimeVariable: typeof window.ctx.setRuntimeVariable,
-        log: typeof window.ctx.log,
-        variablesIsObject: !!(window.ctx.variables && typeof window.ctx.variables === 'object'),
-        hooks: ['onThemeChange','onResponseUpdate','onResultsUpdate','onVariablesUpdate'].filter(function (k) { return k in window.ctx; })
+        ctx: typeof window.bru.ctx,
+        submitRequest: typeof window.bru.ctx.submitRequest,
+        runtimeSet: typeof window.bru.ctx.variables.runtime.set,
+        log: typeof window.bru.ctx.log,
+        resolvedVariablesIsObject: !!(window.bru.ctx.variables.resolved && typeof window.bru.ctx.variables.resolved === 'object'),
+        hooks: ['onThemeChange','onAssertionsChange','onTestsChange','onVariablesChange'].filter(function (k) { return k in window.bru.ctx; }),
+        httpHook: typeof window.bru.ctx.http.onResponseChange
       })`
     );
     const surface = JSON.parse(raw as string);
 
     expect(surface.ctx).toBe('object');
-    expect(surface.sendRequest).toBe('function');
-    expect(surface.setRuntimeVariable).toBe('function');
+    expect(surface.submitRequest).toBe('function');
+    expect(surface.runtimeSet).toBe('function');
     expect(surface.log).toBe('function');
-    expect(surface.variablesIsObject).toBe(true);
-    expect(surface.hooks).toEqual(['onThemeChange', 'onResponseUpdate', 'onResultsUpdate', 'onVariablesUpdate']);
+    expect(surface.resolvedVariablesIsObject).toBe(true);
+    expect(surface.hooks).toEqual(['onThemeChange', 'onAssertionsChange', 'onTestsChange', 'onVariablesChange']);
+    expect(surface.httpHook).toBe('object');
   });
 
-  test('ctx.theme is applied to the guest document', async ({ page, electronApp, createTmpDir }) => {
+  test('bru.ctx.theme is applied to the guest document', async ({ page, electronApp, createTmpDir }) => {
     const collectionPath = await createTmpDir('apps-ctx-theme');
     await createCollection(page, 'apps-theme', collectionPath);
     await createRequest(page, 'theme-req', 'apps-theme', { url: 'http://localhost:8081/api/echo/anything/x' });
@@ -123,14 +125,21 @@ test.describe('Apps - ctx API', () => {
 
     const raw = await guestEval(
       electronApp,
-      'JSON.stringify({ theme: window.ctx.theme, bodyClass: document.body.className })'
+      `JSON.stringify({
+        name: window.bru.ctx.theme.name,
+        mode: window.bru.ctx.theme.mode,
+        hasConfig: !!(window.bru.ctx.theme.config && typeof window.bru.ctx.theme.config === 'object'),
+        bodyClass: document.body.className
+      })`
     );
-    const { theme, bodyClass } = JSON.parse(raw as string);
-    expect(['light', 'dark']).toContain(theme);
-    expect(bodyClass).toContain(theme);
+    const { name, mode, hasConfig, bodyClass } = JSON.parse(raw as string);
+    expect(typeof name).toBe('string');
+    expect(['light', 'dark']).toContain(mode);
+    expect(hasConfig).toBe(true);
+    expect(bodyClass).toContain(mode);
   });
 
-  test('ctx.log is callable without throwing', async ({ page, electronApp, createTmpDir }) => {
+  test('bru.ctx.log is callable without throwing', async ({ page, electronApp, createTmpDir }) => {
     const collectionPath = await createTmpDir('apps-ctx-log');
     await createCollection(page, 'apps-log', collectionPath);
     await createRequest(page, 'log-req', 'apps-log', { url: 'http://localhost:8081/api/echo/anything/x' });
@@ -144,7 +153,7 @@ test.describe('Apps - ctx API', () => {
     expect(result).toBe('logged');
   });
 
-  test('ctx.sendRequest sends the request and resolves with the response', async ({ page, electronApp, createTmpDir }) => {
+  test('bru.ctx.submitRequest sends the request and resolves with the response', async ({ page, electronApp, createTmpDir }) => {
     const collectionPath = await createTmpDir('apps-ctx-send');
     await createCollection(page, 'apps-send', collectionPath);
     await createRequest(page, 'send-req', 'apps-send', { method: 'POST', url: ECHO_JSON_URL });
@@ -156,18 +165,18 @@ test.describe('Apps - ctx API', () => {
     await previewApp(page);
     await waitForGuestReady(electronApp);
 
-    await test.step('flat override keys become runtime variables', async () => {
-      await guestEval(electronApp, `void window.__send({ q: 'reflectme' })`);
+    await test.step('runtimeVariables override the request body', async () => {
+      await guestEval(electronApp, `void window.__send({ runtimeVariables: { q: 'reflectme' } })`);
       await expect.poll(() => guestResult(electronApp), { timeout: 15000 }).toBe('reflectme');
     });
 
-    await test.step('explicit { variables } override is also honoured', async () => {
-      await guestEval(electronApp, `void window.__send({ variables: { q: 'viaExplicit' } })`);
+    await test.step('a subsequent runtimeVariables override is honoured', async () => {
+      await guestEval(electronApp, `void window.__send({ runtimeVariables: { q: 'viaExplicit' } })`);
       await expect.poll(() => guestResult(electronApp), { timeout: 15000 }).toBe('viaExplicit');
     });
   });
 
-  test('ctx.setRuntimeVariable persists for subsequent sends', async ({ page, electronApp, createTmpDir }) => {
+  test('bru.ctx.variables.runtime.set persists for subsequent sends', async ({ page, electronApp, createTmpDir }) => {
     const collectionPath = await createTmpDir('apps-ctx-setvar');
     await createCollection(page, 'apps-setvar', collectionPath);
     await createRequest(page, 'setvar-req', 'apps-setvar', { method: 'POST', url: ECHO_JSON_URL });
@@ -180,11 +189,11 @@ test.describe('Apps - ctx API', () => {
     await waitForGuestReady(electronApp);
 
     await guestEval(electronApp, `window.__setVar('q', 'viaSet')`);
-    // Wait for the variable to round-trip back into the guest's ctx.variables
+    // Wait for the variable to round-trip back into the guest's bru.ctx.variables.resolved
     // (host dispatch → store update → AppView re-render → variables push) rather
     // than guessing with a fixed timeout, then send with no override.
     await expect
-      .poll(() => guestEval(electronApp, `window.ctx && window.ctx.variables && window.ctx.variables.q`), { timeout: 15000 })
+      .poll(() => guestEval(electronApp, `window.bru && window.bru.ctx.variables.resolved && window.bru.ctx.variables.resolved.q`), { timeout: 15000 })
       .toBe('viaSet');
     await guestEval(electronApp, 'void window.__send()');
     await expect.poll(() => guestResult(electronApp), { timeout: 15000 }).toBe('viaSet');
@@ -201,9 +210,8 @@ test.describe('Apps - ctx API', () => {
 
     const html = await getAppWebviewHtml(page);
     // ctx API surface is present in the injected bootstrap
-    expect(html).toContain('window.ctx');
-    expect(html).toContain('sendRequest');
-    expect(html).toContain('setRuntimeVariable');
+    expect(html).toContain('window.bru');
+    expect(html).toContain('submitRequest');
     expect(html).toContain('__brunoReceive');
     // user code is present
     expect(html).toContain('window.__send');

--- a/tests/apps/apps-ctx-api.spec.ts
+++ b/tests/apps/apps-ctx-api.spec.ts
@@ -17,17 +17,18 @@ import {
  */
 const guestEval = (electronApp: ElectronApplication, code: string) =>
   electronApp.evaluate(async ({ webContents }, c) => {
-    // The app view loads from a data:text/html URL. Filtering on that keeps us
-    // bound to the app guest even if other webviews (e.g. HTML response preview)
-    // are present.
-    const guest = webContents.getAllWebContents().find((wc) => {
+    // The app view loads from a data:text/html URL. Filtering on that and
+    // selecting the newest keeps us bound to the app guest even if other
+    // webviews (e.g. HTML response preview) are present.
+    const guests = webContents.getAllWebContents().filter((wc) => {
       try {
         return wc.getType() === 'webview' && (wc.getURL() || '').startsWith('data:text/html');
       } catch {
         return false;
       }
     });
-    if (!guest) return undefined;
+    if (!guests.length) return undefined;
+    const guest = guests.reduce((newest, wc) => (wc.id > newest.id ? wc : newest));
     return await guest.executeJavaScript(c, true);
   }, code);
 

--- a/tests/apps/collection-apps.spec.ts
+++ b/tests/apps/collection-apps.spec.ts
@@ -41,7 +41,7 @@ const guestEval = (
       for (const guest of guests) {
         try {
           const name = await guest.executeJavaScript(
-            'window.ctx && window.ctx.collection && window.ctx.collection.name',
+            'window.bru && window.bru.ctx.collection && window.bru.ctx.collection.name',
             true
           );
           if (name === params.expectedCollectionName) {
@@ -57,7 +57,7 @@ const guestEval = (
 
 const waitForGuestReady = async (electronApp: ElectronApplication, collectionName?: string) => {
   await expect
-    .poll(async () => guestEval(electronApp, 'typeof window.ctx', collectionName), { timeout: 15000 })
+    .poll(async () => guestEval(electronApp, 'window.bru && typeof window.bru.ctx', collectionName), { timeout: 15000 })
     .toBe('object');
 };
 
@@ -79,12 +79,12 @@ const CTX_APP = `
 <div id="out" data-result="pending">pending</div>
 <script>
   window.__listRequests = async function () {
-    const r = await ctx.listRequests();
+    const r = await bru.ctx.listRequests();
     document.getElementById('out').setAttribute('data-result', JSON.stringify(r.map(x => x.name)));
   };
   window.__runEcho = async function (pathname) {
     try {
-      const res = await ctx.runRequest(pathname, { q: 'echoed' });
+      const res = await bru.ctx.runRequest(pathname, { runtimeVariables: { q: 'echoed' } });
       const data = typeof res.data === 'string' ? JSON.parse(res.data) : res.data;
       document.getElementById('out').setAttribute('data-result', JSON.stringify({ status: res.status, q: data && data.q }));
     } catch (e) {
@@ -92,10 +92,10 @@ const CTX_APP = `
     }
   };
   window.__readVar = function (key) {
-    document.getElementById('out').setAttribute('data-result', String(ctx.variables[key] ?? '(missing)'));
+    document.getElementById('out').setAttribute('data-result', String(bru.ctx.variables.resolved[key] ?? '(missing)'));
   };
   window.__readCollectionName = function () {
-    document.getElementById('out').setAttribute('data-result', String(ctx.collection && ctx.collection.name));
+    document.getElementById('out').setAttribute('data-result', String(bru.ctx.collection && bru.ctx.collection.name));
   };
 </script>`;
 
@@ -123,7 +123,7 @@ test.describe('Collection apps', () => {
     });
   });
 
-  test('ctx.listRequests sees every request in the collection', async ({ page, electronApp, createTmpDir }) => {
+  test('bru.ctx.listRequests sees every request in the collection', async ({ page, electronApp, createTmpDir }) => {
     const collectionPath = await createTmpDir('collection-apps-list');
     await createCollection(page, 'col-apps-list', collectionPath);
     await createRequest(page, 'alpha', 'col-apps-list', { url: 'http://localhost:8081/ping' });
@@ -142,7 +142,7 @@ test.describe('Collection apps', () => {
       .toBe(JSON.stringify(['alpha', 'beta']));
   });
 
-  test('ctx.runRequest executes a request by pathname and reflects the response', async ({ page, electronApp, createTmpDir }) => {
+  test('bru.ctx.runRequest executes a request by pathname and reflects the response', async ({ page, electronApp, createTmpDir }) => {
     const collectionPath = await createTmpDir('collection-apps-run');
     await createCollection(page, 'col-apps-run', collectionPath);
     await createRequest(page, 'echo', 'col-apps-run', { method: 'POST', url: ECHO_JSON_URL });
@@ -165,11 +165,11 @@ test.describe('Collection apps', () => {
     await selectAppView(page, 'preview');
     await waitForGuestReady(electronApp, 'col-apps-run');
 
-    // Resolve the pathname of the 'echo' request via ctx.listRequests, then run it.
+    // Resolve the pathname of the 'echo' request via bru.ctx.listRequests, then run it.
     await guestEval(
       electronApp,
       `(async () => {
-        const requests = await ctx.listRequests();
+        const requests = await bru.ctx.listRequests();
         const echo = requests.find(r => r.name === 'echo');
         await window.__runEcho(echo.pathname);
       })()`,
@@ -181,7 +181,7 @@ test.describe('Collection apps', () => {
       .toBe(JSON.stringify({ status: 200, q: 'echoed' }));
   });
 
-  test('ctx.setRuntimeVariable persists into ctx.variables', async ({ page, electronApp, createTmpDir }) => {
+  test('bru.ctx.variables.runtime.set persists into bru.ctx.variables.resolved', async ({ page, electronApp, createTmpDir }) => {
     const collectionPath = await createTmpDir('collection-apps-vars');
     await createCollection(page, 'col-apps-vars', collectionPath);
 
@@ -192,13 +192,13 @@ test.describe('Collection apps', () => {
     await selectAppView(page, 'preview');
     await waitForGuestReady(electronApp, 'col-apps-vars');
 
-    await guestEval(electronApp, `ctx.setRuntimeVariable('hello', 'world')`, 'col-apps-vars');
+    await guestEval(electronApp, `bru.ctx.variables.runtime.set('hello', 'world')`, 'col-apps-vars');
     await expect
-      .poll(() => guestEval(electronApp, `ctx.variables && ctx.variables.hello`, 'col-apps-vars'), { timeout: 15000 })
+      .poll(() => guestEval(electronApp, `bru.ctx.variables.resolved && bru.ctx.variables.resolved.hello`, 'col-apps-vars'), { timeout: 15000 })
       .toBe('world');
   });
 
-  test('ctx.collection exposes the active collection', async ({ page, electronApp, createTmpDir }) => {
+  test('bru.ctx.collection exposes the active collection', async ({ page, electronApp, createTmpDir }) => {
     const collectionPath = await createTmpDir('collection-apps-meta');
     await createCollection(page, 'col-apps-meta', collectionPath);
 


### PR DESCRIPTION
### Description

- Migrates the Apps context API to a namespaced `bru.ctx.*` 
- Introduces a richer theme object and scoped variables. 
- Applies to both request level and collection level apps.

#### What changed

 Before | After |
|--------|-------|
| `window.ctx` | `window.bru.ctx` |
| `ctx.theme` (`'light'` / `'dark'`) | `bru.ctx.theme` (`{ name, mode, config }`) |
| `ctx.response` | `bru.ctx.http.response` |
| `ctx.assertionResults` / `ctx.testResults` | `bru.ctx.assertions` / `bru.ctx.tests` |
| `ctx.variables` | `bru.ctx.variables.resolved` |
| `ctx.sendRequest(overrides?)` | `bru.ctx.submitRequest(options?)` with `{ runtimeVariables }` |
| `ctx.setRuntimeVariable(key, value)` | `bru.ctx.variables.runtime.set(name, value)` |
| `ctx.onResponseUpdate` | `bru.ctx.http.onResponseChange` |
| `ctx.onResultsUpdate` | `bru.ctx.onAssertionsChange` + `bru.ctx.onTestsChange` |
| `ctx.onVariablesUpdate` | `bru.ctx.onVariablesChange` |
| `ctx.onCollectionUpdate` | `bru.ctx.onCollectionChange` |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `window.bru.ctx` runtime API for embedded request and collection apps (replacing `window.ctx`), including updated request execution, resolved variables, and callback naming.
  - Enhanced theme synchronization by delivering structured theme mode/config and applying updates to the guest.
  - Updated app starter behavior to use `bru.ctx` for listing requests.

- **Documentation**
  - Updated AI-assisted app-generation prompts and inline webview guidance to use the new `bru.ctx` contract and best-practice initialization.

- **Tests**
  - Updated Electron/Playwright coverage to validate `bru.ctx` bootstrapping, request/variable flow, and theme behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->