### PR TITLE
fix(ai): align AI buttons to primary color and refine copy

### DIFF
--- a/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AIAssist/StyledWrapper.js
@@ -203,11 +203,11 @@ export const PopupWrapper = styled.div`
     gap: 6px;
     padding: 5px 12px;
     font-size: 12px;
-    font-weight: 500;
+    font-weight: 400;
     border-radius: ${(props) => props.theme.border.radius.sm};
-    border: 1px solid ${(props) => props.theme.colors.accent};
-    background: ${(props) => props.theme.colors.accent};
-    color: white;
+    border: 1px solid ${(props) => props.theme.button2.color.primary.border};
+    background: ${(props) => props.theme.button2.color.primary.bg};
+    color: ${(props) => props.theme.button2.color.primary.text};
     cursor: pointer;
     transition: opacity 0.15s ease;
 

--- a/packages/bruno-app/src/components/AIAssist/index.spec.js
+++ b/packages/bruno-app/src/components/AIAssist/index.spec.js
@@ -23,6 +23,7 @@ const theme = {
   },
   button2: {
     color: {
+      primary: { bg: '#6366f1', text: '#ffffff', border: '#6366f1' },
       danger: { bg: '#ef4444', text: '#ffffff', border: '#ef4444' }
     }
   },

--- a/packages/bruno-app/src/components/AiChatSidebar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AiChatSidebar/StyledWrapper.js
@@ -804,13 +804,13 @@ const StyledWrapper = styled.div`
       align-items: center;
       gap: 4px;
       padding: 4px 8px;
-      border: none;
+      border: 1px solid ${(props) => props.theme.button2.color.primary.border};
       border-radius: 4px;
       font-size: 11px;
-      font-weight: 500;
+      font-weight: 400;
       cursor: pointer;
-      background: ${(props) => props.theme.brand};
-      color: ${(props) => (props.theme.mode === 'dark' ? '#000' : '#fff')};
+      background: ${(props) => props.theme.button2.color.primary.bg};
+      color: ${(props) => props.theme.button2.color.primary.text};
 
       &:hover {
         opacity: 0.9;

--- a/packages/bruno-app/src/components/AiChatSidebar/index.js
+++ b/packages/bruno-app/src/components/AiChatSidebar/index.js
@@ -875,7 +875,7 @@ const AiChatSidebar = ({ collection, variant = 'sidebar' }) => {
             <button
               className="icon-btn"
               onClick={handleNewChat}
-              title="New chat"
+              title="New Session"
               disabled={isLoading || messages.length === 0}
             >
               <IconPlus size={14} />

--- a/packages/bruno-app/src/components/Preferences/AI/SecurityPane.js
+++ b/packages/bruno-app/src/components/Preferences/AI/SecurityPane.js
@@ -136,7 +136,7 @@ const SecurityPane = ({
   return (
     <div className="security-tab flex flex-col gap-3">
       <div className="ai-empty-notice px-3.5 py-3 text-xs">
-        Bruno strips sensitive values from the context it sends to AI providers. Toggle any check off if it gets in the way, or extend the lists below.
+        Sensitive data is automatically redacted before context is sent to AI providers. Turn off protections if needed, or add custom headers and variables to redact.
       </div>
 
       <div className="security-card">
@@ -144,7 +144,7 @@ const SecurityPane = ({
           <div className="flex flex-col gap-0.5 min-w-0">
             <span className="text-[12.5px] font-semibold">Redact sensitive header values</span>
             <span className="security-sub text-[11px]">
-              Masks Authorization, cookies, API keys, and other credential-bearing headers in the request context.
+              Masks Authorization, cookies, API keys and other credential-bearing headers in the request context.
             </span>
           </div>
           <ToggleSwitch
@@ -243,7 +243,7 @@ const SecurityPane = ({
               <span key={name} className="security-builtin-chip">{name}</span>
             ))}
             <span className="security-builtin-more text-[10.5px]">
-              plus any name matching <code>token</code>, <code>secret</code>, <code>password</code>, or <code>api_key</code>.
+              plus any name matching <code>token</code>, <code>secret</code>, <code>password</code> or <code>api_key</code>.
             </span>
           </div>
         </div>


### PR DESCRIPTION
### Description

Aligns the AI feature's primary buttons with the shared design-system color and tidies some AI related copy texts. 

Ref : BRU-3712, BRU-3800, BRU-3872

#### Screenshots
<img width="592" height="358" alt="image" src="https://github.com/user-attachments/assets/e5e06f5c-9aef-43a5-a919-d5d0723efc13" />


<img width="1224" height="776" alt="image" src="https://github.com/user-attachments/assets/6e278277-3c7e-427b-8c4c-d32c1b508155" />




#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated AI Assist and AI Chat button styling to use consistent primary button design tokens and adjusted font weight for a more uniform look.

* **Documentation**
  * Refreshed AI security redaction copy for clearer guidance and revised the “Already covered by default” wording/keyword list punctuation.
  * Updated the chat sidebar tooltip text from “New chat” to “New Session.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->