### PR TITLE
fix(app): point generated docs to api-docs CDN path

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -36,8 +36,8 @@ const buildHtmlDocument = (collectionName, escapedYamlContent) => `<!DOCTYPE htm
         body { margin: 0; padding: 0; }
         #opencollection-container { width: 100vw; height: 100vh; }
     </style>
-    <link rel="stylesheet" href="${CDN_BASE_URL}/docs/index.css">
-    <script src="${CDN_BASE_URL}/docs/index.js"></script>
+    <link rel="stylesheet" href="${CDN_BASE_URL}/api-docs/api-docs.css">
+    <script src="${CDN_BASE_URL}/api-docs/api-docs.js"></script>
 </head>
 <body>
     <div id="opencollection-container"></div>


### PR DESCRIPTION
### Description

Updates the generated standalone documentation HTML to load the OpenCollection docs bundle from the new CDN path.

- `cdn.usebruno.com/docs/index.css` -> `cdn.usebruno.com/api-docs/api-docs.css`
- `cdn.usebruno.com/docs/index.js` -> `cdn.usebruno.com/api-docs/api-docs.js`

The bundle filenames were renamed to `api-docs.*` in the opencollection repo, and the CDN now serves them under the `/api-docs/` path. This is a string-only change in the generated HTML template; no runtime behaviour changes.

Note: existing already-generated docs continue to reference the old `/docs/` path, which the CDN keeps serving. Only newly generated docs use the new path.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
