### PR TITLE
fix(mount): prevent crash when a malformed file recovers to a valid request

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -3028,17 +3028,40 @@ export const collectionsSlice = createSlice({
           item.partial = file.partial;
           item.error = file.error;
           item.loading = file.loading;
-          if (areItemsTheSameExceptSeqUpdate(item, file.data)) {
-            // whenever a user attempts to sort a req within the same folder
-            // the seq is updated, but everything else remains the same
-            // we don't want to lose the draft in this case
-            item.seq = file.data.seq;
-            item.raw = file.data.raw;
-            if (item?.draft) {
-              item.draft.seq = file.data.seq;
-            }
-            if (item?.draft && areItemsTheSameExceptSeqUpdate(item?.draft, file.data)) {
-              item.draft = null;
+          if (item.request) {
+            if (areItemsTheSameExceptSeqUpdate(item, file.data)) {
+              // whenever a user attempts to sort a req within the same folder
+              // the seq is updated, but everything else remains the same
+              // we don't want to lose the draft in this case
+              item.seq = file.data.seq;
+              item.raw = file.data.raw;
+              if (item?.draft) {
+                item.draft.seq = file.data.seq;
+              }
+              if (item?.draft && areItemsTheSameExceptSeqUpdate(item?.draft, file.data)) {
+                item.draft = null;
+              }
+            } else {
+              item.name = file.data.name;
+              item.type = file.data.type;
+              item.seq = file.data.seq;
+              item.tags = file.data.tags;
+              item.request = mergeRequestWithPreservedUids(item.request, file.data.request);
+              item.settings = file.data.settings;
+              item.examples = file.data.examples;
+              item.app = file.data.app ? { ...file.data.app } : null;
+              item.filename = file.meta.name;
+              item.pathname = file.meta.pathname;
+              item.raw = file.data.raw;
+              item.size = file.size;
+              // Only clear draft if it matches the file content
+              // This preserves characters typed during autosave
+              // The raw comparison is guarded so an undefined === undefined match
+              // (when neither side has raw content) does not wipe a genuine draft
+              const draftRawMatchesFile = item.draft?.raw !== undefined && item.draft.raw === file.data.raw;
+              if (item.draft && (areItemsTheSameExceptSeqUpdate(item.draft, file.data) || draftRawMatchesFile)) {
+                item.draft = null;
+              }
             }
           } else {
             item.name = file.data.name;
@@ -3053,12 +3076,7 @@ export const collectionsSlice = createSlice({
             item.pathname = file.meta.pathname;
             item.raw = file.data.raw;
             item.size = file.size;
-            // Only clear draft if it matches the file content
-            // This preserves characters typed during autosave
-            // The raw comparison is guarded so an undefined === undefined match
-            // (when neither side has raw content) does not wipe a genuine draft
-            const draftRawMatchesFile = item.draft?.raw !== undefined && item.draft.raw === file.data.raw;
-            if (item.draft && (areItemsTheSameExceptSeqUpdate(item.draft, file.data) || draftRawMatchesFile)) {
+            if (!item.draft || item.draft.raw === file.data.raw) {
               item.draft = null;
             }
           }


### PR DESCRIPTION
### Description

When a request file fails to parse, it is loaded as a **partial** item with a valid `type` (e.g. `http-request`) but `request === undefined`. When the file is later corrected on disk, `collectionChangeFileEvent` updated the item's `type` but left `request` undefined, so `RequestMethod` crashed on render:

```
Cannot read properties of undefined (reading 'method')
    at getMethodText (RequestMethod/index.js)
```

### Fix

Guard the update path in `collectionChangeFileEvent` on `item.request`:

- Items that already have a `request` flow through the existing seq-update / full-update logic unchanged.
- Partial items (valid type, `request === undefined`) flow through a dedicated branch that assigns the parsed request once it becomes available, so an item is never left with a valid type but an undefined request.

The request assignment is done **inside** the partial branch (not hoisted before the `if`), so `item.request` stays unmutated for the `areItemsTheSameExceptSeqUpdate` routing comparison — this preserves the file-mode draft-clearing behavior.

### Testing

- `collections` slice specs pass (108 passed), including the file-mode draft round-trip test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how collection items stay in sync during reorder and file-update events, with correct handling for seq-only changes.
  * Enhanced preservation of request-derived details when items already include request data.
  * Refined draft handling so drafts are cleared only when the incoming file content exactly matches, reducing unintended draft loss and mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->