### PR TITLE
fix(app): resolve collection level variables in bru.ctx and add app logs to console

### DIFF
--- a/packages/bruno-app/src/components/AppView/buildVariables.js
+++ b/packages/bruno-app/src/components/AppView/buildVariables.js
@@ -1,0 +1,10 @@
+import { getAllVariables } from 'utils/collections';
+
+// Resolves the variables available to an app. For request level apps, pass
+// the parent request as `item`, otherwise the app is treated as
+// collection level. Excludes non-variable and OAuth2 credential secret
+// entries returned by `getAllVariables()`.
+export const buildVariables = (collection, item) => {
+  const { pathParams, maskedEnvVariables, process, ...variables } = getAllVariables(collection, item) || {};
+  return Object.fromEntries(Object.entries(variables).filter(([key]) => !key.startsWith('$oauth2.')));
+};

--- a/packages/bruno-app/src/components/AppView/buildVariables.spec.js
+++ b/packages/bruno-app/src/components/AppView/buildVariables.spec.js
@@ -1,0 +1,76 @@
+import { buildVariables } from './buildVariables';
+
+describe('buildVariables', () => {
+  const requestItem = {
+    uid: 'r1',
+    type: 'http-request',
+    name: 'Request',
+    request: {
+      method: 'GET',
+      url: '',
+      params: [],
+      vars: { req: [{ name: 'requestVar', value: 'request-value', enabled: true }] }
+    },
+    items: []
+  };
+
+  const folder = {
+    uid: 'f1',
+    type: 'folder',
+    name: 'Folder',
+    root: { request: { vars: { req: [{ name: 'folderVar', value: 'folder-value', enabled: true }] } } },
+    items: [requestItem]
+  };
+
+  const collection = {
+    uid: 'c1',
+    activeEnvironmentUid: 'e1',
+    environments: [
+      { uid: 'e1', name: 'Env', variables: [{ name: 'envVar', value: 'environment-value', enabled: true }] }
+    ],
+    runtimeVariables: { runtimeVar: 'runtime-value' },
+    globalEnvironmentVariables: { globalVar: 'global-value' },
+    oauth2Credentials: [{ credentialsId: 'auth', credentials: { access_token: 'secret-token' } }],
+    root: { request: { vars: { req: [{ name: 'collectionVar', value: 'collection-value', enabled: true }] } } },
+    items: [folder]
+  };
+
+  it('resolves collection, folder and request defined variables for request level app', () => {
+    const result = buildVariables(collection, requestItem);
+    expect(result.collectionVar).toBe('collection-value');
+    expect(result.folderVar).toBe('folder-value');
+    expect(result.requestVar).toBe('request-value');
+    expect(result.envVar).toBe('environment-value');
+    expect(result.globalVar).toBe('global-value');
+    expect(result.runtimeVar).toBe('runtime-value');
+  });
+
+  it('strips the structural meta keys getAllVariables adds', () => {
+    const result = buildVariables(collection, requestItem);
+    expect(result).not.toHaveProperty('pathParams');
+    expect(result).not.toHaveProperty('maskedEnvVariables');
+    expect(result).not.toHaveProperty('process');
+  });
+
+  it('does not surface OAuth2 credential secrets into the guest', () => {
+    const result = buildVariables(collection, requestItem);
+    expect(result).not.toHaveProperty('$oauth2.auth.access_token');
+    expect(Object.keys(result).some((key) => key.startsWith('$oauth2.'))).toBe(false);
+  });
+
+  it('resolves only collection defined variables when no item is passed (collection level app)', () => {
+    const result = buildVariables(collection);
+    expect(result.collectionVar).toBe('collection-value');
+    expect(result.envVar).toBe('environment-value');
+    expect(result.globalVar).toBe('global-value');
+    expect(result.runtimeVar).toBe('runtime-value');
+
+    // No folder or request defined variables
+    expect(result).not.toHaveProperty('folderVar');
+    expect(result).not.toHaveProperty('requestVar');
+  });
+
+  it('returns an empty object for a missing collection', () => {
+    expect(buildVariables(undefined, requestItem)).toEqual({});
+  });
+});

--- a/packages/bruno-app/src/components/AppView/index.js
+++ b/packages/bruno-app/src/components/AppView/index.js
@@ -2,11 +2,7 @@ import React, { useRef, useEffect, useCallback, useMemo } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { useDispatch } from 'react-redux';
 import { sendNetworkRequest } from 'utils/network/index';
