### PR TITLE
feat(code-mirror-search): add replace and replace-all with search position, debouncing and tests

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -103,17 +103,37 @@ class CodeEditor extends React.Component {
       theme: this.props.theme === 'dark' ? 'monokai' : 'default',
       extraKeys: {
         'Cmd-F': (cm) => {
+          const selected = cm.getSelection();
           this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
+            if (selected) {
+              this.searchBarRef.current?.setSearch(selected, cm.getCursor('from'));
+            } else {
+              this.searchBarRef.current?.focus();
+            }
           });
         },
         'Ctrl-F': (cm) => {
+          const selected = cm.getSelection();
           this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
+            if (selected) {
+              this.searchBarRef.current?.setSearch(selected, cm.getCursor('from'));
+            } else {
+              this.searchBarRef.current?.focus();
+            }
           });
         },
-        'Cmd-H': this.props.readOnly ? false : 'replace',
-        'Ctrl-H': this.props.readOnly ? false : 'replace',
+        'Cmd-H': this.props.readOnly ? false : (cm) => {
+          this.setState({ searchBarVisible: true }, () => {
+            this.searchBarRef.current?.focus();
+            this.searchBarRef.current?.openReplace();
+          });
+        },
+        'Ctrl-H': this.props.readOnly ? false : (cm) => {
+          this.setState({ searchBarVisible: true }, () => {
+            this.searchBarRef.current?.focus();
+            this.searchBarRef.current?.openReplace();
+          });
+        },
         'Cmd-Enter': runShortcut,
         'Ctrl-Enter': runShortcut,
         'Tab': function (cm) {
@@ -148,7 +168,7 @@ class CodeEditor extends React.Component {
         },
         'Esc': () => {
           if (this.state.searchBarVisible) {
-            this.setState({ searchBarVisible: false });
+            this.searchBarRef.current?.close();
           }
         }
       },

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -21,6 +21,7 @@ import { setupLinkAware } from 'utils/codemirror/linkAware';
 import { setupLintErrorTooltip } from 'utils/codemirror/lint-errors';
 import { setupCodeMirrorResizeRefresh } from 'utils/codemirror/resize';
 import CodeMirrorSearch from 'components/CodeMirrorSearch/index';
