### PR TITLE
fix(ws): keep body-mode dropdown above collapsed sticky headers

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/WsBody/BodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/BodyMode/index.js
@@ -25,7 +25,11 @@ const WSRequestBodyMode = ({ mode, onModeChange }) => {
 
   const Icon = forwardRef((props, ref) => {
     return (
-      <div ref={ref} className="flex items-center justify-center pl-3 py-1 select-none selected-body-mode">
+      <div
+        ref={ref}
+        className="flex items-center justify-center pl-3 py-1 select-none selected-body-mode"
+        data-testid="ws-body-mode-label"
+      >
         {humanizeRequestBodyMode(mode)}
         {' '}
         <IconCaretDown className="caret ml-2" size={14} strokeWidth={2} />
@@ -35,12 +39,13 @@ const WSRequestBodyMode = ({ mode, onModeChange }) => {
 
   return (
     <StyledWrapper>
-      <div className="inline-flex items-center cursor-pointer body-mode-selector">
+      <div className="inline-flex items-center cursor-pointer body-mode-selector" data-testid="ws-body-mode-selector">
         <Dropdown onCreate={onDropdownCreate} icon={<Icon />} placement="bottom-end">
           <div className="label-item font-medium">Raw</div>
           {RAW_MODES.map((d) => (
             <div
               className="dropdown-item"
+              data-testid={`ws-body-mode-item-${d.key}`}
               key={d.key}
               onClick={() => {
                 dropdownTippyRef.current.hide();

--- a/packages/bruno-app/src/components/RequestPane/WsBody/BodyMode/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/BodyMode/index.js
@@ -40,7 +40,12 @@ const WSRequestBodyMode = ({ mode, onModeChange }) => {
   return (
     <StyledWrapper>
       <div className="inline-flex items-center cursor-pointer body-mode-selector" data-testid="ws-body-mode-selector">
-        <Dropdown onCreate={onDropdownCreate} icon={<Icon />} placement="bottom-end">
+        <Dropdown
+          onCreate={onDropdownCreate}
+          icon={<Icon />}
+          placement="bottom-end"
+          appendTo={() => document.body}
+        >
           <div className="label-item font-medium">Raw</div>
           {RAW_MODES.map((d) => (
             <div

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/StyledWrapper.js
@@ -28,6 +28,12 @@ const StyledWrapper = styled.div`
     top: 0;
     z-index: 1;
     background: ${(props) => props.theme.bg};
+
+    &:hover,
+    &:focus-within {
+      z-index: 2;
+    }
+
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/StyledWrapper.js
@@ -29,8 +29,7 @@ const StyledWrapper = styled.div`
     z-index: 1;
     background: ${(props) => props.theme.bg};
 
-    &:hover,
-    &:focus-within {
+    &:hover {
       z-index: 2;
     }
 

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -237,13 +237,13 @@ export const SingleWSMessage = ({
         </div>
         <div className="accordion-actions" onClick={(e) => e.stopPropagation()}>
           <div className="hover-actions">
-            <ToolHint text="Send" toolhintId={`send-msg-${index}`}>
+            <ToolHint text="Send" toolhintId={`send-msg-${index}`} place="bottom">
               <button onClick={onSendMessage} className="hover-action-btn" data-testid={`ws-send-msg-${index}`}>
                 <IconSend size={14} strokeWidth={1.5} />
               </button>
             </ToolHint>
             {(body.ws || []).length > 1 && (
-              <ToolHint text="Delete" toolhintId={`delete-msg-${index}`}>
+              <ToolHint text="Delete" toolhintId={`delete-msg-${index}`} place="bottom">
                 <button onClick={onDeleteMessage} className="hover-action-btn delete" data-testid={`ws-delete-msg-${index}`}>
                   <IconTrash size={14} strokeWidth={1.5} />
                 </button>

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -2455,6 +2455,23 @@ const openUrlVarTooltip = async (
   return tooltip;
 };
 
+/**
+ * Returns true if the element is on top at its centre (not hidden behind a header),
+ * i.e. the topmost element at its centre is inside a dropdown/tippy container.
+ * @param locator - The dropdown item locator
+ * @returns Whether the item is the topmost element at its own centre
+ */
+const elementIsInsideDropdown = async (locator: Locator) => {
+  const box = await locator.boundingBox();
+  expect(box, 'dropdown item should have a layout box').not.toBeNull();
+  const x = box!.x + box!.width / 2;
+  const y = box!.y + box!.height / 2;
+  return locator.page().evaluate(
+    ({ x, y }) => Boolean(document.elementFromPoint(x, y)?.closest('.tippy-box, .dropdown')),
+    { x, y }
+  );
+};
+
 export {
   waitForReadyPage,
   setRequestUrlAndSave,
@@ -2556,7 +2573,8 @@ export {
   getAppWebviewHtml,
   createApp,
   selectAppView,
-  renameWsMessage
+  renameWsMessage,
+  elementIsInsideDropdown
 };
 
 export type { SandboxMode, EnvironmentType, EnvironmentVariable, ImportCollectionOptions, CreateRequestOptions, CreateUntitledRequestOptions, CreateTransientRequestOptions, AssertionInput };

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -3,6 +3,7 @@ import { buildApiSpecPanelLocators } from './openapi/render-spec';
 import { buildFileModeLocators } from './file-mode';
 import { buildPreferencesLocators } from './preferences';
 import { buildAiPreferencesLocators } from './ai';
+import { buildWebsocketCommonLocators } from './websocket';
 
 export const buildCommonLocators = (page: Page) => ({
   runner: () => page.getByTestId('run-button'),
@@ -364,38 +365,6 @@ export const buildCommonLocators = (page: Page) => ({
       },
       rowValueInput: (rowIndex: number) => baseTable.rowCell('value', rowIndex)
     };
-  }
-});
-
-export const buildWebsocketCommonLocators = (page: Page) => ({
-  connectionControls: {
-    connect: () => page.getByTestId('ws-connect-button'),
-    disconnect: () => page.getByTestId('ws-disconnect-button')
-  },
-  messages: () => page.locator('.ws-message'),
-  message: {
-    container: () => page.getByTestId('ws-messages-container'),
-    addButton: () => page.getByTestId('ws-add-message'),
-    headers: () => page.getByTestId(/^ws-message-header-/),
-    header: (index: number) => page.getByTestId(`ws-message-header-${index}`),
-    body: (index: number) => page.getByTestId(`ws-message-body-${index}`),
-    editor: (index: number) => page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror'),
-    editorPlaceholder: (index: number) =>
-      page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror-placeholder'),
-    editorCode: (index: number) => page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror-code'),
-    labels: () => page.getByTestId(/^ws-message-label-/),
-    label: (index: number) => page.getByTestId(`ws-message-label-${index}`),
-    nameInputs: () => page.getByTestId(/^ws-message-name-input-/),
-    nameInput: (index: number) => page.getByTestId(`ws-message-name-input-${index}`),
-    nameTooltip: () => page.getByTestId('ws-message-name-tooltip'),
-    prettifyAll: () => page.getByTestId('ws-prettify-all'),
-    sendButton: (index: number) => page.getByTestId(`ws-send-msg-${index}`),
-    deleteButton: (index: number) => page.getByTestId(`ws-delete-msg-${index}`)
-  },
-  toolbar: {
-    latestFirst: () => page.getByRole('button', { name: 'Latest First' }),
-    latestLast: () => page.getByRole('button', { name: 'Latest Last' }),
-    clearResponse: () => page.getByTestId('response-clear-btn')
   }
 });
 

--- a/tests/utils/page/websocket.ts
+++ b/tests/utils/page/websocket.ts
@@ -1,0 +1,38 @@
+import { Page } from '../../../playwright';
+
+export const buildWebsocketCommonLocators = (page: Page) => ({
+  connectionControls: {
+    connect: () => page.getByTestId('ws-connect-button'),
+    disconnect: () => page.getByTestId('ws-disconnect-button')
+  },
+  messages: () => page.locator('.ws-message'),
+  message: {
+    container: () => page.getByTestId('ws-messages-container'),
+    addButton: () => page.getByTestId('ws-add-message'),
+    headers: () => page.getByTestId(/^ws-message-header-/),
+    header: (index: number) => page.getByTestId(`ws-message-header-${index}`),
+    body: (index: number) => page.getByTestId(`ws-message-body-${index}`),
+    editor: (index: number) => page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror'),
+    editorPlaceholder: (index: number) =>
+      page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror-placeholder'),
+    editorCode: (index: number) => page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror-code'),
+    labels: () => page.getByTestId(/^ws-message-label-/),
+    label: (index: number) => page.getByTestId(`ws-message-label-${index}`),
+    nameInputs: () => page.getByTestId(/^ws-message-name-input-/),
+    nameInput: (index: number) => page.getByTestId(`ws-message-name-input-${index}`),
+    nameTooltip: () => page.getByTestId('ws-message-name-tooltip'),
+    prettifyAll: () => page.getByTestId('ws-prettify-all'),
+    sendButton: (index: number) => page.getByTestId(`ws-send-msg-${index}`),
+    deleteButton: (index: number) => page.getByTestId(`ws-delete-msg-${index}`),
+    bodyModeSelector: (index: number) =>
+      page.getByTestId(`ws-message-header-${index}`).getByTestId('ws-body-mode-selector'),
+    bodyModeLabel: (index: number) =>
+      page.getByTestId(`ws-message-header-${index}`).getByTestId('ws-body-mode-label'),
+    bodyModeItem: (mode: 'json' | 'xml' | 'text') => page.getByTestId(`ws-body-mode-item-${mode}`)
+  },
+  toolbar: {
+    latestFirst: () => page.getByRole('button', { name: 'Latest First' }),
+    latestLast: () => page.getByRole('button', { name: 'Latest Last' }),
+    clearResponse: () => page.getByTestId('response-clear-btn')
+  }
+});

--- a/tests/websockets/ws-header.spec.ts
+++ b/tests/websockets/ws-header.spec.ts
@@ -25,47 +25,99 @@ test.describe('websocket sticky header dropdown overlap', () => {
   }) => {
     const { websocket } = buildCommonLocators(page);
 
-    await createTransientRequest(page, { requestType: 'WebSocket' });
-    await selectRequestPaneTab(page, 'Message');
+    await test.step('Open a websocket request with several collapsed messages', async () => {
+      await createTransientRequest(page, { requestType: 'WebSocket' });
+      await selectRequestPaneTab(page, 'Message');
 
-    // Build a list of several messages so an upper message's dropdown overlaps
-    // the headers below it.
-    await expect(websocket.message.headers()).toHaveCount(1);
-    for (let i = 0; i < 3; i++) {
-      const before = await websocket.message.headers().count();
-      await websocket.message.addButton().click();
-      await expect(websocket.message.headers()).toHaveCount(before + 1);
-    }
-
-    const total = await websocket.message.headers().count();
-    expect(total).toBeGreaterThanOrEqual(4);
-
-    // Collapse every message so all accordions are closed.
-    for (let i = 0; i < total; i++) {
-      if (await websocket.message.body(i).isVisible()) {
-        await websocket.message.header(i).click();
+      await expect(websocket.message.headers()).toHaveCount(1);
+      for (let i = 0; i < 3; i++) {
+        const before = await websocket.message.headers().count();
+        await websocket.message.addButton().click();
+        await expect(websocket.message.headers()).toHaveCount(before + 1);
       }
-    }
-    for (let i = 0; i < total; i++) {
-      await expect(websocket.message.body(i)).toBeHidden();
-    }
 
-    // Open the first message's body-mode dropdown; its menu opens downward over
-    // the collapsed headers below it.
-    await websocket.message.bodyModeSelector(0).click();
+      const total = await websocket.message.headers().count();
+      expect(total).toBeGreaterThanOrEqual(4);
 
-    // The lowest item is the one most likely to overlap the header below, so it
-    // is the strongest signal that the menu is not covered.
+      // Collapse every message so all accordions are closed.
+      for (let i = 0; i < total; i++) {
+        if (await websocket.message.body(i).isVisible()) {
+          await websocket.message.header(i).click();
+        }
+      }
+      for (let i = 0; i < total; i++) {
+        await expect(websocket.message.body(i)).toBeHidden();
+      }
+    });
+
     const textItem = websocket.message.bodyModeItem('text');
-    await expect(textItem).toBeVisible();
 
-    // The item must be the topmost element at its own centre. Without the fix a
-    // lower header paints over it and this resolves to the header instead.
-    expect(await topElementIsInsideDropdown(textItem)).toBe(true);
+    await test.step('Open the first message dropdown over the headers below', async () => {
+      await websocket.message.bodyModeSelector(0).click();
 
-    // It must also be clickable — Playwright's actionability check fails if the
-    // item is obscured by a sticky header — and selecting it applies.
-    await textItem.click();
-    await expect(websocket.message.bodyModeLabel(0)).toContainText('TEXT');
+      // The lowest item is the one most likely to overlap the header below, so
+      // it is the strongest signal that the menu is not covered.
+      await expect(textItem).toBeVisible();
+
+      // The item must be the topmost element at its own centre. Without the fix
+      // a lower header paints over it and this resolves to the header instead.
+      expect(await topElementIsInsideDropdown(textItem)).toBe(true);
+    });
+
+    await test.step('Select the item and verify it applies', async () => {
+      // Playwright's actionability check fails if the item is obscured.
+      await textItem.click();
+      await expect(websocket.message.bodyModeLabel(0)).toContainText('TEXT');
+    });
+  });
+
+  test.only('open dropdown stays on top when a lower message header is hovered', async ({
+    page
+  }) => {
+    const { websocket } = buildCommonLocators(page);
+    let total = 0;
+
+    await test.step('Open a websocket request with several collapsed messages', async () => {
+      await createTransientRequest(page, { requestType: 'WebSocket' });
+      await selectRequestPaneTab(page, 'Message');
+
+      await expect(websocket.message.headers()).toHaveCount(1);
+      for (let i = 0; i < 3; i++) {
+        const before = await websocket.message.headers().count();
+        await websocket.message.addButton().click();
+        await expect(websocket.message.headers()).toHaveCount(before + 1);
+      }
+
+      total = await websocket.message.headers().count();
+      expect(total).toBeGreaterThanOrEqual(4);
+
+      // Collapse every message so all accordions are closed.
+      for (let i = 0; i < total; i++) {
+        if (await websocket.message.body(i).isVisible()) {
+          await websocket.message.header(i).click();
+        }
+      }
+      for (let i = 0; i < total; i++) {
+        await expect(websocket.message.body(i)).toBeHidden();
+      }
+    });
+
+    const textItem = websocket.message.bodyModeItem('text');
+
+    await test.step('Open the first message dropdown, then hover a header below it', async () => {
+      // The dropdown renders in a portal (appendTo document.body), so hovering a
+      // lower header must not raise that header over the open menu.
+      await websocket.message.bodyModeSelector(0).click();
+      await expect(textItem).toBeVisible();
+
+      // Hover the last message's header — the one furthest under the open menu.
+      await websocket.message.header(total - 1).hover();
+    });
+
+    await test.step('Dropdown stays on top and is still clickable', async () => {
+      expect(await topElementIsInsideDropdown(textItem)).toBe(true);
+      await textItem.click();
+      await expect(websocket.message.bodyModeLabel(0)).toContainText('TEXT');
+    });
   });
 });

--- a/tests/websockets/ws-header.spec.ts
+++ b/tests/websockets/ws-header.spec.ts
@@ -1,24 +1,11 @@
 import { expect, test } from '../../playwright';
-import { closeAllTabs, createTransientRequest, selectRequestPaneTab } from '../utils/page/actions';
+import { closeAllTabs, createTransientRequest, elementIsInsideDropdown, selectRequestPaneTab } from '../utils/page/actions';
 import { buildCommonLocators } from '../utils/page/locators';
-import type { Locator } from '@playwright/test';
 
 test.describe('websocket sticky header dropdown overlap', () => {
   test.afterEach(async ({ page }) => {
     await closeAllTabs(page);
   });
-
-  // Returns true if the dropdown item is on top at its centre (not hidden behind a header).
-  const topElementIsInsideDropdown = async (locator: Locator) => {
-    const box = await locator.boundingBox();
-    expect(box, 'dropdown item should have a layout box').not.toBeNull();
-    const x = box!.x + box!.width / 2;
-    const y = box!.y + box!.height / 2;
-    return locator.page().evaluate(
-      ({ x, y }) => Boolean(document.elementFromPoint(x, y)?.closest('.tippy-box, .dropdown')),
-      { x, y }
-    );
-  };
 
   test('body-mode dropdown of an upper message renders above the collapsed headers below it', async ({
     page
@@ -61,7 +48,7 @@ test.describe('websocket sticky header dropdown overlap', () => {
 
       // The item must be the topmost element at its own centre. Without the fix
       // a lower header paints over it and this resolves to the header instead.
-      expect(await topElementIsInsideDropdown(textItem)).toBe(true);
+      expect(await elementIsInsideDropdown(textItem)).toBe(true);
     });
 
     await test.step('Select the item and verify it applies', async () => {
@@ -115,7 +102,7 @@ test.describe('websocket sticky header dropdown overlap', () => {
     });
 
     await test.step('Dropdown stays on top and is still clickable', async () => {
-      expect(await topElementIsInsideDropdown(textItem)).toBe(true);
+      expect(await elementIsInsideDropdown(textItem)).toBe(true);
       await textItem.click();
       await expect(websocket.message.bodyModeLabel(0)).toContainText('TEXT');
     });

--- a/tests/websockets/ws-header.spec.ts
+++ b/tests/websockets/ws-header.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '../../playwright';
+import { closeAllTabs, createTransientRequest, selectRequestPaneTab } from '../utils/page/actions';
+import { buildCommonLocators } from '../utils/page/locators';
+import type { Locator } from '@playwright/test';
+
+test.describe('websocket sticky header dropdown overlap', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllTabs(page);
+  });
+
+  // Returns true if the dropdown item is on top at its centre (not hidden behind a header).
+  const topElementIsInsideDropdown = async (locator: Locator) => {
+    const box = await locator.boundingBox();
+    expect(box, 'dropdown item should have a layout box').not.toBeNull();
+    const x = box!.x + box!.width / 2;
+    const y = box!.y + box!.height / 2;
+    return locator.page().evaluate(
+      ({ x, y }) => Boolean(document.elementFromPoint(x, y)?.closest('.tippy-box, .dropdown')),
+      { x, y }
+    );
+  };
+
+  test('body-mode dropdown of an upper message renders above the collapsed headers below it', async ({
+    page
+  }) => {
+    const { websocket } = buildCommonLocators(page);
+
+    await createTransientRequest(page, { requestType: 'WebSocket' });
+    await selectRequestPaneTab(page, 'Message');
+
+    // Build a list of several messages so an upper message's dropdown overlaps
+    // the headers below it.
+    await expect(websocket.message.headers()).toHaveCount(1);
+    for (let i = 0; i < 3; i++) {
+      const before = await websocket.message.headers().count();
+      await websocket.message.addButton().click();
+      await expect(websocket.message.headers()).toHaveCount(before + 1);
+    }
+
+    const total = await websocket.message.headers().count();
+    expect(total).toBeGreaterThanOrEqual(4);
+
+    // Collapse every message so all accordions are closed.
+    for (let i = 0; i < total; i++) {
+      if (await websocket.message.body(i).isVisible()) {
+        await websocket.message.header(i).click();
+      }
+    }
+    for (let i = 0; i < total; i++) {
+      await expect(websocket.message.body(i)).toBeHidden();
+    }
+
+    // Open the first message's body-mode dropdown; its menu opens downward over
+    // the collapsed headers below it.
+    await websocket.message.bodyModeSelector(0).click();
+
+    // The lowest item is the one most likely to overlap the header below, so it
+    // is the strongest signal that the menu is not covered.
+    const textItem = websocket.message.bodyModeItem('text');
+    await expect(textItem).toBeVisible();
+
+    // The item must be the topmost element at its own centre. Without the fix a
+    // lower header paints over it and this resolves to the header instead.
+    expect(await topElementIsInsideDropdown(textItem)).toBe(true);
+
+    // It must also be clickable — Playwright's actionability check fails if the
+    // item is obscured by a sticky header — and selecting it applies.
+    await textItem.click();
+    await expect(websocket.message.bodyModeLabel(0)).toContainText('TEXT');
+  });
+});

--- a/tests/websockets/ws-header.spec.ts
+++ b/tests/websockets/ws-header.spec.ts
@@ -71,7 +71,7 @@ test.describe('websocket sticky header dropdown overlap', () => {
     });
   });
 
-  test.only('open dropdown stays on top when a lower message header is hovered', async ({
+  test('open dropdown stays on top when a lower message header is hovered', async ({
     page
   }) => {
     const { websocket } = buildCommonLocators(page);


### PR DESCRIPTION
### Description

WebSocket message headers are position: sticky, and each one sits in its own stacking context at z-index: 1. With multiple collapsed messages, opening a message's body-mode dropdown (JSON/XML/TEXT) dropped its menu down over the headers below but those headers share the same z-index and come later in the DOM, so they painted on top of and hid the open dropdown (and tooltips).

[JIRA](https://usebruno.atlassian.net/browse/BRU-3879)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<img width="601" height="466" alt="image" src="https://github.com/user-attachments/assets/d19c5d83-b00e-43ab-8a4e-1aa37bb3e6c1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved WebSocket message header layering so the body-mode dropdown remains visible above sticky/collapsed headers during hover and expansion.
* **New Features**
  * Added UI test hooks for the WebSocket body-mode label, selector, and dropdown items.
* **Tests**
  * Added end-to-end coverage to verify the dropdown stays topmost and that selecting “text” updates the body-mode label.
  * Expanded WebSocket locator helpers and shared dropdown-visibility assertions.
* **Chores**
  * Refined tooltip placement for WebSocket send/delete hover actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->