### PR TITLE
fix(ui): visual improvements for tables in FileBody and EnvironmentVarsTable

### DIFF
--- a/packages/bruno-app/src/components/DataTypeSelector/index.js
+++ b/packages/bruno-app/src/components/DataTypeSelector/index.js
@@ -75,6 +75,7 @@ const DataTypeSelector = ({ variable, onChange, compact = false }) => {
               size={16}
             />
             <Tooltip
+              positionStrategy="fixed"
               className="tooltip-mod"
               id={`type-error-${variable.uid}`}
               content={typeError}

--- a/packages/bruno-app/src/components/DataTypeSelector/index.js
+++ b/packages/bruno-app/src/components/DataTypeSelector/index.js
@@ -19,6 +19,13 @@ const TYPE_ICONS = {
   object: IconBraces
 };
 
+const TYPE_ICONS_SIZES = {
+  string: 16,
+  number: 18,
+  boolean: 18,
+  object: 18
+};
+
 const DataTypeSelector = ({ variable, onChange, compact = false }) => {
   const selectedType = variable.dataType || 'string';
   const coercedValue = parseValueByDataType(variable.value, selectedType);
@@ -53,7 +60,7 @@ const DataTypeSelector = ({ variable, onChange, compact = false }) => {
             aria-label={`Data type: ${selectedType}`}
           >
             {compact ? (
-              <TypeIcon className="type-icon" size={12} strokeWidth={2} />
+              <TypeIcon className="type-icon" size={TYPE_ICONS_SIZES[selectedType]} strokeWidth={2} />
             ) : (
               <span className="type-label">{selectedType}</span>
             )}

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -80,6 +80,7 @@ const EnvVarValueCell = ({
       trailingContent={variable.secret ? (
         <SecretEyeButton
           masked={masked}
+          testId="secret-reveal-toggle"
           onToggle={() => editorRef.current?.toggleVisibleSecret()}
         />
       ) : null}

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -846,7 +846,7 @@ const EnvironmentVariablesTable = ({
                     <ErrorMessage name={`${actualIndex}.name`} index={actualIndex} />
                   </div>
                 </td>
-                <td style={{ width: columnWidths.value }}>
+                <td style={{ width: columnWidths.value }} className="overflow-hidden">
                   <EnvVarValueCell
                     variable={variable}
                     actualIndex={actualIndex}

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -77,7 +77,7 @@ const EnvVarValueCell = ({
   return (
     <VarValueCell
       onCompactChange={setCompact}
-      trailingContent={variable.secret && compact ? (
+      trailingContent={variable.secret ? (
         <SecretEyeButton
           masked={masked}
           onToggle={() => editorRef.current?.toggleVisibleSecret()}
@@ -96,7 +96,7 @@ const EnvVarValueCell = ({
             value={valueToString(variable.value, 2)}
             placeholder={variable.value == null || (typeof variable.value === 'string' && variable.value.trim() === '') ? 'Value' : ''}
             isSecret={variable.secret}
-            hideSecretEye={variable.secret && compact}
+            hideSecretEye={variable.secret}
             onMaskChange={setMasked}
             onChange={(newValue) => {
               formik.setFieldValue(`${actualIndex}.value`, newValue, true);
@@ -354,7 +354,7 @@ const EnvironmentVariablesTable = ({
       });
       return Object.keys(errors).length > 0 ? errors : {};
     },
-    onSubmit: () => {}
+    onSubmit: () => { }
   });
 
   // Restore draft values on mount or environment switch (not on external filesystem reloads)

--- a/packages/bruno-app/src/components/MultiLineEditor/SecretEyeButton.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/SecretEyeButton.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { IconEye, IconEyeOff } from '@tabler/icons';
 
-const SecretEyeButton = ({ masked, onToggle }) => (
-  <button type="button" className="mx-2 shrink-0" onClick={onToggle}>
+const SecretEyeButton = ({ masked, onToggle, testId }) => (
+  <button type="button" className="mx-2 shrink-0" onClick={onToggle} data-testid={testId}>
     {masked ? (
       <IconEyeOff size={18} strokeWidth={2} />
     ) : (

--- a/packages/bruno-app/src/components/RequestPane/FileBody/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/FileBody/StyledWrapper.js
@@ -40,6 +40,14 @@ const Wrapper = styled.div`
         width: 70px;
       }
     }
+
+
+    thead td div {
+      max-width: 100px;
+      text-overflow: ellipsis; 
+      overflow: hidden;   
+      white-space: nowrap;
+    }
   }
 
   .btn-add-param {

--- a/packages/bruno-app/src/components/RequestPane/FileBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FileBody/index.js
@@ -79,7 +79,9 @@ const FileBody = ({ item, collection }) => {
               <div title="Content-Type" className="flex items-center justify-start">Content-Type</div>
             </td>
             <td>
-              <div title="Selected" className="flex items-center justify-start"></div>
+              <div title="Selected" className="flex items-center justify-start min-w-0">
+                <span className="truncate">Selected</span>
+              </div>
             </td>
             <td>
               <div title="Description" className="flex items-center justify-start">Description</div>

--- a/packages/bruno-app/src/components/RequestPane/FileBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/FileBody/index.js
@@ -73,16 +73,16 @@ const FileBody = ({ item, collection }) => {
         <thead>
           <tr>
             <td>
-              <div className="flex items-center justify-center">File</div>
+              <div title="File" className="flex items-center justify-start">File</div>
             </td>
             <td>
-              <div className="flex items-center justify-center">Content-Type</div>
+              <div title="Content-Type" className="flex items-center justify-start">Content-Type</div>
             </td>
             <td>
-              <div className="flex items-center justify-center">Selected</div>
+              <div title="Selected" className="flex items-center justify-start"></div>
             </td>
             <td>
-              <div className="flex items-center justify-center">Description</div>
+              <div title="Description" className="flex items-center justify-start">Description</div>
             </td>
             <td></td>
           </tr>

--- a/packages/bruno-app/src/components/VarValueCell/StyledWrapper.js
+++ b/packages/bruno-app/src/components/VarValueCell/StyledWrapper.js
@@ -25,7 +25,7 @@ const StyledWrapper = styled.div`
 
   &.var-value-compact .trailing-area .type-selector-overlay {
     right: 100%;
-    margin-right: 4px;
+    margin-right: 0px;
   }
 
   &.var-value-compact > .type-selector-overlay {

--- a/packages/bruno-app/src/components/VarValueCell/index.js
+++ b/packages/bruno-app/src/components/VarValueCell/index.js
@@ -52,6 +52,12 @@ const VarValueCell = ({ editor, renderTypeSelector, trailingContent, onCompactCh
         <>
           {typeSelectorOverlay}
           {!compact && renderTypeSelector && renderTypeSelector({ compact: false })}
+          {trailingContent && (
+            <div className="trailing-area">
+              {typeSelectorOverlay}
+              {trailingContent}
+            </div>
+          )}
         </>
       )}
     </StyledWrapper>


### PR DESCRIPTION
BRU-3893

### Description

- FileBody's table needed a header size fix as we now have the descriptions column as well 
- EnvironmentVars the eye icons looked weird because of alignment so VarValue now always shows it as a trailing item 
- Increased Type Icon sizes for DataTypeSelector to improve visibility


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data type icon sizing across field types, including compact views.
  * Fixed error tooltip positioning for type issues.
  * Ensured secret “reveal” controls display consistently for protected environment values.
  * Avoided rendering empty trailing areas in variable value cells.
  * Updated file and environment tables for better alignment, truncation, and overflow handling.
  * Refined spacing for compact type selector overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->