+import { buildSearchKeyBindings } from 'components/CodeMirrorSearch/searchKeyBindings';
 import {
   applyEditorState,
   captureEditorState,
@@ -102,52 +103,12 @@ class CodeEditor extends React.Component {
       scrollbarStyle: 'overlay',
       theme: this.props.theme === 'dark' ? 'monokai' : 'default',
       extraKeys: {
-        'Cmd-F': (cm) => {
-          const selected = cm.getSelection();
-          const cursor = cm.getCursor('from');
-          this.setState({ searchBarVisible: true }, () => {
-            if (selected) {
-              this.searchBarRef.current?.setSearch(selected, cursor);
-            } else {
-              this.searchBarRef.current?.focusAtCursor(cursor);
-            }
-          });
-        },
-        'Ctrl-F': (cm) => {
-          const selected = cm.getSelection();
-          const cursor = cm.getCursor('from');
-          this.setState({ searchBarVisible: true }, () => {
-            if (selected) {
-              this.searchBarRef.current?.setSearch(selected, cursor);
-            } else {
-              this.searchBarRef.current?.focusAtCursor(cursor);
-            }
-          });
-        },
-        'Cmd-H': this.props.readOnly ? false : () => {
-          this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
-            this.searchBarRef.current?.openReplace();
-          });
-        },
-        'Ctrl-H': this.props.readOnly ? false : () => {
-          this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
-            this.searchBarRef.current?.openReplace();
-          });
-        },
-        'Cmd-Alt-F': this.props.readOnly ? false : () => {
-          this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
-            this.searchBarRef.current?.openReplace();
-          });
-        },
-        'Ctrl-Alt-F': this.props.readOnly ? false : () => {
-          this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
-            this.searchBarRef.current?.openReplace();
-          });
-        },
+        ...buildSearchKeyBindings({
+          setState: (update, cb) => this.setState(update, cb),
+          searchBarRef: this.searchBarRef,
+          isSearchBarVisible: () => this.state.searchBarVisible,
+          readOnly: this.props.readOnly
+        }),
         'Cmd-Enter': runShortcut,
         'Ctrl-Enter': runShortcut,
         'Tab': function (cm) {
@@ -178,11 +139,6 @@ class CodeEditor extends React.Component {
             this.editor.toggleComment({ lineComment: '//', blockComment: '/*' });
           } else {
             this.editor.toggleComment();
-          }
-        },
-        'Esc': () => {
-          if (this.state.searchBarVisible) {
-            this.searchBarRef.current?.close();
           }
         }
       },

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -104,31 +104,45 @@ class CodeEditor extends React.Component {
       extraKeys: {
         'Cmd-F': (cm) => {
           const selected = cm.getSelection();
+          const cursor = cm.getCursor('from');
           this.setState({ searchBarVisible: true }, () => {
             if (selected) {
-              this.searchBarRef.current?.setSearch(selected, cm.getCursor('from'));
+              this.searchBarRef.current?.setSearch(selected, cursor);
             } else {
-              this.searchBarRef.current?.focus();
+              this.searchBarRef.current?.focusAtCursor(cursor);
             }
           });
         },
         'Ctrl-F': (cm) => {
           const selected = cm.getSelection();
+          const cursor = cm.getCursor('from');
           this.setState({ searchBarVisible: true }, () => {
             if (selected) {
-              this.searchBarRef.current?.setSearch(selected, cm.getCursor('from'));
+              this.searchBarRef.current?.setSearch(selected, cursor);
             } else {
-              this.searchBarRef.current?.focus();
+              this.searchBarRef.current?.focusAtCursor(cursor);
             }
           });
         },
-        'Cmd-H': this.props.readOnly ? false : (cm) => {
+        'Cmd-H': this.props.readOnly ? false : () => {
           this.setState({ searchBarVisible: true }, () => {
             this.searchBarRef.current?.focus();
             this.searchBarRef.current?.openReplace();
           });
         },
-        'Ctrl-H': this.props.readOnly ? false : (cm) => {
+        'Ctrl-H': this.props.readOnly ? false : () => {
+          this.setState({ searchBarVisible: true }, () => {
+            this.searchBarRef.current?.focus();
+            this.searchBarRef.current?.openReplace();
+          });
+        },
+        'Cmd-Alt-F': this.props.readOnly ? false : () => {
+          this.setState({ searchBarVisible: true }, () => {
+            this.searchBarRef.current?.focus();
+            this.searchBarRef.current?.openReplace();
+          });
+        },
+        'Ctrl-Alt-F': this.props.readOnly ? false : () => {
           this.setState({ searchBarVisible: true }, () => {
             this.searchBarRef.current?.focus();
             this.searchBarRef.current?.openReplace();
@@ -464,6 +478,7 @@ class CodeEditor extends React.Component {
       <StyledWrapper
         className={`h-full w-full flex flex-col relative graphiql-container ${this.props.readOnly ? 'read-only' : ''}`}
         aria-label="Code Editor"
+        data-testid={this.props.testId}
         font={this.props.font}
         fontSize={this.props.fontSize}
       >

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -474,6 +474,7 @@ class CodeEditor extends React.Component {
           }}
           visible={this.state.searchBarVisible}
           editor={this.editor}
+          readOnly={this.props.readOnly}
           onClose={() => this.setState({ searchBarVisible: false })}
         />
         <div

--- a/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
@@ -3,8 +3,6 @@ import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components';
 import CodeMirrorSearch from './index';
 
-// ─── Mocks ───────────────────────────────────────────────────────────────────
-
 jest.mock('components/ToolHint', () => ({ children }) => <>{children}</>);
 
 const theme = {
@@ -42,7 +40,12 @@ function makeMockEditor(matchResults = []) {
     scrollIntoView: jest.fn(),
     setSelection: jest.fn(),
     focus: jest.fn(),
+    getCursor: jest.fn(() => ({ line: 0, ch: 0 })),
+    getViewport: jest.fn(() => ({ from: 0, to: 100 })),
     getValue: jest.fn(() => 'test content'),
+    lineCount: jest.fn(() => 1),
+    lastLine: jest.fn(() => 0),
+    getLine: jest.fn(() => 'test content'),
     changeGeneration: jest.fn(() => 1),
     on: jest.fn(),
     off: jest.fn(),
@@ -66,13 +69,10 @@ function renderSearch(props = {}, ref = null) {
   return { ...result, ref: defaultRef };
 }
 
-// Type into the search input and advance past the 250ms debounce
 function typeSearch(text) {
   fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: text } });
   act(() => jest.advanceTimersByTime(250));
 }
-
-// ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('CodeMirrorSearch', () => {
   beforeEach(() => jest.useFakeTimers());
@@ -253,8 +253,9 @@ describe('CodeMirrorSearch', () => {
     });
 
     it('replace buttons are enabled once debounce settles', () => {
+      const matches = [{ from: { line: 0, ch: 0 }, to: { line: 0, ch: 4 } }];
       const ref = createRef();
-      renderSearch({}, ref);
+      renderSearch({ editor: makeMockEditor(matches) }, ref);
       act(() => {
         ref.current.openReplace(); jest.runAllTimers();
       });
@@ -299,13 +300,21 @@ describe('CodeMirrorSearch', () => {
   });
 
   describe('handleReplaceAll', () => {
-    it('calls replaceRange for each match in reverse order', () => {
+    it('replaces all matches via a single replaceRange call with the reconstructed text', () => {
+      const content = 'console\nconsole\nconsole';
+      const lines = content.split('\n');
       const matches = [
         { from: { line: 0, ch: 0 }, to: { line: 0, ch: 7 } },
         { from: { line: 1, ch: 0 }, to: { line: 1, ch: 7 } },
         { from: { line: 2, ch: 0 }, to: { line: 2, ch: 7 } }
       ];
-      const editor = makeMockEditor(matches);
+      const editor = {
+        ...makeMockEditor(matches),
+        getValue: jest.fn(() => content),
+        lineCount: jest.fn(() => lines.length),
+        lastLine: jest.fn(() => lines.length - 1),
+        getLine: jest.fn((n) => lines[n])
+      };
       const ref = createRef();
       renderSearch({ editor }, ref);
 
@@ -318,12 +327,8 @@ describe('CodeMirrorSearch', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Replace all' }));
 
       expect(editor.operation).toHaveBeenCalled();
-      expect(editor.replaceRange).toHaveBeenCalledTimes(3);
-
-      const calls = editor.replaceRange.mock.calls;
-      expect(calls[0][1]).toEqual(matches[2].from);
-      expect(calls[1][1]).toEqual(matches[1].from);
-      expect(calls[2][1]).toEqual(matches[0].from);
+      expect(editor.replaceRange).toHaveBeenCalledTimes(1);
+      expect(editor.replaceRange.mock.calls[0][0]).toBe('log\nlog\nlog');
     });
   });
 });

--- a/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
@@ -70,7 +70,7 @@ function renderSearch(props = {}, ref = null) {
 }
 
 function typeSearch(text) {
-  fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: text } });
+  fireEvent.change(screen.getByTestId('codemirror-search-input'), { target: { value: text } });
   act(() => jest.advanceTimersByTime(250));
 }
 
@@ -93,25 +93,25 @@ describe('CodeMirrorSearch', () => {
 
     it('renders search input when visible', () => {
       renderSearch();
-      expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-input')).toBeInTheDocument();
     });
 
     it('does not show replace row by default', () => {
       renderSearch();
-      expect(screen.queryByPlaceholderText('Replace...')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('codemirror-search-replace-input')).not.toBeInTheDocument();
     });
 
     it('shows replace row after toggling chevron', () => {
       renderSearch();
       fireEvent.click(screen.getByTitle('Show replace'));
-      expect(screen.getByPlaceholderText('Replace...')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-replace-input')).toBeInTheDocument();
     });
   });
 
   describe('result count', () => {
     it('shows "0 results" when search is empty', () => {
       renderSearch();
-      expect(screen.getByText('0 results')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('0 results');
     });
 
     it('shows "1 / 3" for first match of 3', () => {
@@ -122,13 +122,13 @@ describe('CodeMirrorSearch', () => {
       ];
       renderSearch({ editor: makeMockEditor(matches) });
       typeSearch('test');
-      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('1 / 3');
     });
 
     it('shows "0 results" when no matches found', () => {
       renderSearch({ editor: makeMockEditor([]) });
       typeSearch('xyz');
-      expect(screen.getByText('0 results')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('0 results');
     });
   });
 
@@ -145,32 +145,32 @@ describe('CodeMirrorSearch', () => {
 
     it('advances to next match on Enter', () => {
       setupWithMatches(3);
-      expect(screen.getByText('1 / 3')).toBeInTheDocument();
-      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Enter' });
-      expect(screen.getByText('2 / 3')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('1 / 3');
+      fireEvent.keyDown(screen.getByTestId('codemirror-search-input'), { key: 'Enter' });
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('2 / 3');
     });
 
     it('goes to previous match on Shift+Enter', () => {
       setupWithMatches(3);
-      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Enter' });
-      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Enter', shiftKey: true });
-      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+      fireEvent.keyDown(screen.getByTestId('codemirror-search-input'), { key: 'Enter' });
+      fireEvent.keyDown(screen.getByTestId('codemirror-search-input'), { key: 'Enter', shiftKey: true });
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('1 / 3');
     });
 
     it('wraps from last to first on next', () => {
       setupWithMatches(3);
-      const input = screen.getByPlaceholderText('Search...');
+      const input = screen.getByTestId('codemirror-search-input');
       fireEvent.keyDown(input, { key: 'Enter' });
       fireEvent.keyDown(input, { key: 'Enter' });
-      expect(screen.getByText('3 / 3')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('3 / 3');
       fireEvent.keyDown(input, { key: 'Enter' });
-      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('1 / 3');
     });
 
     it('wraps from first to last on prev', () => {
       setupWithMatches(3);
-      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Enter', shiftKey: true });
-      expect(screen.getByText('3 / 3')).toBeInTheDocument();
+      fireEvent.keyDown(screen.getByTestId('codemirror-search-input'), { key: 'Enter', shiftKey: true });
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('3 / 3');
     });
   });
 
@@ -179,14 +179,14 @@ describe('CodeMirrorSearch', () => {
       const ref = createRef();
       renderSearch({}, ref);
       act(() => ref.current.focus());
-      expect(document.activeElement).toBe(screen.getByPlaceholderText('Search...'));
+      expect(document.activeElement).toBe(screen.getByTestId('codemirror-search-input'));
     });
 
     it('setSearch(text) populates the input', () => {
       const ref = createRef();
       renderSearch({}, ref);
       act(() => ref.current.setSearch('hello'));
-      expect(screen.getByPlaceholderText('Search...')).toHaveValue('hello');
+      expect(screen.getByTestId('codemirror-search-input')).toHaveValue('hello');
     });
 
     it('setSearch(text, cursorPos) shows the match at cursor position', () => {
@@ -202,7 +202,7 @@ describe('CodeMirrorSearch', () => {
         jest.advanceTimersByTime(250);
       });
 
-      expect(screen.getByText('3 / 5')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('3 / 5');
     });
 
     it('openReplace() shows the replace row', () => {
@@ -212,7 +212,7 @@ describe('CodeMirrorSearch', () => {
         ref.current.openReplace();
         jest.runAllTimers();
       });
-      expect(screen.getByPlaceholderText('Replace...')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-replace-input')).toBeInTheDocument();
     });
 
     it('close() calls onClose and collapses replace', () => {
@@ -224,7 +224,7 @@ describe('CodeMirrorSearch', () => {
       });
       act(() => ref.current.close());
       expect(onClose).toHaveBeenCalled();
-      expect(screen.queryByPlaceholderText('Replace...')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('codemirror-search-replace-input')).not.toBeInTheDocument();
     });
   });
 
@@ -232,7 +232,7 @@ describe('CodeMirrorSearch', () => {
     it('closes the bar and calls onClose', () => {
       const onClose = jest.fn();
       renderSearch({ onClose });
-      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Escape' });
+      fireEvent.keyDown(screen.getByTestId('codemirror-search-input'), { key: 'Escape' });
       expect(onClose).toHaveBeenCalled();
     });
   });
@@ -246,7 +246,7 @@ describe('CodeMirrorSearch', () => {
       });
 
       // Type but do NOT advance timers — debounce still pending
-      fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'test' } });
+      fireEvent.change(screen.getByTestId('codemirror-search-input'), { target: { value: 'test' } });
 
       expect(screen.getByRole('button', { name: 'Replace' })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'Replace all' })).toBeDisabled();
@@ -260,7 +260,7 @@ describe('CodeMirrorSearch', () => {
         ref.current.openReplace(); jest.runAllTimers();
       });
 
-      fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'test' } });
+      fireEvent.change(screen.getByTestId('codemirror-search-input'), { target: { value: 'test' } });
       act(() => jest.advanceTimersByTime(250));
 
       expect(screen.getByRole('button', { name: 'Replace' })).not.toBeDisabled();
@@ -282,7 +282,7 @@ describe('CodeMirrorSearch', () => {
 
       renderSearch({ editor });
       typeSearch('console');
-      expect(screen.getByText('1 / 2')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('1 / 2');
 
       // Simulate undo — document reverts, now no matches
       editor.getSearchCursor.mockImplementation(() => {
@@ -295,7 +295,7 @@ describe('CodeMirrorSearch', () => {
         jest.advanceTimersByTime(100);
       });
 
-      expect(screen.getByText('0 results')).toBeInTheDocument();
+      expect(screen.getByTestId('codemirror-search-result-count')).toHaveTextContent('0 results');
     });
   });
 
@@ -322,7 +322,7 @@ describe('CodeMirrorSearch', () => {
       act(() => {
         ref.current.openReplace(); jest.runAllTimers();
       });
-      fireEvent.change(screen.getByPlaceholderText('Replace...'), { target: { value: 'log' } });
+      fireEvent.change(screen.getByTestId('codemirror-search-replace-input'), { target: { value: 'log' } });
 
       fireEvent.click(screen.getByRole('button', { name: 'Replace all' }));
 

--- a/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
@@ -1,0 +1,329 @@
+import React, { createRef } from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import CodeMirrorSearch from './index';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+jest.mock('components/ToolHint', () => ({ children }) => <>{children}</>);
+
+const theme = {
+  background: { base: '#1e1e1e' },
+  text: { base: '#d4d4d4' },
+  colors: { text: { subtext1: '#888', subtext2: '#aaa' } },
+  border: { border2: '#444', radius: { sm: '4px' } },
+  font: { size: { base: '13px', xs: '11px' } },
+  brand: '#007acc',
+  codemirror: { border: '#555', searchLineHighlightCurrent: 'rgba(255,255,0,0.1)' }
+};
+
+function makeMockEditor(matchResults = []) {
+  const marks = [];
+  return {
+    getSearchCursor: jest.fn(() => {
+      let i = -1;
+      return {
+        findNext: () => {
+          i++; return i < matchResults.length;
+        },
+        from: () => matchResults[i]?.from,
+        to: () => matchResults[i]?.to
+      };
+    }),
+    markText: jest.fn((from, to, opts) => {
+      const mark = { from, to, className: opts.className, clear: jest.fn() };
+      marks.push(mark);
+      return mark;
+    }),
+    replaceRange: jest.fn(),
+    operation: jest.fn((fn) => fn()),
+    addLineClass: jest.fn(),
+    removeLineClass: jest.fn(),
+    scrollIntoView: jest.fn(),
+    setSelection: jest.fn(),
+    focus: jest.fn(),
+    getValue: jest.fn(() => 'test content'),
+    changeGeneration: jest.fn(() => 1),
+    on: jest.fn(),
+    off: jest.fn(),
+    _marks: marks
+  };
+}
+
+function renderSearch(props = {}, ref = null) {
+  const defaultRef = ref || createRef();
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <CodeMirrorSearch
+        visible={true}
+        editor={makeMockEditor()}
+        onClose={jest.fn()}
+        ref={defaultRef}
+        {...props}
+      />
+    </ThemeProvider>
+  );
+  return { ...result, ref: defaultRef };
+}
+
+// Type into the search input and advance past the 250ms debounce
+function typeSearch(text) {
+  fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: text } });
+  act(() => jest.advanceTimersByTime(250));
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('CodeMirrorSearch', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    act(() => jest.runOnlyPendingTimers());
+    jest.useRealTimers();
+  });
+
+  describe('rendering', () => {
+    it('renders nothing when visible is false', () => {
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <CodeMirrorSearch visible={false} editor={makeMockEditor()} onClose={jest.fn()} ref={createRef()} />
+        </ThemeProvider>
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders search input when visible', () => {
+      renderSearch();
+      expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+    });
+
+    it('does not show replace row by default', () => {
+      renderSearch();
+      expect(screen.queryByPlaceholderText('Replace...')).not.toBeInTheDocument();
+    });
+
+    it('shows replace row after toggling chevron', () => {
+      renderSearch();
+      fireEvent.click(screen.getByTitle('Show replace'));
+      expect(screen.getByPlaceholderText('Replace...')).toBeInTheDocument();
+    });
+  });
+
+  describe('result count', () => {
+    it('shows "0 results" when search is empty', () => {
+      renderSearch();
+      expect(screen.getByText('0 results')).toBeInTheDocument();
+    });
+
+    it('shows "1 / 3" for first match of 3', () => {
+      const matches = [
+        { from: { line: 0, ch: 0 }, to: { line: 0, ch: 4 } },
+        { from: { line: 1, ch: 0 }, to: { line: 1, ch: 4 } },
+        { from: { line: 2, ch: 0 }, to: { line: 2, ch: 4 } }
+      ];
+      renderSearch({ editor: makeMockEditor(matches) });
+      typeSearch('test');
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    });
+
+    it('shows "0 results" when no matches found', () => {
+      renderSearch({ editor: makeMockEditor([]) });
+      typeSearch('xyz');
+      expect(screen.getByText('0 results')).toBeInTheDocument();
+    });
+  });
+
+  describe('navigation', () => {
+    function setupWithMatches(count = 3) {
+      const matches = Array.from({ length: count }, (_, i) => ({
+        from: { line: i, ch: 0 },
+        to: { line: i, ch: 4 }
+      }));
+      renderSearch({ editor: makeMockEditor(matches) });
+      typeSearch('test');
+      return matches;
+    }
+
+    it('advances to next match on Enter', () => {
+      setupWithMatches(3);
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Enter' });
+      expect(screen.getByText('2 / 3')).toBeInTheDocument();
+    });
+
+    it('goes to previous match on Shift+Enter', () => {
+      setupWithMatches(3);
+      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Enter' });
+      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Enter', shiftKey: true });
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    });
+
+    it('wraps from last to first on next', () => {
+      setupWithMatches(3);
+      const input = screen.getByPlaceholderText('Search...');
+      fireEvent.keyDown(input, { key: 'Enter' });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(screen.getByText('3 / 3')).toBeInTheDocument();
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    });
+
+    it('wraps from first to last on prev', () => {
+      setupWithMatches(3);
+      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Enter', shiftKey: true });
+      expect(screen.getByText('3 / 3')).toBeInTheDocument();
+    });
+  });
+
+  describe('imperative handle', () => {
+    it('focus() focuses the search input', () => {
+      const ref = createRef();
+      renderSearch({}, ref);
+      act(() => ref.current.focus());
+      expect(document.activeElement).toBe(screen.getByPlaceholderText('Search...'));
+    });
+
+    it('setSearch(text) populates the input', () => {
+      const ref = createRef();
+      renderSearch({}, ref);
+      act(() => ref.current.setSearch('hello'));
+      expect(screen.getByPlaceholderText('Search...')).toHaveValue('hello');
+    });
+
+    it('setSearch(text, cursorPos) shows the match at cursor position', () => {
+      const matches = Array.from({ length: 5 }, (_, i) => ({
+        from: { line: i, ch: 0 },
+        to: { line: i, ch: 7 }
+      }));
+      const ref = createRef();
+      renderSearch({ editor: makeMockEditor(matches) }, ref);
+
+      act(() => {
+        ref.current.setSearch('console', { line: 2, ch: 0 });
+        jest.advanceTimersByTime(250);
+      });
+
+      expect(screen.getByText('3 / 5')).toBeInTheDocument();
+    });
+
+    it('openReplace() shows the replace row', () => {
+      const ref = createRef();
+      renderSearch({}, ref);
+      act(() => {
+        ref.current.openReplace();
+        jest.runAllTimers();
+      });
+      expect(screen.getByPlaceholderText('Replace...')).toBeInTheDocument();
+    });
+
+    it('close() calls onClose and collapses replace', () => {
+      const onClose = jest.fn();
+      const ref = createRef();
+      renderSearch({ onClose }, ref);
+      act(() => {
+        ref.current.openReplace(); jest.runAllTimers();
+      });
+      act(() => ref.current.close());
+      expect(onClose).toHaveBeenCalled();
+      expect(screen.queryByPlaceholderText('Replace...')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Escape key', () => {
+    it('closes the bar and calls onClose', () => {
+      const onClose = jest.fn();
+      renderSearch({ onClose });
+      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), { key: 'Escape' });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('isDebouncing guard', () => {
+    it('replace buttons are disabled while debounce is pending', () => {
+      const ref = createRef();
+      renderSearch({}, ref);
+      act(() => {
+        ref.current.openReplace(); jest.runAllTimers();
+      });
+
+      // Type but do NOT advance timers — debounce still pending
+      fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'test' } });
+
+      expect(screen.getByRole('button', { name: 'Replace' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Replace all' })).toBeDisabled();
+    });
+
+    it('replace buttons are enabled once debounce settles', () => {
+      const ref = createRef();
+      renderSearch({}, ref);
+      act(() => {
+        ref.current.openReplace(); jest.runAllTimers();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'test' } });
+      act(() => jest.advanceTimersByTime(250));
+
+      expect(screen.getByRole('button', { name: 'Replace' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Replace all' })).not.toBeDisabled();
+    });
+  });
+
+  describe('document change (undo/redo/edit)', () => {
+    it('re-runs search and updates count when document changes', () => {
+      let changeHandler;
+      const matches = [
+        { from: { line: 0, ch: 0 }, to: { line: 0, ch: 7 } },
+        { from: { line: 1, ch: 0 }, to: { line: 1, ch: 7 } }
+      ];
+      const editor = makeMockEditor(matches);
+      // Capture the change handler registered by the component
+      editor.on = jest.fn((event, handler) => { if (event === 'change') changeHandler = handler; });
+      editor.off = jest.fn();
+
+      renderSearch({ editor });
+      typeSearch('console');
+      expect(screen.getByText('1 / 2')).toBeInTheDocument();
+
+      // Simulate undo — document reverts, now no matches
+      editor.getSearchCursor.mockImplementation(() => {
+        let i = -1;
+        return { findNext: () => false, from: () => undefined, to: () => undefined };
+      });
+
+      act(() => {
+        changeHandler();
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(screen.getByText('0 results')).toBeInTheDocument();
+    });
+  });
+
+  describe('handleReplaceAll', () => {
+    it('calls replaceRange for each match in reverse order', () => {
+      const matches = [
+        { from: { line: 0, ch: 0 }, to: { line: 0, ch: 7 } },
+        { from: { line: 1, ch: 0 }, to: { line: 1, ch: 7 } },
+        { from: { line: 2, ch: 0 }, to: { line: 2, ch: 7 } }
+      ];
+      const editor = makeMockEditor(matches);
+      const ref = createRef();
+      renderSearch({ editor }, ref);
+
+      typeSearch('console');
+      act(() => {
+        ref.current.openReplace(); jest.runAllTimers();
+      });
+      fireEvent.change(screen.getByPlaceholderText('Replace...'), { target: { value: 'log' } });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Replace all' }));
+
+      expect(editor.operation).toHaveBeenCalled();
+      expect(editor.replaceRange).toHaveBeenCalledTimes(3);
+
+      const calls = editor.replaceRange.mock.calls;
+      expect(calls[0][1]).toEqual(matches[2].from);
+      expect(calls[1][1]).toEqual(matches[1].from);
+      expect(calls[2][1]).toEqual(matches[0].from);
+    });
+  });
+});

--- a/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
@@ -8,81 +8,111 @@ const StyledWrapper = styled.div`
     right: 8px;
     z-index: 20;
     display: flex;
-    align-items: center;
-    flex-wrap: nowrap;
-    gap: 0;
-    padding: 1px 3px;
+    flex-direction: row;
+    align-items: stretch;
+    padding: 4px 4px;
+    gap: 4px;
     width: auto;
-    max-width: 320px;
-    min-height: 22px;
     background: ${(props) => props.theme.background.base};
     color: ${(props) => props.theme.text.base};
     border: solid 1px ${(props) => props.theme.border.border2};
     border-radius: ${(props) => props.theme.border.radius.sm};
+    overflow: hidden;
   }
 
-  .bruno-search-bar input {
-    min-width: 80px;
-    background: transparent;
-    color: inherit;
+  .toggle-replace-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 18px;
+    align-self: stretch;
+    background: none;
     border: none;
+    cursor: pointer;
+    color: ${(props) => props.theme.colors.text.subtext1};
+    padding: 0;
+    border-radius: 3px;
+  }
+
+  .toggle-replace-btn:hover {
+    background: ${(props) => rgba(props.theme.brand, 0.08)};
+    color: ${(props) => props.theme.brand};
+  }
+
+  /* Column: search row stacked above replace row */
+  .search-replace-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .search-row,
+  .replace-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  /* Each input gets its own bordered box */
+  .bruno-search-bar input {
+    width: 180px;
+    flex: 0 0 180px;
+    background: transparent;
+    color: ${(props) => props.theme.colors.text.subtext2};
+    border: 1px solid ${(props) => props.theme.border.border2};
+    border-radius: ${(props) => props.theme.border.radius.sm};
     outline: none;
-    padding: 1px 2px;
+    padding: 2px 6px;
     font-size: ${(props) => props.theme.font.size.base};
-    margin: 0 1px;
-    height: 28px;
+    height: 26px;
+    font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important;
+  }
+
+  .bruno-search-bar input:focus {
+    border-color: ${(props) => props.theme.brand};
   }
 
   .searchbar-icon-btn {
     background: none;
     border: none;
     padding: 0 1px;
-    margin: 0 1px;
     cursor: pointer;
     color: ${(props) => props.theme.colors.text.subtext1};
     border-radius: 3px;
     height: 18px;
     width: 18px;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
   }
 
+  .searchbar-icon-btn:hover {
+    color: ${(props) => props.theme.text.base};
+  }
+
   .searchbar-result-count {
-    min-width: 28px;
-    text-align: center;
     font-size: ${(props) => props.theme.font.size.xs};
     color: ${(props) => props.theme.colors.text.subtext1};
-    margin: 0 8px 0 1px; 
     white-space: nowrap;
+    flex-shrink: 0;
+    width: 68px;
+    margin-left: 4px;
   }
 
-  .bruno-search-bar input {
-    background: transparent;
-    color: ${(props) => props.theme.colors.text.subtext2};
-    border: none;
-    outline: none;
-    font-size: ${(props) => props.theme.font.size.base};
-    padding: 1px 2px;
-    min-width: 80px;
-  }
-
-  .searchbar-icon-btn:focus {
+  .searchbar-icon-btn:focus,
+  .searchbar-text-btn:focus {
     outline: 1px solid ${(props) => props.theme.codemirror.border};
-  }
-
-  .bruno-search-bar, .bruno-search-bar input {
-    font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important;
-  }
-
-  .cm-search-line-highlight {
-    background: ${(props) => props.theme.codemirror.searchLineHighlightCurrent};
   }
 
   .searchbar-icon-btn.active {
     color: ${(props) => props.theme.brand};
     background-color: ${(props) => rgba(props.theme.brand, 0.1)};
-    font-weight: 500;
+  }
+
+  .cm-search-line-highlight {
+    background: ${(props) => props.theme.codemirror.searchLineHighlightCurrent};
   }
 `;
 

--- a/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
@@ -98,6 +98,12 @@ const StyledWrapper = styled.div`
     color: ${(props) => props.theme.text.base};
   }
 
+  .searchbar-icon-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+    pointer-events: none;
+  }
+
   .searchbar-result-count {
     font-size: ${(props) => props.theme.font.size.xs};
     color: ${(props) => props.theme.colors.text.subtext1};

--- a/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
@@ -26,7 +26,8 @@ const StyledWrapper = styled.div`
     justify-content: center;
     flex-shrink: 0;
     width: 18px;
-    align-self: stretch;
+    align-self: flex-start;
+    height: 26px;
     background: none;
     border: none;
     cursor: pointer;
@@ -38,6 +39,11 @@ const StyledWrapper = styled.div`
   .toggle-replace-btn:hover {
     background: ${(props) => rgba(props.theme.brand, 0.08)};
     color: ${(props) => props.theme.brand};
+  }
+
+  .toggle-replace-btn.active {
+    color: ${(props) => props.theme.brand};
+    background-color: ${(props) => rgba(props.theme.brand, 0.1)};
   }
 
   /* Column: search row stacked above replace row */
@@ -97,7 +103,8 @@ const StyledWrapper = styled.div`
     color: ${(props) => props.theme.colors.text.subtext1};
     white-space: nowrap;
     flex-shrink: 0;
-    width: 68px;
+    min-width: 68px;
+    width: max-content;
     margin-left: 4px;
   }
 

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -3,50 +3,11 @@ import { IconRegex, IconArrowUp, IconArrowDown, IconX, IconLetterCase, IconLette
 import ToolHint from 'components/ToolHint';
 import StyledWrapper from './StyledWrapper';
 import useDebounce from 'hooks/useDebounce';
+import { replaceSingle, replaceAll } from './replaceUtils';
+import { findSearchMatches, createCacheKey } from './searchUtils';
+import { markViewportMatches, clearMarks } from './markingUtils';
 
-function escapeRegExp(string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-const MAX_MATCHES = 99_999;
-function findSearchMatches(editor, searchText, regex, caseSensitive, wholeWord) {
-  try {
-    let query, options = {};
-    if (regex) {
-      try {
-        query = new RegExp(searchText, caseSensitive ? 'g' : 'gi');
-      } catch (error) {
-        console.warn('Invalid regex provided in search!', error);
-        return [];
-      }
-    } else if (wholeWord) {
-      const escaped = escapeRegExp(searchText);
-      query = new RegExp(`\\b${escaped}\\b`, caseSensitive ? 'g' : 'gi');
-    } else {
-      query = searchText;
-      options = { caseFold: !caseSensitive };
-    }
-
-    const cursor = editor.getSearchCursor(query, { line: 0, ch: 0 }, options);
-    const out = [];
-    while (cursor.findNext()) {
-      out.push({ from: cursor.from(), to: cursor.to() });
-      if (out.length >= MAX_MATCHES) {
-        break;
-      }
-    }
-    return out;
-  } catch (e) {
-    console.error('Search error:', e);
-    return [];
-  }
-}
-
-function createCacheKey(editor, searchText, regex, caseSensitive, wholeWord) {
-  return `${editor.getValue().length}⇴${searchText}⇴${regex}⇴${caseSensitive}⇴${wholeWord}`;
-}
-
-const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
+const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref) => {
   const [searchText, setSearchText] = useState('');
   const [replaceText, setReplaceText] = useState('');
   const [replaceVisible, setReplaceVisible] = useState(false);
@@ -60,12 +21,20 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
   const searchLineHighlight = useRef(null);
   const searchMatches = useRef([]);
   const searchCacheKey = useRef('');
+  const currentMatchIndex = useRef(0);
+  const docVersion = useRef(0);
   const inputRef = useRef(null);
   const replaceInputRef = useRef(null);
   const containerRef = useRef(null);
   const initialIndexRef = useRef(null);
+  const rafRef = useRef(null);
 
   const debouncedSearchText = useDebounce(searchText, 250);
+
+  const redrawMarks = useCallback(() => {
+    if (!editor) return;
+    markViewportMatches(editor, searchMatches.current, currentMatchIndex.current, searchMarks.current);
+  }, [editor]);
 
   const doSearch = useCallback((text, newIndex = 0) => {
     if (!editor || !visible) {
@@ -80,14 +49,14 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     if (!text) {
       setMatchCount(0);
       setMatchIndex(0);
+      currentMatchIndex.current = 0;
       searchMatches.current = [];
-      searchMarks.current.forEach((mark) => mark.clear());
-      searchMarks.current = [];
+      clearMarks(searchMarks.current);
       return;
     }
 
     try {
-      const newCacheKey = createCacheKey(editor, text, regex, caseSensitive, wholeWord);
+      const newCacheKey = createCacheKey(docVersion.current, text, regex, caseSensitive, wholeWord);
       const isCacheHit = newCacheKey === searchCacheKey.current;
 
       let matches = searchMatches.current;
@@ -100,83 +69,45 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
 
       if (!matches.length) {
         setMatchIndex(0);
-        // Clear previous marks
-        searchMarks.current.forEach((mark) => mark.clear());
-        searchMarks.current = [];
+        currentMatchIndex.current = 0;
+        clearMarks(searchMarks.current);
         return;
       }
 
-      const matchIndex = Math.max(0, Math.min(newIndex, matches.length - 1));
-      setMatchIndex(matchIndex);
+      const resolvedIndex = Math.max(0, Math.min(newIndex, matches.length - 1));
+      setMatchIndex(resolvedIndex);
+      currentMatchIndex.current = resolvedIndex;
 
-      if (isCacheHit) {
-        // Clear only old current mark
-        const oldIndex = searchMarks.current.findIndex((mark) => mark.className?.includes('cm-search-current'));
+      redrawMarks();
 
-        if (oldIndex !== -1) {
-          searchMarks.current[oldIndex].clear();
-          searchMarks.current.splice(oldIndex, 1);
-        }
-
-        // Add mark to the new current and remark the previous and next
-        const toMark = [
-          // Previous
-          matchIndex > 0 ? matchIndex - 1 : null,
-          // Current
-          matchIndex,
-          // Next
-          matchIndex < matches.length - 1 ? matchIndex + 1 : null
-        ].filter((i) => i !== null);
-
-        toMark.forEach((i) => {
-          const mark = editor.markText(matches[i].from, matches[i].to, {
-            className: i === matchIndex ? 'cm-search-current' : 'cm-search-match',
-            clearOnEnter: true
-          });
-          searchMarks.current.push(mark);
-        });
-      } else {
-        // Clear previous marks
-        searchMarks.current.forEach((mark) => mark.clear());
-        searchMarks.current = [];
-
-        // Mark all on new search
-        matches.forEach((m, i) => {
-          const mark = editor.markText(m.from, m.to, {
-            className: i === matchIndex ? 'cm-search-current' : 'cm-search-match',
-            clearOnEnter: true
-          });
-          searchMarks.current.push(mark);
-        });
-      }
-
-      const currentLine = matches[matchIndex].from.line;
+      const currentLine = matches[resolvedIndex].from.line;
       editor.addLineClass(currentLine, 'wrap', 'cm-search-line-highlight');
       searchLineHighlight.current = currentLine;
 
-      editor.scrollIntoView(matches[matchIndex].from, 100);
-      editor.setSelection(matches[matchIndex].from, matches[matchIndex].to);
+      editor.scrollIntoView(matches[resolvedIndex].from, 100);
+      editor.setSelection(matches[resolvedIndex].from, matches[resolvedIndex].to);
     } catch (e) {
       console.error('Search error:', e);
       setMatchCount(0);
       setMatchIndex(0);
+      currentMatchIndex.current = 0;
       searchMatches.current = [];
       searchCacheKey.current = '';
     }
-  }, [regex, caseSensitive, wholeWord, editor, visible]);
+  }, [regex, caseSensitive, wholeWord, editor, visible, redrawMarks]);
 
   const handleSearchBarClose = useCallback(() => {
-    searchMarks.current.forEach((mark) => mark.clear());
-    searchMarks.current = [];
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    clearMarks(searchMarks.current);
     if (searchLineHighlight.current !== null && editor) {
       editor.removeLineClass(searchLineHighlight.current, 'wrap', 'cm-search-line-highlight');
       searchLineHighlight.current = null;
     }
     searchMatches.current = [];
     searchCacheKey.current = '';
+    currentMatchIndex.current = 0;
     setReplaceVisible(false);
     if (onClose) onClose();
-    // Focus the editor after closing the search bar
     if (editor) {
       setTimeout(() => editor.focus(), 0);
     }
@@ -200,13 +131,11 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
         const targetIdx = matchAtCursorIdx >= 0 ? matchAtCursorIdx : 0;
         // Pre-populate cache so doSearch hits it regardless of path
         searchMatches.current = matches;
-        searchCacheKey.current = createCacheKey(editor, text, regex, caseSensitive, wholeWord);
+        searchCacheKey.current = createCacheKey(docVersion.current, text, regex, caseSensitive, wholeWord);
         // Set both count and index immediately to avoid "1 / N" flash before debounce fires
         setMatchCount(matches.length);
         setMatchIndex(targetIdx);
-        // Call immediately — text is passed directly, no debounce dependency
         doSearch(text, targetIdx);
-        // Store so the debounce-fired effect uses the right index instead of 0
         if (text !== searchText) {
           initialIndexRef.current = { idx: targetIdx, forText: text };
         }
@@ -231,7 +160,6 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
 
   useEffect(() => {
     if (initialIndexRef.current) {
-      // setSearch has pre-computed a result — wait for debouncedSearchText to catch up
       if (initialIndexRef.current.forText === debouncedSearchText) {
         const idx = initialIndexRef.current.idx;
         initialIndexRef.current = null;
@@ -256,12 +184,29 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     return () => container.removeEventListener('keydown', onKeyDown, true);
   }, [visible, handleSearchBarClose]);
 
-  // Re-run search when the document changes (undo, redo, edits)
+  useEffect(() => {
+    if (!editor || !visible) return;
+
+    const handleScroll = () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        redrawMarks();
+      });
+    };
+
+    editor.on('scroll', handleScroll);
+    return () => {
+      editor.off('scroll', handleScroll);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [editor, visible, redrawMarks]);
+
   useEffect(() => {
     if (!editor || !visible) return;
 
     let timeoutId;
     const handleChange = () => {
+      docVersion.current += 1;
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
         searchCacheKey.current = '';
@@ -310,36 +255,26 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
 
   const handleReplace = useCallback(() => {
     if (!editor || !searchMatches.current.length) return;
-    const match = searchMatches.current[matchIndex];
-    if (!match) return;
-    editor.replaceRange(replaceText, match.from, match.to);
+    if (!searchMatches.current[matchIndex]) return;
 
-    const replaceLines = replaceText.split('\n');
-    const endLine = match.from.line + replaceLines.length - 1;
-    const endCh = replaceLines.length === 1
-      ? match.from.ch + replaceText.length
-      : replaceLines[replaceLines.length - 1].length;
+    const { endLine, endCh } = replaceSingle(editor, searchMatches.current, matchIndex, replaceText);
 
-    // Re-search and pre-populate the cache so doSearch uses these results directly
     const newMatches = findSearchMatches(editor, debouncedSearchText, regex, caseSensitive, wholeWord);
     searchMatches.current = newMatches;
-    searchCacheKey.current = createCacheKey(editor, debouncedSearchText, regex, caseSensitive, wholeWord);
+    searchCacheKey.current = createCacheKey(docVersion.current, debouncedSearchText, regex, caseSensitive, wholeWord);
     setMatchCount(newMatches.length);
 
-    // Find the first match that starts after the replacement end
     const nextIdx = newMatches.findIndex(
       (m) => m.from.line > endLine || (m.from.line === endLine && m.from.ch >= endCh)
     );
-
     doSearch(debouncedSearchText, nextIdx >= 0 ? nextIdx : 0);
   }, [editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
 
   const handleReplaceAll = useCallback(() => {
     if (!editor || !searchMatches.current.length) return;
-    const matches = [...searchMatches.current].reverse();
-    editor.operation(() => {
-      matches.forEach((match) => editor.replaceRange(replaceText, match.from, match.to));
-    });
+
+    replaceAll(editor, searchMatches.current, replaceText);
+
     searchCacheKey.current = '';
     doSearch(debouncedSearchText, 0);
   }, [editor, replaceText, debouncedSearchText, doSearch]);
@@ -353,9 +288,10 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       <div className="bruno-search-bar" ref={containerRef}>
         <button
           type="button"
-          className="toggle-replace-btn"
+          className={`toggle-replace-btn${replaceVisible ? ' active' : ''}`}
           title={replaceVisible ? 'Hide replace' : 'Show replace'}
           onClick={() => setReplaceVisible((prev) => !prev)}
+          style={readOnly ? { display: 'none' } : {}}
         >
           <IconChevronRight
             size={12}
@@ -391,7 +327,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
             <button type="button" className="searchbar-icon-btn" title="Next (Enter)" onClick={handleNext}><IconArrowDown size={14} /></button>
             <button type="button" className="searchbar-icon-btn" title="Close" onClick={handleSearchBarClose}><IconX size={14} /></button>
           </div>
-          {replaceVisible && (
+          {replaceVisible && !readOnly && (
             <div className="replace-row">
               <input
                 ref={replaceInputRef}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -64,13 +64,11 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
   const replaceInputRef = useRef(null);
   const containerRef = useRef(null);
   const initialIndexRef = useRef(null);
-  const visibleRef = useRef(visible);
-  useEffect(() => { visibleRef.current = visible; }, [visible]);
 
   const debouncedSearchText = useDebounce(searchText, 250);
 
-  const doSearch = useCallback((newIndex = 0) => {
-    if (!editor || !visibleRef.current) {
+  const doSearch = useCallback((text, newIndex = 0) => {
+    if (!editor || !visible) {
       return;
     }
 
@@ -79,7 +77,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       searchLineHighlight.current = null;
     }
 
-    if (!debouncedSearchText) {
+    if (!text) {
       setMatchCount(0);
       setMatchIndex(0);
       searchMatches.current = [];
@@ -89,12 +87,12 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     }
 
     try {
-      const newCacheKey = createCacheKey(editor, debouncedSearchText, regex, caseSensitive, wholeWord);
+      const newCacheKey = createCacheKey(editor, text, regex, caseSensitive, wholeWord);
       const isCacheHit = newCacheKey === searchCacheKey.current;
 
       let matches = searchMatches.current;
       if (!isCacheHit) {
-        matches = findSearchMatches(editor, debouncedSearchText, regex, caseSensitive, wholeWord);
+        matches = findSearchMatches(editor, text, regex, caseSensitive, wholeWord);
         searchMatches.current = matches;
         searchCacheKey.current = newCacheKey;
         setMatchCount(matches.length);
@@ -165,7 +163,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       searchMatches.current = [];
       searchCacheKey.current = '';
     }
-  }, [debouncedSearchText, regex, caseSensitive, wholeWord, editor]);
+  }, [regex, caseSensitive, wholeWord, editor, visible]);
 
   const handleSearchBarClose = useCallback(() => {
     searchMarks.current.forEach((mark) => mark.clear());
@@ -206,12 +204,10 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
         // Set both count and index immediately to avoid "1 / N" flash before debounce fires
         setMatchCount(matches.length);
         setMatchIndex(targetIdx);
-        if (text === searchText) {
-          // Same text — debouncedSearchText won't change, effect won't fire. Call directly.
-          setTimeout(() => doSearch(targetIdx), 0);
-        } else {
-          // Text changed — effect will fire after debounce. Store text+index together
-          // so the effect only consumes it when debouncedSearchText has caught up.
+        // Call immediately — text is passed directly, no debounce dependency
+        doSearch(text, targetIdx);
+        // Store so the debounce-fired effect uses the right index instead of 0
+        if (text !== searchText) {
           initialIndexRef.current = { idx: targetIdx, forText: text };
         }
       } else {
@@ -234,12 +230,15 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
   }));
 
   useEffect(() => {
-    if (initialIndexRef.current && initialIndexRef.current.forText === debouncedSearchText) {
-      const idx = initialIndexRef.current.idx;
-      initialIndexRef.current = null;
-      doSearch(idx);
+    if (initialIndexRef.current) {
+      // setSearch has pre-computed a result — wait for debouncedSearchText to catch up
+      if (initialIndexRef.current.forText === debouncedSearchText) {
+        const idx = initialIndexRef.current.idx;
+        initialIndexRef.current = null;
+        doSearch(debouncedSearchText, idx);
+      }
     } else {
-      doSearch(0);
+      doSearch(debouncedSearchText, 0);
     }
   }, [debouncedSearchText, doSearch]);
 
@@ -266,7 +265,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
         searchCacheKey.current = '';
-        doSearch(0);
+        doSearch(debouncedSearchText, 0);
       }, 100);
     };
 
@@ -275,7 +274,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       editor.off('change', handleChange);
       clearTimeout(timeoutId);
     };
-  }, [editor, visible, doSearch]);
+  }, [editor, visible, doSearch, debouncedSearchText]);
 
   const handleSearchTextChange = (text) => {
     setSearchText(text);
@@ -300,13 +299,13 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
   const handleNext = () => {
     if (!searchMatches.current || !searchMatches.current.length) return;
     const next = (matchIndex + 1) % searchMatches.current.length;
-    doSearch(next);
+    doSearch(debouncedSearchText, next);
   };
 
   const handlePrev = () => {
     if (!searchMatches.current || !searchMatches.current.length) return;
     const prev = (matchIndex - 1 + searchMatches.current.length) % searchMatches.current.length;
-    doSearch(prev);
+    doSearch(debouncedSearchText, prev);
   };
 
   const handleReplace = useCallback(() => {
@@ -332,7 +331,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       (m) => m.from.line > endLine || (m.from.line === endLine && m.from.ch >= endCh)
     );
 
-    doSearch(nextIdx >= 0 ? nextIdx : 0);
+    doSearch(debouncedSearchText, nextIdx >= 0 ? nextIdx : 0);
   }, [editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
 
   const handleReplaceAll = useCallback(() => {
@@ -342,8 +341,8 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       matches.forEach((match) => editor.replaceRange(replaceText, match.from, match.to));
     });
     searchCacheKey.current = '';
-    doSearch(0);
-  }, [editor, replaceText, doSearch]);
+    doSearch(debouncedSearchText, 0);
+  }, [editor, replaceText, debouncedSearchText, doSearch]);
 
   const isDebouncing = searchText !== debouncedSearchText;
 

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -52,6 +52,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
       setMatchIndex(0);
       currentMatchIndex.current = 0;
       searchMatches.current = [];
+      searchCacheKey.current = '';
       clearMarks(searchMarks.current);
       return;
     }
@@ -194,13 +195,14 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
   }));
 
   useEffect(() => {
-    if (initialIndexRef.current) {
-      if (initialIndexRef.current.forText === debouncedSearchText) {
-        const idx = initialIndexRef.current.idx;
-        initialIndexRef.current = null;
-        doSearch(debouncedSearchText, idx);
-      }
+    if (initialIndexRef.current && initialIndexRef.current.forText === debouncedSearchText) {
+      // Pre-populated index still matches — honour it and consume it.
+      const idx = initialIndexRef.current.idx;
+      initialIndexRef.current = null;
+      doSearch(debouncedSearchText, idx);
     } else {
+      // Stale or absent initial index — discard and run a normal cursor-anchored search.
+      initialIndexRef.current = null;
       const cursor = editor?.getCursor('from');
       const cursorLine = cursor ? cursor.line : null;
       doSearch(debouncedSearchText, 0, cursorLine);
@@ -281,13 +283,13 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
   };
 
   const handleNext = () => {
-    if (!searchMatches.current || !searchMatches.current.length) return;
+    if (isDebouncing || !searchMatches.current || !searchMatches.current.length) return;
     const next = (matchIndex + 1) % searchMatches.current.length;
     doSearch(debouncedSearchText, next, null, true);
   };
 
   const handlePrev = () => {
-    if (!searchMatches.current || !searchMatches.current.length) return;
+    if (isDebouncing || !searchMatches.current || !searchMatches.current.length) return;
     const prev = (matchIndex - 1 + searchMatches.current.length) % searchMatches.current.length;
     doSearch(debouncedSearchText, prev, null, true);
   };
@@ -315,7 +317,9 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
   const handleReplaceAll = useCallback(() => {
     if (!editor || !searchMatches.current.length) return;
 
-    replaceAll(editor, searchMatches.current, replaceText);
+    // Use an uncapped scan so all matches are replaced, not just the first MAX_MATCHES.
+    const allMatches = findSearchMatches(editor, debouncedSearchText, regex, caseSensitive, wholeWord, Infinity);
+    replaceAll(editor, allMatches, replaceText);
 
     searchCacheKey.current = '';
     doSearch(debouncedSearchText, 0);

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -333,7 +333,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
 
   return (
     <StyledWrapper $replaceVisible={replaceVisible}>
-      <div className="bruno-search-bar" ref={containerRef} data-testid="search-bar">
+      <div className="bruno-search-bar" ref={containerRef} data-testid="codemirror-search-bar">
         <button
           type="button"
           className={`toggle-replace-btn${replaceVisible ? ' active' : ''}`}
@@ -357,7 +357,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
               onChange={(e) => handleSearchTextChange(e.target.value)}
               placeholder="Search..."
               spellCheck={false}
-              data-testid="search-input"
+              data-testid="codemirror-search-input"
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && replaceVisible && !isReplaceDisabled) {
                   e.preventDefault();
@@ -369,19 +369,19 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
                 }
               }}
             />
-            <span className="searchbar-result-count" data-testid="match-count">{matchCount > 0 ? `${matchIndex + 1} / ${matchCount}` : '0 results'}</span>
+            <span className="searchbar-result-count" data-testid="codemirror-search-result-count">{matchCount > 0 ? `${matchIndex + 1} / ${matchCount}` : '0 results'}</span>
             <ToolHint text="Regex search" toolhintId="searchbar-regex-toolhint" place="top">
-              <button type="button" className={`searchbar-icon-btn ${regex ? 'active' : ''}`} onClick={handleToggleRegex} data-testid="search-regex-btn"><IconRegex size={16} /></button>
+              <button type="button" className={`searchbar-icon-btn ${regex ? 'active' : ''}`} onClick={handleToggleRegex} data-testid="codemirror-search-regex-btn"><IconRegex size={16} /></button>
             </ToolHint>
             <ToolHint text="Case sensitive" toolhintId="searchbar-case-toolhint" place="top">
-              <button type="button" className={`searchbar-icon-btn ${caseSensitive ? 'active' : ''}`} onClick={handleToggleCase} data-testid="search-case-btn"><IconLetterCase size={14} /></button>
+              <button type="button" className={`searchbar-icon-btn ${caseSensitive ? 'active' : ''}`} onClick={handleToggleCase} data-testid="codemirror-search-case-btn"><IconLetterCase size={14} /></button>
             </ToolHint>
             <ToolHint text="Whole word" toolhintId="searchbar-wholeword-toolhint" place="top">
-              <button type="button" className={`searchbar-icon-btn ${wholeWord ? 'active' : ''}`} onClick={handleToggleWholeWord} data-testid="search-wholeword-btn"><IconLetterW size={14} /></button>
+              <button type="button" className={`searchbar-icon-btn ${wholeWord ? 'active' : ''}`} onClick={handleToggleWholeWord} data-testid="codemirror-search-wholeword-btn"><IconLetterW size={14} /></button>
             </ToolHint>
-            <button type="button" className="searchbar-icon-btn" title="Previous (Shift+Enter)" onClick={handlePrev} data-testid="search-prev-btn"><IconArrowUp size={14} /></button>
-            <button type="button" className="searchbar-icon-btn" title="Next (Enter)" onClick={handleNext} data-testid="search-next-btn"><IconArrowDown size={14} /></button>
-            <button type="button" className="searchbar-icon-btn" title="Close" onClick={handleSearchBarClose} data-testid="search-close-btn"><IconX size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Previous (Shift+Enter)" onClick={handlePrev} data-testid="codemirror-search-prev-btn"><IconArrowUp size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Next (Enter)" onClick={handleNext} data-testid="codemirror-search-next-btn"><IconArrowDown size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Close" onClick={handleSearchBarClose} data-testid="codemirror-search-close-btn"><IconX size={14} /></button>
           </div>
           {replaceVisible && !readOnly && (
             <div className="replace-row">
@@ -392,7 +392,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
                 onChange={(e) => setReplaceText(e.target.value)}
                 placeholder="Replace..."
                 spellCheck={false}
-                data-testid="replace-input"
+                data-testid="codemirror-search-replace-input"
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !isReplaceDisabled) {
                     e.preventDefault();
@@ -403,10 +403,10 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
                 }}
               />
               <ToolHint text="Replace" toolhintId="searchbar-replace-toolhint" place="top">
-                <button type="button" aria-label="Replace" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplace} data-testid="replace-btn"><IconReplace size={15} /></button>
+                <button type="button" aria-label="Replace" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplace} data-testid="codemirror-search-replace-btn"><IconReplace size={15} /></button>
               </ToolHint>
               <ToolHint text="Replace all" toolhintId="searchbar-replaceall-toolhint" place="top">
-                <button type="button" aria-label="Replace all" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplaceAll} data-testid="replace-all-btn"><IconArrowsExchange2 size={15} /></button>
+                <button type="button" aria-label="Replace all" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplaceAll} data-testid="codemirror-search-replaceall-btn"><IconArrowsExchange2 size={15} /></button>
               </ToolHint>
             </div>
           )}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -27,6 +27,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
   const replaceInputRef = useRef(null);
   const containerRef = useRef(null);
   const initialIndexRef = useRef(null);
+  const pendingSearchIndexRef = useRef(null);
   const rafRef = useRef(null);
 
   const debouncedSearchText = useDebounce(searchText, 250);
@@ -36,7 +37,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     markViewportMatches(editor, searchMatches.current, currentMatchIndex.current, searchMarks.current);
   }, [editor]);
 
-  const doSearch = useCallback((text, newIndex = 0) => {
+  const doSearch = useCallback((text, newIndex = 0, preferLine = null, shouldScroll = false) => {
     if (!editor || !visible) {
       return;
     }
@@ -65,6 +66,11 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
         searchMatches.current = matches;
         searchCacheKey.current = newCacheKey;
         setMatchCount(matches.length);
+
+        if (preferLine !== null && newIndex === 0) {
+          const nearestIdx = matches.findIndex((m) => m.from.line >= preferLine);
+          newIndex = nearestIdx >= 0 ? nearestIdx : 0;
+        }
       }
 
       if (!matches.length) {
@@ -84,8 +90,10 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
       editor.addLineClass(currentLine, 'wrap', 'cm-search-line-highlight');
       searchLineHighlight.current = currentLine;
 
-      editor.scrollIntoView(matches[resolvedIndex].from, 100);
-      editor.setSelection(matches[resolvedIndex].from, matches[resolvedIndex].to);
+      if (shouldScroll) {
+        editor.scrollIntoView(matches[resolvedIndex].from, 100);
+      }
+      editor.setSelection(matches[resolvedIndex].from, matches[resolvedIndex].to, { scroll: false });
     } catch (e) {
       console.error('Search error:', e);
       setMatchCount(0);
@@ -109,6 +117,10 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     setReplaceVisible(false);
     if (onClose) onClose();
     if (editor) {
+      // Collapse the match selection to a cursor so that re-opening the bar
+      // doesn't mistake the highlighted match text for a user selection.
+      const cursor = editor.getCursor('from');
+      editor.setSelection(cursor, cursor, { scroll: false });
       setTimeout(() => editor.focus(), 0);
     }
   }, [editor, onClose]);
@@ -135,12 +147,35 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
         // Set both count and index immediately to avoid "1 / N" flash before debounce fires
         setMatchCount(matches.length);
         setMatchIndex(targetIdx);
-        doSearch(text, targetIdx);
-        if (text !== searchText) {
-          initialIndexRef.current = { idx: targetIdx, forText: text };
-        }
+        doSearch(text, targetIdx, null, true);
+        initialIndexRef.current = { idx: targetIdx, forText: text };
       } else {
         setMatchIndex(0);
+      }
+      setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.focus();
+          inputRef.current.select();
+        }
+      }, 0);
+    },
+    focusAtCursor: (cursorPos) => {
+      // If there's existing search text, navigate to nearest match at cursor
+      if (cursorPos && editor && searchText) {
+        const matches = searchMatches.current.length
+          ? searchMatches.current
+          : findSearchMatches(editor, searchText, regex, caseSensitive, wholeWord);
+        const startsAtOrAfterCursor = (match) =>
+          match.from.line > cursorPos.line
+          || (match.from.line === cursorPos.line && match.from.ch >= cursorPos.ch);
+        const targetIdx = matches.findIndex(startsAtOrAfterCursor);
+        const resolvedIdx = targetIdx >= 0 ? targetIdx : 0;
+        searchMatches.current = matches;
+        searchCacheKey.current = createCacheKey(docVersion.current, searchText, regex, caseSensitive, wholeWord);
+        setMatchCount(matches.length);
+        setMatchIndex(resolvedIdx);
+        initialIndexRef.current = { idx: resolvedIdx, forText: searchText };
+        doSearch(searchText, resolvedIdx);
       }
       setTimeout(() => {
         if (inputRef.current) {
@@ -166,9 +201,11 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
         doSearch(debouncedSearchText, idx);
       }
     } else {
-      doSearch(debouncedSearchText, 0);
+      const cursor = editor?.getCursor('from');
+      const cursorLine = cursor ? cursor.line : null;
+      doSearch(debouncedSearchText, 0, cursorLine);
     }
-  }, [debouncedSearchText, doSearch]);
+  }, [debouncedSearchText, doSearch, editor]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -210,7 +247,9 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
         searchCacheKey.current = '';
-        doSearch(debouncedSearchText, 0);
+        const idx = pendingSearchIndexRef.current ?? 0;
+        pendingSearchIndexRef.current = null;
+        doSearch(debouncedSearchText, idx);
       }, 100);
     };
 
