### PR TITLE
Used shared Button for Stop action to keep chat and generation stylin…

### DIFF
--- a/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
@@ -221,26 +221,6 @@ export const PopupWrapper = styled.div`
     }
   }
 
-  .btn-stop {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 5px 12px;
-    font-size: 12px;
-    font-weight: 500;
-    border-radius: ${(props) => props.theme.border.radius.sm};
-    border: 1px solid ${(props) => props.theme.input.border};
-    background: ${(props) => props.theme.input.bg};
-    color: ${(props) => props.theme.text};
-    cursor: pointer;
-    transition: background-color 0.15s ease, border-color 0.15s ease;
-
-    &:hover {
-      border-color: ${(props) => props.theme.colors.text.danger};
-      color: ${(props) => props.theme.colors.text.danger};
-    }
-  }
-
   .btn-secondary {
     padding: 5px 12px;
     font-size: 12px;

--- a/packages/bruno-app/src/components/AIAssist/index.js
+++ b/packages/bruno-app/src/components/AIAssist/index.js
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 import Tippy from '@tippyjs/react';
 import { IconX, IconArrowBackUp, IconPlayerStop } from '@tabler/icons';
 import IconSparkles from 'components/Icons/IconSparkles';
+import Button from 'ui/Button';
 import { aiGenerateScript, stopAiGeneration } from 'utils/ai';
 import StyledWrapper, { PopupWrapper } from './StyledWrapper';
 
@@ -243,14 +244,17 @@ const AIAssist = ({ scriptType, currentScript, requestContext, docsContext, vari
                     <span className="popup-hint">Enter to generate · Shift+Enter for newline</span>
                   )}
                   {isLoading ? (
-                    <button
-                      className="btn-stop"
-                      type="button"
+                    <Button
+                      variant="filled"
+                      color="danger"
+                      size="sm"
+                      rounded="sm"
+                      icon={<IconPlayerStop size={12} />}
                       onClick={handleStop}
                       title="Stop generating"
                     >
-                      <IconPlayerStop size={12} /> Stop
-                    </button>
+                      Stop
+                    </Button>
                   ) : (
                     <button
                       className="btn-generate"

--- a/packages/bruno-app/src/components/AIAssist/index.spec.js
+++ b/packages/bruno-app/src/components/AIAssist/index.spec.js
@@ -15,18 +15,23 @@ jest.mock('utils/ai', () => ({
 const theme = {
   bg: '#1e1e1e',
   text: '#ffffff',
-  border: { radius: { sm: '4px', md: '6px' } },
+  border: { radius: { sm: '4px', base: '5px', md: '6px', lg: '8px' } },
   colors: {
     accent: '#6366f1',
     text: { muted: '#9ca3af', danger: '#ef4444' },
     bg: { danger: '#ef4444' }
+  },
+  button2: {
+    color: {
+      danger: { bg: '#ef4444', text: '#ffffff', border: '#ef4444' }
+    }
   },
   input: {
     border: '#374151',
     bg: '#111827',
     focusBorder: '#6366f1'
   },
-  font: { monospace: 'monospace' }
+  font: { monospace: 'monospace', size: { xs: '11px', sm: '12px', base: '13px' } }
 };
 
 const createStore = (aiEnabled = true) => configureStore({

--- a/packages/bruno-app/src/components/AiChatSidebar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AiChatSidebar/StyledWrapper.js
@@ -799,7 +799,7 @@ const StyledWrapper = styled.div`
       }
     }
 
-    .send-btn, .stop-btn {
+    .send-btn {
       display: flex;
       align-items: center;
       gap: 4px;
@@ -809,9 +809,6 @@ const StyledWrapper = styled.div`
       font-size: 11px;
       font-weight: 500;
       cursor: pointer;
-    }
-
-    .send-btn {
       background: ${(props) => props.theme.brand};
       color: ${(props) => (props.theme.mode === 'dark' ? '#000' : '#fff')};
 
@@ -822,15 +819,6 @@ const StyledWrapper = styled.div`
       &:disabled {
         opacity: 0.4;
         cursor: not-allowed;
-      }
-    }
-
-    .stop-btn {
-      background: ${(props) => props.theme.colors.text.danger};
-      color: ${(props) => (props.theme.mode === 'dark' ? '#000' : '#fff')};
-
-      &:hover {
-        opacity: 0.9;
       }
     }
   }

--- a/packages/bruno-app/src/components/AiChatSidebar/index.js
+++ b/packages/bruno-app/src/components/AiChatSidebar/index.js
@@ -18,6 +18,7 @@ import IconSparkles from 'components/Icons/IconSparkles';
 import get from 'lodash/get';
 import find from 'lodash/find';
 import MenuDropdown from 'ui/MenuDropdown';
+import Button from 'ui/Button';
 import { focusTab } from 'providers/ReduxStore/slices/tabs';
 import {
   closeAiSidebar,
@@ -942,9 +943,17 @@ const AiChatSidebar = ({ collection, variant = 'sidebar' }) => {
                   </MenuDropdown>
                 </div>
                 {isLoading ? (
-                  <button className="stop-btn" onClick={handleStop} title="Stop generating">
-                    <IconPlayerStop size={12} /> Stop
-                  </button>
+                  <Button
+                    variant="filled"
+                    color="danger"
+                    size="xs"
+                    rounded="sm"
+                    icon={<IconPlayerStop size={12} />}
+                    onClick={handleStop}
+                    title="Stop generating"
+                  >
+                    Stop
+                  </Button>
                 ) : (
                   <button
                     className="send-btn"


### PR DESCRIPTION
[JIRA](https://usebruno.atlassian.net/browse/BRU-3757)

### Description

**Problem**
The AI Stop button was inconsistent; the button had a solid danger-red fill in the AI Chat Bar, but a non-filled outlined button in the AI Generation tabs (Docs, Tests, Scripts, Generate App). 

**Reason**
Both surfaces created their own Stop button CSS in local StyledWrapper.js files; the chat .stop-btn used theme.colors.text.danger as a solid fill, whereas the generation .btn-stop used theme.input.bg with an outlined button border. Since there was no shared component that provided consistent styling, both styles became inconsistent over time.

**Solution**
Both inconsistent buttons were replaced by the existing shared ui/Button (with variant=filled and color=danger), resulting in the same button2.color.danger theme token to be used on both surfaces. The inconsistency can’t occur because the buttons use a shared component; the dead CSS was removed and the mock theme used in the AIAssist unit test was updated.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated AI Assist and AI Chat stop-generation controls with consistent shared button styling.
  * Applied danger-themed, filled button treatment with stop icons.
  * Refined send-button states, including hover and disabled behavior.
* **Tests**
  * Updated component test theme configuration to support the revised button styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->