### PR TITLE
fix(ws): preserve expanded messages and editor scroll on tab switch

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -248,6 +248,19 @@ class CodeEditor extends React.Component {
           this.props.onScroll(this._lastScrollTop);
         }
       });
+
+      // For editors inside a scroll container (e.g. the WebSocket message list),
+      // stop the browser from scrolling that container on focus. Otherwise a
+      // click shifts the content mid-click, landing the cursor on the wrong line
+      // and jumping the editor. preventScroll keeps CodeMirror's own scrolling.
+      if (this.props.containScroll) {
+        const inputField = editor.getInputField();
+        if (inputField && typeof inputField.focus === 'function') {
+          const nativeFocus = inputField.focus.bind(inputField);
+          inputField.focus = (options) => nativeFocus({ ...(options || {}), preventScroll: true });
+        }
+      }
+
       this.addOverlay();
 
       const getAllVariablesHandler = () => getAllVariables(this.props.collection, this.props.item);

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -270,6 +270,7 @@ export const SingleWSMessage = ({
             onSave={onSave}
             mode={codemirrorMode[displayMode] ?? 'text/plain'}
             enableVariableHighlighting={true}
+            docKey={`${item.uid}:ws-msg:${message.uid ?? index}`}
           />
         </div>
       )}

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -271,6 +271,7 @@ export const SingleWSMessage = ({
             mode={codemirrorMode[displayMode] ?? 'text/plain'}
             enableVariableHighlighting={true}
             docKey={`${item.uid}:ws-msg:${message.uid ?? index}`}
+            containScroll={true}
           />
         </div>
       )}

--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.js
@@ -148,16 +148,45 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     setNewMessageUid(null);
   }, []);
 
-  // Restore the last scroll position on mount (component remounts on tab switch,
-  // so listScrollTop is read synchronously for this request).
+  // Restore the last scroll position on mount (component remounts on tab switch).
+  // The editors render their height after mount, so a one-shot set gets clamped
+  // by a not-yet-full scrollHeight and lands short of where we left off (e.g. the
+  // bottom). Re-apply the target each frame until it sticks (content is tall
+  // enough), then stop. While restoring we suppress handleScroll so the clamped
+  // value can't overwrite the saved one; a real user scroll cancels the restore.
+  const isRestoringRef = useRef(false);
+  const restoreRafRef = useRef(null);
+  const cancelRestore = useCallback(() => {
+    if (restoreRafRef.current !== null) {
+      cancelAnimationFrame(restoreRafRef.current);
+      restoreRafRef.current = null;
+    }
+    isRestoringRef.current = false;
+  }, []);
   useEffect(() => {
     const container = messagesContainerRef.current;
-    if (container) {
-      container.scrollTop = listScrollTop;
-    }
-  }, [item.uid]);
+    if (!container) return;
+    const target = listScrollTop;
+    if (!target) return; // nothing to restore (top) — don't fight a fresh scroll
+    isRestoringRef.current = true;
+    let frames = 0;
+    const apply = () => {
+      const el = messagesContainerRef.current;
+      if (!el || !isRestoringRef.current) return; // cancelled by a user scroll
+      el.scrollTop = target;
+      const stuck = el.scrollTop === target; // false while still clamped by a short scrollHeight
+      if (!stuck && ++frames < 20) {
+        restoreRafRef.current = requestAnimationFrame(apply);
+      } else {
+        cancelRestore();
+      }
+    };
+    restoreRafRef.current = requestAnimationFrame(apply);
+    return cancelRestore;
+  }, [item.uid, cancelRestore]);
 
   const handleScroll = useCallback(() => {
+    if (isRestoringRef.current) return; // don't persist the clamped value mid-restore
     const container = messagesContainerRef.current;
     if (container) {
       setListScrollTop(container.scrollTop);
@@ -188,13 +217,15 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     pinScrollRef.current = requestAnimationFrame(pin);
   }, []);
 
-  // A real user scroll (wheel/touch) releases the pin immediately.
+  // A real user scroll (wheel/touch) releases the pin and cancels any in-flight
+  // scroll restore immediately the user is taking over.
   const releasePin = useCallback(() => {
     if (pinScrollRef.current !== null) {
       cancelAnimationFrame(pinScrollRef.current);
       pinScrollRef.current = null;
     }
-  }, []);
+    cancelRestore();
+  }, [cancelRestore]);
 
   useEffect(() => () => cancelAnimationFrame(pinScrollRef.current), []);
 

--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.js
@@ -122,6 +122,15 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     prevMessagesLengthRef.current = messages.length;
   }, [messages.length]);
 
+  // Drop uids of deleted messages so the persisted list doesn't accumulate stale
+  // entries over the request's lifetime.
+  useEffect(() => {
+    const hasStale = expandedUidList.some((uid) => !messages.some((m) => m.uid === uid));
+    if (hasStale) {
+      setExpandedUidList((prev) => prev.filter((uid) => messages.some((m) => m.uid === uid)));
+    }
+  }, [messages, expandedUidList, setExpandedUidList]);
+
   const handleNewMessageRendered = useCallback(() => {
     setNewMessageUid(null);
   }, []);

--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.js
@@ -164,10 +164,10 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     }
   }, [setListScrollTop]);
 
-  // Clicking or typing in an editor makes the browser scroll the list to reveal
-  // CodeMirror's cursor, flinging the whole panel. Pin the list's scrollTop for a
-  // few frames so focus/keystrokes can't move it (the editor still scrolls
-  // internally); a real user scroll (wheel/touch) releases the pin.
+  // Typing can make the browser scroll the list to follow the cursor, flinging
+  // the panel. Hold the list's scroll for a few frames so keystrokes can't move
+  // it; a real scroll (wheel/touch) releases it. Clicks are handled separately
+  // by the editor's `containScroll`.
   const pinListScroll = useCallback(() => {
     const container = messagesContainerRef.current;
     if (!container) return;
@@ -196,8 +196,6 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     }
   }, []);
 
-  // Cancel any in-flight scroll/pin animation when the component unmounts (e.g.
-  // on tab switch) so a stray frame doesn't fire after teardown.
   useEffect(() => () => cancelAnimationFrame(pinScrollRef.current), []);
 
   if (!messages.length) {
@@ -221,7 +219,6 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
         className="messages-container"
         data-testid="ws-messages-container"
         onScroll={handleScroll}
-        onMouseDownCapture={pinListScroll}
         onKeyDownCapture={pinListScroll}
         onWheel={releasePin}
         onTouchMove={releasePin}

--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.js
@@ -15,6 +15,7 @@ const getSelectedIndex = (messages) => {
 const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
   const dispatch = useDispatch();
   const messagesContainerRef = useRef(null);
+  const pinScrollRef = useRef(null);
   const [listScrollTop, setListScrollTop] = usePersistedState({
     key: `ws-list-scroll-${item.uid}`,
     default: 0
@@ -65,12 +66,37 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     }));
   }, [body, dispatch, item.uid, collection.uid]);
 