@@ -244,13 +283,13 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
   const handleNext = () => {
     if (!searchMatches.current || !searchMatches.current.length) return;
     const next = (matchIndex + 1) % searchMatches.current.length;
-    doSearch(debouncedSearchText, next);
+    doSearch(debouncedSearchText, next, null, true);
   };
 
   const handlePrev = () => {
     if (!searchMatches.current || !searchMatches.current.length) return;
     const prev = (matchIndex - 1 + searchMatches.current.length) % searchMatches.current.length;
-    doSearch(debouncedSearchText, prev);
+    doSearch(debouncedSearchText, prev, null, true);
   };
 
   const handleReplace = useCallback(() => {
@@ -267,7 +306,10 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     const nextIdx = newMatches.findIndex(
       (m) => m.from.line > endLine || (m.from.line === endLine && m.from.ch >= endCh)
     );
-    doSearch(debouncedSearchText, nextIdx >= 0 ? nextIdx : 0);
+    const resolvedNextIdx = nextIdx >= 0 ? nextIdx : 0;
+    pendingSearchIndexRef.current = resolvedNextIdx;
+    doSearch(debouncedSearchText, resolvedNextIdx, null, true);
+    setTimeout(() => inputRef.current?.focus(), 0);
   }, [editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
 
   const handleReplaceAll = useCallback(() => {
@@ -277,21 +319,24 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
 
     searchCacheKey.current = '';
     doSearch(debouncedSearchText, 0);
+    setTimeout(() => inputRef.current?.focus(), 0);
   }, [editor, replaceText, debouncedSearchText, doSearch]);
 
   const isDebouncing = searchText !== debouncedSearchText;
+  const isReplaceDisabled = isDebouncing || !searchText.trim() || matchCount === 0;
 
   if (!visible) return null;
 
   return (
     <StyledWrapper $replaceVisible={replaceVisible}>
-      <div className="bruno-search-bar" ref={containerRef}>
+      <div className="bruno-search-bar" ref={containerRef} data-testid="search-bar">
         <button
           type="button"
           className={`toggle-replace-btn${replaceVisible ? ' active' : ''}`}
           title={replaceVisible ? 'Hide replace' : 'Show replace'}
           onClick={() => setReplaceVisible((prev) => !prev)}
           style={readOnly ? { display: 'none' } : {}}
+          data-testid="toggle-replace-btn"
         >
           <IconChevronRight
             size={12}
@@ -308,24 +353,31 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
               onChange={(e) => handleSearchTextChange(e.target.value)}
               placeholder="Search..."
               spellCheck={false}
+              data-testid="search-input"
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) handleNext();
-                if (e.key === 'Enter' && e.shiftKey) handlePrev();
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && replaceVisible && !isReplaceDisabled) {
+                  e.preventDefault();
+                  handleReplaceAll();
+                } else if (e.key === 'Enter' && !e.shiftKey) {
+                  handleNext();
+                } else if (e.key === 'Enter' && e.shiftKey) {
+                  handlePrev();
+                }
               }}
             />
