### PR TITLE
scoped autocomplete API hints by scriptType so pre-request ne…

### DIFF
--- a/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.js
@@ -199,7 +199,7 @@ const ensureNewlineAfterComment = (prefix, suggestion) => {
   return '\n' + suggestion;
 };
 
-const RES_API_USAGE_RE = /\bres\s*[.([]/;
+const RES_API_USAGE_RE = /\bres\s*\??[.([]/;
 
 const stripDisallowedApis = (suggestion, scriptType) => {
   if (!suggestion) return suggestion;

--- a/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.js
@@ -207,11 +207,29 @@ const stripDisallowedApis = (suggestion, scriptType) => {
   return suggestion;
 };
 
+const TRAILING_IDENTIFIER_RE = /[\w$]+$/;
+
+const stripTypedPrefixOverlap = (prefix, suggestion) => {
+  if (!prefix || !suggestion) return suggestion;
+  const typed = prefix.match(TRAILING_IDENTIFIER_RE);
+  if (typed && suggestion.startsWith(typed[0])) return suggestion.slice(typed[0].length);
+  return suggestion;
+};
+
+const sanitizeSuggestion = ({ text, prefix, scriptType }) => {
+  const cleaned = cleanSuggestion(text || '');
+  const allowed = stripDisallowedApis(cleaned, scriptType);
+  const deduped = stripTypedPrefixOverlap(prefix, allowed);
+  return ensureNewlineAfterComment(prefix, deduped);
+};
+
 module.exports = {
   buildSystemPrompt,
   buildUserPrompt,
   STOP_SEQUENCES,
   cleanSuggestion,
   ensureNewlineAfterComment,
-  stripDisallowedApis
+  stripDisallowedApis,
+  stripTypedPrefixOverlap,
+  sanitizeSuggestion
 };

--- a/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.js
@@ -7,22 +7,30 @@
  *    instruction. Output is appended verbatim at the cursor.
  */
 
-const BRUNO_API_SUMMARY = `## Bruno runtime APIs (available inside scripts)
-
-bru:    env/global/collection/folder/request/runtime vars — get/set/has/delete,
+const API_BLOCKS = {
+  bru: `bru:    env/global/collection/folder/request/runtime vars — get/set/has/delete,
         interpolate(strOrObj), sleep(ms), sendRequest(cfg), setNextRequest(name),
-        cookies, utils.minifyJson/Xml, getEnvName, getCollectionName, cwd
-
-req:    url, method, headers, body, timeout. getUrl/setUrl, getHeader/setHeader,
-        getBody/setBody, getMethod/setMethod, getTimeout/setTimeout. Available in
-        pre-request, post-response and tests.
-
-res:    status, headers, body, responseTime. getStatus, getStatusText,
+        cookies, utils.minifyJson/Xml, getEnvName, getCollectionName, cwd`,
+  req: `req:    url, method, headers, body, timeout. getUrl/setUrl, getHeader/setHeader,
+        getBody/setBody, getMethod/setMethod, getTimeout/setTimeout.`,
+  res: `res:    status, headers, body, responseTime. getStatus, getStatusText,
         getHeader, getHeaders, getBody, getResponseTime, getSize. res('json.path')
-        for JSONPath-style queries. Available in post-response and tests.
+        for JSONPath-style queries.`,
+  test: `test/expect:  Chai-style assertions inside test("name", () => { ... }) blocks.`
+};
 
-test/expect:  Chai-style assertions inside test("name", () => { ... }) blocks.
-              Available in tests only.`;
+const API_BLOCKS_BY_SCRIPT_TYPE = {
+  'pre-request': ['bru', 'req'],
+  'post-response': ['bru', 'req', 'res'],
+  'tests': ['bru', 'req', 'res', 'test']
+};
+
+const buildApiSummary = (scriptType) => {
+  const blocks = API_BLOCKS_BY_SCRIPT_TYPE[scriptType] || Object.keys(API_BLOCKS);
+  return `## Bruno runtime APIs (available inside scripts)
+
+${blocks.map((block) => API_BLOCKS[block]).join('\n\n')}`;
+};
 
 const SCRIPT_CONTEXTS = {
   'tests': `Tests run AFTER the response. Globals: bru, req, res, test, expect. Assertions go inside test("name", () => { ... }) blocks. Don't call bru.setEnvVar / setVar — keep tests pure.`,
@@ -41,7 +49,7 @@ const buildSystemPrompt = (scriptType) => {
   const context = SCRIPT_CONTEXTS[scriptType] || '';
   return `You are an inline code-completion engine for ${label}.
 
-${BRUNO_API_SUMMARY}
+${buildApiSummary(scriptType)}
 
 ## Context for ${scriptType}
 ${context}
@@ -191,10 +199,19 @@ const ensureNewlineAfterComment = (prefix, suggestion) => {
   return '\n' + suggestion;
 };
 
+const RES_API_USAGE_RE = /\bres\s*[.([]/;
+
+const stripDisallowedApis = (suggestion, scriptType) => {
+  if (!suggestion) return suggestion;
+  if (scriptType === 'pre-request' && RES_API_USAGE_RE.test(suggestion)) return '';
+  return suggestion;
+};
+
 module.exports = {
   buildSystemPrompt,
   buildUserPrompt,
   STOP_SEQUENCES,
   cleanSuggestion,
-  ensureNewlineAfterComment
+  ensureNewlineAfterComment,
+  stripDisallowedApis
 };

--- a/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.spec.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.spec.js
@@ -83,6 +83,15 @@ describe('stripDisallowedApis', () => {
     expect(stripDisallowedApis('res[\'body\'];', 'pre-request')).toBe('');
   });
 
+  it('drops a pre-request suggestion that uses optional-chained res', () => {
+    expect(stripDisallowedApis('res?.getStatus();', 'pre-request')).toBe('');
+    expect(stripDisallowedApis('res?.[\'body\'];', 'pre-request')).toBe('');
+  });
+
+  it('keeps optional-chained res usage in post-response', () => {
+    expect(stripDisallowedApis('res?.getStatus();', 'post-response')).toBe('res?.getStatus();');
+  });
+
   it('leaves a pre-request suggestion using bru untouched', () => {
     expect(stripDisallowedApis('bru.getEnvVar(\'token\');', 'pre-request')).toBe('bru.getEnvVar(\'token\');');
   });
@@ -135,12 +144,12 @@ describe('stripTypedPrefixOverlap', () => {
 });
 
 describe('sanitizeSuggestion', () => {
-  it('drops a pre-request suggestion that uses res (BRU-3820)', () => {
+  it('drops a pre-request suggestion that uses res', () => {
     expect(sanitizeSuggestion({ text: 'res.getStatus()', prefix: 'const status = ', scriptType: 'pre-request' }))
       .toBe('');
   });
 
-  it('trims a repeated partial keyword (BRU-3787)', () => {
+  it('trims a repeated partial keyword', () => {
     expect(sanitizeSuggestion({ text: 'const variable1 = 1;', prefix: 'con', scriptType: 'pre-request' }))
       .toBe('st variable1 = 1;');
   });

--- a/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.spec.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.spec.js
@@ -1,4 +1,4 @@
-const { ensureNewlineAfterComment, cleanSuggestion, buildSystemPrompt, stripDisallowedApis } = require('./autocomplete-prompts');
+const { ensureNewlineAfterComment, cleanSuggestion, buildSystemPrompt, stripDisallowedApis, stripTypedPrefixOverlap, sanitizeSuggestion } = require('./autocomplete-prompts');
 
 describe('ensureNewlineAfterComment', () => {
   it('prepends a newline when code is suggested at the end of a comment line', () => {
@@ -104,5 +104,64 @@ describe('stripDisallowedApis', () => {
 
   it('handles empty suggestions', () => {
     expect(stripDisallowedApis('', 'pre-request')).toBe('');
+  });
+});
+
+describe('stripTypedPrefixOverlap', () => {
+  it('trims a repeated partial identifier from the suggestion', () => {
+    expect(stripTypedPrefixOverlap('con', 'const variable1 = ')).toBe('st variable1 = ');
+  });
+
+  it('trims a repeated full identifier from the suggestion', () => {
+    expect(stripTypedPrefixOverlap('bru', 'bru.getVar()')).toBe('.getVar()');
+  });
+
+  it('leaves a correct remainder-only suggestion untouched', () => {
+    expect(stripTypedPrefixOverlap('con', 'st variable1 = ')).toBe('st variable1 = ');
+  });
+
+  it('does not trim when the cursor is not after an identifier', () => {
+    expect(stripTypedPrefixOverlap('const x = ', 'res.getBody()')).toBe('res.getBody()');
+  });
+
+  it('does not trim across a member access dot', () => {
+    expect(stripTypedPrefixOverlap('bru.', 'getVar()')).toBe('getVar()');
+  });
+
+  it('handles empty prefix or suggestion', () => {
+    expect(stripTypedPrefixOverlap('', 'const x')).toBe('const x');
+    expect(stripTypedPrefixOverlap('con', '')).toBe('');
+  });
+});
+
+describe('sanitizeSuggestion', () => {
+  it('drops a pre-request suggestion that uses res (BRU-3820)', () => {
+    expect(sanitizeSuggestion({ text: 'res.getStatus()', prefix: 'const status = ', scriptType: 'pre-request' }))
+      .toBe('');
+  });
+
+  it('trims a repeated partial keyword (BRU-3787)', () => {
+    expect(sanitizeSuggestion({ text: 'const variable1 = 1;', prefix: 'con', scriptType: 'pre-request' }))
+      .toBe('st variable1 = 1;');
+  });
+
+  it('drops pre-request res even when the typed prefix overlaps res', () => {
+    expect(sanitizeSuggestion({ text: 'res.getStatus()', prefix: 'res', scriptType: 'pre-request' }))
+      .toBe('');
+  });
+
+  it('keeps res in post-response while still trimming the typed overlap', () => {
+    expect(sanitizeSuggestion({ text: 'const x = res.getBody();', prefix: 'con', scriptType: 'post-response' }))
+      .toBe('st x = res.getBody();');
+  });
+
+  it('strips code fences before other passes', () => {
+    expect(sanitizeSuggestion({ text: '```js\nconst x = 1;\n```', prefix: 'con', scriptType: 'pre-request' }))
+      .toBe('st x = 1;');
+  });
+
+  it('prepends a newline when completing after a comment', () => {
+    expect(sanitizeSuggestion({ text: 'const body = req.getBody();', prefix: '// get body', scriptType: 'pre-request' }))
+      .toBe('\nconst body = req.getBody();');
   });
 });

--- a/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.spec.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.spec.js
@@ -1,4 +1,4 @@
-const { ensureNewlineAfterComment, cleanSuggestion } = require('./autocomplete-prompts');
+const { ensureNewlineAfterComment, cleanSuggestion, buildSystemPrompt, stripDisallowedApis } = require('./autocomplete-prompts');
 
 describe('ensureNewlineAfterComment', () => {
   it('prepends a newline when code is suggested at the end of a comment line', () => {
@@ -45,5 +45,64 @@ describe('ensureNewlineAfterComment', () => {
 describe('cleanSuggestion', () => {
   it('keeps indentation while stripping fences', () => {
     expect(cleanSuggestion('```js\n  const a = 1;\n```')).toBe('  const a = 1;');
+  });
+});
+
+describe('buildSystemPrompt', () => {
+  it('omits the res API block for pre-request', () => {
+    const prompt = buildSystemPrompt('pre-request');
+    expect(prompt).not.toContain('res:');
+    expect(prompt).toContain('bru:');
+    expect(prompt).toContain('req:');
+  });
+
+  it('includes the res API block for post-response', () => {
+    const prompt = buildSystemPrompt('post-response');
+    expect(prompt).toContain('res:');
+    expect(prompt).toContain('bru:');
+    expect(prompt).toContain('req:');
+  });
+
+  it('includes res and test/expect for tests', () => {
+    const prompt = buildSystemPrompt('tests');
+    expect(prompt).toContain('res:');
+    expect(prompt).toContain('test/expect:');
+  });
+});
+
+describe('stripDisallowedApis', () => {
+  it('drops a pre-request suggestion that uses res.method()', () => {
+    expect(stripDisallowedApis('res.getStatus();', 'pre-request')).toBe('');
+  });
+
+  it('drops a pre-request suggestion that uses res() JSONPath form', () => {
+    expect(stripDisallowedApis('res(\'data.id\');', 'pre-request')).toBe('');
+  });
+
+  it('drops a pre-request suggestion that uses res bracket access', () => {
+    expect(stripDisallowedApis('res[\'body\'];', 'pre-request')).toBe('');
+  });
+
+  it('leaves a pre-request suggestion using bru untouched', () => {
+    expect(stripDisallowedApis('bru.getEnvVar(\'token\');', 'pre-request')).toBe('bru.getEnvVar(\'token\');');
+  });
+
+  it('does not flag a variable named result/response in pre-request', () => {
+    expect(stripDisallowedApis('const result = bru.getVar("x");', 'pre-request'))
+      .toBe('const result = bru.getVar("x");');
+    expect(stripDisallowedApis('const response = 1;', 'pre-request')).toBe('const response = 1;');
+  });
+
+  it('keeps res usage in post-response', () => {
+    expect(stripDisallowedApis('res.getStatus();', 'post-response')).toBe('res.getStatus();');
+  });
+
+  it('keeps res usage in tests', () => {
+    expect(stripDisallowedApis('expect(res.getStatus()).to.equal(200);', 'tests'))
+      .toBe('expect(res.getStatus()).to.equal(200);');
+  });
+
+  it('handles empty suggestions', () => {
+    expect(stripDisallowedApis('', 'pre-request')).toBe('');
   });
 });

--- a/packages/bruno-electron/src/ipc/ai/autocomplete.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete.js
@@ -3,7 +3,7 @@ const { generateText } = require('ai');
 const { getPreferences } = require('../../store/preferences');
 const { aiKeyStore } = require('../../store/ai-keys');
 const { getModel, getAvailableModels, isReasoningModel, isOpenAiReasoningModel } = require('./providers');
-const { buildSystemPrompt, buildUserPrompt, STOP_SEQUENCES, cleanSuggestion, ensureNewlineAfterComment } = require('./autocomplete-prompts');
+const { buildSystemPrompt, buildUserPrompt, STOP_SEQUENCES, cleanSuggestion, ensureNewlineAfterComment, stripDisallowedApis } = require('./autocomplete-prompts');
 
 const SUPPORTED_SCRIPT_TYPES = ['tests', 'pre-request', 'post-response'];
 
@@ -162,7 +162,10 @@ const registerAutocompleteIpc = () => {
         abortSignal: controller.signal
       });
 
-      const suggestion = ensureNewlineAfterComment(prefix, cleanSuggestion(text || ''));
+      const suggestion = stripDisallowedApis(
+        ensureNewlineAfterComment(prefix, cleanSuggestion(text || '')),
+        scriptType
+      );
       if (suggestion) cacheSet(key, suggestion);
       return { suggestion, modelId };
     } catch (err) {

--- a/packages/bruno-electron/src/ipc/ai/autocomplete.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete.js
@@ -3,7 +3,7 @@ const { generateText } = require('ai');
 const { getPreferences } = require('../../store/preferences');
 const { aiKeyStore } = require('../../store/ai-keys');
 const { getModel, getAvailableModels, isReasoningModel, isOpenAiReasoningModel } = require('./providers');
-const { buildSystemPrompt, buildUserPrompt, STOP_SEQUENCES, cleanSuggestion, ensureNewlineAfterComment, stripDisallowedApis } = require('./autocomplete-prompts');
+const { buildSystemPrompt, buildUserPrompt, STOP_SEQUENCES, sanitizeSuggestion } = require('./autocomplete-prompts');
 
 const SUPPORTED_SCRIPT_TYPES = ['tests', 'pre-request', 'post-response'];
 
@@ -162,10 +162,7 @@ const registerAutocompleteIpc = () => {
         abortSignal: controller.signal
       });
 
-      const suggestion = stripDisallowedApis(
-        ensureNewlineAfterComment(prefix, cleanSuggestion(text || '')),
-        scriptType
-      );
+      const suggestion = sanitizeSuggestion({ text, prefix, scriptType });
       if (suggestion) cacheSet(key, suggestion);
       return { suggestion, modelId };
     } catch (err) {


### PR DESCRIPTION

[JIRA - BRU-3820 & BRU-3787]

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced AI autocomplete prompts to dynamically tailor “Bruno runtime APIs” to the selected script type.

* **Bug Fixes**
  * Improved autocomplete sanitization to remove disallowed `res`-based suggestions for pre-request scripts while preserving valid `bru` usage and `res` where allowed.
  * Trimmed overlapping typed prefixes to produce cleaner, more accurate completions.

* **Tests**
  * Expanded coverage for script-type prompt composition and end-to-end suggestion sanitization across multiple syntax patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->