### PR TITLE
feat(overview): show human-readable size for unloaded requests

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/RequestsNotLoaded/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { flattenItems } from 'utils/collections';
 import { IconAlertTriangle } from '@tabler/icons';
 import StyledWrapper from './StyledWrapper';
@@ -27,6 +27,11 @@ const RequestsNotLoaded = ({ collection }) => {
       return (item?.partial && !item?.loading) || item?.error;
     }) ?? [];
   }, [collection.items]);
+
+  const getSizeAndUnit = useCallback((megabytes) => {
+    const [value, unit] = megabytes < 1 ? [megabytes * 1024, 'KB'] : megabytes < 1024 ? [megabytes, 'MB'] : [megabytes / 1024, 'GB'];
+    return { size: Math.round(value * 100) / 100, unit };
+  }, []);
 
   if (!itemsFailedLoading.length) {
     return null;
@@ -72,16 +77,19 @@ const RequestsNotLoaded = ({ collection }) => {
           </tr>
         </thead>
         <tbody>
-          {itemsFailedLoading.map((item) => (
-            <tr key={item?.pathname} className="cursor-pointer" onClick={handleRequestClick(item)}>
-              <td className="py-1.5 px-3">
-                {toRelativePathname(item?.pathname, collection?.pathname)}
-              </td>
-              <td className="py-1.5 px-3">
-                {item?.size ? `${item.size?.toFixed?.(2)} MB` : '-'}
-              </td>
-            </tr>
-          ))}
+          {itemsFailedLoading.map((item) => {
+            const { size, unit } = getSizeAndUnit(item?.size ?? 0);
+            return (
+              <tr key={item?.pathname} className="cursor-pointer" onClick={handleRequestClick(item)}>
+                <td className="py-1.5 px-3">
+                  {toRelativePathname(item?.pathname, collection?.pathname)}
+                </td>
+                <td className="py-1.5 px-3">
+                  {`${size} ${unit}`}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </StyledWrapper>


### PR DESCRIPTION
## Description

In the Collection Overview's "Requests not loaded" table, file sizes were always rendered in MB (e.g. `0.00 MB` for small files, unreadable for large ones). This formats the size into the most appropriate unit.

## Changes

- Add `getSizeAndUnit` which converts the request's size (stored in MB) to `KB`, `MB`, or `GB` based on magnitude, rounded to 2 decimals.
- Render `${size} ${unit}` in the Size column.

## Behavior

- \< 1 MB → KB
- 1 MB – 1 GB → MB
- ≥ 1 GB → GB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of failed request sizes in Collection Settings.
  * Sizes are now shown in appropriate units (KB, MB, or GB) with clearer rounding.
  * Missing size values now display as 0 instead of an empty placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->