-            <span className="searchbar-result-count">{matchCount > 0 ? `${matchIndex + 1} / ${matchCount}` : '0 results'}</span>
+            <span className="searchbar-result-count" data-testid="match-count">{matchCount > 0 ? `${matchIndex + 1} / ${matchCount}` : '0 results'}</span>
             <ToolHint text="Regex search" toolhintId="searchbar-regex-toolhint" place="top">
-              <button type="button" className={`searchbar-icon-btn ${regex ? 'active' : ''}`} onClick={handleToggleRegex}><IconRegex size={16} /></button>
+              <button type="button" className={`searchbar-icon-btn ${regex ? 'active' : ''}`} onClick={handleToggleRegex} data-testid="search-regex-btn"><IconRegex size={16} /></button>
             </ToolHint>
             <ToolHint text="Case sensitive" toolhintId="searchbar-case-toolhint" place="top">
-              <button type="button" className={`searchbar-icon-btn ${caseSensitive ? 'active' : ''}`} onClick={handleToggleCase}><IconLetterCase size={14} /></button>
+              <button type="button" className={`searchbar-icon-btn ${caseSensitive ? 'active' : ''}`} onClick={handleToggleCase} data-testid="search-case-btn"><IconLetterCase size={14} /></button>
             </ToolHint>
             <ToolHint text="Whole word" toolhintId="searchbar-wholeword-toolhint" place="top">
-              <button type="button" className={`searchbar-icon-btn ${wholeWord ? 'active' : ''}`} onClick={handleToggleWholeWord}><IconLetterW size={14} /></button>
+              <button type="button" className={`searchbar-icon-btn ${wholeWord ? 'active' : ''}`} onClick={handleToggleWholeWord} data-testid="search-wholeword-btn"><IconLetterW size={14} /></button>
             </ToolHint>
-            <button type="button" className="searchbar-icon-btn" title="Previous (Shift+Enter)" onClick={handlePrev}><IconArrowUp size={14} /></button>
-            <button type="button" className="searchbar-icon-btn" title="Next (Enter)" onClick={handleNext}><IconArrowDown size={14} /></button>
-            <button type="button" className="searchbar-icon-btn" title="Close" onClick={handleSearchBarClose}><IconX size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Previous (Shift+Enter)" onClick={handlePrev} data-testid="search-prev-btn"><IconArrowUp size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Next (Enter)" onClick={handleNext} data-testid="search-next-btn"><IconArrowDown size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Close" onClick={handleSearchBarClose} data-testid="search-close-btn"><IconX size={14} /></button>
           </div>
           {replaceVisible && !readOnly && (
             <div className="replace-row">
@@ -336,15 +388,21 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
                 onChange={(e) => setReplaceText(e.target.value)}
                 placeholder="Replace..."
                 spellCheck={false}
+                data-testid="replace-input"
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !isDebouncing) handleReplace();
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !isReplaceDisabled) {
+                    e.preventDefault();
+                    handleReplaceAll();
+                  } else if (e.key === 'Enter' && !isReplaceDisabled) {
+                    handleReplace();
+                  }
                 }}
               />
-              <ToolHint text="Replace (Enter)" toolhintId="searchbar-replace-toolhint" place="top">
-                <button type="button" aria-label="Replace" className="searchbar-icon-btn" disabled={isDebouncing} onClick={handleReplace}><IconReplace size={15} /></button>
+              <ToolHint text="Replace" toolhintId="searchbar-replace-toolhint" place="top">
+                <button type="button" aria-label="Replace" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplace} data-testid="replace-btn"><IconReplace size={15} /></button>
               </ToolHint>
               <ToolHint text="Replace all" toolhintId="searchbar-replaceall-toolhint" place="top">
-                <button type="button" aria-label="Replace all" className="searchbar-icon-btn" disabled={isDebouncing} onClick={handleReplaceAll}><IconArrowsExchange2 size={15} /></button>
+                <button type="button" aria-label="Replace all" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplaceAll} data-testid="replace-all-btn"><IconArrowsExchange2 size={15} /></button>
               </ToolHint>
             </div>
           )}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -1,11 +1,11 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
-import { IconRegex, IconArrowUp, IconArrowDown, IconX, IconLetterCase, IconLetterW } from '@tabler/icons';
+import React, { useState, useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
+import { IconRegex, IconArrowUp, IconArrowDown, IconX, IconLetterCase, IconLetterW, IconChevronRight, IconReplace, IconArrowsExchange2 } from '@tabler/icons';
 import ToolHint from 'components/ToolHint';
 import StyledWrapper from './StyledWrapper';
 import useDebounce from 'hooks/useDebounce';
 
 function escapeRegExp(string) {
-  return string.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&');
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 const MAX_MATCHES = 99_999;
@@ -48,6 +48,8 @@ function createCacheKey(editor, searchText, regex, caseSensitive, wholeWord) {
 
 const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
   const [searchText, setSearchText] = useState('');
+  const [replaceText, setReplaceText] = useState('');
+  const [replaceVisible, setReplaceVisible] = useState(false);
   const [regex, setRegex] = useState(false);
   const [caseSensitive, setCaseSensitive] = useState(false);
   const [wholeWord, setWholeWord] = useState(false);
@@ -59,10 +61,16 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
   const searchMatches = useRef([]);
   const searchCacheKey = useRef('');
   const inputRef = useRef(null);
+  const replaceInputRef = useRef(null);
+  const containerRef = useRef(null);
+  const initialIndexRef = useRef(null);
+  const visibleRef = useRef(visible);
+  useEffect(() => { visibleRef.current = visible; }, [visible]);
 
   const debouncedSearchText = useDebounce(searchText, 250);
+
   const doSearch = useCallback((newIndex = 0) => {
-    if (!editor || !visible) {
+    if (!editor || !visibleRef.current) {
       return;
     }
 
@@ -157,19 +165,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
       searchMatches.current = [];
       searchCacheKey.current = '';
     }
-  }, [debouncedSearchText, regex, caseSensitive, wholeWord, editor, visible]);
-
-  useImperativeHandle(ref, () => ({
-    focus: () => {
-      if (inputRef.current) {
-        inputRef.current.focus();
-      }
-    }
-  }));
-
-  useEffect(() => {
-    doSearch(0);
-  }, [debouncedSearchText, doSearch]);
+  }, [debouncedSearchText, regex, caseSensitive, wholeWord, editor]);
 
   const handleSearchBarClose = useCallback(() => {
     searchMarks.current.forEach((mark) => mark.clear());
@@ -180,6 +176,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     }
     searchMatches.current = [];
     searchCacheKey.current = '';
+    setReplaceVisible(false);
     if (onClose) onClose();
     // Focus the editor after closing the search bar
     if (editor) {
@@ -187,9 +184,102 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     }
   }, [editor, onClose]);
 
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    },
+    setSearch: (text, cursorPos) => {
+      setSearchText(text);
+      if (cursorPos && editor && text) {
+        const matches = findSearchMatches(editor, text, regex, caseSensitive, wholeWord);
+        const startsAtOrAfterCursor = (match) =>
+          match.from.line > cursorPos.line
+          || (match.from.line === cursorPos.line && match.from.ch >= cursorPos.ch);
+
+        const matchAtCursorIdx = matches.findIndex(startsAtOrAfterCursor);
+        const targetIdx = matchAtCursorIdx >= 0 ? matchAtCursorIdx : 0;
+        // Pre-populate cache so doSearch hits it regardless of path
+        searchMatches.current = matches;
+        searchCacheKey.current = createCacheKey(editor, text, regex, caseSensitive, wholeWord);
+        // Set both count and index immediately to avoid "1 / N" flash before debounce fires
+        setMatchCount(matches.length);
+        setMatchIndex(targetIdx);
+        if (text === searchText) {
+          // Same text — debouncedSearchText won't change, effect won't fire. Call directly.
+          setTimeout(() => doSearch(targetIdx), 0);
+        } else {
+          // Text changed — effect will fire after debounce. Store text+index together
+          // so the effect only consumes it when debouncedSearchText has caught up.
+          initialIndexRef.current = { idx: targetIdx, forText: text };
+        }
+      } else {
+        setMatchIndex(0);
+      }
+      setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.focus();
+          inputRef.current.select();
+        }
+      }, 0);
+    },
+    openReplace: () => {
+      setReplaceVisible(true);
+      setTimeout(() => replaceInputRef.current?.focus(), 0);
+    },
+    close: () => {
+      handleSearchBarClose();
+    }
+  }));
+
+  useEffect(() => {
+    if (initialIndexRef.current && initialIndexRef.current.forText === debouncedSearchText) {
+      const idx = initialIndexRef.current.idx;
+      initialIndexRef.current = null;
+      doSearch(idx);
+    } else {
+      doSearch(0);
+    }
+  }, [debouncedSearchText, doSearch]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !visible) return;
+
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        handleSearchBarClose();
+      }
+    };
+
+    container.addEventListener('keydown', onKeyDown, true);
+    return () => container.removeEventListener('keydown', onKeyDown, true);
+  }, [visible, handleSearchBarClose]);
+
+  // Re-run search when the document changes (undo, redo, edits)
+  useEffect(() => {
+    if (!editor || !visible) return;
+
+    let timeoutId;
+    const handleChange = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        searchCacheKey.current = '';
+        doSearch(0);
+      }, 100);
+    };
+
+    editor.on('change', handleChange);
+    return () => {
+      editor.off('change', handleChange);
+      clearTimeout(timeoutId);
+    };
+  }, [editor, visible, doSearch]);
+
   const handleSearchTextChange = (text) => {
     setSearchText(text);
-    setMatchIndex(0);
+    // setMatchIndex(0);
   };
 
   const handleToggleRegex = () => {
@@ -219,39 +309,111 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, onClose }, ref) => {
     doSearch(prev);
   };
 
