### PR TITLE
chore(electron): update notarization team ID and add app requirements

### DIFF
--- a/packages/bruno-electron/electron-builder-config.js
+++ b/packages/bruno-electron/electron-builder-config.js
@@ -35,10 +35,11 @@ const config = {
     ],
     icon: 'resources/icons/mac/icon.icns',
     hardenedRuntime: true,
-    identity: 'Bruno Software, Inc. (P3WTZH48ZB)',
+    identity: 'Anoop MD (W7LPPWA48L)',
     entitlements: 'resources/entitlements.mac.plist',
     entitlementsInherit: 'resources/entitlements.mac.plist',
     notarize: false,
+    requirements: 'resources/app-requirements.txt',
     protocols: [
       {
         name: 'Bruno',

--- a/packages/bruno-electron/notarize.js
+++ b/packages/bruno-electron/notarize.js
@@ -17,7 +17,7 @@ const notarize = async function (params) {
   }
 
   console.log(`Notarizing ${appId} found at ${appPath} using Apple ID ${process.env.APPLE_ID}`);
-  const teamId = 'P3WTZH48ZB';
+  const teamId = 'W7LPPWA48L';
   try {
     await electron_notarize.notarize({
       tool: 'notarytool',

--- a/packages/bruno-electron/resources/app-requirements.txt
+++ b/packages/bruno-electron/resources/app-requirements.txt
@@ -1,0 +1,1 @@
+designated => anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and (certificate leaf[subject.OU] = "W7LPPWA48L" or certificate leaf[subject.OU] = "P3WTZH48ZB")


### PR DESCRIPTION
### Description

Revert the cert updates for a while to smoothen out the transisition

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated macOS signing and notarization settings for the latest application certificate.
  * Added certificate validation requirements supporting the updated signing identity while retaining compatibility with the existing identity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->