### PR TITLE
feat(mount): follow symlinks when walking collections

### DIFF
--- a/packages/bruno-electron/src/utils/mount.js
+++ b/packages/bruno-electron/src/utils/mount.js
@@ -29,10 +29,24 @@ const walk = (root, denylist) => {
     for (const entry of entries) {
       const childAbs = path.join(absDir, entry.name);
       const childRel = relDir ? path.join(relDir, entry.name) : entry.name;
-      if (entry.isDirectory()) {
+
+      let isDir = entry.isDirectory();
+      let isFile = entry.isFile();
+
+      if (entry.isSymbolicLink()) {
+        try {
+          const stat = fs.statSync(childAbs);
+          isDir = stat.isDirectory();
+          isFile = stat.isFile();
+        } catch (err) {
+          continue;
+        }
+      }
+
+      if (isDir) {
         if (DENY_DIRS.has(entry.name)) continue;
         visit(childAbs, childRel);
-      } else if (entry.isFile()) {
+      } else if (isFile) {
         if (isDenied(posixifyPath(childRel), denylist)) continue;
         out.push({ relativePath: childRel, absolutePath: childAbs });
       }

--- a/packages/bruno-electron/src/utils/mount.js
+++ b/packages/bruno-electron/src/utils/mount.js
@@ -24,7 +24,17 @@ const isDenied = (relativePathPosix, patterns) => {
 
 const walk = (root, denylist) => {
   const out = [];
+  const visited = new Set();
   const visit = (absDir, relDir) => {
+    let canonicalDir;
+    try {
+      canonicalDir = fs.realpathSync(absDir);
+    } catch (err) {
+      return;
+    }
+    if (visited.has(canonicalDir)) return;
+    visited.add(canonicalDir);
+
     const entries = fs.readdirSync(absDir, { withFileTypes: true });
     for (const entry of entries) {
       const childAbs = path.join(absDir, entry.name);

--- a/tests/mounting/symlinks.spec.ts
+++ b/tests/mounting/symlinks.spec.ts
@@ -1,0 +1,155 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { test, expect, ElectronApplication, Page } from '../../playwright';
+import { getCollectionTreeStructure, CollectionTreeItem, closeAllCollections } from '../utils/page';
+
+const formats = ['bru', 'yml'] as const;
+type Format = (typeof formats)[number];
+
+const cacheModes = [
+  { label: 'file-cache off', fileCacheEnabled: false },
+  { label: 'file-cache on', fileCacheEnabled: true }
+];
+
+const COLLECTION_NAME = 'Symlink Collection';
+
+const requestFile = (format: Format, name: string) =>
+  format === 'bru'
+    ? `meta {\n  name: ${name}\n  type: http\n  seq: 1\n}\n\nget {\n  url: {{host}}/api/resource\n  body: none\n  auth: none\n}\n`
+    : `info:\n  name: ${name}\n  type: http\n  seq: 1\n\nhttp:\n  method: GET\n  url: "{{host}}/api/resource"\n`;
+
+const collectionFile = (format: Format) =>
+  format === 'bru'
+    ? `meta {\n  name: ${COLLECTION_NAME}\n}\n`
+    : `opencollection: "1.0.0"\ninfo:\n  name: ${COLLECTION_NAME}\n`;
+
+const symlinkType = (isDir: boolean): fs.symlink.Type =>
+  process.platform === 'win32' ? (isDir ? 'junction' : 'file') : (isDir ? 'dir' : 'file');
+
+interface SymlinkFixture {
+  collectionPath: string;
+  userDataPath: string;
+  symlinksSupported: boolean;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Build a collection whose entries include a symlinked request file and a
+ * symlinked directory. The link targets live outside the collection root, so the
+ * linked items surface in the tree only if the mount walk follows symlinks.
+ */
+async function buildSymlinkFixture(format: Format, fileCacheEnabled: boolean): Promise<SymlinkFixture> {
+  const ext = format;
+  const userDataPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bruno-test-userdata-'));
+  const collectionPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bruno-test-collection-'));
+  const targetsPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bruno-test-targets-'));
+
+  const cleanup = async () => {
+    await Promise.all([
+      fs.promises.rm(userDataPath, { recursive: true, force: true }),
+      fs.promises.rm(collectionPath, { recursive: true, force: true }),
+      fs.promises.rm(targetsPath, { recursive: true, force: true })
+    ]);
+  };
+
+  try {
+    await fs.promises.writeFile(
+      path.join(collectionPath, 'bruno.json'),
+      JSON.stringify({ version: '1', name: COLLECTION_NAME, type: 'collection' }, null, 2)
+    );
+    const collectionRootFile = format === 'bru' ? 'collection.bru' : 'opencollection.yml';
+    await fs.promises.writeFile(path.join(collectionPath, collectionRootFile), collectionFile(format));
+    await fs.promises.writeFile(path.join(collectionPath, `RealRequest.${ext}`), requestFile(format, 'RealRequest'));
+
+    // Symlink targets, kept outside the collection so they surface only via the links.
+    const targetRequest = path.join(targetsPath, `linked-request.${ext}`);
+    await fs.promises.writeFile(targetRequest, requestFile(format, 'LinkedRequest'));
+
+    const targetDir = path.join(targetsPath, 'linked-folder');
+    await fs.promises.mkdir(targetDir);
+    await fs.promises.writeFile(path.join(targetDir, `NestedRequest.${ext}`), requestFile(format, 'NestedRequest'));
+
+    let symlinksSupported = true;
+    try {
+      await fs.promises.symlink(targetRequest, path.join(collectionPath, `LinkedRequest.${ext}`), symlinkType(false));
+      await fs.promises.symlink(targetDir, path.join(collectionPath, 'LinkedFolder'), symlinkType(true));
+    } catch (err: any) {
+      // Windows without Developer Mode / admin rights rejects symlink creation.
+      if (err.code === 'EPERM' || err.code === 'EACCES') {
+        symlinksSupported = false;
+      } else {
+        throw err;
+      }
+    }
+
+    const preferences = {
+      lastOpenedCollections: [collectionPath],
+      preferences: {
+        cache: {
+          file: { enabled: fileCacheEnabled }
+        },
+        onboarding: {
+          hasLaunchedBefore: true,
+          hasSeenWelcomeModal: true
+        }
+      }
+    };
+    await fs.promises.writeFile(path.join(userDataPath, 'preferences.json'), JSON.stringify(preferences, null, 2));
+
+    return { collectionPath, userDataPath, symlinksSupported, cleanup };
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+}
+
+for (const { label, fileCacheEnabled } of cacheModes) {
+  for (const format of formats) {
+    test.describe(`[${format}] [${label}] Symlinked Collection Entries`, () => {
+      let fixture: SymlinkFixture;
+      let app: ElectronApplication;
+      let page: Page;
+
+      test.beforeAll(async ({ launchElectronApp }) => {
+        fixture = await buildSymlinkFixture(format, fileCacheEnabled);
+        app = await launchElectronApp({ userDataPath: fixture.userDataPath });
+        page = await app.firstWindow();
+        await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+      });
+
+      test.afterAll(async () => {
+        if (page) {
+          await closeAllCollections(page);
+        }
+        if (app) {
+          await app.context().close();
+          await app.close();
+        }
+        if (fixture) {
+          await fixture.cleanup();
+        }
+      });
+
+      test('should list symlinked request and directory entries in the tree', async () => {
+        test.skip(!fixture.symlinksSupported, 'symlink creation not permitted on this platform');
+
+        const tree = await getCollectionTreeStructure(page, COLLECTION_NAME);
+
+        const requestNames = tree.items.filter((item) => item.type === 'request').map((item) => item.name);
+        expect(requestNames).toContain('RealRequest');
+        expect(requestNames).toContain('LinkedRequest');
+
+        const linkedFolder = tree.items.find(
+          (item): item is CollectionTreeItem => item.type === 'folder' && item.name === 'LinkedFolder'
+        );
+        expect(linkedFolder).toBeDefined();
+
+        const nestedRequestNames = (linkedFolder?.items ?? [])
+          .filter((item) => item.type === 'request')
+          .map((item) => item.name);
+        expect(nestedRequestNames).toContain('NestedRequest');
+      });
+    });
+  }
+}

--- a/tests/mounting/symlinks.spec.ts
+++ b/tests/mounting/symlinks.spec.ts
@@ -74,6 +74,9 @@ async function buildSymlinkFixture(format: Format, fileCacheEnabled: boolean): P
     try {
       await fs.promises.symlink(targetRequest, path.join(collectionPath, `LinkedRequest.${ext}`), symlinkType(false));
       await fs.promises.symlink(targetDir, path.join(collectionPath, 'LinkedFolder'), symlinkType(true));
+      if (fileCacheEnabled) {
+        await fs.promises.symlink(collectionPath, path.join(collectionPath, 'AncestorLink'), symlinkType(true));
+      }
     } catch (err: any) {
       // Windows without Developer Mode / admin rights rejects symlink creation.
       if (err.code === 'EPERM' || err.code === 'EACCES') {
@@ -147,6 +150,25 @@ for (const { label, fileCacheEnabled } of cacheModes) {
           .filter((item) => item.type === 'request')
           .map((item) => item.name);
         expect(nestedRequestNames).toContain('NestedRequest');
+      });
+
+      test('should skip a directory symlink that resolves to an ancestor', async () => {
+        test.skip(!fixture.symlinksSupported, 'symlink creation not permitted on this platform');
+        test.skip(!fileCacheEnabled, 'the cycle guard applies to the file-cache walk path');
+
+        const tree = await getCollectionTreeStructure(page, COLLECTION_NAME);
+
+        const countRequests = (items: CollectionTreeItem[]): number =>
+          items.reduce(
+            (count, item) =>
+              item.type === 'request'
+                ? count + 1
+                : count + countRequests(item.items ?? []),
+            0
+          );
+
+        expect(tree.items.some((item) => item.type === 'folder' && item.name === 'AncestorLink')).toBe(false);
+        expect(countRequests(tree.items)).toBe(3);
       });
     });
   }

--- a/tests/mounting/symlinks.spec.ts
+++ b/tests/mounting/symlinks.spec.ts
@@ -1,7 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
-import { test, expect, ElectronApplication, Page } from '../../playwright';
+import { test, expect, ElectronApplication, Page, waitForReadyPage, closeElectronApp } from '../../playwright';
 import { getCollectionTreeStructure, CollectionTreeItem, closeAllCollections } from '../utils/page';
 
 const formats = ['bru', 'yml'] as const;
@@ -114,8 +114,7 @@ for (const { label, fileCacheEnabled } of cacheModes) {
       test.beforeAll(async ({ launchElectronApp }) => {
         fixture = await buildSymlinkFixture(format, fileCacheEnabled);
         app = await launchElectronApp({ userDataPath: fixture.userDataPath });
-        page = await app.firstWindow();
-        await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+        page = await waitForReadyPage(app);
       });
 
       test.afterAll(async () => {
@@ -123,8 +122,7 @@ for (const { label, fileCacheEnabled } of cacheModes) {
           await closeAllCollections(page);
         }
         if (app) {
-          await app.context().close();
-          await app.close();
+          await closeElectronApp(app);
         }
         if (fixture) {
           await fixture.cleanup();


### PR DESCRIPTION
## Description

The mountv2 collection walk previously classified entries solely by `Dirent.isDirectory()` / `isFile()`, which both return `false` for symbolic links. As a result, symlinked request files and folders inside a collection were silently skipped and never appeared in the sidebar tree.

This resolves each symbolic-link entry by stat-ing its target so a symlinked file or directory is classified and listed like its real counterpart. Broken/dangling links are skipped rather than throwing.

## Changes

- `bruno-electron/src/utils/mount.js`: when a directory entry is a symlink, `fs.statSync` the target to determine whether it is a file or directory; skip the entry if the target can't be resolved.
- Add `tests/mounting/symlinks.spec.ts` covering a symlinked request file and a symlinked directory (with a nested request). The spec runs across both formats (`bru`, `yml`) and with the on-disk file cache both **off** and **on** — the cached path uses this walk, the legacy path relies on chokidar's symlink following — giving 4 scenarios. Symlink creation that the OS rejects (e.g. Windows without Developer Mode) skips gracefully.

## Verification

Ran `tests/mounting/symlinks.spec.ts` — all 4 tests passing (bru/yml × cache off/on).

Ticket - BRU-3947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved mounted-collection handling for symbolic links by correctly resolving whether a symlink points to a file or folder.
  * Symlinked requests and folders are now included when their targets are accessible, even when located outside the collection root.
  * Broken or inaccessible symbolic links are ignored safely (including appropriate skipping of disallowed/ancestor links).

* **Tests**
  * Added end-to-end coverage for symlinked request files and folders across supported formats and cache modes, with automatic skipping when symlinks aren’t permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->