+  const handleReplace = useCallback(() => {
+    if (!editor || !searchMatches.current.length) return;
+    const match = searchMatches.current[matchIndex];
+    if (!match) return;
+    editor.replaceRange(replaceText, match.from, match.to);
+
+    const replaceLines = replaceText.split('\n');
+    const endLine = match.from.line + replaceLines.length - 1;
+    const endCh = replaceLines.length === 1
+      ? match.from.ch + replaceText.length
+      : replaceLines[replaceLines.length - 1].length;
+
+    // Re-search and pre-populate the cache so doSearch uses these results directly
+    const newMatches = findSearchMatches(editor, debouncedSearchText, regex, caseSensitive, wholeWord);
+    searchMatches.current = newMatches;
+    searchCacheKey.current = createCacheKey(editor, debouncedSearchText, regex, caseSensitive, wholeWord);
+    setMatchCount(newMatches.length);
+
+    // Find the first match that starts after the replacement end
+    const nextIdx = newMatches.findIndex(
+      (m) => m.from.line > endLine || (m.from.line === endLine && m.from.ch >= endCh)
+    );
+
+    doSearch(nextIdx >= 0 ? nextIdx : 0);
+  }, [editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
+
+  const handleReplaceAll = useCallback(() => {
+    if (!editor || !searchMatches.current.length) return;
+    const matches = [...searchMatches.current].reverse();
+    editor.operation(() => {
+      matches.forEach((match) => editor.replaceRange(replaceText, match.from, match.to));
+    });
+    searchCacheKey.current = '';
+    doSearch(0);
+  }, [editor, replaceText, doSearch]);
+
+  const isDebouncing = searchText !== debouncedSearchText;
+
   if (!visible) return null;
 
   return (
-    <StyledWrapper>
-      <div className="bruno-search-bar" data-testid="codemirror-search-bar">
-        <input
-          ref={inputRef}
-          data-testid="codemirror-search-input"
-          autoFocus
-          type="text"
-          value={searchText}
-          onChange={(e) => handleSearchTextChange(e.target.value)}
-          placeholder="Search..."
-          spellCheck={false}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) handleNext();
-            if (e.key === 'Enter' && e.shiftKey) handlePrev();
-            if (e.key === 'Escape') handleSearchBarClose();
-          }}
-        />
-        <span className="searchbar-result-count" data-testid="codemirror-search-result-count">{matchCount > 0 ? `${matchIndex + 1} / ${matchCount}` : '0 results'}</span>
-        <ToolHint text="Regex search" toolhintId="searchbar-regex-toolhint" place="top">
-          <button className={`searchbar-icon-btn ${regex ? 'active' : ''}`} onClick={handleToggleRegex}><IconRegex size={16} /></button>
-        </ToolHint>
-        <ToolHint text="Case sensitive" toolhintId="searchbar-case-toolhint" place="top">
-          <button className={`searchbar-icon-btn ${caseSensitive ? 'active' : ''}`} onClick={handleToggleCase}><IconLetterCase size={14} /></button>
-        </ToolHint>
-        <ToolHint text="Whole word" toolhintId="searchbar-wholeword-toolhint" place="top">
-          <button className={`searchbar-icon-btn ${wholeWord ? 'active' : ''}`} onClick={handleToggleWholeWord}><IconLetterW size={14} /></button>
-        </ToolHint>
-        <button className="searchbar-icon-btn" title="Previous" onClick={handlePrev}><IconArrowUp size={14} /></button>
-        <button className="searchbar-icon-btn" title="Next" onClick={handleNext}><IconArrowDown size={14} /></button>
-        <button className="searchbar-icon-btn" title="Close" onClick={handleSearchBarClose}><IconX size={14} /></button>
+    <StyledWrapper $replaceVisible={replaceVisible}>
+      <div className="bruno-search-bar" ref={containerRef}>
+        <button
+          type="button"
+          className="toggle-replace-btn"
+          title={replaceVisible ? 'Hide replace' : 'Show replace'}
+          onClick={() => setReplaceVisible((prev) => !prev)}
+        >
+          <IconChevronRight
+            size={12}
+            style={{ transform: replaceVisible ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }}
+          />
+        </button>
+        <div className="search-replace-rows">
+          <div className="search-row">
+            <input
+              ref={inputRef}
+              autoFocus
+              type="text"
+              value={searchText}
+              onChange={(e) => handleSearchTextChange(e.target.value)}
+              placeholder="Search..."
+              spellCheck={false}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) handleNext();
+                if (e.key === 'Enter' && e.shiftKey) handlePrev();
+              }}
+            />
+            <span className="searchbar-result-count">{matchCount > 0 ? `${matchIndex + 1} / ${matchCount}` : '0 results'}</span>
+            <ToolHint text="Regex search" toolhintId="searchbar-regex-toolhint" place="top">
+              <button type="button" className={`searchbar-icon-btn ${regex ? 'active' : ''}`} onClick={handleToggleRegex}><IconRegex size={16} /></button>
+            </ToolHint>
+            <ToolHint text="Case sensitive" toolhintId="searchbar-case-toolhint" place="top">
+              <button type="button" className={`searchbar-icon-btn ${caseSensitive ? 'active' : ''}`} onClick={handleToggleCase}><IconLetterCase size={14} /></button>
+            </ToolHint>
+            <ToolHint text="Whole word" toolhintId="searchbar-wholeword-toolhint" place="top">
+              <button type="button" className={`searchbar-icon-btn ${wholeWord ? 'active' : ''}`} onClick={handleToggleWholeWord}><IconLetterW size={14} /></button>
+            </ToolHint>
+            <button type="button" className="searchbar-icon-btn" title="Previous (Shift+Enter)" onClick={handlePrev}><IconArrowUp size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Next (Enter)" onClick={handleNext}><IconArrowDown size={14} /></button>
+            <button type="button" className="searchbar-icon-btn" title="Close" onClick={handleSearchBarClose}><IconX size={14} /></button>
+          </div>
+          {replaceVisible && (
+            <div className="replace-row">
+              <input
+                ref={replaceInputRef}
+                type="text"
+                value={replaceText}
+                onChange={(e) => setReplaceText(e.target.value)}
+                placeholder="Replace..."
+                spellCheck={false}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !isDebouncing) handleReplace();
+                }}
+              />
+              <ToolHint text="Replace (Enter)" toolhintId="searchbar-replace-toolhint" place="top">
+                <button type="button" aria-label="Replace" className="searchbar-icon-btn" disabled={isDebouncing} onClick={handleReplace}><IconReplace size={15} /></button>
+              </ToolHint>
+              <ToolHint text="Replace all" toolhintId="searchbar-replaceall-toolhint" place="top">
+                <button type="button" aria-label="Replace all" className="searchbar-icon-btn" disabled={isDebouncing} onClick={handleReplaceAll}><IconArrowsExchange2 size={15} /></button>
+              </ToolHint>
+            </div>
+          )}
+        </div>
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/CodeMirrorSearch/markingUtils.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/markingUtils.js
@@ -1,0 +1,63 @@
+const VIEWPORT_BUFFER = 100;
+
+/**
+ * Clears all existing marks and redraws only matches visible in the current
+ * viewport ± VIEWPORT_BUFFER lines. Always marks the active match regardless
+ * of scroll position.
+ *
+ * @param {CodeMirror.Editor} editor
+ * @param {Array}  matches      - full sorted match list
+ * @param {number} activeIndex  - index of the current match
+ * @param {Array}  marksRef     - mutable ref array to track active marks
+ */
+export function markViewportMatches(editor, matches, activeIndex, marksRef) {
+  marksRef.forEach((mark) => mark.clear());
+  marksRef.length = 0;
+
+  if (!matches.length) return;
+
+  const viewport = editor.getViewport();
+  const fromLine = Math.max(0, viewport.from - VIEWPORT_BUFFER);
+  const toLine = viewport.to + VIEWPORT_BUFFER;
+
+  // Binary search for first match at or after fromLine
+  let lo = 0, hi = matches.length - 1, start = matches.length;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (matches[mid].from.line >= fromLine) {
+      start = mid;
+      hi = mid - 1;
+    } else {
+      lo = mid + 1;
+    }
+  }
+
+  const marked = new Set();
+  for (let i = start; i < matches.length && matches[i].from.line <= toLine; i++) {
+    const mark = editor.markText(matches[i].from, matches[i].to, {
+      className: i === activeIndex ? 'cm-search-current' : 'cm-search-match',
+      clearOnEnter: true
+    });
+    marksRef.push(mark);
+    marked.add(i);
+  }
+
+  // Always mark the active match even if it's outside the viewport
+  if (!marked.has(activeIndex) && matches[activeIndex]) {
+    const mark = editor.markText(matches[activeIndex].from, matches[activeIndex].to, {
+      className: 'cm-search-current',
+      clearOnEnter: true
+    });
+    marksRef.push(mark);
+  }
+}
+
+/**
+ * Clears all active marks.
+ *
+ * @param {Array} marksRef - mutable ref array tracking active marks
+ */
+export function clearMarks(marksRef) {
+  marksRef.forEach((mark) => mark.clear());
+  marksRef.length = 0;
+}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/replaceUtils.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/replaceUtils.js
@@ -1,10 +1,8 @@
 /**
- * Replaces the current match in the editor and returns info needed to find
- * the next match after the replacement.
  *
  * @param {CodeMirror.Editor} editor
- * @param {Array}  matches     - current match list
- * @param {number} matchIndex  - index of the match to replace
+ * @param {Array}  matches
+ * @param {number} matchIndex
  * @param {string} replaceText
  * @returns {{ endLine: number, endCh: number }} - end position of the replacement
  */
@@ -23,17 +21,14 @@ export function replaceSingle(editor, matches, matchIndex, replaceText) {
 }
 
 /**
- * Replaces all matches in the editor in a single undoable operation.
- * Builds a line offset map in one pass to avoid O(n) indexFromPos calls.
  *
  * @param {CodeMirror.Editor} editor
- * @param {Array}  matches     - full match list
+ * @param {Array}  matches
  * @param {string} replaceText
  */
 export function replaceAll(editor, matches, replaceText) {
   const originalText = editor.getValue();
 
-  // Single-pass line offset map — avoids 42k indexFromPos B-tree traversals
   const lineOffsets = new Uint32Array(editor.lineCount());
   let line = 1;
   for (let i = 0; i < originalText.length; i++) {
@@ -52,7 +47,6 @@ export function replaceAll(editor, matches, replaceText) {
   });
   result += originalText.slice(lastIndex);
 
-  // Single replaceRange = one undo step, no per-match change objects
   editor.operation(() => {
     const lastLine = editor.lastLine();
     editor.replaceRange(result, { line: 0, ch: 0 }, { line: lastLine, ch: editor.getLine(lastLine).length });

--- a/packages/bruno-app/src/components/CodeMirrorSearch/replaceUtils.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/replaceUtils.js
@@ -1,0 +1,60 @@
+/**
+ * Replaces the current match in the editor and returns info needed to find
+ * the next match after the replacement.
+ *
+ * @param {CodeMirror.Editor} editor
+ * @param {Array}  matches     - current match list
+ * @param {number} matchIndex  - index of the match to replace
+ * @param {string} replaceText
+ * @returns {{ endLine: number, endCh: number }} - end position of the replacement
+ */
+export function replaceSingle(editor, matches, matchIndex, replaceText) {
+  const match = matches[matchIndex];
+  editor.replaceRange(replaceText, match.from, match.to);
+
+  const replaceLines = replaceText.split('\n');
+  const endLine = match.from.line + replaceLines.length - 1;
+  const endCh
+    = replaceLines.length === 1
+      ? match.from.ch + replaceText.length
+      : replaceLines[replaceLines.length - 1].length;
+
+  return { endLine, endCh };
+}
+
+/**
+ * Replaces all matches in the editor in a single undoable operation.
+ * Builds a line offset map in one pass to avoid O(n) indexFromPos calls.
+ *
+ * @param {CodeMirror.Editor} editor
+ * @param {Array}  matches     - full match list
+ * @param {string} replaceText
+ */
+export function replaceAll(editor, matches, replaceText) {
+  const originalText = editor.getValue();
+
+  // Single-pass line offset map — avoids 42k indexFromPos B-tree traversals
+  const lineOffsets = new Uint32Array(editor.lineCount());
+  let line = 1;
+  for (let i = 0; i < originalText.length; i++) {
+    if (originalText.charCodeAt(i) === 10) {
+      lineOffsets[line++] = i + 1;
+    }
+  }
+
+  let result = '';
+  let lastIndex = 0;
+  matches.forEach(({ from, to }) => {
+    const fromIndex = lineOffsets[from.line] + from.ch;
+    const toIndex = lineOffsets[to.line] + to.ch;
+    result += originalText.slice(lastIndex, fromIndex) + replaceText;
+    lastIndex = toIndex;
+  });
+  result += originalText.slice(lastIndex);
+
+  // Single replaceRange = one undo step, no per-match change objects
+  editor.operation(() => {
+    const lastLine = editor.lastLine();
+    editor.replaceRange(result, { line: 0, ch: 0 }, { line: lastLine, ch: editor.getLine(lastLine).length });
+  });
+}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/replaceUtils.spec.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/replaceUtils.spec.js
@@ -1,0 +1,96 @@
+import { replaceSingle, replaceAll } from './replaceUtils';
+
+describe('replaceSingle', () => {
+  function makeEditor() {
+    return { replaceRange: jest.fn() };
+  }
+
+  it('calls replaceRange with the replacement text and match bounds', () => {
+    const editor = makeEditor();
+    const matches = [{ from: { line: 0, ch: 0 }, to: { line: 0, ch: 3 } }];
+    replaceSingle(editor, matches, 0, 'bar');
+    expect(editor.replaceRange).toHaveBeenCalledWith('bar', { line: 0, ch: 0 }, { line: 0, ch: 3 });
+  });
+
+  it('replaces the correct match when matchIndex > 0', () => {
+    const editor = makeEditor();
+    const matches = [
+      { from: { line: 0, ch: 0 }, to: { line: 0, ch: 3 } },
+      { from: { line: 1, ch: 4 }, to: { line: 1, ch: 7 } }
+    ];
+    replaceSingle(editor, matches, 1, 'qux');
+    expect(editor.replaceRange).toHaveBeenCalledWith('qux', { line: 1, ch: 4 }, { line: 1, ch: 7 });
+  });
+
+  describe('endLine / endCh calculation', () => {
+    it('single-line replacement: endCh = from.ch + replacement length', () => {
+      const result = replaceSingle(makeEditor(), [{ from: { line: 0, ch: 4 }, to: { line: 0, ch: 7 } }], 0, 'hello');
+      expect(result).toEqual({ endLine: 0, endCh: 9 });
+    });
+
+    it('empty string replacement (deletion): endCh = from.ch', () => {
+      const result = replaceSingle(makeEditor(), [{ from: { line: 0, ch: 4 }, to: { line: 0, ch: 7 } }], 0, '');
+      expect(result).toEqual({ endLine: 0, endCh: 4 });
+    });
+
+    it('multi-line replacement: endLine advances, endCh = last line length', () => {
+      const result = replaceSingle(makeEditor(), [{ from: { line: 1, ch: 0 }, to: { line: 1, ch: 3 } }], 0, 'foo\nbar');
+      expect(result).toEqual({ endLine: 2, endCh: 3 });
+    });
+  });
+});
+
+describe('replaceAll', () => {
+  function makeEditor(text) {
+    const lines = text.split('\n');
+    return {
+      getValue: jest.fn(() => text),
+      lineCount: jest.fn(() => lines.length),
+      lastLine: jest.fn(() => lines.length - 1),
+      getLine: jest.fn((n) => lines[n]),
+      replaceRange: jest.fn(),
+      operation: jest.fn((fn) => fn())
+    };
+  }
+
+  it('makes exactly one replaceRange call with the fully reconstructed text', () => {
+    const editor = makeEditor('foo bar foo');
+    const matches = [
+      { from: { line: 0, ch: 0 }, to: { line: 0, ch: 3 } },
+      { from: { line: 0, ch: 8 }, to: { line: 0, ch: 11 } }
+    ];
+    replaceAll(editor, matches, 'qux');
+    expect(editor.operation).toHaveBeenCalled();
+    expect(editor.replaceRange).toHaveBeenCalledTimes(1);
+    expect(editor.replaceRange.mock.calls[0][0]).toBe('qux bar qux');
+  });
+
+  it('deletes matches when replacing with an empty string', () => {
+    const editor = makeEditor('foo bar foo');
+    const matches = [
+      { from: { line: 0, ch: 0 }, to: { line: 0, ch: 3 } },
+      { from: { line: 0, ch: 8 }, to: { line: 0, ch: 11 } }
+    ];
+    replaceAll(editor, matches, '');
+    expect(editor.replaceRange.mock.calls[0][0]).toBe(' bar ');
+  });
+
+  it('handles replacements across multiple lines', () => {
+    const editor = makeEditor('foo\nfoo');
+    const matches = [
+      { from: { line: 0, ch: 0 }, to: { line: 0, ch: 3 } },
+      { from: { line: 1, ch: 0 }, to: { line: 1, ch: 3 } }
+    ];
+    replaceAll(editor, matches, 'bar');
+    expect(editor.replaceRange.mock.calls[0][0]).toBe('bar\nbar');
+  });
+
+  it('replaces the range spanning the entire document', () => {
+    const editor = makeEditor('foo bar');
+    const matches = [{ from: { line: 0, ch: 0 }, to: { line: 0, ch: 3 } }];
+    replaceAll(editor, matches, 'qux');
+    const [, from, to] = editor.replaceRange.mock.calls[0];
+    expect(from).toEqual({ line: 0, ch: 0 });
+    expect(to).toEqual({ line: 0, ch: 7 });
+  });
+});

--- a/packages/bruno-app/src/components/CodeMirrorSearch/searchKeyBindings.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/searchKeyBindings.js
@@ -1,0 +1,48 @@
+/**
+ * Builds the CodeMirror extraKeys entries for the search/replace bar.
+ *
+ * Centralises the key handlers so they stay in sync across every CodeEditor
+ * variant that embeds <CodeMirrorSearch />.
+ *
+ * @param {object} opts
+ * @param {(update: object, cb?: () => void) => void} opts.setState
+ * @param {{ current: object | null }} opts.searchBarRef
+ * @param {() => boolean} opts.isSearchBarVisible
+ * @param {boolean} opts.readOnly
+ */
+export function buildSearchKeyBindings({ setState, searchBarRef, isSearchBarVisible, readOnly }) {
+  const openSearch = (cm) => {
+    const selected = cm.getSelection();
+    const cursor = cm.getCursor('from');
+    setState({ searchBarVisible: true }, () => {
+      if (selected) {
+        searchBarRef.current?.setSearch(selected, cursor);
+      } else {
+        searchBarRef.current?.focusAtCursor(cursor);
+      }
+    });
+  };
+
+  const openReplace = readOnly
+    ? false
+    : () => {
+        setState({ searchBarVisible: true }, () => {
+          searchBarRef.current?.focus();
+          searchBarRef.current?.openReplace();
+        });
+      };
+
+  return {
+    'Cmd-F': openSearch,
+    'Ctrl-F': openSearch,
+    'Cmd-H': openReplace,
+    'Ctrl-H': openReplace,
+    'Cmd-Alt-F': openReplace,
+    'Ctrl-Alt-F': openReplace,
+    'Esc': () => {
+      if (isSearchBarVisible()) {
+        searchBarRef.current?.close();
+      }
+    }
+  };
+}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/searchUtils.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/searchUtils.js
@@ -1,0 +1,60 @@
+const MAX_MATCHES = 99_999;
+
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Finds all matches in the editor for the given search parameters.
+ *
+ * @param {CodeMirror.Editor} editor
+ * @param {string}  searchText
+ * @param {boolean} regex
+ * @param {boolean} caseSensitive
+ * @param {boolean} wholeWord
+ * @returns {Array<{ from: {line, ch}, to: {line, ch} }>}
+ */
+export function findSearchMatches(editor, searchText, regex, caseSensitive, wholeWord) {
+  try {
+    let query, options = {};
+    if (regex) {
+      try {
+        query = new RegExp(searchText, caseSensitive ? 'g' : 'gi');
+      } catch (error) {
+        console.warn('Invalid regex provided in search!', error);
+        return [];
+      }
+    } else if (wholeWord) {
+      const escaped = escapeRegExp(searchText);
+      query = new RegExp(`\\b${escaped}\\b`, caseSensitive ? 'g' : 'gi');
+    } else {
+      query = searchText;
+      options = { caseFold: !caseSensitive };
+    }
+
+    const cursor = editor.getSearchCursor(query, { line: 0, ch: 0 }, options);
+    const out = [];
+    while (cursor.findNext()) {
+      out.push({ from: cursor.from(), to: cursor.to() });
+      if (out.length >= MAX_MATCHES) break;
+    }
+    return out;
+  } catch (e) {
+    console.error('Search error:', e);
+    return [];
+  }
+}
+
+/**
+ * Creates a cache key for the current search state.
+ *
+ * @param {number}  docVersion
+ * @param {string}  searchText
+ * @param {boolean} regex
+ * @param {boolean} caseSensitive
+ * @param {boolean} wholeWord
+ * @returns {string}
+ */
+export function createCacheKey(docVersion, searchText, regex, caseSensitive, wholeWord) {
+  return `${docVersion}⇴${searchText}⇴${regex}⇴${caseSensitive}⇴${wholeWord}`;
+}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/searchUtils.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/searchUtils.js
@@ -14,7 +14,7 @@ function escapeRegExp(string) {
  * @param {boolean} wholeWord
  * @returns {Array<{ from: {line, ch}, to: {line, ch} }>}
  */
-export function findSearchMatches(editor, searchText, regex, caseSensitive, wholeWord) {
+export function findSearchMatches(editor, searchText, regex, caseSensitive, wholeWord, limit = MAX_MATCHES) {
   try {
     let query, options = {};
     if (regex) {
@@ -36,7 +36,7 @@ export function findSearchMatches(editor, searchText, regex, caseSensitive, whol
     const out = [];
     while (cursor.findNext()) {
       out.push({ from: cursor.from(), to: cursor.to() });
-      if (out.length >= MAX_MATCHES) break;
+      if (out.length >= limit) break;
     }
     return out;
   } catch (e) {

--- a/packages/bruno-app/src/components/CodeMirrorSearch/searchUtils.spec.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/searchUtils.spec.js
@@ -1,0 +1,140 @@
+import { findSearchMatches, createCacheKey } from './searchUtils';
+
+function makeMockEditor(matchResults = []) {
+  return {
+    getSearchCursor: jest.fn(() => {
+      let i = -1;
+      return {
+        findNext: () => {
+          i++; return i < matchResults.length;
+        },
+        from: () => matchResults[i]?.from,
+        to: () => matchResults[i]?.to
+      };
+    })
+  };
+}
+
+describe('findSearchMatches', () => {
+  describe('literal search (default)', () => {
+    it('passes caseFold:true for case-insensitive search', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'foo', false, false, false);
+      expect(editor.getSearchCursor).toHaveBeenCalledWith('foo', { line: 0, ch: 0 }, { caseFold: true });
+    });
+
+    it('passes caseFold:false when caseSensitive is true', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'foo', false, true, false);
+      expect(editor.getSearchCursor).toHaveBeenCalledWith('foo', { line: 0, ch: 0 }, { caseFold: false });
+    });
+
+    it('returns all matches from the editor cursor', () => {
+      const matches = [
+        { from: { line: 0, ch: 0 }, to: { line: 0, ch: 3 } },
+        { from: { line: 1, ch: 5 }, to: { line: 1, ch: 8 } }
+      ];
+      const result = findSearchMatches(makeMockEditor(matches), 'foo', false, false, false);
+      expect(result).toEqual(matches);
+    });
+
+    it('returns an empty array when there are no matches', () => {
+      const result = findSearchMatches(makeMockEditor([]), 'foo', false, false, false);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('whole-word search', () => {
+    it('wraps the query in word-boundary regex', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'foo', false, false, true);
+      const [query] = editor.getSearchCursor.mock.calls[0];
+      expect(query).toBeInstanceOf(RegExp);
+      expect(query.source).toBe('\\bfoo\\b');
+    });
+
+    it('is case-insensitive by default', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'foo', false, false, true);
+      const [query] = editor.getSearchCursor.mock.calls[0];
+      expect(query.flags).toContain('i');
+    });
+
+    it('is case-sensitive when caseSensitive=true', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'foo', false, true, true);
+      const [query] = editor.getSearchCursor.mock.calls[0];
+      expect(query.flags).not.toContain('i');
+    });
+
+    it('escapes special regex characters in the search term', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'foo.bar', false, false, true);
+      const [query] = editor.getSearchCursor.mock.calls[0];
+      expect(query.source).toBe('\\bfoo\\.bar\\b');
+    });
+  });
+
+  describe('regex search', () => {
+    it('builds a RegExp from the search text', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'Section \\d+', true, false, false);
+      const [query] = editor.getSearchCursor.mock.calls[0];
+      expect(query).toBeInstanceOf(RegExp);
+      expect(query.source).toBe('Section \\d+');
+    });
+
+    it('is case-insensitive by default', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'foo', true, false, false);
+      const [query] = editor.getSearchCursor.mock.calls[0];
+      expect(query.flags).toContain('i');
+    });
+
+    it('is case-sensitive when caseSensitive=true', () => {
+      const editor = makeMockEditor();
+      findSearchMatches(editor, 'foo', true, true, false);
+      const [query] = editor.getSearchCursor.mock.calls[0];
+      expect(query.flags).not.toContain('i');
+    });
+
+    it('returns [] and skips getSearchCursor for an invalid regex', () => {
+      const editor = makeMockEditor();
+      const result = findSearchMatches(editor, '[invalid', true, false, false);
+      expect(result).toEqual([]);
+      expect(editor.getSearchCursor).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('createCacheKey', () => {
+  it('produces the same key for identical params', () => {
+    expect(createCacheKey(1, 'foo', false, false, false))
+      .toBe(createCacheKey(1, 'foo', false, false, false));
+  });
+
+  it('produces a different key when docVersion changes', () => {
+    expect(createCacheKey(1, 'foo', false, false, false))
+      .not.toBe(createCacheKey(2, 'foo', false, false, false));
+  });
+
+  it('produces a different key when searchText changes', () => {
+    expect(createCacheKey(1, 'foo', false, false, false))
+      .not.toBe(createCacheKey(1, 'bar', false, false, false));
+  });
+
+  it('produces a different key when regex flag changes', () => {
+    expect(createCacheKey(1, 'foo', false, false, false))
+      .not.toBe(createCacheKey(1, 'foo', true, false, false));
+  });
+
+  it('produces a different key when caseSensitive flag changes', () => {
+    expect(createCacheKey(1, 'foo', false, false, false))
+      .not.toBe(createCacheKey(1, 'foo', false, true, false));
+  });
+
+  it('produces a different key when wholeWord flag changes', () => {
+    expect(createCacheKey(1, 'foo', false, false, false))
+      .not.toBe(createCacheKey(1, 'foo', false, false, true));
+  });
+});

--- a/packages/bruno-app/src/components/Documentation/index.js
+++ b/packages/bruno-app/src/components/Documentation/index.js
@@ -72,6 +72,7 @@ const Documentation = ({ item, collection }) => {
             mode="application/text"
             initialScroll={scroll}
             onScroll={setScroll}
+            testId="docs-editor"
           />
           <AIAssist
             scriptType="docs"

--- a/packages/bruno-app/src/components/FileEditor/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/FileEditor/CodeEditor/index.js
@@ -13,6 +13,7 @@ import StyledWrapper from './StyledWrapper';
 import * as jsonlint from '@prantlf/jsonlint';
 import { JSHINT } from 'jshint';
 import CodeMirrorSearch from 'components/CodeMirrorSearch';
+import { buildSearchKeyBindings } from 'components/CodeMirrorSearch/searchKeyBindings';
 let CodeMirror;
 const SERVER_RENDERED = typeof window === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
 
@@ -72,42 +73,12 @@ export default class CodeEditor extends React.Component {
             this.props.toggleFileMode();
           }
         },
-        'Cmd-F': (cm) => {
-          const selected = cm.getSelection();
-          const cursor = cm.getCursor('from');
-          this.setState({ searchBarVisible: true }, () => {
-            if (selected) {
-              this.searchBarRef.current?.setSearch(selected, cursor);
-            } else {
-              this.searchBarRef.current?.focusAtCursor(cursor);
-            }
-          });
-        },
-        'Ctrl-F': (cm) => {
-          const selected = cm.getSelection();
-          const cursor = cm.getCursor('from');
-          this.setState({ searchBarVisible: true }, () => {
-            if (selected) {
-              this.searchBarRef.current?.setSearch(selected, cursor);
-            } else {
-              this.searchBarRef.current?.focusAtCursor(cursor);
-            }
-          });
-        },
-        'Cmd-Alt-F': this.props.readOnly ? false : () => {
-          this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
-            this.searchBarRef.current?.openReplace();
-          });
-        },
-        'Ctrl-Alt-F': this.props.readOnly ? false : () => {
-          this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
-            this.searchBarRef.current?.openReplace();
-          });
-        },
-        'Cmd-H': 'replace',
-        'Ctrl-H': 'replace',
+        ...buildSearchKeyBindings({
+          setState: (update, cb) => this.setState(update, cb),
+          searchBarRef: this.searchBarRef,
+          isSearchBarVisible: () => this.state.searchBarVisible,
+          readOnly: this.props.readOnly
+        }),
         'Tab': function (cm) {
           cm.getSelection().includes('\n') || editor.getLine(cm.getCursor().line) == cm.getSelection()
             ? cm.execCommand('indentMore')
@@ -119,12 +90,7 @@ export default class CodeEditor extends React.Component {
         'Ctrl-Y': 'foldAll',
         'Cmd-Y': 'foldAll',
         'Ctrl-I': 'unfoldAll',
-        'Cmd-I': 'unfoldAll',
-        'Esc': () => {
-          if (this.state.searchBarVisible) {
-            this.searchBarRef.current?.close();
-          }
-        }
+        'Cmd-I': 'unfoldAll'
       }
     }));
     if (editor) {

--- a/packages/bruno-app/src/components/FileEditor/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/FileEditor/CodeEditor/index.js
@@ -72,14 +72,38 @@ export default class CodeEditor extends React.Component {
             this.props.toggleFileMode();
           }
         },
