### PR TITLE
fix(new-app): prevented validation error on blur and dialog layout shift

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewApp/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewApp/index.js
@@ -47,7 +47,7 @@ const NewApp = ({ collectionUid, item, onClose }) => {
 
   return (
     <Modal
-      size="sm"
+      size="md"
       title="New App"
       confirmText="Create"
       handleConfirm={onSubmit}
@@ -70,10 +70,9 @@ const NewApp = ({ collectionUid, item, onClose }) => {
           className="block textbox mt-2 w-full"
           value={formik.values.appName}
           onChange={formik.handleChange}
-          onBlur={formik.handleBlur}
         />
         {formik.touched.appName && formik.errors.appName ? (
-          <div className="text-red-500 text-xs mt-1">{formik.errors.appName}</div>
+          <div className="text-red-500 text-xs mt-2">{formik.errors.appName}</div>
         ) : (
           <div className="text-xs mt-2 opacity-70">
             Creates a standalone app file in {item ? 'this folder' : `collection "${collection?.name || ''}"`}.


### PR DESCRIPTION
### Description

[JIRA: BRU-3867]

#### Issue 
In the New App dialog, clicking outside the name field showed "App name is required" and the dialog shrank/shifted.

#### Cause
The input's onBlur={formik.handleBlur} marked the field touched on blur, triggering the error. The sm modal is shrink-to-fit, so swapping the long helper text for the short error narrowed and reflowed the card.

#### Resolution
Removed onBlur (error now only on submit, like other dialogs), switched to size="md" so its 500px min-width pins the card so it can't shrink, and aligned the error/helper margins to stop the vertical shift.
#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
