### PR TITLE
fix(ws): remove default '{}' message body and make all message headers sticky

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/StyledWrapper.js
@@ -23,14 +23,11 @@ const StyledWrapper = styled.div`
     }
   }
 
-  &:not(.disabled) .accordion-header {
+  .accordion-header {
     position: sticky;
     top: 0;
     z-index: 1;
     background: ${(props) => props.theme.bg};
-  }
-
-  .accordion-header {
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -660,7 +660,7 @@ ${indentString(body.sparql)}
         }
 
         // Convert content to JSON string if it's an object
-        let contentValue = typeof content === 'object' ? JSON.stringify(content, null, 2) : content || '{}';
+        let contentValue = typeof content === 'object' ? JSON.stringify(content, null, 2) : content || '';
 
         // Wrap content with triple quotes for multiline support, without extra indentation
         bru += `${indentString(`content: '''\n${indentString(contentValue)}\n'''`)}\n`;

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -52,6 +52,26 @@ describe('jsonToBru stringify', () => {
       expect(output).toMatch(new RegExp(`keepAliveInterval: ${input.settings.keepAliveInterval}`));
       expect(output).toMatch(new RegExp(`timeout: ${input.settings.timeout}`));
     });
+
+    it('serializes falsy content to an empty content block', () => {
+      const input = {
+        body: {
+          mode: 'ws',
+          ws: [
+            {
+              content: '',
+              name: 'message 1'
+            }
+          ]
+        }
+      };
+
+      const output = stringify(input);
+
+      // Content block is emitted but empty (no '{}' fallback).
+      expect(output).toMatch(/content: '''\s*'''/);
+      expect(output).not.toContain('{}');
+    });
   });
 
   describe('body:multipart-form file values', () => {

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1653,10 +1653,16 @@ const closeAllTabs = async (page: Page) => {
     // Click "Close All" menu item
     await dropdown.locator('[role="menuitem"][data-item-id="close-all"]').click();
 
-    // Handle "Unsaved Transient Requests" modal if it appears
+    // Handle "Unsaved Transient Requests" modal if it appears (multiple transient requests)
     const discardAllButton = page.getByRole('button', { name: 'Discard All' });
     if (await discardAllButton.isVisible({ timeout: 1000 }).catch(() => false)) {
       await discardAllButton.click();
+    }
+
+    const saveTransientModal = page.getByTestId('save-transient-request-modal');
+    if (await saveTransientModal.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await saveTransientModal.getByRole('button', { name: 'Cancel' }).click();
+      await expect(saveTransientModal).toBeHidden();
     }
   });
 };

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1653,7 +1653,7 @@ const closeAllTabs = async (page: Page) => {
     // Click "Close All" menu item
     await dropdown.locator('[role="menuitem"][data-item-id="close-all"]').click();
 
-    // Handle "Unsaved Transient Requests" modal if it appears (multiple transient requests)
+    // Handle "Unsaved Transient Requests" modal if it appears
     const discardAllButton = page.getByRole('button', { name: 'Discard All' });
     if (await discardAllButton.isVisible({ timeout: 1000 }).catch(() => false)) {
       await discardAllButton.click();

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -356,6 +356,10 @@ export const buildWebsocketCommonLocators = (page: Page) => ({
     headers: () => page.getByTestId(/^ws-message-header-/),
     header: (index: number) => page.getByTestId(`ws-message-header-${index}`),
     body: (index: number) => page.getByTestId(`ws-message-body-${index}`),
+    editor: (index: number) => page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror'),
+    editorPlaceholder: (index: number) =>
+      page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror-placeholder'),
+    editorCode: (index: number) => page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror-code'),
     label: (index: number) => page.getByTestId(`ws-message-label-${index}`),
     nameInput: (index: number) => page.getByTestId(`ws-message-name-input-${index}`),
     nameTooltip: () => page.getByTestId('ws-message-name-tooltip'),

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -351,9 +351,16 @@ export const buildWebsocketCommonLocators = (page: Page) => ({
   },
   messages: () => page.locator('.ws-message'),
   message: {
+    container: () => page.getByTestId('ws-messages-container'),
+    addButton: () => page.getByTestId('ws-add-message'),
+    headers: () => page.getByTestId(/^ws-message-header-/),
+    header: (index: number) => page.getByTestId(`ws-message-header-${index}`),
+    body: (index: number) => page.getByTestId(`ws-message-body-${index}`),
     label: (index: number) => page.getByTestId(`ws-message-label-${index}`),
     nameInput: (index: number) => page.getByTestId(`ws-message-name-input-${index}`),
-    nameTooltip: () => page.getByTestId('ws-message-name-tooltip')
+    nameTooltip: () => page.getByTestId('ws-message-name-tooltip'),
+    sendButton: (index: number) => page.getByTestId(`ws-send-msg-${index}`),
+    deleteButton: (index: number) => page.getByTestId(`ws-delete-msg-${index}`)
   },
   toolbar: {
     latestFirst: () => page.getByRole('button', { name: 'Latest First' }),

--- a/tests/websockets/message-body-default.spec.ts
+++ b/tests/websockets/message-body-default.spec.ts
@@ -1,33 +1,51 @@
 import { expect, test } from '../../playwright';
-import { closeAllCollections } from '../utils/page/actions';
-
-const REQ_NAME = /^ws-default-body-request$/;
+import { closeAllTabs, createTransientRequest, selectRequestPaneTab } from '../utils/page/actions';
+import { buildWebsocketCommonLocators } from '../utils/page/locators';
 
 test.describe('websocket message default body', () => {
-  test.afterAll(async ({ pageWithUserData: page }) => {
-    await closeAllCollections(page);
+  test.afterEach(async ({ page }) => {
+    await closeAllTabs(page);
   });
 
   test('a newly added message defaults to an empty body showing the placeholder', async ({
-    pageWithUserData: page
+    page
   }) => {
-    // Open the preloaded websocket request
-    await page.getByTestId('sidebar-collection-row').click();
-    await page.getByTitle(REQ_NAME).click();
+    const ws = buildWebsocketCommonLocators(page);
 
-    const headers = page.getByTestId(/^ws-message-header-/);
-    const beforeCount = await headers.count();
+    await createTransientRequest(page, { requestType: 'WebSocket' });
+    await selectRequestPaneTab(page, 'Message');
 
-    await page.getByTestId('ws-add-message').click();
-    await expect(headers).toHaveCount(beforeCount + 1);
+    const beforeCount = await ws.message.headers().count();
+
+    await ws.message.addButton().click();
+    await expect(ws.message.headers()).toHaveCount(beforeCount + 1);
 
     // The newly added message is the last one and auto-expands.
-    const newBody = page.getByTestId(`ws-message-body-${beforeCount}`);
+    const newBody = ws.message.body(beforeCount);
     await expect(newBody).toBeVisible();
 
     const editor = newBody.locator('.CodeMirror');
     // Body should be empty (previously defaulted to '{}'); the editor should
     // surface the '...' placeholder instead of any '{}' content.
+    await expect(editor.locator('.CodeMirror-placeholder')).toHaveText('...');
+    await expect(editor.locator('.CodeMirror-code')).not.toContainText('{}');
+  });
+
+  test('the default first message of a newly created websocket request has an empty body', async ({
+    page
+  }) => {
+    const ws = buildWebsocketCommonLocators(page);
+
+    await createTransientRequest(page, { requestType: 'WebSocket' });
+    await selectRequestPaneTab(page, 'Message');
+
+    // The default first message auto-expands.
+    const body = ws.message.body(0);
+    await expect(body).toBeVisible();
+
+    const editor = body.locator('.CodeMirror');
+    // Body must be empty (previously defaulted to '{}'); the editor should surface
+    // the '...' placeholder rather than any '{}' content.
     await expect(editor.locator('.CodeMirror-placeholder')).toHaveText('...');
     await expect(editor.locator('.CodeMirror-code')).not.toContainText('{}');
   });

--- a/tests/websockets/message-body-default.spec.ts
+++ b/tests/websockets/message-body-default.spec.ts
@@ -21,14 +21,12 @@ test.describe('websocket message default body', () => {
     await expect(ws.message.headers()).toHaveCount(beforeCount + 1);
 
     // The newly added message is the last one and auto-expands.
-    const newBody = ws.message.body(beforeCount);
-    await expect(newBody).toBeVisible();
+    await expect(ws.message.body(beforeCount)).toBeVisible();
 
-    const editor = newBody.locator('.CodeMirror');
     // Body should be empty (previously defaulted to '{}'); the editor should
     // surface the '...' placeholder instead of any '{}' content.
-    await expect(editor.locator('.CodeMirror-placeholder')).toHaveText('...');
-    await expect(editor.locator('.CodeMirror-code')).not.toContainText('{}');
+    await expect(ws.message.editorPlaceholder(beforeCount)).toHaveText('...');
+    await expect(ws.message.editorCode(beforeCount)).not.toContainText('{}');
   });
 
   test('the default first message of a newly created websocket request has an empty body', async ({
@@ -40,13 +38,11 @@ test.describe('websocket message default body', () => {
     await selectRequestPaneTab(page, 'Message');
 
     // The default first message auto-expands.
-    const body = ws.message.body(0);
-    await expect(body).toBeVisible();
+    await expect(ws.message.body(0)).toBeVisible();
 
-    const editor = body.locator('.CodeMirror');
     // Body must be empty (previously defaulted to '{}'); the editor should surface
     // the '...' placeholder rather than any '{}' content.
-    await expect(editor.locator('.CodeMirror-placeholder')).toHaveText('...');
-    await expect(editor.locator('.CodeMirror-code')).not.toContainText('{}');
+    await expect(ws.message.editorPlaceholder(0)).toHaveText('...');
+    await expect(ws.message.editorCode(0)).not.toContainText('{}');
   });
 });


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-3701)

1. **Empty message body no longer defaults to `{}`.** 

2. **Sticky headers for all messages.** Only the selected message's header stuck to the top when scrolling; now every message header is sticky.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket `body:ws` content now defaults to an empty payload (no `{}`) when content is missing/falsy.
  * Accordion headers now remain sticky during scrolling (with the correct background styling), including for disabled rows.

* **Tests**
  * Updated WebSocket UI tests to use shared locators/utilities and improved tab/cleanup handling.
  * Added coverage to confirm default message bodies stay empty and expanded websocket locators/action helpers for add/send/delete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->