### PR TITLE
fix(snapshot): exclude 'changelog' tabs from snapshot processing

### DIFF
--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -28,7 +28,6 @@ const NON_REPLACEABLE_SINGLETON_TAB_TYPES = new Set([
 
 const IGNORED_TAB_TYPES = new Set([
   'v4-migration',
-  // ponytail: one-shot upgrade tab; pathname accessor leaves uid unset on restore
   'changelog'
 ]);
 

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -27,7 +27,9 @@ const NON_REPLACEABLE_SINGLETON_TAB_TYPES = new Set([
 ]);
 
 const IGNORED_TAB_TYPES = new Set([
-  'v4-migration'
+  'v4-migration',
+  // ponytail: one-shot upgrade tab; pathname accessor leaves uid unset on restore
+  'changelog'
 ]);
 
 export const WORKSPACE_TAB_UID_SUFFIX_BY_TYPE = {
@@ -86,7 +88,8 @@ const sanitizeSnapshotTabs = (tabsSnapshot) => {
 };
 
 export const shouldExcludeTab = (tab, transientDirectory) => {
-  return transientDirectory && tab.pathname?.startsWith(transientDirectory);
+  return IGNORED_TAB_TYPES.has(tab?.type)
+    || (transientDirectory && tab.pathname?.startsWith(transientDirectory));
 };
 
 const normalizeSnapshotPathRef = (value) => {

--- a/packages/bruno-app/src/utils/snapshot/index.spec.js
+++ b/packages/bruno-app/src/utils/snapshot/index.spec.js
@@ -248,6 +248,27 @@ describe('hydrateSnapshotLookups', () => {
       { type: 'variables', accessor: 'type', permanent: true }
     ]);
   });
+
+  it('drops changelog tabs from snapshot lookups', () => {
+    const snapshot = {
+      collections: [
+        {
+          pathname: '/collections/a',
+          activeTab: { accessor: 'type', value: 'changelog' },
+          tabs: [
+            { type: 'changelog', accessor: 'pathname', permanent: true },
+            { type: 'variables', accessor: 'type', permanent: true }
+          ]
+        }
+      ]
+    };
+
+    const lookups = hydrateSnapshotLookups(snapshot);
+
+    expect(lookups.tabsByCollectionPath['/collections/a'].tabs).toEqual([
+      { type: 'variables', accessor: 'type', permanent: true }
+    ]);
+  });
 });
 
 describe('deserializeTab', () => {
@@ -817,6 +838,41 @@ describe('hydrateCollectionTabs', () => {
 
     await hydrateCollectionTabs(
       { uid: 'collection-uid', pathname: '/collections/legacy' },
+      dispatch,
+      restoreTabs,
+      null,
+      null,
+      true
+    );
+
+    expect(restoreTabs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabs: [{ type: 'variables', accessor: 'type', permanent: true }],
+        activeTab: null
+      })
+    );
+  });
+
+  it('does not restore changelog tabs from direct tab snapshots', async () => {
+    global.window.ipcRenderer.invoke.mockResolvedValue({
+      tabs: [
+        { type: 'changelog', accessor: 'pathname', permanent: true },
+        { type: 'variables', accessor: 'type', permanent: true }
+      ],
+      activeTab: {
+        accessor: 'type',
+        value: 'changelog'
+      }
+    });
+
+    const dispatch = jest.fn();
+    const restoreTabs = jest.fn((payload) => ({
+      type: 'tabs/restoreTabs',
+      payload
+    }));
+
+    await hydrateCollectionTabs(
+      { uid: 'collection-uid', pathname: '/collections/a' },
       dispatch,
       restoreTabs,
       null,


### PR DESCRIPTION
### Description

Added changes to exclude 'changelog' tabs from snapshot 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changelog tabs are now excluded when restoring collection snapshots.
  * Snapshot restoration no longer selects a changelog tab as the active tab.
  * Variable and other supported tabs continue to restore correctly.
* **Tests**
  * Added coverage to ensure changelog tabs are filtered out during snapshot hydration and restoration, including active-tab handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->