### PR TITLE
fix: avoid network probe in PAC myIpAddress

### DIFF
--- a/packages/bruno-requests/src/utils/pac-resolver.spec.ts
+++ b/packages/bruno-requests/src/utils/pac-resolver.spec.ts
@@ -9,6 +9,12 @@ describe('pac-resolver (shared)', () => {
     jest.clearAllMocks();
   });
 
+  const expectedPacOptions = expect.objectContaining({
+    sandbox: expect.objectContaining({
+      myIpAddress: expect.any(Function)
+    })
+  });
+
   /** Mock pac-resolver (v7: { createPacResolver }) and quickjs-emscripten */
   const setupPacMocks = (resolverFn: (...args: any[]) => Promise<any> = async () => 'PROXY p.example:8080; DIRECT') => {
     jest.doMock('quickjs-emscripten', () => ({
@@ -64,8 +70,31 @@ describe('pac-resolver (shared)', () => {
 
     const directives = await wrapper.resolve('http://foo.example/');
     expect(directives).toEqual(['PROXY p.example:8080', 'DIRECT']);
-    expect(createPacResolverMock).toHaveBeenCalledWith(expect.any(Object), pacScript);
+    expect(createPacResolverMock).toHaveBeenCalledWith(expect.any(Object), pacScript, expectedPacOptions);
     expect(axiosGet).toHaveBeenCalledWith(pacSource, expect.objectContaining({ proxy: false }));
+  });
+
+  test('overrides PAC myIpAddress helper with a local interface lookup', async () => {
+    const os = require('node:os');
+    const networkInterfacesSpy = jest.spyOn(os, 'networkInterfaces').mockReturnValue({
+      lo: [{ address: '127.0.0.1', family: 'IPv4', internal: true }],
+      eth0: [{ address: '10.24.0.5', family: 'IPv4', internal: false }]
+    } as any);
+
+    mockAxiosSuccess('script');
+    const { createPacResolverMock } = setupPacMocks(async () => 'DIRECT');
+
+    try {
+      const { getPacResolver } = require('./pac-resolver');
+      await getPacResolver({ pacSource: 'http://example.com/proxy.pac' });
+
+      const options = createPacResolverMock.mock.calls[0][2];
+      expect(options).toEqual(expectedPacOptions);
+      expect(options.sandbox.myIpAddress()).toBe('10.24.0.5');
+      expect(networkInterfacesSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      networkInterfacesSpy.mockRestore();
+    }
   });
 
   test('passes TLS options to https.Agent for HTTPS pac URLs', async () => {
@@ -196,7 +225,7 @@ describe('pac-resolver (shared)', () => {
 
     expect(readFile).toHaveBeenCalledWith(expectedPath, 'utf8');
     expect(axiosGetMock).not.toHaveBeenCalled();
-    expect(createPacResolverMock).toHaveBeenCalledWith(expect.any(Object), pacScript);
+    expect(createPacResolverMock).toHaveBeenCalledWith(expect.any(Object), pacScript, expectedPacOptions);
 
     const directives = await wrapper.resolve('http://foo.example/');
     expect(directives).toEqual(['PROXY p.example:8080']);

--- a/packages/bruno-requests/src/utils/pac-resolver.ts
+++ b/packages/bruno-requests/src/utils/pac-resolver.ts
@@ -2,11 +2,27 @@ import axios from 'axios';
 import crypto from 'node:crypto';
 import { readFile } from 'fs/promises';
 import https, { type AgentOptions } from 'https';
+import { networkInterfaces } from 'node:os';
 import { fileURLToPath } from 'url';
 import { createPacResolver } from 'pac-resolver';
 import { getQuickJS } from 'quickjs-emscripten';
 
 const CACHE = new Map<string, { wrapper: Promise<PacWrapper>; ts: number }>();
+
+function getLocalIpAddress(): string {
+  const interfaces = networkInterfaces();
+
+  for (const addresses of Object.values(interfaces)) {
+    for (const address of addresses ?? []) {
+      const family = String(address.family);
+      if (!address.internal && (family === 'IPv4' || family === '4')) {
+        return address.address;
+      }
+    }
+  }
+
+  return '127.0.0.1';
+}
 
 type TlsOptions = {
   ca?: string | string[];
@@ -78,7 +94,11 @@ export async function getPacResolver({ pacSource, httpsAgentRequestFields = {}, 
 
     // pac-resolver v7 uses QuickJS WASM sandbox — not affected by CVE GHSA-9j49-mfvp-vmhm (<v5)
     const qjs = await getQuickJS();
-    const resolverFn = createPacResolver(qjs, script);
+    const resolverFn = createPacResolver(qjs, script, {
+      sandbox: {
+        myIpAddress: getLocalIpAddress
+      }
+    });
 
     return {
       resolve: async (url: string) => {


### PR DESCRIPTION
### Description

Fixes #8576.

This overrides `pac-resolver`'s PAC `myIpAddress()` helper with a local network-interface lookup when Bruno compiles PAC scripts. That avoids the upstream helper's outbound TCP probe to `8.8.8.8:53`, which can add ~2 seconds to each PAC evaluation on networks where that connection is blocked or dropped.

Tests updated to assert the PAC resolver receives the `myIpAddress` sandbox override and that it selects a non-internal IPv4 address without using the upstream network probe.

Tests run:
- `npx eslint packages/bruno-requests/src/utils/pac-resolver.ts packages/bruno-requests/src/utils/pac-resolver.spec.ts`
- `npm run test --workspace=packages/bruno-requests -- pac-resolver.spec.ts --runInBand`
- `npm run test --workspace=packages/bruno-requests -- --runInBand`
- `npm run build --workspace=packages/bruno-requests` (completed successfully; Rollup/TypeScript warnings from `@faker-js/faker` declaration syntax were emitted)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** (N/A)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PAC proxy resolution by providing the local IPv4 address to PAC scripts.
  * Added a fallback to `127.0.0.1` when no suitable local network address is available.
  * Enhanced handling for PAC files loaded from downloads and local file sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