-import {
-  findEnvironmentInCollection,
-  getEnvironmentVariables,
-  getGlobalEnvironmentVariables
-} from 'utils/collections';
+import { findEnvironmentInCollection } from 'utils/collections';
 import {
   responseReceived,
   appSetRuntimeVariable,
@@ -18,6 +14,7 @@ import { useTheme } from 'providers/Theme';
 import Button from 'ui/Button';
 import StyledWrapper from './StyledWrapper';
 import EmptyAppState from './EmptyAppState';
+import { buildVariables } from './buildVariables';
 import {
   SENTINEL,
   wrapHtml,
@@ -147,20 +144,6 @@ const REQUEST_CTX_BOOTSTRAP = `<script>
 })();
 </script>`;
 
-const buildVariables = (collection) => {
-  const env = getEnvironmentVariables(collection);
-  const global = getGlobalEnvironmentVariables({
-    globalEnvironments: collection?.globalEnvironments || [],
-    activeGlobalEnvironmentUid: collection?.activeGlobalEnvironmentUid
-  });
-  return {
-    ...global,
-    ...env,
-    ...(collection?.collectionVariables || {}),
-    ...(collection?.runtimeVariables || {})
-  };
-};
-
 const AppView = ({ item, collection, code }) => {
   const dispatch = useDispatch();
   const { displayedTheme, theme, themeVariantLight, themeVariantDark } = useTheme();
@@ -179,7 +162,7 @@ const AppView = ({ item, collection, code }) => {
     () => findEnvironmentInCollection(collection, collection.activeEnvironmentUid),
     [collection]
   );
-  const variables = useMemo(() => buildVariables(collection), [collection]);
+  const variables = useMemo(() => buildVariables(collection, item), [collection, item]);
   const response = useMemo(() => (item.response ? projectResponse(item.response) : null), [item.response]);
   const assertionResults = useMemo(() => item.assertionResults || [], [item.assertionResults]);
   const testResults = useMemo(() => item.testResults || [], [item.testResults]);

--- a/packages/bruno-app/src/components/AppView/index.js
+++ b/packages/bruno-app/src/components/AppView/index.js
@@ -9,6 +9,7 @@ import {
   initRunRequestEvent
 } from 'providers/ReduxStore/slices/collections';
 import { updateRequestPaneTab, setTabAppPreview } from 'providers/ReduxStore/slices/tabs';
+import { addLog } from 'providers/ReduxStore/slices/logs';
 import { uuid } from 'utils/common';
 import { useTheme } from 'providers/Theme';
 import Button from 'ui/Button';
@@ -247,6 +248,7 @@ const AppView = ({ item, collection, code }) => {
           break;
         case 'log':
           console.log('[app]', ...(data.args || []));
+          dispatch(addLog({ type: 'log', args: ['[app]', ...(data.args || [])], timestamp: new Date().toISOString() }));
           break;
         default:
           break;

--- a/packages/bruno-app/src/components/CollectionApp/index.js
+++ b/packages/bruno-app/src/components/CollectionApp/index.js
@@ -18,6 +18,7 @@ import {
   updateAppCode
 } from 'providers/ReduxStore/slices/collections';
 import { saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { addLog } from 'providers/ReduxStore/slices/logs';
 import { useTheme } from 'providers/Theme';
 import CodeEditor from 'components/CodeEditor';
 import AIAssist from 'components/AIAssist';
@@ -288,6 +289,7 @@ const CollectionApp = ({ item, collection }) => {
           break;
         case 'log':
           console.log('[app]', ...(data.args || []));
+          dispatch(addLog({ type: 'log', args: ['[app]', ...(data.args || [])], timestamp: new Date().toISOString() }));
           break;
         case 'setRuntimeVariable':
           if (typeof data.key === 'string' && data.key.length) {

--- a/packages/bruno-app/src/components/CollectionApp/index.js
+++ b/packages/bruno-app/src/components/CollectionApp/index.js
@@ -8,8 +8,6 @@ import {
   findEnvironmentInCollection,
   findItemInCollectionByPathname,
   flattenItems,
-  getEnvironmentVariables,
-  getGlobalEnvironmentVariables,
   isItemARequest
 } from 'utils/collections';
 import { uuid } from 'utils/common';
@@ -26,6 +24,7 @@ import AIAssist from 'components/AIAssist';
 import { buildAiVariablesPayload, buildDocsContextFromCollection } from 'utils/ai';
 import StyledWrapper from './StyledWrapper';
 import EmptyAppState from '../AppView/EmptyAppState';
+import { buildVariables } from '../AppView/buildVariables';
 import {
   SENTINEL,
   wrapHtml,
@@ -155,20 +154,6 @@ const COLLECTION_CTX_BOOTSTRAP = `<script>
   }
 })();
 </script>`;
-
-const buildVariables = (collection) => {
-  const env = getEnvironmentVariables(collection);
-  const global = getGlobalEnvironmentVariables({
-    globalEnvironments: collection?.globalEnvironments || [],
-    activeGlobalEnvironmentUid: collection?.activeGlobalEnvironmentUid
-  });
-  return {
-    ...global,
-    ...env,
-    ...(collection?.collectionVariables || {}),
-    ...(collection?.runtimeVariables || {})
-  };
-};
 
 const listRequestSummaries = (collection) =>
   flattenItems(collection?.items || [])


### PR DESCRIPTION
### Description

Fixes two issues affecting variable resolution and logging in the App runtime.

Ref: BRU-3892, BRU-3901

`bru.ctx.variables.resolved` now correctly includes collection level variables, which were previously unresolved due to incorrect resolution.

 Additionally, `bru.ctx.log()` output is now displayed in the in-app Bruno Console alongside the browser/devtools console, making app logs directly accessible within Bruno.
 
 #### Screenshot
 
<img width="1470" height="787" alt="image" src="https://github.com/user-attachments/assets/a23a2f01-5d6a-4796-bb39-0e7f559dd574" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guest app log messages are now captured in the application logs with timestamps.
  * Request execution now receives variables from collection, folder, request, environment, global, and runtime scopes.

* **Bug Fixes**
  * OAuth2 access tokens and internal variable metadata are no longer exposed to the guest runtime.
  * Missing collections or variables are handled safely without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->