-        'Cmd-F': () => {
+        'Cmd-F': (cm) => {
+          const selected = cm.getSelection();
+          const cursor = cm.getCursor('from');
           this.setState({ searchBarVisible: true }, () => {
-            this.searchBarRef.current?.focus();
+            if (selected) {
+              this.searchBarRef.current?.setSearch(selected, cursor);
+            } else {
+              this.searchBarRef.current?.focusAtCursor(cursor);
+            }
           });
         },
-        'Ctrl-F': () => {
+        'Ctrl-F': (cm) => {
+          const selected = cm.getSelection();
+          const cursor = cm.getCursor('from');
+          this.setState({ searchBarVisible: true }, () => {
+            if (selected) {
+              this.searchBarRef.current?.setSearch(selected, cursor);
+            } else {
+              this.searchBarRef.current?.focusAtCursor(cursor);
+            }
+          });
+        },
+        'Cmd-Alt-F': this.props.readOnly ? false : () => {
           this.setState({ searchBarVisible: true }, () => {
             this.searchBarRef.current?.focus();
+            this.searchBarRef.current?.openReplace();
+          });
+        },
+        'Ctrl-Alt-F': this.props.readOnly ? false : () => {
+          this.setState({ searchBarVisible: true }, () => {
+            this.searchBarRef.current?.focus();
+            this.searchBarRef.current?.openReplace();
           });
         },
         'Cmd-H': 'replace',
@@ -98,7 +122,7 @@ export default class CodeEditor extends React.Component {
         'Cmd-I': 'unfoldAll',
         'Esc': () => {
           if (this.state.searchBarVisible) {
-            this.setState({ searchBarVisible: false });
+            this.searchBarRef.current?.close();
           }
         }
       }
@@ -184,6 +208,7 @@ export default class CodeEditor extends React.Component {
           ref={this.searchBarRef}
           visible={this.state.searchBarVisible}
           editor={this.editor}
+          readOnly={this.props.readOnly}
           onClose={() => this.setState({ searchBarVisible: false })}
         />
         <div

--- a/tests/code-editor/search-replace.spec.ts
+++ b/tests/code-editor/search-replace.spec.ts
@@ -1,13 +1,15 @@
 import { test, expect, Page } from '../../playwright';
-import { closeAllCollections, createCollection, createRequest } from '../utils/page';
 import {
-  buildCodeEditorSearchLocators,
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  createRequest,
   openPreRequestScriptEditor,
   setCodeEditorContent,
   openCodeEditorSearchBar,
   openCodeEditorReplaceBar,
   closeCodeEditorSearchBar
-} from '../utils/page/code-editor-search';
+} from '../utils/page';
 import process from 'node:process';
 
 const cmdKey = process.platform === 'darwin' ? 'Meta' : 'Control';
@@ -27,7 +29,7 @@ const LARGE_DOC = Array.from(
  * Assertion helper — calls expect so it stays in the spec, not the page module.
  */
 async function expectMatchCount(page: Page, expected: string) {
-  const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+  const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
   await expect(loc.matchCount()).toHaveText(expected, { timeout: 1500 });
 }
 
@@ -49,7 +51,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
 
   // Dismiss any leftover search bar and restore the full document before each test.
   test.beforeEach(async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openPreRequestScriptEditor(page, EDITOR_ID);
     if (await loc.searchBar().isVisible()) {
       await loc.searchCloseBtn().click();
@@ -59,35 +61,35 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('Cmd+F opens the search bar', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await expect(loc.searchBar()).toBeVisible();
     await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('Escape closes the search bar', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await page.keyboard.press('Escape');
     await expect(loc.searchBar()).toBeHidden();
   });
 
   test('close button closes the search bar', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchCloseBtn().click();
     await expect(loc.searchBar()).toBeHidden();
   });
 
   test('search input is auto-focused on open', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await expect(loc.searchInput()).toBeFocused();
     await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('Cmd+F with text selected pre-fills the search input', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openPreRequestScriptEditor(page, EDITOR_ID);
     await loc.codeMirror().evaluate((el: any) => {
       if (el.CodeMirror) {
@@ -103,7 +105,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('typing finds all matches in the document', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('lorem');
     await expect(loc.matchCount()).toContainText('/ 400', { timeout: 1500 });
@@ -111,7 +113,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('unknown term shows 0 results', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('xyznothere');
     await expect(loc.matchCount()).toHaveText('0 results', { timeout: 1500 });
@@ -119,7 +121,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('clearing the search input resets match count', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('lorem');
     await expectMatchCount(page, '1 / 400');
@@ -129,7 +131,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('Enter navigates to next match', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
@@ -141,7 +143,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('Shift+Enter goes to previous match and wraps from 1 to last', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
@@ -151,7 +153,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('Next/Prev buttons wrap around', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('lorem');
     await expectMatchCount(page, '1 / 400');
@@ -163,7 +165,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('search anchors to cursor position when opened mid-document', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openPreRequestScriptEditor(page, EDITOR_ID);
     await loc.codeMirror().evaluate((el: any) => {
       if (el.CodeMirror) {
@@ -182,7 +184,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('reopening restores previous search text and resumes from cursor at close', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
@@ -200,7 +202,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('reopening after moving cursor starts from the new cursor position', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
@@ -220,7 +222,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('reopening the search bar does not scroll away from the current viewport', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     // Search, navigate to a match, then close — leaving the match text selected in the editor
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('Section');
@@ -245,7 +247,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('case-sensitive toggle halves matches for mixed-case term', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openCodeEditorSearchBar(page, EDITOR_ID);
     await loc.searchInput().fill('lorem');
     await expectMatchCount(page, '1 / 400');
@@ -257,7 +259,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('replace single replaces current match and advances to next', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await setCodeEditorContent(page, EDITOR_ID, 'foo bar foo baz foo');
     await openCodeEditorReplaceBar(page, EDITOR_ID);
     await loc.searchInput().fill('foo');
@@ -269,7 +271,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('replace all replaces every match', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await setCodeEditorContent(page, EDITOR_ID, 'foo bar foo baz foo');
     await openCodeEditorReplaceBar(page, EDITOR_ID);
     await loc.searchInput().fill('foo');
@@ -282,7 +284,7 @@ test.describe.serial('CodeEditor Search/Replace', () => {
   });
 
   test('match count updates when the document is edited while search is open', async ({ page }) => {
-    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    const loc = buildCommonLocators(page).codeEditorSearch(EDITOR_ID);
     await openPreRequestScriptEditor(page, EDITOR_ID);
     await setCodeEditorContent(page, EDITOR_ID, 'foo bar baz');
     await openCodeEditorSearchBar(page, EDITOR_ID);

--- a/tests/code-editor/search-replace.spec.ts
+++ b/tests/code-editor/search-replace.spec.ts
@@ -1,0 +1,362 @@
+import { test, expect, Page } from '../../playwright';
+import { selectRequestPaneTab, closeAllCollections, createCollection, createRequest } from '../utils/page';
+import process from 'node:process';
+
+const cmdKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+const EDITOR_ID = 'pre-request-script-editor';
+const COLLECTION = 'search-replace-test';
+const REQUEST = 'SearchRequest';
+
+const LARGE_DOC = Array.from(
+  { length: 200 },
+  (_, i) =>
+    `## Section ${i + 1}\n\n`
+    + `Lorem ipsum dolor sit amet, consectetur adipiscing elit. lorem paragraph ${i + 1}.\n`
+    + `Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n`
+).join('\n');
+
+async function openScriptEditor(page: Page) {
+  await selectRequestPaneTab(page, 'Script');
+
+  await page.getByTestId('tab-trigger-pre-request').click();
+  await page.getByTestId(EDITOR_ID).waitFor({ state: 'visible' });
+}
+
+async function setEditorContent(page: Page, content: string) {
+  const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
+  await cm.waitFor({ state: 'visible' });
+  await cm.evaluate((el: any, val: string) => {
+    if (el.CodeMirror) el.CodeMirror.setValue(val);
+  }, content);
+  await page.waitForTimeout(50);
+}
+
+async function resetSearchOptions(page: Page) {
+  for (const testId of ['search-case-btn', 'search-regex-btn', 'search-wholeword-btn']) {
+    const btn = page.getByTestId(EDITOR_ID).getByTestId(testId);
+    const cls = await btn.getAttribute('class');
+    if (cls?.includes('active')) await btn.click();
+  }
+}
+
+async function openSearchBar(page: Page) {
+  await openScriptEditor(page);
+  const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
+  await cm.evaluate((el: any) => {
+    if (el.CodeMirror) {
+      el.CodeMirror.setCursor({ line: 0, ch: 0 });
+      el.CodeMirror.focus();
+    }
+  });
+  await page.keyboard.press(`${cmdKey}+f`);
+  await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
+  await resetSearchOptions(page);
+}
+
+async function openReplaceBar(page: Page) {
+  await openScriptEditor(page);
+  const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
+  await cm.evaluate((el: any) => {
+    if (el.CodeMirror) {
+      el.CodeMirror.setCursor({ line: 0, ch: 0 });
+      el.CodeMirror.focus();
+    }
+  });
+
+  await page.keyboard.press('Control+Alt+f');
+  await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
+  await page.getByTestId(EDITOR_ID).getByTestId('replace-input').waitFor({ state: 'visible' });
+  await resetSearchOptions(page);
+}
+
+async function closeSearchBar(page: Page) {
+  await page.keyboard.press('Escape');
+  await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'hidden' });
+}
+
+async function expectMatchCount(page: Page, expected: string) {
+  await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toHaveText(expected, { timeout: 1500 });
+}
+
+test.describe.serial('CodeEditor Search/Replace', () => {
+  test.beforeAll(async ({ page, createTmpDir }) => {
+    const tmpDir = await createTmpDir('search-replace');
+    await createCollection(page, COLLECTION, tmpDir);
+    await createRequest(page, REQUEST, COLLECTION);
+    await openScriptEditor(page);
+    await setEditorContent(page, LARGE_DOC);
+  });
+
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await openScriptEditor(page);
+    const searchBar = page.getByTestId(EDITOR_ID).getByTestId('search-bar');
+    if (await searchBar.isVisible()) {
+      await page.getByTestId(EDITOR_ID).getByTestId('search-close-btn').click();
+      await searchBar.waitFor({ state: 'hidden' });
+    }
+    await setEditorContent(page, LARGE_DOC);
+  });
+
+  test('Cmd+F opens the search bar', async ({ page }) => {
+    await openSearchBar(page);
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-bar')).toBeVisible();
+    await closeSearchBar(page);
+  });
+
+  test('Escape closes the search bar', async ({ page }) => {
+    await openSearchBar(page);
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-bar')).toBeHidden();
+  });
+
+  test('close button closes the search bar', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-close-btn').click();
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-bar')).toBeHidden();
+  });
+
+  test('search input is auto-focused on open', async ({ page }) => {
+    await openSearchBar(page);
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-input')).toBeFocused();
+    await closeSearchBar(page);
+  });
+
+  test('Cmd+F with text selected pre-fills the search input', async ({ page }) => {
+    await openScriptEditor(page);
+    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
+    await cm.evaluate((el: any) => {
+      if (el.CodeMirror) {
+        el.CodeMirror.setSelection({ line: 0, ch: 3 }, { line: 0, ch: 10 });
+        el.CodeMirror.focus();
+      }
+    });
+    await page.keyboard.press(`${cmdKey}+f`);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-input')).toHaveValue('Section');
+    await expectMatchCount(page, '1 / 200');
+    await closeSearchBar(page);
+  });
+
+  test('typing finds all matches in the document', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('lorem');
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toContainText('/ 400', { timeout: 1500 });
+    await closeSearchBar(page);
+  });
+
+  test('unknown term shows 0 results', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('xyznothere');
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toHaveText('0 results', { timeout: 1500 });
+    await closeSearchBar(page);
+  });
+
+  test('clearing the search input resets match count', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('lorem');
+    await expectMatchCount(page, '1 / 400');
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('');
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toHaveText('0 results', { timeout: 1500 });
+    await closeSearchBar(page);
+  });
+
+  test('Enter navigates to next match', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    await expectMatchCount(page, '1 / 200');
+    await page.keyboard.press('Enter');
+    await expectMatchCount(page, '2 / 200');
+    await page.keyboard.press('Enter');
+    await expectMatchCount(page, '3 / 200');
+    await closeSearchBar(page);
+  });
+
+  test('Shift+Enter goes to previous match and wraps from 1 to last', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    await expectMatchCount(page, '1 / 200');
+    await page.keyboard.press('Shift+Enter');
+    await expectMatchCount(page, '200 / 200');
+    await closeSearchBar(page);
+  });
+
+  test('Next/Prev buttons wrap around', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('lorem');
+    await expectMatchCount(page, '1 / 400');
+
+    await page.getByTestId(EDITOR_ID).getByTestId('search-prev-btn').click();
+    await expectMatchCount(page, '400 / 400');
+
+    await page.getByTestId(EDITOR_ID).getByTestId('search-next-btn').click();
+    await expectMatchCount(page, '1 / 400');
+
+    await closeSearchBar(page);
+  });
+
+  test('search anchors to cursor position when opened mid-document', async ({ page }) => {
+    await openScriptEditor(page);
+
+    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
+    await cm.evaluate((el: any) => {
+      if (el.CodeMirror) {
+        el.CodeMirror.setCursor({ line: 500, ch: 0 });
+        el.CodeMirror.focus();
+      }
+    });
+
+    await page.keyboard.press(`${cmdKey}+f`);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
+
+    await cm.evaluate((el: any) => {
+      if (el.CodeMirror) el.CodeMirror.setCursor({ line: 500, ch: 0 });
+    });
+
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    await expectMatchCount(page, '101 / 200');
+
+    await closeSearchBar(page);
+  });
+
+  test('reopening restores previous search text and resumes from cursor at close', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    await expectMatchCount(page, '1 / 200');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await expectMatchCount(page, '3 / 200');
+    await closeSearchBar(page);
+
+    await page.keyboard.press(`${cmdKey}+f`);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
+
+    // Text is preserved; match resumes from Section 3 where the cursor was left
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-input')).toHaveValue('Section');
+    await expectMatchCount(page, '3 / 200');
+
+    await closeSearchBar(page);
+  });
+
+  test('reopening after moving cursor starts from the new cursor position', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    await expectMatchCount(page, '1 / 200');
+    await closeSearchBar(page);
+
+    // Simulate scroll + click somewhere else in the document, cursor moves to Section 101 (line 500)
+    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
+    await cm.evaluate((el: any) => {
+      if (el.CodeMirror) {
+        el.CodeMirror.setCursor({ line: 500, ch: 0 });
+        el.CodeMirror.focus();
+      }
+    });
+
+    await page.keyboard.press(`${cmdKey}+f`);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
+
+    await expectMatchCount(page, '101 / 200');
+
+    await closeSearchBar(page);
+  });
+
+  test('reopening the search bar does not scroll away from the current viewport', async ({ page }) => {
+    // Search, navigate to a match, then close — leaving the match text selected in the editor
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    await expectMatchCount(page, '1 / 200');
+    await closeSearchBar(page);
+
+    // Scroll to the middle of the document without moving the cursor
+    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
+    await cm.evaluate((el: any) => {
+      if (el.CodeMirror) {
+        el.CodeMirror.scrollTo(null, el.CodeMirror.heightAtLine(500, 'local'));
+      }
+    });
+
+    const scrollBefore = await cm.evaluate((el: any) => el.CodeMirror?.getScrollInfo().top ?? 0);
+
+    // Reopen — previously this would re-detect the selected match text and scroll back to it
+    await page.keyboard.press(`${cmdKey}+f`);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
+
+    const scrollAfter = await cm.evaluate((el: any) => el.CodeMirror?.getScrollInfo().top ?? 0);
+    expect(Math.abs(scrollAfter - scrollBefore)).toBeLessThan(50);
+
+    await closeSearchBar(page);
+  });
+
+  test('case-sensitive toggle halves matches for mixed-case term', async ({ page }) => {
+    await openSearchBar(page);
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('lorem');
+    await expectMatchCount(page, '1 / 400');
+
+    await page.getByTestId(EDITOR_ID).getByTestId('search-case-btn').click();
+    await expectMatchCount(page, '1 / 200');
+
+    await page.getByTestId(EDITOR_ID).getByTestId('search-case-btn').click();
+    await expectMatchCount(page, '1 / 400');
+
+    await closeSearchBar(page);
+  });
+
+  test('replace single replaces current match and advances to next', async ({ page }) => {
+    await setEditorContent(page, 'foo bar foo baz foo');
+    await openReplaceBar(page);
+
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('foo');
+    await expectMatchCount(page, '1 / 3');
+
+    await page.getByTestId(EDITOR_ID).getByTestId('replace-input').fill('qux');
+    await page.getByTestId(EDITOR_ID).getByTestId('replace-btn').click();
+
+    await expectMatchCount(page, '1 / 2');
+
+    await closeSearchBar(page);
+  });
+
+  test('replace all replaces every match', async ({ page }) => {
+    await setEditorContent(page, 'foo bar foo baz foo');
+    await openReplaceBar(page);
+
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('foo');
+    await expectMatchCount(page, '1 / 3');
+
+    await page.getByTestId(EDITOR_ID).getByTestId('replace-input').fill('qux');
+    await page.getByTestId(EDITOR_ID).getByTestId('replace-all-btn').click();
+
+    await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toHaveText('0 results', { timeout: 1500 });
+
+    await closeSearchBar(page);
+
+    await setEditorContent(page, LARGE_DOC);
+  });
+
+  test('match count updates when the document is edited while search is open', async ({ page }) => {
+    await openScriptEditor(page);
+    await setEditorContent(page, 'foo bar baz');
+    await openSearchBar(page);
+
+    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('foo');
+    await expectMatchCount(page, '1 / 1');
+
+    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
+    await cm.evaluate((el: any) => {
+      if (el.CodeMirror) {
+        const lastLine = el.CodeMirror.lastLine();
+        const lastCh = el.CodeMirror.getLine(lastLine).length;
+        el.CodeMirror.replaceRange(' foo', { line: lastLine, ch: lastCh });
+      }
+    });
+
+    await expectMatchCount(page, '1 / 2');
+
+    await closeSearchBar(page);
+    await setEditorContent(page, LARGE_DOC);
+  });
+});

--- a/tests/code-editor/search-replace.spec.ts
+++ b/tests/code-editor/search-replace.spec.ts
@@ -1,5 +1,13 @@
 import { test, expect, Page } from '../../playwright';
-import { selectRequestPaneTab, closeAllCollections, createCollection, createRequest } from '../utils/page';
+import { closeAllCollections, createCollection, createRequest } from '../utils/page';
+import {
+  buildCodeEditorSearchLocators,
+  openPreRequestScriptEditor,
+  setCodeEditorContent,
+  openCodeEditorSearchBar,
+  openCodeEditorReplaceBar,
+  closeCodeEditorSearchBar
+} from '../utils/page/code-editor-search';
 import process from 'node:process';
 
 const cmdKey = process.platform === 'darwin' ? 'Meta' : 'Control';
@@ -15,348 +23,280 @@ const LARGE_DOC = Array.from(
     + `Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n`
 ).join('\n');
 
-async function openScriptEditor(page: Page) {
-  await selectRequestPaneTab(page, 'Script');
-
-  await page.getByTestId('tab-trigger-pre-request').click();
-  await page.getByTestId(EDITOR_ID).waitFor({ state: 'visible' });
-}
-
-async function setEditorContent(page: Page, content: string) {
-  const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
-  await cm.waitFor({ state: 'visible' });
-  await cm.evaluate((el: any, val: string) => {
-    if (el.CodeMirror) el.CodeMirror.setValue(val);
-  }, content);
-  await page.waitForTimeout(50);
-}
-
-async function resetSearchOptions(page: Page) {
-  for (const testId of ['search-case-btn', 'search-regex-btn', 'search-wholeword-btn']) {
-    const btn = page.getByTestId(EDITOR_ID).getByTestId(testId);
-    const cls = await btn.getAttribute('class');
-    if (cls?.includes('active')) await btn.click();
-  }
-}
-
-async function openSearchBar(page: Page) {
-  await openScriptEditor(page);
-  const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
-  await cm.evaluate((el: any) => {
-    if (el.CodeMirror) {
-      el.CodeMirror.setCursor({ line: 0, ch: 0 });
-      el.CodeMirror.focus();
-    }
-  });
-  await page.keyboard.press(`${cmdKey}+f`);
-  await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
-  await resetSearchOptions(page);
-}
-
-async function openReplaceBar(page: Page) {
-  await openScriptEditor(page);
-  const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
-  await cm.evaluate((el: any) => {
-    if (el.CodeMirror) {
-      el.CodeMirror.setCursor({ line: 0, ch: 0 });
-      el.CodeMirror.focus();
-    }
-  });
-
-  await page.keyboard.press('Control+Alt+f');
-  await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
-  await page.getByTestId(EDITOR_ID).getByTestId('replace-input').waitFor({ state: 'visible' });
-  await resetSearchOptions(page);
-}
-
-async function closeSearchBar(page: Page) {
-  await page.keyboard.press('Escape');
-  await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'hidden' });
-}
-
+/**
+ * Assertion helper — calls expect so it stays in the spec, not the page module.
+ */
 async function expectMatchCount(page: Page, expected: string) {
-  await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toHaveText(expected, { timeout: 1500 });
+  const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+  await expect(loc.matchCount()).toHaveText(expected, { timeout: 1500 });
 }
 
+// Serial so each test sees the editor state left by the previous one (shared CM instance).
 test.describe.serial('CodeEditor Search/Replace', () => {
+  // Create the collection + request once and seed the editor with LARGE_DOC.
   test.beforeAll(async ({ page, createTmpDir }) => {
     const tmpDir = await createTmpDir('search-replace');
     await createCollection(page, COLLECTION, tmpDir);
     await createRequest(page, REQUEST, COLLECTION);
-    await openScriptEditor(page);
-    await setEditorContent(page, LARGE_DOC);
+    await openPreRequestScriptEditor(page, EDITOR_ID);
+    await setCodeEditorContent(page, EDITOR_ID, LARGE_DOC);
   });
 
+  // Remove the collection so the workspace is clean for the next suite.
   test.afterAll(async ({ page }) => {
     await closeAllCollections(page);
   });
 
+  // Dismiss any leftover search bar and restore the full document before each test.
   test.beforeEach(async ({ page }) => {
-    await openScriptEditor(page);
-    const searchBar = page.getByTestId(EDITOR_ID).getByTestId('search-bar');
-    if (await searchBar.isVisible()) {
-      await page.getByTestId(EDITOR_ID).getByTestId('search-close-btn').click();
-      await searchBar.waitFor({ state: 'hidden' });
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openPreRequestScriptEditor(page, EDITOR_ID);
+    if (await loc.searchBar().isVisible()) {
+      await loc.searchCloseBtn().click();
+      await loc.searchBar().waitFor({ state: 'hidden' });
     }
-    await setEditorContent(page, LARGE_DOC);
+    await setCodeEditorContent(page, EDITOR_ID, LARGE_DOC);
   });
 
   test('Cmd+F opens the search bar', async ({ page }) => {
-    await openSearchBar(page);
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-bar')).toBeVisible();
-    await closeSearchBar(page);
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await expect(loc.searchBar()).toBeVisible();
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('Escape closes the search bar', async ({ page }) => {
-    await openSearchBar(page);
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
     await page.keyboard.press('Escape');
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-bar')).toBeHidden();
+    await expect(loc.searchBar()).toBeHidden();
   });
 
   test('close button closes the search bar', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-close-btn').click();
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-bar')).toBeHidden();
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchCloseBtn().click();
+    await expect(loc.searchBar()).toBeHidden();
   });
 
   test('search input is auto-focused on open', async ({ page }) => {
-    await openSearchBar(page);
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-input')).toBeFocused();
-    await closeSearchBar(page);
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await expect(loc.searchInput()).toBeFocused();
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('Cmd+F with text selected pre-fills the search input', async ({ page }) => {
-    await openScriptEditor(page);
-    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
-    await cm.evaluate((el: any) => {
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openPreRequestScriptEditor(page, EDITOR_ID);
+    await loc.codeMirror().evaluate((el: any) => {
       if (el.CodeMirror) {
         el.CodeMirror.setSelection({ line: 0, ch: 3 }, { line: 0, ch: 10 });
         el.CodeMirror.focus();
       }
     });
     await page.keyboard.press(`${cmdKey}+f`);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-input')).toHaveValue('Section');
+    await loc.searchBar().waitFor({ state: 'visible' });
+    await expect(loc.searchInput()).toHaveValue('Section');
     await expectMatchCount(page, '1 / 200');
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('typing finds all matches in the document', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('lorem');
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toContainText('/ 400', { timeout: 1500 });
-    await closeSearchBar(page);
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('lorem');
+    await expect(loc.matchCount()).toContainText('/ 400', { timeout: 1500 });
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('unknown term shows 0 results', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('xyznothere');
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toHaveText('0 results', { timeout: 1500 });
-    await closeSearchBar(page);
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('xyznothere');
+    await expect(loc.matchCount()).toHaveText('0 results', { timeout: 1500 });
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('clearing the search input resets match count', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('lorem');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('lorem');
     await expectMatchCount(page, '1 / 400');
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('');
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toHaveText('0 results', { timeout: 1500 });
-    await closeSearchBar(page);
+    await loc.searchInput().fill('');
+    await expect(loc.matchCount()).toHaveText('0 results', { timeout: 1500 });
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('Enter navigates to next match', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
     await page.keyboard.press('Enter');
     await expectMatchCount(page, '2 / 200');
     await page.keyboard.press('Enter');
     await expectMatchCount(page, '3 / 200');
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('Shift+Enter goes to previous match and wraps from 1 to last', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
     await page.keyboard.press('Shift+Enter');
     await expectMatchCount(page, '200 / 200');
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('Next/Prev buttons wrap around', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('lorem');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('lorem');
     await expectMatchCount(page, '1 / 400');
-
-    await page.getByTestId(EDITOR_ID).getByTestId('search-prev-btn').click();
+    await loc.searchPrevBtn().click();
     await expectMatchCount(page, '400 / 400');
-
-    await page.getByTestId(EDITOR_ID).getByTestId('search-next-btn').click();
+    await loc.searchNextBtn().click();
     await expectMatchCount(page, '1 / 400');
-
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('search anchors to cursor position when opened mid-document', async ({ page }) => {
-    await openScriptEditor(page);
-
-    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
-    await cm.evaluate((el: any) => {
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openPreRequestScriptEditor(page, EDITOR_ID);
+    await loc.codeMirror().evaluate((el: any) => {
       if (el.CodeMirror) {
         el.CodeMirror.setCursor({ line: 500, ch: 0 });
         el.CodeMirror.focus();
       }
     });
-
     await page.keyboard.press(`${cmdKey}+f`);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
-
-    await cm.evaluate((el: any) => {
+    await loc.searchBar().waitFor({ state: 'visible' });
+    await loc.codeMirror().evaluate((el: any) => {
       if (el.CodeMirror) el.CodeMirror.setCursor({ line: 500, ch: 0 });
     });
-
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    await loc.searchInput().fill('Section');
     await expectMatchCount(page, '101 / 200');
-
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('reopening restores previous search text and resumes from cursor at close', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
     await page.keyboard.press('Enter');
     await page.keyboard.press('Enter');
     await expectMatchCount(page, '3 / 200');
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
 
     await page.keyboard.press(`${cmdKey}+f`);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
-
+    await loc.searchBar().waitFor({ state: 'visible' });
     // Text is preserved; match resumes from Section 3 where the cursor was left
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('search-input')).toHaveValue('Section');
+    await expect(loc.searchInput()).toHaveValue('Section');
     await expectMatchCount(page, '3 / 200');
-
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('reopening after moving cursor starts from the new cursor position', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
 
     // Simulate scroll + click somewhere else in the document, cursor moves to Section 101 (line 500)
-    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
-    await cm.evaluate((el: any) => {
+    await loc.codeMirror().evaluate((el: any) => {
       if (el.CodeMirror) {
         el.CodeMirror.setCursor({ line: 500, ch: 0 });
         el.CodeMirror.focus();
       }
     });
-
     await page.keyboard.press(`${cmdKey}+f`);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
-
+    await loc.searchBar().waitFor({ state: 'visible' });
     await expectMatchCount(page, '101 / 200');
-
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('reopening the search bar does not scroll away from the current viewport', async ({ page }) => {
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
     // Search, navigate to a match, then close — leaving the match text selected in the editor
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('Section');
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('Section');
     await expectMatchCount(page, '1 / 200');
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
 
     // Scroll to the middle of the document without moving the cursor
-    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
-    await cm.evaluate((el: any) => {
+    await loc.codeMirror().evaluate((el: any) => {
       if (el.CodeMirror) {
         el.CodeMirror.scrollTo(null, el.CodeMirror.heightAtLine(500, 'local'));
       }
     });
-
-    const scrollBefore = await cm.evaluate((el: any) => el.CodeMirror?.getScrollInfo().top ?? 0);
+    const scrollBefore = await loc.codeMirror().evaluate((el: any) => el.CodeMirror?.getScrollInfo().top ?? 0);
 
     // Reopen — previously this would re-detect the selected match text and scroll back to it
     await page.keyboard.press(`${cmdKey}+f`);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-bar').waitFor({ state: 'visible' });
-
-    const scrollAfter = await cm.evaluate((el: any) => el.CodeMirror?.getScrollInfo().top ?? 0);
+    await loc.searchBar().waitFor({ state: 'visible' });
+    const scrollAfter = await loc.codeMirror().evaluate((el: any) => el.CodeMirror?.getScrollInfo().top ?? 0);
     expect(Math.abs(scrollAfter - scrollBefore)).toBeLessThan(50);
 
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('case-sensitive toggle halves matches for mixed-case term', async ({ page }) => {
-    await openSearchBar(page);
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('lorem');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('lorem');
     await expectMatchCount(page, '1 / 400');
-
-    await page.getByTestId(EDITOR_ID).getByTestId('search-case-btn').click();
+    await loc.searchCaseBtn().click();
     await expectMatchCount(page, '1 / 200');
-
-    await page.getByTestId(EDITOR_ID).getByTestId('search-case-btn').click();
+    await loc.searchCaseBtn().click();
     await expectMatchCount(page, '1 / 400');
-
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('replace single replaces current match and advances to next', async ({ page }) => {
-    await setEditorContent(page, 'foo bar foo baz foo');
-    await openReplaceBar(page);
-
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('foo');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await setCodeEditorContent(page, EDITOR_ID, 'foo bar foo baz foo');
+    await openCodeEditorReplaceBar(page, EDITOR_ID);
+    await loc.searchInput().fill('foo');
     await expectMatchCount(page, '1 / 3');
-
-    await page.getByTestId(EDITOR_ID).getByTestId('replace-input').fill('qux');
-    await page.getByTestId(EDITOR_ID).getByTestId('replace-btn').click();
-
+    await loc.replaceInput().fill('qux');
+    await loc.replaceBtn().click();
     await expectMatchCount(page, '1 / 2');
-
-    await closeSearchBar(page);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
   });
 
   test('replace all replaces every match', async ({ page }) => {
-    await setEditorContent(page, 'foo bar foo baz foo');
-    await openReplaceBar(page);
-
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('foo');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await setCodeEditorContent(page, EDITOR_ID, 'foo bar foo baz foo');
+    await openCodeEditorReplaceBar(page, EDITOR_ID);
+    await loc.searchInput().fill('foo');
     await expectMatchCount(page, '1 / 3');
-
-    await page.getByTestId(EDITOR_ID).getByTestId('replace-input').fill('qux');
-    await page.getByTestId(EDITOR_ID).getByTestId('replace-all-btn').click();
-
-    await expect(page.getByTestId(EDITOR_ID).getByTestId('match-count')).toHaveText('0 results', { timeout: 1500 });
-
-    await closeSearchBar(page);
-
-    await setEditorContent(page, LARGE_DOC);
+    await loc.replaceInput().fill('qux');
+    await loc.replaceAllBtn().click();
+    await expect(loc.matchCount()).toHaveText('0 results', { timeout: 1500 });
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
+    await setCodeEditorContent(page, EDITOR_ID, LARGE_DOC);
   });
 
   test('match count updates when the document is edited while search is open', async ({ page }) => {
-    await openScriptEditor(page);
-    await setEditorContent(page, 'foo bar baz');
-    await openSearchBar(page);
-
-    await page.getByTestId(EDITOR_ID).getByTestId('search-input').fill('foo');
+    const loc = buildCodeEditorSearchLocators(page, EDITOR_ID);
+    await openPreRequestScriptEditor(page, EDITOR_ID);
+    await setCodeEditorContent(page, EDITOR_ID, 'foo bar baz');
+    await openCodeEditorSearchBar(page, EDITOR_ID);
+    await loc.searchInput().fill('foo');
     await expectMatchCount(page, '1 / 1');
-
-    const cm = page.getByTestId(EDITOR_ID).locator('.CodeMirror').first();
-    await cm.evaluate((el: any) => {
+    await loc.codeMirror().evaluate((el: any) => {
       if (el.CodeMirror) {
         const lastLine = el.CodeMirror.lastLine();
         const lastCh = el.CodeMirror.getLine(lastLine).length;
         el.CodeMirror.replaceRange(' foo', { line: lastLine, ch: lastCh });
       }
     });
-
     await expectMatchCount(page, '1 / 2');
-
-    await closeSearchBar(page);
-    await setEditorContent(page, LARGE_DOC);
+    await closeCodeEditorSearchBar(page, EDITOR_ID);
+    await setCodeEditorContent(page, EDITOR_ID, LARGE_DOC);
   });
 });

--- a/tests/utils/page/code-editor-search.ts
+++ b/tests/utils/page/code-editor-search.ts
@@ -14,18 +14,18 @@ export const buildCodeEditorSearchLocators = (page: Page, editorId: string) => {
   return {
     editor: () => page.getByTestId(editorId),
     codeMirror: () => page.getByTestId(editorId).locator('.CodeMirror').first(),
-    searchBar: () => scoped('search-bar'),
-    searchInput: () => scoped('search-input'),
-    replaceInput: () => scoped('replace-input'),
-    matchCount: () => scoped('match-count'),
-    searchRegexBtn: () => scoped('search-regex-btn'),
-    searchCaseBtn: () => scoped('search-case-btn'),
-    searchWholeWordBtn: () => scoped('search-wholeword-btn'),
-    searchPrevBtn: () => scoped('search-prev-btn'),
-    searchNextBtn: () => scoped('search-next-btn'),
-    searchCloseBtn: () => scoped('search-close-btn'),
-    replaceBtn: () => scoped('replace-btn'),
-    replaceAllBtn: () => scoped('replace-all-btn')
+    searchBar: () => scoped('codemirror-search-bar'),
+    searchInput: () => scoped('codemirror-search-input'),
+    replaceInput: () => scoped('codemirror-search-replace-input'),
+    matchCount: () => scoped('codemirror-search-result-count'),
+    searchRegexBtn: () => scoped('codemirror-search-regex-btn'),
+    searchCaseBtn: () => scoped('codemirror-search-case-btn'),
+    searchWholeWordBtn: () => scoped('codemirror-search-wholeword-btn'),
+    searchPrevBtn: () => scoped('codemirror-search-prev-btn'),
+    searchNextBtn: () => scoped('codemirror-search-next-btn'),
+    searchCloseBtn: () => scoped('codemirror-search-close-btn'),
+    replaceBtn: () => scoped('codemirror-search-replace-btn'),
+    replaceAllBtn: () => scoped('codemirror-search-replaceall-btn')
   };
 };
 

--- a/tests/utils/page/code-editor-search.ts
+++ b/tests/utils/page/code-editor-search.ts
@@ -1,0 +1,112 @@
+import { Page } from '../../../playwright';
+import { selectRequestPaneTab } from './actions';
+import process from 'node:process';
+
+const cmdKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+/**
+ * Locators for the CodeMirrorSearch bar, scoped to a specific editor identified by testId.
+ * Every locator is a function so Playwright re-evaluates the selector on each call,
+ * keeping them resilient to React re-renders.
+ */
+export const buildCodeEditorSearchLocators = (page: Page, editorId: string) => {
+  const scoped = (testId: string) => page.getByTestId(editorId).getByTestId(testId);
+  return {
+    editor: () => page.getByTestId(editorId),
+    codeMirror: () => page.getByTestId(editorId).locator('.CodeMirror').first(),
+    searchBar: () => scoped('search-bar'),
+    searchInput: () => scoped('search-input'),
+    replaceInput: () => scoped('replace-input'),
+    matchCount: () => scoped('match-count'),
+    searchRegexBtn: () => scoped('search-regex-btn'),
+    searchCaseBtn: () => scoped('search-case-btn'),
+    searchWholeWordBtn: () => scoped('search-wholeword-btn'),
+    searchPrevBtn: () => scoped('search-prev-btn'),
+    searchNextBtn: () => scoped('search-next-btn'),
+    searchCloseBtn: () => scoped('search-close-btn'),
+    replaceBtn: () => scoped('replace-btn'),
+    replaceAllBtn: () => scoped('replace-all-btn')
+  };
+};
+
+/**
+ * Navigate to the Script > Pre Request tab and wait for the given editor to appear.
+ */
+export const openPreRequestScriptEditor = async (page: Page, editorId: string) => {
+  await selectRequestPaneTab(page, 'Script');
+  await page.getByTestId('tab-trigger-pre-request').click();
+  await page.getByTestId(editorId).waitFor({ state: 'visible' });
+};
+
+/**
+ * Replace the full CodeMirror editor content via the CM API (bypasses slow keyboard input).
+ */
+export const setCodeEditorContent = async (page: Page, editorId: string, content: string) => {
+  const cm = page.getByTestId(editorId).locator('.CodeMirror').first();
+  await cm.waitFor({ state: 'visible' });
+  await cm.evaluate((el: any, val: string) => {
+    if (el.CodeMirror) el.CodeMirror.setValue(val);
+  }, content);
+  await page.waitForTimeout(50);
+};
+
+/**
+ * Deactivate any active search option toggles (case, regex, whole-word).
+ * Call before opening the search bar in tests that care about a clean option state.
+ */
+export const resetCodeEditorSearchOptions = async (page: Page, editorId: string) => {
+  const loc = buildCodeEditorSearchLocators(page, editorId);
+  for (const btn of [loc.searchCaseBtn(), loc.searchRegexBtn(), loc.searchWholeWordBtn()]) {
+    const cls = await btn.getAttribute('class');
+    if (cls?.includes('active')) await btn.click();
+  }
+};
+
+/**
+ * Open the search bar via Cmd/Ctrl+F, reset all option toggles, and wait for the bar.
+ */
+export const openCodeEditorSearchBar = async (page: Page, editorId: string) => {
+  await openPreRequestScriptEditor(page, editorId);
+  const cm = page.getByTestId(editorId).locator('.CodeMirror').first();
+  await cm.evaluate((el: any) => {
+    if (el.CodeMirror) {
+      el.CodeMirror.setCursor({ line: 0, ch: 0 });
+      el.CodeMirror.focus();
+    }
+  });
+  await page.keyboard.press(`${cmdKey}+f`);
+  const loc = buildCodeEditorSearchLocators(page, editorId);
+  await loc.searchBar().waitFor({ state: 'visible' });
+  await resetCodeEditorSearchOptions(page, editorId);
+};
+
+/**
+ * Open the replace bar via Ctrl+Alt+F and wait for both the search bar and replace input.
+ *
+ * Uses the keyboard shortcut rather than clicking toggle-replace-btn to avoid CI failures
+ * where the sidebar can overlap the button.
+ */
+export const openCodeEditorReplaceBar = async (page: Page, editorId: string) => {
+  await openPreRequestScriptEditor(page, editorId);
+  const cm = page.getByTestId(editorId).locator('.CodeMirror').first();
+  await cm.evaluate((el: any) => {
+    if (el.CodeMirror) {
+      el.CodeMirror.setCursor({ line: 0, ch: 0 });
+      el.CodeMirror.focus();
+    }
+  });
+  await page.keyboard.press('Control+Alt+f');
+  const loc = buildCodeEditorSearchLocators(page, editorId);
+  await loc.searchBar().waitFor({ state: 'visible' });
+  await loc.replaceInput().waitFor({ state: 'visible' });
+  await resetCodeEditorSearchOptions(page, editorId);
+};
+
+/**
+ * Close the search bar via Escape and wait for it to be hidden.
+ */
+export const closeCodeEditorSearchBar = async (page: Page, editorId: string) => {
+  await page.keyboard.press('Escape');
+  const loc = buildCodeEditorSearchLocators(page, editorId);
+  await loc.searchBar().waitFor({ state: 'hidden' });
+};

--- a/tests/utils/page/index.ts
+++ b/tests/utils/page/index.ts
@@ -1,4 +1,5 @@
 export * from './actions';
+export * from './code-editor-search';
 export * from './file-mode';
 export * from './runner';
 export * from './locators';

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -3,10 +3,12 @@ import { buildApiSpecPanelLocators } from './openapi/render-spec';
 import { buildFileModeLocators } from './file-mode';
 import { buildPreferencesLocators } from './preferences';
 import { buildAiPreferencesLocators } from './ai';
+import { buildCodeEditorSearchLocators } from './code-editor-search';
 
 export const buildCommonLocators = (page: Page) => ({
   runner: () => page.getByTestId('run-button'),
   fileMode: buildFileModeLocators(page),
+  codeEditorSearch: (editorId: string) => buildCodeEditorSearchLocators(page, editorId),
   openApi: {
     render: buildApiSpecPanelLocators(page)
   },


### PR DESCRIPTION
### Description

[JIRA](https://usebruno.atlassian.net/browse/BRU-2623)

Curently users can only search a text in codemirror. There is no option to replace the selected text.

Adding replace and replace all feature in code mirror. Users can select a text for search and can replace the selected text by replace one-by-one or replace all. Adding the keyboard shortcuts for opening the serach and replace.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

https://github.com/user-attachments/assets/41d44a65-8acc-4b56-97f3-4a664fb55739

### CodeMirrorSearch/index.js

**Replace functionality**
- Added `replaceText` state and `replaceVisible` toggle
- `handleReplace` — replaces the current match via `editor.replaceRange`, invalidates the search cache, and re-runs search at the same index
- `handleReplaceAll` — replaces all matches in reverse order (to preserve character positions) inside `editor.operation()` for a single undo step

**Layout**
- Chevron (`IconChevronRight`) extracted as a full-height left column — spans both rows when expanded, matching VS Code's widget
- Rows restructured into `.toggle-replace-btn` + `.search-replace-rows` (column of `.search-row` / `.replace-row`)
- Replace action buttons use `IconReplace` and `IconArrowsExchange2` with `ToolHint` tooltips

**Keyboard & focus**
- Native `keydown` listener attached in the **capture phase** (`{ capture: true }`) on the container — ensures `Escape` is intercepted before CodeMirror or the browser can act on it
- `type="button"` added to all buttons for correct focusability

**Imperative handle** — exposes four methods via `useImperativeHandle`:

| Method | Purpose |
|--------|---------|
| `focus()` | Focus the search input |
| `setSearch(text)` | Set search text, reset match index, focus and select input |
| `openReplace()` | Expand replace row and focus replace input |
| `close()` | Clean up marks, collapse replace, call `onClose` |


---

### CodeMirrorSearch/StyledWrapper.js

- Container changed to `flex-direction: row` — chevron column on the left, rows column on the right
- `.toggle-replace-btn` uses `align-self: stretch` for full-height
- Each input has its own `border` box, fixed `180px` width — both rows visually identical
- `.search-row` gets a `border-bottom` only when replace is expanded
- Removed `.searchbar-text-btn` styles (replaced by icon buttons)

---

### CodeEditor/index.js

**`Cmd/Ctrl+H`** — replaced `'replace'` string command with a handler that opens the search bar and calls `searchBarRef.current?.openReplace()`

**`Cmd/Ctrl+F`** — updated to check `cm.getSelection()`:
- Selection present → calls `setSearch(selectedText)` to prefill and re-run search (works whether bar is open or closed)
- No selection → calls `focus()` to move cursor to the input without clearing existing search text

**`Esc` extraKey** — updated from bare `setState` to `searchBarRef.current?.close()` so marks are properly cleaned up when Esc is pressed while the editor has focus

## Performance Improvements

### 1. Only highlight what's visible

The search still finds **all matches** in the document, but it only creates highlights (`markText()`) for matches that are currently visible in the editor (plus a small buffer of ±100 lines). The currently selected match is always highlighted, even if it's outside the viewport.

For example, in a 10,000-line file with 500 matches, the editor typically creates only **5–10 highlights instead of 500**, significantly reducing DOM work. As you scroll, old highlights are removed and new ones are drawn for the visible area.

**Files**
- `components/CodeMirrorSearch/markingUtils.js`

---

### 2. Cache search results

Scanning the entire document with CodeMirror's `getSearchCursor()` can be expensive on large files.

Search results are cached and reused until something that affects the results changes:
- Document content
- Search text
- Regex mode
- Case sensitivity
- Whole-word mode

This means actions like **Next**, **Previous**, scrolling, or component re-renders reuse the existing match list instead of rescanning the document every time.

**Files**
- `components/CodeMirrorSearch/searchUtils.js` (`createCacheKey`)
- `components/CodeMirrorSearch/index.js` (`searchCacheKey`, `isCacheHit`)

---

### 3. Debounce search while typing

Instead of performing a full document scan on every keystroke, the search waits until the user stops typing for **250 ms** before running.

Typing stays responsive because intermediate keystrokes only update the input field without triggering an expensive search.

**Files**
- `components/CodeMirrorSearch/index.js` (`useDebounce(searchText, 250)`)

---

### 4. Jump directly to visible matches

When drawing highlights, the code uses a **binary search** to quickly locate the first match inside the current viewport instead of checking every match from the beginning.

This reduces the work from scanning the entire match list to only processing the matches that are actually visible.

**Files**
- `components/CodeMirrorSearch/markingUtils.js`

---

### 5. Limit extremely large searches

To avoid freezing the UI on pathological searches (for example, searching for a single character in a very large minified file), the search stops after **99,999 matches**.

This provides a reasonable safety limit while still supporting very large result sets.

**Files**
- `components/CodeMirrorSearch/searchUtils.js` (`MAX_MATCHES`)

---

### 6. Scroll only when it makes sense

Searching no longer automatically scrolls the editor every time results are updated.

The editor scrolls only when explicitly requested, such as:
- Next / Previous
- Replace
- Opening search with selected text

It does **not** scroll during:
- Debounced searches while typing
- Automatic re-scans after document changes
- Reopening the search bar

This prevents the editor from unexpectedly jumping away from the user's current position.

**Files**
- `components/CodeMirrorSearch/index.js` (`doSearch(..., shouldScroll = false)`)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved editor Search/Replace UX: opens based on current selection/cursor, adds robust match navigation, and enhances Replace/Replace all interactions (with read-only safeguards).
  * Refined Search/Replace layout and controls, including a dedicated replace toggle and clearer keyboard behavior.
* **Bug Fixes**
  * Stabilized match counting/highlighting through typing and document edits, with reliable close/dismiss behavior (including Escape).
* **Tests**
  * Added unit tests for search/replace utilities and the search component, plus Playwright E2E coverage for large-document behavior, state persistence, and viewport stability.
* **Documentation**
  * Added a targeted test identifier for the documentation editor UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->