### PR TITLE
fix(ws): keep selection on current message when deleting another

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -179,8 +179,10 @@ export const SingleWSMessage = ({
   return (
     <StyledWrapper
       className={!isSelected ? 'disabled' : ''}
-      onMouseUpCapture={() => {
-        if (!isSelected) onSelect();
+      data-testid={`ws-message-${index}`}
+      onMouseUpCapture={(e) => {
+        if (isSelected || e.target.closest('.hover-action-btn.delete')) return;
+        onSelect();
       }}
     >
       <div

--- a/tests/utils/page/websocket.ts
+++ b/tests/utils/page/websocket.ts
@@ -11,6 +11,7 @@ export const buildWebsocketCommonLocators = (page: Page) => ({
     addButton: () => page.getByTestId('ws-add-message'),
     headers: () => page.getByTestId(/^ws-message-header-/),
     header: (index: number) => page.getByTestId(`ws-message-header-${index}`),
+    messageWrapper: (index: number) => page.getByTestId(`ws-message-${index}`),
     body: (index: number) => page.getByTestId(`ws-message-body-${index}`),
     editor: (index: number) => page.getByTestId(`ws-message-body-${index}`).locator('.CodeMirror'),
     editorPlaceholder: (index: number) =>

--- a/tests/websockets/headers.spec.ts
+++ b/tests/websockets/headers.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '../../playwright';
 import { buildCommonLocators } from '../utils/page/locators';
-import { createTransientRequest, selectRequestPaneTab, closeAllTabs } from '../utils/page/actions';
 
 const BRU_REQ_NAME = /^ws-test-request-with-headers$/;
 
@@ -18,70 +17,5 @@ test.describe.serial('headers', () => {
     // Check if the message has the authorisation header
     await expect(locators.websocket.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(authorization)\"\:\s+\"Dummy\"/);
     await expect(locators.websocket.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(x-bruno-collection-var)\"\:\s+\"Variable Value\"/);
-  });
-});
-
-test.describe('message header selection on delete', () => {
-  test.afterEach(async ({ page }) => {
-    await closeAllTabs(page);
-  });
-
-  test('deleting an unselected message keeps the current selection (does not jump to first)', async ({
-    page
-  }) => {
-    const { websocket } = buildCommonLocators(page);
-
-    await test.step('Create a WebSocket request with three messages', async () => {
-      await createTransientRequest(page, { requestType: 'WebSocket' });
-      await selectRequestPaneTab(page, 'Message');
-
-      for (let i = 0; i < 2; i++) {
-        await websocket.message.addButton().click();
-        await websocket.message.nameInputs().press('Escape');
-      }
-      await expect(websocket.message.headers()).toHaveCount(3);
-    });
-
-    await test.step('The last-added message (index 2) is the selected one', async () => {
-      await expect(websocket.message.messageWrapper(2)).not.toHaveClass(/disabled/);
-      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
-    });
-
-    await test.step('Delete a different, unselected message (the first one)', async () => {
-      await websocket.message.header(0).hover();
-      await websocket.message.deleteButton(0).click();
-      await expect(websocket.message.headers()).toHaveCount(2);
-    });
-
-    await test.step('The previously selected message stays selected — not the first', async () => {
-      // It has shifted from index 2 to index 1 after the delete.
-      await expect(websocket.message.messageWrapper(1)).not.toHaveClass(/disabled/);
-      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
-    });
-  });
-
-  test('clicking a message (not its delete button) still selects it', async ({ page }) => {
-    const { websocket } = buildCommonLocators(page);
-
-    await test.step('Create a WebSocket request with two messages', async () => {
-      await createTransientRequest(page, { requestType: 'WebSocket' });
-      await selectRequestPaneTab(page, 'Message');
-
-      await websocket.message.addButton().click();
-      await websocket.message.nameInputs().press('Escape');
-      await expect(websocket.message.headers()).toHaveCount(2);
-    });
-
-    await test.step('The newly added message (index 1) is selected', async () => {
-      await expect(websocket.message.messageWrapper(1)).not.toHaveClass(/disabled/);
-      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
-    });
-
-    await test.step('Clicking the first message header selects it', async () => {
-      // Only the delete button is exempt from selecting the row.
-      await websocket.message.header(0).click();
-      await expect(websocket.message.messageWrapper(0)).not.toHaveClass(/disabled/);
-      await expect(websocket.message.messageWrapper(1)).toHaveClass(/disabled/);
-    });
   });
 });

--- a/tests/websockets/headers.spec.ts
+++ b/tests/websockets/headers.spec.ts
@@ -35,10 +35,10 @@ test.describe('message header selection on delete', () => {
       await createTransientRequest(page, { requestType: 'WebSocket' });
       await selectRequestPaneTab(page, 'Message');
 
-      await websocket.message.addButton().click();
-      await websocket.message.nameInputs().press('Escape');
-      await websocket.message.addButton().click();
-      await websocket.message.nameInputs().press('Escape');
+      for (let i = 0; i < 2; i++) {
+        await websocket.message.addButton().click();
+        await websocket.message.nameInputs().press('Escape');
+      }
       await expect(websocket.message.headers()).toHaveCount(3);
     });
 

--- a/tests/websockets/headers.spec.ts
+++ b/tests/websockets/headers.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../playwright';
 import { buildCommonLocators } from '../utils/page/locators';
+import { createTransientRequest, selectRequestPaneTab, closeAllTabs } from '../utils/page/actions';
 
 const BRU_REQ_NAME = /^ws-test-request-with-headers$/;
 
@@ -17,5 +18,70 @@ test.describe.serial('headers', () => {
     // Check if the message has the authorisation header
     await expect(locators.websocket.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(authorization)\"\:\s+\"Dummy\"/);
     await expect(locators.websocket.messages().nth(2).locator('.text-ellipsis')).toHaveText(/\"(x-bruno-collection-var)\"\:\s+\"Variable Value\"/);
+  });
+});
+
+test.describe('message header selection on delete', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllTabs(page);
+  });
+
+  test('deleting an unselected message keeps the current selection (does not jump to first)', async ({
+    page
+  }) => {
+    const { websocket } = buildCommonLocators(page);
+
+    await test.step('Create a WebSocket request with three messages', async () => {
+      await createTransientRequest(page, { requestType: 'WebSocket' });
+      await selectRequestPaneTab(page, 'Message');
+
+      await websocket.message.addButton().click();
+      await websocket.message.nameInputs().press('Escape');
+      await websocket.message.addButton().click();
+      await websocket.message.nameInputs().press('Escape');
+      await expect(websocket.message.headers()).toHaveCount(3);
+    });
+
+    await test.step('The last-added message (index 2) is the selected one', async () => {
+      await expect(websocket.message.messageWrapper(2)).not.toHaveClass(/disabled/);
+      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
+    });
+
+    await test.step('Delete a different, unselected message (the first one)', async () => {
+      await websocket.message.header(0).hover();
+      await websocket.message.deleteButton(0).click();
+      await expect(websocket.message.headers()).toHaveCount(2);
+    });
+
+    await test.step('The previously selected message stays selected — not the first', async () => {
+      // It has shifted from index 2 to index 1 after the delete.
+      await expect(websocket.message.messageWrapper(1)).not.toHaveClass(/disabled/);
+      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
+    });
+  });
+
+  test('clicking a message (not its delete button) still selects it', async ({ page }) => {
+    const { websocket } = buildCommonLocators(page);
+
+    await test.step('Create a WebSocket request with two messages', async () => {
+      await createTransientRequest(page, { requestType: 'WebSocket' });
+      await selectRequestPaneTab(page, 'Message');
+
+      await websocket.message.addButton().click();
+      await websocket.message.nameInputs().press('Escape');
+      await expect(websocket.message.headers()).toHaveCount(2);
+    });
+
+    await test.step('The newly added message (index 1) is selected', async () => {
+      await expect(websocket.message.messageWrapper(1)).not.toHaveClass(/disabled/);
+      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
+    });
+
+    await test.step('Clicking the first message header selects it', async () => {
+      // Only the delete button is exempt from selecting the row.
+      await websocket.message.header(0).click();
+      await expect(websocket.message.messageWrapper(0)).not.toHaveClass(/disabled/);
+      await expect(websocket.message.messageWrapper(1)).toHaveClass(/disabled/);
+    });
   });
 });

--- a/tests/websockets/message-header.spec.ts
+++ b/tests/websockets/message-header.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '../../playwright';
+import { buildCommonLocators } from '../utils/page/locators';
+import { createTransientRequest, selectRequestPaneTab, closeAllTabs } from '../utils/page/actions';
+
+test.describe('websocket message header selection on delete', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllTabs(page);
+  });
+
+  test('deleting an unselected message keeps the current selection (does not jump to first)', async ({
+    page
+  }) => {
+    const { websocket } = buildCommonLocators(page);
+
+    await test.step('Create a WebSocket request with three messages', async () => {
+      await createTransientRequest(page, { requestType: 'WebSocket' });
+      await selectRequestPaneTab(page, 'Message');
+
+      for (let i = 0; i < 2; i++) {
+        await websocket.message.addButton().click();
+        await websocket.message.nameInputs().press('Escape');
+      }
+      await expect(websocket.message.headers()).toHaveCount(3);
+    });
+
+    await test.step('The last-added message (index 2) is the selected one', async () => {
+      await expect(websocket.message.messageWrapper(2)).not.toHaveClass(/disabled/);
+      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
+    });
+
+    await test.step('Delete a different, unselected message (the first one)', async () => {
+      await websocket.message.header(0).hover();
+      await websocket.message.deleteButton(0).click();
+      await expect(websocket.message.headers()).toHaveCount(2);
+    });
+
+    await test.step('The previously selected message stays selected — not the first', async () => {
+      // It has shifted from index 2 to index 1 after the delete.
+      await expect(websocket.message.messageWrapper(1)).not.toHaveClass(/disabled/);
+      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
+    });
+  });
+
+  test('clicking a message (not its delete button) still selects it', async ({ page }) => {
+    const { websocket } = buildCommonLocators(page);
+
+    await test.step('Create a WebSocket request with two messages', async () => {
+      await createTransientRequest(page, { requestType: 'WebSocket' });
+      await selectRequestPaneTab(page, 'Message');
+
+      await websocket.message.addButton().click();
+      await websocket.message.nameInputs().press('Escape');
+      await expect(websocket.message.headers()).toHaveCount(2);
+    });
+
+    await test.step('The newly added message (index 1) is selected', async () => {
+      await expect(websocket.message.messageWrapper(1)).not.toHaveClass(/disabled/);
+      await expect(websocket.message.messageWrapper(0)).toHaveClass(/disabled/);
+    });
+
+    await test.step('Clicking the first message header selects it', async () => {
+      // Only the delete button is exempt from selecting the row.
+      await websocket.message.header(0).click();
+      await expect(websocket.message.messageWrapper(0)).not.toHaveClass(/disabled/);
+      await expect(websocket.message.messageWrapper(1)).toHaveClass(/disabled/);
+    });
+  });
+});

--- a/tests/websockets/message-header.spec.ts
+++ b/tests/websockets/message-header.spec.ts
@@ -18,7 +18,7 @@ test.describe('websocket message header selection on delete', () => {
 
       for (let i = 0; i < 2; i++) {
         await websocket.message.addButton().click();
-        await websocket.message.nameInputs().press('Escape');
+        await websocket.message.nameInput(i + 1).press('Escape');
       }
       await expect(websocket.message.headers()).toHaveCount(3);
     });
@@ -49,7 +49,7 @@ test.describe('websocket message header selection on delete', () => {
       await selectRequestPaneTab(page, 'Message');
 
       await websocket.message.addButton().click();
-      await websocket.message.nameInputs().press('Escape');
+      await websocket.message.nameInput(1).press('Escape');
       await expect(websocket.message.headers()).toHaveCount(2);
     });
 


### PR DESCRIPTION
### Description

Fixes a WebSocket multi-message bug: when a message was selected and you deleted a **different** message, the selection jumped to the first message.

**Cause:** the message row selects itself on mouse-up (capture phase), so clicking an unselected message's delete button first selected that message and then deleted it leaving nothing selected, which falls back to the first message.

BRU-3890

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**



https://github.com/user-attachments/assets/d4229232-a49c-46a8-8923-f75c32a57cd7




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed WebSocket message selection behavior so deleting an unselected message no longer changes the active selection.
  - Ensured message selection occurs when clicking a message header, while interactions from the delete action don’t trigger row selection.

- **Tests**
  - Added end-to-end Playwright coverage for WebSocket message header selection and delete behavior to prevent selection “jumps.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->