### PR TITLE
fix: preserve SSH_AUTH_SOCK and process.env in simple-git configuration

### DIFF
--- a/packages/bruno-electron/src/utils/git.js
+++ b/packages/bruno-electron/src/utils/git.js
@@ -24,6 +24,7 @@ const getSimpleGitInstanceForPath = (gitRootPath) => {
   let git = simpleGitInstances.get(gitRootPath);
   if (!git) {
     git = simpleGit(gitRootPath);
+    git.env({ ...process.env, GIT_OPTIONAL_LOCKS: '0' });
     simpleGitInstances.set(gitRootPath, git);
   }
   return git;


### PR DESCRIPTION
## Description

When Bruno configures simple-git with `git.env('GIT_OPTIONAL_LOCKS', '0')`, the `simple-git` library initializes a custom child-process environment that replaces `process.env` instead of extending it. This causes `SSH_AUTH_SOCK` and other critical environment variables to be absent from spawned git/ssh processes, breaking SSH-based Git authentication.

## Fix

Changed the simple-git environment configuration to preserve the existing process environment while adding `GIT_OPTIONAL_LOCKS`, so spawned git processes inherit the necessary environment variables (including `SSH_AUTH_SOCK` for SSH agent forwarding).

Fixes #8594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git operation reliability by preventing optional lock contention during repository actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->