### PR TITLE
feat(collections): open multiple collections from a monorepo

### DIFF
--- a/packages/bruno-app/src/components/AppTitleBar/AppMenu/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/AppMenu/index.js
@@ -16,7 +16,7 @@ const AppMenu = () => {
         {
           id: 'open-collection',
           label: 'Open Collection',
-          onClick: () => ipcRenderer?.invoke('renderer:open-collection')
+          onClick: () => ipcRenderer?.send('main:open-collection')
         },
         { type: 'divider', id: 'file-div-1' },
         {

--- a/packages/bruno-app/src/components/AppTitleBar/AppMenu/index.js
+++ b/packages/bruno-app/src/components/AppTitleBar/AppMenu/index.js
@@ -16,7 +16,7 @@ const AppMenu = () => {
         {
           id: 'open-collection',
           label: 'Open Collection',
-          onClick: () => ipcRenderer?.send('main:open-collection')
+          onClick: () => ipcRenderer?.send('renderer:open-collection')
         },
         { type: 'divider', id: 'file-div-1' },
         {

--- a/packages/bruno-app/src/components/Sidebar/Collections/CreateOrOpenCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/CreateOrOpenCollection/index.js
@@ -1,8 +1,7 @@
 import { useTheme } from '../../../../providers/Theme';
 import { useDispatch } from 'react-redux';
-import { openCollection } from 'providers/ReduxStore/slices/collections/actions';
+import { setIsOpeningCollection } from 'providers/ReduxStore/slices/app';
 
-import toast from 'react-hot-toast';
 import styled from 'styled-components';
 import StyledWrapper from './StyledWrapper';
 
@@ -15,12 +14,7 @@ const CreateOrOpenCollection = ({ onCreateClick }) => {
   const dispatch = useDispatch();
 
   const handleOpenCollection = () => {
-    dispatch(openCollection()).catch(
-      (err) => {
-        console.log(err);
-        toast.error('An error occurred while opening the collection');
-      }
-    );
+    dispatch(setIsOpeningCollection(true));
   };
   const CreateLink = () => (
     <LinkStyle

--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/StyledWrapper.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import { IMPORT_COLLECTION_SELECTION_WIDTH } from 'components/SelectionList/constants';
+
+const StyledWrapper = styled.div`
+  width: ${IMPORT_COLLECTION_SELECTION_WIDTH};
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
@@ -63,10 +63,11 @@ const OpenCollectionModal = ({ onClose }) => {
 
         if (items.length === 0) {
           if (failedScans.length) {
-            toast.error(`Failed to scan ${failedScans.length} folder${failedScans.length === 1 ? '' : 's'} for collections.`);
+            toast.error(`Failed to scan ${failedScans.length} folder${failedScans.length === 1 ? '' : 's'} for collections`);
+          } else if (skippedItems.length) {
+            toast.error(`No Bruno collections found. ${skippedItems.length} skipped, config could not be read`);
           } else {
-            const skippedNote = skippedItems.length ? ` (${skippedItems.length} skipped, config could not be read)` : '';
-            toast.error(`No Bruno collections were found${skippedNote}.`);
+            toast.error('No Bruno collections found. Couldn\'t find a bruno.json or opencollection.yml');
           }
           onClose();
           return;

--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
@@ -24,6 +24,13 @@ const OpenCollectionModal = ({ onClose }) => {
   const [selectedCollectionPaths, setSelectedCollectionPaths] = useState([]);
   const startedRef = useRef(false);
 
+  const notifyOpenFailures = (result) => {
+    const failedCount = (result?.failed?.length || 0) + (result?.invalid?.length || 0);
+    if (failedCount > 0) {
+      toast.error(`Failed to open ${failedCount} collection${failedCount === 1 ? '' : 's'}`);
+    }
+  };
+
   useEffect(() => {
     // Guard against opening the picker twice
     if (startedRef.current) return;
@@ -73,19 +80,32 @@ const OpenCollectionModal = ({ onClose }) => {
           return;
         }
 
-        // If all selected folders are collections and nothing is skipped, open them directly
+        if (failedScans.length) {
+          toast.error(`Failed to scan ${failedScans.length} folder${failedScans.length === 1 ? '' : 's'} for collections`);
+        }
+
+        // If all selected folders are collections, open them directly
         const pickedFolders = new Set(dirPaths.map(normalizePath));
         const noNestedCollections = items.every((item) => pickedFolders.has(normalizePath(item.pathname)));
-        if (skippedItems.length === 0 && noNestedCollections) {
-          dispatch(openMultipleCollections(items.map((item) => item.pathname)))
-            .catch(() => toast.error('An error occurred while opening the collections'));
+        if (
+          failedScans.length === 0
+          && skippedItems.length === 0
+          && items.length === pickedFolders.size
+          && noNestedCollections
+        ) {
+          try {
+            const result = await dispatch(openMultipleCollections(items.map((item) => item.pathname)));
+            notifyOpenFailures(result);
+          } catch {
+            toast.error('An error occurred while opening the collections');
+          }
           onClose();
           return;
         }
 
         setCollectionPaths(items);
         setSkippedCollectionPaths(skippedItems);
-        setSelectedCollectionPaths(items.map((collection) => collection.pathname));
+        setSelectedCollectionPaths([]);
         setShowSelection(true);
       } catch (err) {
         console.error(err);
@@ -111,12 +131,17 @@ const OpenCollectionModal = ({ onClose }) => {
     );
   };
 
-  const handleConfirm = () => {
-    if (selectedCollectionPaths.length > 0) {
-      dispatch(openMultipleCollections(selectedCollectionPaths))
-        .catch(() => toast.error('An error occurred while opening the collections'));
-      onClose();
+  const handleConfirm = async () => {
+    if (selectedCollectionPaths.length === 0) {
+      return;
     }
+    try {
+      const result = await dispatch(openMultipleCollections(selectedCollectionPaths));
+      notifyOpenFailures(result);
+    } catch {
+      toast.error('An error occurred while opening the collections');
+    }
+    onClose();
   };
 
   const describeLocation = (collection) => {

--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
@@ -1,0 +1,182 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import toast from 'react-hot-toast';
+import { setIsOpeningCollection } from 'providers/ReduxStore/slices/app';
+import {
+  browseDirectories,
+  scanForBrunoFiles,
+  openMultipleCollections
+} from 'providers/ReduxStore/slices/collections/actions';
+import Modal from 'components/Modal';
+import Portal from 'components/Portal';
+import SelectionList from 'components/SelectionList';
+import SelectionFooter from 'components/SelectionFooter';
+import SkippedPathsWarning from 'components/SkippedPathsWarning';
+import { getRelativePath, normalizePath } from 'utils/common/path';
+import StyledWrapper from './StyledWrapper';
+
+const OpenCollectionModal = ({ onClose }) => {
+  const dispatch = useDispatch();
+
+  const [showSelection, setShowSelection] = useState(false);
+  const [collectionPaths, setCollectionPaths] = useState([]);
+  const [skippedCollectionPaths, setSkippedCollectionPaths] = useState([]);
+  const [selectedCollectionPaths, setSelectedCollectionPaths] = useState([]);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    // Guard against opening the picker twice
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    (async () => {
+      try {
+        const dirPaths = await dispatch(browseDirectories());
+        if (!Array.isArray(dirPaths) || dirPaths.length === 0) {
+          onClose();
+          return;
+        }
+
+        const scanResults = await Promise.all(
+          dirPaths.map((dirPath) =>
+            dispatch(scanForBrunoFiles(dirPath))
+              .then((res) => ({ dirPath, res }))
+              .catch(() => ({ dirPath, res: null }))
+          )
+        );
+
+        const itemsByPath = new Map();
+        const skippedSet = new Set();
+        scanResults.forEach(({ dirPath, res }) => {
+          (res?.items || []).forEach((item) => {
+            if (!itemsByPath.has(item.pathname)) {
+              // add basePath so the list item can show its location as a relative path to that folder
+              itemsByPath.set(item.pathname, { ...item, basePath: dirPath });
+            }
+          });
+          (res?.skippedItems || []).forEach((skippedPath) => skippedSet.add(skippedPath));
+        });
+
+        const items = [...itemsByPath.values()];
+        const skippedItems = [...skippedSet];
+        const failedScans = scanResults.filter(({ res }) => !res);
+
+        if (items.length === 0) {
+          if (failedScans.length) {
+            toast.error(`Failed to scan ${failedScans.length} folder${failedScans.length === 1 ? '' : 's'} for collections.`);
+          } else {
+            const skippedNote = skippedItems.length ? ` (${skippedItems.length} skipped, config could not be read)` : '';
+            toast.error(`No Bruno collections were found${skippedNote}.`);
+          }
+          onClose();
+          return;
+        }
+
+        // If all selected folders are collections and nothing is skipped, open them directly
+        const pickedFolders = new Set(dirPaths.map(normalizePath));
+        const noNestedCollections = items.every((item) => pickedFolders.has(normalizePath(item.pathname)));
+        if (skippedItems.length === 0 && noNestedCollections) {
+          dispatch(openMultipleCollections(items.map((item) => item.pathname)))
+            .catch(() => toast.error('An error occurred while opening the collections'));
+          onClose();
+          return;
+        }
+
+        setCollectionPaths(items);
+        setSkippedCollectionPaths(skippedItems);
+        setSelectedCollectionPaths(items.map((collection) => collection.pathname));
+        setShowSelection(true);
+      } catch (err) {
+        console.error(err);
+        toast.error('An error occurred while scanning for collections');
+        onClose();
+      }
+    })();
+  }, []);
+
+  const handleCollectionSelect = (collectionPathname) => {
+    setSelectedCollectionPaths((prevSelected) =>
+      prevSelected.includes(collectionPathname)
+        ? prevSelected.filter((pathname) => pathname !== collectionPathname)
+        : [...prevSelected, collectionPathname]
+    );
+  };
+
+  const handleSelectAllCollections = (e, filteredCollectionPaths) => {
+    setSelectedCollectionPaths((prevSelected) =>
+      e.target.checked
+        ? Array.from(new Set([...prevSelected, ...filteredCollectionPaths]))
+        : prevSelected.filter((pathname) => !filteredCollectionPaths.includes(pathname))
+    );
+  };
+
+  const handleConfirm = () => {
+    if (selectedCollectionPaths.length > 0) {
+      dispatch(openMultipleCollections(selectedCollectionPaths))
+        .catch(() => toast.error('An error occurred while opening the collections'));
+      onClose();
+    }
+  };
+
+  const describeLocation = (collection) => {
+    const relative = getRelativePath(collection.basePath, collection.pathname);
+    // When the folder itself is the collection, relative resolves to '.' so use its folder name instead.
+    return relative === '.' ? normalizePath(collection.pathname).split('/').pop() : relative;
+  };
+
+  // Only show the modal if there are collections to select from
+  if (!showSelection) {
+    return null;
+  }
+
+  return (
+    <Portal id="open-collection-portal">
+      <Modal
+        size="md"
+        title="Open Collection"
+        confirmText="Open"
+        handleConfirm={handleConfirm}
+        handleCancel={onClose}
+        confirmDisabled={selectedCollectionPaths.length === 0}
+        footerLeft={(
+          <SelectionFooter>
+            <span>{selectedCollectionPaths.length}</span> of {collectionPaths.length} selected
+          </SelectionFooter>
+        )}
+      >
+        <StyledWrapper>
+          <div className="w-full min-w-0 flex flex-col gap-3">
+            <SkippedPathsWarning paths={skippedCollectionPaths} itemNoun="collections" />
+            <SelectionList
+              title="Collections"
+              searchPlaceholder="Search Collections"
+              items={collectionPaths}
+              selectedItems={selectedCollectionPaths}
+              onSelectAll={handleSelectAllCollections}
+              onItemToggle={handleCollectionSelect}
+              getItemId={(collection) => collection.pathname}
+              renderItemTitle={(collection) => collection.name}
+              renderItemDescription={describeLocation}
+              visibleRows={8}
+              rowHeight={60}
+              rowGap={4}
+            />
+          </div>
+        </StyledWrapper>
+      </Modal>
+    </Portal>
+  );
+};
+
+const OpenCollection = () => {
+  const dispatch = useDispatch();
+  const isOpeningCollection = useSelector((state) => state.app.isOpeningCollection);
+
+  if (!isOpeningCollection) {
+    return null;
+  }
+
+  return <OpenCollectionModal onClose={() => dispatch(setIsOpeningCollection(false))} />;
+};
+
+export default OpenCollection;

--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
@@ -141,10 +141,12 @@ const OpenCollectionModal = ({ onClose }) => {
     try {
       const result = await dispatch(openMultipleCollections(selectedCollectionPaths, { silent: true }));
       notifyOpenResult(result);
+      if (result?.opened?.length) {
+        onClose();
+      }
     } catch {
       toast.error('An error occurred while opening the collections');
     }
-    onClose();
   };
 
   const describeLocation = (collection) => {

--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
@@ -23,9 +23,12 @@ const OpenCollectionModal = ({ onClose }) => {
   const [skippedCollectionPaths, setSkippedCollectionPaths] = useState([]);
   const [selectedCollectionPaths, setSelectedCollectionPaths] = useState([]);
   const startedRef = useRef(false);
-
-  const notifyOpenFailures = (result) => {
+  const notifyOpenResult = (result) => {
+    const openedCount = result?.opened?.length || 0;
     const failedCount = (result?.failed?.length || 0) + (result?.invalid?.length || 0);
+    if (openedCount > 0) {
+      toast.success(`${openedCount === 1 ? 'Collection' : 'Collections'} added to workspace`);
+    }
     if (failedCount > 0) {
       toast.error(`Failed to open ${failedCount} collection${failedCount === 1 ? '' : 's'}`);
     }
@@ -94,8 +97,8 @@ const OpenCollectionModal = ({ onClose }) => {
           && noNestedCollections
         ) {
           try {
-            const result = await dispatch(openMultipleCollections(items.map((item) => item.pathname)));
-            notifyOpenFailures(result);
+            const result = await dispatch(openMultipleCollections(items.map((item) => item.pathname), { silent: true }));
+            notifyOpenResult(result);
           } catch {
             toast.error('An error occurred while opening the collections');
           }
@@ -136,8 +139,8 @@ const OpenCollectionModal = ({ onClose }) => {
       return;
     }
     try {
-      const result = await dispatch(openMultipleCollections(selectedCollectionPaths));
-      notifyOpenFailures(result);
+      const result = await dispatch(openMultipleCollections(selectedCollectionPaths, { silent: true }));
+      notifyOpenResult(result);
     } catch {
       toast.error('An error occurred while opening the collections');
     }

--- a/packages/bruno-app/src/components/Sidebar/Sections/CollectionsSection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Sections/CollectionsSection/index.js
@@ -16,9 +16,9 @@ import {
   IconTerminal2
 } from '@tabler/icons';
 
-import { importCollection, openCollection, importCollectionFromZip, newHttpRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { importCollection, importCollectionFromZip, newHttpRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { sortCollections } from 'providers/ReduxStore/slices/collections/index';
-import { savePreferences, setIsCreatingCollection, toggleSidebarSearch } from 'providers/ReduxStore/slices/app';
+import { savePreferences, setIsCreatingCollection, setIsOpeningCollection, toggleSidebarSearch } from 'providers/ReduxStore/slices/app';
 import { normalizePath } from 'utils/common/path';
 import { isScratchCollection, flattenItems, isItemTransientRequest } from 'utils/collections';
 import { sanitizeName } from 'utils/common/regex';
@@ -184,14 +184,7 @@ const CollectionsSection = () => {
   };
 
   const handleOpenCollection = () => {
-    const options = {};
-    if (activeWorkspace?.pathname) {
-      options.workspaceId = activeWorkspace.pathname;
-    }
-
-    dispatch(openCollection(options)).catch((err) => {
-      toast.error('An error occurred while opening the collection');
-    });
+    dispatch(setIsOpeningCollection(true));
   };
 
   const handleStartRequest = () => {

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/index.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { IconPlus, IconFolder, IconDownload } from '@tabler/icons';
-import { importCollection, openCollection, importCollectionFromZip } from 'providers/ReduxStore/slices/collections/actions';
-import { setIsCreatingCollection, toggleSidebarCollapse } from 'providers/ReduxStore/slices/app';
+import { importCollection, importCollectionFromZip } from 'providers/ReduxStore/slices/collections/actions';
+import { setIsCreatingCollection, setIsOpeningCollection, toggleSidebarCollapse } from 'providers/ReduxStore/slices/app';
 import toast from 'react-hot-toast';
 import ImportCollection from 'components/Sidebar/ImportCollection';
 import ImportCollectionLocation from 'components/Sidebar/ImportCollectionLocation';
@@ -55,10 +55,7 @@ const WorkspaceOverview = ({ workspace }) => {
   };
 
   const handleOpenCollection = () => {
-    dispatch(openCollection()).catch((err) => {
-      console.error(err);
-      toast.error('An error occurred while opening the collection');
-    });
+    dispatch(setIsOpeningCollection(true));
   };
 
   const handleImportCollection = () => {

--- a/packages/bruno-app/src/pages/Bruno/index.js
+++ b/packages/bruno-app/src/pages/Bruno/index.js
@@ -7,6 +7,7 @@ import AppPreviewKeepAlive from 'components/AppPreviewKeepAlive';
 import AiChatSidebar from 'components/AiChatSidebar';
 import AiChatPopout from 'components/AiChatSidebar/Popout';
 import Sidebar from 'components/Sidebar';
+import OpenCollection from 'components/Sidebar/OpenCollection';
 import StatusBar from 'components/StatusBar';
 import AppTitleBar from 'components/AppTitleBar';
 import ApiSpecPanel from 'components/ApiSpecPanel';
@@ -187,6 +188,7 @@ export default function Main() {
       <Devtools mainSectionRef={mainSectionRef} />
       <StatusBar />
       <TransientRequestModalsRenderer modals={saveTransientRequestModals} />
+      <OpenCollection />
     </div>
     // </ErrorCapture>
   );

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -124,9 +124,9 @@ const useIpcEvents = () => {
 
     const removeApiSpecTreeUpdateListener = ipcRenderer.on('main:apispec-tree-updated', _apiSpecTreeUpdated);
 
-    const removeOpenCollectionListener = ipcRenderer.on('main:collection-opened', async (pathname, uid, brunoConfig) => {
+    const removeOpenCollectionListener = ipcRenderer.on('main:collection-opened', async (pathname, uid, brunoConfig, options) => {
       try {
-        await dispatch(openCollectionEvent(uid, pathname, brunoConfig));
+        await dispatch(openCollectionEvent(uid, pathname, brunoConfig, options));
       } finally {
         dispatch(hydrateSnapshotForOpenedCollection(pathname));
       }

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -136,7 +136,7 @@ const useIpcEvents = () => {
       dispatch(workspaceOpenedEvent(workspacePath, workspaceUid, workspaceConfig));
     });
 
-    const removeShowOpenCollectionListener = ipcRenderer.on('main:show-open-collection', () => {
+    const removeOpenCollectionModalListener = ipcRenderer.on('main:open-collection', () => {
       dispatch(setIsOpeningCollection(true));
     });
 
@@ -391,7 +391,7 @@ const useIpcEvents = () => {
       removeApiSpecTreeUpdateListener();
       removeOpenCollectionListener();
       removeOpenWorkspaceListener();
-      removeShowOpenCollectionListener();
+      removeOpenCollectionModalListener();
       removeWorkspacesReadyListener();
       removeWorkspaceConfigUpdatedListener();
       removeWorkspaceEnvironmentAddedListener();

--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -2,7 +2,8 @@ import { useEffect } from 'react';
 import {
   updateCookies,
   updatePreferences,
-  setGitVersion
+  setGitVersion,
+  setIsOpeningCollection
 } from 'providers/ReduxStore/slices/app';
 import {
   addTab
@@ -133,6 +134,10 @@ const useIpcEvents = () => {
 
     const removeOpenWorkspaceListener = ipcRenderer.on('main:workspace-opened', (workspacePath, workspaceUid, workspaceConfig) => {
       dispatch(workspaceOpenedEvent(workspacePath, workspaceUid, workspaceConfig));
+    });
+
+    const removeShowOpenCollectionListener = ipcRenderer.on('main:show-open-collection', () => {
+      dispatch(setIsOpeningCollection(true));
     });
 
     const removeWorkspacesReadyListener = ipcRenderer.on('main:workspaces-ready', () => {
@@ -386,6 +391,7 @@ const useIpcEvents = () => {
       removeApiSpecTreeUpdateListener();
       removeOpenCollectionListener();
       removeOpenWorkspaceListener();
+      removeShowOpenCollectionListener();
       removeWorkspacesReadyListener();
       removeWorkspaceConfigUpdatedListener();
       removeWorkspaceEnvironmentAddedListener();

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -107,7 +107,8 @@ const initialState = {
       secrets: { query: '', expanded: false }
     }
   },
-  isCreatingCollection: false
+  isCreatingCollection: false,
+  isOpeningCollection: false
 };
 
 export const appSlice = createSlice({
@@ -252,6 +253,9 @@ export const appSlice = createSlice({
     },
     setIsCreatingCollection: (state, action) => {
       state.isCreatingCollection = action.payload;
+    },
+    setIsOpeningCollection: (state, action) => {
+      state.isOpeningCollection = action.payload;
     }
   },
   extraReducers: (builder) => {
@@ -302,7 +306,8 @@ export const {
   setClipboard,
   setEnvVarSearchQuery,
   setEnvVarSearchExpanded,
-  setIsCreatingCollection
+  setIsCreatingCollection,
+  setIsOpeningCollection
 } = appSlice.actions;
 
 export const savePreferences = (preferences) => (dispatch, getState) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2799,7 +2799,7 @@ export const openScratchCollectionEvent = (uid, pathname, brunoConfig) => (dispa
   });
 };
 
-export const openCollectionEvent = (uid, pathname, brunoConfig) => (dispatch, getState) => {
+export const openCollectionEvent = (uid, pathname, brunoConfig, options = {}) => (dispatch, getState) => {
   const { ipcRenderer } = window;
 
   return new Promise((resolve, reject) => {
@@ -2816,7 +2816,9 @@ export const openCollectionEvent = (uid, pathname, brunoConfig) => (dispatch, ge
     );
 
     if (existingCollection && isAlreadyInWorkspace) {
-      toast.success('Collection is already opened');
+      if (!options.silent) {
+        toast.success('Collection is already opened');
+      }
       resolve();
       return;
     }
@@ -2835,7 +2837,9 @@ export const openCollectionEvent = (uid, pathname, brunoConfig) => (dispatch, ge
         ipcRenderer
           .invoke('renderer:add-collection-to-workspace', activeWorkspace.pathname, workspaceCollection)
           .then(() => {
-            toast.success('Collection added to workspace');
+            if (!options.silent) {
+              toast.success('Collection added to workspace');
+            }
           })
           .catch((err) => {
             console.error('Failed to add collection to workspace', err);

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2677,6 +2677,14 @@ export const browseDirectory = () => (dispatch, getState) => {
   });
 };
 
+export const browseDirectories = () => (dispatch, getState) => {
+  const { ipcRenderer } = window;
+
+  return new Promise((resolve, reject) => {
+    ipcRenderer.invoke('renderer:browse-directories').then(resolve).catch(reject);
+  });
+};
+
 export const browseFiles = (filters, properties) => (_dispatch, _getState) => {
   const { ipcRenderer } = window;
 
@@ -2940,25 +2948,6 @@ export const cloneCollection = (collectionName, collectionFolderName, collection
     previousPath
   );
 };
-export const openCollection = (options = {}) => (dispatch, getState) => {
-  return new Promise((resolve, reject) => {
-    const { ipcRenderer } = window;
-
-    const state = getState();
-    const activeWorkspace = state.workspaces.workspaces.find((w) => w.uid === state.workspaces.activeWorkspaceUid);
-
-    if (!options.workspaceId) {
-      options.workspaceId = activeWorkspace?.pathname || 'default';
-    }
-
-    ipcRenderer.invoke('renderer:open-collection', options)
-      .then((result) => {
-        resolve(result);
-      })
-      .catch(reject);
-  });
-};
-
 export const openMultipleCollections = (collectionPaths, options = {}) => () => {
   return new Promise((resolve, reject) => {
     const { ipcRenderer } = window;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -8,7 +8,7 @@ import {
   updateWorkspaceLoadingState,
   setWorkspaceScratchCollection
 } from '../workspaces';
-import { createCollection, openCollection, openMultipleCollections, openScratchCollectionEvent, mountCollection, hydrateCollectionWithUiStateSnapshot } from '../collections/actions';
+import { createCollection, openMultipleCollections, openScratchCollectionEvent, mountCollection } from '../collections/actions';
 import { removeCollection, addTransientDirectory, updateCollectionMountStatus, expandCollection, sortCollections } from '../collections';
 import { sanitizeName } from 'utils/common/regex';
 import { clearCollectionState } from '../openapi-sync';
@@ -1001,10 +1001,6 @@ export const createCollectionInWorkspace = (collectionName, collectionFolderName
       workspaceId: currentWorkspace.pathname
     }));
   };
-};
-
-export const openCollectionInWorkspace = () => {
-  return (dispatch) => dispatch(openCollection());
 };
 
 const handleWorkspaceAction = async (action, workspaceUid, ...args) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -8,7 +8,7 @@ import {
   updateWorkspaceLoadingState,
   setWorkspaceScratchCollection
 } from '../workspaces';
-import { createCollection, openMultipleCollections, openScratchCollectionEvent, mountCollection } from '../collections/actions';
+import { createCollection, openMultipleCollections, openScratchCollectionEvent, mountCollection, hydrateCollectionWithUiStateSnapshot } from '../collections/actions';
 import { removeCollection, addTransientDirectory, updateCollectionMountStatus, expandCollection, sortCollections } from '../collections';
 import { sanitizeName } from 'utils/common/regex';
 import { clearCollectionState } from '../openapi-sync';

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -91,7 +91,7 @@ const openCollection = async (win, watcher, collectionPath, options = {}) => {
       const { size, filesCount } = await getCollectionStats(collectionPath);
       brunoConfig.size = size;
       brunoConfig.filesCount = filesCount;
-      win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig);
+      win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig, { silent: !!options.silent });
       return {
         path: collectionPath,
         opened: true,
@@ -127,7 +127,7 @@ const openCollection = async (win, watcher, collectionPath, options = {}) => {
     brunoConfig.size = size;
     brunoConfig.filesCount = filesCount;
 
-    win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig);
+    win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig, { silent: !!options.silent });
     ipcMain.emit('main:collection-opened', win, collectionPath, uid, brunoConfig);
     return {
       path: collectionPath,

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { dialog, ipcMain } = require('electron');
+const { ipcMain } = require('electron');
 const Yup = require('yup');
 const { isDirectory, getCollectionStats, normalizeAndResolvePath } = require('../utils/filesystem');
 const { generateUidBasedOnHash } = require('../utils/common');
@@ -78,41 +78,6 @@ const getCollectionConfigFile = async (pathname) => {
   await validateSchema(config);
 
   return config;
-};
-
-const openCollectionDialog = async (win, watcher) => {
-  const { canceled, filePaths } = await dialog.showOpenDialog(win, {
-    properties: ['openDirectory', 'createDirectory', 'multiSelections']
-  });
-
-  if (!canceled && filePaths?.length > 0) {
-    // Using Set to remove duplicates
-    const { openCollectionPromises, invalidPaths } = [...new Set(filePaths)].reduce((acc, filePath) => {
-      const resolvedPath = path.resolve(filePath);
-
-      if (isDirectory(resolvedPath)) {
-        // Open each valid collection in parallel
-        acc.openCollectionPromises.push(openCollection(win, watcher, resolvedPath).catch((err) => {
-          console.error(`[ERROR] Failed to open collection at "${resolvedPath}":`, err.message);
-          return { error: err, path: resolvedPath };
-        }));
-      } else {
-        acc.invalidPaths.push(resolvedPath);
-        console.error(`[ERROR] Cannot open unknown folder: "${resolvedPath}"`);
-      }
-
-      return acc;
-    },
-    { openCollectionPromises: [], invalidPaths: [] });
-
-    // Wait for all valid collections to be opened
-    await Promise.all(openCollectionPromises);
-
-    // Notify about any invalid paths
-    if (invalidPaths.length > 0) {
-      win.webContents.send('main:display-error', `Some selected folders could not be opened: ${invalidPaths.join(', ')}`);
-    }
-  }
 };
 
 const openCollection = async (win, watcher, collectionPath, options = {}) => {
@@ -225,7 +190,6 @@ const openCollectionsByPathname = async (win, watcher, collectionPaths, options 
 module.exports = {
   getCollectionConfigFile,
   openCollection,
-  openCollectionDialog,
   openCollectionsByPathname,
   registerScratchCollectionPath
 };

--- a/packages/bruno-electron/src/app/menu-template.js
+++ b/packages/bruno-electron/src/app/menu-template.js
@@ -11,7 +11,7 @@ const template = [
       {
         label: 'Open Collection',
         click() {
-          ipcMain.emit('main:open-collection');
+          ipcMain.emit('menu:open-collection');
         }
       },
       {

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -61,7 +61,7 @@ const {
   scanForBrunoFiles,
   withFileLock
 } = require('../utils/filesystem');
-const { getCollectionConfigFile, openCollection, openCollectionDialog, openCollectionsByPathname, registerScratchCollectionPath } = require('../app/collections');
+const { getCollectionConfigFile, openCollection, openCollectionsByPathname, registerScratchCollectionPath } = require('../app/collections');
 const { generateUidBasedOnHash, stringifyJson, safeStringifyJSON, safeParseJSON } = require('../utils/common');
 const { isValidNpmPackageName, runNpmInstall } = require('../utils/install-packages');
 const { waitForShellEnv } = require('../store/shell-env-state');
@@ -1240,12 +1240,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
     }
 
     return results;
-  });
-
-  ipcMain.handle('renderer:open-collection', async () => {
-    if (watcher && mainWindow) {
-      await openCollectionDialog(mainWindow, watcher);
-    }
   });
 
   ipcMain.handle('renderer:open-multiple-collections', async (e, collectionPaths, options = {}) => {
@@ -2815,10 +2809,10 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
   });
 };
 
-const registerMainEventHandlers = (mainWindow, watcher) => {
+const registerMainEventHandlers = (mainWindow) => {
   ipcMain.on('main:open-collection', () => {
-    if (watcher && mainWindow) {
-      openCollectionDialog(mainWindow, watcher);
+    if (mainWindow) {
+      mainWindow.webContents.send('main:show-open-collection');
     }
   });
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -2810,11 +2810,14 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 };
 
 const registerMainEventHandlers = (mainWindow) => {
-  ipcMain.on('main:open-collection', () => {
+  const triggerOpenCollection = () => {
     if (mainWindow) {
-      mainWindow.webContents.send('main:show-open-collection');
+      mainWindow.webContents.send('main:open-collection');
     }
-  });
+  };
+
+  ipcMain.on('renderer:open-collection', triggerOpenCollection);
+  ipcMain.on('menu:open-collection', triggerOpenCollection);
 
   ipcMain.on('main:open-docs', () => {
     const docsURL = 'https://docs.usebruno.com';

--- a/packages/bruno-electron/src/ipc/filesystem.js
+++ b/packages/bruno-electron/src/ipc/filesystem.js
@@ -4,6 +4,7 @@ const { pathToFileURL } = require('node:url');
 
 const {
   browseDirectory,
+  browseDirectories,
   browseFiles,
   normalizeAndResolvePath,
   isFile,
@@ -15,6 +16,14 @@ const registerFilesystemIpc = (mainWindow) => {
   ipcMain.handle('renderer:browse-directory', async (event, pathname, request) => {
     try {
       return await browseDirectory(mainWindow);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  });
+
+  ipcMain.handle('renderer:browse-directories', async () => {
+    try {
+      return await browseDirectories(mainWindow);
     } catch (error) {
       return Promise.reject(error);
     }

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -178,6 +178,19 @@ const browseDirectory = async (win) => {
   return isDirectory(resolvedPath) ? resolvedPath : false;
 };
 
+const browseDirectories = async (win) => {
+  const { filePaths } = await dialog.showOpenDialog(win, {
+    properties: ['openDirectory', 'createDirectory', 'multiSelections']
+  });
+
+  if (!filePaths || !filePaths.length) {
+    return [];
+  }
+
+  const resolvedPaths = filePaths.map((filePath) => path.resolve(filePath)).filter((resolvedPath) => isDirectory(resolvedPath));
+  return [...new Set(resolvedPaths)];
+};
+
 const browseFiles = async (win, filters = [], properties = []) => {
   const { filePaths } = await dialog.showOpenDialog(win, {
     properties: ['openFile', ...properties],
@@ -581,6 +594,7 @@ module.exports = {
   hasRequestExtension,
   createDirectory,
   browseDirectory,
+  browseDirectories,
   browseFiles,
   chooseFileToSave,
   searchForFiles,

--- a/packages/bruno-electron/src/utils/tests/filesystem/browse-directories.spec.js
+++ b/packages/bruno-electron/src/utils/tests/filesystem/browse-directories.spec.js
@@ -1,0 +1,68 @@
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+jest.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: jest.fn()
+  }
+}));
+
+const { dialog } = require('electron');
+const { browseDirectories } = require('../../filesystem');
+
+describe('browseDirectories', () => {
+  let tempDir;
+  let dirA;
+  let dirB;
+  let filePath;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-browse-dirs-'));
+    dirA = path.join(tempDir, 'collection-a');
+    dirB = path.join(tempDir, 'collection-b');
+    filePath = path.join(tempDir, 'note.txt');
+    fs.mkdirSync(dirA);
+    fs.mkdirSync(dirB);
+    fs.writeFileSync(filePath, 'hello');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    dialog.showOpenDialog.mockReset();
+  });
+
+  it('returns an empty array when the picker is cancelled', async () => {
+    dialog.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+    await expect(browseDirectories()).resolves.toEqual([]);
+  });
+
+  it('returns an empty array when no filePaths are provided', async () => {
+    dialog.showOpenDialog.mockResolvedValue({});
+    await expect(browseDirectories()).resolves.toEqual([]);
+  });
+
+  it('returns the selected directories as absolute paths', async () => {
+    dialog.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [dirA, dirB] });
+    const result = await browseDirectories();
+    expect(result).toEqual([dirA, dirB]);
+    result.forEach((p) => expect(path.isAbsolute(p)).toBe(true));
+  });
+
+  it('filters out entries that are not directories or non-existent paths', async () => {
+    const missing = path.join(tempDir, 'does-not-exist');
+    dialog.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [dirA, filePath, missing] });
+    await expect(browseDirectories()).resolves.toEqual([dirA]);
+  });
+
+  it('opens a multi selection directory picker on the given window', async () => {
+    dialog.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [dirA] });
+    await browseDirectories('main-window');
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith('main-window', {
+      properties: ['openDirectory', 'createDirectory', 'multiSelections']
+    });
+  });
+});

--- a/tests/collection/open/open-collection-selection.spec.ts
+++ b/tests/collection/open/open-collection-selection.spec.ts
@@ -50,6 +50,15 @@ const openCollectionModal = (page: Page) => buildCommonLocators(page).modal.byTi
 
 const listTitles = (page: Page) => page.locator('[data-testid="selection-list"] .selection-item-title');
 
+const listDescriptions = (page: Page) => page.locator('[data-testid="selection-list"] .selection-item-description');
+
+const toggleCollection = (page: Page, name: string) =>
+  openCollectionModal(page)
+    .locator('[data-testid="selection-list"] li')
+    .filter({ hasText: name })
+    .getByRole('checkbox')
+    .click();
+
 const closeModal = async (page: Page) => {
   await buildCommonLocators(page).modal.closeButton().click();
   await expect(openCollectionModal(page)).toHaveCount(0);
@@ -105,6 +114,7 @@ test.describe('Open Collection - selection flow', () => {
     await expect(openCollectionModal(page)).toBeVisible();
     await expect(listTitles(page)).toHaveText('Nested JSON Collection');
 
+    await toggleCollection(page, 'Nested JSON Collection');
     await locators.modal.button('Open').click();
 
     await expect(locators.sidebar.collection('Nested JSON Collection')).toBeVisible();
@@ -131,7 +141,7 @@ test.describe('Open Collection - selection flow', () => {
     await closeAllCollections(page);
   });
 
-  test('shows the selection modal for nested collections, preselected, and opens all', async ({
+  test('shows the selection modal for nested collections and opens the selected ones', async ({
     page,
     electronApp,
     createTmpDir
@@ -147,7 +157,11 @@ test.describe('Open Collection - selection flow', () => {
     await expect(openCollectionModal(page)).toBeVisible();
     await expect(page.getByTestId('selection-count')).toHaveText('2');
     await expect(listTitles(page)).toHaveCount(2);
-    // Everything found is preselected.
+
+    await expect(locators.modal.footer()).toContainText('0 of 2 selected');
+    await expect(locators.modal.button('Open')).toBeDisabled();
+
+    await page.getByTestId('selection-select-all-toggle').getByRole('checkbox').click();
     await expect(locators.modal.footer()).toContainText('2 of 2 selected');
 
     await locators.modal.button('Open').click();
@@ -157,7 +171,50 @@ test.describe('Open Collection - selection flow', () => {
     await closeAllCollections(page);
   });
 
-  test('opens only the selected subset after deselecting one', async ({ page, electronApp, createTmpDir }) => {
+  test('shows the selection modal when picking a collection alongside a folder with no collection', async ({
+    page,
+    electronApp,
+    createTmpDir
+  }) => {
+    const locators = buildCommonLocators(page);
+    const collectionDir = await createTmpDir('valid-collection');
+    const emptyDir = await createTmpDir('empty-folder');
+    writeCollection(collectionDir, 'Picked Collection');
+    fs.writeFileSync(path.join(emptyDir, 'readme.txt'), 'no collection here');
+
+    await mockPickerPaths(electronApp, [collectionDir, emptyDir]);
+    await openViaSidebar(page);
+
+    await expect(openCollectionModal(page)).toBeVisible();
+    await expect(listTitles(page)).toHaveText('Picked Collection');
+
+    await toggleCollection(page, 'Picked Collection');
+    await locators.modal.button('Open').click();
+
+    await expect(locators.sidebar.collection('Picked Collection')).toBeVisible();
+    await closeAllCollections(page);
+  });
+
+  test('scans for deeply nested collections', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const base = await createTmpDir('nested-collection');
+    writeCollection(path.join(base, 'api', 'v2', 'users'), 'Users API');
+
+    await mockPickerPaths(electronApp, [base]);
+    await openViaSidebar(page);
+
+    await expect(openCollectionModal(page)).toBeVisible();
+    await expect(listTitles(page)).toHaveText('Users API');
+    await expect(listDescriptions(page)).toContainText('api/v2/users');
+
+    await toggleCollection(page, 'Users API');
+    await locators.modal.button('Open').click();
+
+    await expect(locators.sidebar.collection('Users API')).toBeVisible();
+    await closeAllCollections(page);
+  });
+
+  test('opens only the checked collections', async ({ page, electronApp, createTmpDir }) => {
     const locators = buildCommonLocators(page);
     const base = await createTmpDir('subset-nested');
     writeCollection(path.join(base, 'keep'), 'Keep Collection');
@@ -168,12 +225,8 @@ test.describe('Open Collection - selection flow', () => {
 
     await expect(openCollectionModal(page)).toBeVisible();
 
-    // Uncheck the "Drop" collection.
-    await openCollectionModal(page)
-      .locator('[data-testid="selection-list"] li')
-      .filter({ hasText: 'Drop Collection' })
-      .getByRole('checkbox')
-      .click();
+    // Check only the "Keep" collection.
+    await toggleCollection(page, 'Keep Collection');
     await expect(locators.modal.footer()).toContainText('1 of 2 selected');
 
     await locators.modal.button('Open').click();
@@ -183,7 +236,7 @@ test.describe('Open Collection - selection flow', () => {
     await closeAllCollections(page);
   });
 
-  test('select-all toggle clears the selection and disables Open', async ({ page, electronApp, createTmpDir }) => {
+  test('select-all toggle selects every collection and enables Open', async ({ page, electronApp, createTmpDir }) => {
     const locators = buildCommonLocators(page);
     const base = await createTmpDir('select-all');
     writeCollection(path.join(base, 'one'), 'One Collection');
@@ -197,7 +250,6 @@ test.describe('Open Collection - selection flow', () => {
     const openButton = locators.modal.button('Open');
     const selectAll = page.getByTestId('selection-select-all-toggle').getByRole('checkbox');
 
-    await selectAll.click();
     await expect(locators.modal.footer()).toContainText('0 of 2 selected');
     await expect(openButton).toBeDisabled();
 
@@ -208,7 +260,7 @@ test.describe('Open Collection - selection flow', () => {
     await closeModal(page);
   });
 
-  test('cancelling the picker shows no modal and no error toast', async ({ page, electronApp }) => {
+  test('cancelling the picker shows no modal', async ({ page, electronApp }) => {
     await electronApp.evaluate(({ dialog }) => {
       dialog.showOpenDialog = async () => ({ canceled: true, filePaths: [] });
     });
@@ -216,8 +268,6 @@ test.describe('Open Collection - selection flow', () => {
     await openViaSidebar(page);
 
     await expect(openCollectionModal(page)).toHaveCount(0);
-    await expect(page.getByText('An error occurred while scanning for collections')).toHaveCount(0);
-    await expect(page.getByText('No Bruno collections found')).toHaveCount(0);
   });
 
   test('reports a toast when a folder has no collections', async ({
@@ -255,7 +305,7 @@ test.describe('Open Collection - selection flow', () => {
     // Skipped-paths warning is shown for the invalid collection.
     await expect(modal.getByText(/were skipped because their config could not be read/)).toBeVisible();
 
-    // The valid collection is still listed and preselected.
+    // The valid collection is still listed and selectable.
     await expect(page.getByTestId('selection-count')).toHaveText('1');
     await expect(listTitles(page)).toHaveText('Good Nested');
 
@@ -310,8 +360,12 @@ test.describe('Open Collection - selection flow', () => {
     await mockPickerPaths(electronApp, [second]);
     await openViaSidebar(page);
     await expect(openCollectionModal(page)).toBeVisible();
-    await expect(listTitles(page)).toHaveText(['Reopen Gamma', 'Reopen Delta']);
-    await expect(locators.modal.footer()).toContainText('2 of 2 selected');
+    await expect(listTitles(page)).toHaveCount(2);
+    await expect(listTitles(page).filter({ hasText: 'Reopen Gamma' })).toBeVisible();
+    await expect(listTitles(page).filter({ hasText: 'Reopen Delta' })).toBeVisible();
+    await expect(listTitles(page).filter({ hasText: 'Reopen Alpha' })).toHaveCount(0);
+
+    await expect(locators.modal.footer()).toContainText('0 of 2 selected');
 
     await closeModal(page);
   });

--- a/tests/collection/open/open-collection-selection.spec.ts
+++ b/tests/collection/open/open-collection-selection.spec.ts
@@ -217,7 +217,7 @@ test.describe('Open Collection - selection flow', () => {
 
     await expect(openCollectionModal(page)).toHaveCount(0);
     await expect(page.getByText('An error occurred while scanning for collections')).toHaveCount(0);
-    await expect(page.getByText('No Bruno collections were found')).toHaveCount(0);
+    await expect(page.getByText('No Bruno collections found')).toHaveCount(0);
   });
 
   test('reports a toast when a folder has no collections', async ({
@@ -231,7 +231,9 @@ test.describe('Open Collection - selection flow', () => {
     await mockPickerPaths(electronApp, [empty]);
     await openViaSidebar(page);
 
-    await expect(page.getByText('No Bruno collections were found.')).toBeVisible();
+    await expect(
+      page.getByText('No Bruno collections found. Couldn\'t find a bruno.json or opencollection.yml')
+    ).toBeVisible();
     await expect(openCollectionModal(page)).toHaveCount(0);
   });
 

--- a/tests/collection/open/open-collection-selection.spec.ts
+++ b/tests/collection/open/open-collection-selection.spec.ts
@@ -1,0 +1,350 @@
+import { test, expect, ElectronApplication, Page } from '../../../playwright';
+import * as path from 'path';
+import * as fs from 'fs';
+import { buildCommonLocators, closeAllCollections } from '../../utils/page';
+
+const writeCollection = (dir: string, name: string) => {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'opencollection.yml'), `opencollection: "1.0.0"\ninfo:\n  name: ${name}\n`);
+};
+
+const writeBrunoJsonCollection = (dir: string, name: string) => {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'bruno.json'),
+    JSON.stringify({ version: '1', name, type: 'collection' }, null, 2)
+  );
+};
+
+const writeInvalidCollection = (dir: string) => {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'opencollection.yml'), 'opencollection: "1.0.0"\ninfo: {name:');
+};
+
+const mockPickerPaths = async (electronApp: ElectronApplication, filePaths: string[]) => {
+  await electronApp.evaluate(({ dialog }, paths) => {
+    dialog.showOpenDialog = async () => ({ canceled: false, filePaths: paths });
+  }, filePaths);
+};
+
+const mockPickerCancelWithFlag = async (electronApp: ElectronApplication) => {
+  await electronApp.evaluate(({ dialog }) => {
+    (global as any).__pickerOpened = false;
+    dialog.showOpenDialog = async () => {
+      (global as any).__pickerOpened = true;
+      return { canceled: true, filePaths: [] };
+    };
+  });
+};
+
+const wasPickerOpened = (electronApp: ElectronApplication): Promise<boolean> =>
+  electronApp.evaluate(() => (global as any).__pickerOpened);
+
+const openViaSidebar = async (page: Page) => {
+  const { plusMenu, dropdown } = buildCommonLocators(page);
+  await plusMenu.button().click();
+  await dropdown.tippyItem('Open collection').click();
+};
+
+const openCollectionModal = (page: Page) => buildCommonLocators(page).modal.byTitle('Open Collection');
+
+const listTitles = (page: Page) => page.locator('[data-testid="selection-list"] .selection-item-title');
+
+const closeModal = async (page: Page) => {
+  await buildCommonLocators(page).modal.closeButton().click();
+  await expect(openCollectionModal(page)).toHaveCount(0);
+};
+
+test.describe('Open Collection - selection flow', () => {
+  test.beforeAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      (global as any).__origShowOpenDialog = dialog.showOpenDialog;
+    });
+  });
+
+  test.afterAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = (global as any).__origShowOpenDialog;
+    });
+  });
+
+  test('opens a single picked collection directly, with no modal', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const dir = await createTmpDir('single-direct');
+    writeCollection(dir, 'Single Collection');
+
+    await mockPickerPaths(electronApp, [dir]);
+    await openViaSidebar(page);
+
+    await expect(locators.sidebar.collection('Single Collection')).toBeVisible();
+    await expect(openCollectionModal(page)).toHaveCount(0);
+    await closeAllCollections(page);
+  });
+
+  test('opens a bruno.json collection directly', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const dir = await createTmpDir('bruno-json');
+    writeBrunoJsonCollection(dir, 'Bruno JSON Collection');
+
+    await mockPickerPaths(electronApp, [dir]);
+    await openViaSidebar(page);
+
+    await expect(locators.sidebar.collection('Bruno JSON Collection')).toBeVisible();
+    await expect(openCollectionModal(page)).toHaveCount(0);
+    await closeAllCollections(page);
+  });
+
+  test('shows the selection modal for a nested bruno.json collection', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const base = await createTmpDir('nested-bruno-json');
+    writeBrunoJsonCollection(path.join(base, 'nested'), 'Nested JSON Collection');
+
+    await mockPickerPaths(electronApp, [base]);
+    await openViaSidebar(page);
+
+    await expect(openCollectionModal(page)).toBeVisible();
+    await expect(listTitles(page)).toHaveText('Nested JSON Collection');
+
+    await locators.modal.button('Open').click();
+
+    await expect(locators.sidebar.collection('Nested JSON Collection')).toBeVisible();
+    await closeAllCollections(page);
+  });
+
+  test('opens multiple picked collections directly when each folder is a collection', async ({
+    page,
+    electronApp,
+    createTmpDir
+  }) => {
+    const locators = buildCommonLocators(page);
+    const dir1 = await createTmpDir('direct-1');
+    const dir2 = await createTmpDir('direct-2');
+    writeCollection(dir1, 'Direct One');
+    writeCollection(dir2, 'Direct Two');
+
+    await mockPickerPaths(electronApp, [dir1, dir2]);
+    await openViaSidebar(page);
+
+    await expect(locators.sidebar.collection('Direct One')).toBeVisible();
+    await expect(locators.sidebar.collection('Direct Two')).toBeVisible();
+    await expect(openCollectionModal(page)).toHaveCount(0);
+    await closeAllCollections(page);
+  });
+
+  test('shows the selection modal for nested collections, preselected, and opens all', async ({
+    page,
+    electronApp,
+    createTmpDir
+  }) => {
+    const locators = buildCommonLocators(page);
+    const base = await createTmpDir('multi-nested');
+    writeCollection(path.join(base, 'alpha'), 'Alpha Collection');
+    writeCollection(path.join(base, 'beta'), 'Beta Collection');
+
+    await mockPickerPaths(electronApp, [base]);
+    await openViaSidebar(page);
+
+    await expect(openCollectionModal(page)).toBeVisible();
+    await expect(page.getByTestId('selection-count')).toHaveText('2');
+    await expect(listTitles(page)).toHaveCount(2);
+    // Everything found is preselected.
+    await expect(locators.modal.footer()).toContainText('2 of 2 selected');
+
+    await locators.modal.button('Open').click();
+
+    await expect(locators.sidebar.collection('Alpha Collection')).toBeVisible();
+    await expect(locators.sidebar.collection('Beta Collection')).toBeVisible();
+    await closeAllCollections(page);
+  });
+
+  test('opens only the selected subset after deselecting one', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const base = await createTmpDir('subset-nested');
+    writeCollection(path.join(base, 'keep'), 'Keep Collection');
+    writeCollection(path.join(base, 'drop'), 'Drop Collection');
+
+    await mockPickerPaths(electronApp, [base]);
+    await openViaSidebar(page);
+
+    await expect(openCollectionModal(page)).toBeVisible();
+
+    // Uncheck the "Drop" collection.
+    await openCollectionModal(page)
+      .locator('[data-testid="selection-list"] li')
+      .filter({ hasText: 'Drop Collection' })
+      .getByRole('checkbox')
+      .click();
+    await expect(locators.modal.footer()).toContainText('1 of 2 selected');
+
+    await locators.modal.button('Open').click();
+
+    await expect(locators.sidebar.collection('Keep Collection')).toBeVisible();
+    await expect(locators.sidebar.collection('Drop Collection')).toHaveCount(0);
+    await closeAllCollections(page);
+  });
+
+  test('select-all toggle clears the selection and disables Open', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const base = await createTmpDir('select-all');
+    writeCollection(path.join(base, 'one'), 'One Collection');
+    writeCollection(path.join(base, 'two'), 'Two Collection');
+
+    await mockPickerPaths(electronApp, [base]);
+    await openViaSidebar(page);
+
+    await expect(openCollectionModal(page)).toBeVisible();
+
+    const openButton = locators.modal.button('Open');
+    const selectAll = page.getByTestId('selection-select-all-toggle').getByRole('checkbox');
+
+    await selectAll.click();
+    await expect(locators.modal.footer()).toContainText('0 of 2 selected');
+    await expect(openButton).toBeDisabled();
+
+    await selectAll.click();
+    await expect(locators.modal.footer()).toContainText('2 of 2 selected');
+    await expect(openButton).toBeEnabled();
+
+    await closeModal(page);
+  });
+
+  test('cancelling the picker shows no modal and no error toast', async ({ page, electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = async () => ({ canceled: true, filePaths: [] });
+    });
+
+    await openViaSidebar(page);
+
+    await expect(openCollectionModal(page)).toHaveCount(0);
+    await expect(page.getByText('An error occurred while scanning for collections')).toHaveCount(0);
+    await expect(page.getByText('No Bruno collections were found')).toHaveCount(0);
+  });
+
+  test('reports a toast when a folder has no collections', async ({
+    page,
+    electronApp,
+    createTmpDir
+  }) => {
+    const empty = await createTmpDir('no-collections');
+    fs.writeFileSync(path.join(empty, 'readme.txt'), 'nothing here');
+
+    await mockPickerPaths(electronApp, [empty]);
+    await openViaSidebar(page);
+
+    await expect(page.getByText('No Bruno collections were found.')).toBeVisible();
+    await expect(openCollectionModal(page)).toHaveCount(0);
+  });
+
+  test('surfaces skipped or invalid collections while keeping valid ones selectable', async ({
+    page,
+    electronApp,
+    createTmpDir
+  }) => {
+    const base = await createTmpDir('with-skipped');
+    writeCollection(path.join(base, 'good'), 'Good Nested');
+    writeInvalidCollection(path.join(base, 'bad'));
+
+    await mockPickerPaths(electronApp, [base]);
+    await openViaSidebar(page);
+
+    const modal = openCollectionModal(page);
+    await expect(modal).toBeVisible();
+
+    // Skipped-paths warning is shown for the invalid collection.
+    await expect(modal.getByText(/were skipped because their config could not be read/)).toBeVisible();
+
+    // The valid collection is still listed and preselected.
+    await expect(page.getByTestId('selection-count')).toHaveText('1');
+    await expect(listTitles(page)).toHaveText('Good Nested');
+
+    await closeModal(page);
+  });
+
+  test('search narrows the list and shows a no matching collections found message', async ({ page, electronApp, createTmpDir }) => {
+    const base = await createTmpDir('search-nested');
+    writeCollection(path.join(base, 'payments'), 'Payments API');
+    writeCollection(path.join(base, 'inventory'), 'Inventory API');
+
+    await mockPickerPaths(electronApp, [base]);
+    await openViaSidebar(page);
+
+    const modal = openCollectionModal(page);
+    await expect(modal).toBeVisible();
+    await expect(listTitles(page)).toHaveCount(2);
+
+    const search = page.getByTestId('selection-search-input');
+    await search.fill('payments');
+    await expect(listTitles(page)).toHaveText('Payments API');
+
+    await search.fill('zzzzz');
+    await expect(modal.getByText('No matching collections found')).toBeVisible();
+
+    await closeModal(page);
+  });
+
+  test('reopening starts from fresh state', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const first = await createTmpDir('reopen-first');
+    writeCollection(path.join(first, 'alpha'), 'Reopen Alpha');
+    writeCollection(path.join(first, 'beta'), 'Reopen Beta');
+
+    const second = await createTmpDir('reopen-second');
+    writeCollection(path.join(second, 'gamma'), 'Reopen Gamma');
+    writeCollection(path.join(second, 'delta'), 'Reopen Delta');
+
+    // First open
+    await mockPickerPaths(electronApp, [first]);
+    await openViaSidebar(page);
+    await expect(openCollectionModal(page)).toBeVisible();
+    await openCollectionModal(page)
+      .locator('[data-testid="selection-list"] li')
+      .filter({ hasText: 'Reopen Alpha' })
+      .getByRole('checkbox')
+      .click();
+    await expect(locators.modal.footer()).toContainText('1 of 2 selected');
+    await closeModal(page);
+
+    // Second open
+    await mockPickerPaths(electronApp, [second]);
+    await openViaSidebar(page);
+    await expect(openCollectionModal(page)).toBeVisible();
+    await expect(listTitles(page)).toHaveText(['Reopen Gamma', 'Reopen Delta']);
+    await expect(locators.modal.footer()).toContainText('2 of 2 selected');
+
+    await closeModal(page);
+  });
+
+  test('the sidebar empty state "Open" link opens the folder picker', async ({ page, electronApp }) => {
+    await closeAllCollections(page);
+    await mockPickerCancelWithFlag(electronApp);
+
+    await expect(page.getByText('No collections found.')).toBeVisible();
+    await page.getByText('Open', { exact: true }).click();
+
+    await expect.poll(() => wasPickerOpened(electronApp)).toBe(true);
+    await expect(openCollectionModal(page)).toHaveCount(0);
+  });
+
+  test('the workspace overview "Open Collection" button opens the folder picker', async ({ page, electronApp }) => {
+    await mockPickerCancelWithFlag(electronApp);
+
+    // Navigate to the workspace overview
+    await page.locator('.titlebar-left .home-button').click();
+    await page.getByRole('button', { name: 'Open Collection' }).click();
+
+    await expect.poll(() => wasPickerOpened(electronApp)).toBe(true);
+    await expect(openCollectionModal(page)).toHaveCount(0);
+  });
+
+  test('the native App menu entry opens the folder picker', async ({ page, electronApp }) => {
+    await mockPickerCancelWithFlag(electronApp);
+
+    // Simulate the OS-level "File > Open Collection" menu
+    await electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.emit('menu:open-collection');
+    });
+
+    await expect.poll(() => wasPickerOpened(electronApp)).toBe(true);
+    await expect(openCollectionModal(page)).toHaveCount(0);
+  });
+});

--- a/tests/collection/open/open-multiple-collections.spec.ts
+++ b/tests/collection/open/open-multiple-collections.spec.ts
@@ -102,7 +102,7 @@ test.describe('Open Multiple Collections', () => {
     await expect(page.locator('#sidebar-collection-name')).toHaveCount(collectionCountBefore);
 
     // Verify invalid collection error
-    const invalidCollectionError = page.getByText('The collection is not valid').first();
+    const invalidCollectionError = page.getByText('No Bruno collections were found').first();
     await expect(invalidCollectionError).toBeVisible();
   });
 });

--- a/tests/collection/open/open-multiple-collections.spec.ts
+++ b/tests/collection/open/open-multiple-collections.spec.ts
@@ -102,7 +102,7 @@ test.describe('Open Multiple Collections', () => {
     await expect(page.locator('#sidebar-collection-name')).toHaveCount(collectionCountBefore);
 
     // Verify invalid collection error
-    const invalidCollectionError = page.getByText('No Bruno collections were found').first();
+    const invalidCollectionError = page.getByText('No Bruno collections found').first();
     await expect(invalidCollectionError).toBeVisible();
   });
 });


### PR DESCRIPTION
### Description

Adds support for discovering nested Bruno collections when opening a folder. If multiple collections are found, Bruno presents them in a selection modal so users can choose which collections to open. The workflow mirrors the existing Git clone experience.

Ref: BRU-141

#### Changes

1. The user selects one or more folders using the native directory picker.
2. The app scans the selected folders for valid collections and then either:
   - Opens them directly if each selected folder is itself a Bruno collection (existing behavior is preserved).
   - Displays a selection modal when nested collections are found, allowing the user to choose which collections to open.
   
This gives users visibility and control when opening folders that contain multiple collections or nested collections.

#### Screen Recording

https://github.com/user-attachments/assets/952924ed-2c67-4366-89f3-b1e74226181f


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Updated “Open Collection” flow to browse directories, discover collections, and show a searchable selection modal when deeper scanning is needed.
  * Modal supports per-item toggles, select-all, and clears/reset behavior on re-open.

* **Bug Fixes**
  * Improved consistency across sidebar, workspace, and menu triggers, including cancellation handling and clearer “no collections found” and skipped/invalid messaging.

* **Tests**
  * Added end-to-end coverage for discovery, selection, filtering/search, validation states, multi-open behavior, and modal reset.
  * Updated expected “no collections found” toast text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->