### PR TITLE
fix(variable-tooltip): mask secret variables of non-string dataType

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -398,6 +398,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
         </div>
         <div
           id="request-url"
+          data-testid="request-url"
           className="h-full w-full flex flex-row items-center input-container overflow-hidden"
         >
           <SingleLineEditor

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -84,7 +84,7 @@ const getScopeLabel = (scopeType) => {
 
 // Get the masked display text based on the value length
 const getMaskedDisplay = (value) => {
-  const contentLength = (value || '').length;
+  const contentLength = (value === undefined || value === null ? '' : String(value)).length;
   return contentLength > 0 ? '*'.repeat(contentLength) : '';
 };
 
@@ -137,6 +137,7 @@ const getCopyButton = (getVariableValue, onCopyCallback) => {
   const copyButton = document.createElement('button');
 
   copyButton.className = 'copy-button';
+  copyButton.setAttribute('data-testid', 'var-info-copy-button');
   copyButton.innerHTML = COPY_ICON_SVG_TEXT;
   copyButton.type = 'button';
 
@@ -300,10 +301,12 @@ export const renderVarInfo = (token, options) => {
 
   const varName = document.createElement('span');
   varName.className = 'var-name';
+  varName.setAttribute('data-testid', 'var-info-name');
   varName.textContent = variableName;
 
   const scopeBadge = document.createElement('span');
   scopeBadge.className = 'var-scope-badge';
+  scopeBadge.setAttribute('data-testid', 'var-info-scope-badge');
 
   // Check if a runtime variable exists - if so, show Runtime scope (even if detected as collection/folder/environment)
   const displayScopeType = hasRuntimeVariable ? 'runtime' : (scopeInfo ? scopeInfo.type : 'Unknown');
@@ -323,6 +326,7 @@ export const renderVarInfo = (token, options) => {
   if (!isValidVariableName) {
     const warningNote = document.createElement('div');
     warningNote.className = 'var-warning-note';
+    warningNote.setAttribute('data-testid', 'var-info-warning-note');
     warningNote.textContent = 'Invalid variable name! Variables must only contain alpha-numeric characters, "-", "_", "."';
     into.appendChild(warningNote);
 
@@ -334,6 +338,7 @@ export const renderVarInfo = (token, options) => {
   if (scopeInfo.type === 'dynamic' && !scopeInfo.isValidDynamicVariable) {
     const warningNote = document.createElement('div');
     warningNote.className = 'var-warning-note';
+    warningNote.setAttribute('data-testid', 'var-info-warning-note');
     warningNote.textContent = `Unknown dynamic variable "${variableName}". Check the variable name.`;
     into.appendChild(warningNote);
     return into;
@@ -343,6 +348,7 @@ export const renderVarInfo = (token, options) => {
   if (scopeInfo.type === 'dynamic' && scopeInfo.isValidDynamicVariable) {
     const readOnlyNote = document.createElement('div');
     readOnlyNote.className = 'var-readonly-note';
+    readOnlyNote.setAttribute('data-testid', 'var-info-readonly-note');
     readOnlyNote.textContent = scopeInfo.isTimeBased
       ? 'Generates current timestamp on each request'
       : 'Generates random value on each request';
@@ -354,6 +360,7 @@ export const renderVarInfo = (token, options) => {
   if (scopeInfo.type === 'oauth2' && !scopeInfo.isValidOAuth2Variable) {
     const warningNote = document.createElement('div');
     warningNote.className = 'var-warning-note';
+    warningNote.setAttribute('data-testid', 'var-info-warning-note');
     warningNote.textContent = `OAuth2 token not found. Make sure you have fetched the token with the correct Token ID.`;
     into.appendChild(warningNote);
     return into;
@@ -371,12 +378,14 @@ export const renderVarInfo = (token, options) => {
     // Create display element (shows interpolated value by default)
     const valueDisplay = document.createElement('div');
     valueDisplay.className = 'var-value-editable-display';
+    valueDisplay.setAttribute('data-testid', 'var-info-value-editable');
     // Mask the displayed value if it contains secrets or references to secrets
     updateValueDisplay(valueDisplay, variableValue, shouldMaskValue, isMasked, false);
 
     // Create container for CodeMirror (hidden by default)
     const editorContainer = document.createElement('div');
     editorContainer.className = 'var-value-editor';
+    editorContainer.setAttribute('data-testid', 'var-info-value-editor');
     editorContainer.style.display = 'none'; // Hidden initially
 
     // Detect current theme from DOM
@@ -462,6 +471,7 @@ export const renderVarInfo = (token, options) => {
     if (shouldMaskValue || isMasked) {
       const toggleButton = document.createElement('button');
       toggleButton.className = 'secret-toggle-button';
+      toggleButton.setAttribute('data-testid', 'var-info-secret-toggle');
       toggleButton.innerHTML = EYE_ICON_SVG;
       toggleButton.type = 'button';
 
@@ -598,6 +608,7 @@ export const renderVarInfo = (token, options) => {
 
     const valueDisplay = document.createElement('div');
     valueDisplay.className = 'var-value-display';
+    valueDisplay.setAttribute('data-testid', 'var-info-value-display');
     // For read-only variables, still check if they reference secrets
     updateValueDisplay(valueDisplay, variableValue, shouldMaskValue, isMasked, false);
 
@@ -609,6 +620,7 @@ export const renderVarInfo = (token, options) => {
     if (shouldMaskValue || isMasked) {
       const toggleButton = document.createElement('button');
       toggleButton.className = 'secret-toggle-button';
+      toggleButton.setAttribute('data-testid', 'var-info-secret-toggle');
       toggleButton.innerHTML = EYE_ICON_SVG;
       toggleButton.type = 'button';
 
@@ -635,21 +647,25 @@ export const renderVarInfo = (token, options) => {
     if (scopeInfo.type === 'process.env') {
       const readOnlyNote = document.createElement('div');
       readOnlyNote.className = 'var-readonly-note';
+      readOnlyNote.setAttribute('data-testid', 'var-info-readonly-note');
       readOnlyNote.textContent = 'read-only';
       into.appendChild(readOnlyNote);
     } else if (scopeInfo.type === 'runtime' || hasRuntimeVariable) {
       const readOnlyNote = document.createElement('div');
       readOnlyNote.className = 'var-readonly-note';
+      readOnlyNote.setAttribute('data-testid', 'var-info-readonly-note');
       readOnlyNote.textContent = 'Set by scripts (read-only)';
       into.appendChild(readOnlyNote);
     } else if (scopeInfo.type === 'oauth2') {
       const readOnlyNote = document.createElement('div');
       readOnlyNote.className = 'var-readonly-note';
+      readOnlyNote.setAttribute('data-testid', 'var-info-readonly-note');
       readOnlyNote.textContent = 'read-only';
       into.appendChild(readOnlyNote);
     } else if (scopeInfo.type === 'undefined') {
       const readOnlyNote = document.createElement('div');
       readOnlyNote.className = 'var-readonly-note';
+      readOnlyNote.setAttribute('data-testid', 'var-info-readonly-note');
       readOnlyNote.textContent = 'No active environment';
       into.appendChild(readOnlyNote);
     }
@@ -847,6 +863,7 @@ if (!SERVER_RENDERED) {
 
     const popup = document.createElement('div');
     popup.className = 'CodeMirror-brunoVarInfo';
+    popup.setAttribute('data-testid', 'var-info-popup');
     popup.appendChild(brunoVarInfo);
     document.body.appendChild(popup);
 

--- a/tests/utils/constants/index.ts
+++ b/tests/utils/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './auth';
+export * from './variables';

--- a/tests/utils/constants/variables.ts
+++ b/tests/utils/constants/variables.ts
@@ -1,0 +1,14 @@
+export type VariableDataType = 'string' | 'number' | 'boolean' | 'object';
+
+export type SecretDatatypeCase = {
+  dataType: Exclude<VariableDataType, 'string'>;
+  varName: string;
+  value: string;
+  revealContains: string;
+};
+
+export const SECRET_DATATYPE_CASES: SecretDatatypeCase[] = [
+  { dataType: 'number', varName: 'secretNumber', value: '12345', revealContains: '12345' },
+  { dataType: 'boolean', varName: 'secretBoolean', value: 'true', revealContains: 'true' },
+  { dataType: 'object', varName: 'secretObject', value: '{"k":1}', revealContains: '"k"' }
+];

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -2428,13 +2428,13 @@ const setRequestUrlAndSave = async (page: Page, url: string) => {
  * Hover a `{{var}}` token in the URL editor and return its (visible) info tooltip.
  * @param page - The page object
  * @param varName - The variable name inside the braces
- * @param state - Highlight class to match: 'valid' (known), 'invalid' (unknown), or 'any'
+ * @param state - Highlight class to match: 'valid' (known) or 'invalid' (unknown); omit to match either
  * @returns The tooltip popup locator
  */
 const openUrlVarTooltip = async (
   page: Page,
   varName: string,
-  state: 'valid' | 'invalid' | 'any' = 'valid'
+  state?: 'valid' | 'invalid'
 ): Promise<Locator> => {
   const { request, varInfoPopup } = buildCommonLocators(page);
   // Dismiss any previously-open tooltip first.

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -748,8 +748,6 @@ type EnvironmentVariable = {
   name: string;
   value: string;
   isSecret?: boolean;
-  // Non-string dataType to assign via the DataTypeSelector. Omit for the
-  // default `string` type.
   dataType?: 'number' | 'boolean' | 'object';
 };
 
@@ -816,7 +814,6 @@ const addRowToActiveTab = async (
     await codeMirror.scrollIntoViewIfNeeded();
     await codeMirror.click();
     if (dataType) {
-      // `insertText` avoids CodeMirror's auto-pair smart input (e.g. on object braces).
       await expect(codeMirror).toHaveClass(/CodeMirror-focused/);
       await page.keyboard.insertText(value);
 
@@ -824,8 +821,6 @@ const addRowToActiveTab = async (
       await codeMirror.hover();
       await dataTypeSelector.typeLabel(row).click();
       await dataTypeSelector.menuItem(dataType).click();
-      // The attribute reflecting the applied dataType is the settle signal — the
-      // Redux mutation has landed once it's present, so no fixed wait is needed.
       await expect(dataTypeSelector.typeLabel(row)).toHaveAttribute('data-selected-type', dataType);
     } else {
       await page.keyboard.type(value);

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -748,6 +748,9 @@ type EnvironmentVariable = {
   name: string;
   value: string;
   isSecret?: boolean;
+  // Non-string dataType to assign via the DataTypeSelector. Omit for the
+  // default `string` type.
+  dataType?: 'number' | 'boolean' | 'object';
 };
 
 /**
@@ -766,7 +769,7 @@ const addEnvironmentVariable = async (page: Page, variable: EnvironmentVariable)
     await tab.click();
     await expect(tab).toHaveClass(/active/);
 
-    await addRowToActiveTab(page, variable.name, variable.value);
+    await addRowToActiveTab(page, variable.name, variable.value, variable.dataType);
   });
 };
 
@@ -788,13 +791,19 @@ const addEnvironmentVariables = async (page: Page, variables: EnvironmentVariabl
 /**
  * Add a variable or secret to whichever environment tab (Variables / Secrets) is
  * currently active. The active tab determines the row's type, so select the tab
- * before calling.
+ * before calling. When `dataType` is given, its type is set via the DataTypeSelector.
  * @param page - The page object
  * @param name - The variable/secret name
  * @param value - The variable/secret value
+ * @param dataType - Optional non-string dataType to assign (default `string`)
  * @returns void
  */
-const addRowToActiveTab = async (page: Page, name: string, value: string) => {
+const addRowToActiveTab = async (
+  page: Page,
+  name: string,
+  value: string,
+  dataType?: 'number' | 'boolean' | 'object'
+) => {
   await test.step(`Add row "${name}" to the active environment tab`, async () => {
     const nameInput = page.locator('input[placeholder="Name"]').last();
     await nameInput.waitFor({ state: 'visible' });
@@ -806,7 +815,21 @@ const addRowToActiveTab = async (page: Page, name: string, value: string) => {
     const codeMirror = row.getByTestId(/^test-multiline-editor-\d+\.value$/).locator('.CodeMirror').first();
     await codeMirror.scrollIntoViewIfNeeded();
     await codeMirror.click();
-    await page.keyboard.type(value);
+    if (dataType) {
+      // `insertText` avoids CodeMirror's auto-pair smart input (e.g. on object braces).
+      await expect(codeMirror).toHaveClass(/CodeMirror-focused/);
+      await page.keyboard.insertText(value);
+
+      const { dataTypeSelector } = buildCommonLocators(page);
+      await codeMirror.hover();
+      await dataTypeSelector.typeLabel(row).click();
+      await dataTypeSelector.menuItem(dataType).click();
+      // The attribute reflecting the applied dataType is the settle signal — the
+      // Redux mutation has landed once it's present, so no fixed wait is needed.
+      await expect(dataTypeSelector.typeLabel(row)).toHaveAttribute('data-selected-type', dataType);
+    } else {
+      await page.keyboard.type(value);
+    }
   });
 };
 
@@ -2390,8 +2413,48 @@ const scrollVirtuosoRowIntoView = async (page: Page, target: Locator) => {
   await target.scrollIntoViewIfNeeded().catch(() => { });
 };
 
+/**
+ * Set the active request's URL and save it. Typed char-by-char so CodeMirror
+ * tokenizes `{{var}}` references (vs. a bulk fill that skips tokenization).
+ * @param page - The page object
+ * @param url - The URL to type into the request URL editor
+ */
+const setRequestUrlAndSave = async (page: Page, url: string) => {
+  await test.step(`Set request URL: ${url}`, async () => {
+    const { request } = buildCommonLocators(page);
+    const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
+    await request.urlInput().click();
+    await page.keyboard.type(url);
+    await page.keyboard.press(saveShortcut);
+  });
+};
+
+/**
+ * Hover a `{{var}}` token in the URL editor and return its (visible) info tooltip.
+ * @param page - The page object
+ * @param varName - The variable name inside the braces
+ * @param state - Highlight class to match: 'valid' (known), 'invalid' (unknown), or 'any'
+ * @returns The tooltip popup locator
+ */
+const openUrlVarTooltip = async (
+  page: Page,
+  varName: string,
+  state: 'valid' | 'invalid' | 'any' = 'valid'
+): Promise<Locator> => {
+  const { request, varInfoPopup } = buildCommonLocators(page);
+  // Dismiss any previously-open tooltip first.
+  await page.mouse.move(0, 0);
+  await request.urlVariableToken(varName, state).hover();
+
+  const tooltip = varInfoPopup.all().first();
+  await expect(tooltip).toBeVisible();
+  return tooltip;
+};
+
 export {
   waitForReadyPage,
+  setRequestUrlAndSave,
+  openUrlVarTooltip,
   scrollVirtuosoRowIntoView,
   dismissImportIssuesToasts,
   closeAllCollections,

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -165,8 +165,8 @@ export const buildCommonLocators = (page: Page) => ({
     menuItem: (type: string) => page.locator('[role="menu"]').last().getByText(type, { exact: true })
   },
   request: {
-    urlInput: () => page.locator('#request-url .CodeMirror'),
-    urlLine: () => page.locator('#request-url .CodeMirror-line'),
+    urlInput: () => page.getByTestId('request-url').locator('.CodeMirror'),
+    urlLine: () => page.getByTestId('request-url').locator('.CodeMirror-line'),
     sendButton: () => page.getByTestId('send-arrow-icon'),
     methodDropdown: () => page.getByTestId('request-method-selector'),
     newRequestUrl: () => page.locator('#new-request-url .CodeMirror'),
@@ -177,17 +177,28 @@ export const buildCommonLocators = (page: Page) => ({
     bodyEditor: () => page.getByTestId('request-body-editor'),
     bodyVariableToken: (name: string) =>
       page.getByTestId('request-body-editor').locator('.CodeMirror .cm-variable-valid').filter({ hasText: name }),
+    urlVariableToken: (name: string, state: 'valid' | 'invalid' | 'any' = 'valid') => {
+      const selector = state === 'any' ? '.cm-variable-valid, .cm-variable-invalid' : `.cm-variable-${state}`;
+      return page.getByTestId('request-url').locator('.CodeMirror').locator(selector).filter({ hasText: name }).first();
+    },
     pane: () => page.getByTestId('request-pane')
   },
   // The variable-info popup shown when hovering a `{{var}}` token in an editor.
   varInfoPopup: {
-    all: () => page.locator('.CodeMirror-brunoVarInfo'),
+    all: () => page.getByTestId('var-info-popup'),
     byName: (name: string) =>
-      page.locator('.CodeMirror-brunoVarInfo').filter({ has: page.locator('.var-name').filter({ hasText: new RegExp(`^${name}$`) }) }),
-    valueDisplay: (popup: Locator) => popup.locator('.var-value-editable-display, .var-value-display').first(),
-    editableValue: (popup: Locator) => popup.locator('.var-value-editable-display').first(),
-    secretToggle: (popup: Locator) => popup.locator('.secret-toggle-button'),
-    editor: (popup: Locator) => popup.locator('.var-value-editor .CodeMirror')
+      page.getByTestId('var-info-popup').filter({ has: page.getByTestId('var-info-name').filter({ hasText: new RegExp(`^${name}$`) }) }),
+    name: (popup: Locator) => popup.getByTestId('var-info-name'),
+    scopeBadge: (popup: Locator) => popup.getByTestId('var-info-scope-badge'),
+    valueDisplay: (popup: Locator) => popup.getByTestId(/^var-info-value-(editable|display)$/).first(),
+    editableValue: (popup: Locator) => popup.getByTestId('var-info-value-editable').first(),
+    secretToggle: (popup: Locator) => popup.getByTestId('var-info-secret-toggle'),
+    copyButton: (popup: Locator) => popup.getByTestId('var-info-copy-button'),
+    readonlyNote: (popup: Locator) => popup.getByTestId('var-info-readonly-note'),
+    warningNote: (popup: Locator) => popup.getByTestId('var-info-warning-note'),
+    // The editor container itself (hidden until the value display is clicked).
+    editorContainer: (popup: Locator) => popup.getByTestId('var-info-value-editor'),
+    editor: (popup: Locator) => popup.getByTestId('var-info-value-editor').locator('.CodeMirror')
   },
   auth: {
     apiKey: {

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -175,11 +175,17 @@ export const buildCommonLocators = (page: Page) => ({
     generateCodeButton: () => page.getByTestId('generate-code-button'),
     bodyModeSelector: () => page.getByTestId('request-body-mode-selector'),
     bodyEditor: () => page.getByTestId('request-body-editor'),
-    bodyVariableToken: (name: string) =>
-      page.getByTestId('request-body-editor').locator('.CodeMirror .cm-variable-valid').filter({ hasText: name }),
-    urlVariableToken: (name: string, state: 'valid' | 'invalid' | 'any' = 'valid') => {
-      const selector = state === 'any' ? '.cm-variable-valid, .cm-variable-invalid' : `.cm-variable-${state}`;
+    bodyVariableToken: (name: string, state?: 'valid' | 'invalid') => {
+      const selector = state ? `.cm-variable-${state}` : '.cm-variable-valid, .cm-variable-invalid';
+      return page.getByTestId('request-body-editor').locator('.CodeMirror').locator(selector).filter({ hasText: name }).first();
+    },
+    urlVariableToken: (name: string, state?: 'valid' | 'invalid') => {
+      const selector = state ? `.cm-variable-${state}` : '.cm-variable-valid, .cm-variable-invalid';
       return page.getByTestId('request-url').locator('.CodeMirror').locator(selector).filter({ hasText: name }).first();
+    },
+    headerVariableToken: (row: Locator, name: string, state?: 'valid' | 'invalid') => {
+      const selector = state ? `.cm-variable-${state}` : '.cm-variable-valid, .cm-variable-invalid';
+      return row.locator('.CodeMirror').nth(1).locator(selector).filter({ hasText: name }).first();
     },
     pane: () => page.getByTestId('request-pane')
   },

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -29,7 +29,7 @@ test.describe('Variable Tooltip', () => {
 
   test('should test tooltip functionality with environment variables', async ({ page, createTmpDir }) => {
     const collectionName = 'tooltip-test';
-    const { sidebar, varInfoPopup } = buildCommonLocators(page);
+    const { sidebar, request, varInfoPopup } = buildCommonLocators(page);
 
     await test.step('Create collection and add environment variables', async () => {
       await createCollection(page, collectionName, await createTmpDir('tooltip-collection'));
@@ -77,8 +77,7 @@ test.describe('Variable Tooltip', () => {
       await page.keyboard.press(saveShortcut);
 
       // Hover the secret token in the header value editor.
-      const secretVar = headerValueEditor.locator('.cm-variable-valid').filter({ hasText: 'secretToken' }).first();
-      await secretVar.hover();
+      await request.headerVariableToken(headerRow, 'secretToken').hover();
 
       const tooltip = varInfoPopup.all().first();
       await expect(tooltip).toBeVisible();
@@ -197,7 +196,7 @@ test.describe('Variable Tooltip', () => {
       await page.keyboard.press(saveShortcut);
 
       // process.env vars can render as valid or invalid depending on presence.
-      const tooltip = await openUrlVarTooltip(page, 'process.env.HOME', 'any');
+      const tooltip = await openUrlVarTooltip(page, 'process.env.HOME');
       await expect(varInfoPopup.name(tooltip)).toContainText('process.env.HOME');
       await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Process Env');
 
@@ -314,8 +313,7 @@ test.describe('Variable Tooltip', () => {
 
       // Hover over the invalid variable.
       await page.mouse.move(0, 0);
-      const invalidVar = bodyEditor.locator('.cm-variable-invalid, .cm-variable-valid').filter({ hasText: 'user id' }).first();
-      await invalidVar.hover();
+      await request.bodyVariableToken('user id', 'invalid').hover();
 
       // Verify tooltip shows a warning and hides the editable input.
       const tooltip = varInfoPopup.all().first();

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -6,12 +6,17 @@ import {
   createFolder,
   expandFolder,
   createEnvironment,
+  addEnvironmentVariable,
   addEnvironmentVariables,
   saveEnvironment,
   selectRequestPaneTab,
-  closeEnvironmentPanel
+  closeEnvironmentPanel,
+  deleteAllGlobalEnvironments,
+  setRequestUrlAndSave,
+  openUrlVarTooltip
 } from '../utils/page';
 import { buildCommonLocators } from '../utils/page/locators';
+import { SECRET_DATATYPE_CASES } from '../utils/constants';
 
 const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
 
@@ -24,6 +29,7 @@ test.describe('Variable Tooltip', () => {
 
   test('should test tooltip functionality with environment variables', async ({ page, createTmpDir }) => {
     const collectionName = 'tooltip-test';
+    const { sidebar, varInfoPopup } = buildCommonLocators(page);
 
     await test.step('Create collection and add environment variables', async () => {
       await createCollection(page, collectionName, await createTmpDir('tooltip-collection'));
@@ -40,29 +46,17 @@ test.describe('Variable Tooltip', () => {
     });
 
     await test.step('Create request and test tooltip', async () => {
-      // Create request using utility method
       await createRequest(page, 'Test Request', collectionName);
-
-      // Set the URL
-      await page.locator('.collection-item-name').filter({ hasText: 'Test Request' }).click();
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
-      await page.keyboard.type('https://api.example.com?key={{apiKey}}');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.request('Test Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?key={{apiKey}}');
     });
 
     await test.step('Test basic tooltip', async () => {
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const apiKeyVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'apiKey' }).first();
-
-      await apiKeyVar.hover();
-
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip.locator('.var-name')).toContainText('apiKey');
-      await expect(tooltip.locator('.var-scope-badge')).toContainText('Environment');
-      await expect(tooltip.locator('.var-value-editable-display')).toContainText('test-key-123');
-      await expect(tooltip.locator('.copy-button')).toBeVisible();
+      const tooltip = await openUrlVarTooltip(page, 'apiKey');
+      await expect(varInfoPopup.name(tooltip)).toContainText('apiKey');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('test-key-123');
+      await expect(varInfoPopup.copyButton(tooltip)).toBeVisible();
     });
 
     await test.step('Test secret variable with toggle', async () => {
@@ -82,27 +76,26 @@ test.describe('Variable Tooltip', () => {
       await page.keyboard.type('Bearer {{secretToken}}');
       await page.keyboard.press(saveShortcut);
 
-      // Test tooltip with secret
+      // Hover the secret token in the header value editor.
       const secretVar = headerValueEditor.locator('.cm-variable-valid').filter({ hasText: 'secretToken' }).first();
       await secretVar.hover();
 
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
+      const tooltip = varInfoPopup.all().first();
       await expect(tooltip).toBeVisible();
 
-      // Verify masked
-      const valueDisplay = tooltip.locator('.var-value-editable-display');
+      // Verify masked (asterisks, not the actual value).
+      const valueDisplay = varInfoPopup.editableValue(tooltip);
       const maskedText = await valueDisplay.textContent();
-      // Check that value is masked (contains bullet points and not the actual value)
       expect(maskedText).not.toContain('secret-xyz');
       expect(maskedText?.length).toBeGreaterThan(0);
 
-      // Test toggle
-      const toggleButton = tooltip.locator('.secret-toggle-button');
+      // Reveal via the eye toggle.
+      const toggleButton = varInfoPopup.secretToggle(tooltip);
       await expect(toggleButton).toBeVisible();
       await toggleButton.click();
       await expect(valueDisplay).toContainText('secret-xyz');
 
-      // Toggle back
+      // Toggle back to masked.
       await toggleButton.click();
       const remaskedText = await valueDisplay.textContent();
       expect(remaskedText).not.toContain('secret-xyz');
@@ -112,6 +105,7 @@ test.describe('Variable Tooltip', () => {
 
   test('should test tooltip with variable references', async ({ page, createTmpDir }) => {
     const collectionName = 'tooltip-reference-test';
+    const { sidebar, varInfoPopup } = buildCommonLocators(page);
 
     await test.step('Create collection with interdependent variables', async () => {
       await createCollection(page, collectionName, await createTmpDir('tooltip-ref-collection'));
@@ -128,104 +122,58 @@ test.describe('Variable Tooltip', () => {
     });
 
     await test.step('Create request with variable references', async () => {
-      // Create request using utility method
       await createRequest(page, 'Ref Test Request', collectionName);
-
-      // Set the URL
-      await page.locator('.collection-item-name').filter({ hasText: 'Ref Test Request' }).click();
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
-      await page.keyboard.type('{{endpoint}}');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.request('Ref Test Request').click();
+      await setRequestUrlAndSave(page, '{{endpoint}}');
     });
 
     await test.step('Test variable referencing other variables', async () => {
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const endpointVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'endpoint' }).first();
+      const tooltip = await openUrlVarTooltip(page, 'endpoint');
+      await expect(varInfoPopup.name(tooltip)).toContainText('endpoint');
 
-      await endpointVar.hover();
-
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip.locator('.var-name')).toContainText('endpoint');
-
-      // Should show resolved value
-      await expect(tooltip.locator('.var-value-editable-display')).toContainText('https://api.example.com/users');
-
-      // Should have copy button
-      await expect(tooltip.locator('.copy-button')).toBeVisible();
+      // Should show resolved value.
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('https://api.example.com/users');
+      await expect(varInfoPopup.copyButton(tooltip)).toBeVisible();
     });
 
     await test.step('Test editing variable with references', async () => {
-      // Move mouse away to dismiss any active tooltip
-      await page.mouse.move(0, 0);
+      const tooltip = await openUrlVarTooltip(page, 'endpoint');
 
-      // URL editor is always visible at the top
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const endpointVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'endpoint' }).first();
-
-      await endpointVar.hover();
-
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-
-      // Click on value to edit
-      const valueDisplay = tooltip.locator('.var-value-editable-display');
+      // Click on value to edit.
+      const valueDisplay = varInfoPopup.editableValue(tooltip);
       await valueDisplay.click();
 
-      // Should show editor with raw value (not resolved)
-      const editor = tooltip.locator('.var-value-editor .CodeMirror');
+      // Should show editor with raw value (not resolved).
+      const editor = varInfoPopup.editor(tooltip);
       await expect(editor).toBeVisible();
-
-      // Verify it shows the raw value with variable references
-      // focus on the editor
       const editorContent = await editor.locator('.CodeMirror-line').textContent();
       expect(editorContent).toContain('{{host}}');
 
-      // Edit the value
+      // Edit the value, click outside to save.
       await page.keyboard.press('End');
       await page.keyboard.type('/posts');
-
-      // Click outside to save
       await page.locator('body').click();
 
-      // Move mouse away and back to get fresh tooltip
-      await page.mouse.move(0, 0);
-
-      // Hover again to verify the change
-      await endpointVar.hover();
-
-      const newTooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(newTooltip).toBeVisible();
-
-      // Should show updated resolved value
-      await expect(newTooltip.locator('.var-value-editable-display')).toContainText('https://api.example.com/users/posts');
+      // Hover again to verify the change.
+      const newTooltip = await openUrlVarTooltip(page, 'endpoint');
+      await expect(varInfoPopup.editableValue(newTooltip)).toContainText('https://api.example.com/users/posts');
     });
 
     await test.step('Test copy button', async () => {
-      // Move mouse away to dismiss any active tooltip
-      await page.mouse.move(0, 0);
-
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const endpointVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'endpoint' }).first();
-
-      await endpointVar.hover();
-
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-
-      const copyButton = tooltip.locator('.copy-button');
+      const tooltip = await openUrlVarTooltip(page, 'endpoint');
+      const copyButton = varInfoPopup.copyButton(tooltip);
       await expect(copyButton).toBeVisible();
-
-      // Click copy button
       await copyButton.click();
 
-      await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 1000 }).toBe('https://api.example.com/users/posts');
+      await expect
+        .poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 1000 })
+        .toBe('https://api.example.com/users/posts');
     });
   });
 
   test('should handle runtime and process.env variables', async ({ page, createTmpDir }) => {
     const collectionName = 'tooltip-readonly-test';
+    const { sidebar, request, varInfoPopup } = buildCommonLocators(page);
 
     await test.step('Create collection and request', async () => {
       await createCollection(page, collectionName, await createTmpDir('tooltip-readonly-collection'));
@@ -234,149 +182,103 @@ test.describe('Variable Tooltip', () => {
       await saveEnvironment(page);
       await closeEnvironmentPanel(page);
 
-      // Create request using utility method
       await createRequest(page, 'Readonly Test', collectionName);
-
-      // Set the URL
-      const locators = buildCommonLocators(page);
-      await locators.sidebar.request('Readonly Test').click();
-      const urlEditor = locators.request.urlInput();
-      await urlEditor.click();
-      await page.keyboard.type('https://example.com');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.request('Readonly Test').click();
+      await setRequestUrlAndSave(page, 'https://example.com');
     });
 
     await test.step('Test process.env variable tooltip', async () => {
-      // Move mouse away to dismiss any active tooltip
       await page.mouse.move(0, 0);
 
-      // Add a process.env variable in URL (URL editor is always visible at the top)
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
+      // Append a process.env variable to the URL.
+      await request.urlInput().click();
       await page.keyboard.press('End');
       await page.keyboard.type('?env={{process.env.HOME}}');
       await page.keyboard.press(saveShortcut);
 
-      // Hover over process.env variable
-      const processEnvVar = urlEditor.locator('.cm-variable-valid, .cm-variable-invalid').filter({ hasText: 'process.env.HOME' }).first();
-      await processEnvVar.hover();
+      // process.env vars can render as valid or invalid depending on presence.
+      const tooltip = await openUrlVarTooltip(page, 'process.env.HOME', 'any');
+      await expect(varInfoPopup.name(tooltip)).toContainText('process.env.HOME');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Process Env');
 
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip.locator('.var-name')).toContainText('process.env.HOME');
-      await expect(tooltip.locator('.var-scope-badge')).toContainText('Process Env');
-
-      // Should show read-only note
-      await expect(tooltip.locator('.var-readonly-note')).toContainText('read-only');
-
-      // Should have copy button but not be editable
-      await expect(tooltip.locator('.copy-button')).toBeVisible();
-      await expect(tooltip.locator('.var-value-editor')).not.toBeVisible();
+      // Should show read-only note, a copy button, but no editable editor.
+      await expect(varInfoPopup.readonlyNote(tooltip)).toContainText('read-only');
+      await expect(varInfoPopup.copyButton(tooltip)).toBeVisible();
+      await expect(varInfoPopup.editorContainer(tooltip)).not.toBeVisible();
     });
   });
 
   test('should auto-save request when creating variable via tooltip', async ({ page, createTmpDir }) => {
     const collectionName = 'draft-autosave-test';
+    const { sidebar, request, varInfoPopup } = buildCommonLocators(page);
+    const requestTab = page.locator('.request-tab').filter({ has: page.locator('.tab-label', { hasText: 'Autosave Test' }) });
 
     await test.step('Setup collection and request', async () => {
       await createCollection(page, collectionName, await createTmpDir('draft-autosave'));
 
-      // Create request using utility method
       await createRequest(page, 'Autosave Test', collectionName);
-
-      // Set the URL
-      await page.locator('.collection-item-name').filter({ hasText: 'Autosave Test' }).click();
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
-      await page.keyboard.type('https://api.example.com');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.request('Autosave Test').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
     });
 
     await test.step('Edit URL to create draft with undefined variable', async () => {
-      // Edit the URL to add a variable reference
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
+      await request.urlInput().click();
       await page.keyboard.press('End');
       await page.keyboard.type('/users/{{myApiKey}}');
 
-      // Verify draft indicator appears (unsaved changes) in the request tab
-      const requestTab = page.locator('.request-tab').filter({ has: page.locator('.tab-label', { hasText: 'Autosave Test' }) });
+      // Verify draft indicator appears (unsaved changes) in the request tab.
       await expect(requestTab.locator('.has-changes-icon')).toBeVisible();
     });
 
     await test.step('Create variable via tooltip - should auto-save entire request', async () => {
-      // Hover over the undefined variable {{myApiKey}}
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const undefinedVar = urlEditor.locator('.cm-variable-invalid').filter({ hasText: 'myApiKey' }).first();
-      await undefinedVar.hover();
+      const tooltip = await openUrlVarTooltip(page, 'myApiKey', 'invalid');
+      await expect(varInfoPopup.name(tooltip)).toContainText('myApiKey');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Request');
 
-      // Tooltip should appear
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip.locator('.var-name')).toContainText('myApiKey');
-      await expect(tooltip.locator('.var-scope-badge')).toContainText('Request');
-
-      // Click to edit the variable
-      const valueDisplay = tooltip.locator('.var-value-editable-display');
-      await valueDisplay.click();
-
-      // Type value
-      const editor = tooltip.locator('.var-value-editor .CodeMirror');
-      await expect(editor).toBeVisible();
+      // Click to edit the variable and type a value.
+      await varInfoPopup.editableValue(tooltip).click();
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
       await page.keyboard.type('secret-key-123');
 
-      // Click outside to close editor - this will auto-save the entire request
+      // Click outside to close editor - this auto-saves the entire request.
       await page.locator('body').click();
     });
 
     await test.step('Verify request was auto-saved with URL changes and new variable', async () => {
-      // Move mouse away
+      // Variable is now valid (green) in the URL.
+      await expect(request.urlVariableToken('myApiKey', 'valid')).toBeVisible();
+
+      // Hover to verify the value was saved.
+      const tooltip = await openUrlVarTooltip(page, 'myApiKey', 'valid');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('secret-key-123');
       await page.mouse.move(0, 0);
 
-      // Verify variable is now valid (green) in the URL
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const validVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'myApiKey' });
-      await expect(validVar).toBeVisible();
-
-      // Hover to verify value was saved
-      await validVar.first().hover();
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip.locator('.var-value-editable-display')).toContainText('secret-key-123');
-
-      // Move mouse away
-      await page.mouse.move(0, 0);
-
-      // Verify the URL changes were also saved
-      const urlContent = await urlEditor.locator('.CodeMirror-line').first().textContent();
+      // Verify the URL changes were also saved.
+      const urlContent = await request.urlLine().first().textContent();
       expect(urlContent).toContain('api.example.com/users');
       expect(urlContent).toContain('myApiKey');
 
-      // Verify draft indicator is GONE (everything was auto-saved)
-      const requestTab = page.locator('.request-tab').filter({ has: page.locator('.tab-label', { hasText: 'Autosave Test' }) });
+      // Verify draft indicator is GONE (everything was auto-saved).
       await expect(requestTab.locator('.has-changes-icon')).not.toBeVisible();
       await expect(requestTab.locator('.close-icon')).toBeVisible();
     });
 
     await test.step('Verify variable exists in Vars tab', async () => {
-      // Check variable is saved to file - should appear in the Vars tab
       await selectRequestPaneTab(page, 'Vars');
 
-      // The variable should exist in the saved file
       const varsTable = page.locator('table').first();
       await expect(varsTable).toBeVisible();
 
       const varRow = varsTable.locator('tbody tr').first();
       await expect(varRow).toBeVisible();
 
-      // Check variable name
+      // Check variable name.
       const varNameInput = varRow.locator('td').nth(1).getByRole('textbox');
       await expect(varNameInput).toBeVisible();
       await expect(varNameInput).toHaveValue('myApiKey');
 
-      // Check variable value
-      const varValueTd = varRow.locator('td').nth(2);
-      const varValue = varValueTd.locator('.CodeMirror');
+      // Check variable value.
+      const varValue = varRow.locator('td').nth(2).locator('.CodeMirror');
       await expect(varValue).toBeVisible();
       const varValueContent = await varValue.locator('.CodeMirror-line').textContent();
       expect(varValueContent).toContain('secret-key-123');
@@ -385,53 +287,48 @@ test.describe('Variable Tooltip', () => {
 
   test('should handle invalid variable names with warning', async ({ page, createTmpDir }) => {
     const collectionName = 'invalid-var-test';
+    const { sidebar, request, varInfoPopup, dropdown } = buildCommonLocators(page);
 
     await test.step('Setup collection and request', async () => {
       await createCollection(page, collectionName, await createTmpDir('invalid-var-collection'));
 
-      // Create request using utility method
       await createRequest(page, 'Invalid Var Test', collectionName);
-
-      // Set the URL
-      await page.locator('.collection-item-name').filter({ hasText: 'Invalid Var Test' }).click();
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
-      await page.keyboard.type('https://api.example.com');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.request('Invalid Var Test').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
     });
 
     await test.step('Test invalid variable name with space', async () => {
       await selectRequestPaneTab(page, 'Body');
 
-      // Select JSON body mode
-      await page.locator('.body-mode-selector').click();
-      await page.locator('.dropdown-item').filter({ hasText: 'JSON' }).click();
+      // Select JSON body mode.
+      await request.bodyModeSelector().click();
+      await dropdown.item('JSON').click();
 
       const bodyEditor = page.locator('.CodeMirror').last();
       await bodyEditor.click();
-
       await bodyEditor.evaluate((el: any) => {
         const cm = el.CodeMirror;
         cm.setValue('{\n  "userId": "{{user id}}"\n}');
       });
       await page.keyboard.press(saveShortcut);
 
-      // Hover over the invalid variable
+      // Hover over the invalid variable.
       await page.mouse.move(0, 0);
       const invalidVar = bodyEditor.locator('.cm-variable-invalid, .cm-variable-valid').filter({ hasText: 'user id' }).first();
       await invalidVar.hover();
 
-      // Verify tooltip shows warning and hides input
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
+      // Verify tooltip shows a warning and hides the editable input.
+      const tooltip = varInfoPopup.all().first();
       await expect(tooltip).toBeVisible();
-      await expect(tooltip.locator('.var-name')).toContainText('user id');
-      await expect(tooltip.locator('.var-warning-note')).toBeVisible();
-      await expect(tooltip.locator('.var-value-editable-display')).not.toBeVisible();
+      await expect(varInfoPopup.name(tooltip)).toContainText('user id');
+      await expect(varInfoPopup.warningNote(tooltip)).toBeVisible();
+      await expect(varInfoPopup.editableValue(tooltip)).not.toBeVisible();
     });
   });
 
   test('should keep tooltip open while editing when mouse leaves popup area', async ({ page, createTmpDir }) => {
     const collectionName = 'tooltip-pin-test';
+    const { sidebar, varInfoPopup } = buildCommonLocators(page);
 
     await test.step('Setup collection, environment variable, and request', async () => {
       await createCollection(page, collectionName, await createTmpDir('tooltip-pin-collection'));
@@ -442,31 +339,19 @@ test.describe('Variable Tooltip', () => {
       await closeEnvironmentPanel(page);
 
       await createRequest(page, 'Pin Test Request', collectionName);
-      await page.locator('.collection-item-name').filter({ hasText: 'Pin Test Request' }).click();
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
-      await page.keyboard.type('https://api.example.com?key={{pinVar}}');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.request('Pin Test Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?key={{pinVar}}');
     });
 
     await test.step('Tooltip stays open and accepts input while mouse is outside popup', async () => {
-      await page.mouse.move(0, 0);
+      const tooltip = await openUrlVarTooltip(page, 'pinVar');
 
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const pinVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'pinVar' }).first();
-      await pinVar.hover();
-
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-
-      // Click value display to enter edit mode (this also pins the popup)
-      const valueDisplay = tooltip.locator('.var-value-editable-display');
-      await valueDisplay.click();
-
-      const editor = tooltip.locator('.var-value-editor .CodeMirror');
+      // Click value display to enter edit mode (this also pins the popup).
+      await varInfoPopup.editableValue(tooltip).click();
+      const editor = varInfoPopup.editor(tooltip);
       await expect(editor).toBeVisible();
 
-      // Move mouse far outside the popup
+      // Move mouse far outside the popup.
       await page.mouse.move(0, 0);
 
       // Type with a per-keystroke delay so the typing window spans past the internal
@@ -476,15 +361,14 @@ test.describe('Variable Tooltip', () => {
       await page.keyboard.press('End');
       await page.keyboard.type('-still-editable-after-mouse-left', { delay: 25 });
 
-      await expect(editor.locator('.CodeMirror-line')).toContainText(
-        'pin-value-still-editable-after-mouse-left'
-      );
+      await expect(editor.locator('.CodeMirror-line')).toContainText('pin-value-still-editable-after-mouse-left');
       await expect(tooltip).toBeVisible();
     });
   });
 
   test('should persist subsequent edits while popup stays open', async ({ page, createTmpDir }) => {
     const collectionName = 'tooltip-subsequent-edit-test';
+    const { sidebar, varInfoPopup } = buildCommonLocators(page);
 
     await test.step('Setup collection, environment variable, and request', async () => {
       await createCollection(page, collectionName, await createTmpDir('tooltip-subsequent-collection'));
@@ -495,80 +379,56 @@ test.describe('Variable Tooltip', () => {
       await closeEnvironmentPanel(page);
 
       await createRequest(page, 'Edit Test Request', collectionName);
-      await page.locator('.collection-item-name').filter({ hasText: 'Edit Test Request' }).click();
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
-      await page.keyboard.type('https://api.example.com?key={{editVar}}');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.request('Edit Test Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?key={{editVar}}');
     });
 
     await test.step('First edit saves via Enter and keeps popup open', async () => {
-      await page.mouse.move(0, 0);
+      const tooltip = await openUrlVarTooltip(page, 'editVar');
 
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const editVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'editVar' }).first();
-      await editVar.hover();
-
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-
-      const valueDisplay = tooltip.locator('.var-value-editable-display');
+      const valueDisplay = varInfoPopup.editableValue(tooltip);
       await expect(valueDisplay).toContainText('initial');
-
       await valueDisplay.click();
 
-      const editor = tooltip.locator('.var-value-editor .CodeMirror');
-      await expect(editor).toBeVisible();
-
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
       await page.keyboard.press('End');
       await page.keyboard.type('-one');
 
-      // Pressing Enter saves and keeps the popup open (does not click outside)
+      // Pressing Enter saves and keeps the popup open (does not click outside).
       await page.keyboard.press('Enter');
 
-      // Display reflects the saved value, and tooltip is still visible
       await expect(valueDisplay).toContainText('initial-one');
       await expect(tooltip).toBeVisible();
     });
 
     await test.step('Second edit on the same popup also saves', async () => {
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
+      const tooltip = varInfoPopup.all().first();
       await expect(tooltip).toBeVisible();
 
-      const valueDisplay = tooltip.locator('.var-value-editable-display');
+      const valueDisplay = varInfoPopup.editableValue(tooltip);
       await valueDisplay.click();
 
-      const editor = tooltip.locator('.var-value-editor .CodeMirror');
-      await expect(editor).toBeVisible();
-
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
       await page.keyboard.press('End');
       await page.keyboard.type('-two');
-
       await page.keyboard.press('Enter');
 
       await expect(valueDisplay).toContainText('initial-one-two');
     });
 
     await test.step('Reopen tooltip and verify the second edit persisted', async () => {
-      // Close the existing tooltip with an outside click, then re-hover to get a fresh one
+      // Close the existing tooltip with an outside click, then re-hover for a fresh one.
       await page.locator('body').click();
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).not.toBeVisible();
+      await expect(varInfoPopup.all().first()).not.toBeVisible();
 
-      await page.mouse.move(0, 0);
-
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const editVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'editVar' }).first();
-      await editVar.hover();
-
-      const newTooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(newTooltip).toBeVisible();
-      await expect(newTooltip.locator('.var-value-editable-display')).toContainText('initial-one-two');
+      const tooltip = await openUrlVarTooltip(page, 'editVar');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('initial-one-two');
     });
   });
 
   test('should copy latest value after editing within the same tooltip', async ({ page, createTmpDir }) => {
     const collectionName = 'tooltip-copy-latest-test';
+    const { sidebar, varInfoPopup } = buildCommonLocators(page);
 
     await test.step('Setup collection, environment variable, and request', async () => {
       await createCollection(page, collectionName, await createTmpDir('tooltip-copy-latest-collection'));
@@ -579,57 +439,43 @@ test.describe('Variable Tooltip', () => {
       await closeEnvironmentPanel(page);
 
       await createRequest(page, 'Copy Test Request', collectionName);
-      await page.locator('.collection-item-name').filter({ hasText: 'Copy Test Request' }).click();
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
-      await page.keyboard.type('https://api.example.com?key={{copyVar}}');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.request('Copy Test Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?key={{copyVar}}');
     });
 
     await test.step('Copy button copies the initial value', async () => {
-      await page.mouse.move(0, 0);
+      const tooltip = await openUrlVarTooltip(page, 'copyVar');
 
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const copyVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'copyVar' }).first();
-      await copyVar.hover();
-
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-
-      const copyButton = tooltip.locator('.copy-button');
+      const copyButton = varInfoPopup.copyButton(tooltip);
       await copyButton.click();
 
-      // Success state confirms writeText resolved before we read the clipboard
+      // Success state confirms writeText resolved before we read the clipboard.
       await expect(copyButton.locator('svg polyline')).toBeVisible({ timeout: 1000 });
 
       const initialClipboard = await page.evaluate(() => navigator.clipboard.readText());
       expect(initialClipboard).toBe('original-copy');
 
-      // Wait for the icon to revert so the next click is allowed
+      // Wait for the icon to revert so the next click is allowed.
       await expect(copyButton.locator('svg rect')).toBeVisible();
     });
 
     await test.step('Edit value, save with Enter, then copy without re-hovering', async () => {
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
+      const tooltip = varInfoPopup.all().first();
       await expect(tooltip).toBeVisible();
 
-      const valueDisplay = tooltip.locator('.var-value-editable-display');
+      const valueDisplay = varInfoPopup.editableValue(tooltip);
       await valueDisplay.click();
 
-      const editor = tooltip.locator('.var-value-editor .CodeMirror');
-      await expect(editor).toBeVisible();
-
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
       await page.keyboard.press('End');
       await page.keyboard.type('-edited');
-
       await page.keyboard.press('Enter');
 
-      // Wait for the display to reflect the saved value before clicking copy
+      // Wait for the display to reflect the saved value before clicking copy.
       await expect(valueDisplay).toContainText('original-copy-edited');
 
-      const copyButton = tooltip.locator('.copy-button');
+      const copyButton = varInfoPopup.copyButton(tooltip);
       await copyButton.click();
-
       await expect(copyButton.locator('svg polyline')).toBeVisible({ timeout: 1000 });
 
       const updatedClipboard = await page.evaluate(() => navigator.clipboard.readText());
@@ -637,29 +483,84 @@ test.describe('Variable Tooltip', () => {
     });
   });
 
+  for (const testCase of SECRET_DATATYPE_CASES) {
+    test(`should mask a secret ${testCase.dataType}-typed variable in the tooltip`, async ({ page, createTmpDir }) => {
+      const collectionName = `tooltip-secret-${testCase.dataType}-test`;
+      const envName = `Secret ${testCase.dataType} Env`;
+      const { environment, sidebar, varInfoPopup } = buildCommonLocators(page);
+
+      await test.step(`Create collection with a secret ${testCase.dataType}-typed env variable`, async () => {
+        await createCollection(page, collectionName, await createTmpDir(`tooltip-secret-${testCase.dataType}-collection`));
+
+        // Create a collection environment.
+        await environment.selector().click();
+        await environment.collectionTab().click();
+        await environment.createEnvButton().click();
+        await environment.envNameInput().fill(envName);
+        await page.getByRole('button', { name: 'Create', exact: true }).click();
+        await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+
+        // `isSecret` routes the row to the Secrets tab; `dataType` sets its type.
+        await addEnvironmentVariable(page, {
+          name: testCase.varName,
+          value: testCase.value,
+          isSecret: true,
+          dataType: testCase.dataType
+        });
+
+        await environment.saveAll().click();
+        await closeEnvironmentPanel(page);
+      });
+
+      await test.step('Reference the secret in a request URL', async () => {
+        await createRequest(page, `Secret ${testCase.dataType} Request`, collectionName);
+        await sidebar.request(`Secret ${testCase.dataType} Request`).click();
+        await setRequestUrlAndSave(page, `https://api.example.com?v={{${testCase.varName}}}`);
+      });
+
+      await test.step('Tooltip masks the value (non-empty) and reveals the real value', async () => {
+        const tooltip = await openUrlVarTooltip(page, testCase.varName);
+        await expect(varInfoPopup.name(tooltip)).toContainText(testCase.varName);
+
+        const valueDisplay = varInfoPopup.editableValue(tooltip);
+
+        // Core regression assertion: the masked display is NON-EMPTY. Before the
+        // fix this was '' for any non-string secret value.
+        await expect
+          .poll(async () => ((await valueDisplay.textContent()) ?? '').length)
+          .toBeGreaterThan(0);
+        // Masking must never leak the raw value.
+        expect(await valueDisplay.textContent()).not.toContain(testCase.revealContains);
+
+        // Revealing shows the actual value.
+        const toggleButton = varInfoPopup.secretToggle(tooltip);
+        await expect(toggleButton).toBeVisible();
+        await toggleButton.click();
+        await expect(valueDisplay).toContainText(testCase.revealContains);
+      });
+    });
+  }
+
   test('should copy pretty-printed JSON for an object-typed folder variable', async ({ page, createTmpDir }) => {
     const collectionName = 'tooltip-object-copy-test';
     const folderName = 'objFolder';
     const objectValue = { city: 'NYC', zip: 10001 };
-
     const expectedJson = JSON.stringify(objectValue, null, 2);
+
+    const { sidebar, paneTabs, dataTypeSelector, varInfoPopup } = buildCommonLocators(page);
 
     await test.step('Create a folder with an object-typed folder variable', async () => {
       await createCollection(page, collectionName, await createTmpDir('tooltip-object-collection'));
       await createFolder(page, folderName, collectionName);
 
-      const locators = buildCommonLocators(page);
+      // Open Folder Settings > Vars tab.
+      await sidebar.folder(folderName).dblclick();
+      await paneTabs.folderSettingsTab('vars').click();
 
-      // Open Folder Settings > Vars tab
-      const folderRow = locators.sidebar.folder(folderName);
-      await folderRow.dblclick();
-      await locators.paneTabs.folderSettingsTab('vars').click();
-
-      // Add the variable row and type its value
+      // Add the variable row and type its value.
       const tableContainer = page.getByTestId('folder-vars-req').first();
       const lastRow = tableContainer.locator('tbody tr').last();
-      const nameInput = lastRow.locator('input[type="text"]').first();
-      await nameInput.click();
+      await lastRow.locator('input[type="text"]').first().click();
       await page.keyboard.type('objVar');
 
       const namedRow = tableContainer.locator('tbody tr[data-row-name="objVar"]');
@@ -670,43 +571,31 @@ test.describe('Variable Tooltip', () => {
       await expect(valueEditor).toHaveClass(/CodeMirror-focused/);
       await page.keyboard.insertText(JSON.stringify(objectValue));
 
-      // Switch the variable's dataType from the default `string` to `object`
-      const typeTrigger = locators.dataTypeSelector.typeLabel(namedRow);
+      // Switch the variable's dataType from the default `string` to `object`.
+      const typeTrigger = dataTypeSelector.typeLabel(namedRow);
       await typeTrigger.click();
-      await locators.dataTypeSelector.menuItem('object').click();
+      await dataTypeSelector.menuItem('object').click();
       await expect(typeTrigger).toHaveText('object');
 
       await page.getByRole('button', { name: 'Save', exact: true }).first().click();
-      await page.waitForTimeout(500);
     });
 
     await test.step('Create request inside the folder referencing the object variable', async () => {
       await expandFolder(page, folderName);
       await createRequest(page, 'Object Copy Request', folderName, { inFolder: true });
-
-      const locators = buildCommonLocators(page);
-      await locators.sidebar.folderRequest(folderName, 'Object Copy Request').click();
-
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      await urlEditor.click();
-      await page.keyboard.type('https://api.example.com?data={{objVar}}');
-      await page.keyboard.press(saveShortcut);
+      await sidebar.folderRequest(folderName, 'Object Copy Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?data={{objVar}}');
     });
 
     await test.step('Tooltip shows pretty-printed JSON and copy button copies it verbatim', async () => {
-      const urlEditor = page.locator('#request-url .CodeMirror');
-      const objVar = urlEditor.locator('.cm-variable-valid').filter({ hasText: 'objVar' }).first();
-      await objVar.hover();
-
-      const tooltip = page.locator('.CodeMirror-brunoVarInfo').first();
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip.locator('.var-scope-badge')).toContainText('Folder');
+      const tooltip = await openUrlVarTooltip(page, 'objVar');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Folder');
 
       // Parse back and deep-compare so the assertion isn't coupled to whitespace.
-      const valueDisplay = tooltip.locator('.var-value-editable-display');
+      const valueDisplay = varInfoPopup.editableValue(tooltip);
       await expect.poll(async () => JSON.parse((await valueDisplay.textContent()) ?? 'null')).toEqual(objectValue);
 
-      const copyButton = tooltip.locator('.copy-button');
+      const copyButton = varInfoPopup.copyButton(tooltip);
       await copyButton.click();
 
       // Success state confirms writeText resolved before we read the clipboard.
@@ -716,4 +605,70 @@ test.describe('Variable Tooltip', () => {
       expect(clipboardText).toBe(expectedJson);
     });
   });
+});
+
+test.describe('Variable Tooltip - Global Secret Variables', () => {
+  test.afterEach(async ({ page }) => {
+    if (!page.isClosed()) {
+      await deleteAllGlobalEnvironments(page);
+      await closeAllCollections(page);
+    }
+  });
+
+  // One test case per non-string dataType, mirroring the collection-scoped
+  // tests but for a GLOBAL environment (which has its own Secrets tab).
+  for (const testCase of SECRET_DATATYPE_CASES) {
+    test(`should mask a secret GLOBAL ${testCase.dataType}-typed variable in the tooltip`, async ({ page, createTmpDir }) => {
+      const collectionName = `tooltip-global-secret-${testCase.dataType}-test`;
+      const envName = `Global Secret ${testCase.dataType} Env`;
+      const { environment, sidebar, varInfoPopup } = buildCommonLocators(page);
+
+      await test.step(`Create a global env with a secret ${testCase.dataType}-typed variable`, async () => {
+        await createCollection(page, collectionName, await createTmpDir(`tooltip-global-secret-${testCase.dataType}-collection`));
+
+        // Create + select the global environment via the shared helper.
+        await createEnvironment(page, envName, 'global');
+
+        // Focus the Global Environments editor tab; `isSecret` then routes the
+        // row to its Secrets sub-tab and `dataType` sets the type.
+        await environment.globalEnvTab().click();
+        await addEnvironmentVariable(page, {
+          name: testCase.varName,
+          value: testCase.value,
+          isSecret: true,
+          dataType: testCase.dataType
+        });
+
+        await environment.saveAll().click();
+        await closeEnvironmentPanel(page);
+      });
+
+      await test.step('Reference the global secret in a request URL', async () => {
+        await createRequest(page, `Global Secret ${testCase.dataType} Request`, collectionName);
+        await sidebar.request(`Global Secret ${testCase.dataType} Request`).click();
+        await setRequestUrlAndSave(page, `https://api.example.com?v={{${testCase.varName}}}`);
+      });
+
+      await test.step('Tooltip masks the value (non-empty) and reveals the real value', async () => {
+        const tooltip = await openUrlVarTooltip(page, testCase.varName);
+        await expect(varInfoPopup.name(tooltip)).toContainText(testCase.varName);
+
+        const valueDisplay = varInfoPopup.editableValue(tooltip);
+
+        // Core regression assertion: the masked display is NON-EMPTY. Before the
+        // fix this was '' for any non-string secret value.
+        await expect
+          .poll(async () => ((await valueDisplay.textContent()) ?? '').length)
+          .toBeGreaterThan(0);
+        // Masking must never leak the raw value.
+        expect(await valueDisplay.textContent()).not.toContain(testCase.revealContains);
+
+        // Revealing shows the actual value.
+        const toggleButton = varInfoPopup.secretToggle(tooltip);
+        await expect(toggleButton).toBeVisible();
+        await toggleButton.click();
+        await expect(valueDisplay).toContainText(testCase.revealContains);
+      });
+    });
+  }
 });

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -631,7 +631,6 @@ test.describe('Variable Tooltip - Global Secret Variables', () => {
 
         // Focus the Global Environments editor tab; `isSecret` then routes the
         // row to its Secrets sub-tab and `dataType` sets the type.
-        await environment.globalEnvTab().click();
         await addEnvironmentVariable(page, {
           name: testCase.varName,
           value: testCase.value,


### PR DESCRIPTION
### Description

Fixes the variable-info tooltip rendering an empty value for secret variables whose dataType is not a string (number, boolean, object).

**Root cause**: getMaskedDisplay measured .length on the raw value to decide how many mask characters `(*)` to render. A non-string value (e.g. the number 12345) has no `.length`, so it evaluated to undefined, producing zero mask characters a blank tooltip. Plain (non-secret) variables were unaffected because they skip masking and coerce to a string via textContent.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3848)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

https://github.com/user-attachments/assets/6afdb54d-4f6c-431c-b3a9-f1cc223cde18



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved masked secret-variable rendering so `null`/`undefined` display correctly, and masking length is computed more reliably across typed values (number, boolean, object).

* **Tests**
  * Refreshed end-to-end coverage for request URL variables and variable info popups using shared helpers and testid-based selectors.
  * Expanded typed secret scenarios (global and folder variables), including masking/non-leak checks, reveal behavior, pinned tooltip editing persistence, and copy-latest-value validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->