### PR TITLE
feat(size/XS)Generate documentation modal text and style changes

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
@@ -20,7 +20,7 @@ const StyledWrapper = styled.div`
       width: 100%;
 
       .version-info {
-        padding: 0.75rem 1rem;
+        padding: 0.75rem;
         background-color: ${(props) => props.theme.background.mantle};
 
         .version-line {
@@ -72,7 +72,7 @@ const StyledWrapper = styled.div`
       }
 
       .env-section {
-        padding: 1rem;
+        padding: 0.75rem;
 
         .env-checkbox {
           width: 1rem;
@@ -80,6 +80,7 @@ const StyledWrapper = styled.div`
           margin: 0;
           flex-shrink: 0;
           cursor: pointer;
+          accent-color: ${(props) => props.theme.primary.solid};
         }
 
         .env-section-header {
@@ -130,17 +131,19 @@ const StyledWrapper = styled.div`
         .env-row {
           display: flex;
           align-items: center;
-          gap: 0.5rem;
-          /* Fixed row height — MUST match ENV_ROW_HEIGHT (Virtuoso fixedItemHeight)
-             in EnvironmentSelectionList. The inter-row spacing is baked in here. */
           height: 28px;
           cursor: pointer;
           margin: 0;
+
+          .env-checkbox {
+            margin-right: 10px;
+          }
 
           .env-name {
             font-size: ${(props) => props.theme.font.size.base};
             color: ${(props) => props.theme.text};
             min-width: 0;
+            margin-left: 6px;
           }
         }
       }

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -232,7 +232,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
               </div>
 
               <p className="note m-0">
-                The generated file loads OpenCollection's JavaScript and CSS files from a CDN, which requires an internet connection.
+                The generated file loads Bruno's JavaScript and CSS files from a CDN, which requires an internet connection.
               </p>
             </div>
           )}


### PR DESCRIPTION
### Description

1. Changed the text to “The generated file loads Bruno’s JavaScript and CSS files from a CDN, which requires an internet connection.”

2. Fixed some padding issues.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

BRU - 3753

<img width="648" height="502" alt="Screenshot 2026-07-16 at 2 49 06 PM" src="https://github.com/user-attachments/assets/0f04bc11-6619-4dd2-9acd-f516cd60aa04" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified that generated HTML documentation loads Bruno’s JavaScript and CSS from a CDN and requires internet access.

* **Style**
  * Improved spacing and alignment in the documentation configuration and environment sections.
  * Updated environment checkbox styling for clearer visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->