### PR TITLE
chore(claude): add .claude config into the repo

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,3 @@
+settings.local.json
+scheduled_tasks.lock
+*.lock

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,75 @@
+# Project Guide
+
+Bruno fork — open-source API client (Electron + React + Redux).
+
+Bruno is an API **client**, not a server: it sends requests and handles responses (auth, params, headers, bodies, environments, cookies). Judge every behavior and edge case by "what should a *client* do here?" — surface malformed or hostile responses clearly and stay robust; don't enforce server-side correctness.
+
+## Quick Commands
+
+```bash
+npm run dev              # Run electron + react concurrently
+npm run dev:watch        # Same, with hot-reload of the electron main process
+npm run storybook        # Component dev (bruno-app)
+npm run lint:fix         # ESLint fix
+npm test --workspaces    # Unit tests (Jest) across all packages
+```
+
+Full script list: root `package.json`. Setup: `nvm use && npm i --legacy-peer-deps && npm run setup` (Node **v22.12.0**, see `.nvmrc`).
+
+### Running a single test
+
+```bash
+# Single unit test (Jest) — scope to the workspace, pass a path/pattern after --
+npm test --workspace=packages/bruno-app -- path/to/file.spec.js
+npm test --workspace=packages/bruno-requests -- -t "test name pattern"
+
+# Single e2e test (Playwright) — a project flag is REQUIRED (config has no default)
+npx playwright test tests/collection/create-collection.spec.ts --project=default
+npx playwright test --project=default -g "test name pattern"
+```
+
+Prefer the smallest scope — one workspace, one spec — over `--workspaces` or the full e2e run.
+
+### Building shared packages
+
+`npm run dev` does **not** rebuild the shared packages (bruno-common, bruno-requests,
+bruno-filestore, bruno-converters, bruno-query, bruno-schema-types, bruno-graphql-docs).
+After editing one, rebuild it or run its watcher, or the app won't pick up changes:
+
+```bash
+npm run build:bruno-common      # also :bruno-requests, :bruno-filestore, etc.
+npm run watch:common            # also watch:requests, watch:converters
+```
+
+## Key Architecture
+
+- **Main process entry**: `packages/bruno-electron/src/index.js`
+- **Renderer + Redux store**: `packages/bruno-app/src/providers/ReduxStore/`
+- Packages live under `packages/`, with top-level `tests/` and `playwright/`.
+
+## Testing
+
+- **Unit**: Jest, config per-package (`packages/*/jest.config.js`); bruno-app uses jsdom + `jest.setup.js`.
+- **E2E**: Playwright — fixtures, helpers, isolation rules, and pitfalls live in
+  `.claude/rules/testing.md`; use the `write-e2e-test` skill when adding specs.
+
+## Coding Standards
+
+Full list: `CODING_STANDARDS.md`. Mechanical style (indent, quotes, semicolons, no trailing
+commas, arrow-param parens) is ESLint-enforced — run `npm run lint:fix`, don't hand-police it.
+Non-obvious project rules worth holding:
+
+- React: avoid `useEffect` (prefer derived state / custom hooks); import hooks by name, never `React.useX`; a component is controlled XOR uncontrolled; Tailwind for layout, styled-components `theme` for colors.
+- Extract for readability or clear reuse; avoid only indirection that adds no payoff. Add `data-testid` attributes for Playwright selectors.
+
+## Detailed rules & references
+
+Path-scoped rules in `.claude/rules/` auto-attach when you touch matching files:
+`architecture.md` (`@usebruno/*` dependency boundaries), `electron-ipc.md` (IPC handlers + startup),
+`redux-store.md` (slices/middleware), `testing.md` (e2e patterns & gotchas), `cross-platform.md`
+(Windows file/process/path pitfalls), `dsl-changes.md` (on-disk `.bru`/`.yml` format & backward
+compat), `conventions.md` (readability + comment/diff hygiene).
+
+Read on demand (not auto-loaded): `.claude/reference/architecture.md` — the monorepo map, request
+pipeline, sandbox, core types, and dependency versions. Consult it before cross-package or
+architectural work.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,141 @@
+# Claude Config
+
+The [Claude Code](https://docs.claude.com/en/docs/claude-code) configuration for
+[Bruno](https://github.com/usebruno/bruno) — the project context, architecture notes, coding
+rules, and review/test skills the team has tuned while working on Bruno. Claude picks it up
+automatically when you launch from the project root.
+
+<!-- This README is a human maintainer guide. It is NOT a memory file and is never imported into
+     Claude's always-loaded context — keep contributor/ownership guidance here, not in CLAUDE.md. -->
+
+## What's inside
+
+| Path | What it is | Loads |
+|------|------------|-------|
+| `CLAUDE.md` | Project overview — commands, key architecture, coding standards, index of rules/references. | Every session (auto). |
+| `rules/*.md` | Path-scoped engineering guidance: `architecture` (`@usebruno/*` dependency boundaries), `redux-store`, `electron-ipc`, `dsl-changes` (on-disk `.bru`/`.yml` format), `cross-platform`, `testing`, `conventions` (readability + comment/diff hygiene). | When Claude touches files matching each rule's `paths:`. |
+| `reference/architecture.md` | The monorepo map — request pipeline, sandbox, file formats, core types, dependency versions. Too big to auto-load. | On demand only (Claude reads it when a task needs it). |
+| `skills/code-review/` | `/code-review` — reviews the current branch/PR via focused lenses in parallel; takes base pointers from `.coderabbit.yaml`. | On invocation / when relevant. |
+| `skills/write-e2e-test/` | `/write-e2e-test` — writes a Playwright E2E test following Bruno's fixtures and conventions. | On invocation / when relevant. |
+| `settings.json` | Shared project settings, checked in for the team. Denies `Read` on `**/dist/**` so Claude works from `src/`, not generated bundles. | At startup, from the launch directory. |
+| `settings.local.json` | Your machine-specific overrides. Gitignored — never committed. | At startup, if present. |
+
+## Requirements
+
+- [Claude Code](https://docs.claude.com/en/docs/claude-code) installed (`npm i -g @anthropic-ai/claude-code`).
+- A local checkout of Bruno (or a Bruno fork).
+
+## Install
+
+Start Claude Code (`claude`) from the Bruno root and everything loads on its own:
+
+- **`.claude/CLAUDE.md`** loads every session — it is a first-class project-instruction location,
+  so **no root `CLAUDE.md` and no `@` import are needed**; keeping all shared guidance under
+  `.claude/` leaves the Claude config self-contained in one folder.
+- **Path-scoped rules** attach automatically when Claude reads a matching file (e.g. `dsl-changes`
+  kicks in on `bruno-filestore`). Launching from a package subdirectory still loads this root
+  `.claude/` (rules + `CLAUDE.md`) from the ancestor directory.
+- **`reference/architecture.md`** is *not* auto-loaded; Claude reads it on demand.
+- **Skills** are discovered from `.claude/skills/` — type `/code-review` or `/write-e2e-test`.
+
+## Everyday use
+
+```bash
+/code-review            # review the current branch against main before pushing
+/write-e2e-test         # scaffold a Playwright spec under tests/
+```
+
+Otherwise just work normally — Claude consults the rules on demand. Machine-specific overrides go
+in `.claude/settings.local.json` (already gitignored), not in `settings.json`.
+
+---
+
+## Maintaining this config
+
+This section is for whoever edits the config. The goal is **high instruction adherence at the
+lowest always-loaded cost**: put each instruction in the mechanism that loads it exactly when it's
+needed, and no sooner.
+
+It operationalizes the Claude Code docs — read them before making structural changes:
+[Write an effective CLAUDE.md](https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md)
+(the *"would removing this cause a mistake?"* test below is from it),
+[Memory](https://code.claude.com/docs/en/memory) (CLAUDE.md loading + `.claude/rules/`),
+[Large codebases](https://code.claude.com/docs/en/large-codebases) (monorepo scoping), and
+[Skills](https://code.claude.com/docs/en/skills).
+
+### Where does a new instruction go?
+
+| Mechanism | Lives in | Loads | Use it for |
+|---|---|---|---|
+| Project instructions | `.claude/CLAUDE.md` | Every session (full file) | Facts true in nearly every session and not inferable from code: orientation, non-obvious setup, global invariants, pointers to everything else. |
+| Path-scoped rule | `.claude/rules/<topic>.md` with `paths:` | When Claude reads a file matching `paths:` | A coding constraint or convention specific to one area (a package, `tests/`, DSL files). One topic per file. |
+| On-demand reference | `.claude/reference/<topic>.md` | Only when Claude `Read`s it | Long maps / reference material too big to auto-load. Point to it from CLAUDE.md or a rule. |
+| Skill | `.claude/skills/<name>/SKILL.md` (+ support files) | On `/invoke` or when the model judges the description relevant | A reusable multi-step *procedure* or workflow (review, scaffold a test). Not a fact. |
+| Settings / hooks | `.claude/settings.json` | Startup (from launch dir) / deterministic lifecycle events | Shared permissions/env; deterministic enforcement that must happen every time regardless of the model. Advisory guidance is **not** a hook. |
+
+**Why no nested per-package `CLAUDE.md`?** Central path-scoped rules keep all conventions in one
+maintained place under `.claude/` and attach exactly where they're needed (see the Claude Code
+"large codebases" guide) — simpler than scattering `CLAUDE.md` files across package directories.
+
+### Budgets
+
+- `CLAUDE.md`: target **≤ 120 lines**, hard cap 200. For every line ask *"would removing this cause
+  Claude to make a recurring project-specific mistake?"* If not, cut or relocate it.
+- Rules: one coherent topic each; keep concise. If a rule grows a long reference tail (maps, tables,
+  worked examples), move that tail to `reference/` and leave the invariants in the rule.
+- Skills: keep `SKILL.md` focused (aim < 150 lines); push long checklists/examples to support files.
+  Descriptions **< ~200 chars**, leading with words a triggering request would contain.
+- Prefer a small, distinct skill catalog — names + descriptions cost discovery context even though
+  bodies load lazily.
+
+### Add / retire a rule or skill
+
+- **Add a rule**: create a flat `rules/<topic>.md` with accurate `paths:` frontmatter (globs against
+  real repo paths). Record only non-obvious conventions or constraints static tooling (ESLint, TS)
+  doesn't already enforce. Only split a topic into a subfolder once it has several rules.
+- **Add a skill**: unique stable directory name; description states *what* + *when*; set
+  `disable-model-invocation: true` for side-effectful workflows (publish/commit/release). Verify it
+  passes the reuse / project-specific / non-trivial-procedure tests before adding.
+- **Retire**: delete the file and remove any pointer to it from `CLAUDE.md` and other rules/skills.
+
+### Keep it consistent
+
+- **Detect duplication/conflicts**: `grep -rn "<claim>" .claude` before writing a fact; if two files
+  state the same thing, keep it in one and point to it. Watch for the same fact drifting across
+  `CLAUDE.md`, a rule, a skill, and `CODING_STANDARDS.md` / `.coderabbit.yaml`.
+- **Verify against real code.** Every rule/example must reflect the actual repo — grep the source,
+  don't assume. Rules are the source of truth; reviewer lenses and CLAUDE.md are thin pointers.
+- **Don't hardcode volatile catalogs** (slice lists, handler names, dep versions that drift).
+  Describe the category and tell Claude where to read the current set.
+- Imports (`@path`) improve organization but **do not reduce startup context** — the imported file
+  still loads in full. To keep something out of context, use a rule (`paths:`), a `reference/` doc,
+  or a skill instead.
+- Team-wide requirements belong in these committed files, **not** only in Claude's auto memory
+  (`~/.claude/projects/.../memory/`), which is machine-local and unshared.
+- **`Read`-deny rules are for build output, not dependencies.** `settings.json` denies
+  `Read(./**/dist/**)` so Claude edits `src/`, never the generated bundles the app consumes.
+  `node_modules/` is deliberately *not* denied — `.gitignore` already keeps it (and `dist/`) out of
+  search, and reading a dependency's source or `@types` is legitimate maintenance. Don't add deny
+  rules for gitignored paths just to keep them out of search; that's already handled. Note
+  `settings.json` loads only from the launch directory, so this deny applies on a root launch, not
+  when starting inside a package.
+
+### Validate a change
+
+- `git diff --check` (whitespace); confirm `settings.json` still parses as JSON.
+- Check every rule has `paths:` (an accidental unscoped rule loads in *every* session):
+  `grep -L "paths:" .claude/rules/*.md` should print nothing.
+- Confirm cross-references resolve (no pointer to a moved/renamed file):
+  `grep -rn "\.md" .claude CLAUDE.md`.
+- **Loading**: run `/memory` in a session to list what actually loaded; open a file in a package to
+  confirm the right rule attaches. Use the `InstructionsLoaded` hook only temporarily if you need to
+  debug lazy loading — don't commit a diagnostic hook.
+- **Skill triggering**: from the repo root, phrase a request the skill should catch ("review my
+  changes", "add an e2e test for X") and confirm it's offered; phrase a near-miss ("explain how
+  requests are persisted") and confirm it is *not* auto-invoked.
+
+### When to revisit
+
+Review this config after: Claude repeats the same project-specific mistake, a major repo
+restructuring (packages moved/renamed, build tooling changed), or a major Claude Code release that
+changes loading/skill behavior. Treat config edits like code — review them in PRs.

--- a/.claude/reference/architecture.md
+++ b/.claude/reference/architecture.md
@@ -1,0 +1,128 @@
+# Architecture, Data Model & Dependencies (reference)
+
+On-demand reference for the monorepo layout, the request pipeline, the sandbox, the core
+data-model types, and dependency versions. This file is **not** auto-loaded — read it before
+non-trivial cross-package or architectural work. The dependency DAG and ownership guardrails
+(the invariants Claude must not break) live in the auto-attached rule
+`.claude/rules/architecture.md`; the area-specific rules (`.claude/rules/electron-ipc.md`,
+`.claude/rules/redux-store.md`, `.claude/rules/dsl-changes.md`) go deeper. This file is the map.
+
+## Monorepo structure (npm workspaces)
+
+```
+packages/
+  bruno-app/          React renderer (rsbuild, Redux Toolkit, styled-components)   [name @usebruno/app]
+  bruno-electron/     Electron main process (electron-builder)                     [name "bruno" — NOT scoped]
+  bruno-js/           JS sandbox for user scripts (QuickJS + node:vm)
+  bruno-common/       Shared utilities — the base leaf (rollup → dist/cjs+esm)
+  bruno-converters/   Import/export (Postman, Insomnia, OpenAPI, …) (rollup)
+  bruno-requests/     Shared HTTP/gRPC/WS request building blocks (rollup)
+  bruno-filestore/    .bru/.yml serialization (rollup + tsc --emitDeclarationOnly)
+  bruno-query/        JSONPath-style query engine (rollup)
+  bruno-lang/         Bru DSL grammars — v1 (arcsecond, legacy) + v2 (ohm-js, current)
+  bruno-schema/       Yup runtime validation of collections/requests
+  bruno-schema-types/ TypeScript type definitions only (tsc, types-only)
+  bruno-graphql-docs/ GraphQL documentation generator (rollup)
+  bruno-toml/         Thin wrapper over @iarna/toml (orphaned — on no live data path)
+  bruno-cli/          Command-line runner (run straight from src/)
+  bruno-tests/        Test servers (express: HTTP/HTTPS/proxy/GraphQL)
+  bruno-docs/         @usebruno/docs — placeholder stub (only package.json + readme, no src/)
+tests/                Playwright e2e tests
+playwright/           Test fixtures and helpers (index.ts)
+```
+
+Build tool per package (matters for the "rebuild shared packages" step in `.claude/CLAUDE.md`):
+- **rollup** (emits `dist/cjs` + `dist/esm`): bruno-common, bruno-converters, bruno-requests,
+  bruno-query, bruno-graphql-docs; **bruno-filestore** additionally runs `tsc --emitDeclarationOnly`.
+- **tsc only**: bruno-schema-types.
+- **rsbuild**: bruno-app.
+- **no build step (consumed straight from `src/`)**: bruno-js, bruno-lang, bruno-schema,
+  bruno-toml, bruno-cli, bruno-electron, bruno-tests, bruno-docs.
+
+The 7 packages that must be rebuilt after editing (they emit `dist/`): bruno-common,
+bruno-requests, bruno-filestore, bruno-converters, bruno-query, bruno-graphql-docs,
+bruno-schema-types. Editing bruno-js / bruno-lang / bruno-schema / bruno-toml needs no rebuild.
+
+## Dependency direction & ownership boundaries
+
+The internal `@usebruno/*` dependency DAG and the guardrails that protect it (bruno-common
+browser-safe, bruno-js Electron-free, schema vs schema-types, no upward imports) are the
+auto-loaded rule — see `.claude/rules/architecture.md`.
+
+## Request execution pipeline
+
+1. Renderer invokes `ipcMain.handle('send-http-request', …)` (`bruno-electron/src/ipc/network/index.js`).
+2. Variables are interpolated via `interpolate` from `@usebruno/common`
+   (`ipc/network/interpolate-vars.js`).
+3. Pre-request scripts run via `ScriptRuntime` (`bruno-js/src/runtime/script-runtime.js`).
+4. The request is built/sent — axios for HTTP, plus gRPC (`@grpc/grpc-js`) and WebSocket clients;
+   shared building blocks (auth interceptors like `addDigestInterceptor`/`applyOAuth1ToRequest`,
+   cookies, `scripting.buildScriptedEntry`, grpc/ws helpers) come from `@usebruno/requests`.
+   bruno-requests is a *library of request pieces*, not the orchestrator — orchestration lives in
+   `ipc/network`.
+5. Post-response: **var extraction** via `VarsRuntime`, **tests** via `TestRuntime`, and
+   **assertions** via `AssertRuntime` (all in `bruno-js/src/runtime/`) — these are distinct
+   runtimes, not `ScriptRuntime`.
+6. Result is returned to the renderer as a data object with an `error` field on failure (the
+   handler does not reject — see `.claude/rules/electron-ipc.md` error convention).
+
+## Script sandboxing (`bruno-js`)
+
+- **QuickJS** (default / "safe" mode): WebAssembly sandbox via `quickjs-emscripten`
+  (`src/sandbox/quickjs/`).
+- **Node VM** ("developer" mode): `node:vm` `runInContext` (`src/sandbox/node-vm/`).
+- Runtime selection is centralized: `getJsSandboxRuntime` maps
+  `collection.securityConfig.jsSandboxMode` (`'safe'` default → `SANDBOX.QUICKJS`; `'developer'`
+  → `SANDBOX.NODEVM`) — see `bruno-js/src/utils/sandbox.js` and `ipc/network/index.js`. Route new
+  sandbox-mode logic through `getJsSandboxRuntime`; do not re-derive the mapping.
+- Scripts get a `bru`, `req`, `res` (post-response only), `test`, `expect` (chai), `assert`
+  (chai), and `console` context (`script-runtime.js`).
+
+## File format system
+
+- `bruno-filestore` is the central parse/serialize entry (`src/index.ts`), delegating to
+  `formats/bru` and `formats/yml`.
+- Two on-disk formats: **`.bru`** (Bru DSL) and **`.yml`** (OpenCollection YAML). New collections
+  default to **`.yml`** (`DEFAULT_COLLECTION_FORMAT = 'yml'`).
+- The current `.bru` grammar is **v2 (ohm-js)** (`bruno-lang/v2/src/`, used by filestore via
+  `bruToJsonV2`/`jsonToBruV2`). **v1 (arcsecond)** (`bruno-lang/v1/src/`) is legacy.
+- Collections live on the filesystem and are watched by chokidar.
+
+Any on-disk shape change → follow `.claude/rules/dsl-changes.md`.
+
+## Redux store (app side)
+
+The authoritative slice list is the `reducer` map in
+`bruno-app/src/providers/ReduxStore/index.js` (~11 slices; `collections/` is by far the largest).
+Conventions, middleware, and side-effect boundaries: `.claude/rules/redux-store.md`.
+
+## Providers (`bruno-app/src/providers/`)
+
+Read the directory for the current set: `App/`, `ReduxStore/`, `Theme/`, `Hotkeys/`, `Toaster/`,
+`PromptVariables/`.
+
+## Key types (`bruno-schema-types`)
+
+Core types live in `packages/bruno-schema-types/src/` — read them for the current shapes. The
+top-level request is a union: `Request = HttpRequest | GrpcRequest | WebSocketRequest`
+(`requests/index.ts`); code that handles "a request" must account for all three. Other central
+types: `Collection` (`collection/collection.ts`), `Item` (request or folder, discriminated by
+`type`, `collection/item.ts`), `Auth` (a `mode` union, `common/auth.ts`), `KeyValue` (headers /
+params / assertions, `common/key-value.ts`), `Environment`, `Script`.
+
+## Key dependencies (actual majors — verify in the relevant `package.json` before assuming)
+
+Several are pinned to majors below the latest — do **not** assume the newest API:
+
+- Frontend (`bruno-app`): **react 19**, **@reduxjs/toolkit ^1.8 (v1, NOT v2)**,
+  **react-redux ^7 (v7)**, **styled-components ^5 (NOT v6)**, **tailwindcss ^3**,
+  **@rsbuild/core ^1.1**, **codemirror 5.65.2 (CodeMirror 5, NOT the scoped `@codemirror/*`)**.
+- Desktop (`bruno-electron`): **electron ~37.6**, **electron-builder 24.13.3**, **chokidar ^3.5**,
+  **@grpc/grpc-js ^1.13**, **js-yaml ^4.1**, **electron-store ^8.1**. (`ws` is a dep of
+  bruno-requests/bruno-tests, **not** bruno-electron.)
+- Parsing (`bruno-lang`): **arcsecond ^5** (v1, legacy), **ohm-js ^16.6** (v2, current).
+  `bruno-toml` wraps **@iarna/toml** but is currently unused.
+- **Hard pins in root `package.json` `overrides`: axios `1.16.0`, rollup `3.30.0`.** Bumping these
+  in a leaf package has no effect — change the root override.
+- **TypeScript is not uniform**: bruno-common `^5.8`, bruno-schema-types `^5.0`, but
+  bruno-converters/filestore/graphql-docs/query/requests are `^4.8`. There is no root TS dep.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,41 @@
+---
+paths:
+  - "packages/**/*"
+---
+
+# Dependency Boundaries
+
+Internal `@usebruno/*` dependencies (from each `package.json`) form a strict DAG. **New code must
+respect it** — a cyclic or upward dependency is an architectural bug, not a convenience.
+
+The full monorepo map (build tools, request pipeline, sandbox, file formats, core data-model
+types, dependency versions) is the on-demand reference `.claude/reference/architecture.md` — read
+it before non-trivial cross-package or architectural work.
+
+## Dependency direction & ownership boundaries
+
+- **Leaf libs — zero internal `@usebruno/*` deps:** bruno-common, bruno-lang, bruno-query,
+  bruno-requests, bruno-graphql-docs, bruno-schema, bruno-schema-types, bruno-toml.
+- **Mid consumers:** bruno-js → (common, query); bruno-converters → (common, schema; schema-types
+  as devDep); bruno-filestore → (common, lang; schema-types as devDep).
+- **Top consumers (things flow *into* them, never out):** bruno-cli → (common, converters,
+  filestore, js, lang, requests); bruno-electron → (common, converters, filestore, js, lang,
+  requests, schema); bruno-app → (common, converters, graphql-docs, schema).
+
+Guardrails this enforces:
+
+1. **bruno-common is the browser-safe base leaf.** It runs in the web renderer (`bruno-app`), not
+   just Node, so it must stay platform-neutral: no Node built-ins (`fs`, `path`, `os`, `crypto`,
+   `child_process`, `node:*`) and no dependency that itself pulls in Node. It currently ships with
+   zero runtime dependencies — keep it that way. It also depends on no other `@usebruno/*` package;
+   a util that needs Node or another bruno package belongs in a different package.
+2. **No shared/library package may import bruno-app or bruno-electron.** Renderer- or
+   Electron-specific code must not be pushed down into a lib to make it importable upward.
+3. **bruno-js must stay Electron-free.** It runs in both the Electron main process *and* the CLI
+   (bruno-cli → js). Adding an `electron`/IPC import to bruno-js breaks the CLI. Sandbox logic
+   belongs in bruno-js; host wiring belongs in bruno-electron.
+4. **bruno-schema-types is types-only** (a *devDependency* of converters/filestore, built with
+   plain `tsc`). Import types from it; never add runtime code or a runtime import of it.
+5. **bruno-schema (Yup) and bruno-schema-types (TS types) are distinct and both live.** app +
+   converters use `@usebruno/schema` for runtime validation; filestore + converters use
+   `@usebruno/schema-types` for compile-time types. A data-model change usually touches both.

--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -1,0 +1,65 @@
+---
+paths:
+  - "packages/**/*"
+  - "tests/**/*"
+  - "scripts/**/*"
+---
+
+# Coding Conventions, Readability & Hygiene
+
+`CODING_STANDARDS.md` is the source of truth for Bruno's coding standards — read it. This file is
+the judgment layer over those standards: the readability and code-hygiene calls a linter can't make.
+Code and comments must read as a natural, permanent part of the project — never as artifacts of the
+task or session that produced them.
+
+## Style & formatting
+
+The mechanical style — 2-space indent, single quotes (double for JSX/TSX attributes), semicolons,
+no trailing commas, parenthesized arrow params, spacing around arrows, no space before call parens
+— is enforced by ESLint and auto-fixed by `npm run lint:fix`. These deviations are real but
+low-value to catch by hand: note them briefly rather than dwelling. Naming and casing that ESLint
+can't mechanically repair still warrant attention.
+
+## Readability
+
+- **Descriptive names.** Functions and variables carry concise, descriptive names; an unclear or
+  misleading name is worth raising even when the code is otherwise correct.
+- **Extraction & abstraction.** Extract a helper or shared abstraction whenever it genuinely
+  improves readability or serves a clear, anticipated reuse — this is encouraged and not gated on a
+  minimum number of call sites; suggest it where it would help. Avoid only *unnecessary* abstraction:
+  a layer that adds indirection without improving clarity or earning reuse — a generalized utility
+  built for a single site with no foreseeable second user, or options/config added "for later."
+  Breaking a long, complex function into well-named local helpers for readability is always fine.
+- **Single-line indirection.** A one-line function that only forwards to another — adding a stack
+  frame without adding meaning — should be inlined.
+- **Optional chaining.** `?.` belongs only where the null case is handled right there (a fallback,
+  early return, or guard). Used elsewhere it hides whether a value can genuinely be null and works
+  against TypeScript's guarantees; fix the type or narrow first.
+- **Comments explain the why.** Genuinely complex flow deserves a comment covering the rationale an
+  obvious reading can't; self-explanatory code does not. Full bar in **Comments** below.
+- **Functional, but readable.** Prefer obvious, linear pipelines over deep functional machinery
+  (ADTs, monads) — the code should stay easy for any contributor to follow and extend.
+
+## Comments
+
+- **No situational or prompt-driven comments.** A comment must not reference the change, the task, or
+  the moment it was written. Drop `// added to fix ...`, `// as requested`, `// new logic for X`,
+  `// updated to handle ...`, `// per review`. If the reason genuinely matters, state it as a
+  timeless fact about the code (or link the issue/PR) — not as "what I just did".
+- **No obvious comments.** Don't restate what the code already says. `// loop over items` above a
+  loop, `// set the name` above `obj.name = name`, `// return the result` — these add nothing. If the
+  code is self-explanatory, leave it uncommented.
+- **Comment the why, not the what.** Reserve comments for what the code can't show: non-obvious
+  rationale, invariants, edge cases, a workaround and the constraint forcing it, units, or a pointer
+  to a spec/issue. These stay useful long after the change lands.
+- **No scaffolding or narration.** No `// ... existing code ...`, no placeholder or TODO-for-me
+  notes, no changelog or step-by-step narration in comments, no commented-out code left behind.
+
+## Beyond comments
+
+- Don't add speculative options, parameters, or configuration "for later" that nothing in the change
+  uses — build for the actual need. Extracting a helper for readability or clear, foreseeable reuse is
+  fine (see **Readability → Extraction & abstraction** above).
+- Match the surrounding code's style and naming so a change is indistinguishable from the existing
+  codebase, not visibly bolted on.
+- Keep diffs minimal — no unrelated reformatting or whitespace churn.

--- a/.claude/rules/cross-platform.md
+++ b/.claude/rules/cross-platform.md
@@ -1,0 +1,46 @@
+---
+paths:
+  - "scripts/**/*"
+  - "packages/bruno-electron/**/*"
+---
+
+# Cross-Platform Guidelines
+
+This is an Electron app targeting macOS, Windows, and Linux. All code touching the filesystem, child processes, signals, or paths must work on all three platforms.
+
+## Filesystem
+
+- `fs.rmSync` with `force: true` only suppresses `ENOENT`, NOT `EPERM`/`EBUSY`. Windows locks files aggressively (antivirus, indexing, open handles). Always use `maxRetries` and `retryDelay` when deleting directories.
+- Use `path.join()` / `path.resolve()` for all paths — never hardcode `/` separators.
+- Windows paths are case-insensitive. Use `normalizePath()` (from `utils/common/path`) when comparing collection/workspace paths.
+- `app.getPath()` returns platform-specific directories (`userData`, `documents`, etc.). Never assume POSIX-style locations.
+- File watchers (chokidar) may emit different event orderings across platforms. Don't depend on specific add/change/unlink sequences.
+
+## Child Processes
+
+- `spawn('npm', [...])` requires `shell: true` on Windows because `npm` is `npm.cmd`.
+- `child.kill()` with `shell: true` only kills the shell wrapper (`cmd.exe`) on Windows, leaving orphaned children. Use `taskkill /pid <pid> /T /F` to kill the entire process tree on Windows.
+- `execSync` / `spawn` commands must avoid Unix-only syntax (`&&` chains work in cmd.exe, but pipes and redirects differ).
+
+## Signals & Shutdown
+
+- `SIGINT` / `SIGTERM` are unreliable on Windows with `shell: true`. Also handle `SIGHUP` as fallback.
+- App shutdown must close all file watchers. Each watcher class implements `closeAllWatchers()`, orchestrated by `closeAllWatchers()` in `index.js`.
+
+## Line Endings
+
+- Files authored on Windows use CRLF. When parsing multiline `.bru`/text blocks line by line, split with a CRLF-aware regex (`/\r\n|\r|\n/`), never on `\n` alone — a trailing `\r` otherwise leaks into parsed values and causes spurious dirty-state and diffs. the `.split(/\r\n|\r|\n/)` in `bruno-lang`'s `v2/src/envToJson.js` is the reference pattern; keep new parsers consistent with it.
+
+## stdout vs stderr
+
+- Dev tools (rsbuild, webpack, electron-builder) may route startup output to stderr on Windows. When detecting patterns in process output, check both streams.
+
+## Platform-Specific Dependencies
+
+- `forceInstallPlatformDeps()` in `scripts/setup.js` installs platform-specific native modules (e.g., `@lydell/node-pty-{platform}-{arch}`).
+- Electron builder config handles platform-specific packaging (`mac`/`win`/`linux` targets).
+
+## Path Separators in Collection/Workspace Stores
+
+- electron-store persists paths as-is. A workspace opened on macOS stores `/Users/...`, on Windows `C:\Users\...`.
+- `ELECTRON_USER_DATA_PATH` only applies when `isDev` is true (`index.js:22`).

--- a/.claude/rules/dsl-changes.md
+++ b/.claude/rules/dsl-changes.md
@@ -1,0 +1,174 @@
+---
+paths:
+  - "packages/bruno-app/**"
+  - "packages/bruno-electron/**"
+  - "packages/bruno-cli/**"
+  - "packages/bruno-lang/**"
+  - "packages/bruno-filestore/**"
+  - "packages/bruno-schema/**"
+  - "packages/bruno-schema-types/**"
+  - "packages/bruno-converters/**"
+---
+
+# On-Disk DSL & Serialization Changes
+
+Bruno persists everything users create — collections, requests, environments, folders, and
+config — as plain-text files on the user's disk and in their Git repos. Two on-disk formats
+exist:
+
+- **`.bru`** — the Bru DSL. Read/write goes through the **v2 (ohm-js)** grammar in
+  `packages/bruno-lang/v2/src`, via `packages/bruno-filestore/src/formats/bru`
+  (`bruToJsonV2` / `jsonToBruV2`). Make all `.bru` changes in v2.
+- **`.yml`** — OpenCollection YAML, handled by `packages/bruno-filestore/src/formats/yml`. This is
+  the current `DEFAULT_COLLECTION_FORMAT` (canonical: `packages/bruno-filestore/src/constants.ts`,
+  duplicated for the renderer in `packages/bruno-app/src/utils/common/constants.js`), so new
+  collections are `.yml` unless the user chooses otherwise.
+- Plus `bruno.json` (per-collection config, passed through `stringifyCollection`) and `.env` files
+  (`parseDotEnv` / `dotenvToJson`).
+
+(`packages/bruno-toml` exists but is **orphaned** — imported nowhere outside its own test and on no
+serialization path; a DSL change never needs it. `preferences.json` is app-level electron-store
+state under `userData`, not part of a collection's on-disk contract, so it is out of scope here.)
+
+These files outlive the version that wrote them: an older Bruno reads files written by a
+newer one, teammates on different versions share the same repo, and users hand-commit these
+files. **A change to the on-disk shape is a change to a public contract.** Get it wrong and
+you break parsing, corrupt collections, or silently drop user data — on collections you
+can't reach to fix.
+
+The in-memory objects that become these files are often assembled far from the serialization
+layer — in `bruno-electron` (IPC handlers) or `bruno-app` (Redux) — and handed to
+`bruno-filestore`, which can't tell that a field's shape changed upstream. So a DSL-affecting
+change can originate in *any* package on the data path, not just the format packages. Treat
+this rule as in scope for changes anywhere the collection/request/environment/config object
+is built, mutated, or serialized — the serialization packages plus `bruno-app`,
+`bruno-electron`, and `bruno-cli`, where these objects are assembled or read/written. Adding a
+persisted field in app/electron without wiring it through `bruno-filestore` (both formats) and
+`bruno-schema` silently drops or rejects data on save — the exact bug this rule guards against.
+
+## Rules
+
+**Avoid unnecessary DSL changes.** First ask whether the need can be met in memory, in the
+UI, or as a derived value without touching the serialized shape at all — most enhancements
+can. Only change the on-disk format when the data genuinely must persist.
+
+**Additive and optional only.** A new field must be optional with a safe default, so files
+without it still parse and behave. Never rename, remove, repurpose, or retype an existing
+field, and never change its semantics — old files and old app versions depend on the
+current meaning.
+
+**Round-trip must be lossless.** `parse(stringify(x))` must equal `x`, and `stringify` must
+never drop fields it doesn't recognize. A file written by a newer version, opened and
+re-saved by an older one, must not lose the newer fields.
+
+**Prove escaping on the written bytes, not in memory.** When a value is embedded in a
+delimited block (`.bru` multiline `'''…'''`, annotation args), an in-memory `escape`/`unescape`
+round-trip can pass while the on-disk file still corrupts — the parser terminates at the first
+re-introduced delimiter. Test `parse(read(serialize(x)))` on the actual bytes, and fuzz across
+quote/backslash runs. Escape at single-character granularity: escaping a multi-character
+delimiter by splitting on the whole delimiter (`split("'''")`) leaves fragments that recombine
+on runs of length ≥ the delimiter; escape the backslash first, then every single delimiter char.
+Ref: `escapeMultilineDescription` in `bruno-lang/v2/src/utils.js`.
+
+**New syntax breaks older parsers — not just older fields.** The additive-and-optional rule
+protects field-level compat, but adding new `.bru` *syntax* (a new escape form, block delimiter,
+or annotation grammar) makes files written by the new version fail to *parse* in older versions,
+which have no handling for it. This is a forward-compat break beyond field loss; it needs an
+explicit decision and a compatibility path before shipping.
+
+**Descriptions are string-only internally.** Every inline `description` field (headers, params,
+assertions, variables, body entries, ...) is stored as a plain `string`. On the **yml** side,
+parsers accept a bare string *or* a legacy `{ content }` object on read and normalize to the
+string (`formats/yml/common/{headers,variables,assertions,actions}.ts`, `parseEnvironment.ts`,
+`body.ts`); writers emit a bare string. This read-accepts-object / write-emits-string asymmetry is
+an established convention — not a lossy round-trip — proven by `formats/yml/common/variables.spec.ts`.
+The `.bru` side has no `{ content }` handling; it stores descriptions as annotation/textblock
+strings straight from the grammar. New inline description-like fields should follow this
+string-only shape.
+
+*Exception — `docs` is not string-only.* Collection/folder documentation (`docs`) is written by
+the **yml** layer as an **object** `{ content, type: 'text/markdown' }`
+(`formats/yml/stringifyCollection.ts`, `stringifyFolder.ts`) and normalized back to a string on
+read; the `.bru` side writes it as a plain textblock. So "follow the string-only shape" applies to
+inline `description`, *not* to `docs`-style documentation fields — check which family a new field
+belongs to before copying either pattern.
+
+**Keep both formats in lockstep.** Any field added or changed must be handled in *both*
+`bru` and `yml` — parse and stringify on each side — or the same collection behaves
+differently depending on its format. There is **no dedicated `bru`↔`yml` converter**: a request
+moves between formats by being parsed in its source format to the shared in-memory object and
+re-stringified in the target format (see `SaveTransientRequest` passing `sourceFormat` +
+`targetFormat` to `renderer:save-transient-request`). So a field handled in only one format is
+**silently dropped** the moment a request is copied/saved from a `.bru` collection into a `.yml`
+one (or vice-versa). Pay attention to the *unset* case: a field that defaults or persists one way
+in `.bru` and another in `.yml` (e.g. one path returns `''`, the other `'1'`) is a divergence bug.
+The default app-data workspace and custom-filesystem workspaces are a second such twin — a value
+that persists in one but is silently dropped in the other is the same class of bug. Update every
+layer the field touches: `bruno-schema-types` (types), `bruno-schema` (Yup validation),
+`bruno-filestore` (both formats), `bruno-converters` (import/export), and the grammar in
+`bruno-lang` **v2** if `.bru` syntax itself changes.
+
+**`bruno-schema` (Yup) is not optional — it will reject your field.** The collection/request/
+environment Yup schemas are declared `.noUnknown(true).strict()`, and they are validated on the
+**save path** (e.g. `itemSchema.validate` / `environmentSchema.validateSync` in
+`bruno-app`'s `slices/collections/actions.js` and `bruno-electron`'s `store/global-environments.js`).
+A new serialized field that round-trips through filestore but is **not** added to
+`packages/bruno-schema` will throw a validation error on save. `bruno-schema` (runtime Yup) and
+`bruno-schema-types` (TS types) are distinct and both must be updated.
+
+**When a shape must change, migrate on read — never make users edit files.** Add a
+read-time compatibility shim that upgrades the old shape as it is parsed, following the
+existing patterns: `ensureAuthV3Rc1BackwardsCompatibility` in `formats/yml/parseItem.ts`,
+and the pre-v3 status/statusText swap in `formats/bru/index.ts`. Gate any eventual removal
+behind a major version bump and leave a dated `TODO(remove after vN)`.
+
+**Design for scale and consistency.** New keys follow the naming and nesting of the existing
+`meta`/section blocks (`meta.name`, `meta.seq`, `meta.type`, `meta.tags`, ...). Prefer
+structures that extend cleanly — a keyed list over a positional one, an object over a
+widening union — and match how neighbouring fields are already modelled. Note the on-disk
+`meta {}` block does **not** map 1:1 to the type: in `bruno-schema-types` those keys are flattened
+onto `Item` (`seq`, `name`, `type`, `tags`, `description` directly on the item), and the v2 ohm
+grammar treats `meta` as an open dictionary — the four names above are the *modeled* ones, not a
+closed set.
+
+**Name properties like they're permanent — because they are.** A DSL key is written once and
+effectively forever: renaming it breaks every existing file and forces a compat shim. These
+names are also user-facing — people read and hand-edit `.bru`/`.yml` — and are read by AI
+agents reasoning over collections. Choose clear, descriptive, fully spelled-out names, with
+no cryptic abbreviations or ambiguity, consistent with existing keys, and get it right the
+first time. A property name deserves stricter scrutiny than an ordinary variable.
+
+**Test the contract.** Add round-trip tests (parse → stringify → parse) for the new field in
+*both* formats, plus a golden fixture of the *old* format that must still parse unchanged. The
+paired `parseItem.spec.ts` / `stringifyItem.spec.ts` (and `parse*`/`stringify*` for collection,
+folder, environment) next to each serializer in `bruno-filestore/src/formats/yml` are the pattern;
+`common/variables.spec.ts` and `common/datatype.spec.ts` show field-level cases.
+
+## A new persisted field — the files it usually touches
+
+Adding a single field tends to span several packages (a `.bru`-centric change lands mostly in
+`bruno-lang/v2`):
+
+- `bruno-lang/v2/src` — the `.bru` entry points: `bruToJson.js`, `collectionBruToJson.js`,
+  `envToJson.js`, `jsonToBru.js`, `jsonToCollectionBru.js`, `jsonToEnv.js`, plus `utils.js` for
+  shared helpers.
+- `bruno-filestore/src/formats/yml` — parse **and** stringify for the `.yml` side.
+- `bruno-schema/src/collections/index.js` — the Yup schema (skip this and it fails on save).
+- `bruno-schema-types/src/collection/item.ts` — the TypeScript type.
+- `bruno-converters`, and the collection utils in `bruno-electron` / `bruno-app` that build the object.
+- Round-trip specs next to the serializers (`formats/yml/parseItem.spec.ts` + `stringifyItem.spec.ts`).
+
+Find a comparable field already in the code and follow how it's wired before adding yours.
+
+## Before changing the DSL — checklist
+
+- [ ] Change is genuinely necessary (can't be solved in memory / UI)
+- [ ] New field is optional with a safe default; nothing renamed, removed, or retyped
+- [ ] Handled in both `bru` and `yml`, parse **and** stringify
+- [ ] Types (`bruno-schema-types`), Yup schema (`bruno-schema`), and converters updated
+- [ ] Old files still parse — read-time compat shim added if the shape changed
+- [ ] No new `.bru` syntax that older parsers can't read (or a forward-compat path decided)
+- [ ] Any new escaping proven via on-disk reparse + fuzz, escaping single chars not the delimiter
+- [ ] `bru`/`yml` (and default vs custom workspace) behave identically, including the unset case
+- [ ] Round-trip + old-format fixture tests added
+- [ ] Naming/structure consistent with existing blocks and scalable

--- a/.claude/rules/electron-ipc.md
+++ b/.claude/rules/electron-ipc.md
@@ -1,0 +1,191 @@
+---
+paths:
+  - "packages/bruno-electron/**/*"
+---
+
+# Electron Main Process Guide
+
+The main process (`packages/bruno-electron/src/index.js`) owns the filesystem, network, child
+processes, and all electron-store data. The renderer reaches it **only** over IPC through the
+preload bridge — there is no direct Node access in the renderer despite `nodeIntegration: true`
+(see Security below). Before adding or changing any IPC, read this file plus the target
+`src/ipc/<domain>.js` handler.
+
+## Preload bridge & renderer access
+
+`src/preload.js` is the *only* surface the renderer sees. It exposes, via
+`contextBridge.exposeInMainWorld('ipcRenderer', …)`, exactly:
+
+- `invoke(channel, ...args)` → `ipcRenderer.invoke` (renderer→main request/response)
+- `send(channel, ...args)` → `ipcRenderer.send` (fire-and-forget)
+- `on(channel, handler)` → subscribe; **returns an unsubscribe function** and **strips the
+  Electron `event`/`sender` arg** — renderer handlers receive `(...args)`, not `(event, ...args)`
+- `getFilePath(file)` (via `webUtils.getPathForFile`) and `openExternal(url)` (via `shell.openExternal`)
+
+Also exposed: `window.isPlaywright` (`process.env.PLAYWRIGHT === 'true'`).
+
+Renderer code accesses this as `window.ipcRenderer` (e.g. `const { ipcRenderer } = window;` in
+`bruno-app/src/providers/App/useIpcEvents.js`). **There is no channel allowlist** — any channel
+string is forwarded. Do not rely on the preload to gate channels; validate inputs inside the
+handler.
+
+## Channel naming convention
+
+Follow the prefix that matches the direction — the vast majority of handlers already do:
+
+- **`renderer:*`** — renderer→main via `ipcMain.handle` (the default for new work; ~255 of ~290
+  handlers). e.g. `renderer:ready`, `renderer:save-request`, `renderer:create-workspace`,
+  `renderer:browse-directory`, `renderer:get-global-environments`.
+- **`main:*`** — main→renderer push via `webContents.send`. e.g. `main:load-preferences`,
+  `main:collection-opened`, `main:workspace-opened`, `main:collection-tree-updated`,
+  `main:display-error`, `main:app-loaded`. A few `main:*` names are *internal* main-process
+  events routed through `ipcMain.emit`/`ipcMain.on` (`main:renderer-ready`,
+  `main:workspaces-ready`) — see the startup sequence.
+- **Domain-namespaced invokes** for stateful sub-protocols: `grpc:*`, `renderer:ws:*` (WebSocket),
+  `terminal:*`, `menu:*` (menu→main), `internal:*` (main-to-main only).
+- **Legacy unprefixed network channels** — `send-http-request`, `cancel-http-request`,
+  `fetch-gql-schema`, `clear-oauth2-cache`, `connections-changed`. These predate the convention;
+  prefer a `renderer:*` name for new request-side channels rather than adding to this unprefixed set.
+
+## Handler registration
+
+All handlers are registered inside `app.on('ready')` in `index.js` (the `// register all ipc
+handlers` block) by calling per-domain `register*Ipc(mainWindow, …)` functions, each `require`d
+at the top of `index.js`. `registerPreferencesIpc` (which kicks off onboarding + the
+`renderer:ready` handler) runs *before* `registerWorkspaceIpc` (which owns `main:renderer-ready`);
+this is safe because `renderer:ready` only fires after the renderer mounts, by which point every
+handler is registered. **A new IPC domain must add its own `register*Ipc` call here** — a handler
+file that is never `require`d + called registers nothing.
+
+## Where new handler code goes — keep it small and testable
+
+**Don't let a handler file keep growing to where its size hurts readability and maintainability.**
+When a group of handlers forms a separable feature, give it its own `ipc/<domain>.js` with its own
+`register*Ipc` (wired into `index.js` as above) rather than appending to an existing large file —
+separate it whenever it makes sense. Splitting by domain is already the norm here (`apiSpec.js`,
+`workspace.js`, `mount.js`, …).
+
+**Structure a handler so its callback is unit-testable.** Write the logic as a named, exported
+function and let the thin `ipcMain.handle(channel, fn)` line just call it — not an inline anonymous
+arrow, which can only be exercised through Electron. The exported callback can then be tested
+without spinning up the main process: see `ipc/swagger-fetch.js` (`proxySwaggerFetch`) and the
+specs under `ipc/network/` and `ipc/ai/`.
+
+## Error-handling convention
+
+Two patterns by handler type — match the one that fits:
+
+- **CRUD / lifecycle handlers throw or reject.** Validation failures use bare
+  `throw new Error(...)`; caught errors are re-surfaced with `return Promise.reject(error)` or
+  `throw error`. The renderer `invoke` promise rejects and is shown via a `main:display-error`
+  toast (`useIpcEvents.js`). A few read-only probes intentionally swallow and return a fallback
+  (e.g. `exists-sync` → `false`, `get-collection-workspaces` → `[]`).
+- **Request-execution handlers embed the error in the result.** `send-http-request`
+  (`ipc/network/index.js`) does **not** reject on a failed request/script/test — it returns a
+  result object carrying an `error` field so the renderer can render the failure as data. New
+  network handlers follow this embed-in-result shape; new CRUD handlers throw/reject.
+
+## Security constraints
+
+`BrowserWindow` `webPreferences` (in `index.js`): `nodeIntegration: true`,
+`contextIsolation: true`, `preload: preload.js`, `webviewTag: true`. **This `nodeIntegration:
+true` + `contextIsolation: true` combination is intentional — do not "fix" it.** No `sandbox`
+key (defaults off); `webSecurity` defaults on. A CSP is set via `electron-util`'s
+`setContentSecurityPolicy` in `index.js` (`default-src 'self'`; `connect-src` adds PostHog;
+`script-src 'self' data:`; `img-src` allows http/https/blob/data). `form-action 'none'` is
+deliberately commented out to keep OAuth2 working. External navigation is hardened via
+`will-redirect` + `setWindowOpenHandler`, which route http/https to `shell.openExternal` and deny
+everything else — preserve this when touching window/navigation code.
+
+## IPC startup sequence
+
+```
+renderer mounts
+  -> useEffect: ipcRenderer.invoke('renderer:ready')    [useIpcEvents.js]
+     -> main handles 'renderer:ready'                    [ipc/preferences.js]
+          await onboardingPromise
+          send main:load-preferences
+          send main:load-global-environments (+ main:git-version, reopen last apispecs, ...)
+          ipcMain.emit('main:renderer-ready')
+            -> workspace.js listener:                     [ipc/workspace.js]
+                 await ensureDefaultWorkspaceExists()
+                 send main:workspace-opened (per workspace)
+                 send + ipcMain.emit('main:workspaces-ready')
+                   -> onboarding.js sends main:collection-opened  [app/onboarding.js]
+
+did-finish-load (independent, from Chromium):                     [index.js]
+  -> wraps webContents.send with a safeStringify/safeParse JSON roundtrip
+  -> send main:app-loaded
+     -> renderer sink sets data-app-state="loaded"        [pages/Bruno/index.js, NOT useIpcEvents.js]
+```
+
+## IPC race-condition pattern
+
+When `ipcMain.emit` triggers multiple `ipcMain.on` listeners:
+- Sync listeners complete fully before the next starts.
+- Async listeners yield at the first `await`, letting the next listener start.
+- `webContents.send` from earlier listeners can arrive at the renderer before messages from
+  later async continuations.
+
+Fix: chained events (`main:renderer-ready` → `main:workspaces-ready` → deferred
+`main:collection-opened`) enforce ordering. Reuse this pattern rather than adding `setTimeout`s.
+
+## Persistent stores (`src/store/`, electron-store)
+
+Stores are electron-store JSON files under `app.getPath('userData')`, one module per file —
+**read the directory for the current set** (it is large: preferences, cookies, oauth2,
+collection-security, secrets, workspace/global environments, last-opened-*, window-state, …).
+Gotcha: multiple modules can share the *same* JSON file. `lastOpenedCollections` lives in
+`preferences.json` but is owned by `store/last-opened-collections.js` (a distinct
+`new Store({ name: 'preferences' })` module), **not** by `store/preferences.js`. Don't assume a
+store key belongs to the module named after the file.
+
+## File watchers (`src/app/`)
+
+Watchers live in `src/app/` — **read the directory for the current set** (`collection-watcher.js`,
+`workspace-watcher.js`, `apiSpecsWatcher.js`, `dotenv-watcher.js`). Cleanup is
+**not** uniform:
+- `closeAllWatchers()` in `index.js` tears down exactly three —
+  `collectionWatcher`, `workspaceWatcher`, `apiSpecWatcher` — each of which exposes
+  its own `closeAllWatchers()`.
+- `dotenv-watcher.js` is a shared singleton exposing `closeAll()` and is torn down transitively by
+  the workspace watcher (and driven by the collection watcher), **not** from `index.js`.
+
+When adding a watcher, decide which lifecycle it belongs to and register its cleanup in the
+matching place — a top-level watcher goes into `closeAllWatchers()` in `index.js`; a
+per-workspace/per-collection one hangs off the owning watcher.
+
+## Onboarding flow
+
+Entry: `src/app/onboarding.js` (`onboardUser`), invoked synchronously when `registerPreferencesIpc`
+runs.
+
+1. Checks `preferencesUtil.hasLaunchedBefore()`.
+2. New users: imports the sample collection from `resources/data/sample-collection.json`.
+3. Defers `main:collection-opened` (via a pending-collection var) until `main:workspaces-ready`.
+4. `DISABLE_SAMPLE_COLLECTION_IMPORT === 'true'` skips the import (set in Playwright).
+
+## Key environment variables
+
+- `ELECTRON_USER_DATA_PATH` — custom userData path, **dev mode only** (`index.js:22`, guarded by `isDev`).
+- `DISABLE_SAMPLE_COLLECTION_IMPORT` — skip sample collection on first launch.
+- `PLAYWRIGHT` — signals the app is running under Playwright (read in `preload.js`, stores, etc.).
+- `DISABLE_SINGLE_INSTANCE` — allow multiple app instances.
+
+(All four are set to `'true'` for e2e in `playwright/index.ts`.)
+
+## Before adding or changing an IPC handler — checklist
+
+- [ ] Handler added in `src/ipc/<domain>.js` as `ipcMain.handle('renderer:<verb>', …)` (or the
+      matching domain prefix); no new unprefixed channel.
+- [ ] New handler lives in a focused `ipc/<domain>.js` — a separable feature gets its own file
+      rather than bloating an existing one; its callback is a named exported function
+      (unit-testable), not an inline arrow.
+- [ ] If it's a new domain, its `register*Ipc(mainWindow, …)` is called in `index.js`'s ready block.
+- [ ] Inputs validated inside the handler (the preload has no allowlist).
+- [ ] Error path matches the handler type — CRUD throws/rejects; request-execution embeds `error`
+      in the result.
+- [ ] For a `main:*` push channel, the renderer adds a listener **and** an unsubscribe in
+      `useIpcEvents.js`'s cleanup.
+- [ ] Cross-process values survive the `did-finish-load` JSON roundtrip (no functions,
+      class instances, or circular refs in payloads).

--- a/.claude/rules/redux-store.md
+++ b/.claude/rules/redux-store.md
@@ -1,0 +1,140 @@
+---
+paths:
+  - "packages/bruno-app/**/*"
+---
+
+# React / Redux Architecture
+
+## Store configuration
+
+`configureStore` (Redux Toolkit **v1.8**, not v2) is set up in
+`src/providers/ReduxStore/index.js`. That file's `reducer` map is the **authoritative slice list**
+(~11 keys); read it rather than trusting any list here. Middleware is
+`getDefaultMiddleware().concat([...])` with **no options passed**, so RTK's defaults —
+`thunk`, plus `serializableCheck` and `immutableCheck` in dev — are all active.
+
+**Consequences to respect:**
+- **State must stay serializable.** Don't put functions, class instances, Promises, or DOM nodes
+  in the store — dev `serializableCheck` will flag them. Do **not** disable `serializableCheck` in
+  the real store to work around it (the only place it's disabled is a middleware unit test).
+- **Reducers mutate the Immer draft directly.** `createSlice` reducers write
+  `state.collections.push(...)`, `item.name = ...`, `.splice(...)` — do **not** spread-clone or
+  return new objects unless replacing wholesale. Match the surrounding reducer.
+
+## Slice organization
+
+Slices live in `src/providers/ReduxStore/slices/`, one domain each; `collections/` is by far the
+largest (collection tree, requests, environments, runner, drafts — ~200 reducer action creators in
+`collections/index.js`, plus ~150 thunks in `collections/actions.js`, and more spread in from
+`collections/exampleReducers.js`). Read the specific slice for its real state and actions.
+
+Two gotchas:
+- **Reducer key ≠ folder/file name.** e.g. `globalEnvironments` comes from
+  `slices/global-environments.js`; `openapiSync` from `slices/openapi-sync.js`.
+- **Action-type prefix follows the slice's `name:`, not the reducer key.** e.g.
+  `global-environments/…`, `collections/…`, `app/…`. Grep the action type, not the key, when
+  tracing dispatches.
+
+## Actions / thunks convention
+
+Async logic is written as plain hand-written thunks — a function that returns
+`(dispatch, getState) => …`. `createAsyncThunk` isn't used anywhere today:
+
+```javascript
+export const saveRequest = (itemUid, collectionUid) => (dispatch, getState) => { ... };
+// or async
+export const openCollectionEvent = (uid, pathname, ...) => async (dispatch, getState) => { ... };
+```
+
+Thunks live in the slice's `actions.js` (`slices/collections/actions.js` is the big one:
+`sendRequest`, `saveRequest`, `importCollection`, `pasteItem`, `deleteItem`, `openCollectionEvent`
+— the last handles the `main:collection-opened` IPC). Reducers (in the slice's `index.js`) stay
+synchronous. Follow the plain-thunk shape by default so new code matches the rest — but this is a
+convention, not a blocker: if a feature genuinely benefits from `createAsyncThunk` (e.g. its
+built-in pending/fulfilled/rejected states), it's fine to reach for it deliberately.
+
+## Side-effect boundaries
+
+- **Reducers are pure** — no IPC, no network, no `Date.now`/random, no async. Immer draft
+  mutations only.
+- **Side effects live in thunks and middleware.** IPC is invoked from thunks via
+  `window.ipcRenderer` (e.g. `saveRequest` → `ipcRenderer.invoke('renderer:save-request', …)`); the
+  `collections/actions.js` file alone has ~200 `ipcRenderer` calls.
+- **The file-IO → open-tab pattern** is split across a thunk and the `tasks` middleware: a thunk
+  queues an `OPEN_REQUEST`/`OPEN_EXAMPLE` task (`insertTaskIntoQueue`) and fires the IPC write; the
+  `tasks` middleware watches for the resulting `main:*` file event, then dispatches `addTab` +
+  `removeTaskFromQueue`. Reuse this queue rather than opening the tab optimistically.
+
+## Custom middleware (`middlewares/`)
+
+Five middlewares, registered in `index.js` (read the directory + registration array for the live
+set):
+- **`tasks`** — listener middleware; opens a request/example tab after the file event for a queued
+  task arrives (see file-IO pattern above).
+- **`draft`** — on the first edit action, promotes a *preview* tab to permanent
+  (`handleMakeTabParmanent`). It does **not** write draft state — the reducers do.
+- **`autosave`** — debounced by `preferences.autoSave.interval`, gated on
+  `app.preferences.autoSave.enabled`; dispatches the `save*` thunks.
+- **`snapshot`** — debounced (~1s), gated on `app.snapshotReady`; persists a curated state subset
+  to disk (see Persistence).
+- **`debug`** (dev only) — logs every action; added only when `import.meta.env.MODE ===
+  'development'`.
+
+## Persistence / serialization constraints
+
+The store isn't persisted wholesale, and there's no `redux-persist`. Instead the `snapshot`
+middleware serializes a **curated subset** — workspaces, collection metadata, per-collection tabs,
+selected environments, and devtools console open-state (`extras.devTools`, from the `logs` slice;
+see `middlewares/snapshot/serializeSnapshot.js`) — and writes it to disk via IPC. Request/response
+bodies are deliberately not persisted. To persist a new piece of state, extend `serializeSnapshot`
+and its save-trigger list (`utils/snapshot`) — the snapshot is the established mechanism, so prefer
+it over adding `redux-persist` or `localStorage`.
+
+## Selectors
+
+Inline `useSelector` in components is the norm (hundreds of usages); memoized `createSelector` is
+used in just one place (`src/selectors/tab.js`). Default to inline
+`useSelector`, and reach for `createSelector` when a derivation is genuinely expensive or reused.
+
+## What belongs in Redux (and what doesn't)
+
+- **In Redux:** draft / unsaved state (`item.draft`, `collection.draft`, `environmentsDraft`,
+  `globalEnvironmentDraft`), and cross-component or persisted UI state (`sidebarCollapsed`,
+  `leftSidebarWidth`, `taskQueue`, `item.collapsed`, active tab).
+- **Local `useState`:** ephemeral, component-scoped UI — search text, inline-create toggles, hover,
+  transient form state. Don't lift these into a slice.
+
+## Sidebar collection visibility
+
+Collections render in the sidebar only when they belong to the **active workspace**.
+`Sidebar/Collections/index.js` builds the list in a `useMemo` that walks
+`activeWorkspace.collections`, matches loaded collections through a `Map` keyed on
+`normalizePath(pathname)`, **excludes scratch collections** (`isScratchCollection`), adds "ghost"
+git-remote rows (`GitRemoteCollectionRow`) for non-default workspaces, and sorts alphabetically.
+Read the current `useMemo` before changing this. Collapsed folders do **not** render their children
+in the DOM (conditional render on `item.collapsed`).
+
+## Sidebar DOM structure (for Playwright)
+
+`.collection-item-name` is the class on the **row-wrapper** div for every item (folders, requests,
+JS files) in `Sidebar/Collections/Collection/CollectionItem/index.js` — the wrapper also contains
+the name span and `.menu-icon`. Use it for Playwright locators.
+
+## Providers (`src/providers/`)
+
+Read the directory for the current set: `App/` (IPC listeners in `useIpcEvents.js`, app init),
+`ReduxStore/`, `Theme/`, `Hotkeys/`, `Toaster/`, `PromptVariables/`.
+
+## Checks after changing a slice / middleware
+
+Slices and middleware have Jest coverage under `src/providers/ReduxStore/` (e.g.
+`slices/collections/*.spec.js`, `slices/global-environments.spec.js`,
+`middlewares/snapshot/serializeSnapshot.spec.js`). After a change, run the relevant spec:
+
+```bash
+npm test --workspace=packages/bruno-app -- <path-or-pattern>
+```
+
+If you touch the reducer map, thunks that fire IPC, or the snapshot subset, also sanity-check that
+state stays serializable (no dev `serializableCheck` warnings) and that persisted shape still
+round-trips through `serializeSnapshot`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,95 @@
+---
+paths:
+  - "tests/**/*"
+  - "playwright/**/*"
+  - "playwright.config.ts"
+---
+
+# Playwright E2E Testing Guide
+
+> **Reference:** For the full narrative guide — test structure, the page-module locator/action pattern, and worked examples — see [`docs/playwright-testing-guide.md`](../../docs/playwright-testing-guide.md). This file is the terse, path-scoped quick reference; the guide is the canonical source for conventions.
+
+## Running Tests
+
+```bash
+npm run test:e2e                           # default + system-pac projects (starts dev servers automatically)
+npx playwright test tests/request/         # Run specific directory
+npx playwright test --project=default      # Run specific project
+npx playwright test --headed               # Watch mode
+```
+
+Projects: `default` (main), `system-pac` (depends on `default`), `auth`, `ssl`.
+`npm run test:e2e` runs `default` + `system-pac`; the rest have their own
+`test:e2e:*` scripts. Config: `playwright.config.ts` — `fullyParallel: true`, `workers` unset
+(Playwright default, not single-worker), retries 0 local / 2 CI.
+
+## Test Fixtures (playwright/index.ts)
+
+See `playwright/index.ts` for the current set; the table covers the common ones.
+
+| Fixture | Scope | Purpose |
+|---------|-------|---------|
+| `page` | test | Default page from `electronApp` |
+| `electronApp` | worker | Default Electron launch (skips onboarding) |
+| `launchElectronApp(opts)` | worker | Custom launch with userData, env, init data |
+| `reuseOrLaunchElectronApp(opts)` | worker | Caches app instances by key |
+| `pageWithUserData` | test | Loads `init-user-data/` from test dir, waits for app ready |
+| `createTmpDir(tag?)` | worker | Temp directory, auto-cleaned after worker |
+| `collectionFixturePath` | test | Copies `fixtures/collection(s)/` to temp dir |
+| `restartApp(opts)` | test | Restart with fresh user data |
+| `newPage` | test | Fresh app instance with tracing |
+
+## Test Data Conventions
+
+- `tests/<suite>/init-user-data/` — Seed data for existing-user tests (`pageWithUserData`)
+- `tests/<suite>/init-user-data-fresh/` — Seed data for new-user tests (hasLaunchedBefore: false)
+- `tests/<suite>/fixtures/collection(s)/` — Collection fixtures auto-copied to temp dirs
+- `initUserDataPath` files support `{{projectRoot}}` template variable
+- No `initUserDataPath` → default prefs with `hasLaunchedBefore: true` (skip onboarding)
+- `dotEnv` overrides defaults (e.g., `DISABLE_SAMPLE_COLLECTION_IMPORT: 'false'`)
+- Adding/changing a key in the app's `preferences.json` defaults? Mirror it in the `defaultPreferences` mock in `playwright/index.ts` — see [the guide](../../docs/playwright-testing-guide.md#3-keep-defaultpreferences-in-sync-with-app-preferences).
+
+## Test Helpers (tests/utils/)
+
+Reuse existing helpers instead of hand-rolling clicks; read the module for its current exports
+(e.g. `grep "^export" tests/utils/page/actions.ts`). Modules by responsibility:
+
+- `page/actions.ts` — high-level user actions (create/open collections, requests, folders, environments; send/save requests; workspace + tab management; import)
+- `page/locators.ts` — locator builders (`buildCommonLocators(page)` + per-protocol/feature variants) and table helpers
+- `page/runner.ts` — collection/folder runner actions and result assertions
+- `tests/utils/cli.ts` — `runCLI(cwd, args)` for bruno-cli testing
+- `tests/utils/wait.ts` — polling helpers (e.g. `waitForPredicate(predicate, {tries, interval})`)
+
+**Convention:** a spec must never inline raw selectors. Each `page/*` module owns one UI section and exports both a locator builder and its actions; a new section gets a new file whose builder is mapped into `buildCommonLocators`. Full pattern + examples in [the guide](../../docs/playwright-testing-guide.md#1-centralize-locators-and-actions-in-page-modules).
+
+## Waiting for App Ready
+
+```javascript
+await page.locator('[data-app-state="loaded"]').waitFor();
+```
+
+This attribute is set when `main:app-loaded` IPC arrives (independent of `renderer:ready` chain).
+
+## Mutating Fixtures
+
+The suite must be isolated (unique tmp paths, no shared state).
+
+Most specs load fixtures via `collectionFixturePath` (copies `fixtures/collection(s)/` to a temp dir) or `pageWithUserData` (loads `init-user-data/` into a fresh temp userData dir). These operate on **temp copies** — they need **no** cleanup, even though they mutate files on disk (e.g. persistence specs writing to `environments/*.bru` or `collection.bru`). Only a spec that mutates a **committed** fixture **in place** must restore it in `afterAll` — those use `git checkout <fixturePath>`. Don't flag a missing `afterAll` on a temp-copy spec.
+
+## Common Pitfalls
+
+1. **Worker-scoped fixtures persist across test retries** — app state from failed attempts carries over. If test creates resources (folders, collections), retries may fail trying to create duplicates.
+
+2. **Collapsed folders hide children from DOM** — `toHaveCount`/`toBeVisible` won't find items inside collapsed folders. Expand folders before asserting on their children.
+
+3. **Sequential tests sharing state** — Tests in the same `describe` that depend on prior test state will cascade-fail. The `afterAll` cleanup only runs once, not between retries.
+
+4. **File watcher timing** — After creating files via IPC, the collection watcher must detect and process the change before the UI updates. Use Playwright's auto-retrying assertions (e.g., `expect(locator).toBeVisible()`) rather than immediate checks.
+
+5. **Default env vars in fixture** — `launchElectronApp` sets `DISABLE_SAMPLE_COLLECTION_IMPORT: 'true'` by default. Tests that need onboarding must override via `dotEnv`.
+
+## Test Coverage Areas
+
+Test suites live under `tests/`, one directory per feature area — list that directory for the
+current set. Examples: `request/`, `collection/`, `environments/`, `runner/`,
+`scripting/`, `graphql/`, `grpc/`, `websockets/`, `auth/`, `ssl/`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./**/dist/**)"
+    ]
+  }
+}

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: code-review
+description: Review a Bruno diff, PR, or branch via focused reviewers run in parallel —
+  correctness, security, DSL, React, cross-platform, tests. Mirrors the CodeRabbit /
+  CODING_STANDARDS review.
+---
+
+# Reviewing Bruno code
+
+This skill mirrors the automated CodeRabbit review (`.coderabbit.yaml`) so you can run
+the same review locally. Source-of-truth order: coding standards → `CODING_STANDARDS.md`;
+architecture/behavior → `.claude/rules/*`. `.coderabbit.yaml` mirrors these for CI parity —
+read it for a path instruction not summarized here, but the rules win if they ever disagree.
+
+The review is **split into focused lenses that run in parallel**, so a large diff is
+covered faster and each reviewer stays sharply scoped to one concern. Each lens lives in
+its own file under `reviewers/`. You (the orchestrator) dispatch the reviewers, then
+merge and report their findings.
+
+## How to review (orchestration)
+
+1. **Get the diff.** Review only what changed — never untouched code. Pick the mode:
+   - **Committed range** (default): `git diff main...HEAD` against the base branch
+     (`main` or `release/*`). Update the base first (`git fetch` and confirm the local
+     base is current) — a stale base inflates the diff with already-merged, unrelated
+     changes and wastes a full fan-out. Each reviewer re-runs this scoped to its own
+     globs; since the range is pinned to fixed commits they all see identical bytes, so
+     there's no need to snapshot.
+   - **Working tree / uncommitted changes** (when asked to review unstaged or staged
+     work): the tree can shift mid-review, so re-running `git diff` per reviewer risks
+     each seeing a different snapshot. Instead, capture the diff **once** to a scratch
+     file and hand every reviewer that path. `git diff HEAD` covers staged + unstaged
+     tracked changes; run `git add -N .` first (reversible with `git reset`) so any new
+     untracked files also show up:
+     ```bash
+     git add -N . && git diff HEAD > "$SCRATCH/review.diff"
+     ```
+     `$SCRATCH` is your environment's scratchpad dir. Reviewers read this frozen diff for
+     their globs plus the on-disk files for surrounding context — the working-tree files
+     already hold the uncommitted state.
+2. **Enumerate changed files** — `git diff --name-only main...HEAD` (committed range) or
+   `git diff --name-only HEAD` (working tree). Use this to skip any lens whose file scope
+   isn't touched (e.g. no `packages/bruno-app/**` change → skip `react.md`; no `tests/**`
+   change → skip `e2e-tests.md`). Never skip the lenses scoped to all files.
+3. **Fan out the reviewers in parallel.** In a *single message*, launch one `Agent`
+   (subagent_type `Explore` or `general-purpose`) per in-scope reviewer below. Give each
+   subagent this exact briefing:
+   - The diff source — the committed range (e.g. `main...HEAD`) or the snapshot file path
+     (`$SCRATCH/review.diff`) — and the file globs it owns (from the reviewer file's
+     "Scope" line). For a snapshot, tell the reviewer to read that file for its globs
+     rather than re-run `git diff`.
+   - "Read `.claude/skills/code-review/reviewers/_contract.md` for the shared persona and
+     output contract, then read `.claude/skills/code-review/reviewers/<file>` — and any rule
+     or source file it points to (e.g. `CODING_STANDARDS.md`, `.claude/rules/*.md`), which
+     hold the detailed checklist. Apply **only** that lens to the changed files in your
+     scope, at the severities the reviewer specifies. Do not review outside your scope."
+   Reviewers are read-only and independent — they don't coordinate, and overlap between
+   lenses is fine (you dedupe at merge time).
+4. **Merge and report.** Collect every reviewer's findings, drop exact duplicates, and
+   when two lenses flag the same `file:line` keep the higher severity. Regroup **by
+   file**, each finding tagged by severity (blocker / suggestion / nit) with `file:line`.
+   If the review request carries a problem statement or acceptance criteria (e.g. passed
+   as args), reconcile its enumerated deliverables — docs, migration notes, a test per new
+   default/branch — against the diff and flag any that are absent. If nothing's wrong, say
+   so briefly — don't manufacture nits.
+
+## Reviewers
+
+Each file is a self-contained checklist for one lens:
+
+| Reviewer file | Lens | Scope |
+|---|---|---|
+| `reviewers/correctness.md` | Correctness & root-cause | all source (excl. `tests/**`) |
+| `reviewers/architecture.md` | Architecture & dependency boundaries | `packages/**` |
+| `reviewers/conventions.md` | Coding standards & readability | all files |
+| `reviewers/react.md` | React — app files | `packages/bruno-app/**` |
+| `reviewers/cross-platform.md` | Cross-platform (macOS/Windows/Linux) | all files |
+| `reviewers/security.md` | Security & data safety | all source (excl. `tests/**`) |
+| `reviewers/dsl-changes.md` | On-disk DSL & serialization (backward compat) | `bruno-app`, `bruno-electron`, `bruno-cli`, `bruno-lang`, `bruno-filestore`, `bruno-schema(-types)`, `bruno-converters` |
+| `reviewers/e2e-tests.md` | Playwright E2E tests | `tests/**` |
+
+## Shared reviewer persona & output contract
+
+Defined once in `reviewers/_contract.md` — the small file every reviewer reads (dispatched
+reviewers read it, not this orchestration file). Keep the persona and the
+`<blocker|suggestion|nit> | <file>:<line> | <finding>` output shape there, not duplicated here,
+so a change updates a single place.

--- a/.claude/skills/code-review/reviewers/_contract.md
+++ b/.claude/skills/code-review/reviewers/_contract.md
@@ -1,0 +1,19 @@
+# Shared reviewer persona & output contract
+
+Read by every `code-review` reviewer. (Orchestration lives in `../SKILL.md`; the per-lens
+checklists live in the sibling `*.md` files.)
+
+**Persona** — an expert reviewer in TypeScript, JavaScript, Node.js, and Electron on an
+enterprise team. Be **concise**: one clear sentence per finding; elaborate only when asked.
+Review to the project's standard regardless of who authored or requested the change — never
+soften severity for assumed intent or seniority. Ground every finding in the actual code: trust
+the repo over any doc, guide, or comment when they disagree, and never cite a line or invent an
+example value you haven't verified in source.
+
+**Output contract** — return a flat list, one finding per line:
+
+```
+<blocker|suggestion|nit> | <file>:<line> | <one-sentence finding>
+```
+
+Return `no findings` (nothing else) when the scope is clean. Never invent nits to fill the list.

--- a/.claude/skills/code-review/reviewers/architecture.md
+++ b/.claude/skills/code-review/reviewers/architecture.md
@@ -1,0 +1,21 @@
+# Architecture & dependency-boundaries reviewer
+
+**Scope:** `packages/**`.
+
+Adopt the reviewer persona and return findings in the output contract defined in
+`_contract.md`.
+
+Review the diff against **`.claude/rules/architecture.md`** — read its "Dependency direction &
+ownership boundaries" section. The `@usebruno/*` packages form a strict dependency DAG and some
+carry hard platform constraints. Report violations with `file:line`, severity:
+
+- **blocker** — a new internal `@usebruno/*` dependency that points *upward* or forms a cycle (a
+  shared lib importing `@usebruno/app` or `@usebruno/electron`); `bruno-common` importing a Node
+  built-in (`fs`/`path`/`os`/`crypto`/`child_process`/`node:*`) or any other `@usebruno/*` package
+  (it must stay browser-safe and dependency-free); `bruno-js` importing `electron`/IPC (it also runs
+  in the CLI); a runtime import of `bruno-schema-types` (types-only).
+- **suggestion** — code placed in the wrong package/layer: renderer-only logic in a shared lib,
+  host/Electron wiring pushed into `bruno-js`, or a util added to `bruno-common` that needs another
+  package; a new shared dependency that would be better kept local.
+- **Not a finding:** dependency edges already in the DAG, or a new *downward* dependency that fits
+  the established direction.

--- a/.claude/skills/code-review/reviewers/conventions.md
+++ b/.claude/skills/code-review/reviewers/conventions.md
@@ -1,0 +1,17 @@
+# Coding standards & readability reviewer
+
+**Scope:** all changed files (`**/*`).
+
+Adopt the reviewer persona and return findings in the output contract defined in
+`_contract.md`.
+
+Review the diff against **`.claude/rules/conventions.md`** (read it; it points to
+`CODING_STANDARDS.md`, the code-guidelines source of truth). Report each violation with
+`file:line`, severity:
+
+- **suggestion** — readability problems from the rule: unclear or misleading names, unnecessary
+  abstraction (indirection that earns no readability or reuse), single-line indirection, `?.` where
+  the null case isn't handled right there, needless whitespace/diff churn, or missing comments on
+  genuinely complex flow.
+- **nit** — pure style/formatting/naming deviations (indent, quotes, semicolons, trailing commas,
+  arrow parens, casing) — most are auto-fixed by ESLint, so keep these brief.

--- a/.claude/skills/code-review/reviewers/correctness.md
+++ b/.claude/skills/code-review/reviewers/correctness.md
@@ -1,0 +1,36 @@
+# Correctness & root-cause reviewer
+
+**Scope:** all changed source (`**/*`, excluding `tests/**`).
+
+Adopt the reviewer persona and return findings in the output contract defined in
+`_contract.md`.
+
+Validate that the change is correct and, for every bug fix, that it addresses the
+underlying problem rather than the visible symptom. Surface-level patches that mask a
+defect without resolving it are a **blocker**:
+
+- Understand *why* the issue exists before accepting the fix — trace the bug to its origin,
+  don't stop at where it surfaced.
+- Flag patches that suppress a symptom (extra null guards, try/catch swallowing, defensive
+  re-checks, retries, timeouts, clamping values) while leaving the real cause in place. Ask:
+  if this defends against a bad value, *where does the bad value come from*, and should it be
+  fixed there instead?
+- A fix at the wrong layer (UI guard for a data-layer bug, caller working around a callee's
+  contract violation) is a symptom patch — call out the correct layer.
+- Watch for fixes scoped to one reproduction case when the same root cause can manifest
+  elsewhere; the correct fix usually covers all call sites, not just the reported one.
+- When a fix looks like a workaround, say so and name the deeper change that would actually
+  resolve it — even if the larger fix is out of scope, the PR should acknowledge it.
+- Beyond bug fixes, check ordinary correctness: off-by-one and boundary errors, unhandled
+  promise rejections / missing `await`, swallowed errors, incorrect null/undefined handling,
+  and edge cases the change introduces.
+- **Check the twin path.** Bruno keeps parallel implementations of the same behavior — `.bru`
+  vs `.yml` serializers, the default app-data workspace vs custom-filesystem workspaces. A
+  change that touches one path must be verified against its twin; behavior that diverges
+  between them (a value that persists or defaults in one but is dropped or defaulted
+  differently in the other) is a bug, not two independent features.
+- **`x || default` on a field whose absence is meaningful.** When "not set" / "never
+  configured" is a distinct state, falsy-coalescing (`version || '1'`) fabricates a value for
+  the unset case, erases the distinction, and often diverges from a sibling path that handles
+  it correctly. Flag it; use `??` or an explicit `undefined` check when the unset state must
+  survive.

--- a/.claude/skills/code-review/reviewers/cross-platform.md
+++ b/.claude/skills/code-review/reviewers/cross-platform.md
@@ -1,0 +1,19 @@
+# Cross-platform reviewer
+
+**Scope:** all changed files (`**/*`).
+
+Adopt the reviewer persona and return findings in the output contract defined in
+`_contract.md`.
+
+Review the diff against **`.claude/rules/cross-platform.md`** (read it) — Bruno ships on macOS,
+Windows, and Linux. Report each violation with `file:line`, severity:
+
+- **blocker** — anything that breaks a platform: hardcoded `/` or `\` separators instead of
+  `path.join`/`path.resolve`; hardcoded paths (`/home/`, `C:\Users\`, `~/`) instead of
+  `os.homedir()`/`app.getPath()`; platform-specific shell/`child_process` without a fallback
+  (`which` vs `where`, `spawn` needing `shell:true` on Windows); Unix-only signals; `/tmp`
+  instead of `os.tmpdir()`.
+- **suggestion** — portable-but-fragile patterns not yet a concrete break: case-sensitivity
+  assumptions, inconsistent CRLF/LF handling, `fs.chmod`/`fs.access` assuming Unix permission bits.
+- **suggestion** — multiline `.bru`/text-block parsing that splits on `\n` instead of a
+  CRLF-aware regex (`/\r\n|\r|\n/`) — see the rule's Line Endings section.

--- a/.claude/skills/code-review/reviewers/dsl-changes.md
+++ b/.claude/skills/code-review/reviewers/dsl-changes.md
@@ -1,0 +1,32 @@
+# On-disk DSL & serialization reviewer
+
+**Scope:** `packages/bruno-app/**`, `packages/bruno-electron/**`, `packages/bruno-cli/**`,
+`packages/bruno-lang/**`, `packages/bruno-filestore/**`, `packages/bruno-schema/**`,
+`packages/bruno-schema-types/**`, `packages/bruno-converters/**`.
+The format packages own serialization, but DSL objects are assembled in `bruno-app` (Redux)
+and `bruno-electron` (IPC), and `bruno-cli` reads/writes these files directly — a shape change
+made there won't be caught by the serialization layer, so they're all in scope.
+
+Adopt the reviewer persona and return findings in the output contract defined in
+`_contract.md`.
+
+Review the diff against **`.claude/rules/dsl-changes.md`** (read it) — Bruno persists
+collections/requests/environments/config as `.bru` and `.yml` files read across app versions, so
+backward compatibility is the priority. Report violations with `file:line`, severity:
+
+- **blocker** — a breaking field change (rename, remove, retype, repurpose, or changed
+  default/semantics); a new field that isn't optional with a safe default; format drift between
+  `bru` and `yml` (or between parse and stringify); a lossy round-trip (`stringify` drops
+  unknown fields, or `parse(stringify(x)) !== x`); a shape change with no read-time compat shim;
+  a cryptic, abbreviated, or inconsistent property name (names are permanent and user-facing).
+- **blocker** — new `.bru` *syntax* (escape form, block delimiter, annotation grammar) that older
+  parsers can't read; an escaping/delimiter change not proven by on-disk reparse
+  (`parse(read(serialize(x)))`) or that escapes a multi-char delimiter by splitting on the whole
+  delimiter. See the rule's escaping and forward-compat sections.
+- **suggestion** — missing round-trip test in both formats or missing old-format golden fixture;
+  a name/structure that won't scale (positional vs keyed, widening union).
+- Also push back on any **unnecessary** DSL change that could be solved in memory / UI without
+  altering the serialized shape.
+- **Not a finding:** the read-accepts-`{content}` / write-emits-`string` asymmetry on
+  `description` fields — string-only internally is an established convention (see rule), not a
+  lossy round-trip.

--- a/.claude/skills/code-review/reviewers/e2e-tests.md
+++ b/.claude/skills/code-review/reviewers/e2e-tests.md
@@ -1,0 +1,22 @@
+# E2E tests reviewer
+
+**Scope:** files under `tests/**` (`path: 'tests/**/**.*'`).
+
+Adopt the reviewer persona and return findings in the output contract defined in
+`_contract.md`.
+
+Review the diff against **`.claude/rules/testing.md`** and the e2e checklist in
+**`.coderabbit.yaml`** (read both). Report violations with `file:line`, severity:
+
+- **blocker** — `test.only`; `page.pause()`.
+- **suggestion** — `page.waitForTimeout()` where an `expect()` locator assertion could wait
+  instead; inline raw selectors instead of `tests/utils/page/*` modules; a spec that mutates a
+  committed fixture without restoring it in `afterAll`; shared state / non-isolated tmp paths.
+- **suggestion** — a non-discriminating assertion: `toContain('description:')` when the fixture
+  already carries that substring on unrelated rows passes even if the change under test never
+  happened; assert the unique value actually written by this change.
+- **suggestion** — parallel `.bru` and `.yml` fixtures for the same scenario that disagree
+  field-for-field (e.g. a row `selected: false` in one, enabled in the other) — a fixture bug
+  even when the current assertion tolerates it.
+- **nit** — locators not stored in variables; a single broad assertion where several focused
+  ones fit; steps not wrapped in `test.step`.

--- a/.claude/skills/code-review/reviewers/react.md
+++ b/.claude/skills/code-review/reviewers/react.md
@@ -1,0 +1,25 @@
+# React — app files reviewer
+
+**Scope:** `packages/bruno-app/**`.
+
+Adopt the reviewer persona and return findings in the output contract defined in
+`_contract.md`.
+
+Review changed components against **`CODING_STANDARDS.md` §React** (read it); for changes that
+touch the store, also consult **`.claude/rules/redux-store.md`**. Report violations with
+`file:line`, severity:
+
+- **blocker** — an `useEffect` that could be derived state, an event handler, or a custom hook;
+  a hardcoded hex/rgb/hsl/named color instead of the styled-components `theme` prop (breaks
+  other themes — verify the theme path exists); namespaced hook import (`React.useX`);
+  a component that mixes controlled and uncontrolled state.
+- **suggestion** — a missing memo that breaks a dependency array or re-renders a heavy child, or
+  a gratuitous memo wrapping a cheap primitive; Tailwind used for colors (layout only);
+  a testable element without `data-testid`; misplaced component-specific vs shared utilities.
+- **suggestion** — a new `EditableTable` column that omits the `readOnly`/`editMode` gating its
+  sibling columns carry (`readOnly={column.readOnly}` at render): the field stays editable in
+  view / read-only mode even though the change handler discards the edit.
+- **suggestion** — optimistic success state (`copied`, `saved`, `done`) set unconditionally
+  rather than gated on the operation resolving — e.g. `copied = true` after an optional-chained
+  `navigator.clipboard?.writeText` that no-ops in an insecure context — showing a false
+  confirmation.

--- a/.claude/skills/code-review/reviewers/security.md
+++ b/.claude/skills/code-review/reviewers/security.md
@@ -1,0 +1,30 @@
+# Security & data safety reviewer
+
+**Scope:** all changed source (`**/*`, excluding `tests/**`).
+
+Adopt the reviewer persona and return findings in the output contract defined in
+`_contract.md`.
+
+Bruno is an offline API client that handles user credentials, tokens, and runs
+user-authored scripts in a sandbox. Review changes for these Bruno-specific risks:
+
+- **No secret leakage.** Auth tokens, passwords, API keys, OAuth2 secrets, and env-var
+  values must never be written to logs, console, error messages, or telemetry. A secret
+  logged in cleartext is a **blocker**. Watch for `console.log`/logger calls that dump a
+  whole request, header set, or config object containing credentials.
+- **Script sandbox integrity** (`bruno-js`, QuickJS / Node VM). Changes that widen the
+  sandbox surface — exposing new Node built-ins, `require`, filesystem, or `process` to
+  user scripts, or passing unsanitized script output back into privileged code — are a
+  potential sandbox escape; call them out.
+- **IPC input validation** (`bruno-electron` handlers, `preload.js`). Treat every argument
+  arriving from the renderer as untrusted: validate file paths (guard against traversal
+  outside the collection dir), types, and bounds before acting on them.
+- **Path traversal & arbitrary writes.** File reads/writes derived from user or request
+  data must be confined to the intended directory — no `../` escape, no writing outside the
+  collection root.
+- **Injection & unsafe eval.** Flag string-built shell commands, `eval`, or dynamic
+  `Function` on untrusted input, and unescaped interpolation into commands or queries.
+- **Dependency & network surface.** Note new runtime dependencies or outbound network calls
+  that don't fit Bruno's offline-first, privacy-first posture.
+
+Keep findings concrete — tie each to how the tainted value reaches the sink.

--- a/.claude/skills/write-e2e-test/SKILL.md
+++ b/.claude/skills/write-e2e-test/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: write-e2e-test
+description: Write a Playwright E2E test for Bruno. Use when adding or modifying
+  tests under tests/, creating a new test suite, or reproducing a bug as an
+  e2e spec.
+---
+
+# Writing a Bruno E2E test
+
+Read `.claude/rules/testing.md` first for the full fixture and helper reference. See
+`docs/playwright-testing-guide.md` for the extended walkthrough (codegen, running,
+debugging, troubleshooting) — but where it disagrees with this skill or the actual repo,
+trust the repo: specs live in `tests/` (not `e2e-tests/`), the suite is `fullyParallel`,
+and projects are `default`, `system-pac`, `auth`, and `ssl`
+(verify in `playwright.config.ts`).
+
+## Start with codegen or by hand
+
+- **Codegen** (fastest for a new flow): `npm run test:codegen <name>` launches the app,
+  records your clicks, and writes `tests/<name>.spec.ts`. Treat the output as a rough
+  draft — move it into the right area folder, swap generated selectors for `data-testid`
+  or helpers, wrap steps in `test.step`, and delete dead recorded actions.
+- **By hand**: `import { test, expect } from '../../playwright'` and follow the steps below.
+
+## Steps
+
+1. **Place the spec** at `tests/<area>/<name>.spec.ts` — reuse an existing area dir under
+   `tests/` (list it for the current set; e.g. `request/`, `collection/`, `environments/`,
+   `runner/`, `scripting/`) or add one. Pick the project: `default` for most specs;
+   `auth` / `ssl` / `system-pac` only when the test needs those
+   servers or external dependencies.
+2. **Use fixtures** from `playwright/index.ts` (read it for the full set) instead of launching
+   the app yourself:
+   - `page` / `electronApp` — default app with onboarding skipped.
+   - `pageWithUserData` — seeds data from `tests/<area>/init-user-data/`
+     (use `init-user-data-fresh/` for new-user flows).
+   - `createTmpDir(tag?)` — throwaway dir for collections/files the test creates; cleaned
+     up automatically, so prefer it over hardcoded paths.
+   - `newPage`, `launchElectronApp`, `reuseOrLaunchElectronApp`, `restartApp` — for
+     multi-window or app-restart scenarios.
+   - `collectionFixturePath` / `workspaceFixturePath` — copy a committed fixture to a tmp
+     dir and get its path.
+3. **Use helpers** from `tests/utils/page/` instead of hand-rolling clicks — read the module
+   for the current set (e.g. `createCollection`, `sendRequest`, `runCollection`).
+4. **Structure each test** arrange → act → assert, and wrap the phases in `test.step` so
+   the HTML report reads clearly. Prefer several focused assertions over one broad check.
+5. **Wait for readiness**: `await page.locator('[data-app-state="loaded"]').waitFor()`
+   before asserting on app state.
+6. **Locate** by `data-testid` (Bruno's dominant convention) or documented classes
+   (`.collection-item-name`); stable `getByRole` / `getByText` locators are fine too.
+   Avoid brittle CSS, `#id`, or index-based selectors. If no stable selector exists, add a
+   `data-testid` to the component rather than locating by text.
+7. **If the test mutates a committed fixture**, restore it in `afterAll`. Existing specs
+   do this with `git checkout <fixturePath>` (e.g. `tests/response-examples/*.spec.ts`) —
+   follow the pattern already used by neighbouring specs in that area.
+8. **Use auto-retrying assertions** (`expect(locator).toBeVisible()`); never assert
+   immediately after a file-watcher-triggered change (created files take a tick to appear).
+   Reserve `page.waitForTimeout()` for when no locator assertion can wait instead.
+9. **Run it**: `npx playwright test tests/<area>/<name>.spec.ts --project=default`
+   (the web + test servers start automatically). Debug with `--ui`, `--headed`, `--debug`,
+   or `--trace on` (then `npx playwright show-trace test-results/**/trace.zip`).
+
+## Checklist before done
+
+- [ ] Test is isolated — unique tmp paths (`createTmpDir`), no state shared with other tests
+- [ ] Passes on a clean second run (retry-safe; worker fixtures persist across retries)
+- [ ] Folders expanded before asserting on their children (collapsed = not in DOM)
+- [ ] Any mutated committed fixture is restored in `afterAll`
+- [ ] Any codegen-generated draft refactored to fixtures/helpers + stable selectors
+- [ ] Steps wrapped in `test.step`; no `test.only`, no `page.pause()`

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ bruno.iml
 .idea
 .vscode
 .cursor
-.claude
 .codex
 .agents
 .agent
@@ -63,7 +62,7 @@ tests/benchmarks/results/
 /benchmark-report/
 
 # Development plan files
-CLAUDE.md
+CLAUDE.local.md
 AGENTS.md
 *.plan.md
 


### PR DESCRIPTION
### Description

Adds a .claude/ Claude Code configuration for the project:

- CLAUDE.md: project overview — commands, key architecture, coding standards
- rules/: path-scoped engineering rules (architecture, redux-store,
  electron-ipc, dsl-changes, cross-platform, testing, conventions)
- reference/architecture.md: on-demand monorepo map
- skills/: /code-review and /write-e2e-test workflows
- settings.json: shared project settings (denies Read on **/dist/**)
- README.md: maintainer guide for the config

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project guidance covering architecture, coding conventions, cross-platform development, data formats, testing, and Electron integration.
  * Added maintenance guidance for development assistant configuration and reusable review and end-to-end testing workflows.
* **Chores**
  * Added configuration safeguards for local settings, generated files, and build output.
  * Updated repository ignore rules so shared development guidance can be version controlled while local overrides remain excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->