### PR TITLE
test(sidebar): move sidebar locators to a dedicated file

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItem/index.js
@@ -45,6 +45,7 @@ const DeleteCollectionItem = ({ onClose, item, collectionUid }) => {
         confirmButtonColor="danger"
         handleConfirm={onConfirm}
         handleCancel={onClose}
+        dataTestId="delete-collection-item-modal"
       >
         Are you sure you want to delete <span className="font-medium">{item.name}</span> ?
       </Modal>

--- a/tests/utils/page/collection/delete-collection-item.ts
+++ b/tests/utils/page/collection/delete-collection-item.ts
@@ -1,0 +1,13 @@
+import { Page } from '../../../../playwright';
+
+/**
+ * Confirmation modal shown when deleting a collection item (request or folder).
+ */
+export const buildDeleteCollectionItemModalLocators = (page: Page) => {
+  const modal = () => page.getByTestId('delete-collection-item-modal');
+
+  return {
+    modal,
+    submitButton: () => modal().getByTestId('delete-collection-item-modal-submit-btn')
+  };
+};

--- a/tests/utils/page/index.ts
+++ b/tests/utils/page/index.ts
@@ -2,6 +2,7 @@ export * from './actions';
 export * from './file-mode';
 export * from './runner';
 export * from './locators';
+export * from './sidebar';
 export * from './mounting';
 export * from './preferences';
 export * from './ai';

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -3,6 +3,8 @@ import { buildApiSpecPanelLocators } from './openapi/render-spec';
 import { buildFileModeLocators } from './file-mode';
 import { buildPreferencesLocators } from './preferences';
 import { buildAiPreferencesLocators } from './ai';
+import { buildSidebarLocators } from './sidebar';
+import { buildDeleteCollectionItemModalLocators } from './collection/delete-collection-item';
 
 export const buildCommonLocators = (page: Page) => ({
   runner: () => page.getByTestId('run-button'),
@@ -15,28 +17,8 @@ export const buildCommonLocators = (page: Page) => ({
   websocket: buildWebsocketCommonLocators(page),
   saveButton: () => page.getByTestId('save-request-button'),
   openPreferences: () => page.getByRole('button', { name: 'Open Preferences' }),
-  sidebar: {
-    collectionsContainer: () => page.getByTestId('collections'),
-    collection: (name: string) => page.locator('#sidebar-collection-name').filter({ hasText: name }),
-    folder: (name: string) => page.locator('.collection-item-name').filter({ hasText: name }),
-    request: (name: string) => page.locator('.collection-item-name').filter({ hasText: name }),
-    folderRequest: (folderName: string, requestName: string) => {
-      // Find the folder's collection-item-name, then navigate to its parent wrapper container (StyledWrapper),
-      // and search for the request within that container's descendants.
-      // Using .locator('..') gets the parent element of the folder's collection-item-name div.
-      const folderWrapper = page.locator('.collection-item-name').filter({ hasText: folderName }).locator('..');
-      return folderWrapper.locator('.collection-item-name').filter({ hasText: requestName });
-    },
-    closeAllCollectionsButton: () => page.getByTestId('collections-header-actions-menu-close-all'),
-    collectionRow: (name: string) => page.getByTestId('sidebar-collection-row').filter({ hasText: name }),
-    itemRow: (name: string) => page.getByTestId('sidebar-collection-item-row').filter({ hasText: name }),
-    requestExamplesToggle: (requestName: string) =>
-      page.getByTestId('sidebar-collection-item-row').filter({ hasText: requestName }).getByTestId('request-item-chevron'),
-    example: (name: string) => page.getByTestId('sidebar-response-example-item').filter({ hasText: name }),
-    // The sidebar tree wraps each collection in `#collection-<slug>`; scope queries
-    // to it to disambiguate items that share names across collections.
-    collectionScope: (name: string) => page.locator(`#collection-${name.replace(/\s+/g, '-').toLowerCase()}`)
-  },
+  sidebar: buildSidebarLocators(page),
+  deleteCollectionItemModal: buildDeleteCollectionItemModalLocators(page),
   actions: {
     collectionActions: (collectionName: string) =>
       page.getByTestId('collections').locator('.collection-name')

--- a/tests/utils/page/sidebar/index.ts
+++ b/tests/utils/page/sidebar/index.ts
@@ -1,0 +1,44 @@
+import { Page } from '../../../../playwright';
+
+/**
+ * Locators for the sidebar (collections tree) section.
+ */
+export const buildSidebarLocators = (page: Page) => {
+  const collectionRow = (name: string) => page.getByTestId('sidebar-collection-row').filter({ hasText: name });
+  const itemRow = (name: string) => page.getByTestId('sidebar-collection-item-row').filter({ hasText: name });
+
+  return {
+    collectionsContainer: () => page.getByTestId('collections'),
+    collection: (name: string) => page.locator('#sidebar-collection-name').filter({ hasText: name }),
+    folder: (name: string) => page.locator('.collection-item-name').filter({ hasText: name }),
+    request: (name: string) => page.locator('.collection-item-name').filter({ hasText: name }),
+    folderRequest: (folderName: string, requestName: string) => {
+      // Find the folder's collection-item-name, then navigate to its parent wrapper container (StyledWrapper),
+      // and search for the request within that container's descendants.
+      // Using .locator('..') gets the parent element of the folder's collection-item-name div.
+      const folderWrapper = page.locator('.collection-item-name').filter({ hasText: folderName }).locator('..');
+      return folderWrapper.locator('.collection-item-name').filter({ hasText: requestName });
+    },
+    closeAllCollectionsButton: () => page.getByTestId('collections-header-actions-menu-close-all'),
+    collectionRow,
+    itemRow,
+    // The "..." menu on a sidebar row. `type` picks the row and the testid prefix:
+    // 'item' for a collection item row (`collection-item-menu-*`), 'collection' for a
+    // top-level collection row (`collection-actions-*`). Trigger is in the row; items
+    // are portaled to <body>, so page-scoped.
+    rowMenu: (name: string, type: 'item' | 'collection' = 'item') => {
+      const row = type === 'collection' ? collectionRow(name) : itemRow(name);
+      const testId = type === 'collection' ? 'collection-actions' : 'collection-item-menu';
+      return {
+        trigger: () => row.getByTestId(testId),
+        item: (action: string) => page.getByTestId(`${testId}-${action}`)
+      };
+    },
+    requestExamplesToggle: (requestName: string) =>
+      page.getByTestId('sidebar-collection-item-row').filter({ hasText: requestName }).getByTestId('request-item-chevron'),
+    example: (name: string) => page.getByTestId('sidebar-response-example-item').filter({ hasText: name }),
+    // The sidebar tree wraps each collection in `#collection-<slug>`; scope queries
+    // to it to disambiguate items that share names across collections.
+    collectionScope: (name: string) => page.locator(`#collection-${name.replace(/\s+/g, '-').toLowerCase()}`)
+  };
+};


### PR DESCRIPTION
### Description

Refactors the sidebar test locators for better reuse and readability.

- Moves the inline `sidebar` locators out of `locators.ts` into a dedicated `buildSidebarLocators()` module (`tests/utils/page/sidebar`), and adds a `rowMenu()` helper for the sidebar row "..." menus.
- Adds a `deleteCollectionItemModal` locator (`buildDeleteCollectionItemModalLocators()`) for the delete-confirmation modal.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when locating and interacting with the collection deletion confirmation dialog by adding a stable test identifier.

* **Tests**
  * Added dedicated, reusable locators for the delete confirmation modal and its submit button.
  * Introduced a dedicated set of sidebar/collections locators (including menus and examples).
  * Updated shared page locators to use the new sidebar locator utilities and added modal locator support for consistent end-to-end coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->