### PR TITLE
feat(migration): enhance folder migration process to preserve display order

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -73,6 +73,7 @@ const snapshotManager = require('../services/snapshot');
 const interpolateVars = require('./network/interpolate-vars');
 const { interpolateString } = require('./network/interpolate-string');
 const { getEnvVars, getTreePathFromCollectionToItem, mergeVars, parseBruFileMeta, hydrateRequestWithUuid, transformRequestToSaveToFilesystem } = require('../utils/collection');
+const { stampFolderSeqFromDisplayOrder } = require('./migrate-folder-seq');
 const { getProcessEnvVars } = require('../store/process-env');
 const { getOAuth2TokenUsingAuthorizationCode, getOAuth2TokenUsingClientCredentials, getOAuth2TokenUsingPasswordCredentials, getOAuth2TokenUsingImplicitGrant, refreshOauth2Token } = require('../utils/oauth2');
 const { getCertsAndProxyConfig } = require('./network/cert-utils');
@@ -2727,6 +2728,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       const bruFiles = searchForFiles(collectionPathname, '.bru');
       const envDirPath = path.join(collectionPathname, 'environments');
       const bruFilesToDelete = [];
+      const folderMigrateItems = [];
 
       for (const bruFilePath of bruFiles) {
         const basename = path.basename(bruFilePath);
@@ -2744,11 +2746,13 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         if (basename === 'folder.bru') {
           const folderBruContent = fs.readFileSync(bruFilePath, 'utf8');
           const folderData = parseFolder(folderBruContent, { format: 'bru' });
-          const ymlContent = stringifyFolder(folderData, { format: 'yml' });
-          const ymlFilePath = path.join(dirname, 'folder.yml');
-          await writeFile(ymlFilePath, ymlContent);
-          writtenYmlFiles.push(ymlFilePath);
-          bruFilesToDelete.push(bruFilePath);
+          folderMigrateItems.push({
+            bruFilePath,
+            folderPath: dirname,
+            name: folderData?.meta?.name || path.basename(dirname),
+            seq: folderData?.meta?.seq,
+            folderData
+          });
           continue;
         }
 
@@ -2761,6 +2765,16 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         tabPathMap[bruFilePath] = ymlFilePath;
         writtenYmlFiles.push(ymlFilePath);
         bruFilesToDelete.push(bruFilePath);
+      }
+
+      // Freeze pre-migrate display order (alpha + drag seq) as contiguous yml seq
+      stampFolderSeqFromDisplayOrder(folderMigrateItems);
+      for (const item of folderMigrateItems) {
+        const ymlContent = stringifyFolder(item.folderData, { format: 'yml' });
+        const ymlFilePath = path.join(item.folderPath, 'folder.yml');
+        await writeFile(ymlFilePath, ymlContent);
+        writtenYmlFiles.push(ymlFilePath);
+        bruFilesToDelete.push(item.bruFilePath);
       }
 
       if (fs.existsSync(envDirPath)) {

--- a/packages/bruno-electron/src/ipc/migrate-folder-seq.js
+++ b/packages/bruno-electron/src/ipc/migrate-folder-seq.js
@@ -1,0 +1,39 @@
+const path = require('path');
+const { sortByNameThenSequence } = require('../utils/collection');
+
+/**
+ * Stamp contiguous seq on folder.bru siblings using current bru display order
+ * (sortByNameThenSequence), so yml migration keeps drag/alpha order.
+ */
+const stampFolderSeqFromDisplayOrder = (folderItems) => {
+  const byParent = new Map();
+
+  for (const item of folderItems) {
+    const parentPath = path.dirname(item.folderPath);
+    if (!byParent.has(parentPath)) {
+      byParent.set(parentPath, []);
+    }
+    byParent.get(parentPath).push(item);
+  }
+
+  for (const siblings of byParent.values()) {
+    const sorted = sortByNameThenSequence(
+      siblings.map((item) => ({
+        ...item,
+        name: item.name,
+        seq: item.seq
+      }))
+    );
+
+    sorted.forEach((item, index) => {
+      if (!item.folderData.meta) {
+        item.folderData.meta = {};
+      }
+      item.folderData.meta.seq = index + 1;
+    });
+  }
+
+  return folderItems;
+};
+
+module.exports = { stampFolderSeqFromDisplayOrder };

--- a/packages/bruno-electron/src/ipc/migrate-folder-seq.spec.js
+++ b/packages/bruno-electron/src/ipc/migrate-folder-seq.spec.js
@@ -1,0 +1,62 @@
+const { stampFolderSeqFromDisplayOrder } = require('./migrate-folder-seq');
+
+describe('stampFolderSeqFromDisplayOrder', () => {
+  it('assigns contiguous seq matching bru display order including drag seq', () => {
+    const items = [
+      {
+        folderPath: '/col/zeta',
+        name: 'zeta',
+        seq: undefined,
+        folderData: { meta: { name: 'zeta' } }
+      },
+      {
+        folderPath: '/col/alpha',
+        name: 'alpha',
+        seq: undefined,
+        folderData: { meta: { name: 'alpha' } }
+      },
+      {
+        folderPath: '/col/dragged',
+        name: 'dragged',
+        seq: 1,
+        folderData: { meta: { name: 'dragged', seq: 1 } }
+      }
+    ];
+
+    stampFolderSeqFromDisplayOrder(items);
+
+    // bru display: dragged @ seq1, then alpha/zeta alpha
+    expect(items.find((i) => i.name === 'dragged').folderData.meta.seq).toBe(1);
+    expect(items.find((i) => i.name === 'alpha').folderData.meta.seq).toBe(2);
+    expect(items.find((i) => i.name === 'zeta').folderData.meta.seq).toBe(3);
+  });
+
+  it('sequences each parent independently', () => {
+    const items = [
+      {
+        folderPath: '/col/a',
+        name: 'b-folder',
+        seq: undefined,
+        folderData: { meta: { name: 'b-folder' } }
+      },
+      {
+        folderPath: '/col/a2',
+        name: 'a-folder',
+        seq: undefined,
+        folderData: { meta: { name: 'a-folder' } }
+      },
+      {
+        folderPath: '/col/nested/z',
+        name: 'z',
+        seq: undefined,
+        folderData: { meta: { name: 'z' } }
+      }
+    ];
+
+    stampFolderSeqFromDisplayOrder(items);
+
+    expect(items.find((i) => i.name === 'a-folder').folderData.meta.seq).toBe(1);
+    expect(items.find((i) => i.name === 'b-folder').folderData.meta.seq).toBe(2);
+    expect(items.find((i) => i.name === 'z').folderData.meta.seq).toBe(1);
+  });
+});

--- a/packages/bruno-electron/src/ipc/migrate-folder-seq.spec.js
+++ b/packages/bruno-electron/src/ipc/migrate-folder-seq.spec.js
@@ -1,22 +1,23 @@
+const path = require('path');
 const { stampFolderSeqFromDisplayOrder } = require('./migrate-folder-seq');
 
 describe('stampFolderSeqFromDisplayOrder', () => {
   it('assigns contiguous seq matching bru display order including drag seq', () => {
     const items = [
       {
-        folderPath: '/col/zeta',
+        folderPath: path.join('/col', 'zeta'),
         name: 'zeta',
         seq: undefined,
         folderData: { meta: { name: 'zeta' } }
       },
       {
-        folderPath: '/col/alpha',
+        folderPath: path.join('/col', 'alpha'),
         name: 'alpha',
         seq: undefined,
         folderData: { meta: { name: 'alpha' } }
       },
       {
-        folderPath: '/col/dragged',
+        folderPath: path.join('/col', 'dragged'),
         name: 'dragged',
         seq: 1,
         folderData: { meta: { name: 'dragged', seq: 1 } }
@@ -34,19 +35,19 @@ describe('stampFolderSeqFromDisplayOrder', () => {
   it('sequences each parent independently', () => {
     const items = [
       {
-        folderPath: '/col/a',
+        folderPath: path.join('/col', 'a'),
         name: 'b-folder',
         seq: undefined,
         folderData: { meta: { name: 'b-folder' } }
       },
       {
-        folderPath: '/col/a2',
+        folderPath: path.join('/col', 'a2'),
         name: 'a-folder',
         seq: undefined,
         folderData: { meta: { name: 'a-folder' } }
       },
       {
-        folderPath: '/col/nested/z',
+        folderPath: path.join('/col', 'nested', 'z'),
         name: 'z',
         seq: undefined,
         folderData: { meta: { name: 'z' } }

--- a/packages/bruno-filestore/src/formats/yml/parseFolder.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseFolder.ts
@@ -17,7 +17,7 @@ const parseFolder = (ymlString: string): FolderRoot => {
     const folderRoot: FolderRoot = {
       meta: {
         name: ensureString(info?.name, 'Untitled Folder'),
-        seq: info?.seq || 1
+        ...(typeof info?.seq === 'number' ? { seq: info.seq } : {})
       },
       request: {
         headers: [],

--- a/packages/bruno-filestore/src/formats/yml/stringifyFolder.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyFolder.ts
@@ -37,12 +37,14 @@ const stringifyFolder = (folderRoot: FolderRoot): string => {
   try {
     const ocFolder: Folder = {};
 
-    // info block
+    // omit seq when unset so alphabetical folder order is preserved
     const info: FolderInfo = {
       name: folderRoot.meta?.name || 'Untitled Folder',
-      type: 'folder',
-      seq: folderRoot.meta?.seq || 1
+      type: 'folder'
     };
+    if (typeof folderRoot.meta?.seq === 'number') {
+      info.seq = folderRoot.meta.seq;
+    }
     ocFolder.info = info;
 
     // request defaults


### PR DESCRIPTION
### Description


- Introduced `stampFolderSeqFromDisplayOrder` to maintain the sequence of folders during migration.
- Updated folder parsing and stringification to conditionally include the sequence number only when set.
- Improved handling of folder data during the migration process, ensuring proper YML file generation and cleanup of .bru files.

BRU-3854

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder migration so saved folder order now matches the order shown before migration.
  * Preserved custom folder ordering within each parent directory during migration.
  * Prevented missing/invalid folder sequence values from being replaced with a default, maintaining alphabetical ordering when no custom order is set.
* **Tests**
  * Added Jest coverage to verify sequence stamping aligned to display order, including dragged items and independent ordering per parent folder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->