### PR TITLE
fix(scripting): preserve variables set in req.onFail

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1058,10 +1058,9 @@ const registerNetworkIpc = (mainWindow) => {
             response.data = await promisifyStream(response.data);
           }
         } else {
-          const onFailScriptResult = await executeRequestOnFailHandler(request, error);
-          if (onFailScriptResult) {
+          await executeRequestOnFailHandler(request, error, (onFailScriptResult) => {
             sendVariableUpdates(onFailScriptResult, { collectionUid, requestUid, collection });
-          }
+          });
 
           // if it's not a network error, don't continue
           // we are not rejecting the promise here and instead returning a response object with `error` which is handled in the `send-http-request` invocation
@@ -1938,10 +1937,9 @@ const registerNetworkIpc = (mainWindow) => {
                   ...eventData
                 });
               } else {
-                const onFailScriptResult = await executeRequestOnFailHandler(request, error);
-                if (onFailScriptResult) {
+                await executeRequestOnFailHandler(request, error, (onFailScriptResult) => {
                   sendVariableUpdates(onFailScriptResult, { collectionUid, requestUid, collection });
-                }
+                });
 
                 // if it's not a network error, don't continue
                 throw error;
@@ -2230,14 +2228,19 @@ const registerNetworkIpc = (mainWindow) => {
  * Executes the custom error handler if it exists on the request
  * @param {Object} request - The request object that may contain an onFailHandler
  * @param {Error} error - The error that occurred
+ * @param {Function} onResult - Callback for handling the script result
  */
-const executeRequestOnFailHandler = async (request, error) => {
+const executeRequestOnFailHandler = async (request, error, onResult) => {
   if (!request || typeof request.onFailHandler !== 'function') {
     return;
   }
 
   try {
-    return await request.onFailHandler(error);
+    const result = await request.onFailHandler(error);
+    if (result && typeof onResult === 'function') {
+      onResult(result);
+    }
+    return result;
   } catch (handlerError) {
     console.error('Error executing onFail handler', handlerError);
     // @TODO: This is a temporary solution to display the error message in the response pane. Revisit and handle properly.

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1058,7 +1058,10 @@ const registerNetworkIpc = (mainWindow) => {
             response.data = await promisifyStream(response.data);
           }
         } else {
-          await executeRequestOnFailHandler(request, error);
+          const onFailScriptResult = await executeRequestOnFailHandler(request, error);
+          if (onFailScriptResult) {
+            sendVariableUpdates(onFailScriptResult, { collectionUid, requestUid, collection });
+          }
 
           // if it's not a network error, don't continue
           // we are not rejecting the promise here and instead returning a response object with `error` which is handled in the `send-http-request` invocation
@@ -1935,7 +1938,10 @@ const registerNetworkIpc = (mainWindow) => {
                   ...eventData
                 });
               } else {
-                await executeRequestOnFailHandler(request, error);
+                const onFailScriptResult = await executeRequestOnFailHandler(request, error);
+                if (onFailScriptResult) {
+                  sendVariableUpdates(onFailScriptResult, { collectionUid, requestUid, collection });
+                }
 
                 // if it's not a network error, don't continue
                 throw error;
@@ -2231,7 +2237,7 @@ const executeRequestOnFailHandler = async (request, error) => {
   }
 
   try {
-    await request.onFailHandler(error);
+    return await request.onFailHandler(error);
   } catch (handlerError) {
     console.error('Error executing onFail handler', handlerError);
     // @TODO: This is a temporary solution to display the error message in the response pane. Revisit and handle properly.

--- a/packages/bruno-electron/tests/network/execute-request-error-handler.spec.js
+++ b/packages/bruno-electron/tests/network/execute-request-error-handler.spec.js
@@ -39,18 +39,27 @@ describe('executeRequestOnFailHandler', () => {
 
   it('should return the result from onFailHandler', async () => {
     const handlerResult = {
+      envVariables: {
+        environmentToken: 'updated'
+      },
       runtimeVariables: {
-        token: 'updated'
+        runtimeToken: 'updated'
+      },
+      globalEnvironmentVariables: {
+        globalToken: 'updated'
       }
     };
     const mockHandler = jest.fn().mockResolvedValue(handlerResult);
+    const onResult = jest.fn();
     const request = { onFailHandler: mockHandler };
     const error = new Error('Test error');
 
-    const result = await executeRequestOnFailHandler(request, error);
+    const result = await executeRequestOnFailHandler(request, error, onResult);
 
     expect(mockHandler).toHaveBeenCalledWith(error);
     expect(mockHandler).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith(handlerResult);
+    expect(onResult).toHaveBeenCalledTimes(1);
     expect(result).toEqual(handlerResult);
     expect(consoleSpy).not.toHaveBeenCalled();
   });

--- a/packages/bruno-electron/tests/network/execute-request-error-handler.spec.js
+++ b/packages/bruno-electron/tests/network/execute-request-error-handler.spec.js
@@ -37,15 +37,21 @@ describe('executeRequestOnFailHandler', () => {
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 
-  it('should call onFailHandler when it exists and is a function', async () => {
-    const mockHandler = jest.fn();
+  it('should return the result from onFailHandler', async () => {
+    const handlerResult = {
+      runtimeVariables: {
+        token: 'updated'
+      }
+    };
+    const mockHandler = jest.fn().mockResolvedValue(handlerResult);
     const request = { onFailHandler: mockHandler };
     const error = new Error('Test error');
 
-    await executeRequestOnFailHandler(request, error);
+    const result = await executeRequestOnFailHandler(request, error);
 
     expect(mockHandler).toHaveBeenCalledWith(error);
     expect(mockHandler).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(handlerResult);
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -101,6 +101,18 @@ class ScriptRuntime {
       scriptedRequestEntries: cleanJson(bru.scriptedRequestEntries || [])
     });
 
+    const wrapRequestOnFailHandler = () => {
+      if (typeof request.onFailHandler !== 'function') {
+        return;
+      }
+
+      const onFailHandler = request.onFailHandler;
+      request.onFailHandler = async (error) => {
+        await onFailHandler(error);
+        return buildRequestScriptResult();
+      };
+    };
+
     // Track script errors to attach partial results before re-throwing
     // This ensures that any test() calls that passed before the error are preserved
     // Similar pattern to test-runtime.js which already handles this correctly
@@ -126,6 +138,7 @@ class ScriptRuntime {
         throw scriptError;
       }
 
+      wrapRequestOnFailHandler();
       return buildRequestScriptResult();
     }
 
@@ -146,6 +159,7 @@ class ScriptRuntime {
       throw scriptError;
     }
 
+    wrapRequestOnFailHandler();
     return buildRequestScriptResult();
   }
 

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -120,6 +120,29 @@ describe('runtime', () => {
         const result = await runtime.runRequestScript(script, { ...baseRequest }, {}, {}, '.', null, process.env);
         expect(result.runtimeVariables.validation).toBeTruthy();
       });
+
+      it('should return variable updates made in req.onFail', async () => {
+        const script = `
+          bru.setVar('runtimeToken', 'before');
+          bru.setEnvVar('environmentToken', 'before');
+          bru.setGlobalEnvVar('globalToken', 'before');
+
+          req.onFail(() => {
+            bru.setVar('runtimeToken', 'after');
+            bru.setEnvVar('environmentToken', 'after');
+            bru.setGlobalEnvVar('globalToken', 'after');
+          });
+        `;
+        const request = { ...baseRequest };
+        const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+
+        await runtime.runRequestScript(script, request, {}, {}, '.', null, process.env);
+        const result = await request.onFailHandler(new Error('Connection failed'));
+
+        expect(result.runtimeVariables.runtimeToken).toBe('after');
+        expect(result.envVariables.environmentToken).toBe('after');
+        expect(result.globalEnvironmentVariables.globalToken).toBe('after');
+      });
     });
 
     describe('run-response-script', () => {


### PR DESCRIPTION
### Description

Variables updated with `bru.setVar()`, `bru.setEnvVar()`, or `bru.setGlobalEnvVar()` inside `req.onFail()` were updated in the script runtime but were not forwarded to the renderer after the handler completed.

Fixes #8569.

This change:

- returns the latest script variable result after `req.onFail()` runs
- forwards those updates through the existing variable update channels
- applies the same behavior to individual requests and collection runs
- adds regression tests for the handler result and variable updates

### Validation

- `node --experimental-vm-modules ../../node_modules/jest/bin/jest.js tests/runtime.spec.js --runInBand` (34 passed)
- `HOME=/tmp/bruno-jest-home npm run test --workspace=packages/bruno-electron -- tests/network/execute-request-error-handler.spec.js -t "should return the result" --runInBand`
- `npm run lint -- packages/bruno-js/src/runtime/script-runtime.js packages/bruno-js/tests/runtime.spec.js packages/bruno-electron/src/ipc/network/index.js packages/bruno-electron/tests/network/execute-request-error-handler.spec.js`

The full Electron test file contains existing environment-dependent DNS and timeout assertions. In this environment, one assertion receives `EPERM` in the sandbox and the DNS assertion receives a TLS disconnect outside it; the focused regression test passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve and propagate variable changes made inside request failure (`onFail`) handlers, including updates to runtime and environment variables.
  * When a failure handler returns a value, that result is now used consistently to forward variable updates, improving correctness across request and collection/folder failure scenarios.
  * Failure scripts now produce consistent result payloads across supported execution modes.
* **Tests**
  * Added and updated tests to verify `onFail` handler return values and that variable updates are correctly returned and applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->