### PR TITLE
feat(proxy-settings): show "last refreshed" timestamp on System Proxy panel

### DIFF
--- a/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { IconLoader2, IconRefresh } from '@tabler/icons';
 import { getSystemProxyVariables, refreshSystemProxy } from 'providers/ReduxStore/slices/app';
 import StyledWrapper from '../StyledWrapper';
-import { formatTimestamp } from 'utils/common';
+import { formatProxyTimestamp } from 'utils/common';
 
 const SystemProxy = () => {
   const dispatch = useDispatch();
@@ -103,13 +103,18 @@ const SystemProxy = () => {
           <span
             className="text-link cursor-pointer hover:underline default-collection-location-browse flex flex-row items-center"
             onClick={handleRefresh}
+            data-testid="system-proxy-refresh-button"
           >
             <IconRefresh size={14} strokeWidth={1.5} className="mr-1" />
             Refresh
           </span>
           {lastRefreshedAt && (
-            <small className="system-proxy-last-refreshed text-muted">
-              Last refreshed at {formatTimestamp(lastRefreshedAt)}
+            <small
+              className="text-muted"
+              data-testid="system-proxy-last-refreshed"
+              data-refreshed-at={lastRefreshedAt.getTime()}
+            >
+              Last refreshed at {formatProxyTimestamp(lastRefreshedAt)}
             </small>
           )}
         </div>

--- a/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { IconLoader2, IconRefresh } from '@tabler/icons';
 import { getSystemProxyVariables, refreshSystemProxy } from 'providers/ReduxStore/slices/app';
 import StyledWrapper from '../StyledWrapper';
+import { formatTimestamp } from 'utils/common';
 
 const SystemProxy = () => {
   const dispatch = useDispatch();
@@ -10,13 +11,19 @@ const SystemProxy = () => {
   const { source, http_proxy, https_proxy, no_proxy, pac_url } = systemProxyVariables || {};
   const [isFetching, setIsFetching] = useState(true);
   const [error, setError] = useState(null);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState(null);
 
   const fetchProxy = (forceRefresh = false) => {
     setIsFetching(true);
     setError(null);
     const action = forceRefresh ? refreshSystemProxy : getSystemProxyVariables;
     dispatch(action())
-      .then(() => setError(null))
+      .then(() => {
+        setError(null);
+        if (forceRefresh) {
+          setLastRefreshedAt(new Date());
+        }
+      })
       .catch((err) => setError(err.message || String(err)))
       .finally(() => setIsFetching(false));
   };
@@ -92,13 +99,20 @@ const SystemProxy = () => {
             <div className="system-proxy-value">{pac_url || '-'}</div>
           </div>
         </div>
-        <span
-          className="text-link cursor-pointer hover:underline default-collection-location-browse flex flex-row items-center"
-          onClick={handleRefresh}
-        >
-          <IconRefresh size={14} strokeWidth={1.5} className="mr-1" />
-          Refresh
-        </span>
+        <div className="flex flex-row items-center gap-2">
+          <span
+            className="text-link cursor-pointer hover:underline default-collection-location-browse flex flex-row items-center"
+            onClick={handleRefresh}
+          >
+            <IconRefresh size={14} strokeWidth={1.5} className="mr-1" />
+            Refresh
+          </span>
+          {lastRefreshedAt && (
+            <small className="system-proxy-last-refreshed text-muted">
+              Last refreshed at {formatTimestamp(lastRefreshedAt)}
+            </small>
+          )}
+        </div>
       </div>
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
@@ -8,10 +8,10 @@ import { formatProxyTimestamp } from 'utils/common';
 const SystemProxy = () => {
   const dispatch = useDispatch();
   const systemProxyVariables = useSelector((state) => state.app.systemProxyVariables);
+  const lastRefreshedAt = useSelector((state) => state.app.systemProxyLastRefreshedAt);
   const { source, http_proxy, https_proxy, no_proxy, pac_url } = systemProxyVariables || {};
   const [isFetching, setIsFetching] = useState(true);
   const [error, setError] = useState(null);
-  const [lastRefreshedAt, setLastRefreshedAt] = useState(null);
 
   const fetchProxy = (forceRefresh = false) => {
     setIsFetching(true);
@@ -20,9 +20,6 @@ const SystemProxy = () => {
     dispatch(action())
       .then(() => {
         setError(null);
-        if (forceRefresh) {
-          setLastRefreshedAt(new Date());
-        }
       })
       .catch((err) => setError(err.message || String(err)))
       .finally(() => setIsFetching(false));
@@ -112,7 +109,7 @@ const SystemProxy = () => {
             <small
               className="text-muted"
               data-testid="system-proxy-last-refreshed"
-              data-refreshed-at={lastRefreshedAt.getTime()}
+              data-refreshed-at={lastRefreshedAt}
             >
               Last refreshed at {formatProxyTimestamp(lastRefreshedAt)}
             </small>

--- a/packages/bruno-app/src/components/Preferences/ProxySettings/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/index.js
@@ -140,7 +140,7 @@ const ProxySettings = ({ close }) => {
             Mode
           </label>
           <div className="flex items-center">
-            <label className="flex items-center cursor-pointer">
+            <label className="flex items-center cursor-pointer" data-testid="off-proxy-mode">
               <input
                 type="radio"
                 name="mode"
@@ -154,7 +154,7 @@ const ProxySettings = ({ close }) => {
               />
               Off
             </label>
-            <label className="flex items-center ml-4 cursor-pointer">
+            <label className="flex items-center ml-4 cursor-pointer" data-testid="manual-proxy-mode">
               <input
                 type="radio"
                 name="mode"
@@ -169,7 +169,7 @@ const ProxySettings = ({ close }) => {
               />
               On
             </label>
-            <label className="flex items-center ml-4 cursor-pointer">
+            <label className="flex items-center ml-4 cursor-pointer" data-testid="system-proxy-mode">
               <input
                 type="radio"
                 name="mode"
@@ -184,7 +184,7 @@ const ProxySettings = ({ close }) => {
               />
               System Proxy
             </label>
-            <label className="flex items-center ml-4 cursor-pointer">
+            <label className="flex items-center ml-4 cursor-pointer" data-testid="pac-proxy-mode">
               <input
                 type="radio"
                 name="mode"

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -97,6 +97,7 @@ const initialState = {
     hasCopiedItems: false // Whether clipboard has Bruno data (for UI)
   },
   systemProxyVariables: {},
+  systemProxyLastRefreshedAt: null,
   envVarSearch: {
     collection: {
       variables: { query: '', expanded: false },
@@ -210,6 +211,9 @@ export const appSlice = createSlice({
     updateSystemProxyVariables: (state, action) => {
       state.systemProxyVariables = action.payload;
     },
+    updateSystemProxyLastRefreshedAt: (state, action) => {
+      state.systemProxyLastRefreshedAt = action.payload;
+    },
     updateGenerateCode: (state, action) => {
       state.generateCode = {
         ...state.generateCode,
@@ -292,6 +296,7 @@ export const {
   removeTaskFromQueue,
   removeAllTasksFromQueue,
   updateSystemProxyVariables,
+  updateSystemProxyLastRefreshedAt,
   updateGenerateCode,
   toggleSidebarCollapse,
   toggleSidebarSearch,
@@ -397,6 +402,7 @@ export const refreshSystemProxy = () => (dispatch, getState) => {
     ipcRenderer.invoke('renderer:refresh-system-proxy')
       .then((variables) => {
         dispatch(updateSystemProxyVariables(variables));
+        dispatch(updateSystemProxyLastRefreshedAt(Date.now()));
         return variables;
       })
       .then(resolve).catch(reject);

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -555,8 +555,8 @@ export function isHexFormat(str) {
   return false;
 }
 
-export const formatProxyTimestamp = (date) => {
-  return date.toLocaleString('en-GB', {
+export const formatProxyTimestamp = (timestamp) => {
+  return new Date(timestamp).toLocaleString('en-GB', {
     day: '2-digit',
     month: 'short',
     year: 'numeric',

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -296,7 +296,7 @@ export const formatResponse = (data, dataBufferString, mode, filter, bufferThres
       if (filter) {
         return safeStringifyJSON(applyJSONPathFilter(data, filter), true);
       }
-    } catch (error) {}
+    } catch (error) { }
 
     if (isVeryLargeResponse) {
       return safeStringifyJSON(data, false);
@@ -304,7 +304,7 @@ export const formatResponse = (data, dataBufferString, mode, filter, bufferThres
 
     try {
       return fastJsonFormat(rawData);
-    } catch (error) {}
+    } catch (error) { }
 
     if (typeof data === 'string') {
       return data;
@@ -554,3 +554,14 @@ export function isHexFormat(str) {
 
   return false;
 }
+
+export const formatTimestamp = (date) => {
+  return date.toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true
+  });
+};

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -555,7 +555,7 @@ export function isHexFormat(str) {
   return false;
 }
 
-export const formatTimestamp = (date) => {
+export const formatProxyTimestamp = (date) => {
   return date.toLocaleString('en-GB', {
     day: '2-digit',
     month: 'short',

--- a/tests/preferences/system-proxy-timestamp.spec.ts
+++ b/tests/preferences/system-proxy-timestamp.spec.ts
@@ -2,10 +2,10 @@ import { expect, test } from '../../playwright';
 import { buildPreferencesLocators, openSystemProxyPanel } from '../utils/page';
 
 // The System Proxy panel renders a "Last refreshed at <timestamp>" label that is
-// produced by the `formatTimestamp` util. The label is created only when the user
+// produced by the `formatProxyTimestamp` util. The label is created only when the user
 // explicitly clicks "Refresh" (a forced refresh), not on the initial auto-fetch.
 //
-// formatTimestamp uses `toLocaleString('en-GB', { day: '2-digit', month: 'short',
+// formatProxyTimestamp uses `toLocaleString('en-GB', { day: '2-digit', month: 'short',
 // year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true })`, e.g.
 //   "15 Jul 2026, 04:30 pm"
 const TIMESTAMP_REGEX = /^Last refreshed at \d{2} [A-Z][a-z]{2} \d{4},\s+\d{2}:\d{2}\s?(am|pm)$/i;

--- a/tests/preferences/system-proxy-timestamp.spec.ts
+++ b/tests/preferences/system-proxy-timestamp.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '../../playwright';
+import { buildPreferencesLocators, openSystemProxyPanel } from '../utils/page';
+
+// The System Proxy panel renders a "Last refreshed at <timestamp>" label that is
+// produced by the `formatTimestamp` util. The label is created only when the user
+// explicitly clicks "Refresh" (a forced refresh), not on the initial auto-fetch.
+//
+// formatTimestamp uses `toLocaleString('en-GB', { day: '2-digit', month: 'short',
+// year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true })`, e.g.
+//   "15 Jul 2026, 04:30 pm"
+const TIMESTAMP_REGEX = /^Last refreshed at \d{2} [A-Z][a-z]{2} \d{4},\s+\d{2}:\d{2}\s?(am|pm)$/i;
+
+test.describe('System Proxy - last refreshed timestamp', () => {
+  test('does not show a timestamp before the user forces a refresh', async ({ page }) => {
+    await openSystemProxyPanel(page);
+
+    const systemProxyLocators = buildPreferencesLocators(page).systemProxy;
+
+    await expect(systemProxyLocators.systemProxyLastRefreshedLabel()).not.toBeVisible();
+  });
+
+  test('shows a correctly formatted timestamp after clicking Refresh', async ({ page }) => {
+    await openSystemProxyPanel(page);
+
+    const systemProxyLocators = buildPreferencesLocators(page).systemProxy;
+    await systemProxyLocators.systemProxyRefreshButton().click();
+
+    await expect(systemProxyLocators.systemProxyLastRefreshedLabel()).toBeVisible();
+
+    await expect(systemProxyLocators.systemProxyLastRefreshedLabel()).toHaveText(TIMESTAMP_REGEX);
+  });
+
+  test('updates the timestamp on a subsequent Refresh', async ({ page }) => {
+    await openSystemProxyPanel(page);
+
+    const systemProxyLocators = buildPreferencesLocators(page).systemProxy;
+
+    // first refresh click sets the timestamp
+    await systemProxyLocators.systemProxyRefreshButton().click();
+    await expect(systemProxyLocators.systemProxyLastRefreshedLabel()).toBeVisible();
+    await expect(systemProxyLocators.systemProxyLastRefreshedLabel()).toHaveText(TIMESTAMP_REGEX);
+
+    const firstRefreshedAt = Number(
+      await systemProxyLocators.systemProxyLastRefreshedLabel().getAttribute('data-refreshed-at')
+    );
+
+    await page.waitForTimeout(2000);
+
+    // second refresh click should update the timestamp
+    await systemProxyLocators.systemProxyRefreshButton().click();
+    await expect(systemProxyLocators.systemProxyLastRefreshedLabel()).toBeVisible();
+    await expect(systemProxyLocators.systemProxyLastRefreshedLabel()).toHaveText(TIMESTAMP_REGEX);
+
+    // The refresh handler sets the timestamp asynchronously (after the dispatched
+    // thunk resolves), so the `data-refreshed-at` attribute is not updated the moment
+    // the click returns. `toHaveText` above doesn't help here since the regex matches
+    // any valid timestamp, including the stale first value. Poll until the attribute
+    // actually changes before reading it, otherwise we could capture the old value.
+    await expect
+      .poll(async () =>
+        Number(
+          await systemProxyLocators.systemProxyLastRefreshedLabel().getAttribute('data-refreshed-at')
+        )
+      )
+      .not.toBe(firstRefreshedAt);
+
+    const secondRefreshedAt = Number(
+      await systemProxyLocators.systemProxyLastRefreshedLabel().getAttribute('data-refreshed-at')
+    );
+
+    // the two refreshes should be more than 1 second apart
+    expect(secondRefreshedAt - firstRefreshedAt).toBeGreaterThan(1000);
+  });
+});

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -3,6 +3,7 @@ import process from 'node:process';
 import * as path from 'path';
 import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators } from './locators';
 import { waitForCollectionMount } from './mounting';
+import { buildPreferencesLocators, openPreferences, selectPreferencesTab } from './preferences';
 
 type SandboxMode = 'safe' | 'developer';
 
@@ -2472,6 +2473,20 @@ const elementIsInsideDropdown = async (locator: Locator) => {
   );
 };
 
+/**
+* Open the System Proxy panel in the Preferences dialog and wait for the refresh button to be visible.
+* @param page - The page object
+*/
+
+const openSystemProxyPanel = async (page: Page) => {
+  await openPreferences(page);
+  await selectPreferencesTab(page, 'Proxy');
+
+  const systemProxyLocators = buildPreferencesLocators(page).systemProxy;
+  await systemProxyLocators.systemProxyMode().click();
+  await systemProxyLocators.systemProxyRefreshButton().waitFor({ state: 'visible' });
+};
+
 export {
   waitForReadyPage,
   setRequestUrlAndSave,
@@ -2574,7 +2589,8 @@ export {
   createApp,
   selectAppView,
   renameWsMessage,
-  elementIsInsideDropdown
+  elementIsInsideDropdown,
+  openSystemProxyPanel
 };
 
 export type { SandboxMode, EnvironmentType, EnvironmentVariable, ImportCollectionOptions, CreateRequestOptions, CreateUntitledRequestOptions, CreateTransientRequestOptions, AssertionInput };

--- a/tests/utils/page/preferences.ts
+++ b/tests/utils/page/preferences.ts
@@ -8,7 +8,20 @@ export const buildPreferencesLocators = (page: Page) => ({
   /** Status-bar button that opens the Preferences dialog */
   statusBarTrigger: () => page.getByRole('button', { name: 'Open Preferences' }),
   /** A top-level tab inside the Preferences dialog (exact name match) */
-  tab: (name: string) => page.getByRole('tab', { name, exact: true })
+  tab: (name: string) => page.getByRole('tab', { name, exact: true }),
+
+  /** Locators for the System Proxy panel */
+  systemProxy: buildSystemProxyModeLocators(page)
+
+});
+
+const buildSystemProxyModeLocators = (page: Page) => ({
+  /** Returns the locator for the System Proxy mode radio button */
+  systemProxyMode: () => page.getByRole('radio', { name: 'System Proxy' }),
+  /** The "Refresh" button in the System Proxy panel */
+  systemProxyRefreshButton: () => page.getByTestId('system-proxy-refresh-button'),
+  /** The "Last refreshed at <timestamp>" label in the System Proxy panel */
+  systemProxyLastRefreshedLabel: () => page.getByTestId('system-proxy-last-refreshed')
 });
 
 /**


### PR DESCRIPTION
BRU-3880
### Description

In Preferences → Proxy Settings → System Proxy, users can refresh the detected system proxy variables (HTTP/HTTPS proxy, no_proxy, PAC URL) but had no feedback about when the values were last pulled. This PR adds a visible "Last refreshed at ..." timestamp so users can confirm the displayed values are current after hitting Refresh.

## Changes
Added a Last Refreshed At timestamp to the Proxy Settings UI, which updates each time the Refresh button is used.

##Tests: 
E2E: verifies the timestamp is hidden initially and rendered/updated after clicking Refresh.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Last refreshed at” timestamp to the System Proxy settings after a successful refresh.
  * Added localized timestamp formatting for proxy refresh times.

* **Bug Fixes**
  * Improved resilience when formatting JSON responses by continuing through fallback formatting options if an earlier method fails.

* **Tests**
  * Added coverage for timestamp visibility, formatting, and updates after repeated refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->