### PR TITLE
fix(collections): reflect external collection deletion in the app

### DIFF
--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -5,7 +5,8 @@ import {
   setGitVersion
 } from 'providers/ReduxStore/slices/app';
 import {
-  addTab
+  addTab,
+  closeAllCollectionTabs
 } from 'providers/ReduxStore/slices/tabs';
 import {
   brunoConfigUpdateEvent,
@@ -14,6 +15,7 @@ import {
   collectionChangeFileEvent,
   collectionRenamedEvent,
   collectionUnlinkDirectoryEvent,
+  collectionUnlinkCollectionEvent,
   collectionUnlinkEnvFileEvent,
   collectionUnlinkFileEvent,
   processEnvUpdateEvent,
@@ -96,6 +98,11 @@ const useIpcEvents = () => {
             directory: val
           })
         );
+      }
+      if (type === 'unlinkCollection') {
+        const { collectionUid } = val.meta;
+        dispatch(closeAllCollectionTabs({ collectionUid }));
+        dispatch(collectionUnlinkCollectionEvent({ collectionUid }));
       }
       if (type === 'addEnvironmentFile') {
         dispatch(collectionAddEnvFileEvent(val));

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -3107,6 +3107,10 @@ export const collectionsSlice = createSlice({
         }
       }
     },
+    collectionUnlinkCollectionEvent: (state, action) => {
+      const { collectionUid } = action.payload;
+      state.collections = filter(state.collections, (c) => c.uid !== collectionUid);
+    },
     collectionAddEnvFileEvent: (state, action) => {
       const { environment, collectionUid } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
@@ -4084,6 +4088,7 @@ export const {
   collectionChangeFileEvent,
   collectionUnlinkFileEvent,
   collectionUnlinkDirectoryEvent,
+  collectionUnlinkCollectionEvent,
   collectionAddEnvFileEvent,
   collectionRenamedEvent,
   resetRunResults,

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -661,6 +661,15 @@ const unlink = (win, pathname, collectionUid, collectionPath) => {
 
 const unlinkDir = async (win, pathname, collectionUid, collectionPath) => {
   try {
+    if (path.normalize(pathname) === path.normalize(collectionPath)) {
+      win.webContents.send('main:collection-tree-updated', 'unlinkCollection', {
+        meta: {
+          collectionUid,
+          pathname: collectionPath
+        }
+      });
+      return;
+    }
     if (!fs.existsSync(collectionPath)) {
       return;
     }

--- a/tests/collection/external-deletion/collection-external-deletion.spec.ts
+++ b/tests/collection/external-deletion/collection-external-deletion.spec.ts
@@ -1,0 +1,33 @@
+import path from 'path';
+import fs from 'fs';
+import { test, expect } from '../../../playwright';
+import { createCollection, createRequest, closeAllCollections } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe('Collection: external filesystem deletion', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('removes the collection from the sidebar when its root folder is deleted on disk', async ({
+    page,
+    createTmpDir
+  }) => {
+    const colPath = await createTmpDir('external-deletion-col');
+    const { sidebar } = buildCommonLocators(page);
+
+    // Create a collection (with a request so the tree is fully mounted/watched) and confirm it's visible.
+    await createCollection(page, 'DeleteMe', colPath);
+    await createRequest(page, 'ReqAlpha', 'DeleteMe', { url: 'https://echo.usebruno.com', method: 'GET' });
+    await expect(sidebar.collection('DeleteMe')).toHaveCount(1);
+
+    // Delete the collection root directory externally.
+    // createCollection writes the collection into a single sub-folder of colPath.
+    const [collectionFolder] = fs.readdirSync(colPath);
+    expect(collectionFolder, 'collection folder should exist on disk').toBeTruthy();
+    await fs.promises.rm(path.join(colPath, collectionFolder), { recursive: true, force: true });
+
+    // The collection disappears from the sidebar without a restart.
+    await expect(sidebar.collection('DeleteMe')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
### Description

**Problem:** When a collection's root folder was deleted from the filesystem (outside Bruno e.g. via Finder/terminal), the collection stayed in the sidebar until the app was restarted. Deleting a folder or request *inside* a collection already updated live, but deleting the whole collection did not.

**Fix:**
- **Main process** (`collection-watcher.js`): before the `existsSync` guard, detect when the deleted directory is the collection root itself and emit a new `unlinkCollection` tree event.
- **Renderer** (`useIpcEvents.js` + collections slice): route `unlinkCollection` to a new `collectionUnlinkCollectionEvent` reducer that removes the collection from state mirroring how unlinked folders/requests are handled.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


https://github.com/user-attachments/assets/18aed855-ba61-4c91-aac5-cc0a3206405f




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collections deleted externally from the filesystem are now removed from the app sidebar automatically.
  * Open tabs for externally deleted collections are closed to prevent stale content from remaining visible.

* **Tests**
  * Added coverage verifying that deleting a collection folder outside the app updates the sidebar without requiring a restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->