### PR TITLE
test(tabs): enhance tab migration tests and add restoreTabs functionality

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs-migrate.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs-migrate.spec.js
@@ -1,15 +1,18 @@
-import { tabsSlice } from './tabs';
+const path = require('path');
+const { tabsSlice } = require('./tabs');
 
-const { migrateCollectionTabsToYml } = tabsSlice.actions;
+const { migrateCollectionTabsToYml, restoreTabs } = tabsSlice.actions;
 const reducer = tabsSlice.reducer;
+
+const p = (...parts) => path.join(...parts);
 
 const makeState = () => ({
   tabs: [
-    { uid: 'r1', collectionUid: 'col1', type: 'http-request', pathname: '/c/ping.bru' },
-    { uid: 'r2', collectionUid: 'col1', type: 'http-request', pathname: '/c/api/users.bru' },
-    { uid: 'fs1', collectionUid: 'col1', type: 'folder-settings', pathname: '/c/api' },
+    { uid: 'r1', collectionUid: 'col1', type: 'http-request', pathname: p('c', 'ping.bru') },
+    { uid: 'r2', collectionUid: 'col1', type: 'http-request', pathname: p('c', 'api', 'users.bru') },
+    { uid: 'fs1', collectionUid: 'col1', type: 'folder-settings', pathname: p('c', 'api') },
     { uid: 'cs1', collectionUid: 'col1', type: 'collection-settings' },
-    { uid: 'other', collectionUid: 'col2', type: 'http-request', pathname: '/c2/req.bru' }
+    { uid: 'other', collectionUid: 'col2', type: 'http-request', pathname: p('c2', 'req.bru') }
   ],
   activeTabUid: 'r1'
 });
@@ -19,16 +22,16 @@ describe('migrateCollectionTabsToYml', () => {
     const next = reducer(makeState(), migrateCollectionTabsToYml({ collectionUid: 'col1' }));
     const byUid = (uid) => next.tabs.find((t) => t.uid === uid);
 
-    expect(byUid('r1').pathname).toBe('/c/ping.yml');
-    expect(byUid('r2').pathname).toBe('/c/api/users.yml');
-    expect(byUid('other').pathname).toBe('/c2/req.bru');
+    expect(byUid('r1').pathname).toBe(p('c', 'ping.yml'));
+    expect(byUid('r2').pathname).toBe(p('c', 'api', 'users.yml'));
+    expect(byUid('other').pathname).toBe(p('c2', 'req.bru'));
   });
 
   it('leaves folder-settings (directory) paths and tabs without a pathname untouched', () => {
     const next = reducer(makeState(), migrateCollectionTabsToYml({ collectionUid: 'col1' }));
     const byUid = (uid) => next.tabs.find((t) => t.uid === uid);
 
-    expect(byUid('fs1').pathname).toBe('/c/api');
+    expect(byUid('fs1').pathname).toBe(p('c', 'api'));
     expect(byUid('cs1').pathname).toBeUndefined();
   });
 
@@ -36,5 +39,24 @@ describe('migrateCollectionTabsToYml', () => {
     const next = reducer(makeState(), migrateCollectionTabsToYml({ collectionUid: 'col1' }));
     expect(next.tabs.map((t) => t.uid)).toEqual(['r1', 'r2', 'fs1', 'cs1', 'other']);
     expect(next.activeTabUid).toBe('r1');
+  });
+});
+
+describe('restoreTabs', () => {
+  it('skips remapped .yml request paths when reopening a bru collection', () => {
+    const next = reducer(
+      { tabs: [], activeTabUid: null, recentlyClosedTabs: [] },
+      restoreTabs({
+        collection: { uid: 'col1', format: 'bru', items: [] },
+        tabs: [
+          { type: 'http-request', accessor: 'pathname', pathname: p('c', 'ping.yml'), permanent: true },
+          { type: 'collection-settings', accessor: 'type', permanent: true },
+          { type: 'folder-settings', accessor: 'pathname', pathname: p('c', 'api'), permanent: true }
+        ],
+        activeTab: null
+      })
+    );
+
+    expect(next.tabs.map((t) => t.type)).toEqual(['collection-settings', 'folder-settings']);
   });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -495,7 +495,14 @@ export const tabsSlice = createSlice({
         state.activeTabUid = null;
       }
 
+      // Drop request tabs remapped by bru↔yml migrate that no longer match collection format
+      const staleExt = collection.format === 'yml' ? /\.bru$/i : /\.ya?ml$/i;
+
       (snapshotTabs || []).forEach((snapshotTab) => {
+        if (typeof snapshotTab.pathname === 'string' && staleExt.test(snapshotTab.pathname)) {
+          return;
+        }
+
         const tab = deserializeTab(snapshotTab, collection);
         state.tabs.push(tab);
 


### PR DESCRIPTION
### Description


- Updated tab migration tests to use path.join for pathname consistency.
- Added tests for restoreTabs to ensure remapped .yml request paths are skipped when reopening a bru collection.
- Improved handling of stale request paths in the tabs slice reducer during collection restoration.

BRU-3859

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated request tabs from reopening when a collection’s file format has changed.
  * Ensured collection and folder settings tabs continue to restore correctly.
* **Tests**
  * Added coverage for restoring tabs after collection format migration.
  * Updated migration tests to validate platform-independent file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->