+  const scrollMessageToTop = useCallback((uid) => {
+    const index = messages.findIndex((m) => m.uid === uid);
+    if (index < 0) return;
+    if (pinScrollRef.current !== null) cancelAnimationFrame(pinScrollRef.current);
+    let frames = 0;
+    const align = () => {
+      const el = messagesContainerRef.current;
+      if (!el || pinScrollRef.current === null) return;
+      const wrapper = el.children[index];
+      if (wrapper) {
+        el.scrollTop += wrapper.getBoundingClientRect().top - el.getBoundingClientRect().top;
+      }
+      if (++frames < 12) {
+        pinScrollRef.current = requestAnimationFrame(align);
+      } else {
+        pinScrollRef.current = null;
+      }
+    };
+    pinScrollRef.current = requestAnimationFrame(align);
+  }, [messages]);
+
   const toggleMessage = useCallback((uid) => {
     if (!uid) return;
+    const willOpen = !expandedUids.has(uid);
     setExpandedUidList((prev) => (
       prev.includes(uid) ? prev.filter((u) => u !== uid) : [...prev, uid]
     ));
-  }, [setExpandedUidList]);
+    // Opening a message brings its header to the top of the list; collapsing
+    // leaves the list where it is.
+    if (willOpen) scrollMessageToTop(uid);
+  }, [expandedUids, setExpandedUidList, scrollMessageToTop]);
 
   const handleSelect = useCallback((index) => {
     if (index !== selectedIndex) {
@@ -120,7 +146,6 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
   // CodeMirror's cursor, flinging the whole panel. Pin the list's scrollTop for a
   // few frames so focus/keystrokes can't move it (the editor still scrolls
   // internally); a real user scroll (wheel/touch) releases the pin.
-  const pinScrollRef = useRef(null);
   const pinListScroll = useCallback(() => {
     const container = messagesContainerRef.current;
     if (!container) return;

--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 import { updateRequestBody } from 'providers/ReduxStore/slices/collections';
 import { IconPlus } from '@tabler/icons';
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { usePersistedState } from 'hooks/usePersistedState';
 import StyledWrapper from './StyledWrapper';
@@ -24,11 +24,18 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
 
   const selectedIndex = getSelectedIndex(messages);
 
-  // Expand the selected message by default (falls back to first)
-  const [expandedUids, setExpandedUids] = useState(() => {
-    const uid = messages[selectedIndex]?.uid || messages[0]?.uid;
-    return new Set(uid ? [uid] : []);
+  // Persist which messages are expanded per request so switching tabs and coming
+  // back keeps every open message open (not just the selected one). Stored as an
+  // array of uids since localStorage can't serialize a Set; defaults to the
+  // selected message (falls back to first).
+  const [expandedUidList, setExpandedUidList] = usePersistedState({
+    key: `ws-expanded-${item.uid}`,
+    default: (() => {
+      const uid = messages[selectedIndex]?.uid || messages[0]?.uid;
+      return uid ? [uid] : [];
+    })()
   });
+  const expandedUids = useMemo(() => new Set(expandedUidList), [expandedUidList]);
   const [newMessageUid, setNewMessageUid] = useState(null);
   const prevMessagesLengthRef = useRef(messages.length);
 
@@ -60,16 +67,10 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
 
   const toggleMessage = useCallback((uid) => {
     if (!uid) return;
-    setExpandedUids((prev) => {
-      const next = new Set(prev);
-      if (next.has(uid)) {
-        next.delete(uid);
-      } else {
-        next.add(uid);
-      }
-      return next;
-    });
-  }, []);
+    setExpandedUidList((prev) => (
+      prev.includes(uid) ? prev.filter((u) => u !== uid) : [...prev, uid]
+    ));
+  }, [setExpandedUidList]);
 
   const handleSelect = useCallback((index) => {
     if (index !== selectedIndex) {
@@ -82,7 +83,7 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     if (messages.length > prevMessagesLengthRef.current) {
       const newMsg = messages[messages.length - 1];
       if (newMsg?.uid) {
-        setExpandedUids((prev) => new Set(prev).add(newMsg.uid));
+        setExpandedUidList((prev) => (prev.includes(newMsg.uid) ? prev : [...prev, newMsg.uid]));
         setNewMessageUid(newMsg.uid);
         setSelectedIndex(messages.length - 1);
       }

--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.js
@@ -29,12 +29,15 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
   // back keeps every open message open (not just the selected one). Stored as an
   // array of uids since localStorage can't serialize a Set; defaults to the
   // selected message (falls back to first).
+  // Computed once (usePersistedState only reads default on first mount) so it
+  // isn't rebuilt on every render.
+  const defaultExpanded = useMemo(() => {
+    const uid = messages[selectedIndex]?.uid || messages[0]?.uid;
+    return uid ? [uid] : [];
+  }, []);
   const [expandedUidList, setExpandedUidList] = usePersistedState({
     key: `ws-expanded-${item.uid}`,
-    default: (() => {
-      const uid = messages[selectedIndex]?.uid || messages[0]?.uid;
-      return uid ? [uid] : [];
-    })()
+    default: defaultExpanded
   });
   const expandedUids = useMemo(() => new Set(expandedUidList), [expandedUidList]);
   const [newMessageUid, setNewMessageUid] = useState(null);
@@ -66,18 +69,28 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     }));
   }, [body, dispatch, item.uid, collection.uid]);
 
+  // Scroll the list so the given message's header sits at the top. Runs for a few
+  // frames because the list is still growing as the message expands.
   const scrollMessageToTop = useCallback((uid) => {
+    // Find where this message sits in the list; its DOM wrapper is the child at
+    // the same position.
     const index = messages.findIndex((m) => m.uid === uid);
     if (index < 0) return;
+    // Stop any animation already running so they don't fight over the scroll.
     if (pinScrollRef.current !== null) cancelAnimationFrame(pinScrollRef.current);
     let frames = 0;
     const align = () => {
       const el = messagesContainerRef.current;
+      // Bail if the list is gone (unmounted) or this run was cancelled.
       if (!el || pinScrollRef.current === null) return;
       const wrapper = el.children[index];
       if (wrapper) {
+        // Nudge the list by the gap between the wrapper's top and the list's top,
+        // bringing the header flush with the top.
         el.scrollTop += wrapper.getBoundingClientRect().top - el.getBoundingClientRect().top;
       }
+      // Keep re-aligning for up to 12 frames while the editor finishes opening,
+      // then stop.
       if (++frames < 12) {
         pinScrollRef.current = requestAnimationFrame(align);
       } else {
@@ -182,6 +195,10 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
       pinScrollRef.current = null;
     }
   }, []);
+
+  // Cancel any in-flight scroll/pin animation when the component unmounts (e.g.
+  // on tab switch) so a stray frame doesn't fire after teardown.
+  useEffect(() => () => cancelAnimationFrame(pinScrollRef.current), []);
 
   if (!messages.length) {
     return (

--- a/packages/bruno-app/src/components/RequestPane/WsBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/index.js
@@ -29,12 +29,13 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
   // back keeps every open message open (not just the selected one). Stored as an
   // array of uids since localStorage can't serialize a Set; defaults to the
   // selected message (falls back to first).
-  // Computed once (usePersistedState only reads default on first mount) so it
-  // isn't rebuilt on every render.
+  // usePersistedState only reads `default` when there's no persisted value (first
+  // mount, or when the key changes), so recomputing this is cheap and keeps it in
+  // sync with the current messages for those reads.
   const defaultExpanded = useMemo(() => {
     const uid = messages[selectedIndex]?.uid || messages[0]?.uid;
     return uid ? [uid] : [];
-  }, []);
+  }, [messages, selectedIndex]);
   const [expandedUidList, setExpandedUidList] = usePersistedState({
     key: `ws-expanded-${item.uid}`,
     default: defaultExpanded
@@ -69,6 +70,19 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     }));
   }, [body, dispatch, item.uid, collection.uid]);
 
+  // Refs/cancel for the mount scroll-restore loop (defined further below). Declared
+  // here so scrollMessageToTop can cancel an in-flight restore before it starts
+  // driving the scroll itself.
+  const isRestoringRef = useRef(false);
+  const restoreRafRef = useRef(null);
+  const cancelRestore = useCallback(() => {
+    if (restoreRafRef.current !== null) {
+      cancelAnimationFrame(restoreRafRef.current);
+      restoreRafRef.current = null;
+    }
+    isRestoringRef.current = false;
+  }, []);
+
   // Scroll the list so the given message's header sits at the top. Runs for a few
   // frames because the list is still growing as the message expands.
   const scrollMessageToTop = useCallback((uid) => {
@@ -76,6 +90,9 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
     // the same position.
     const index = messages.findIndex((m) => m.uid === uid);
     if (index < 0) return;
+    // A deliberate expand takes over the scroll: cancel any in-flight restore so
+    // the two RAF loops don't fight over scrollTop.
+    cancelRestore();
     // Stop any animation already running so they don't fight over the scroll.
     if (pinScrollRef.current !== null) cancelAnimationFrame(pinScrollRef.current);
     let frames = 0;
@@ -98,7 +115,7 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
       }
     };
     pinScrollRef.current = requestAnimationFrame(align);
-  }, [messages]);
+  }, [messages, cancelRestore]);
 
   const toggleMessage = useCallback((uid) => {
     if (!uid) return;
@@ -153,16 +170,8 @@ const WSBody = ({ item, collection, handleRun, onAddMessage }) => {
   // by a not-yet-full scrollHeight and lands short of where we left off (e.g. the
   // bottom). Re-apply the target each frame until it sticks (content is tall
   // enough), then stop. While restoring we suppress handleScroll so the clamped
-  // value can't overwrite the saved one; a real user scroll cancels the restore.
-  const isRestoringRef = useRef(false);
-  const restoreRafRef = useRef(null);
-  const cancelRestore = useCallback(() => {
-    if (restoreRafRef.current !== null) {
-      cancelAnimationFrame(restoreRafRef.current);
-      restoreRafRef.current = null;
-    }
-    isRestoringRef.current = false;
-  }, []);
+  // value can't overwrite the saved one; a real user scroll (or a deliberate
+  // expand) cancels the restore.
   useEffect(() => {
     const container = messagesContainerRef.current;
     if (!container) return;

--- a/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
+++ b/packages/bruno-app/src/components/RequestTabs/DraggableTab.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
-const DraggableTab = ({ id, onMoveTab, index, children, className, onClick }) => {
+const DraggableTab = ({ id, onMoveTab, index, children, className, onClick, active }) => {
   const ref = React.useRef(null);
 
   const [{ handlerId, isOver }, drop] = useDrop({
@@ -35,6 +35,8 @@ const DraggableTab = ({ id, onMoveTab, index, children, className, onClick }) =>
       className={className}
       ref={ref}
       role="tab"
+      aria-selected={active}
+      data-testid="request-tab"
       style={{ opacity: isDragging || isOver ? 0 : 1 }}
       onClick={onClick}
       data-handler-id={handlerId}

--- a/packages/bruno-app/src/components/RequestTabs/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/index.js
@@ -149,6 +149,7 @@ const RequestTabs = () => {
                             }));
                           }}
                           className={getTabClassname(tab, index)}
+                          active={tab.uid === activeTabUid}
                           onClick={() => handleClick(tab)}
                         >
                           <RequestTab

--- a/tests/ssl/custom-ca-certs/tests/wss-success/wss-success.spec.ts
+++ b/tests/ssl/custom-ca-certs/tests/wss-success/wss-success.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '../../../../../playwright';
 import { openCollection } from '../../../../utils/page';
-import { buildWebsocketCommonLocators } from '../../../../utils/page/locators';
+import { buildCommonLocators } from '../../../../utils/page/locators';
 
 const BRU_REQ_NAME = /^ws-ssl-request$/;
 
 test.describe.serial('wss with custom ca cert', () => {
   test('websocket connects over ssl', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
 
     // Define reusable locators
     const requestItem = page.getByTitle(BRU_REQ_NAME);
@@ -17,13 +17,13 @@ test.describe.serial('wss with custom ca cert', () => {
 
     await test.step('Connect to WSS', async () => {
       await requestItem.click();
-      await locators.connectionControls.connect().click();
-      await expect(locators.connectionControls.disconnect()).toBeAttached();
+      await locators.websocket.connectionControls.connect().click();
+      await expect(locators.websocket.connectionControls.disconnect()).toBeAttached();
     });
 
     await test.step('Send message and verify response', async () => {
       await locators.runner().click();
-      const responseMessage = locators.messages().nth(2).locator('.text-ellipsis');
+      const responseMessage = locators.websocket.messages().nth(2).locator('.text-ellipsis');
       await expect(responseMessage).toHaveText(/\"headers\"/);
     });
   });

--- a/tests/transient-requests/transient-requests.spec.ts
+++ b/tests/transient-requests/transient-requests.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../../playwright';
 import { createTransientRequest, fillRequestUrl, closeAllCollections, createCollection, sendRequest, clickResponseAction, selectRequestPaneTab } from '../utils/page';
-import { buildCommonLocators, buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -2349,9 +2349,9 @@ const selectAppView = async (page: Page, view: 'code' | 'preview') => {
  */
 const renameWsMessage = async (page: Page, index: number, name: string) => {
   await test.step(`Rename websocket message ${index} to "${name}"`, async () => {
-    const ws = buildCommonLocators(page);
-    await ws.websocket.message.label(index).dblclick();
-    const nameInput = ws.websocket.message.nameInput(index);
+    const { websocket } = buildCommonLocators(page);
+    await websocket.message.label(index).dblclick();
+    const nameInput = websocket.message.nameInput(index);
     await expect(nameInput).toBeVisible();
     await nameInput.selectText();
     await page.keyboard.type(name);

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1667,6 +1667,15 @@ const closeAllTabs = async (page: Page) => {
   });
 };
 
+// Switch to an already-open request tab by its label (e.g. transient tabs are "Untitled N").
+const switchToOpenTab = async (page: Page, label: string) => {
+  await test.step(`Switch to tab "${label}"`, async () => {
+    const tab = page.getByTestId('request-tab').filter({ hasText: label });
+    await tab.click();
+    await expect(tab).toHaveAttribute('aria-selected', 'true');
+  });
+};
+
 /**
  * Create a new workspace via the title bar dropdown inline rename flow
  * @param page - The page object
@@ -2449,6 +2458,7 @@ export {
   generateGrpcSampleMessage,
   selectGrpcMethod,
   closeAllTabs,
+  switchToOpenTab,
   createWorkspace,
   switchWorkspace,
   selectScriptSubTab,

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page, Locator, ElectronApplication, waitForReadyPage as waitForReadyPageImpl } from '../../../playwright';
 import process from 'node:process';
 import * as path from 'path';
-import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators, buildWebsocketCommonLocators } from './locators';
+import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators } from './locators';
 import { waitForCollectionMount } from './mounting';
 
 type SandboxMode = 'safe' | 'developer';
@@ -1670,7 +1670,7 @@ const closeAllTabs = async (page: Page) => {
 // Switch to an already-open request tab by its label (e.g. transient tabs are "Untitled N").
 const switchToOpenTab = async (page: Page, label: string) => {
   await test.step(`Switch to tab "${label}"`, async () => {
-    const tab = page.getByTestId('request-tab').filter({ hasText: label });
+    const tab = page.getByTestId('request-tab').filter({ has: page.getByText(label, { exact: true }) });
     await tab.click();
     await expect(tab).toHaveAttribute('aria-selected', 'true');
   });
@@ -2349,9 +2349,9 @@ const selectAppView = async (page: Page, view: 'code' | 'preview') => {
  */
 const renameWsMessage = async (page: Page, index: number, name: string) => {
   await test.step(`Rename websocket message ${index} to "${name}"`, async () => {
-    const ws = buildWebsocketCommonLocators(page);
-    await ws.message.label(index).dblclick();
-    const nameInput = ws.message.nameInput(index);
+    const ws = buildCommonLocators(page);
+    await ws.websocket.message.label(index).dblclick();
+    const nameInput = ws.websocket.message.nameInput(index);
     await expect(nameInput).toBeVisible();
     await nameInput.selectText();
     await page.keyboard.type(name);

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -346,11 +346,11 @@ export const buildCommonLocators = (page: Page) => ({
       },
       rowValueInput: (rowIndex: number) => baseTable.rowCell('value', rowIndex)
     };
-  }
+  },
+  websocket: buildWebsocketCommonLocators(page)
 });
 
 export const buildWebsocketCommonLocators = (page: Page) => ({
-  ...buildCommonLocators(page),
   connectionControls: {
     connect: () => page.getByTestId('ws-connect-button'),
     disconnect: () => page.getByTestId('ws-disconnect-button')

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -12,6 +12,7 @@ export const buildCommonLocators = (page: Page) => ({
   },
   preferences: buildPreferencesLocators(page),
   ai: buildAiPreferencesLocators(page),
+  websocket: buildWebsocketCommonLocators(page),
   saveButton: () => page.getByTestId('save-request-button'),
   openPreferences: () => page.getByRole('button', { name: 'Open Preferences' }),
   sidebar: {
@@ -346,8 +347,7 @@ export const buildCommonLocators = (page: Page) => ({
       },
       rowValueInput: (rowIndex: number) => baseTable.rowCell('value', rowIndex)
     };
-  },
-  websocket: buildWebsocketCommonLocators(page)
+  }
 });
 
 export const buildWebsocketCommonLocators = (page: Page) => ({

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -366,9 +366,12 @@ export const buildWebsocketCommonLocators = (page: Page) => ({
     editorPlaceholder: (index: number) =>
       page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror-placeholder'),
     editorCode: (index: number) => page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror-code'),
+    labels: () => page.getByTestId(/^ws-message-label-/),
     label: (index: number) => page.getByTestId(`ws-message-label-${index}`),
+    nameInputs: () => page.getByTestId(/^ws-message-name-input-/),
     nameInput: (index: number) => page.getByTestId(`ws-message-name-input-${index}`),
     nameTooltip: () => page.getByTestId('ws-message-name-tooltip'),
+    prettifyAll: () => page.getByTestId('ws-prettify-all'),
     sendButton: (index: number) => page.getByTestId(`ws-send-msg-${index}`),
     deleteButton: (index: number) => page.getByTestId(`ws-delete-msg-${index}`)
   },

--- a/tests/websockets/connection.spec.ts
+++ b/tests/websockets/connection.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../../playwright';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 const MAX_CONNECTION_TIME = 3000;
 const BRU_REQ_NAME = /^ws-test-request$/;
@@ -12,42 +12,42 @@ test.describe.serial('websockets', () => {
   });
 
   test('websocket connects', async ({ pageWithUserData: page, restartApp }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
 
     // Attempt a connection for the specified request
     await page.getByTitle(BRU_REQ_NAME).click();
-    await locators.connectionControls.connect().click();
+    await locators.websocket.connectionControls.connect().click();
 
     // See if the socket connected by monitoring the opposite state
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await expect(locators.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
   });
 
   test('websocket closes', async ({ pageWithUserData: page, restartApp }) => {
-    const locators = buildWebsocketCommonLocators(page);
-    await locators.connectionControls.disconnect().click();
+    const locators = buildCommonLocators(page);
+    await locators.websocket.connectionControls.disconnect().click();
 
     // See if the socket disconnected by monitoring the opposite state
-    await expect(locators.connectionControls.connect()).toBeVisible();
+    await expect(locators.websocket.connectionControls.connect()).toBeVisible();
   });
 
   test('websocket messages were recorded', async ({ pageWithUserData: page, restartApp }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
 
     // Hard validate the recieved messages to confirm the connection state
-    await expect(locators.messages().first().getByText('Connected to ws://')).toBeAttached();
-    await expect(locators.messages().nth(1).getByText('Closed')).toBeAttached();
+    await expect(locators.websocket.messages().first().getByText('Connected to ws://')).toBeAttached();
+    await expect(locators.websocket.messages().nth(1).getByText('Closed')).toBeAttached();
   });
 
   test('websocket request can send messages', async ({ pageWithUserData: page, restartApp }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
 
-    await locators.toolbar.clearResponse().click();
+    await locators.websocket.toolbar.clearResponse().click();
     await locators.runner().click();
 
     // Check if the messages from the request are actually displayed on the messages container
-    await expect(locators.messages().nth(1).locator('.text-ellipsis')).toHaveText('{ "foo": "bar" }');
-    await expect(locators.messages().nth(2).locator('.text-ellipsis')).toHaveText('{ "data": { "foo": "bar" } }');
+    await expect(locators.websocket.messages().nth(1).locator('.text-ellipsis')).toHaveText('{ "foo": "bar" }');
+    await expect(locators.websocket.messages().nth(2).locator('.text-ellipsis')).toHaveText('{ "data": { "foo": "bar" } }');
   });
 });

--- a/tests/websockets/expanded-persistence.spec.ts
+++ b/tests/websockets/expanded-persistence.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../../playwright';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 import { createTransientRequest, selectRequestPaneTab, closeAllTabs, switchToOpenTab } from '../utils/page/actions';
 
 test.describe('websocket expanded-message persistence across tab switches', () => {
@@ -10,18 +10,18 @@ test.describe('websocket expanded-message persistence across tab switches', () =
   test('keeps every open message open (not just the selected one) after switching tabs and back', async ({
     page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     // Tab A: a WebSocket request with two messages, both expanded.
     await createTransientRequest(page, { requestType: 'WebSocket' });
     await selectRequestPaneTab(page, 'Message');
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     // Adding a second message auto-expands it (and selects it), so both are open.
-    await ws.message.addButton().click();
-    await expect(ws.message.headers()).toHaveCount(2);
-    await expect(ws.message.body(0)).toBeVisible();
-    await expect(ws.message.body(1)).toBeVisible();
+    await ws.websocket.message.addButton().click();
+    await expect(ws.websocket.message.headers()).toHaveCount(2);
+    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(1)).toBeVisible();
 
     // Tab B: another request to switch to, unmounting tab A's message list.
     await createTransientRequest(page, { requestType: 'WebSocket' });
@@ -32,7 +32,7 @@ test.describe('websocket expanded-message persistence across tab switches', () =
 
     // Both messages must remain expanded — previously only the selected message
     // was restored on remount and the rest collapsed.
-    await expect(ws.message.body(0)).toBeVisible();
-    await expect(ws.message.body(1)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(1)).toBeVisible();
   });
 });

--- a/tests/websockets/expanded-persistence.spec.ts
+++ b/tests/websockets/expanded-persistence.spec.ts
@@ -10,18 +10,18 @@ test.describe('websocket expanded-message persistence across tab switches', () =
   test('keeps every open message open (not just the selected one) after switching tabs and back', async ({
     page
   }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
 
     // Tab A: a WebSocket request with two messages, both expanded.
     await createTransientRequest(page, { requestType: 'WebSocket' });
     await selectRequestPaneTab(page, 'Message');
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     // Adding a second message auto-expands it (and selects it), so both are open.
-    await ws.websocket.message.addButton().click();
-    await expect(ws.websocket.message.headers()).toHaveCount(2);
-    await expect(ws.websocket.message.body(0)).toBeVisible();
-    await expect(ws.websocket.message.body(1)).toBeVisible();
+    await websocket.message.addButton().click();
+    await expect(websocket.message.headers()).toHaveCount(2);
+    await expect(websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(1)).toBeVisible();
 
     // Tab B: another request to switch to, unmounting tab A's message list.
     await createTransientRequest(page, { requestType: 'WebSocket' });
@@ -32,7 +32,7 @@ test.describe('websocket expanded-message persistence across tab switches', () =
 
     // Both messages must remain expanded — previously only the selected message
     // was restored on remount and the rest collapsed.
-    await expect(ws.websocket.message.body(0)).toBeVisible();
-    await expect(ws.websocket.message.body(1)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(1)).toBeVisible();
   });
 });

--- a/tests/websockets/expanded-persistence.spec.ts
+++ b/tests/websockets/expanded-persistence.spec.ts
@@ -1,13 +1,6 @@
-import { expect, test, Page } from '../../playwright';
+import { expect, test } from '../../playwright';
 import { buildWebsocketCommonLocators } from '../utils/page/locators';
-import { createTransientRequest, selectRequestPaneTab, closeAllTabs } from '../utils/page/actions';
-
-// Switch to an already-open request tab by its label (transient tabs are "Untitled N").
-const switchToTab = async (page: Page, label: string) => {
-  const tab = page.getByTestId('request-tab').filter({ hasText: label });
-  await tab.click();
-  await expect(tab).toHaveAttribute('aria-selected', 'true');
-};
+import { createTransientRequest, selectRequestPaneTab, closeAllTabs, switchToOpenTab } from '../utils/page/actions';
 
 test.describe('websocket expanded-message persistence across tab switches', () => {
   test.afterEach(async ({ page }) => {
@@ -34,7 +27,7 @@ test.describe('websocket expanded-message persistence across tab switches', () =
     await createTransientRequest(page, { requestType: 'WebSocket' });
 
     // Back to tab A.
-    await switchToTab(page, 'Untitled 1');
+    await switchToOpenTab(page, 'Untitled 1');
     await selectRequestPaneTab(page, 'Message');
 
     // Both messages must remain expanded — previously only the selected message

--- a/tests/websockets/expanded-persistence.spec.ts
+++ b/tests/websockets/expanded-persistence.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test, Page } from '../../playwright';
+import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { createTransientRequest, selectRequestPaneTab, closeAllTabs } from '../utils/page/actions';
+
+// Switch to an already-open request tab by its label (transient tabs are "Untitled N").
+const switchToTab = async (page: Page, label: string) => {
+  const tab = page.getByTestId('request-tab').filter({ hasText: label });
+  await tab.click();
+  await expect(tab).toHaveAttribute('aria-selected', 'true');
+};
+
+test.describe('websocket expanded-message persistence across tab switches', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllTabs(page);
+  });
+
+  test('keeps every open message open (not just the selected one) after switching tabs and back', async ({
+    page
+  }) => {
+    const ws = buildWebsocketCommonLocators(page);
+
+    // Tab A: a WebSocket request with two messages, both expanded.
+    await createTransientRequest(page, { requestType: 'WebSocket' });
+    await selectRequestPaneTab(page, 'Message');
+    await expect(ws.message.body(0)).toBeVisible();
+
+    // Adding a second message auto-expands it (and selects it), so both are open.
+    await ws.message.addButton().click();
+    await expect(ws.message.headers()).toHaveCount(2);
+    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.message.body(1)).toBeVisible();
+
+    // Tab B: another request to switch to, unmounting tab A's message list.
+    await createTransientRequest(page, { requestType: 'WebSocket' });
+
+    // Back to tab A.
+    await switchToTab(page, 'Untitled 1');
+    await selectRequestPaneTab(page, 'Message');
+
+    // Both messages must remain expanded — previously only the selected message
+    // was restored on remount and the rest collapsed.
+    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.message.body(1)).toBeVisible();
+  });
+});

--- a/tests/websockets/headers.spec.ts
+++ b/tests/websockets/headers.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '../../playwright';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 const BRU_REQ_NAME = /^ws-test-request-with-headers$/;
 
 test.describe.serial('headers', () => {
   test('headers are returned if passed', async ({ pageWithUserData: page, restartApp }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
 
     // Open the most recent collection
     await page.locator('#sidebar-collection-name').click();
@@ -15,7 +15,7 @@ test.describe.serial('headers', () => {
     await locators.runner().click();
 
     // Check if the message has the authorisation header
-    await expect(locators.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(authorization)\"\:\s+\"Dummy\"/);
-    await expect(locators.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(x-bruno-collection-var)\"\:\s+\"Variable Value\"/);
+    await expect(locators.websocket.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(authorization)\"\:\s+\"Dummy\"/);
+    await expect(locators.websocket.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(x-bruno-collection-var)\"\:\s+\"Variable Value\"/);
   });
 });

--- a/tests/websockets/message-body-default.spec.ts
+++ b/tests/websockets/message-body-default.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../playwright';
 import { closeAllTabs, createTransientRequest, selectRequestPaneTab } from '../utils/page/actions';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 test.describe('websocket message default body', () => {
   test.afterEach(async ({ page }) => {
@@ -10,39 +10,39 @@ test.describe('websocket message default body', () => {
   test('a newly added message defaults to an empty body showing the placeholder', async ({
     page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await createTransientRequest(page, { requestType: 'WebSocket' });
     await selectRequestPaneTab(page, 'Message');
 
-    const beforeCount = await ws.message.headers().count();
+    const beforeCount = await ws.websocket.message.headers().count();
 
-    await ws.message.addButton().click();
-    await expect(ws.message.headers()).toHaveCount(beforeCount + 1);
+    await ws.websocket.message.addButton().click();
+    await expect(ws.websocket.message.headers()).toHaveCount(beforeCount + 1);
 
     // The newly added message is the last one and auto-expands.
-    await expect(ws.message.body(beforeCount)).toBeVisible();
+    await expect(ws.websocket.message.body(beforeCount)).toBeVisible();
 
     // Body should be empty (previously defaulted to '{}'); the editor should
     // surface the '...' placeholder instead of any '{}' content.
-    await expect(ws.message.editorPlaceholder(beforeCount)).toHaveText('...');
-    await expect(ws.message.editorCode(beforeCount)).not.toContainText('{}');
+    await expect(ws.websocket.message.editorPlaceholder(beforeCount)).toHaveText('...');
+    await expect(ws.websocket.message.editorCode(beforeCount)).not.toContainText('{}');
   });
 
   test('the default first message of a newly created websocket request has an empty body', async ({
     page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await createTransientRequest(page, { requestType: 'WebSocket' });
     await selectRequestPaneTab(page, 'Message');
 
     // The default first message auto-expands.
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     // Body must be empty (previously defaulted to '{}'); the editor should surface
     // the '...' placeholder rather than any '{}' content.
-    await expect(ws.message.editorPlaceholder(0)).toHaveText('...');
-    await expect(ws.message.editorCode(0)).not.toContainText('{}');
+    await expect(ws.websocket.message.editorPlaceholder(0)).toHaveText('...');
+    await expect(ws.websocket.message.editorCode(0)).not.toContainText('{}');
   });
 });

--- a/tests/websockets/message-body-default.spec.ts
+++ b/tests/websockets/message-body-default.spec.ts
@@ -10,39 +10,39 @@ test.describe('websocket message default body', () => {
   test('a newly added message defaults to an empty body showing the placeholder', async ({
     page
   }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
 
     await createTransientRequest(page, { requestType: 'WebSocket' });
     await selectRequestPaneTab(page, 'Message');
 
-    const beforeCount = await ws.websocket.message.headers().count();
+    const beforeCount = await websocket.message.headers().count();
 
-    await ws.websocket.message.addButton().click();
-    await expect(ws.websocket.message.headers()).toHaveCount(beforeCount + 1);
+    await websocket.message.addButton().click();
+    await expect(websocket.message.headers()).toHaveCount(beforeCount + 1);
 
     // The newly added message is the last one and auto-expands.
-    await expect(ws.websocket.message.body(beforeCount)).toBeVisible();
+    await expect(websocket.message.body(beforeCount)).toBeVisible();
 
     // Body should be empty (previously defaulted to '{}'); the editor should
     // surface the '...' placeholder instead of any '{}' content.
-    await expect(ws.websocket.message.editorPlaceholder(beforeCount)).toHaveText('...');
-    await expect(ws.websocket.message.editorCode(beforeCount)).not.toContainText('{}');
+    await expect(websocket.message.editorPlaceholder(beforeCount)).toHaveText('...');
+    await expect(websocket.message.editorCode(beforeCount)).not.toContainText('{}');
   });
 
   test('the default first message of a newly created websocket request has an empty body', async ({
     page
   }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
 
     await createTransientRequest(page, { requestType: 'WebSocket' });
     await selectRequestPaneTab(page, 'Message');
 
     // The default first message auto-expands.
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     // Body must be empty (previously defaulted to '{}'); the editor should surface
     // the '...' placeholder rather than any '{}' content.
-    await expect(ws.websocket.message.editorPlaceholder(0)).toHaveText('...');
-    await expect(ws.websocket.message.editorCode(0)).not.toContainText('{}');
+    await expect(websocket.message.editorPlaceholder(0)).toHaveText('...');
+    await expect(websocket.message.editorCode(0)).not.toContainText('{}');
   });
 });

--- a/tests/websockets/message-editor-scroll.spec.ts
+++ b/tests/websockets/message-editor-scroll.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../playwright';
 import { openRequest, closeAllCollections } from '../utils/page/actions';
+import { buildWebsocketCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
 const SCROLL_REQ = 'ws-scroll-top';
@@ -11,63 +12,65 @@ test.describe('websocket message editor scroll behaviour', () => {
   });
 
   test('reopening a message restores the scroll position where we left it', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
+    // CodeMirror's scroller lives inside the message body.
+    const cmScroll = (index: number) => ws.message.body(index).locator('.CodeMirror-scroll');
+
     await openRequest(page, COLLECTION_NAME, SCROLL_REQ);
 
-    const header = page.getByTestId('ws-message-header-0');
-    const body = page.getByTestId('ws-message-body-0');
-    await expect(body).toBeVisible();
+    await expect(ws.message.body(0)).toBeVisible();
 
-    const cmScroll = body.locator('.CodeMirror-scroll');
     await expect
-      .poll(() => cmScroll.evaluate((el) => el.scrollHeight - el.clientHeight))
+      .poll(() => cmScroll(0).evaluate((el) => el.scrollHeight - el.clientHeight))
       .toBeGreaterThan(0);
 
     // Scroll down into the body.
-    const target = await cmScroll.evaluate((el) => {
+    const target = await cmScroll(0).evaluate((el) => {
       el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) * 0.6);
       return el.scrollTop;
     });
     expect(target).toBeGreaterThan(0);
 
     // Collapse then reopen.
-    await header.click({ position: { x: 8, y: 12 } });
-    await expect(body).toBeHidden();
-    await header.click({ position: { x: 8, y: 12 } });
-    await expect(body).toBeVisible();
+    await ws.message.header(0).click({ position: { x: 8, y: 12 } });
+    await expect(ws.message.body(0)).toBeHidden();
+    await ws.message.header(0).click({ position: { x: 8, y: 12 } });
+    await expect(ws.message.body(0)).toBeVisible();
 
     // Editor should return to where we left it, not to the top.
     await expect
-      .poll(() => page.getByTestId('ws-message-body-0').locator('.CodeMirror-scroll').evaluate((el) => el.scrollTop))
+      .poll(() => cmScroll(0).evaluate((el) => el.scrollTop))
       .toBeGreaterThan(target - 60);
   });
 
   test('selecting another message does not reset the deselected editor scroll to top', async ({
     pageWithUserData: page
   }) => {
+    const ws = buildWebsocketCommonLocators(page);
+    const cmScroll = (index: number) => ws.message.body(index).locator('.CodeMirror-scroll');
+
     await openRequest(page, COLLECTION_NAME, TWO_MSG_REQ);
 
     // Message 1 is selected + expanded by default.
-    const firstBody = page.getByTestId('ws-message-body-0');
-    await expect(firstBody).toBeVisible();
+    await expect(ws.message.body(0)).toBeVisible();
 
-    const firstScroll = firstBody.locator('.CodeMirror-scroll');
     await expect
-      .poll(() => firstScroll.evaluate((el) => el.scrollHeight - el.clientHeight))
+      .poll(() => cmScroll(0).evaluate((el) => el.scrollHeight - el.clientHeight))
       .toBeGreaterThan(0);
 
     // Scroll message 1's editor down into the body.
-    const target = await firstScroll.evaluate((el) => {
+    const target = await cmScroll(0).evaluate((el) => {
       el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) * 0.6);
       return el.scrollTop;
     });
     expect(target).toBeGreaterThan(0);
 
     // Select message 2.
-    await page.getByTestId('ws-message-header-1').click({ position: { x: 8, y: 12 } });
+    await ws.message.header(1).click({ position: { x: 8, y: 12 } });
 
     // Message 1 stays expanded; its scroll must not have jumped to the top.
     await expect
-      .poll(() => page.getByTestId('ws-message-body-0').locator('.CodeMirror-scroll').evaluate((el) => el.scrollTop))
+      .poll(() => cmScroll(0).evaluate((el) => el.scrollTop))
       .toBeGreaterThan(target - 60);
   });
 });

--- a/tests/websockets/message-editor-scroll.spec.ts
+++ b/tests/websockets/message-editor-scroll.spec.ts
@@ -12,13 +12,13 @@ test.describe('websocket message editor scroll behaviour', () => {
   });
 
   test('reopening a message restores the scroll position where we left it', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
     // CodeMirror's scroller lives inside the message body.
-    const cmScroll = (index: number) => ws.websocket.message.body(index).locator('.CodeMirror-scroll');
+    const cmScroll = (index: number) => websocket.message.body(index).locator('.CodeMirror-scroll');
 
     await openRequest(page, COLLECTION_NAME, SCROLL_REQ);
 
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     await expect
       .poll(() => cmScroll(0).evaluate((el) => el.scrollHeight - el.clientHeight))
@@ -32,10 +32,10 @@ test.describe('websocket message editor scroll behaviour', () => {
     expect(target).toBeGreaterThan(0);
 
     // Collapse then reopen.
-    await ws.websocket.message.header(0).click({ position: { x: 8, y: 12 } });
-    await expect(ws.websocket.message.body(0)).toBeHidden();
-    await ws.websocket.message.header(0).click({ position: { x: 8, y: 12 } });
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await websocket.message.header(0).click({ position: { x: 8, y: 12 } });
+    await expect(websocket.message.body(0)).toBeHidden();
+    await websocket.message.header(0).click({ position: { x: 8, y: 12 } });
+    await expect(websocket.message.body(0)).toBeVisible();
 
     // Editor should return to where we left it, not to the top.
     await expect
@@ -46,14 +46,14 @@ test.describe('websocket message editor scroll behaviour', () => {
   test('opening a collapsed message scrolls its header to the top of the list', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildCommonLocators(page);
-    const container = ws.websocket.message.container();
+    const { websocket } = buildCommonLocators(page);
+    const container = websocket.message.container();
 
     await openRequest(page, COLLECTION_NAME, TWO_MSG_REQ);
 
     // Message 1 is expanded by default; message 2 starts collapsed and below it.
-    await expect(ws.websocket.message.body(0)).toBeVisible();
-    await expect(ws.websocket.message.body(1)).toHaveCount(0);
+    await expect(websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(1)).toHaveCount(0);
 
     // Start from the top of the list so message 2 is below the fold.
     await container.evaluate((el) => {
@@ -61,8 +61,8 @@ test.describe('websocket message editor scroll behaviour', () => {
     });
 
     // Open message 2.
-    await ws.websocket.message.header(1).click({ position: { x: 8, y: 12 } });
-    await expect(ws.websocket.message.body(1)).toBeVisible();
+    await websocket.message.header(1).click({ position: { x: 8, y: 12 } });
+    await expect(websocket.message.body(1)).toBeVisible();
 
     // Its (sticky) header should settle at the top of the list — i.e. the message
     // wrapper's top aligns with the container's top.
@@ -81,13 +81,13 @@ test.describe('websocket message editor scroll behaviour', () => {
   test('selecting another message does not reset the deselected editor scroll to top', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildCommonLocators(page);
-    const cmScroll = (index: number) => ws.websocket.message.body(index).locator('.CodeMirror-scroll');
+    const { websocket } = buildCommonLocators(page);
+    const cmScroll = (index: number) => websocket.message.body(index).locator('.CodeMirror-scroll');
 
     await openRequest(page, COLLECTION_NAME, TWO_MSG_REQ);
 
     // Message 1 is selected + expanded by default.
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     await expect
       .poll(() => cmScroll(0).evaluate((el) => el.scrollHeight - el.clientHeight))
@@ -101,11 +101,47 @@ test.describe('websocket message editor scroll behaviour', () => {
     expect(target).toBeGreaterThan(0);
 
     // Select message 2.
-    await ws.websocket.message.header(1).click({ position: { x: 8, y: 12 } });
+    await websocket.message.header(1).click({ position: { x: 8, y: 12 } });
 
     // Message 1 stays expanded; its scroll must not have jumped to the top.
     await expect
       .poll(() => cmScroll(0).evaluate((el) => el.scrollTop))
       .toBeGreaterThan(target - 60);
+  });
+
+  test('clicking a reopened message body does not move the scroll position', async ({ pageWithUserData: page }) => {
+    const { websocket } = buildCommonLocators(page);
+    const container = websocket.message.container();
+    const cmScroll = (index: number) => websocket.message.body(index).locator('.CodeMirror-scroll');
+
+    await openRequest(page, COLLECTION_NAME, TWO_MSG_REQ);
+    await expect(websocket.message.body(0)).toBeVisible();
+
+    // Open message 2 so both messages are expanded.
+    await websocket.message.header(1).click({ position: { x: 8, y: 12 } });
+    await expect(websocket.message.body(1)).toBeVisible();
+
+    // Go to the top of the list.
+    await container.evaluate((el) => { el.scrollTop = 0; });
+
+    // Close message 1, then open it again.
+    await websocket.message.header(0).click({ position: { x: 8, y: 12 } });
+    await expect(websocket.message.body(0)).toBeHidden();
+    await websocket.message.header(0).click({ position: { x: 8, y: 12 } });
+    await expect(websocket.message.body(0)).toBeVisible();
+
+    // Wait for any open-scroll animation to settle, then record the positions.
+    const listBefore = await container.evaluate((el) => Math.round(el.scrollTop));
+    const cmBefore = await cmScroll(0).evaluate((el) => Math.round(el.scrollTop));
+
+    // Click on the message body.
+    await websocket.message.editor(0).click();
+
+    // The position must be the same after clicking.
+    const listAfter = await container.evaluate((el) => Math.round(el.scrollTop));
+    const cmAfter = await cmScroll(0).evaluate((el) => Math.round(el.scrollTop));
+
+    expect(Math.abs(listAfter - listBefore)).toBeLessThanOrEqual(4);
+    expect(Math.abs(cmAfter - cmBefore)).toBeLessThanOrEqual(4);
   });
 });

--- a/tests/websockets/message-editor-scroll.spec.ts
+++ b/tests/websockets/message-editor-scroll.spec.ts
@@ -43,6 +43,41 @@ test.describe('websocket message editor scroll behaviour', () => {
       .toBeGreaterThan(target - 60);
   });
 
+  test('opening a collapsed message scrolls its header to the top of the list', async ({
+    pageWithUserData: page
+  }) => {
+    const ws = buildWebsocketCommonLocators(page);
+    const container = ws.message.container();
+
+    await openRequest(page, COLLECTION_NAME, TWO_MSG_REQ);
+
+    // Message 1 is expanded by default; message 2 starts collapsed and below it.
+    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.message.body(1)).toHaveCount(0);
+
+    // Start from the top of the list so message 2 is below the fold.
+    await container.evaluate((el) => {
+      el.scrollTop = 0;
+    });
+
+    // Open message 2.
+    await ws.message.header(1).click({ position: { x: 8, y: 12 } });
+    await expect(ws.message.body(1)).toBeVisible();
+
+    // Its (sticky) header should settle at the top of the list — i.e. the message
+    // wrapper's top aligns with the container's top.
+    await expect
+      .poll(() =>
+        container.evaluate((el) => {
+          const header = el.querySelector('[data-testid="ws-message-header-1"]');
+          const wrapper = header?.parentElement;
+          if (!wrapper) return Number.MAX_SAFE_INTEGER;
+          return Math.round(wrapper.getBoundingClientRect().top - el.getBoundingClientRect().top);
+        })
+      )
+      .toBeLessThanOrEqual(4);
+  });
+
   test('selecting another message does not reset the deselected editor scroll to top', async ({
     pageWithUserData: page
   }) => {

--- a/tests/websockets/message-editor-scroll.spec.ts
+++ b/tests/websockets/message-editor-scroll.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../playwright';
 import { openRequest, closeAllCollections } from '../utils/page/actions';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
 const SCROLL_REQ = 'ws-scroll-top';
@@ -12,13 +12,13 @@ test.describe('websocket message editor scroll behaviour', () => {
   });
 
   test('reopening a message restores the scroll position where we left it', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     // CodeMirror's scroller lives inside the message body.
-    const cmScroll = (index: number) => ws.message.body(index).locator('.CodeMirror-scroll');
+    const cmScroll = (index: number) => ws.websocket.message.body(index).locator('.CodeMirror-scroll');
 
     await openRequest(page, COLLECTION_NAME, SCROLL_REQ);
 
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     await expect
       .poll(() => cmScroll(0).evaluate((el) => el.scrollHeight - el.clientHeight))
@@ -32,10 +32,10 @@ test.describe('websocket message editor scroll behaviour', () => {
     expect(target).toBeGreaterThan(0);
 
     // Collapse then reopen.
-    await ws.message.header(0).click({ position: { x: 8, y: 12 } });
-    await expect(ws.message.body(0)).toBeHidden();
-    await ws.message.header(0).click({ position: { x: 8, y: 12 } });
-    await expect(ws.message.body(0)).toBeVisible();
+    await ws.websocket.message.header(0).click({ position: { x: 8, y: 12 } });
+    await expect(ws.websocket.message.body(0)).toBeHidden();
+    await ws.websocket.message.header(0).click({ position: { x: 8, y: 12 } });
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     // Editor should return to where we left it, not to the top.
     await expect
@@ -46,14 +46,14 @@ test.describe('websocket message editor scroll behaviour', () => {
   test('opening a collapsed message scrolls its header to the top of the list', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
-    const container = ws.message.container();
+    const ws = buildCommonLocators(page);
+    const container = ws.websocket.message.container();
 
     await openRequest(page, COLLECTION_NAME, TWO_MSG_REQ);
 
     // Message 1 is expanded by default; message 2 starts collapsed and below it.
-    await expect(ws.message.body(0)).toBeVisible();
-    await expect(ws.message.body(1)).toHaveCount(0);
+    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(1)).toHaveCount(0);
 
     // Start from the top of the list so message 2 is below the fold.
     await container.evaluate((el) => {
@@ -61,8 +61,8 @@ test.describe('websocket message editor scroll behaviour', () => {
     });
 
     // Open message 2.
-    await ws.message.header(1).click({ position: { x: 8, y: 12 } });
-    await expect(ws.message.body(1)).toBeVisible();
+    await ws.websocket.message.header(1).click({ position: { x: 8, y: 12 } });
+    await expect(ws.websocket.message.body(1)).toBeVisible();
 
     // Its (sticky) header should settle at the top of the list — i.e. the message
     // wrapper's top aligns with the container's top.
@@ -81,13 +81,13 @@ test.describe('websocket message editor scroll behaviour', () => {
   test('selecting another message does not reset the deselected editor scroll to top', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
-    const cmScroll = (index: number) => ws.message.body(index).locator('.CodeMirror-scroll');
+    const ws = buildCommonLocators(page);
+    const cmScroll = (index: number) => ws.websocket.message.body(index).locator('.CodeMirror-scroll');
 
     await openRequest(page, COLLECTION_NAME, TWO_MSG_REQ);
 
     // Message 1 is selected + expanded by default.
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     await expect
       .poll(() => cmScroll(0).evaluate((el) => el.scrollHeight - el.clientHeight))
@@ -101,7 +101,7 @@ test.describe('websocket message editor scroll behaviour', () => {
     expect(target).toBeGreaterThan(0);
 
     // Select message 2.
-    await ws.message.header(1).click({ position: { x: 8, y: 12 } });
+    await ws.websocket.message.header(1).click({ position: { x: 8, y: 12 } });
 
     // Message 1 stays expanded; its scroll must not have jumped to the top.
     await expect

--- a/tests/websockets/message-scroll.spec.ts
+++ b/tests/websockets/message-scroll.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../playwright';
 import { openRequest, selectRequestPaneTab, closeAllCollections } from '../utils/page/actions';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
 const LONG_MSG_REQ = 'ws-long-msg';
@@ -13,13 +13,13 @@ test.describe('websocket message list scroll on tab switch', () => {
   test('does not scroll the expanded message list when switching request pane tabs', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, LONG_MSG_REQ);
 
-    const container = ws.message.container();
+    const container = ws.websocket.message.container();
     await expect(container).toBeVisible();
 
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     // the container must actually be scrollable.
     await expect
@@ -38,7 +38,7 @@ test.describe('websocket message list scroll on tab switch', () => {
     await selectRequestPaneTab(page, 'Message');
 
     await expect(container).toBeVisible();
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     // The scroll position must not have jumped to the bottom on remount.
     await expect.poll(() => container.evaluate((el) => el.scrollTop)).toBe(0);
@@ -47,12 +47,12 @@ test.describe('websocket message list scroll on tab switch', () => {
   test('restores the scroll position when switching back to the Message tab', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, LONG_MSG_REQ);
 
-    const container = ws.message.container();
+    const container = ws.websocket.message.container();
     await expect(container).toBeVisible();
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     // The container must actually be scrollable.
     await expect
@@ -74,7 +74,7 @@ test.describe('websocket message list scroll on tab switch', () => {
     await selectRequestPaneTab(page, 'Message');
 
     await expect(container).toBeVisible();
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     // The scroll position must be restored to where we left off.
     await expect.poll(() => container.evaluate((el) => el.scrollTop)).toBe(targetScroll);

--- a/tests/websockets/message-scroll.spec.ts
+++ b/tests/websockets/message-scroll.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../playwright';
 import { openRequest, selectRequestPaneTab, closeAllCollections } from '../utils/page/actions';
+import { buildWebsocketCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
 const LONG_MSG_REQ = 'ws-long-msg';
@@ -12,12 +13,13 @@ test.describe('websocket message list scroll on tab switch', () => {
   test('does not scroll the expanded message list when switching request pane tabs', async ({
     pageWithUserData: page
   }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, LONG_MSG_REQ);
 
-    const container = page.getByTestId('ws-messages-container');
+    const container = ws.message.container();
     await expect(container).toBeVisible();
 
-    await expect(page.getByTestId('ws-message-body-0')).toBeVisible();
+    await expect(ws.message.body(0)).toBeVisible();
 
     // the container must actually be scrollable.
     await expect
@@ -36,7 +38,7 @@ test.describe('websocket message list scroll on tab switch', () => {
     await selectRequestPaneTab(page, 'Message');
 
     await expect(container).toBeVisible();
-    await expect(page.getByTestId('ws-message-body-0')).toBeVisible();
+    await expect(ws.message.body(0)).toBeVisible();
 
     // The scroll position must not have jumped to the bottom on remount.
     await expect.poll(() => container.evaluate((el) => el.scrollTop)).toBe(0);
@@ -45,11 +47,12 @@ test.describe('websocket message list scroll on tab switch', () => {
   test('restores the scroll position when switching back to the Message tab', async ({
     pageWithUserData: page
   }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, LONG_MSG_REQ);
 
-    const container = page.getByTestId('ws-messages-container');
+    const container = ws.message.container();
     await expect(container).toBeVisible();
-    await expect(page.getByTestId('ws-message-body-0')).toBeVisible();
+    await expect(ws.message.body(0)).toBeVisible();
 
     // The container must actually be scrollable.
     await expect
@@ -71,7 +74,7 @@ test.describe('websocket message list scroll on tab switch', () => {
     await selectRequestPaneTab(page, 'Message');
 
     await expect(container).toBeVisible();
-    await expect(page.getByTestId('ws-message-body-0')).toBeVisible();
+    await expect(ws.message.body(0)).toBeVisible();
 
     // The scroll position must be restored to where we left off.
     await expect.poll(() => container.evaluate((el) => el.scrollTop)).toBe(targetScroll);

--- a/tests/websockets/message-scroll.spec.ts
+++ b/tests/websockets/message-scroll.spec.ts
@@ -13,13 +13,13 @@ test.describe('websocket message list scroll on tab switch', () => {
   test('does not scroll the expanded message list when switching request pane tabs', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, LONG_MSG_REQ);
 
-    const container = ws.websocket.message.container();
+    const container = websocket.message.container();
     await expect(container).toBeVisible();
 
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     // the container must actually be scrollable.
     await expect
@@ -38,7 +38,7 @@ test.describe('websocket message list scroll on tab switch', () => {
     await selectRequestPaneTab(page, 'Message');
 
     await expect(container).toBeVisible();
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     // The scroll position must not have jumped to the bottom on remount.
     await expect.poll(() => container.evaluate((el) => el.scrollTop)).toBe(0);
@@ -47,12 +47,12 @@ test.describe('websocket message list scroll on tab switch', () => {
   test('restores the scroll position when switching back to the Message tab', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, LONG_MSG_REQ);
 
-    const container = ws.websocket.message.container();
+    const container = websocket.message.container();
     await expect(container).toBeVisible();
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     // The container must actually be scrollable.
     await expect
@@ -74,7 +74,7 @@ test.describe('websocket message list scroll on tab switch', () => {
     await selectRequestPaneTab(page, 'Message');
 
     await expect(container).toBeVisible();
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     // The scroll position must be restored to where we left off.
     await expect.poll(() => container.evaluate((el) => el.scrollTop)).toBe(targetScroll);

--- a/tests/websockets/message-scroll.spec.ts
+++ b/tests/websockets/message-scroll.spec.ts
@@ -4,6 +4,7 @@ import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
 const LONG_MSG_REQ = 'ws-long-msg';
+const TWO_MSG_REQ = 'ws-two-long-msgs';
 
 test.describe('websocket message list scroll on tab switch', () => {
   test.afterEach(async ({ pageWithUserData: page }) => {
@@ -78,5 +79,56 @@ test.describe('websocket message list scroll on tab switch', () => {
 
     // The scroll position must be restored to where we left off.
     await expect.poll(() => container.evaluate((el) => el.scrollTop)).toBe(targetScroll);
+  });
+
+  test('restores both list and editor scroll at the bottom after switching tabs', async ({ pageWithUserData: page }) => {
+    const { websocket } = buildCommonLocators(page);
+    await openRequest(page, COLLECTION_NAME, TWO_MSG_REQ);
+
+    const container = websocket.message.container();
+    const editorScroll = websocket.message.body(1).locator('.CodeMirror-scroll'); // message 2's tall editor
+    // "At the bottom" = within a few px of the element's CURRENT max scroll
+    // (the max can shift slightly across remounts, so don't compare to a fixed value).
+    const atBottom = (locator: typeof container) =>
+      locator.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop <= 8);
+
+    await expect(container).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
+
+    // Expand the second message too so the list is as tall as possible.
+    await websocket.message.header(1).click({ position: { x: 8, y: 12 } });
+    await expect(websocket.message.body(1)).toBeVisible();
+    await expect.poll(() => container.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(0);
+    await expect.poll(() => editorScroll.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(0);
+
+    // Wait for the open-scroll animation (scrollMessageToTop) to settle so it
+    // doesn't override the scroll-to-bottom below (two equal reads in a row).
+    let prevTop = -1;
+    await expect
+      .poll(async () => {
+        const cur = await container.evaluate((el) => Math.round(el.scrollTop));
+        const settled = cur === prevTop;
+        prevTop = cur;
+        return settled;
+      })
+      .toBe(true);
+
+    // Scroll BOTH the inner editor and the outer list to the bottom.
+    await editorScroll.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    await container.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    await expect.poll(() => atBottom(editorScroll)).toBe(true);
+    await expect.poll(() => atBottom(container)).toBe(true);
+
+    // Switch away from the Message tab and back — this remounts WsBody.
+    await selectRequestPaneTab(page, 'Headers');
+    await expect(container).toBeHidden();
+    await selectRequestPaneTab(page, 'Message');
+
+    await expect(container).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
+
+    // Both scrolls must return to the bottom, not land short of it.
+    await expect.poll(() => atBottom(container)).toBe(true);
+    await expect.poll(() => atBottom(editorScroll)).toBe(true);
   });
 });

--- a/tests/websockets/message-typing-scroll.spec.ts
+++ b/tests/websockets/message-typing-scroll.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../playwright';
 import { openRequest, closeAllCollections } from '../utils/page/actions';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
 const SCROLL_REQ = 'ws-scroll-top';
@@ -11,11 +11,11 @@ test.describe('websocket message editor typing scroll', () => {
   });
 
   test('typing does not jump the list to the end', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SCROLL_REQ);
 
-    const container = ws.message.container();
-    const body = ws.message.body(0);
+    const container = ws.websocket.message.container();
+    const body = ws.websocket.message.body(0);
     await expect(container).toBeVisible();
     await expect(body).toBeVisible();
 
@@ -28,7 +28,7 @@ test.describe('websocket message editor typing scroll', () => {
     await cmScroll.evaluate((el) => {
       el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) / 2);
     });
-    await ws.message.editor(0).click();
+    await ws.websocket.message.editor(0).click();
 
     const containerBefore = await container.evaluate((el) => el.scrollTop);
     const cmBefore = await cmScroll.evaluate((el) => el.scrollTop);

--- a/tests/websockets/message-typing-scroll.spec.ts
+++ b/tests/websockets/message-typing-scroll.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '../../playwright';
 import { openRequest, closeAllCollections } from '../utils/page/actions';
+import { buildWebsocketCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
 const SCROLL_REQ = 'ws-scroll-top';
-const MULTI_REQ = 'ws-long-msg';
 
 test.describe('websocket message editor typing scroll', () => {
   test.afterEach(async ({ pageWithUserData: page }) => {
@@ -11,10 +11,11 @@ test.describe('websocket message editor typing scroll', () => {
   });
 
   test('typing does not jump the list to the end', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SCROLL_REQ);
 
-    const container = page.getByTestId('ws-messages-container');
-    const body = page.getByTestId('ws-message-body-0');
+    const container = ws.message.container();
+    const body = ws.message.body(0);
     await expect(container).toBeVisible();
     await expect(body).toBeVisible();
 
@@ -27,7 +28,7 @@ test.describe('websocket message editor typing scroll', () => {
     await cmScroll.evaluate((el) => {
       el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) / 2);
     });
-    await body.locator('.CodeMirror').click();
+    await ws.message.editor(0).click();
 
     const containerBefore = await container.evaluate((el) => el.scrollTop);
     const cmBefore = await cmScroll.evaluate((el) => el.scrollTop);

--- a/tests/websockets/message-typing-scroll.spec.ts
+++ b/tests/websockets/message-typing-scroll.spec.ts
@@ -11,11 +11,11 @@ test.describe('websocket message editor typing scroll', () => {
   });
 
   test('typing does not jump the list to the end', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SCROLL_REQ);
 
-    const container = ws.websocket.message.container();
-    const body = ws.websocket.message.body(0);
+    const container = websocket.message.container();
+    const body = websocket.message.body(0);
     await expect(container).toBeVisible();
     await expect(body).toBeVisible();
 
@@ -28,7 +28,7 @@ test.describe('websocket message editor typing scroll', () => {
     await cmScroll.evaluate((el) => {
       el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) / 2);
     });
-    await ws.websocket.message.editor(0).click();
+    await websocket.message.editor(0).click();
 
     const containerBefore = await container.evaluate((el) => el.scrollTop);
     const cmBefore = await cmScroll.evaluate((el) => el.scrollTop);

--- a/tests/websockets/multi-message-bru/message-name-style.spec.ts
+++ b/tests/websockets/multi-message-bru/message-name-style.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../../playwright';
 import { openRequest, closeAllCollections } from '../../utils/page/actions';
+import { buildWebsocketCommonLocators } from '../../utils/page/locators';
 
 const COLLECTION_NAME = 'ws-multi-message';
 const SINGLE_MSG_REQ = 'ws-single-msg';
@@ -10,25 +11,27 @@ test.describe('websocket message name styling', () => {
   });
 
   test('editable message name uses the text (I-beam) cursor', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await expect(page.getByTestId('ws-message-label-0')).toHaveCSS('cursor', 'text');
+    await expect(ws.message.label(0)).toHaveCSS('cursor', 'text');
   });
 
   test('long message name truncates instead of overflowing', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     const longName = 'this is a very long websocket message name that should be truncated with an ellipsis';
 
     // Rename the message to a name far wider than the row
-    await page.getByTestId('ws-message-label-0').dblclick();
-    const nameInput = page.getByTestId('ws-message-name-input-0');
+    await ws.message.label(0).dblclick();
+    const nameInput = ws.message.nameInput(0);
     await expect(nameInput).toBeVisible();
     await nameInput.selectText();
     await page.keyboard.type(longName);
     await nameInput.press('Enter');
 
-    const messageLabel = page.getByTestId('ws-message-label-0').filter({ hasText: longName });
+    const messageLabel = ws.message.label(0).filter({ hasText: longName });
     await expect(messageLabel).toBeVisible();
     await expect(messageLabel).toHaveCSS('white-space', 'nowrap');
     await expect(messageLabel).toHaveCSS('text-overflow', 'ellipsis');

--- a/tests/websockets/multi-message-bru/message-name-style.spec.ts
+++ b/tests/websockets/multi-message-bru/message-name-style.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../../playwright';
 import { openRequest, closeAllCollections } from '../../utils/page/actions';
-import { buildWebsocketCommonLocators } from '../../utils/page/locators';
+import { buildCommonLocators } from '../../utils/page/locators';
 
 const COLLECTION_NAME = 'ws-multi-message';
 const SINGLE_MSG_REQ = 'ws-single-msg';
@@ -11,27 +11,27 @@ test.describe('websocket message name styling', () => {
   });
 
   test('editable message name uses the text (I-beam) cursor', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await expect(ws.message.label(0)).toHaveCSS('cursor', 'text');
+    await expect(ws.websocket.message.label(0)).toHaveCSS('cursor', 'text');
   });
 
   test('long message name truncates instead of overflowing', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     const longName = 'this is a very long websocket message name that should be truncated with an ellipsis';
 
     // Rename the message to a name far wider than the row
-    await ws.message.label(0).dblclick();
-    const nameInput = ws.message.nameInput(0);
+    await ws.websocket.message.label(0).dblclick();
+    const nameInput = ws.websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
     await nameInput.selectText();
     await page.keyboard.type(longName);
     await nameInput.press('Enter');
 
-    const messageLabel = ws.message.label(0).filter({ hasText: longName });
+    const messageLabel = ws.websocket.message.label(0).filter({ hasText: longName });
     await expect(messageLabel).toBeVisible();
     await expect(messageLabel).toHaveCSS('white-space', 'nowrap');
     await expect(messageLabel).toHaveCSS('text-overflow', 'ellipsis');

--- a/tests/websockets/multi-message-bru/message-name-style.spec.ts
+++ b/tests/websockets/multi-message-bru/message-name-style.spec.ts
@@ -11,27 +11,27 @@ test.describe('websocket message name styling', () => {
   });
 
   test('editable message name uses the text (I-beam) cursor', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await expect(ws.websocket.message.label(0)).toHaveCSS('cursor', 'text');
+    await expect(websocket.message.label(0)).toHaveCSS('cursor', 'text');
   });
 
   test('long message name truncates instead of overflowing', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     const longName = 'this is a very long websocket message name that should be truncated with an ellipsis';
 
     // Rename the message to a name far wider than the row
-    await ws.websocket.message.label(0).dblclick();
-    const nameInput = ws.websocket.message.nameInput(0);
+    await websocket.message.label(0).dblclick();
+    const nameInput = websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
     await nameInput.selectText();
     await page.keyboard.type(longName);
     await nameInput.press('Enter');
 
-    const messageLabel = ws.websocket.message.label(0).filter({ hasText: longName });
+    const messageLabel = websocket.message.label(0).filter({ hasText: longName });
     await expect(messageLabel).toBeVisible();
     await expect(messageLabel).toHaveCSS('white-space', 'nowrap');
     await expect(messageLabel).toHaveCSS('text-overflow', 'ellipsis');

--- a/tests/websockets/multi-message-bru/message-name-tooltip.spec.ts
+++ b/tests/websockets/multi-message-bru/message-name-tooltip.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../../playwright';
 import { openRequest, closeAllCollections, renameWsMessage } from '../../utils/page/actions';
-import { buildWebsocketCommonLocators } from '../../utils/page/locators';
+import { buildCommonLocators } from '../../utils/page/locators';
 
 const COLLECTION_NAME = 'ws-multi-message';
 const SINGLE_MSG_REQ = 'ws-single-msg';
@@ -16,11 +16,11 @@ test.describe('websocket message name tooltip', () => {
   test('shows the full name in a tooltip on hover', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    const messageLabel = ws.message.label(0);
-    const tooltip = ws.message.nameTooltip();
+    const messageLabel = ws.websocket.message.label(0);
+    const tooltip = ws.websocket.message.nameTooltip();
 
     await test.step('short name → tooltip shows the name on hover', async () => {
       await renameWsMessage(page, 0, 'hi');

--- a/tests/websockets/multi-message-bru/message-name-tooltip.spec.ts
+++ b/tests/websockets/multi-message-bru/message-name-tooltip.spec.ts
@@ -16,11 +16,11 @@ test.describe('websocket message name tooltip', () => {
   test('shows the full name in a tooltip on hover', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    const messageLabel = ws.websocket.message.label(0);
-    const tooltip = ws.websocket.message.nameTooltip();
+    const messageLabel = websocket.message.label(0);
+    const tooltip = websocket.message.nameTooltip();
 
     await test.step('short name → tooltip shows the name on hover', async () => {
       await renameWsMessage(page, 0, 'hi');

--- a/tests/websockets/multi-message-bru/multi-message.spec.ts
+++ b/tests/websockets/multi-message-bru/multi-message.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../../../playwright';
-import { buildWebsocketCommonLocators } from '../../utils/page/locators';
+import { buildCommonLocators } from '../../utils/page/locators';
 import { openRequest, saveRequest, closeAllCollections } from '../../utils/page/actions';
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
@@ -30,20 +30,20 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('add a new message and save', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.message.addButton().click();
+    await ws.websocket.message.addButton().click();
 
-    const nameInput = ws.message.nameInputs();
+    const nameInput = ws.websocket.message.nameInputs();
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('ping message');
     await nameInput.press('Enter');
 
-    await expect(ws.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
-    await expect(ws.message.headers()).toHaveCount(3);
+    await expect(ws.websocket.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
+    await expect(ws.websocket.message.headers()).toHaveCount(3);
 
     await saveRequest(page);
 
@@ -52,16 +52,16 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('edit message content and verify persistence', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    if (!(await ws.message.body(0).isVisible())) {
-      await ws.message.header(0).click();
+    if (!(await ws.websocket.message.body(0).isVisible())) {
+      await ws.websocket.message.header(0).click();
     }
-    const editor = ws.message.editor(0);
+    const editor = ws.websocket.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
@@ -75,13 +75,13 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('messages with different types persist correctly', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    const firstHeader = ws.message.header(0);
+    const firstHeader = ws.websocket.message.header(0);
     await expect(firstHeader.locator('.selected-body-mode')).toContainText('JSON');
 
-    const secondHeader = ws.message.header(1);
+    const secondHeader = ws.websocket.message.header(1);
     await expect(secondHeader.locator('.selected-body-mode')).toContainText('TEXT');
 
     // Change message 1 type from json to xml
@@ -100,21 +100,21 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(ws.message.header(0).locator('.selected-body-mode')).toContainText('XML');
-    await expect(ws.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
+    await expect(ws.websocket.message.header(0).locator('.selected-body-mode')).toContainText('XML');
+    await expect(ws.websocket.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
   });
 
   test('send selected message to active connection', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.connectionControls.connect().click();
-    await expect(ws.connectionControls.disconnect()).toBeAttached({
+    await ws.websocket.connectionControls.connect().click();
+    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    const messageItems = ws.messages().locator('.text-ellipsis');
+    const messageItems = ws.websocket.messages().locator('.text-ellipsis');
     const beforeCount = await messageItems.count();
 
     // Click the main send button — sends the currently selected message
@@ -123,19 +123,19 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     // Expect at least one new message (outgoing + echo response from server)
     await expect.poll(() => messageItems.count(), { timeout: MAX_CONNECTION_TIME }).toBeGreaterThan(beforeCount);
 
-    await ws.connectionControls.disconnect().click();
-    await expect(ws.connectionControls.connect()).toBeVisible();
+    await ws.websocket.connectionControls.disconnect().click();
+    await expect(ws.websocket.connectionControls.connect()).toBeVisible();
   });
 
   test('first message is implicitly selected when no message is marked selected', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // ws-multi-msg.bru has two messages with no `selected: true` flag. The
     // main send button should therefore dispatch the first message.
-    await ws.connectionControls.connect().click();
-    await expect(ws.connectionControls.disconnect()).toBeAttached({
+    await ws.websocket.connectionControls.connect().click();
+    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
@@ -143,74 +143,74 @@ test.describe.serial('websocket multi-message (bru format)', () => {
 
     // the first message's content ("subscribe"), and none should carry the
     // second message's content ("hello world").
-    await expect(ws.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
+    await expect(ws.websocket.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
+    await expect(ws.websocket.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
 
-    await ws.connectionControls.disconnect().click();
+    await ws.websocket.connectionControls.disconnect().click();
   });
 
   test('selecting a different message routes run-button to that message', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Select the second message by clicking its header
-    await ws.message.header(1).click();
+    await ws.websocket.message.header(1).click();
 
-    await ws.connectionControls.connect().click();
-    await expect(ws.connectionControls.disconnect()).toBeAttached({
+    await ws.websocket.connectionControls.connect().click();
+    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
     await ws.runner().click();
 
-    await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(ws.websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
+    await expect(ws.websocket.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
 
-    await ws.connectionControls.disconnect().click();
+    await ws.websocket.connectionControls.disconnect().click();
   });
 
   test('per-message send button sends that specific message', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Hover the header to reveal hover-actions, then click the second
-    await ws.message.header(1).hover();
-    await ws.message.sendButton(1).click();
+    await ws.websocket.message.header(1).hover();
+    await ws.websocket.message.sendButton(1).click();
 
-    await expect(ws.connectionControls.disconnect()).toBeAttached({
+    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(ws.websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await ws.connectionControls.disconnect().click();
+    await ws.websocket.connectionControls.disconnect().click();
   });
 
   test('prettify json message content', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    if (!(await ws.message.body(0).isVisible())) {
-      await ws.message.header(0).click();
+    if (!(await ws.websocket.message.body(0).isVisible())) {
+      await ws.websocket.message.header(0).click();
     }
-    const editor = ws.message.editor(0);
+    const editor = ws.websocket.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
     await page.keyboard.press(selectAllShortcut);
     await page.keyboard.insertText('{"name":"bruno","version":"1.0"}');
 
-    await ws.message.prettifyAll().click();
+    await ws.websocket.message.prettifyAll().click();
 
     // Verify prettification split single line into multiple lines
     const lineNumbers = await editor.locator('.CodeMirror-linenumber').count();
@@ -218,16 +218,16 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('delete a message', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(ws.message.headers()).toHaveCount(2);
+    await expect(ws.websocket.message.headers()).toHaveCount(2);
 
     // Hover over the message header to reveal the delete button
-    await ws.message.header(1).hover();
-    await ws.message.deleteButton(1).click();
+    await ws.websocket.message.header(1).hover();
+    await ws.websocket.message.deleteButton(1).click();
 
-    await expect(ws.message.headers()).toHaveCount(1);
+    await expect(ws.websocket.message.headers()).toHaveCount(1);
 
     await saveRequest(page);
 
@@ -237,19 +237,19 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('rename a message via double-click', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await ws.message.label(0).dblclick();
+    await ws.websocket.message.label(0).dblclick();
 
-    const nameInput = ws.message.nameInput(0);
+    const nameInput = ws.websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('subscribe request');
     await nameInput.press('Enter');
 
-    await expect(ws.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
+    await expect(ws.websocket.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
 
     await saveRequest(page);
 
@@ -258,14 +258,14 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('rename a message and save with the keyboard shortcut while editing', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await ws.message.label(0).dblclick();
+    await ws.websocket.message.label(0).dblclick();
 
-    const nameInput = ws.message.nameInput(0);
+    const nameInput = ws.websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
@@ -276,7 +276,7 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     await nameInput.press(saveShortcut);
 
     // The editing input closes and the new name is committed to the UI.
-    await expect(ws.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
+    await expect(ws.websocket.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
 
     // The rename must be written to disk by the shortcut-triggered save.
     await expect

--- a/tests/websockets/multi-message-bru/multi-message.spec.ts
+++ b/tests/websockets/multi-message-bru/multi-message.spec.ts
@@ -30,20 +30,20 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('add a new message and save', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.websocket.message.addButton().click();
+    await websocket.message.addButton().click();
 
-    const nameInput = ws.websocket.message.nameInputs();
+    const nameInput = websocket.message.nameInputs();
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('ping message');
     await nameInput.press('Enter');
 
-    await expect(ws.websocket.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
-    await expect(ws.websocket.message.headers()).toHaveCount(3);
+    await expect(websocket.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
+    await expect(websocket.message.headers()).toHaveCount(3);
 
     await saveRequest(page);
 
@@ -52,16 +52,16 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('edit message content and verify persistence', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    if (!(await ws.websocket.message.body(0).isVisible())) {
-      await ws.websocket.message.header(0).click();
+    if (!(await websocket.message.body(0).isVisible())) {
+      await websocket.message.header(0).click();
     }
-    const editor = ws.websocket.message.editor(0);
+    const editor = websocket.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
@@ -75,13 +75,13 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('messages with different types persist correctly', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    const firstHeader = ws.websocket.message.header(0);
+    const firstHeader = websocket.message.header(0);
     await expect(firstHeader.locator('.selected-body-mode')).toContainText('JSON');
 
-    const secondHeader = ws.websocket.message.header(1);
+    const secondHeader = websocket.message.header(1);
     await expect(secondHeader.locator('.selected-body-mode')).toContainText('TEXT');
 
     // Change message 1 type from json to xml
@@ -100,117 +100,117 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(ws.websocket.message.header(0).locator('.selected-body-mode')).toContainText('XML');
-    await expect(ws.websocket.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
+    await expect(websocket.message.header(0).locator('.selected-body-mode')).toContainText('XML');
+    await expect(websocket.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
   });
 
   test('send selected message to active connection', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.websocket.connectionControls.connect().click();
-    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
+    await websocket.connectionControls.connect().click();
+    await expect(websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    const messageItems = ws.websocket.messages().locator('.text-ellipsis');
+    const messageItems = websocket.messages().locator('.text-ellipsis');
     const beforeCount = await messageItems.count();
 
     // Click the main send button — sends the currently selected message
-    await ws.runner().click();
+    await runner().click();
 
     // Expect at least one new message (outgoing + echo response from server)
     await expect.poll(() => messageItems.count(), { timeout: MAX_CONNECTION_TIME }).toBeGreaterThan(beforeCount);
 
-    await ws.websocket.connectionControls.disconnect().click();
-    await expect(ws.websocket.connectionControls.connect()).toBeVisible();
+    await websocket.connectionControls.disconnect().click();
+    await expect(websocket.connectionControls.connect()).toBeVisible();
   });
 
   test('first message is implicitly selected when no message is marked selected', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // ws-multi-msg.bru has two messages with no `selected: true` flag. The
     // main send button should therefore dispatch the first message.
-    await ws.websocket.connectionControls.connect().click();
-    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
+    await websocket.connectionControls.connect().click();
+    await expect(websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await ws.runner().click();
+    await runner().click();
 
     // the first message's content ("subscribe"), and none should carry the
     // second message's content ("hello world").
-    await expect(ws.websocket.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
+    await expect(websocket.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.websocket.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
+    await expect(websocket.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
 
-    await ws.websocket.connectionControls.disconnect().click();
+    await websocket.connectionControls.disconnect().click();
   });
 
   test('selecting a different message routes run-button to that message', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Select the second message by clicking its header
-    await ws.websocket.message.header(1).click();
+    await websocket.message.header(1).click();
 
-    await ws.websocket.connectionControls.connect().click();
-    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
+    await websocket.connectionControls.connect().click();
+    await expect(websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await ws.runner().click();
+    await runner().click();
 
-    await expect(ws.websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.websocket.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
+    await expect(websocket.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
 
-    await ws.websocket.connectionControls.disconnect().click();
+    await websocket.connectionControls.disconnect().click();
   });
 
   test('per-message send button sends that specific message', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Hover the header to reveal hover-actions, then click the second
-    await ws.websocket.message.header(1).hover();
-    await ws.websocket.message.sendButton(1).click();
+    await websocket.message.header(1).hover();
+    await websocket.message.sendButton(1).click();
 
-    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
+    await expect(websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await ws.websocket.connectionControls.disconnect().click();
+    await websocket.connectionControls.disconnect().click();
   });
 
   test('prettify json message content', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    if (!(await ws.websocket.message.body(0).isVisible())) {
-      await ws.websocket.message.header(0).click();
+    if (!(await websocket.message.body(0).isVisible())) {
+      await websocket.message.header(0).click();
     }
-    const editor = ws.websocket.message.editor(0);
+    const editor = websocket.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
     await page.keyboard.press(selectAllShortcut);
     await page.keyboard.insertText('{"name":"bruno","version":"1.0"}');
 
-    await ws.websocket.message.prettifyAll().click();
+    await websocket.message.prettifyAll().click();
 
     // Verify prettification split single line into multiple lines
     const lineNumbers = await editor.locator('.CodeMirror-linenumber').count();
@@ -218,16 +218,16 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('delete a message', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(ws.websocket.message.headers()).toHaveCount(2);
+    await expect(websocket.message.headers()).toHaveCount(2);
 
     // Hover over the message header to reveal the delete button
-    await ws.websocket.message.header(1).hover();
-    await ws.websocket.message.deleteButton(1).click();
+    await websocket.message.header(1).hover();
+    await websocket.message.deleteButton(1).click();
 
-    await expect(ws.websocket.message.headers()).toHaveCount(1);
+    await expect(websocket.message.headers()).toHaveCount(1);
 
     await saveRequest(page);
 
@@ -237,19 +237,19 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('rename a message via double-click', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await ws.websocket.message.label(0).dblclick();
+    await websocket.message.label(0).dblclick();
 
-    const nameInput = ws.websocket.message.nameInput(0);
+    const nameInput = websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('subscribe request');
     await nameInput.press('Enter');
 
-    await expect(ws.websocket.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
+    await expect(websocket.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
 
     await saveRequest(page);
 
@@ -258,14 +258,14 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('rename a message and save with the keyboard shortcut while editing', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await ws.websocket.message.label(0).dblclick();
+    await websocket.message.label(0).dblclick();
 
-    const nameInput = ws.websocket.message.nameInput(0);
+    const nameInput = websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
@@ -276,7 +276,7 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     await nameInput.press(saveShortcut);
 
     // The editing input closes and the new name is committed to the UI.
-    await expect(ws.websocket.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
+    await expect(websocket.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
 
     // The rename must be written to disk by the shortcut-triggered save.
     await expect

--- a/tests/websockets/multi-message-bru/multi-message.spec.ts
+++ b/tests/websockets/multi-message-bru/multi-message.spec.ts
@@ -30,19 +30,20 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('add a new message and save', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await page.getByTestId('ws-add-message').click();
+    await ws.message.addButton().click();
 
-    const nameInput = page.getByTestId(/^ws-message-name-input-/);
+    const nameInput = ws.message.nameInputs();
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('ping message');
     await nameInput.press('Enter');
 
-    await expect(page.getByTestId(/^ws-message-label-/).filter({ hasText: 'ping message' })).toBeVisible();
-    await expect(page.getByTestId(/^ws-message-header-/)).toHaveCount(3);
+    await expect(ws.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
+    await expect(ws.message.headers()).toHaveCount(3);
 
     await saveRequest(page);
 
@@ -51,16 +52,16 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('edit message content and verify persistence', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    const editorBody = page.getByTestId('ws-message-body-0');
-    if (!(await editorBody.isVisible())) {
-      await page.getByTestId('ws-message-header-0').click();
+    if (!(await ws.message.body(0).isVisible())) {
+      await ws.message.header(0).click();
     }
-    const editor = editorBody.locator('.CodeMirror');
+    const editor = ws.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
@@ -74,12 +75,13 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('messages with different types persist correctly', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    const firstHeader = page.getByTestId('ws-message-header-0');
+    const firstHeader = ws.message.header(0);
     await expect(firstHeader.locator('.selected-body-mode')).toContainText('JSON');
 
-    const secondHeader = page.getByTestId('ws-message-header-1');
+    const secondHeader = ws.message.header(1);
     await expect(secondHeader.locator('.selected-body-mode')).toContainText('TEXT');
 
     // Change message 1 type from json to xml
@@ -98,21 +100,21 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(page.getByTestId('ws-message-header-0').locator('.selected-body-mode')).toContainText('XML');
-    await expect(page.getByTestId('ws-message-header-1').locator('.selected-body-mode')).toContainText('TEXT');
+    await expect(ws.message.header(0).locator('.selected-body-mode')).toContainText('XML');
+    await expect(ws.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
   });
 
   test('send selected message to active connection', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const ws = buildWebsocketCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await locators.connectionControls.connect().click();
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await ws.connectionControls.connect().click();
+    await expect(ws.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    const messageItems = locators.messages().locator('.text-ellipsis');
+    const messageItems = ws.messages().locator('.text-ellipsis');
     const beforeCount = await messageItems.count();
 
     // Click the main send button — sends the currently selected message
@@ -121,19 +123,19 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     // Expect at least one new message (outgoing + echo response from server)
     await expect.poll(() => messageItems.count(), { timeout: MAX_CONNECTION_TIME }).toBeGreaterThan(beforeCount);
 
-    await locators.connectionControls.disconnect().click();
-    await expect(locators.connectionControls.connect()).toBeVisible();
+    await ws.connectionControls.disconnect().click();
+    await expect(ws.connectionControls.connect()).toBeVisible();
   });
 
   test('first message is implicitly selected when no message is marked selected', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const ws = buildWebsocketCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // ws-multi-msg.bru has two messages with no `selected: true` flag. The
     // main send button should therefore dispatch the first message.
-    await locators.connectionControls.connect().click();
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await ws.connectionControls.connect().click();
+    await expect(ws.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
@@ -141,74 +143,74 @@ test.describe.serial('websocket multi-message (bru format)', () => {
 
     // the first message's content ("subscribe"), and none should carry the
     // second message's content ("hello world").
-    await expect(locators.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
+    await expect(ws.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(locators.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
+    await expect(ws.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
 
-    await locators.connectionControls.disconnect().click();
+    await ws.connectionControls.disconnect().click();
   });
 
   test('selecting a different message routes run-button to that message', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const ws = buildWebsocketCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Select the second message by clicking its header
-    await page.getByTestId('ws-message-header-1').click();
+    await ws.message.header(1).click();
 
-    await locators.connectionControls.connect().click();
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await ws.connectionControls.connect().click();
+    await expect(ws.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
     await page.getByTestId('run-button').click();
 
-    await expect(locators.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(locators.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
+    await expect(ws.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
 
-    await locators.connectionControls.disconnect().click();
+    await ws.connectionControls.disconnect().click();
   });
 
   test('per-message send button sends that specific message', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const ws = buildWebsocketCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Hover the header to reveal hover-actions, then click the second
-    await page.getByTestId('ws-message-header-1').hover();
-    await page.getByTestId('ws-send-msg-1').click();
+    await ws.message.header(1).hover();
+    await ws.message.sendButton(1).click();
 
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await expect(ws.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(locators.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await locators.connectionControls.disconnect().click();
+    await ws.connectionControls.disconnect().click();
   });
 
   test('prettify json message content', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    const editorBody = page.getByTestId('ws-message-body-0');
-    if (!(await editorBody.isVisible())) {
-      await page.getByTestId('ws-message-header-0').click();
+    if (!(await ws.message.body(0).isVisible())) {
+      await ws.message.header(0).click();
     }
-    const editor = editorBody.locator('.CodeMirror');
+    const editor = ws.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
     await page.keyboard.press(selectAllShortcut);
     await page.keyboard.insertText('{"name":"bruno","version":"1.0"}');
 
-    await page.getByTestId('ws-prettify-all').click();
+    await ws.message.prettifyAll().click();
 
     // Verify prettification split single line into multiple lines
     const lineNumbers = await editor.locator('.CodeMirror-linenumber').count();
@@ -216,15 +218,16 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('delete a message', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(page.getByTestId(/^ws-message-header-/)).toHaveCount(2);
+    await expect(ws.message.headers()).toHaveCount(2);
 
     // Hover over the message header to reveal the delete button
-    await page.getByTestId('ws-message-header-1').hover();
-    await page.getByTestId('ws-delete-msg-1').click();
+    await ws.message.header(1).hover();
+    await ws.message.deleteButton(1).click();
 
-    await expect(page.getByTestId(/^ws-message-header-/)).toHaveCount(1);
+    await expect(ws.message.headers()).toHaveCount(1);
 
     await saveRequest(page);
 
@@ -234,19 +237,19 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('rename a message via double-click', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    const messageLabel = page.getByTestId('ws-message-label-0');
-    await messageLabel.dblclick();
+    await ws.message.label(0).dblclick();
 
-    const nameInput = page.getByTestId('ws-message-name-input-0');
+    const nameInput = ws.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('subscribe request');
     await nameInput.press('Enter');
 
-    await expect(page.getByTestId('ws-message-label-0').filter({ hasText: 'subscribe request' })).toBeVisible();
+    await expect(ws.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
 
     await saveRequest(page);
 
@@ -255,14 +258,14 @@ test.describe.serial('websocket multi-message (bru format)', () => {
   });
 
   test('rename a message and save with the keyboard shortcut while editing', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    const messageLabel = page.getByTestId('ws-message-label-0');
-    await messageLabel.dblclick();
+    await ws.message.label(0).dblclick();
 
-    const nameInput = page.getByTestId('ws-message-name-input-0');
+    const nameInput = ws.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
@@ -273,7 +276,7 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     await nameInput.press(saveShortcut);
 
     // The editing input closes and the new name is committed to the UI.
-    await expect(page.getByTestId('ws-message-label-0').filter({ hasText: 'renamed via shortcut' })).toBeVisible();
+    await expect(ws.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
 
     // The rename must be written to disk by the shortcut-triggered save.
     await expect

--- a/tests/websockets/multi-message-bru/multi-message.spec.ts
+++ b/tests/websockets/multi-message-bru/multi-message.spec.ts
@@ -118,7 +118,7 @@ test.describe.serial('websocket multi-message (bru format)', () => {
     const beforeCount = await messageItems.count();
 
     // Click the main send button — sends the currently selected message
-    await page.getByTestId('run-button').click();
+    await ws.runner().click();
 
     // Expect at least one new message (outgoing + echo response from server)
     await expect.poll(() => messageItems.count(), { timeout: MAX_CONNECTION_TIME }).toBeGreaterThan(beforeCount);
@@ -139,7 +139,7 @@ test.describe.serial('websocket multi-message (bru format)', () => {
       timeout: MAX_CONNECTION_TIME
     });
 
-    await page.getByTestId('run-button').click();
+    await ws.runner().click();
 
     // the first message's content ("subscribe"), and none should carry the
     // second message's content ("hello world").
@@ -164,7 +164,7 @@ test.describe.serial('websocket multi-message (bru format)', () => {
       timeout: MAX_CONNECTION_TIME
     });
 
-    await page.getByTestId('run-button').click();
+    await ws.runner().click();
 
     await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME

--- a/tests/websockets/multi-message-yml/message-name-tooltip.spec.ts
+++ b/tests/websockets/multi-message-yml/message-name-tooltip.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../../../playwright';
 import { openRequest, closeAllCollections, renameWsMessage } from '../../utils/page/actions';
-import { buildWebsocketCommonLocators } from '../../utils/page/locators';
+import { buildCommonLocators } from '../../utils/page/locators';
 
 const COLLECTION_NAME = 'ws-multi-message-yml';
 const SINGLE_MSG_REQ = 'ws-single-msg';
@@ -16,11 +16,11 @@ test.describe('websocket message name tooltip (yml format)', () => {
   test('shows the full name in a tooltip on hover', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    const messageLabel = ws.message.label(0);
-    const tooltip = ws.message.nameTooltip();
+    const messageLabel = ws.websocket.message.label(0);
+    const tooltip = ws.websocket.message.nameTooltip();
 
     await test.step('short name → tooltip shows the name on hover', async () => {
       await renameWsMessage(page, 0, 'hi');

--- a/tests/websockets/multi-message-yml/message-name-tooltip.spec.ts
+++ b/tests/websockets/multi-message-yml/message-name-tooltip.spec.ts
@@ -16,11 +16,11 @@ test.describe('websocket message name tooltip (yml format)', () => {
   test('shows the full name in a tooltip on hover', async ({
     pageWithUserData: page
   }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    const messageLabel = ws.websocket.message.label(0);
-    const tooltip = ws.websocket.message.nameTooltip();
+    const messageLabel = websocket.message.label(0);
+    const tooltip = websocket.message.nameTooltip();
 
     await test.step('short name → tooltip shows the name on hover', async () => {
       await renameWsMessage(page, 0, 'hi');

--- a/tests/websockets/multi-message-yml/multi-message.spec.ts
+++ b/tests/websockets/multi-message-yml/multi-message.spec.ts
@@ -30,23 +30,24 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('backward compatibility: old single-message format loads correctly', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // The old format (message: { type, data }) should load as a single accordion
-    await expect(page.getByTestId(/^ws-message-header-/)).toHaveCount(1);
+    await expect(ws.message.headers()).toHaveCount(1);
 
     // Expand the first message if not already expanded
-    if (!(await page.getByTestId('ws-message-body-0').isVisible())) {
-      await page.getByTestId('ws-message-header-0').click();
+    if (!(await ws.message.body(0).isVisible())) {
+      await ws.message.header(0).click();
     }
-    await expect(page.getByTestId('ws-message-body-0')).toBeVisible();
+    await expect(ws.message.body(0)).toBeVisible();
 
     // Verify the type is correctly read from the old format
-    await expect(page.getByTestId('ws-message-header-0').locator('.selected-body-mode')).toContainText('JSON');
+    await expect(ws.message.header(0).locator('.selected-body-mode')).toContainText('JSON');
 
     // Add a second message to trigger format migration
-    await page.getByTestId('ws-add-message').click();
-    const nameInput = page.getByTestId(/^ws-message-name-input-/);
+    await ws.message.addButton().click();
+    const nameInput = ws.message.nameInputs();
     await expect(nameInput).toBeVisible();
     await nameInput.selectText();
     await page.keyboard.type('new message');
@@ -63,23 +64,24 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await expect(page.getByTestId(/^ws-message-header-/)).toHaveCount(2);
+    await expect(ws.message.headers()).toHaveCount(2);
   });
 
   test('add a new message and save', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await page.getByTestId('ws-add-message').click();
+    await ws.message.addButton().click();
 
-    const nameInput = page.getByTestId(/^ws-message-name-input-/);
+    const nameInput = ws.message.nameInputs();
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('ping message');
     await nameInput.press('Enter');
 
-    await expect(page.getByTestId(/^ws-message-label-/).filter({ hasText: 'ping message' })).toBeVisible();
-    await expect(page.getByTestId(/^ws-message-header-/)).toHaveCount(3);
+    await expect(ws.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
+    await expect(ws.message.headers()).toHaveCount(3);
 
     await saveRequest(page);
 
@@ -88,16 +90,16 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('edit message content and verify persistence', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    const editorBody = page.getByTestId('ws-message-body-0');
-    if (!(await editorBody.isVisible())) {
-      await page.getByTestId('ws-message-header-0').click();
+    if (!(await ws.message.body(0).isVisible())) {
+      await ws.message.header(0).click();
     }
-    const editor = editorBody.locator('.CodeMirror');
+    const editor = ws.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
@@ -111,12 +113,13 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('messages with different types persist correctly', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    const firstHeader = page.getByTestId('ws-message-header-0');
+    const firstHeader = ws.message.header(0);
     await expect(firstHeader.locator('.selected-body-mode')).toContainText('JSON');
 
-    const secondHeader = page.getByTestId('ws-message-header-1');
+    const secondHeader = ws.message.header(1);
     await expect(secondHeader.locator('.selected-body-mode')).toContainText('TEXT');
 
     // Change message 1 type from json to xml
@@ -135,21 +138,21 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(page.getByTestId('ws-message-header-0').locator('.selected-body-mode')).toContainText('XML');
-    await expect(page.getByTestId('ws-message-header-1').locator('.selected-body-mode')).toContainText('TEXT');
+    await expect(ws.message.header(0).locator('.selected-body-mode')).toContainText('XML');
+    await expect(ws.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
   });
 
   test('send selected message to active connection', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const ws = buildWebsocketCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await locators.connectionControls.connect().click();
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await ws.connectionControls.connect().click();
+    await expect(ws.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    const messageItems = locators.messages().locator('.text-ellipsis');
+    const messageItems = ws.messages().locator('.text-ellipsis');
     const beforeCount = await messageItems.count();
 
     // Click the main send button — sends the currently selected message
@@ -158,19 +161,19 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     // Expect at least one new message (outgoing + echo response from server)
     await expect.poll(() => messageItems.count(), { timeout: MAX_CONNECTION_TIME }).toBeGreaterThan(beforeCount);
 
-    await locators.connectionControls.disconnect().click();
-    await expect(locators.connectionControls.connect()).toBeVisible();
+    await ws.connectionControls.disconnect().click();
+    await expect(ws.connectionControls.connect()).toBeVisible();
   });
 
   test('first message is implicitly selected when no message is marked selected', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const ws = buildWebsocketCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // ws-multi-msg.yml has two messages with no `selected: true` flag. The
     // main send button should therefore dispatch the first message.
-    await locators.connectionControls.connect().click();
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await ws.connectionControls.connect().click();
+    await expect(ws.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
@@ -178,75 +181,75 @@ test.describe.serial('websocket multi-message (yml format)', () => {
 
     // the first message's content ("subscribe"), and none should carry the
     // second message's content ("hello world").
-    await expect(locators.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
+    await expect(ws.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(locators.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
+    await expect(ws.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
 
-    await locators.connectionControls.disconnect().click();
+    await ws.connectionControls.disconnect().click();
   });
 
   test('selecting a different message routes run-button to that message', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const ws = buildWebsocketCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Select the second message by clicking its header
-    await page.getByTestId('ws-message-header-1').click();
+    await ws.message.header(1).click();
 
-    await locators.connectionControls.connect().click();
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await ws.connectionControls.connect().click();
+    await expect(ws.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
     await page.getByTestId('run-button').click();
 
-    await expect(locators.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(locators.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
+    await expect(ws.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
 
-    await locators.connectionControls.disconnect().click();
+    await ws.connectionControls.disconnect().click();
   });
 
   test('per-message send button sends that specific message', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const ws = buildWebsocketCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Hover the header to reveal hover-actions, then click the second
     // message's send button
-    await page.getByTestId('ws-message-header-1').hover();
-    await page.getByTestId('ws-send-msg-1').click();
+    await ws.message.header(1).hover();
+    await ws.message.sendButton(1).click();
 
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await expect(ws.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(locators.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await locators.connectionControls.disconnect().click();
+    await ws.connectionControls.disconnect().click();
   });
 
   test('prettify json message content', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    const editorBody = page.getByTestId('ws-message-body-0');
-    if (!(await editorBody.isVisible())) {
-      await page.getByTestId('ws-message-header-0').click();
+    if (!(await ws.message.body(0).isVisible())) {
+      await ws.message.header(0).click();
     }
-    const editor = editorBody.locator('.CodeMirror');
+    const editor = ws.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
     await page.keyboard.press(selectAllShortcut);
     await page.keyboard.insertText('{"name":"bruno","version":"1.0"}');
 
-    await page.getByTestId('ws-prettify-all').click();
+    await ws.message.prettifyAll().click();
 
     // Verify prettification split single line into multiple lines
     const lineNumbers = await editor.locator('.CodeMirror-linenumber').count();
@@ -254,15 +257,16 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('delete a message', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(page.getByTestId(/^ws-message-header-/)).toHaveCount(2);
+    await expect(ws.message.headers()).toHaveCount(2);
 
     // Hover over the message header to reveal the delete button
-    await page.getByTestId('ws-message-header-1').hover();
-    await page.getByTestId('ws-delete-msg-1').click();
+    await ws.message.header(1).hover();
+    await ws.message.deleteButton(1).click();
 
-    await expect(page.getByTestId(/^ws-message-header-/)).toHaveCount(1);
+    await expect(ws.message.headers()).toHaveCount(1);
 
     await saveRequest(page);
 
@@ -272,19 +276,19 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('rename a message via double-click', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    const messageLabel = page.getByTestId('ws-message-label-0');
-    await messageLabel.dblclick();
+    await ws.message.label(0).dblclick();
 
-    const nameInput = page.getByTestId('ws-message-name-input-0');
+    const nameInput = ws.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('subscribe request');
     await nameInput.press('Enter');
 
-    await expect(page.getByTestId('ws-message-label-0').filter({ hasText: 'subscribe request' })).toBeVisible();
+    await expect(ws.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
 
     await saveRequest(page);
 
@@ -293,14 +297,14 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('rename a message and save with the keyboard shortcut while editing', async ({ pageWithUserData: page }) => {
+    const ws = buildWebsocketCommonLocators(page);
     const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    const messageLabel = page.getByTestId('ws-message-label-0');
-    await messageLabel.dblclick();
+    await ws.message.label(0).dblclick();
 
-    const nameInput = page.getByTestId('ws-message-name-input-0');
+    const nameInput = ws.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
@@ -311,7 +315,7 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await nameInput.press(saveShortcut);
 
     // The editing input closes and the new name is committed to the UI.
-    await expect(page.getByTestId('ws-message-label-0').filter({ hasText: 'renamed via shortcut' })).toBeVisible();
+    await expect(ws.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
 
     // The rename must be written to disk by the shortcut-triggered save.
     await expect

--- a/tests/websockets/multi-message-yml/multi-message.spec.ts
+++ b/tests/websockets/multi-message-yml/multi-message.spec.ts
@@ -156,7 +156,7 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     const beforeCount = await messageItems.count();
 
     // Click the main send button — sends the currently selected message
-    await page.getByTestId('run-button').click();
+    await ws.runner().click();
 
     // Expect at least one new message (outgoing + echo response from server)
     await expect.poll(() => messageItems.count(), { timeout: MAX_CONNECTION_TIME }).toBeGreaterThan(beforeCount);
@@ -177,7 +177,7 @@ test.describe.serial('websocket multi-message (yml format)', () => {
       timeout: MAX_CONNECTION_TIME
     });
 
-    await page.getByTestId('run-button').click();
+    await ws.runner().click();
 
     // the first message's content ("subscribe"), and none should carry the
     // second message's content ("hello world").
@@ -202,7 +202,7 @@ test.describe.serial('websocket multi-message (yml format)', () => {
       timeout: MAX_CONNECTION_TIME
     });
 
-    await page.getByTestId('run-button').click();
+    await ws.runner().click();
 
     await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME

--- a/tests/websockets/multi-message-yml/multi-message.spec.ts
+++ b/tests/websockets/multi-message-yml/multi-message.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../../../playwright';
-import { buildWebsocketCommonLocators } from '../../utils/page/locators';
+import { buildCommonLocators } from '../../utils/page/locators';
 import { openRequest, saveRequest, closeAllCollections } from '../../utils/page/actions';
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
@@ -30,24 +30,24 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('backward compatibility: old single-message format loads correctly', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // The old format (message: { type, data }) should load as a single accordion
-    await expect(ws.message.headers()).toHaveCount(1);
+    await expect(ws.websocket.message.headers()).toHaveCount(1);
 
     // Expand the first message if not already expanded
-    if (!(await ws.message.body(0).isVisible())) {
-      await ws.message.header(0).click();
+    if (!(await ws.websocket.message.body(0).isVisible())) {
+      await ws.websocket.message.header(0).click();
     }
-    await expect(ws.message.body(0)).toBeVisible();
+    await expect(ws.websocket.message.body(0)).toBeVisible();
 
     // Verify the type is correctly read from the old format
-    await expect(ws.message.header(0).locator('.selected-body-mode')).toContainText('JSON');
+    await expect(ws.websocket.message.header(0).locator('.selected-body-mode')).toContainText('JSON');
 
     // Add a second message to trigger format migration
-    await ws.message.addButton().click();
-    const nameInput = ws.message.nameInputs();
+    await ws.websocket.message.addButton().click();
+    const nameInput = ws.websocket.message.nameInputs();
     await expect(nameInput).toBeVisible();
     await nameInput.selectText();
     await page.keyboard.type('new message');
@@ -64,24 +64,24 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await expect(ws.message.headers()).toHaveCount(2);
+    await expect(ws.websocket.message.headers()).toHaveCount(2);
   });
 
   test('add a new message and save', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.message.addButton().click();
+    await ws.websocket.message.addButton().click();
 
-    const nameInput = ws.message.nameInputs();
+    const nameInput = ws.websocket.message.nameInputs();
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('ping message');
     await nameInput.press('Enter');
 
-    await expect(ws.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
-    await expect(ws.message.headers()).toHaveCount(3);
+    await expect(ws.websocket.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
+    await expect(ws.websocket.message.headers()).toHaveCount(3);
 
     await saveRequest(page);
 
@@ -90,16 +90,16 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('edit message content and verify persistence', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    if (!(await ws.message.body(0).isVisible())) {
-      await ws.message.header(0).click();
+    if (!(await ws.websocket.message.body(0).isVisible())) {
+      await ws.websocket.message.header(0).click();
     }
-    const editor = ws.message.editor(0);
+    const editor = ws.websocket.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
@@ -113,13 +113,13 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('messages with different types persist correctly', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    const firstHeader = ws.message.header(0);
+    const firstHeader = ws.websocket.message.header(0);
     await expect(firstHeader.locator('.selected-body-mode')).toContainText('JSON');
 
-    const secondHeader = ws.message.header(1);
+    const secondHeader = ws.websocket.message.header(1);
     await expect(secondHeader.locator('.selected-body-mode')).toContainText('TEXT');
 
     // Change message 1 type from json to xml
@@ -138,21 +138,21 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(ws.message.header(0).locator('.selected-body-mode')).toContainText('XML');
-    await expect(ws.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
+    await expect(ws.websocket.message.header(0).locator('.selected-body-mode')).toContainText('XML');
+    await expect(ws.websocket.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
   });
 
   test('send selected message to active connection', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.connectionControls.connect().click();
-    await expect(ws.connectionControls.disconnect()).toBeAttached({
+    await ws.websocket.connectionControls.connect().click();
+    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    const messageItems = ws.messages().locator('.text-ellipsis');
+    const messageItems = ws.websocket.messages().locator('.text-ellipsis');
     const beforeCount = await messageItems.count();
 
     // Click the main send button — sends the currently selected message
@@ -161,19 +161,19 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     // Expect at least one new message (outgoing + echo response from server)
     await expect.poll(() => messageItems.count(), { timeout: MAX_CONNECTION_TIME }).toBeGreaterThan(beforeCount);
 
-    await ws.connectionControls.disconnect().click();
-    await expect(ws.connectionControls.connect()).toBeVisible();
+    await ws.websocket.connectionControls.disconnect().click();
+    await expect(ws.websocket.connectionControls.connect()).toBeVisible();
   });
 
   test('first message is implicitly selected when no message is marked selected', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // ws-multi-msg.yml has two messages with no `selected: true` flag. The
     // main send button should therefore dispatch the first message.
-    await ws.connectionControls.connect().click();
-    await expect(ws.connectionControls.disconnect()).toBeAttached({
+    await ws.websocket.connectionControls.connect().click();
+    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
@@ -181,75 +181,75 @@ test.describe.serial('websocket multi-message (yml format)', () => {
 
     // the first message's content ("subscribe"), and none should carry the
     // second message's content ("hello world").
-    await expect(ws.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
+    await expect(ws.websocket.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
+    await expect(ws.websocket.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
 
-    await ws.connectionControls.disconnect().click();
+    await ws.websocket.connectionControls.disconnect().click();
   });
 
   test('selecting a different message routes run-button to that message', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Select the second message by clicking its header
-    await ws.message.header(1).click();
+    await ws.websocket.message.header(1).click();
 
-    await ws.connectionControls.connect().click();
-    await expect(ws.connectionControls.disconnect()).toBeAttached({
+    await ws.websocket.connectionControls.connect().click();
+    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
     await ws.runner().click();
 
-    await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(ws.websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
+    await expect(ws.websocket.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
 
-    await ws.connectionControls.disconnect().click();
+    await ws.websocket.connectionControls.disconnect().click();
   });
 
   test('per-message send button sends that specific message', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Hover the header to reveal hover-actions, then click the second
     // message's send button
-    await ws.message.header(1).hover();
-    await ws.message.sendButton(1).click();
+    await ws.websocket.message.header(1).hover();
+    await ws.websocket.message.sendButton(1).click();
 
-    await expect(ws.connectionControls.disconnect()).toBeAttached({
+    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(ws.websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await ws.connectionControls.disconnect().click();
+    await ws.websocket.connectionControls.disconnect().click();
   });
 
   test('prettify json message content', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    if (!(await ws.message.body(0).isVisible())) {
-      await ws.message.header(0).click();
+    if (!(await ws.websocket.message.body(0).isVisible())) {
+      await ws.websocket.message.header(0).click();
     }
-    const editor = ws.message.editor(0);
+    const editor = ws.websocket.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
     await page.keyboard.press(selectAllShortcut);
     await page.keyboard.insertText('{"name":"bruno","version":"1.0"}');
 
-    await ws.message.prettifyAll().click();
+    await ws.websocket.message.prettifyAll().click();
 
     // Verify prettification split single line into multiple lines
     const lineNumbers = await editor.locator('.CodeMirror-linenumber').count();
@@ -257,16 +257,16 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('delete a message', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(ws.message.headers()).toHaveCount(2);
+    await expect(ws.websocket.message.headers()).toHaveCount(2);
 
     // Hover over the message header to reveal the delete button
-    await ws.message.header(1).hover();
-    await ws.message.deleteButton(1).click();
+    await ws.websocket.message.header(1).hover();
+    await ws.websocket.message.deleteButton(1).click();
 
-    await expect(ws.message.headers()).toHaveCount(1);
+    await expect(ws.websocket.message.headers()).toHaveCount(1);
 
     await saveRequest(page);
 
@@ -276,19 +276,19 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('rename a message via double-click', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.message.label(0).dblclick();
+    await ws.websocket.message.label(0).dblclick();
 
-    const nameInput = ws.message.nameInput(0);
+    const nameInput = ws.websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('subscribe request');
     await nameInput.press('Enter');
 
-    await expect(ws.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
+    await expect(ws.websocket.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
 
     await saveRequest(page);
 
@@ -297,14 +297,14 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('rename a message and save with the keyboard shortcut while editing', async ({ pageWithUserData: page }) => {
-    const ws = buildWebsocketCommonLocators(page);
+    const ws = buildCommonLocators(page);
     const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await ws.message.label(0).dblclick();
+    await ws.websocket.message.label(0).dblclick();
 
-    const nameInput = ws.message.nameInput(0);
+    const nameInput = ws.websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
@@ -315,7 +315,7 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await nameInput.press(saveShortcut);
 
     // The editing input closes and the new name is committed to the UI.
-    await expect(ws.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
+    await expect(ws.websocket.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
 
     // The rename must be written to disk by the shortcut-triggered save.
     await expect

--- a/tests/websockets/multi-message-yml/multi-message.spec.ts
+++ b/tests/websockets/multi-message-yml/multi-message.spec.ts
@@ -30,24 +30,24 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('backward compatibility: old single-message format loads correctly', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // The old format (message: { type, data }) should load as a single accordion
-    await expect(ws.websocket.message.headers()).toHaveCount(1);
+    await expect(websocket.message.headers()).toHaveCount(1);
 
     // Expand the first message if not already expanded
-    if (!(await ws.websocket.message.body(0).isVisible())) {
-      await ws.websocket.message.header(0).click();
+    if (!(await websocket.message.body(0).isVisible())) {
+      await websocket.message.header(0).click();
     }
-    await expect(ws.websocket.message.body(0)).toBeVisible();
+    await expect(websocket.message.body(0)).toBeVisible();
 
     // Verify the type is correctly read from the old format
-    await expect(ws.websocket.message.header(0).locator('.selected-body-mode')).toContainText('JSON');
+    await expect(websocket.message.header(0).locator('.selected-body-mode')).toContainText('JSON');
 
     // Add a second message to trigger format migration
-    await ws.websocket.message.addButton().click();
-    const nameInput = ws.websocket.message.nameInputs();
+    await websocket.message.addButton().click();
+    const nameInput = websocket.message.nameInputs();
     await expect(nameInput).toBeVisible();
     await nameInput.selectText();
     await page.keyboard.type('new message');
@@ -64,24 +64,24 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await expect(ws.websocket.message.headers()).toHaveCount(2);
+    await expect(websocket.message.headers()).toHaveCount(2);
   });
 
   test('add a new message and save', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.websocket.message.addButton().click();
+    await websocket.message.addButton().click();
 
-    const nameInput = ws.websocket.message.nameInputs();
+    const nameInput = websocket.message.nameInputs();
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('ping message');
     await nameInput.press('Enter');
 
-    await expect(ws.websocket.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
-    await expect(ws.websocket.message.headers()).toHaveCount(3);
+    await expect(websocket.message.labels().filter({ hasText: 'ping message' })).toBeVisible();
+    await expect(websocket.message.headers()).toHaveCount(3);
 
     await saveRequest(page);
 
@@ -90,16 +90,16 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('edit message content and verify persistence', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    if (!(await ws.websocket.message.body(0).isVisible())) {
-      await ws.websocket.message.header(0).click();
+    if (!(await websocket.message.body(0).isVisible())) {
+      await websocket.message.header(0).click();
     }
-    const editor = ws.websocket.message.editor(0);
+    const editor = websocket.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
@@ -113,13 +113,13 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('messages with different types persist correctly', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    const firstHeader = ws.websocket.message.header(0);
+    const firstHeader = websocket.message.header(0);
     await expect(firstHeader.locator('.selected-body-mode')).toContainText('JSON');
 
-    const secondHeader = ws.websocket.message.header(1);
+    const secondHeader = websocket.message.header(1);
     await expect(secondHeader.locator('.selected-body-mode')).toContainText('TEXT');
 
     // Change message 1 type from json to xml
@@ -138,118 +138,118 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(ws.websocket.message.header(0).locator('.selected-body-mode')).toContainText('XML');
-    await expect(ws.websocket.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
+    await expect(websocket.message.header(0).locator('.selected-body-mode')).toContainText('XML');
+    await expect(websocket.message.header(1).locator('.selected-body-mode')).toContainText('TEXT');
   });
 
   test('send selected message to active connection', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.websocket.connectionControls.connect().click();
-    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
+    await websocket.connectionControls.connect().click();
+    await expect(websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    const messageItems = ws.websocket.messages().locator('.text-ellipsis');
+    const messageItems = websocket.messages().locator('.text-ellipsis');
     const beforeCount = await messageItems.count();
 
     // Click the main send button — sends the currently selected message
-    await ws.runner().click();
+    await runner().click();
 
     // Expect at least one new message (outgoing + echo response from server)
     await expect.poll(() => messageItems.count(), { timeout: MAX_CONNECTION_TIME }).toBeGreaterThan(beforeCount);
 
-    await ws.websocket.connectionControls.disconnect().click();
-    await expect(ws.websocket.connectionControls.connect()).toBeVisible();
+    await websocket.connectionControls.disconnect().click();
+    await expect(websocket.connectionControls.connect()).toBeVisible();
   });
 
   test('first message is implicitly selected when no message is marked selected', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // ws-multi-msg.yml has two messages with no `selected: true` flag. The
     // main send button should therefore dispatch the first message.
-    await ws.websocket.connectionControls.connect().click();
-    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
+    await websocket.connectionControls.connect().click();
+    await expect(websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await ws.runner().click();
+    await runner().click();
 
     // the first message's content ("subscribe"), and none should carry the
     // second message's content ("hello world").
-    await expect(ws.websocket.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
+    await expect(websocket.messages().filter({ hasText: 'subscribe' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.websocket.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
+    await expect(websocket.messages().filter({ hasText: 'hello world' })).toHaveCount(0);
 
-    await ws.websocket.connectionControls.disconnect().click();
+    await websocket.connectionControls.disconnect().click();
   });
 
   test('selecting a different message routes run-button to that message', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Select the second message by clicking its header
-    await ws.websocket.message.header(1).click();
+    await websocket.message.header(1).click();
 
-    await ws.websocket.connectionControls.connect().click();
-    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
+    await websocket.connectionControls.connect().click();
+    await expect(websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await ws.runner().click();
+    await runner().click();
 
-    await expect(ws.websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.websocket.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
+    await expect(websocket.messages().filter({ hasText: 'subscribe' })).toHaveCount(0);
 
-    await ws.websocket.connectionControls.disconnect().click();
+    await websocket.connectionControls.disconnect().click();
   });
 
   test('per-message send button sends that specific message', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
 
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
     // Hover the header to reveal hover-actions, then click the second
     // message's send button
-    await ws.websocket.message.header(1).hover();
-    await ws.websocket.message.sendButton(1).click();
+    await websocket.message.header(1).hover();
+    await websocket.message.sendButton(1).click();
 
-    await expect(ws.websocket.connectionControls.disconnect()).toBeAttached({
+    await expect(websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
-    await expect(ws.websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
+    await expect(websocket.messages().filter({ hasText: 'hello world' }).first()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
-    await ws.websocket.connectionControls.disconnect().click();
+    await websocket.connectionControls.disconnect().click();
   });
 
   test('prettify json message content', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
     // Expand the first message if not already expanded
-    if (!(await ws.websocket.message.body(0).isVisible())) {
-      await ws.websocket.message.header(0).click();
+    if (!(await websocket.message.body(0).isVisible())) {
+      await websocket.message.header(0).click();
     }
-    const editor = ws.websocket.message.editor(0);
+    const editor = websocket.message.editor(0);
     await editor.click();
     const textarea = editor.locator('textarea');
     await textarea.focus();
     await page.keyboard.press(selectAllShortcut);
     await page.keyboard.insertText('{"name":"bruno","version":"1.0"}');
 
-    await ws.websocket.message.prettifyAll().click();
+    await websocket.message.prettifyAll().click();
 
     // Verify prettification split single line into multiple lines
     const lineNumbers = await editor.locator('.CodeMirror-linenumber').count();
@@ -257,16 +257,16 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('delete a message', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await expect(ws.websocket.message.headers()).toHaveCount(2);
+    await expect(websocket.message.headers()).toHaveCount(2);
 
     // Hover over the message header to reveal the delete button
-    await ws.websocket.message.header(1).hover();
-    await ws.websocket.message.deleteButton(1).click();
+    await websocket.message.header(1).hover();
+    await websocket.message.deleteButton(1).click();
 
-    await expect(ws.websocket.message.headers()).toHaveCount(1);
+    await expect(websocket.message.headers()).toHaveCount(1);
 
     await saveRequest(page);
 
@@ -276,19 +276,19 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('rename a message via double-click', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     await openRequest(page, COLLECTION_NAME, MULTI_MSG_REQ);
 
-    await ws.websocket.message.label(0).dblclick();
+    await websocket.message.label(0).dblclick();
 
-    const nameInput = ws.websocket.message.nameInput(0);
+    const nameInput = websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
     await page.keyboard.type('subscribe request');
     await nameInput.press('Enter');
 
-    await expect(ws.websocket.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
+    await expect(websocket.message.label(0).filter({ hasText: 'subscribe request' })).toBeVisible();
 
     await saveRequest(page);
 
@@ -297,14 +297,14 @@ test.describe.serial('websocket multi-message (yml format)', () => {
   });
 
   test('rename a message and save with the keyboard shortcut while editing', async ({ pageWithUserData: page }) => {
-    const ws = buildCommonLocators(page);
+    const { websocket, runner } = buildCommonLocators(page);
     const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 
     await openRequest(page, COLLECTION_NAME, SINGLE_MSG_REQ);
 
-    await ws.websocket.message.label(0).dblclick();
+    await websocket.message.label(0).dblclick();
 
-    const nameInput = ws.websocket.message.nameInput(0);
+    const nameInput = websocket.message.nameInput(0);
     await expect(nameInput).toBeVisible();
 
     await nameInput.selectText();
@@ -315,7 +315,7 @@ test.describe.serial('websocket multi-message (yml format)', () => {
     await nameInput.press(saveShortcut);
 
     // The editing input closes and the new name is committed to the UI.
-    await expect(ws.websocket.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
+    await expect(websocket.message.label(0).filter({ hasText: 'renamed via shortcut' })).toBeVisible();
 
     // The rename must be written to disk by the shortcut-triggered save.
     await expect

--- a/tests/websockets/persistence.spec.ts
+++ b/tests/websockets/persistence.spec.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, test } from '../../playwright';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 
@@ -33,7 +33,7 @@ test.describe.serial('persistence', () => {
 
   test('save new websocket url', async ({ pageWithUserData: page }) => {
     const replacementUrl = 'ws://localhost:8083';
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
     const selectAllShortcut = process.platform === 'darwin' ? 'Meta+a' : 'Control+a';
 
     await page.locator('#sidebar-collection-name').click();

--- a/tests/websockets/query.spec.ts
+++ b/tests/websockets/query.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '../../playwright';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 const BRU_REQ_NAME = /^ws-test-request-with-query$/;
 
 test.describe.serial('query params', () => {
   test('query params are returned if passed', async ({ pageWithUserData: page }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
 
     // Open the most recent collection
     await page.locator('#sidebar-collection-name').click();
@@ -15,6 +15,6 @@ test.describe.serial('query params', () => {
     await locators.runner().click();
 
     // Check if the message has the query params
-    await expect(locators.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(testParam)\"\:\s+\"testValue\"/);
+    await expect(locators.websocket.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(testParam)\"\:\s+\"testValue\"/);
   });
 });

--- a/tests/websockets/subproto.spec.ts
+++ b/tests/websockets/subproto.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '../../playwright';
-import { buildWebsocketCommonLocators } from '../utils/page/locators';
+import { buildCommonLocators } from '../utils/page/locators';
 
 const BRU_REQ_NAME = /^ws-test-request-with-subproto$/;
 
 test.describe.serial('subprotocol tests', () => {
   test('has multiple sub proto headers', async ({ pageWithUserData: page, restartApp }) => {
     const originalProtocols = ['soap', 'mqtt'];
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
     // Open the needed request and keep the headers tab in focus for modifications
     await page.locator('#sidebar-collection-name').click();
     await page.getByTitle(BRU_REQ_NAME).click();
@@ -19,7 +19,7 @@ test.describe.serial('subprotocol tests', () => {
   });
 
   test('Only connect if a valid subprotocol is sent with the request', async ({ pageWithUserData: page, restartApp }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
     const clearText = async (text: string) => {
       for (let i = text.length; i > 0; i--) {
         await page.keyboard.press('Backspace');
@@ -39,10 +39,10 @@ test.describe.serial('subprotocol tests', () => {
     await locators.runner().click();
 
     // Check the messages to confirm we ended up connecting
-    await expect(locators.messages().first().locator('.text-ellipsis')).toHaveText(/^(Connected to)/);
+    await expect(locators.websocket.messages().first().locator('.text-ellipsis')).toHaveText(/^(Connected to)/);
 
     // Disconnect the request
-    await locators.connectionControls.disconnect().click();
+    await locators.websocket.connectionControls.disconnect().click();
 
     // Make changes to the header and add in an invalid sub protocol
     await page.locator('pre').filter({ hasText: originalProtocol }).click();
@@ -50,13 +50,13 @@ test.describe.serial('subprotocol tests', () => {
     await page.keyboard.insertText(wrongProtocol);
 
     // clear before making another request
-    await locators.toolbar.clearResponse().click();
+    await locators.websocket.toolbar.clearResponse().click();
 
     // Make another request and check the new set of messages to confirm that we did
     // get an error on connection
     await locators.runner().click();
 
-    await expect(locators.messages().nth(0).locator('.text-ellipsis')).toHaveText(/^(Unexpected server response)/);
+    await expect(locators.websocket.messages().nth(0).locator('.text-ellipsis')).toHaveText(/^(Unexpected server response)/);
 
     // Reset state back to the original
     await page.locator('pre').filter({ hasText: wrongProtocol }).click();

--- a/tests/websockets/variable-interpolation/variable-interpolation.spec.ts
+++ b/tests/websockets/variable-interpolation/variable-interpolation.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { buildWebsocketCommonLocators } from '../../utils/page/locators';
+import { buildCommonLocators } from '../../utils/page/locators';
 import { closeAllCollections, openCollection } from '../../utils/page';
 
 const BRU_REQ_NAME = /^ws-interpolation-test$/;
@@ -11,7 +11,7 @@ test.describe.serial('WebSocket Variable Interpolation', () => {
   });
 
   test('interpolates variables in WebSocket URL', async ({ pageWithUserData: page, restartApp }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
 
     // Open the collection and accept sandbox modal if it appears
     await openCollection(page, 'variable-interpolation');
@@ -27,22 +27,22 @@ test.describe.serial('WebSocket Variable Interpolation', () => {
     await expect(page.locator('.current-environment').filter({ hasText: /Test/ })).toBeVisible();
 
     // Connect WebSocket
-    await locators.connectionControls.connect().click();
+    await locators.websocket.connectionControls.connect().click();
 
     // Wait for connection to establish
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await expect(locators.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
     // Verify the connection message shows interpolated URL
     // The URL should be wss://echo.websocket.org (not wss://echo.{{url}}.org)
-    await expect(locators.messages().first().getByText(/Connected to wss:\/\/echo\.websocket\.org/)).toBeAttached({
+    await expect(locators.websocket.messages().first().getByText(/Connected to wss:\/\/echo\.websocket\.org/)).toBeAttached({
       timeout: 2000
     });
   });
 
   test('interpolates variables in WebSocket message content', async ({ pageWithUserData: page, restartApp }) => {
-    const locators = buildWebsocketCommonLocators(page);
+    const locators = buildCommonLocators(page);
 
     // Wait for collection to be visible (it should auto-load from preferences)
     await expect(page.locator('#sidebar-collection-name').filter({ hasText: 'variable-interpolation' })).toBeVisible({ timeout: 5000 });
@@ -61,19 +61,19 @@ test.describe.serial('WebSocket Variable Interpolation', () => {
     await expect(page.locator('.current-environment').filter({ hasText: /Test/ })).toBeVisible();
 
     // Clear any previous messages
-    await locators.toolbar.clearResponse().click();
+    await locators.websocket.toolbar.clearResponse().click();
 
     // Send the request (connect + send messages)
     await locators.runner().click();
 
     // Wait for connection
-    await expect(locators.connectionControls.disconnect()).toBeAttached({
+    await expect(locators.websocket.connectionControls.disconnect()).toBeAttached({
       timeout: MAX_CONNECTION_TIME
     });
 
     // Verify the sent message contains interpolated value
     // Should send {"test": "test-data"} (not {"test": "{{data}}"})
-    const messages = locators.messages();
+    const messages = locators.websocket.messages();
 
     // Find the outgoing message with interpolated content
     // The echo server will echo back the same message, so we should see it twice


### PR DESCRIPTION
### Description

1. **Open messages collapsed.** With multiple messages expanded, switching to another tab and back collapsed every message except the selected one.
2. **Editor scroll jumped.** A message's editor came back showing a *different* message's scroll position (and cursor), not its own.

## Changes

- **Persist expanded messages per request.** `WsBody` now stores the set of open message uids via `usePersistedState` (`ws-expanded-${item.uid}`), so every open
  message stays open across a tab switch.
- **Scope the editor `docKey` per message.** `SingleWSMessage` passes`docKey={`${item.uid}:ws msg:${message.uid}`}` so each editor keeps its own scroll/cursor/folds.

BRU-3828

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/f98ea56c-c438-4552-8e6e-9fe0231d89d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * WebSocket message expansion now persists when switching request tabs, including newly added messages.
  * Each WebSocket message body now uses its own editor document key to avoid editor state collisions.
  * Opening/reopening/switching messages now improves header alignment and preserves editor scroll position; in-flight scroll alignment is cleaned up on unmount.

* **Accessibility**
  * Request tabs now expose accurate selection state via `aria-selected`.

* **Tests**
  * Added Playwright coverage for expanded-panel persistence and refined scroll-related assertions using shared WebSocket locators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->