### PR TITLE
feat(tls): URL-bar SSL verification lock + fix gRPC scheme requirement

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -27,6 +27,7 @@ import useProtoFileManagement from 'hooks/useProtoFileManagement/index';
 import MethodDropdown from './MethodDropdown';
 import ProtoFileDropdown from './ProtoFileDropdown';
 import ToolHint from 'components/ToolHint';
+import TlsIndicator from 'components/RequestPane/TlsIndicator';
 
 const STREAMING_METHOD_TYPES = ['client-streaming', 'server-streaming', 'bidi-streaming'];
 const CLIENT_STREAMING_METHOD_TYPES = ['client-streaming', 'bidi-streaming'];
@@ -298,6 +299,9 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
 
   return (
     <StyledWrapper className="flex items-center relative" data-testid="grpc-query-url-container">
+      <div className="flex items-center h-full pl-2 pr-1">
+        <TlsIndicator size={18} />
+      </div>
       <div className="flex items-center h-full method-selector-container">
         <div className="flex items-center justify-center h-full px-[10px]" data-testid="grpc-method-indicator">
           <span className="text-xs font-medium" style={{ color: theme.request.grpc }}>gRPC</span>

--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -24,6 +24,7 @@ import { hasRequestChanges } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import GenerateCodeItem from 'components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index';
 import ToolHint from 'components/ToolHint';
+import TlsIndicator from 'components/RequestPane/TlsIndicator';
 import toast from 'react-hot-toast';
 
 const QueryUrl = ({ item, collection, handleRun }) => {
@@ -393,6 +394,9 @@ const QueryUrl = ({ item, collection, handleRun }) => {
   return (
     <StyledWrapper className="flex items-center w-full">
       <div className="flex items-center h-full url-input-group">
+        <div className="flex items-center h-full pl-2 pr-1">
+          <TlsIndicator size={18} />
+        </div>
         <div className="flex items-center h-full min-w-fit">
           <HttpMethodSelector method={method} onMethodSelect={onMethodSelect} />
         </div>

--- a/packages/bruno-app/src/components/RequestPane/TlsIndicator/index.js
+++ b/packages/bruno-app/src/components/RequestPane/TlsIndicator/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { IconLock, IconLockOpen } from '@tabler/icons';
+import { savePreferences } from 'providers/ReduxStore/slices/app';
+import { useTheme } from 'providers/Theme';
+import ToolHint from 'components/ToolHint';
+
+const TlsIndicator = ({ size = 20 }) => {
+  const dispatch = useDispatch();
+  const { theme } = useTheme();
+  const preferences = useSelector((state) => state.app.preferences) || {};
+  const sslVerification = preferences?.request?.sslVerification !== false;
+
+  const handleToggle = (e) => {
+    e.stopPropagation();
+    const next = !sslVerification;
+    dispatch(
+      savePreferences({
+        ...preferences,
+        request: {
+          ...(preferences.request || {}),
+          sslVerification: next
+        }
+      })
+    );
+  };
+
+  const Icon = sslVerification ? IconLock : IconLockOpen;
+  const tooltipText = sslVerification
+    ? 'SSL/TLS verification enabled — click to disable (applies to all requests)'
+    : 'SSL/TLS verification disabled — click to enable (applies to all requests)';
+
+  return (
+    <ToolHint text={tooltipText} toolhintId="tls-indicator" place="top" positionStrategy="fixed">
+      <div className="flex items-center cursor-pointer" onClick={handleToggle} data-testid="tls-indicator">
+        <Icon
+          color={theme.requestTabs.icon.color}
+          strokeWidth={1.5}
+          size={size}
+          style={{ opacity: sslVerification ? 1 : 0.55 }}
+        />
+      </div>
+    </ToolHint>
+  );
+};
+
+export default TlsIndicator;

--- a/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
@@ -1,6 +1,6 @@
 // To implement grpc event handlers
 const { ipcMain, app } = require('electron');
-const { GrpcClient } = require('@usebruno/requests');
+const { GrpcClient, resolveGrpcUseTls } = require('@usebruno/requests');
 const { safeParseJSON, safeStringifyJSON } = require('../../utils/common');
 const { cloneDeep, get } = require('lodash');
 const { preferencesUtil } = require('../../store/preferences');
@@ -157,6 +157,9 @@ const registerGrpcEventHandlers = (window) => {
       const requestCopy = cloneDeep(request);
       const preparedRequest = await prepareGrpcRequest(requestCopy, collection, environment, runtimeVariables, {});
 
+      const sslVerification = preferencesUtil.shouldVerifyTls();
+      const useTls = resolveGrpcUseTls(preparedRequest.url, sslVerification);
+
       const protocolRegex = /^([-+\w]{1,25})(:?\/\/|:)/;
       if (!protocolRegex.test(preparedRequest.url)) {
         preparedRequest.url = `http://${preparedRequest.url}`;
@@ -190,7 +193,7 @@ const registerGrpcEventHandlers = (window) => {
 
       // Configure verify options
       const verifyOptions = {
-        rejectUnauthorized: preferencesUtil.shouldVerifyTls()
+        rejectUnauthorized: sslVerification
       };
 
       // Extract certificate information
@@ -229,6 +232,7 @@ const registerGrpcEventHandlers = (window) => {
         passphrase,
         pfx,
         verifyOptions,
+        useTls,
         includeDirs,
         proxyConfig: grpcProxyConfig
       });
@@ -317,6 +321,9 @@ const registerGrpcEventHandlers = (window) => {
       const requestCopy = cloneDeep(request);
       const preparedRequest = await prepareGrpcRequest(requestCopy, collection, environment, runtimeVariables);
 
+      const sslVerification = preferencesUtil.shouldVerifyTls();
+      const useTls = resolveGrpcUseTls(preparedRequest.url, sslVerification);
+
       const protocolRegex = /^([-+\w]{1,25})(:?\/\/|:)/;
       if (!protocolRegex.test(preparedRequest.url)) {
         preparedRequest.url = `http://${preparedRequest.url}`;
@@ -350,7 +357,7 @@ const registerGrpcEventHandlers = (window) => {
 
       // Configure verify options
       const verifyOptions = {
-        rejectUnauthorized: preferencesUtil.shouldVerifyTls()
+        rejectUnauthorized: sslVerification
       };
 
       // Extract certificate information
@@ -384,6 +391,7 @@ const registerGrpcEventHandlers = (window) => {
         passphrase,
         pfx,
         verifyOptions,
+        useTls,
         sendEvent,
         proxyConfig: grpcProxyConfig
       });
@@ -445,6 +453,9 @@ const registerGrpcEventHandlers = (window) => {
       const requestCopy = cloneDeep(request);
       const preparedRequest = await prepareGrpcRequest(requestCopy, collection, environment, runtimeVariables, {});
 
+      const sslVerification = preferencesUtil.shouldVerifyTls();
+      const useTls = resolveGrpcUseTls(preparedRequest.url, sslVerification);
+
       const protocolRegex = /^([-+\w]{1,25})(:?\/\/|:)/;
       if (!protocolRegex.test(preparedRequest.url)) {
         preparedRequest.url = `http://${preparedRequest.url}`;
@@ -467,7 +478,7 @@ const registerGrpcEventHandlers = (window) => {
         const domain = interpolateString(clientCert?.domain, interpolationOptions);
         const type = clientCert?.type || 'cert';
         if (domain) {
-          const hostRegex = '^(https:\\/\\/|grpc:\\/\\/|grpcs:\\/\\/)' + domain.replaceAll('.', '\\.').replaceAll('*', '.*');
+          const hostRegex = '^(https:\\/\\/|grpc:\\/\\/|grpcs:\\/\\/|http:\\/\\/)?' + domain.replaceAll('.', '\\.').replaceAll('*', '.*');
           const requestUrl = interpolateString(preparedRequest.url, interpolationOptions);
           if (requestUrl.match(hostRegex)) {
             if (type === 'cert') {
@@ -487,7 +498,9 @@ const registerGrpcEventHandlers = (window) => {
           ca: caCertFilePath,
           cert: certFilePath,
           key: keyFilePath
-        }
+        },
+        useTls,
+        sslVerification
       });
 
       return { success: true, command };

--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -112,6 +112,45 @@ const normalizeWindowsNamedPipe = (pipePath) => {
   return pipePath;
 };
 
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
+
+/**
+ * Decide whether a gRPC request should use TLS.
+ *
+ * Precedence (in order):
+ * 1. Unix sockets / Windows named pipes → always insecure (transport can't do TLS).
+ * 2. Explicit `grpc://` or `http://` scheme in the raw URL → insecure (user opt-out).
+ * 3. Explicit `grpcs://` or `https://` scheme → follow `sslVerification`.
+ * 4. No scheme, loopback host (localhost/127.0.0.1/0.0.0.0/::1) → insecure (dev backward compat).
+ * 5. No scheme, remote host → follow `sslVerification`.
+ *
+ * @param {string} url - The raw gRPC URL (as the user typed it, pre-interpolation-safe).
+ * @param {boolean} sslVerification - The global sslVerification preference; `true` means user wants TLS with verification.
+ * @returns {boolean} true → attempt TLS credentials, false → plaintext.
+ */
+const resolveGrpcUseTls = (url, sslVerification = true) => {
+  if (!url) return false;
+
+  if (isUnixSocket(url) || isWindowsNamedPipe(url)) return false;
+
+  const trimmed = url.trim().toLowerCase();
+  const schemeMatch = trimmed.match(/^([a-z][-+.\w]{0,24}):\/\//);
+  if (schemeMatch) {
+    const scheme = schemeMatch[1];
+    if (scheme === 'grpcs' || scheme === 'https') return Boolean(sslVerification);
+    return false; // grpc://, http://, and any other explicit scheme → plaintext
+  }
+
+  // No scheme: infer from host
+  const hostSegment = trimmed.split('/')[0];
+  const hostname = hostSegment.startsWith('[')
+    ? hostSegment.slice(1, hostSegment.indexOf(']'))
+    : hostSegment.split(':')[0];
+  if (LOOPBACK_HOSTS.has(hostname)) return false;
+
+  return Boolean(sslVerification);
+};
+
 // Parse gRPC URL into components, handling TCP, Unix sockets, and Windows named pipes
 const getParsedGrpcUrlObject = (url) => {
   const addProtocolIfMissing = (str) => {
@@ -300,17 +339,18 @@ class GrpcClient {
    * @param {VerifyOptions} verifyOptions - Additional options for verifying the server certificate
    * @returns {import('@grpc/grpc-js').ChannelCredentials} The gRPC channel credentials
    */
-  #getChannelCredentials({ url, rootCertificate, privateKey, certificateChain, passphrase, pfx, verifyOptions }) {
-    const securedProtocols = ['grpcs', 'https'];
+  #getChannelCredentials({ url, useTls, rootCertificate, privateKey, certificateChain, passphrase, pfx, verifyOptions }) {
     try {
-      const { protocol, isLocalTransport } = getParsedGrpcUrlObject(url);
+      const { isLocalTransport } = getParsedGrpcUrlObject(url);
 
       if (isLocalTransport) {
         return ChannelCredentials.createInsecure();
       }
 
-      const isSecureConnection = securedProtocols.some((sp) => protocol === sp);
-      if (!isSecureConnection) {
+      const shouldUseTls = typeof useTls === 'boolean'
+        ? useTls
+        : resolveGrpcUseTls(url, verifyOptions?.rejectUnauthorized !== false);
+      if (!shouldUseTls) {
         return ChannelCredentials.createInsecure();
       }
 
@@ -431,7 +471,7 @@ class GrpcClient {
    * @returns {Promise<boolean>} Whether methods were successfully refreshed
    * @private
    */
-  async #refreshMethods({ url, headers, protoPath, collectionPath, collectionUid, certificates = {}, verifyOptions, includeDirs = [], proxyConfig }) {
+  async #refreshMethods({ url, headers, protoPath, collectionPath, collectionUid, certificates = {}, verifyOptions, useTls, includeDirs = [], proxyConfig }) {
     try {
       // Try reflection first if no proto path is specified
       if (!protoPath) {
@@ -444,6 +484,7 @@ class GrpcClient {
           passphrase: certificates.passphrase,
           pfx: certificates.pfx,
           verifyOptions,
+          useTls,
           sendEvent: () => {}, // No-op for refresh
           proxyConfig
         });
@@ -590,12 +631,14 @@ class GrpcClient {
     passphrase,
     pfx,
     verifyOptions,
+    useTls,
     channelOptions = {},
     includeDirs = [],
     proxyConfig
   }) {
     const credentials = this.#getChannelCredentials({
       url: request.url,
+      useTls,
       rootCertificate,
       privateKey,
       certificateChain,
@@ -629,6 +672,7 @@ class GrpcClient {
           pfx
         },
         verifyOptions,
+        useTls,
         includeDirs,
         proxyConfig
       });
@@ -746,6 +790,7 @@ class GrpcClient {
     passphrase,
     pfx,
     verifyOptions,
+    useTls,
     sendEvent,
     channelOptions = {},
     proxyConfig
@@ -773,6 +818,7 @@ class GrpcClient {
     });
     const credentials = this.#getChannelCredentials({
       url: request.url,
+      useTls,
       rootCertificate,
       privateKey,
       certificateChain,
@@ -987,12 +1033,15 @@ class GrpcClient {
    * @param {Object} options.certificates - Certificate configuration
    * @returns {string} The generated grpcurl command
    */
-  generateGrpcurlCommand({ request, collectionPath = '', shell = 'bash', certificates = {} }) {
+  generateGrpcurlCommand({ request, collectionPath = '', shell = 'bash', certificates = {}, useTls, sslVerification = true }) {
     const { url, method, methodType = 'unary', body, headers, protoPath } = request;
     const useReflection = !protoPath;
     const parts = [];
     const { host, path, protocol } = getParsedGrpcUrlObject(url);
     const { ca, cert, key } = certificates;
+    const shouldUseTls = typeof useTls === 'boolean'
+      ? useTls
+      : resolveGrpcUseTls(url, sslVerification);
 
     parts.push('grpcurl');
 
@@ -1003,7 +1052,10 @@ class GrpcClient {
     } else if (protocol === 'pipe') {
       console.warn('Windows named pipes are not directly supported by grpcurl');
       parts.push('-plaintext');
-    } else if (url.startsWith('grpcs://') || url.startsWith('https://')) {
+    } else if (shouldUseTls) {
+      if (!sslVerification) {
+        parts.push('-insecure');
+      }
       if (ca) {
         /**
          * Instead of using certificate that relies on CN, use SANs
@@ -1074,4 +1126,4 @@ class GrpcClient {
   }
 }
 
-export { GrpcClient };
+export { GrpcClient, resolveGrpcUseTls };

--- a/packages/bruno-requests/src/grpc/grpc-client.spec.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.spec.js
@@ -99,7 +99,8 @@ jest.mock('@grpc/proto-loader', () => ({
   load: jest.fn().mockResolvedValue({})
 }));
 
-import { GrpcClient } from './grpc-client';
+import { GrpcClient, resolveGrpcUseTls } from './grpc-client';
+import { ChannelCredentials } from '@grpc/grpc-js';
 
 describe('GrpcClient', () => {
   let grpcClient;
@@ -652,6 +653,119 @@ describe('GrpcClient', () => {
       expect(capturedChannelOptions['grpc.http_connect_target']).toBe('dns:myserver:50051');
       expect(capturedChannelOptions['grpc.enable_http_proxy']).toBe(0);
       expect(capturedHost).toBe('proxy.example.com:8080');
+    });
+  });
+
+  describe('resolveGrpcUseTls', () => {
+    test('returns false for unix sockets', () => {
+      expect(resolveGrpcUseTls('unix:/var/run/grpc.sock', true)).toBe(false);
+      expect(resolveGrpcUseTls('unix-abstract:my.socket', true)).toBe(false);
+    });
+
+    test('returns false for windows named pipes', () => {
+      expect(resolveGrpcUseTls('\\\\.\\pipe\\mypipe', true)).toBe(false);
+      expect(resolveGrpcUseTls('//./pipe/mypipe', true)).toBe(false);
+    });
+
+    test('explicit grpc:// is always plaintext (user opt-out)', () => {
+      expect(resolveGrpcUseTls('grpc://api.example.com:443', true)).toBe(false);
+      expect(resolveGrpcUseTls('grpc://api.example.com:443', false)).toBe(false);
+    });
+
+    test('explicit http:// is always plaintext (user opt-out)', () => {
+      expect(resolveGrpcUseTls('http://api.example.com:80', true)).toBe(false);
+    });
+
+    test('explicit grpcs:// follows sslVerification', () => {
+      expect(resolveGrpcUseTls('grpcs://api.example.com:443', true)).toBe(true);
+      expect(resolveGrpcUseTls('grpcs://api.example.com:443', false)).toBe(false);
+    });
+
+    test('explicit https:// follows sslVerification', () => {
+      expect(resolveGrpcUseTls('https://api.example.com:443', true)).toBe(true);
+      expect(resolveGrpcUseTls('https://api.example.com:443', false)).toBe(false);
+    });
+
+    test('bare loopback hosts are plaintext (backward compat for local dev)', () => {
+      expect(resolveGrpcUseTls('localhost:50051', true)).toBe(false);
+      expect(resolveGrpcUseTls('127.0.0.1:50051', true)).toBe(false);
+      expect(resolveGrpcUseTls('0.0.0.0:50051', true)).toBe(false);
+      expect(resolveGrpcUseTls('[::1]:50051', true)).toBe(false);
+    });
+
+    test('bare remote host follows sslVerification (this is the bug fix)', () => {
+      expect(resolveGrpcUseTls('api.example.com:443', true)).toBe(true);
+      expect(resolveGrpcUseTls('api.example.com:443', false)).toBe(false);
+    });
+
+    test('unknown scheme defaults to plaintext', () => {
+      expect(resolveGrpcUseTls('ftp://api.example.com', true)).toBe(false);
+    });
+
+    test('empty or nullish URL is plaintext', () => {
+      expect(resolveGrpcUseTls('', true)).toBe(false);
+      expect(resolveGrpcUseTls(null, true)).toBe(false);
+      expect(resolveGrpcUseTls(undefined, true)).toBe(false);
+    });
+  });
+
+  describe('#getChannelCredentials selection via loadMethodsFromReflection', () => {
+    const baseRequest = {
+      url: 'grpc://localhost:50051',
+      uid: 'test-request-uid',
+      headers: {}
+    };
+    const baseParams = {
+      collectionUid: 'test-collection-uid',
+      sendEvent: jest.fn()
+    };
+
+    test('bare host + useTls=true selects SSL credentials (bug fix)', async () => {
+      await grpcClient.loadMethodsFromReflection({
+        ...baseParams,
+        request: { ...baseRequest, url: 'api.example.com:443' },
+        useTls: true
+      });
+      expect(ChannelCredentials.createSsl).toHaveBeenCalled();
+      expect(ChannelCredentials.createInsecure).not.toHaveBeenCalled();
+    });
+
+    test('bare host + useTls=false selects insecure', async () => {
+      await grpcClient.loadMethodsFromReflection({
+        ...baseParams,
+        request: { ...baseRequest, url: 'api.example.com:443' },
+        useTls: false
+      });
+      expect(ChannelCredentials.createInsecure).toHaveBeenCalled();
+      expect(ChannelCredentials.createSsl).not.toHaveBeenCalled();
+    });
+
+    test('grpcs:// + useTls=true selects SSL credentials (regression)', async () => {
+      await grpcClient.loadMethodsFromReflection({
+        ...baseParams,
+        request: { ...baseRequest, url: 'grpcs://api.example.com:443' },
+        useTls: true
+      });
+      expect(ChannelCredentials.createSsl).toHaveBeenCalled();
+    });
+
+    test('unix socket forces insecure regardless of useTls', async () => {
+      await grpcClient.loadMethodsFromReflection({
+        ...baseParams,
+        request: { ...baseRequest, url: 'unix:/var/run/grpc.sock' },
+        useTls: true
+      });
+      expect(ChannelCredentials.createInsecure).toHaveBeenCalled();
+      expect(ChannelCredentials.createSsl).not.toHaveBeenCalled();
+    });
+
+    test('falls back to URL-scheme heuristic when useTls is undefined', async () => {
+      // grpcs:// scheme means the fallback picks SSL
+      await grpcClient.loadMethodsFromReflection({
+        ...baseParams,
+        request: { ...baseRequest, url: 'grpcs://api.example.com:443' }
+      });
+      expect(ChannelCredentials.createSsl).toHaveBeenCalled();
     });
   });
 

--- a/packages/bruno-requests/src/grpc/index.ts
+++ b/packages/bruno-requests/src/grpc/index.ts
@@ -1,2 +1,2 @@
-export { GrpcClient } from './grpc-client';
+export { GrpcClient, resolveGrpcUseTls } from './grpc-client';
 export { generateGrpcSampleMessage } from './grpcMessageGenerator';

--- a/packages/bruno-requests/src/index.ts
+++ b/packages/bruno-requests/src/index.ts
@@ -1,5 +1,5 @@
 export { addDigestInterceptor, getOAuth2Token, createOAuth1Authorizer, computeBodyHash, applyOAuth1ToRequest, addEdgeGridInterceptor } from './auth';
-export { GrpcClient, generateGrpcSampleMessage } from './grpc';
+export { GrpcClient, generateGrpcSampleMessage, resolveGrpcUseTls } from './grpc';
 export { WsClient } from './ws/ws-client';
 export { default as cookies } from './cookies';
 


### PR DESCRIPTION
### Description

https://github.com/user-attachments/assets/ebb98418-0c13-46a2-9c3e-a37da142ae06

<img width="450" height="136" alt="Screenshot 2026-07-11 at 7 31 18 PM" src="https://github.com/user-attachments/assets/b7f318ac-c86b-40bb-9725-f75a8208ca25" />

Fixes #6950.

Two related changes so gRPC TLS behaves predictably and users can see/toggle SSL verification without leaving the request pane.

**1. gRPC TLS no longer requires an explicit `grpcs://` prefix.**

Previously, `#getChannelCredentials` in `packages/bruno-requests/src/grpc/grpc-client.js` gated TLS on the URL scheme being one of `grpcs`/`https`. If the user typed a bare `host:port`, the electron layer would auto-prepend `http://`, the scheme check would fail, and all configured client certs / verify options were silently discarded (`createInsecure()`). This meant TLS "only worked" when the user manually prepended `grpcs://`.

New decision (implemented as `resolveGrpcUseTls(url, sslVerification)`):

- Unix socket / Windows named pipe → plaintext (transport can't do TLS)
- Explicit `grpc://` or `http://` → plaintext (user opt-out escape hatch)
- Explicit `grpcs://` or `https://` → follow `sslVerification`
- Bare loopback host (`localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]`) → plaintext (backward compat for local dev)
- Bare remote host → follow `sslVerification` (**this is the bug fix**)

Threaded a `useTls` boolean through `startConnection`, `#refreshMethods`, `loadMethodsFromReflection`, and `generateGrpcurlCommand`. The grpcurl generator now also emits `-insecure` when TLS is used with verification off. Cert-lookup regex in `grpc-event-handlers.js` was also relaxed to make the scheme prefix optional, matching what `cert-utils.js` already does for HTTP.

**2. TLS lock indicator in the URL bar (HTTP + gRPC).**

Added `packages/bruno-app/src/components/RequestPane/TlsIndicator/index.js` — a browser-style lock icon at the leftmost position of the URL bar on both HTTP and gRPC requests. It reads and writes the existing global `preferences.request.sslVerification` — no new schema or `.bru` field. Tooltip clarifies the toggle is global.

- `IconLock` when verification is on
- `IconLockOpen` (muted) when verification is off
- Click flips `sslVerification` via `savePreferences` (same round-trip as the Preferences dialog)

### Behavior

| URL user types | Before this PR | After this PR (with `sslVerification: true`) |
|---|---|---|
| `grpcs://api.example.com:443` | TLS ✓ | TLS ✓ |
| `api.example.com:443` | Plaintext (silent) — certs dropped | **TLS ✓** |
| `grpc://localhost:50051` | Plaintext | Plaintext (unchanged) |
| `localhost:50051` | Plaintext | Plaintext (unchanged) |
| `unix:/var/run/grpc.sock` | Plaintext | Plaintext (unchanged) |

### No schema / .bru changes

Deliberately: this reuses the existing global `sslVerification` preference rather than adding a per-request field, so no migration is needed and existing collections are unaffected.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**