### PR TITLE
refactor: separate app items from requests in sidebar & sorting logic

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -180,11 +180,27 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     }
   };
 
+  // Which sidebar section an item belongs to. The sidebar renders these three
+  // sections in order (folders → apps → requests), each sorted by seq independently.
+  const getSidebarSection = (i) => {
+    if (isItemAFolder(i)) return 'folder';
+    if (i?.type === 'app') return 'app';
+    return 'request';
+  };
+
   const canItemBeDropped = ({ draggedItem, targetItem, dropType }) => {
     const { uid: targetItemUid, pathname: targetItemPathname } = targetItem;
     const { uid: draggedItemUid, pathname: draggedItemPathname, sourceCollectionUid } = draggedItem;
 
     if (draggedItemUid === targetItemUid) return false;
+
+    // The sidebar renders items grouped by section (folders → apps → requests) and
+    // sorts each section by seq independently. An 'adjacent' drop between two different
+    // sections could never move the item across sections visually, so reject it.
+    // 'inside' drops on a folder are unaffected (that's a directory move, not a reorder).
+    if (dropType === 'adjacent' && getSidebarSection(draggedItem) !== getSidebarSection(targetItem)) {
+      return false;
+    }
 
     // For cross-collection moves, we allow the drop
     if (sourceCollectionUid !== collectionUid) {
@@ -221,6 +237,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
       const dropType = determineDropType(monitor);
       if (!dropType) return;
+      if (!canItemBeDropped({ draggedItem, targetItem: item, dropType })) return;
 
       await dispatch(handleCollectionItemDrop({ targetItem: item, draggedItem, dropType, collectionUid }));
       setDropType(null);
@@ -557,11 +574,10 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
   };
 
   const folderItems = sortByNameThenSequence(filter(item.items, (i) => isItemAFolder(i) && !i.isTransient));
-  // Standalone 'app' items live alongside requests in the folder listing.
-  const requestItems = sortItemsBySequence(
-    filter(item.items, (i) => (isItemARequest(i) || i.type === 'app') && !i.isTransient)
-  );
-  const showEmptyFolderMessage = isFolder && !hasSearchText && !folderItems?.length && !requestItems?.length;
+  const appItems = sortItemsBySequence(filter(item.items, (i) => i.type === 'app' && !i.isTransient));
+  const requestItems = sortItemsBySequence(filter(item.items, (i) => isItemARequest(i) && !i.isTransient));
+  const showEmptyFolderMessage
+    = isFolder && !hasSearchText && !folderItems?.length && !appItems?.length && !requestItems?.length;
 
   const emptyFolderMenuItems = createEmptyStateMenuItems({ dispatch, collection, itemUid: item.uid });
 
@@ -749,6 +765,11 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
         <div>
           {folderItems && folderItems.length
             ? folderItems.map((i) => {
+                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} />;
+              })
+            : null}
+          {appItems && appItems.length
+            ? appItems.map((i) => {
                 return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} />;
               })
             : null}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -337,11 +337,8 @@ const Collection = ({ collection, searchText }) => {
     return items.sort((a, b) => a.seq - b.seq);
   };
 
-  // Standalone 'app' items sit alongside requests in the listing — both are
-  // file leaves that share the seq-based ordering.
-  const requestItems = sortItemsBySequence(
-    filter(collection.items, (i) => (isItemARequest(i) || i.type === 'app') && !i.isTransient)
-  );
+  const requestItems = sortItemsBySequence(filter(collection.items, (i) => isItemARequest(i) && !i.isTransient));
+  const appItems = sortItemsBySequence(filter(collection.items, (i) => i.type === 'app' && !i.isTransient));
   const folderItems = sortByNameThenSequence(filter(collection.items, (i) => isItemAFolder(i) && !i.isTransient));
   const showEmptyCollectionMessage = showEmptyState && !hasSearchText;
 
