### PR TITLE
fix(description): bulk edit round trip looses description information

### DIFF
--- a/packages/bruno-app/src/components/BulkEditor/index.js
+++ b/packages/bruno-app/src/components/BulkEditor/index.js
@@ -1,19 +1,74 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import get from 'lodash/get';
 import CodeEditor from 'components/CodeEditor';
 import { useTheme } from 'providers/Theme';
 import { useSelector } from 'react-redux';
 import { parseBulkKeyValue, serializeBulkKeyValue } from 'utils/common/bulkKeyValueUtils';
 
+/**
+ * Preserve hidden metadata (uid, description, annotations) across a bulk edit
+ * by matching parsed params back to the original set using name + proximity.
+ */
+const preserveMetadata = (parsed, original) => {
+  // Build a lookup of original params grouped by name.
+  const candidatesByName = new Map();
+  original.forEach((param, index) => {
+    const name = param.name || '';
+    if (!candidatesByName.has(name)) {
+      candidatesByName.set(name, []);
+    }
+    candidatesByName.get(name).push({ index, param, matched: false });
+  });
+
+  return parsed.map((item, index) => {
+    const name = item.name || '';
+    const candidates = candidatesByName.get(name);
+
+    if (!candidates || candidates.length === 0) {
+      return { ...item, description: '', annotations: null };
+    }
+
+    let best = null;
+    let bestDistance = Infinity;
+
+    for (const candidate of candidates) {
+      if (candidate.matched) continue;
+      const distance = Math.abs(candidate.index - index);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = candidate;
+      }
+    }
+
+    if (best) {
+      best.matched = true;
+      return {
+        ...item,
+        uid: best.param.uid,
+        description: best.param.description || '',
+        annotations: best.param.annotations ?? null
+      };
+    }
+
+    // All candidates for this name are already consumed (e.g. added duplicates).
+    return { ...item, description: '', annotations: null };
+  });
+};
+
 const BulkEditor = ({ params, onChange, onToggle, onSave, onRun }) => {
   const preferences = useSelector((state) => state.app.preferences);
   const { displayedTheme } = useTheme();
+
+  // Capture the original params on mount so we can preserve fields (like descriptions)
+  // that aren't shown in the bulk editor but should survive the roundtrip.
+  const originalParamsRef = useRef(params);
 
   const parsedParams = useMemo(() => serializeBulkKeyValue(params), [params]);
 
   const handleEdit = (value) => {
     const parsed = parseBulkKeyValue(value);
-    onChange(parsed);
+    const withPreservedMeta = preserveMetadata(parsed, originalParamsRef.current);
+    onChange(withPreservedMeta);
   };
 
   return (

--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -19,8 +19,8 @@ const StyledWrapper = styled.div`
   }
 
   .CodeMirror-placeholder {
-    color: ${(props) => props.theme.text} !important;
-    opacity: 0.5 !important;
+    color: ${(props) => props.theme.codemirror.placeholder.color} !important;
+    opacity: ${(props) => props.theme.codemirror.placeholder.opacity} !important;
   }
 
   .CodeMirror-linenumber {

--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -191,6 +191,11 @@ const StyledWrapper = styled.div`
     &:focus {
       outline: none !important;
     }
+    
+    &::placeholder {
+      color: ${(props) => props.theme.codemirror.placeholder.color} !important;
+      opacity: ${(props) => props.theme.codemirror.placeholder.opacity} !important;
+    }
   }
 
   input[type='checkbox'] {

--- a/packages/bruno-app/src/components/EditableTable/descriptionColumn.js
+++ b/packages/bruno-app/src/components/EditableTable/descriptionColumn.js
@@ -16,7 +16,7 @@ export const createDescriptionColumn = ({
   placeholder: 'Description',
   width: '25%',
   readOnly,
-  render: ({ row, value, onChange, rowIndex }) => (
+  render: ({ row, value, onChange, rowIndex, isLastEmptyRow }) => (
     <MultiLineEditor
       value={value || ''}
       theme={theme}
@@ -27,7 +27,7 @@ export const createDescriptionColumn = ({
           ? (newValue) => onDescriptionChange(newValue, { row, onChange })
           : onChange
       }
-      placeholder={!value ? 'Description' : ''}
+      placeholder={(isLastEmptyRow && !value) ? 'Description' : ''}
       {...(onRun ? { onRun } : {})}
       {...(collection ? { collection } : {})}
       {...(item ? { item } : {})}

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -866,7 +866,7 @@ const EnvironmentVariablesTable = ({
                     collection={_collection}
                     name={`${actualIndex}.description`}
                     value={variable.description ?? ''}
-                    placeholder={!variable.description || (typeof variable.description === 'string' && variable.description.trim() === '') ? 'Description' : ''}
+                    placeholder={isLastEmptyRow && (!variable.description || (typeof variable.description === 'string' && variable.description.trim() === '')) ? 'Description' : ''}
                     onChange={(newValue) => {
                       formik.setFieldValue(`${actualIndex}.description`, newValue, true);
                       if (isLastRow) {

--- a/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/StyledWrapper.js
@@ -30,9 +30,9 @@ const StyledWrapper = styled.div`
     max-height: 200px;
 
     pre.CodeMirror-placeholder {
-      color: ${(props) => props.theme.text};
+      color: ${(props) => props.theme.codemirror.placeholder.color} !important;
+      opacity: ${(props) => props.theme.codemirror.placeholder.opacity} !important;
       padding-left: 0;
-      opacity: 0.5;
     }
 
     .CodeMirror-vscrollbar,

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -183,6 +183,9 @@ class MultiLineEditor extends Component {
     if (this.props.readOnly !== prevProps.readOnly && this.editor) {
       this.editor.setOption('readOnly', this.props.readOnly || false);
     }
+    if (this.props.placeholder !== prevProps.placeholder && this.editor) {
+      this.editor.setOption('placeholder', this.props.placeholder);
+    }
     this.ignoreChangeEvent = false;
   }
 

--- a/packages/bruno-app/src/components/RequestPane/FileBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FileBody/index.js
@@ -162,7 +162,7 @@ const FileBody = ({ item, collection }) => {
                         onRun={handleRun}
                         collection={collection}
                         item={item}
-                        placeholder={!param.description ? 'Description' : ''}
+                        placeholder={!param.filePath && !param.description ? 'Description' : ''}
                       />
                     </td>
                     <td>

--- a/packages/bruno-app/src/components/ResponseExample/ResponseExampleResponsePane/ResponseExampleResponseHeaders/index.js
+++ b/packages/bruno-app/src/components/ResponseExample/ResponseExampleResponsePane/ResponseExampleResponseHeaders/index.js
@@ -96,17 +96,12 @@ const ResponseExampleResponseHeaders = ({ editMode, item, collection, exampleUid
     if (!editMode) {
       return;
     }
-    const cleanedHeaders = newHeaders.map((header) => ({
-      uid: header.uid,
-      name: header.name,
-      value: header.value
-    }));
 
     dispatch(setResponseExampleHeaders({
       itemUid: item.uid,
       collectionUid: collection.uid,
       exampleUid: exampleUid,
-      headers: cleanedHeaders
+      headers: newHeaders
     }));
   };
 

--- a/packages/bruno-app/src/components/SingleLineEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/StyledWrapper.js
@@ -35,7 +35,7 @@ const StyledWrapper = styled.div`
 
       .CodeMirror-placeholder {
         color: ${(props) => props.theme.codemirror.placeholder.color} !important;
-        opacity:  ${(props) => props.theme.codemirror.placeholder.opacity} !important
+        opacity:  ${(props) => props.theme.codemirror.placeholder.opacity} !important;
       }
     }
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/exampleReducers.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/exampleReducers.js
@@ -956,11 +956,11 @@ export const setResponseExampleParams = (state, action) => {
   const example = item.draft.examples.find((e) => e.uid === exampleUid);
   if (!example) return;
 
-  example.request.params = map(params, ({ uid, name = '', value = '', enabled = true, type = 'query' }) => ({
+  example.request.params = map(params, ({ uid, name = '', value = '', description = '', enabled = true, type = 'query' }) => ({
     uid: uid || uuid(),
     name: name,
     value: value,
-    description: '',
+    description,
     enabled: enabled,
     type: type
   }));


### PR DESCRIPTION
### Description

BRU-3847

--- 
- Adds a pass through for the description values in bulk edit mode
- Additional logic for the description columns to be empty if name and value already exist 


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserve request parameter metadata, including descriptions, when applying bulk edits by matching edited entries to their original items.
- Retain descriptions in response example parameters and headers during bulk updates.
- Show description placeholders only for trailing empty rows, preventing existing descriptions from appearing blank during bulk-edit round trips.
- Update CodeMirror and text-input placeholder styling to use theme-provided colors and opacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->