### PR TITLE
test(mounting): run mount tests with file cache on and off

### DIFF
--- a/tests/mounting/item-sorting.spec.ts
+++ b/tests/mounting/item-sorting.spec.ts
@@ -3,114 +3,122 @@ import { setupSortingTestFixture, TestFixture } from '../utils/fixtures';
 import { getCollectionTreeStructure, closeAllCollections } from '../utils/page';
 
 const formats = ['bru', 'yml'] as const;
+const cacheModes = [
+  { label: 'file-cache off', fileCacheEnabled: false },
+  { label: 'file-cache on', fileCacheEnabled: true }
+] as const;
 
-for (const format of formats) {
-  test.describe(`[${format}] Item Sorting`, () => {
-    test.describe('sequence-based sorting', () => {
-      let fixture: TestFixture;
-      let app: ElectronApplication;
-      let page: Page;
+for (const { label, fileCacheEnabled } of cacheModes) {
+  for (const format of formats) {
+    test.describe(`[${format}] [${label}] Item Sorting`, () => {
+      test.describe('sequence-based sorting', () => {
+        let fixture: TestFixture;
+        let app: ElectronApplication;
+        let page: Page;
 
-      test.beforeAll(async ({ launchElectronApp }) => {
-        // Create items with non-alphabetical names but defined sequences
-        // Sequence order should override alphabetical order
-        fixture = await setupSortingTestFixture({
-          name: 'Sequence Sort Collection',
-          format,
-          items: [
-            { name: 'Zebra Request', seq: 1 },
-            { name: 'Apple Request', seq: 2 },
-            { name: 'Mango Request', seq: 3 },
-            { name: 'Banana Request', seq: 4 }
-          ]
+        test.beforeAll(async ({ launchElectronApp }) => {
+          // Create items with non-alphabetical names but defined sequences
+          // Sequence order should override alphabetical order
+          fixture = await setupSortingTestFixture({
+            name: 'Sequence Sort Collection',
+            format,
+            fileCacheEnabled,
+            items: [
+              { name: 'Zebra Request', seq: 1 },
+              { name: 'Apple Request', seq: 2 },
+              { name: 'Mango Request', seq: 3 },
+              { name: 'Banana Request', seq: 4 }
+            ]
+          });
+
+          app = await launchElectronApp({ userDataPath: fixture.userDataPath });
+          page = await app.firstWindow();
+          await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
         });
 
-        app = await launchElectronApp({ userDataPath: fixture.userDataPath });
-        page = await app.firstWindow();
-        await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
-      });
-
-      test.afterAll(async () => {
-        if (page) {
-          await closeAllCollections(page);
-        }
-        if (app) {
-          await app.context().close();
-          await app.close();
-        }
-        if (fixture) {
-          await fixture.cleanup();
-        }
-      });
-
-      test('should sort items by sequence when defined', async () => {
-        const tree = await getCollectionTreeStructure(page, 'Sequence Sort Collection');
-
-        // Extract item names in their rendered order
-        const itemNames = tree.items.map((item) => item.name);
-
-        // Items should be in sequence order, not alphabetical
-        // Zebra (seq: 1), Apple (seq: 2), Mango (seq: 3), Banana (seq: 4)
-        expect(itemNames).toEqual([
-          'Zebra Request',
-          'Apple Request',
-          'Mango Request',
-          'Banana Request'
-        ]);
-      });
-    });
-
-    test.describe('alphabetical sorting', () => {
-      let fixture: TestFixture;
-      let app: ElectronApplication;
-      let page: Page;
-
-      test.beforeAll(async ({ launchElectronApp }) => {
-        // Create items without sequence numbers - should sort alphabetically
-        fixture = await setupSortingTestFixture({
-          name: 'Alpha Sort Collection',
-          format,
-          items: [
-            { name: 'Zebra Request' },
-            { name: 'Apple Request' },
-            { name: 'Mango Request' },
-            { name: 'Banana Request' }
-          ]
+        test.afterAll(async () => {
+          if (page) {
+            await closeAllCollections(page);
+          }
+          if (app) {
+            await app.context().close();
+            await app.close();
+          }
+          if (fixture) {
+            await fixture.cleanup();
+          }
         });
 
-        app = await launchElectronApp({ userDataPath: fixture.userDataPath });
-        page = await app.firstWindow();
-        await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+        test('should sort items by sequence when defined', async () => {
+          const tree = await getCollectionTreeStructure(page, 'Sequence Sort Collection');
+
+          // Extract item names in their rendered order
+          const itemNames = tree.items.map((item) => item.name);
+
+          // Items should be in sequence order, not alphabetical
+          // Zebra (seq: 1), Apple (seq: 2), Mango (seq: 3), Banana (seq: 4)
+          expect(itemNames).toEqual([
+            'Zebra Request',
+            'Apple Request',
+            'Mango Request',
+            'Banana Request'
+          ]);
+        });
       });
 
-      test.afterAll(async () => {
-        if (page) {
-          await closeAllCollections(page);
-        }
-        if (app) {
-          await app.context().close();
-          await app.close();
-        }
-        if (fixture) {
-          await fixture.cleanup();
-        }
-      });
+      test.describe('alphabetical sorting', () => {
+        let fixture: TestFixture;
+        let app: ElectronApplication;
+        let page: Page;
 
-      test('should sort items alphabetically when no sequence defined', async () => {
-        const tree = await getCollectionTreeStructure(page, 'Alpha Sort Collection');
+        test.beforeAll(async ({ launchElectronApp }) => {
+          // Create items without sequence numbers - should sort alphabetically
+          fixture = await setupSortingTestFixture({
+            name: 'Alpha Sort Collection',
+            format,
+            fileCacheEnabled,
+            items: [
+              { name: 'Zebra Request' },
+              { name: 'Apple Request' },
+              { name: 'Mango Request' },
+              { name: 'Banana Request' }
+            ]
+          });
 
-        // Extract item names in their rendered order
-        const itemNames = tree.items.map((item) => item.name);
+          app = await launchElectronApp({ userDataPath: fixture.userDataPath });
+          page = await app.firstWindow();
+          await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+        });
 
-        // Items should be in alphabetical order
-        // Apple, Banana, Mango, Zebra
-        expect(itemNames).toEqual([
-          'Apple Request',
-          'Banana Request',
-          'Mango Request',
-          'Zebra Request'
-        ]);
+        test.afterAll(async () => {
+          if (page) {
+            await closeAllCollections(page);
+          }
+          if (app) {
+            await app.context().close();
+            await app.close();
+          }
+          if (fixture) {
+            await fixture.cleanup();
+          }
+        });
+
+        test('should sort items alphabetically when no sequence defined', async () => {
+          const tree = await getCollectionTreeStructure(page, 'Alpha Sort Collection');
+
+          // Extract item names in their rendered order
+          const itemNames = tree.items.map((item) => item.name);
+
+          // Items should be in alphabetical order
+          // Apple, Banana, Mango, Zebra
+          expect(itemNames).toEqual([
+            'Apple Request',
+            'Banana Request',
+            'Mango Request',
+            'Zebra Request'
+          ]);
+        });
       });
     });
-  });
+  }
 }

--- a/tests/mounting/loading-state.spec.ts
+++ b/tests/mounting/loading-state.spec.ts
@@ -3,67 +3,74 @@ import { setupTestFixture, TestFixture } from '../utils/fixtures';
 import { isCollectionLoading, closeAllCollections } from '../utils/page';
 
 const formats = ['bru', 'yml'] as const;
+const cacheModes = [
+  { label: 'file-cache off', fileCacheEnabled: false },
+  { label: 'file-cache on', fileCacheEnabled: true }
+] as const;
 
-for (const format of formats) {
-  test.describe(`[${format}] Loading State`, () => {
-    let fixture: TestFixture;
-    let app: ElectronApplication;
-    let page: Page;
+for (const { label, fileCacheEnabled } of cacheModes) {
+  for (const format of formats) {
+    test.describe(`[${format}] [${label}] Loading State`, () => {
+      let fixture: TestFixture;
+      let app: ElectronApplication;
+      let page: Page;
 
-    test.beforeAll(async ({ launchElectronApp }) => {
-      // Set up test fixture (collection + user data)
-      fixture = await setupTestFixture({
-        name: 'Test Collection',
-        requestCount: 10,
-        depth: 2,
-        foldersPerLevel: 2,
-        format,
-        environmentCount: 2
+      test.beforeAll(async ({ launchElectronApp }) => {
+        // Set up test fixture (collection + user data)
+        fixture = await setupTestFixture({
+          name: 'Test Collection',
+          requestCount: 10,
+          depth: 2,
+          foldersPerLevel: 2,
+          format,
+          environmentCount: 2,
+          fileCacheEnabled
+        });
+
+        // Launch app with the prepared user data
+        app = await launchElectronApp({ userDataPath: fixture.userDataPath });
+        page = await app.firstWindow();
+
+        // Wait for app to be ready
+        await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
       });
 
-      // Launch app with the prepared user data
-      app = await launchElectronApp({ userDataPath: fixture.userDataPath });
-      page = await app.firstWindow();
+      test.afterAll(async () => {
+        // Close collections before app teardown
+        if (page) {
+          await closeAllCollections(page);
+        }
 
-      // Wait for app to be ready
-      await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
-    });
+        // Close the app to release file locks
+        if (app) {
+          await app.context().close();
+          await app.close();
+        }
 
-    test.afterAll(async () => {
-      // Close collections before app teardown
-      if (page) {
-        await closeAllCollections(page);
-      }
-
-      // Close the app to release file locks
-      if (app) {
-        await app.context().close();
-        await app.close();
-      }
-
-      // Cleanup generated files
-      if (fixture) {
-        await fixture.cleanup();
-      }
-    });
-
-    test('collection should be mounted and visible in sidebar', async () => {
-      // Collection should be in the sidebar
-      const collectionRow = page.getByTestId('sidebar-collection-row').filter({
-        has: page.locator('#sidebar-collection-name', { hasText: 'Test Collection' })
+        // Cleanup generated files
+        if (fixture) {
+          await fixture.cleanup();
+        }
       });
-      await expect(collectionRow).toBeVisible({ timeout: 30000 });
-    });
 
-    test('mounting spinner should not be visible for loaded collections', async () => {
-      const collectionRow = page.getByTestId('sidebar-collection-row').filter({
-        has: page.locator('#sidebar-collection-name', { hasText: 'Test Collection' })
+      test('collection should be mounted and visible in sidebar', async () => {
+        // Collection should be in the sidebar
+        const collectionRow = page.getByTestId('sidebar-collection-row').filter({
+          has: page.locator('#sidebar-collection-name', { hasText: 'Test Collection' })
+        });
+        await expect(collectionRow).toBeVisible({ timeout: 30000 });
       });
-      await expect(collectionRow).toBeVisible({ timeout: 30000 });
 
-      // Verify via helper
-      const loading = await isCollectionLoading(page, 'Test Collection');
-      expect(loading).toBe(false);
+      test('mounting spinner should not be visible for loaded collections', async () => {
+        const collectionRow = page.getByTestId('sidebar-collection-row').filter({
+          has: page.locator('#sidebar-collection-name', { hasText: 'Test Collection' })
+        });
+        await expect(collectionRow).toBeVisible({ timeout: 30000 });
+
+        // Verify via helper
+        const loading = await isCollectionLoading(page, 'Test Collection');
+        expect(loading).toBe(false);
+      });
     });
-  });
+  }
 }

--- a/tests/mounting/tree-construction.spec.ts
+++ b/tests/mounting/tree-construction.spec.ts
@@ -4,169 +4,179 @@ import { setupTestFixture, setupStaticFixture, TestFixture, StaticTestFixture } 
 import { getCollectionTreeStructure, CollectionTreeItem, closeAllCollections } from '../utils/page';
 
 const formats = ['bru', 'yml'] as const;
+const cacheModes = [
+  { label: 'file-cache off', fileCacheEnabled: false },
+  { label: 'file-cache on', fileCacheEnabled: true }
+] as const;
 
-for (const format of formats) {
-  test.describe(`[${format}] Collection Tree Construction`, () => {
-    let fixture: TestFixture;
-    let app: ElectronApplication;
-    let page: Page;
+for (const { label, fileCacheEnabled } of cacheModes) {
+  for (const format of formats) {
+    test.describe(`[${format}] [${label}] Collection Tree Construction`, () => {
+      let fixture: TestFixture;
+      let app: ElectronApplication;
+      let page: Page;
 
-    test.beforeAll(async ({ launchElectronApp }) => {
-      fixture = await setupTestFixture({
-        name: 'Tree Test Collection',
-        requestCount: 10,
-        depth: 2,
-        foldersPerLevel: 2,
-        format,
-        environmentCount: 2,
-        mixedMethods: true
+      test.beforeAll(async ({ launchElectronApp }) => {
+        fixture = await setupTestFixture({
+          name: 'Tree Test Collection',
+          requestCount: 10,
+          depth: 2,
+          foldersPerLevel: 2,
+          format,
+          environmentCount: 2,
+          mixedMethods: true,
+          fileCacheEnabled
+        });
+
+        app = await launchElectronApp({ userDataPath: fixture.userDataPath });
+        page = await app.firstWindow();
+        await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
       });
 
-      app = await launchElectronApp({ userDataPath: fixture.userDataPath });
-      page = await app.firstWindow();
-      await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
-    });
-
-    test.afterAll(async () => {
-      if (page) {
-        await closeAllCollections(page);
-      }
-      if (app) {
-        await app.context().close();
-        await app.close();
-      }
-      if (fixture) {
-        await fixture.cleanup();
-      }
-    });
-
-    test('should render folders with correct hierarchy', async () => {
-      const tree = await getCollectionTreeStructure(page, 'Tree Test Collection');
-
-      // Verify collection name
-      expect(tree.name).toBe('Tree Test Collection');
-
-      // With depth=2 and foldersPerLevel=2, we expect:
-      // - 2 top-level folders (F1, F2)
-      // - Each top-level folder has 2 nested folders (F1-F1, F1-F2, etc.)
-      const folders = tree.items.filter((item) => item.type === 'folder');
-      expect(folders.length).toBeGreaterThanOrEqual(2);
-
-      // Check that folders have the expected naming pattern (F1, F2)
-      const folderNames = folders.map((f) => f.name);
-      expect(folderNames.some((name) => /^F\d+$/.test(name))).toBe(true);
-    });
-
-    test('should render requests under correct parent folders', async () => {
-      const tree = await getCollectionTreeStructure(page, 'Tree Test Collection');
-
-      // Helper to count requests recursively
-      const countRequests = (items: CollectionTreeItem[]): number => {
-        return items.reduce((count, item) => {
-          if (item.type === 'request') {
-            return count + 1;
-          }
-          if (item.type === 'folder' && item.items) {
-            return count + countRequests(item.items);
-          }
-          return count;
-        }, 0);
-      };
-
-      // We generated 10 requests, they should all be present
-      const totalRequests = countRequests(tree.items);
-      expect(totalRequests).toBe(fixture.collection.requestCount);
-
-      // Verify requests exist at various levels (root and in folders)
-      const rootRequests = tree.items.filter((item) => item.type === 'request');
-      const folders = tree.items.filter((item) => item.type === 'folder');
-
-      // Requests should be distributed - some at root, some in folders
-      const hasRequestsInFolders = folders.some(
-        (folder) => folder.items && folder.items.some((item) => item.type === 'request')
-      );
-
-      // Either we have root requests or requests in folders (distribution depends on generator)
-      expect(rootRequests.length > 0 || hasRequestsInFolders).toBe(true);
-    });
-
-    test('should have correct parent-child relationships via naming convention', async () => {
-      const tree = await getCollectionTreeStructure(page, 'Tree Test Collection');
-
-      // Verify items are named with their parent prefix:
-      // - Root requests: R1, R2, ...
-      // - Folder F1 requests: F1-R1, F1-R2, ...
-      // - Nested folder F1-F1 requests: F1-F1-R1, ...
-      const verifyNaming = (items: CollectionTreeItem[], parentPrefix: string) => {
-        for (const item of items) {
-          if (item.type === 'request') {
-            // Request should start with parent prefix (or be R1, R2 at root)
-            if (parentPrefix) {
-              expect(item.name.startsWith(parentPrefix + '-R')).toBe(true);
-            } else {
-              expect(item.name).toMatch(/^R\d+$/);
-            }
-          }
-          if (item.type === 'folder') {
-            // Folder should start with parent prefix (or be F1, F2 at root)
-            if (parentPrefix) {
-              expect(item.name.startsWith(parentPrefix + '-F')).toBe(true);
-            } else {
-              expect(item.name).toMatch(/^F\d+$/);
-            }
-            // Recursively verify children
-            if (item.items) {
-              verifyNaming(item.items, item.name);
-            }
-          }
+      test.afterAll(async () => {
+        if (page) {
+          await closeAllCollections(page);
         }
-      };
+        if (app) {
+          await app.context().close();
+          await app.close();
+        }
+        if (fixture) {
+          await fixture.cleanup();
+        }
+      });
 
-      verifyNaming(tree.items, '');
+      test('should render folders with correct hierarchy', async () => {
+        const tree = await getCollectionTreeStructure(page, 'Tree Test Collection');
+
+        // Verify collection name
+        expect(tree.name).toBe('Tree Test Collection');
+
+        // With depth=2 and foldersPerLevel=2, we expect:
+        // - 2 top-level folders (F1, F2)
+        // - Each top-level folder has 2 nested folders (F1-F1, F1-F2, etc.)
+        const folders = tree.items.filter((item) => item.type === 'folder');
+        expect(folders.length).toBeGreaterThanOrEqual(2);
+
+        // Check that folders have the expected naming pattern (F1, F2)
+        const folderNames = folders.map((f) => f.name);
+        expect(folderNames.some((name) => /^F\d+$/.test(name))).toBe(true);
+      });
+
+      test('should render requests under correct parent folders', async () => {
+        const tree = await getCollectionTreeStructure(page, 'Tree Test Collection');
+
+        // Helper to count requests recursively
+        const countRequests = (items: CollectionTreeItem[]): number => {
+          return items.reduce((count, item) => {
+            if (item.type === 'request') {
+              return count + 1;
+            }
+            if (item.type === 'folder' && item.items) {
+              return count + countRequests(item.items);
+            }
+            return count;
+          }, 0);
+        };
+
+        // We generated 10 requests, they should all be present
+        const totalRequests = countRequests(tree.items);
+        expect(totalRequests).toBe(fixture.collection.requestCount);
+
+        // Verify requests exist at various levels (root and in folders)
+        const rootRequests = tree.items.filter((item) => item.type === 'request');
+        const folders = tree.items.filter((item) => item.type === 'folder');
+
+        // Requests should be distributed - some at root, some in folders
+        const hasRequestsInFolders = folders.some(
+          (folder) => folder.items && folder.items.some((item) => item.type === 'request')
+        );
+
+        // Either we have root requests or requests in folders (distribution depends on generator)
+        expect(rootRequests.length > 0 || hasRequestsInFolders).toBe(true);
+      });
+
+      test('should have correct parent-child relationships via naming convention', async () => {
+        const tree = await getCollectionTreeStructure(page, 'Tree Test Collection');
+
+        // Verify items are named with their parent prefix:
+        // - Root requests: R1, R2, ...
+        // - Folder F1 requests: F1-R1, F1-R2, ...
+        // - Nested folder F1-F1 requests: F1-F1-R1, ...
+        const verifyNaming = (items: CollectionTreeItem[], parentPrefix: string) => {
+          for (const item of items) {
+            if (item.type === 'request') {
+              // Request should start with parent prefix (or be R1, R2 at root)
+              if (parentPrefix) {
+                expect(item.name.startsWith(parentPrefix + '-R')).toBe(true);
+              } else {
+                expect(item.name).toMatch(/^R\d+$/);
+              }
+            }
+            if (item.type === 'folder') {
+              // Folder should start with parent prefix (or be F1, F2 at root)
+              if (parentPrefix) {
+                expect(item.name.startsWith(parentPrefix + '-F')).toBe(true);
+              } else {
+                expect(item.name).toMatch(/^F\d+$/);
+              }
+              // Recursively verify children
+              if (item.items) {
+                verifyNaming(item.items, item.name);
+              }
+            }
+          }
+        };
+
+        verifyNaming(tree.items, '');
+      });
     });
-  });
+  }
 }
 
 // Method indicators are verified against a static, hand-authored collection with
 // exactly one request per HTTP method, so the expected badge set is fixed rather
 // than dependent on the generator's method-cycling behaviour.
-for (const format of formats) {
-  test.describe(`[${format}] Request Method Indicators`, () => {
-    let fixture: StaticTestFixture;
-    let app: ElectronApplication;
-    let page: Page;
+for (const { label, fileCacheEnabled } of cacheModes) {
+  for (const format of formats) {
+    test.describe(`[${format}] [${label}] Request Method Indicators`, () => {
+      let fixture: StaticTestFixture;
+      let app: ElectronApplication;
+      let page: Page;
 
-    test.beforeAll(async ({ launchElectronApp }) => {
-      fixture = await setupStaticFixture(
-        path.join(__dirname, 'fixtures', 'method-indicators', format)
-      );
+      test.beforeAll(async ({ launchElectronApp }) => {
+        fixture = await setupStaticFixture(
+          path.join(__dirname, 'fixtures', 'method-indicators', format),
+          { fileCacheEnabled }
+        );
 
-      app = await launchElectronApp({ userDataPath: fixture.userDataPath });
-      page = await app.firstWindow();
-      await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+        app = await launchElectronApp({ userDataPath: fixture.userDataPath });
+        page = await app.firstWindow();
+        await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+      });
+
+      test.afterAll(async () => {
+        if (page) {
+          await closeAllCollections(page);
+        }
+        if (app) {
+          await app.context().close();
+          await app.close();
+        }
+        if (fixture) {
+          await fixture.cleanup();
+        }
+      });
+
+      test('should display correct request method indicators', async () => {
+        const tree = await getCollectionTreeStructure(page, 'Method Indicators');
+
+        const requests = tree.items.filter((item) => item.type === 'request');
+        const methods = requests.map((r) => r.method).filter(Boolean);
+
+        // One request per method. UI truncates methods > 5 chars to 3 chars (DELETE -> DEL).
+        expect(new Set(methods)).toEqual(new Set(['GET', 'POST', 'PUT', 'DEL', 'PATCH']));
+      });
     });
-
-    test.afterAll(async () => {
-      if (page) {
-        await closeAllCollections(page);
-      }
-      if (app) {
-        await app.context().close();
-        await app.close();
-      }
-      if (fixture) {
-        await fixture.cleanup();
-      }
-    });
-
-    test('should display correct request method indicators', async () => {
-      const tree = await getCollectionTreeStructure(page, 'Method Indicators');
-
-      const requests = tree.items.filter((item) => item.type === 'request');
-      const methods = requests.map((r) => r.method).filter(Boolean);
-
-      // One request per method. UI truncates methods > 5 chars to 3 chars (DELETE -> DEL).
-      expect(new Set(methods)).toEqual(new Set(['GET', 'POST', 'PUT', 'DEL', 'PATCH']));
-    });
-  });
+  }
 }

--- a/tests/utils/fixtures/generator.ts
+++ b/tests/utils/fixtures/generator.ts
@@ -409,6 +409,36 @@ export interface SortingTestCollectionOptions {
   items: SortingTestItem[];
   /** Collection format */
   format: CollectionFormat;
+  /** Enable the on-disk file cache for the mounted collection */
+  fileCacheEnabled?: boolean;
+}
+
+/**
+ * Write the seed preferences.json that preloads the given collections and
+ * toggles the file cache used when mounting them.
+ */
+async function writePreferences(
+  userDataPath: string,
+  lastOpenedCollections: string[],
+  fileCacheEnabled: boolean
+): Promise<void> {
+  const preferences = {
+    lastOpenedCollections,
+    preferences: {
+      onboarding: {
+        hasLaunchedBefore: true,
+        hasSeenWelcomeModal: true
+      },
+      cache: {
+        file: { enabled: fileCacheEnabled }
+      }
+    }
+  };
+
+  await fs.promises.writeFile(
+    path.join(userDataPath, 'preferences.json'),
+    JSON.stringify(preferences, null, 2)
+  );
 }
 
 /**
@@ -503,20 +533,7 @@ export async function setupSortingTestFixture(
   );
 
   try {
-    const preferences = {
-      lastOpenedCollections: [collection.path],
-      preferences: {
-        onboarding: {
-          hasLaunchedBefore: true,
-          hasSeenWelcomeModal: true
-        }
-      }
-    };
-
-    await fs.promises.writeFile(
-      path.join(userDataPath, 'preferences.json'),
-      JSON.stringify(preferences, null, 2)
-    );
+    await writePreferences(userDataPath, [collection.path], options.fileCacheEnabled ?? false);
 
     return {
       collection,
@@ -543,6 +560,8 @@ export async function setupSortingTestFixture(
 export interface TestFixtureOptions extends GenerateCollectionOptions {
   /** Additional collections to preload (paths) */
   additionalCollections?: string[];
+  /** Enable the on-disk file cache for the mounted collection */
+  fileCacheEnabled?: boolean;
 }
 
 /**
@@ -569,7 +588,7 @@ export interface TestFixture {
 export async function setupTestFixture(
   options: TestFixtureOptions
 ): Promise<TestFixture> {
-  const { additionalCollections = [], ...collectionOptions } = options;
+  const { additionalCollections = [], fileCacheEnabled = false, ...collectionOptions } = options;
 
   // Generate the collection
   const collection = await generateCollection(collectionOptions);
@@ -580,21 +599,7 @@ export async function setupTestFixture(
   );
 
   try {
-    // Create preferences.json with collection preloaded
-    const preferences = {
-      lastOpenedCollections: [collection.path, ...additionalCollections],
-      preferences: {
-        onboarding: {
-          hasLaunchedBefore: true,
-          hasSeenWelcomeModal: true
-        }
-      }
-    };
-
-    await fs.promises.writeFile(
-      path.join(userDataPath, 'preferences.json'),
-      JSON.stringify(preferences, null, 2)
-    );
+    await writePreferences(userDataPath, [collection.path, ...additionalCollections], fileCacheEnabled);
 
     return {
       collection,
@@ -638,7 +643,8 @@ export interface StaticTestFixture {
  * fixture. cleanup() removes the temp copy and the user data dir.
  */
 export async function setupStaticFixture(
-  sourceCollectionPath: string
+  sourceCollectionPath: string,
+  options: { fileCacheEnabled?: boolean } = {}
 ): Promise<StaticTestFixture> {
   const userDataPath = await fs.promises.mkdtemp(
     path.join(os.tmpdir(), 'bruno-test-userdata-')
@@ -658,20 +664,7 @@ export async function setupStaticFixture(
     // Copy the committed collection into the temp dir so the app mounts the copy.
     await fs.promises.cp(sourceCollectionPath, collectionPath, { recursive: true });
 
-    const preferences = {
-      lastOpenedCollections: [collectionPath],
-      preferences: {
-        onboarding: {
-          hasLaunchedBefore: true,
-          hasSeenWelcomeModal: true
-        }
-      }
-    };
-
-    await fs.promises.writeFile(
-      path.join(userDataPath, 'preferences.json'),
-      JSON.stringify(preferences, null, 2)
-    );
+    await writePreferences(userDataPath, [collectionPath], options.fileCacheEnabled ?? false);
 
     return { collectionPath, userDataPath, cleanup };
   } catch (error) {


### PR DESCRIPTION
## Description

The collection-mounting e2e suites previously ran only with the on-disk file cache disabled. This parametrizes them over a cache dimension so every mounting test runs with `cache.file.enabled` both **off** and **on**, guarding against mount regressions specific to either path.

## Changes

- Add a `fileCacheEnabled` option to the fixture builders (`setupTestFixture`, `setupSortingTestFixture`, `setupStaticFixture`), seeded into `preferences.json` via a shared `writePreferences` helper (replaces three duplicated preference blocks).
- Wrap each mounting spec's `describe` in a cache-mode loop around the existing format loop, so tests run as `[format] [file-cache off|on]`.

This doubles the mounting coverage from 16 to 32 tests. Each mode uses an isolated temp user-data dir, so the on/off runs never share a cache DB.

## Verification

Ran `tests/mounting/loading-state.spec.ts` (8 tests, bru/yml × off/on) — all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded mounting and loading-state coverage across file-cache enabled and disabled configurations.
  * Verified item sorting, collection tree construction, loading indicators, and request method indicators in both cache modes.
  * Updated test fixtures to generate settings with the selected file-cache configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->