@@ -566,6 +563,9 @@ const Collection = ({ collection, searchText }) => {
         {!collectionIsCollapsed ? (
           <div>
             {folderItems?.map?.((i) => {
+              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} />;
+            })}
+            {appItems?.map?.((i) => {
               return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} />;
             })}
             {requestItems?.map?.((i) => {

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -932,19 +932,19 @@ export const getCollectionItemCounts = (items = []) => {
 
 /**
  * Orders a list of collection items exactly the way the Sidebar tree renders them:
- * folders first (via `sortByNameThenSequence`), then requests ordered by `seq`. The
- * same ordering is applied recursively to every nested folder so an exported/serialized
- * tree matches the sidebar at all depths.
+ * folders first (via `sortByNameThenSequence`), then standalone apps by `seq`, then
+ * requests by `seq`. The same ordering is applied recursively to every nested folder
+ * so an exported/serialized tree matches the sidebar at all depths.
  *
- * Items that are neither folders nor requests (e.g. `js` script files) are excluded,
- * mirroring the sidebar, which only renders folders and requests. Transient items are
- * excluded too.
+ * Items that are none of folder/app/request (e.g. `js` script files) are excluded,
+ * mirroring the sidebar. Transient items are excluded too.
  */
 export const sortItemsBySidebarOrder = (items = []) => {
   const folderItems = sortByNameThenSequence(filter(items, (i) => isItemAFolder(i) && !i.isTransient));
+  const appItems = filter(items, (i) => i.type === 'app' && !i.isTransient).sort((a, b) => a.seq - b.seq);
   const requestItems = filter(items, (i) => isItemARequest(i) && !i.isTransient).sort((a, b) => a.seq - b.seq);
 
-  return [...folderItems, ...requestItems].map((item) =>
+  return [...folderItems, ...appItems, ...requestItems].map((item) =>
     Array.isArray(item.items) ? { ...item, items: sortItemsBySidebarOrder(item.items) } : item
   );
 };

--- a/packages/bruno-app/src/utils/common/sort-items-by-sidebar-order.spec.js
+++ b/packages/bruno-app/src/utils/common/sort-items-by-sidebar-order.spec.js
@@ -3,17 +3,28 @@ const { sortItemsBySidebarOrder } = require('../collections/index');
 
 const folder = (name, seq, items = []) => ({ uid: name, type: 'folder', name, seq, items });
 const request = (name, seq) => ({ uid: name, type: 'http-request', name, seq, request: { method: 'GET', url: '' } });
+const app = (name, seq) => ({ uid: name, type: 'app', name, seq });
 
 const names = (items) => items.map((i) => i.name);
 
 describe('sortItemsBySidebarOrder', () => {
-  describe('Grouping order (folders → requests)', () => {
-    it('places folders first, then requests, then files regardless of input order', () => {
+  describe('Grouping order (folders → apps → requests)', () => {
+    it('places folders first, then apps, then requests regardless of input order', () => {
       const result = sortItemsBySidebarOrder([
         request('req', 1),
+        app('appA', 1),
         folder('dir', 1)
       ]);
-      expect(names(result)).toEqual(['dir', 'req']);
+      expect(names(result)).toEqual(['dir', 'appA', 'req']);
+    });
+
+    it('orders apps by seq', () => {
+      const result = sortItemsBySidebarOrder([
+        app('c', 3),
+        app('a', 1),
+        app('b', 2)
+      ]);
+      expect(names(result)).toEqual(['a', 'b', 'c']);
     });
 
     it('orders folders by seq (via sortByNameThenSequence)', () => {
@@ -38,10 +49,12 @@ describe('sortItemsBySidebarOrder', () => {
       const result = sortItemsBySidebarOrder([
         request('reqB', 2),
         folder('folderB', 2),
+        app('appB', 2),
         request('reqA', 1),
+        app('appA', 1),
         folder('folderA', 1)
       ]);
-      expect(names(result)).toEqual(['folderA', 'folderB', 'reqA', 'reqB']);
+      expect(names(result)).toEqual(['folderA', 'folderB', 'appA', 'appB', 'reqA', 'reqB']);
     });
   });
 
@@ -64,16 +77,19 @@ describe('sortItemsBySidebarOrder', () => {
   });
 
   describe('Filtering', () => {
-    it('excludes transient folders and requests', () => {
+    it('excludes transient folders, apps and requests', () => {
       const transientReq = { ...request('ghost', 5), isTransient: true };
       const transientFolder = { ...folder('ghostDir', 5), isTransient: true };
+      const transientApp = { ...app('ghostApp', 5), isTransient: true };
       const result = sortItemsBySidebarOrder([
         transientFolder,
         folder('real', 1),
+        transientApp,
+        app('realApp', 1),
         transientReq,
         request('realReq', 1)
       ]);
-      expect(names(result)).toEqual(['real', 'realReq']);
+      expect(names(result)).toEqual(['real', 'realApp', 'realReq']);
     });
   });
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1595,6 +1595,17 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             const content = await stringifyRequestViaWorker(itemToSave, { format });
             await writeFile(item.pathname, content);
           }
+        } else if (item?.type === 'app') {
+          if (fs.existsSync(item.pathname)) {
+            const existingContent = fs.readFileSync(item.pathname, 'utf8');
+            const appJson = parseRequest(existingContent, { format });
+            if (appJson?.seq === item.seq) {
+              continue;
+            }
+            appJson.seq = item.seq;
+            const newContent = stringifyRequest(appJson, { format });
+            await writeFile(item.pathname, newContent);
+          }
         }
       }
       return true;


### PR DESCRIPTION
### Description

- Updated the sidebar component to handle app items distinctly from request items.
- Modified the sorting function to include app items in the sidebar order, ensuring they are displayed after folders and before requests.
- Enhanced the CollectionItem component to render app items correctly within their respective sections.
- Adjusted tests to validate the new sorting behavior for apps alongside folders and requests.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone app items now appear as a distinct group in collection sidebars, between folders and requests.
  * App items follow their configured sequence order, including within nested folders.
  * Reordering app items now updates their displayed order correctly.

* **Bug Fixes**
  * Drag-and-drop now prevents invalid moves between incompatible sidebar sections.
  * Empty-folder messaging accurately reflects all supported item types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->