### PR TITLE
feat: add preserve scripts option for Postman import/export

### DIFF
--- a/packages/bruno-app/src/components/ShareCollection/index.js
+++ b/packages/bruno-app/src/components/ShareCollection/index.js
@@ -175,6 +175,7 @@ const ShareCollection = ({ onClose, collectionUid }) => {
             <div
               className={`other-format-card ${selectedFormat === EXPORT_FORMATS.POSTMAN ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
               onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.POSTMAN)}
+              data-testid="export-format-postman"
             >
               <div className="format-icon">
                 <IconFileExport size={28} strokeWidth={1.5} />

--- a/packages/bruno-app/src/components/ShareCollection/index.js
+++ b/packages/bruno-app/src/components/ShareCollection/index.js
@@ -65,10 +65,6 @@ const ShareCollection = ({ onClose, collectionUid }) => {
 
   const handlePostmanModalClose = () => {
     setShowPostmanExportModal(false);
-  };
-
-  const handlePostmanExported = () => {
-    setShowPostmanExportModal(false);
     onClose();
   };
 
@@ -99,6 +95,16 @@ const ShareCollection = ({ onClose, collectionUid }) => {
   };
 
   const isDisabled = isCollectionLoading || isExporting;
+
+  if (showPostmanExportModal) {
+    return (
+      <ExportToPostman
+        collection={collection}
+        onClose={handlePostmanModalClose}
+        onExported={handlePostmanModalClose}
+      />
+    );
+  }
 
   return (
     <>
@@ -207,14 +213,6 @@ const ShareCollection = ({ onClose, collectionUid }) => {
           </div>
         </StyledWrapper>
       </Modal>
-
-      {showPostmanExportModal && (
-        <ExportToPostman
-          collection={collection}
-          onClose={handlePostmanModalClose}
-          onExported={handlePostmanExported}
-        />
-      )}
     </>
   );
 };

--- a/packages/bruno-app/src/components/ShareCollection/index.js
+++ b/packages/bruno-app/src/components/ShareCollection/index.js
@@ -3,7 +3,7 @@ import Modal from 'components/Modal';
 import Button from 'ui/Button';
 import { IconCheck, IconAlertTriangle, IconFileExport } from '@tabler/icons';
 import StyledWrapper from './StyledWrapper';
-import exportPostmanCollection from 'utils/exporters/postman-collection';
+import ExportToPostman from 'components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman';
 import exportOpenCollection from 'utils/exporters/opencollection';
 import { cloneDeep } from 'lodash';
 import { transformCollectionToSaveToExportAsFile } from 'utils/collections/index';
@@ -22,6 +22,7 @@ const ShareCollection = ({ onClose, collectionUid }) => {
   const isCollectionLoading = areItemsLoading(collection);
   const [selectedFormat, setSelectedFormat] = useState(EXPORT_FORMATS.ZIP);
   const [isExporting, setIsExporting] = useState(false);
+  const [showPostmanExportModal, setShowPostmanExportModal] = useState(false);
 
   const hasNonExportableRequestTypes = useMemo(() => {
     let types = new Set();
@@ -62,13 +63,22 @@ const ShareCollection = ({ onClose, collectionUid }) => {
     exportOpenCollection(transformCollectionToSaveToExportAsFile(collectionCopy));
   };
 
-  const handleExportPostman = () => {
-    const collectionCopy = cloneDeep(collection);
-    exportPostmanCollection(collectionCopy);
+  const handlePostmanModalClose = () => {
+    setShowPostmanExportModal(false);
+  };
+
+  const handlePostmanExported = () => {
+    setShowPostmanExportModal(false);
+    onClose();
   };
 
   const handleProceed = async () => {
     if (isCollectionLoading || isExporting) return;
+
+    if (selectedFormat === EXPORT_FORMATS.POSTMAN) {
+      setShowPostmanExportModal(true);
+      return;
+    }
 
     setIsExporting(true);
     try {
@@ -78,9 +88,6 @@ const ShareCollection = ({ onClose, collectionUid }) => {
           break;
         case EXPORT_FORMATS.YAML:
           handleExportYaml();
-          break;
-        case EXPORT_FORMATS.POSTMAN:
-          handleExportPostman();
           break;
       }
       onClose();
@@ -94,110 +101,120 @@ const ShareCollection = ({ onClose, collectionUid }) => {
   const isDisabled = isCollectionLoading || isExporting;
 
   return (
-    <Modal size="lg" title="Share Collection" handleCancel={onClose} hideFooter>
-      <StyledWrapper className="flex flex-col">
-        <p className="text-sm mb-4">
-          Bruno uses{' '}
-          <a
-            href="https://opencollection.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="opencollection-link"
-          >
-            OpenCollection
-          </a>
-          {' '}- An open format for API collections
-        </p>
+    <>
+      <Modal size="lg" title="Share Collection" handleCancel={onClose} hideFooter>
+        <StyledWrapper className="flex flex-col">
+          <p className="text-sm mb-4">
+            Bruno uses{' '}
+            <a
+              href="https://opencollection.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="opencollection-link"
+            >
+              OpenCollection
+            </a>
+            {' '}- An open format for API collections
+          </p>
 
-        {/* Bruno Format Section */}
-        <div className="section-title">Bruno Format</div>
-        <div className="bruno-format-grid mb-6">
-          {/* ZIP Option */}
-          <div
-            className={`format-card ${selectedFormat === EXPORT_FORMATS.ZIP ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-            onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.ZIP)}
-          >
-            <div className="card-header">
-              <span className="card-title">Bruno Collection (ZIP)</span>
-              <span className="recommended-badge">Recommended</span>
+          {/* Bruno Format Section */}
+          <div className="section-title">Bruno Format</div>
+          <div className="bruno-format-grid mb-6">
+            {/* ZIP Option */}
+            <div
+              className={`format-card ${selectedFormat === EXPORT_FORMATS.ZIP ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+              onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.ZIP)}
+            >
+              <div className="card-header">
+                <span className="card-title">Bruno Collection (ZIP)</span>
+                <span className="recommended-badge">Recommended</span>
+              </div>
+              <p className="card-description">OpenCollection format organized as folders and files</p>
+              <div className="feature-list">
+                <div className="feature-item">
+                  <IconCheck size={14} className="checkmark" />
+                  <span>Folder structure with individual .yml files</span>
+                </div>
+                <div className="feature-item">
+                  <IconCheck size={14} className="checkmark" />
+                  <span>Collaborate with your team via pull requests</span>
+                </div>
+                <div className="feature-item">
+                  <IconCheck size={14} className="checkmark" />
+                  <span>Extract and open directly in Bruno</span>
+                </div>
+              </div>
+              <p className="best-for">Best for: Team collaboration, version control, publishing</p>
             </div>
-            <p className="card-description">OpenCollection format organized as folders and files</p>
-            <div className="feature-list">
-              <div className="feature-item">
-                <IconCheck size={14} className="checkmark" />
-                <span>Folder structure with individual .yml files</span>
+
+            {/* Single File YAML Option */}
+            <div
+              className={`format-card ${selectedFormat === EXPORT_FORMATS.YAML ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+              onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.YAML)}
+            >
+              <div className="card-header">
+                <span className="card-title">Single File (YAML)</span>
               </div>
-              <div className="feature-item">
-                <IconCheck size={14} className="checkmark" />
-                <span>Collaborate with your team via pull requests</span>
+              <p className="card-description">OpenCollection format bundled into one .yml file</p>
+              <div className="feature-list">
+                <div className="feature-item">
+                  <IconCheck size={14} className="checkmark" />
+                  <span>Everything in a single YAML file</span>
+                </div>
+                <div className="feature-item">
+                  <IconCheck size={14} className="checkmark" />
+                  <span>Paste in a gist or attach to an issue</span>
+                </div>
               </div>
-              <div className="feature-item">
-                <IconCheck size={14} className="checkmark" />
-                <span>Extract and open directly in Bruno</span>
-              </div>
+              <p className="best-for">Best for: Quick sharing as a single file</p>
             </div>
-            <p className="best-for">Best for: Team collaboration, version control, publishing</p>
           </div>
 
-          {/* Single File YAML Option */}
-          <div
-            className={`format-card ${selectedFormat === EXPORT_FORMATS.YAML ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-            onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.YAML)}
-          >
-            <div className="card-header">
-              <span className="card-title">Single File (YAML)</span>
-            </div>
-            <p className="card-description">OpenCollection format bundled into one .yml file</p>
-            <div className="feature-list">
-              <div className="feature-item">
-                <IconCheck size={14} className="checkmark" />
-                <span>Everything in a single YAML file</span>
+          <div className="section-title">Other Format</div>
+          <div className="other-format-grid">
+            <div
+              className={`other-format-card ${selectedFormat === EXPORT_FORMATS.POSTMAN ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+              onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.POSTMAN)}
+            >
+              <div className="format-icon">
+                <IconFileExport size={28} strokeWidth={1.5} />
               </div>
-              <div className="feature-item">
-                <IconCheck size={14} className="checkmark" />
-                <span>Paste in a gist or attach to an issue</span>
+              <div className="format-info">
+                <div className="format-name">Postman</div>
+                <div className="format-description">Export for Postman</div>
               </div>
             </div>
-            <p className="best-for">Best for: Quick sharing as a single file</p>
           </div>
-        </div>
 
-        <div className="section-title">Other Format</div>
-        <div className="other-format-grid">
-          <div
-            className={`other-format-card ${selectedFormat === EXPORT_FORMATS.POSTMAN ? 'selected' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-            onClick={() => !isDisabled && setSelectedFormat(EXPORT_FORMATS.POSTMAN)}
-          >
-            <div className="format-icon">
-              <IconFileExport size={28} strokeWidth={1.5} />
+          {selectedFormat === EXPORT_FORMATS.POSTMAN && hasNonExportableRequestTypes.has && (
+            <div className="flex items-center mt-4 p-3 rounded" style={{ backgroundColor: 'rgba(251, 191, 36, 0.1)' }}>
+              <IconAlertTriangle size={16} className="mr-2 flex-shrink-0" style={{ color: '#f59e0b' }} />
+              <span className="text-sm" style={{ color: '#f59e0b' }}>
+                Note: {hasNonExportableRequestTypes.types.join(', ')} requests in this collection will not be exported
+              </span>
             </div>
-            <div className="format-info">
-              <div className="format-name">Postman</div>
-              <div className="format-description">Export for Postman</div>
-            </div>
-          </div>
-        </div>
+          )}
 
-        {selectedFormat === EXPORT_FORMATS.POSTMAN && hasNonExportableRequestTypes.has && (
-          <div className="flex items-center mt-4 p-3 rounded" style={{ backgroundColor: 'rgba(251, 191, 36, 0.1)' }}>
-            <IconAlertTriangle size={16} className="mr-2 flex-shrink-0" style={{ color: '#f59e0b' }} />
-            <span className="text-sm" style={{ color: '#f59e0b' }}>
-              Note: {hasNonExportableRequestTypes.types.join(', ')} requests in this collection will not be exported
-            </span>
+          <div className="modal-footer">
+            <Button
+              onClick={handleProceed}
+              disabled={isDisabled}
+              loading={isExporting}
+            >
+              {isExporting ? 'Exporting...' : 'Proceed'}
+            </Button>
           </div>
-        )}
+        </StyledWrapper>
+      </Modal>
 
-        <div className="modal-footer">
-          <Button
-            onClick={handleProceed}
-            disabled={isDisabled}
-            loading={isExporting}
-          >
-            {isExporting ? 'Exporting...' : 'Proceed'}
-          </Button>
-        </div>
-      </StyledWrapper>
-    </Modal>
+      {showPostmanExportModal && (
+        <ExportToPostman
+          collection={collection}
+          onClose={handlePostmanModalClose}
+          onExported={handlePostmanExported}
+        />
+      )}
+    </>
   );
 };
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/StyledWrapper.js
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  .advanced-options {
+    .caret {
+      color: ${(props) => props.theme.textLink};
+      fill: ${(props) => props.theme.textLink};
+    }
+  }
+
+  .error-message {
+    color: ${(props) => props.theme.colors.text.danger};
+  }
+
+  .file-extension {
+    color: ${(props) => props.theme.colors.text.muted};
+  }
+
+  .preserve-scripts-label {
+    font-weight: 500;
+  }
+
+  .preserve-scripts-description {
+    font-size: 0.75rem;
+    color: ${(props) => props.theme.colors.text.muted};
+    margin-top: 0.25rem;
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/StyledWrapper.js
@@ -22,7 +22,7 @@ const StyledWrapper = styled.div`
 
   .preserve-scripts-description {
     font-size: 0.75rem;
-    color: ${(props) => props.theme.colors.text.muted};
+    color: ${(props) => props.theme.colors.text.subtext0};
     margin-top: 0.25rem;
   }
 `;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
@@ -99,6 +99,7 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
         <Modal
           size="md"
           title="Export to Postman"
+          dataTestId="export-to-postman-modal"
           confirmText={fileExists ? 'Replace' : 'Export'}
           confirmButtonColor={fileExists ? 'danger' : 'primary'}
           handleConfirm={() => (fileExists ? handleReplace() : formik.handleSubmit())}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
@@ -171,21 +171,21 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
             </div>
 
             {showAdvancedOptions && (
-              <div className="mt-4">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={preserveScripts}
-                    onChange={(e) => setPreserveScripts(e.target.checked)}
-                    className="checkbox cursor-pointer"
-                    data-testid="preserve-scripts-toggle"
-                  />
+              <label className="mt-4 flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={preserveScripts}
+                  onChange={(e) => setPreserveScripts(e.target.checked)}
+                  className="checkbox cursor-pointer mt-0.5"
+                  data-testid="preserve-scripts-toggle"
+                />
+                <div>
                   <span className="preserve-scripts-label">Preserve scripts</span>
-                </label>
-                <p className="preserve-scripts-description">
-                  Exports bru.* scripts as-is, without translating them to pm.*.
-                </p>
-              </div>
+                  <p className="preserve-scripts-description">
+                    Exports bru.* scripts as-is, without translating them to pm.*.
+                  </p>
+                </div>
+              </label>
             )}
           </form>
         </Modal>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
@@ -36,6 +36,7 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
         .min(1, 'must be at least 1 character')
         .max(255, 'must be 255 characters or less')
         .test('is-valid-name', function (value) {
+          if (!value) return true;
           const isValid = validateName(value);
           return isValid ? true : this.createError({ message: validateNameError(value) });
         })

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
@@ -5,7 +5,7 @@ import * as Yup from 'yup';
 import { cloneDeep } from 'lodash';
 import { IconCaretDown } from '@tabler/icons';
 import toast from 'react-hot-toast';
-import { sanitizeName } from 'utils/common/regex';
+import { sanitizeName, validateName, validateNameError } from 'utils/common/regex';
 import Portal from 'components/Portal';
 import Modal from 'components/Modal';
 import Dropdown from 'components/Dropdown';
@@ -20,6 +20,7 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
   const inputRef = useRef();
   const [preserveScripts, setPreserveScripts] = useState(false);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const optionsDropdownTippyRef = useRef();
   const onOptionsDropdownCreate = (ref) => (optionsDropdownTippyRef.current = ref);
 
@@ -31,8 +32,13 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
     },
     validationSchema: Yup.object({
       fileName: Yup.string()
+        .trim()
         .min(1, 'must be at least 1 character')
         .max(255, 'must be 255 characters or less')
+        .test('is-valid-name', function (value) {
+          const isValid = validateName(value);
+          return isValid ? true : this.createError({ message: validateNameError(value) });
+        })
         .required('Name is required'),
       location: Yup.string().min(1, 'Location is required').required('Location is required')
     }),
@@ -43,9 +49,12 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
   const fileExists = formik.errors.fileName === FILE_EXISTS_ERROR;
 
   async function handleExport(values, overwrite) {
+    if (isExporting) return;
+
+    setIsExporting(true);
     try {
       const content = exportPostmanCollection(cloneDeep(collection), { preserveScripts });
-      await dispatch(exportCollectionToPostman(values.location, `${values.fileName}.json`, content, overwrite));
+      await dispatch(exportCollectionToPostman(values.location, `${values.fileName.trim()}.json`, content, overwrite));
       toast.success('Collection exported successfully');
       onExported();
     } catch (error) {
@@ -57,6 +66,8 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
         return;
       }
       toast.error('Failed to export collection: ' + message);
+    } finally {
+      setIsExporting(false);
     }
   }
 
@@ -102,6 +113,7 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
           dataTestId="export-to-postman-modal"
           confirmText={fileExists ? 'Replace' : 'Export'}
           confirmButtonColor={fileExists ? 'danger' : 'primary'}
+          confirmDisabled={isExporting}
           handleConfirm={() => (fileExists ? handleReplace() : formik.handleSubmit())}
           handleCancel={onClose}
           footerLeft={(
@@ -182,7 +194,7 @@ const ExportToPostman = ({ onClose, onExported, collection }) => {
                 <div>
                   <span className="preserve-scripts-label">Preserve scripts</span>
                   <p className="preserve-scripts-description">
-                    Exports bru.* scripts as-is, without translating them to pm.*.
+                    Export Bruno scripts without translating them.
                   </p>
                 </div>
               </label>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ExportCollection/ExportToPostman/index.js
@@ -1,0 +1,196 @@
+import React, { useState, useRef, useEffect, forwardRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { useFormik } from 'formik';
+import * as Yup from 'yup';
+import { cloneDeep } from 'lodash';
+import { IconCaretDown } from '@tabler/icons';
+import toast from 'react-hot-toast';
+import { sanitizeName } from 'utils/common/regex';
+import Portal from 'components/Portal';
+import Modal from 'components/Modal';
+import Dropdown from 'components/Dropdown';
+import { browseDirectory, exportCollectionToPostman } from 'providers/ReduxStore/slices/collections/actions';
+import { exportPostmanCollection } from 'utils/exporters/postman-collection';
+import StyledWrapper from './StyledWrapper';
+
+const FILE_EXISTS_ERROR = 'Name already exists in this location.';
+
+const ExportToPostman = ({ onClose, onExported, collection }) => {
+  const dispatch = useDispatch();
+  const inputRef = useRef();
+  const [preserveScripts, setPreserveScripts] = useState(false);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const optionsDropdownTippyRef = useRef();
+  const onOptionsDropdownCreate = (ref) => (optionsDropdownTippyRef.current = ref);
+
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      fileName: sanitizeName(collection?.name || ''),
+      location: ''
+    },
+    validationSchema: Yup.object({
+      fileName: Yup.string()
+        .min(1, 'must be at least 1 character')
+        .max(255, 'must be 255 characters or less')
+        .required('Name is required'),
+      location: Yup.string().min(1, 'Location is required').required('Location is required')
+    }),
+    onSubmit: (values) => handleExport(values, false)
+  });
+
+  // a conflicting filename is tracked for showing error
+  const fileExists = formik.errors.fileName === FILE_EXISTS_ERROR;
+
+  async function handleExport(values, overwrite) {
+    try {
+      const content = exportPostmanCollection(cloneDeep(collection), { preserveScripts });
+      await dispatch(exportCollectionToPostman(values.location, `${values.fileName}.json`, content, overwrite));
+      toast.success('Collection exported successfully');
+      onExported();
+    } catch (error) {
+      const message = error?.message || String(error);
+
+      // the filename already exists, surface it as a error message
+      if (!overwrite && message.includes('already exists')) {
+        formik.setFieldError('fileName', FILE_EXISTS_ERROR);
+        return;
+      }
+      toast.error('Failed to export collection: ' + message);
+    }
+  }
+
+  // overwrite = true will replace the existing file in the location
+  const handleReplace = () => handleExport(formik.values, true);
+
+  const browse = () => {
+    dispatch(browseDirectory())
+      .then((dirPath) => {
+        if (typeof dirPath === 'string' && dirPath.length > 0) {
+          formik.setFieldValue('location', dirPath);
+        }
+      })
+      .catch((error) => {
+        formik.setFieldValue('location', '');
+        console.error(error);
+      });
+  };
+
+  useEffect(() => {
+    if (inputRef && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [inputRef]);
+
+  const AdvancedOptions = forwardRef((props, ref) => {
+    return (
+      <div ref={ref} className="flex items-center text-link cursor-pointer">
+        <button className="btn-advanced" type="button">
+          Options
+        </button>
+        <IconCaretDown className="caret ml-1" size={14} strokeWidth={2} />
+      </div>
+    );
+  });
+
+  return (
+    <Portal>
+      <StyledWrapper>
+        <Modal
+          size="md"
+          title="Export to Postman"
+          confirmText={fileExists ? 'Replace' : 'Export'}
+          confirmButtonColor={fileExists ? 'danger' : 'primary'}
+          handleConfirm={() => (fileExists ? handleReplace() : formik.handleSubmit())}
+          handleCancel={onClose}
+          footerLeft={(
+            <div className="advanced-options flex">
+              <Dropdown onCreate={onOptionsDropdownCreate} icon={<AdvancedOptions />} placement="bottom-start">
+                <div
+                  className="dropdown-item"
+                  data-testid="show-advanced-options-toggle"
+                  onClick={() => {
+                    optionsDropdownTippyRef?.current?.hide();
+                    setShowAdvancedOptions(!showAdvancedOptions);
+                  }}
+                >
+                  {showAdvancedOptions ? 'Hide Advanced Options' : 'Show Advanced Options'}
+                </div>
+              </Dropdown>
+            </div>
+          )}
+        >
+          <form className="bruno-form" onSubmit={(e) => e.preventDefault()}>
+            <label htmlFor="fileName" className="block font-medium">
+              Name
+            </label>
+            <div className="relative">
+              <input
+                id="fileName"
+                type="text"
+                name="fileName"
+                ref={inputRef}
+                className="block textbox mt-2 !pr-14 w-full"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck="false"
+                value={formik.values.fileName || ''}
+                onChange={formik.handleChange}
+              />
+              <div className="absolute right-2 top-0 bottom-0 h-full flex items-center file-extension">.json</div>
+            </div>
+            {formik.touched.fileName && formik.errors.fileName ? (
+              <div className="error-message">{formik.errors.fileName}</div>
+            ) : null}
+
+            <label htmlFor="location" className="block font-medium mt-4">
+              Location
+            </label>
+            <input
+              id="location"
+              type="text"
+              name="location"
+              className="block textbox mt-2 w-full cursor-pointer"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck="false"
+              value={formik.values.location || ''}
+              onClick={browse}
+              onChange={(e) => formik.setFieldValue('location', e.target.value)}
+            />
+            {formik.touched.location && formik.errors.location ? (
+              <div className="error-message">{formik.errors.location}</div>
+            ) : null}
+            <div className="mt-1">
+              <span className="text-link cursor-pointer hover:underline" onClick={browse}>
+                Browse
+              </span>
+            </div>
+
+            {showAdvancedOptions && (
+              <div className="mt-4">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={preserveScripts}
+                    onChange={(e) => setPreserveScripts(e.target.checked)}
+                    className="checkbox cursor-pointer"
+                    data-testid="preserve-scripts-toggle"
+                  />
+                  <span className="preserve-scripts-label">Preserve scripts</span>
+                </label>
+                <p className="preserve-scripts-description">
+                  Exports bru.* scripts as-is, without translating them to pm.*.
+                </p>
+              </div>
+            )}
+          </form>
+        </Modal>
+      </StyledWrapper>
+    </Portal>
+  );
+};
+
+export default ExportToPostman;

--- a/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CreateCollection/index.js
@@ -25,7 +25,7 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
   const workspaces = useSelector((state) => state.workspaces?.workspaces || []);
   const workspaceUid = useSelector((state) => state.workspaces?.activeWorkspaceUid);
   const [isEditing, toggleEditing] = useState(false);
-  const [showFileFormat, setShowFileFormat] = useState(false);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const preferences = useSelector((state) => state.app.preferences);
 
   const dropdownTippyRef = useRef();
@@ -243,7 +243,7 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
                 </div>
               )}
 
-              {showFileFormat && (
+              {showAdvancedOptions && (
                 <div className="mt-4">
                   <label htmlFor="format" className="flex items-center font-medium">
                     File Format
@@ -280,14 +280,14 @@ const CreateCollection = ({ onClose, defaultLocation: propDefaultLocation, initi
                 <Dropdown onCreate={onDropdownCreate} icon={<AdvancedOptions />} placement="bottom-start">
                   <div
                     className="dropdown-item"
-                    key="show-file-format"
-                    data-testid="show-file-format-toggle"
+                    key="show-advanced-options"
+                    data-testid="show-advanced-options-toggle"
                     onClick={(e) => {
                       dropdownTippyRef.current.hide();
-                      setShowFileFormat(!showFileFormat);
+                      setShowAdvancedOptions(!showAdvancedOptions);
                     }}
                   >
-                    {showFileFormat ? 'Hide File Format' : 'Show File Format'}
+                    {showAdvancedOptions ? 'Hide Advanced Options' : 'Show Advanced Options'}
                   </div>
                 </Dropdown>
               </div>

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/StyledWrapper.js
@@ -21,6 +21,16 @@ const Wrapper = styled.div`
       fill: ${(props) => props.theme.textLink};
     }
   }
+
+  .preserve-scripts-label {
+    font-weight: 500;
+  }
+
+  .preserve-scripts-description {
+    font-size: 0.75rem;
+    color: ${(props) => props.theme.colors.text.muted};
+    margin-top: 0.25rem;
+  }
 `;
 
 export default Wrapper;

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/StyledWrapper.js
@@ -22,13 +22,13 @@ const Wrapper = styled.div`
     }
   }
 
-  .preserve-scripts-label {
+  .checkbox-option-label {
     font-weight: 500;
   }
 
-  .preserve-scripts-description {
+  .checkbox-option-description {
     font-size: 0.75rem;
-    color: ${(props) => props.theme.colors.text.muted};
+    color: ${(props) => props.theme.colors.text.subtext0};
     margin-top: 0.25rem;
   }
 `;

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -362,21 +362,21 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
               )}
 
               {showAdvancedOptions && isPostman && (
-                <div className="mt-4">
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={preserveScripts}
-                      onChange={(e) => setPreserveScripts(e.target.checked)}
-                      className="checkbox cursor-pointer"
-                      data-testid="preserve-scripts-toggle"
-                    />
-                    <span className="preserve-scripts-label">Preserve scripts</span>
-                  </label>
-                  <p className="preserve-scripts-description">
-                    Imports pm.* scripts as-is, without translating them to bru.*.
-                  </p>
-                </div>
+                <label className="mt-4 flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={preserveScripts}
+                    onChange={(e) => setPreserveScripts(e.target.checked)}
+                    className="checkbox cursor-pointer mt-0.5"
+                    data-testid="preserve-scripts-toggle"
+                  />
+                  <div>
+                    <span className="checkbox-option-label">Preserve scripts</span>
+                    <p className="checkbox-option-description">
+                      Imports pm.* scripts as-is, without translating them to bru.*.
+                    </p>
+                  </div>
+                </label>
               )}
             </div>
 
@@ -410,23 +410,23 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
               </div>
             )}
             {showCheckForSpecUpdatesOption && (
-              <div className={`mt-4 ${isSwagger2 ? 'opacity-50 pointer-events-none' : ''}`}>
-                <label className={`flex items-center gap-2 ${isSwagger2 ? '' : 'cursor-pointer'}`}>
-                  <input
-                    type="checkbox"
-                    checked={isSwagger2 ? false : enableCheckForSpecUpdates}
-                    onChange={(e) => setEnableCheckForSpecUpdates(e.target.checked)}
-                    disabled={isSwagger2}
-                    className={`checkbox ${isSwagger2 ? '' : 'cursor-pointer'}`}
-                  />
-                  <span className="font-medium">Check for Spec Updates</span>
-                </label>
-                <p className="text-muted text-xs mt-1">
-                  {isSwagger2
-                    ? 'OpenAPI Sync is not supported for Swagger 2.0 specs.'
-                    : 'Stay notified of spec changes and sync your collection with the spec.'}
-                </p>
-              </div>
+              <label className={`mt-4 flex items-start gap-2 ${isSwagger2 ? 'opacity-50 pointer-events-none' : 'cursor-pointer'}`}>
+                <input
+                  type="checkbox"
+                  checked={isSwagger2 ? false : enableCheckForSpecUpdates}
+                  onChange={(e) => setEnableCheckForSpecUpdates(e.target.checked)}
+                  disabled={isSwagger2}
+                  className={`checkbox mt-0.5 ${isSwagger2 ? '' : 'cursor-pointer'}`}
+                />
+                <div>
+                  <span className="checkbox-option-label">Check for Spec Updates</span>
+                  <p className="checkbox-option-description">
+                    {isSwagger2
+                      ? 'OpenAPI Sync is not supported for Swagger 2.0 specs.'
+                      : 'Stay notified of spec changes and sync your collection with the spec.'}
+                  </p>
+                </div>
+              </label>
             )}
           </form>
         </Modal>

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -373,7 +373,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
                   <div>
                     <span className="checkbox-option-label">Preserve scripts</span>
                     <p className="checkbox-option-description">
-                      Imports pm.* scripts as-is, without translating them to bru.*.
+                      Import Postman scripts without translating them.
                     </p>
                   </div>
                 </label>

--- a/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ImportCollectionLocation/index.js
@@ -56,7 +56,7 @@ const getCollectionName = (format, rawData) => {
 
 // Convert raw data to Bruno collection format
 // Returns { collection, issues } where issues tracks items that were skipped or degraded
-const convertCollection = async (format, rawData, groupingType, collectionFormat) => {
+const convertCollection = async (format, rawData, groupingType, collectionFormat, preserveScripts) => {
   try {
     let collection;
     let issues = [];
@@ -69,7 +69,7 @@ const convertCollection = async (format, rawData, groupingType, collectionFormat
         collection = await wsdlToBruno(rawData);
         break;
       case 'postman': {
-        const result = await postmanToBruno(rawData);
+        const result = await postmanToBruno(rawData, { preserveScripts });
         collection = result.collection;
         issues = result.issues || [];
         break;
@@ -109,11 +109,13 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
   const dispatch = useDispatch();
   const [groupingType, setGroupingType] = useState('tags');
   const [collectionFormat, setCollectionFormat] = useState(DEFAULT_COLLECTION_FORMAT);
-  const [showFileFormat, setShowFileFormat] = useState(false);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [enableCheckForSpecUpdates, setEnableCheckForSpecUpdates] = useState(false);
+  const [preserveScripts, setPreserveScripts] = useState(false);
   const dropdownTippyRef = useRef();
   const optionsDropdownTippyRef = useRef();
   const isOpenApi = format === 'openapi';
+  const isPostman = format === 'postman';
   const isZipImport = format === 'bruno-zip';
   const isOpenApiFromUrl = isOpenApi && !!sourceUrl && !filePath;
   const isOpenApiFromFile = isOpenApi && !!filePath && !sourceUrl;
@@ -143,7 +145,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
         .required('Location is required')
     }),
     onSubmit: async (values) => {
-      const { collection: convertedCollection, issues } = await convertCollection(format, rawData, groupingType, collectionFormat);
+      const { collection: convertedCollection, issues } = await convertCollection(format, rawData, groupingType, collectionFormat, preserveScripts);
       const options = { format: collectionFormat };
 
       if (showCheckForSpecUpdatesOption && enableCheckForSpecUpdates) {
@@ -274,13 +276,13 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
                 <Dropdown onCreate={onOptionsDropdownCreate} icon={<ImportOptions />} placement="bottom-start">
                   <div
                     className="dropdown-item"
-                    data-testid="show-file-format-toggle"
+                    data-testid="show-advanced-options-toggle"
                     onClick={() => {
                       optionsDropdownTippyRef?.current?.hide();
-                      setShowFileFormat(!showFileFormat);
+                      setShowAdvancedOptions(!showAdvancedOptions);
                     }}
                   >
-                    {showFileFormat ? 'Hide File Format' : 'Show File Format'}
+                    {showAdvancedOptions ? 'Hide Advanced Options' : 'Show Advanced Options'}
                   </div>
                 </Dropdown>
               </div>
@@ -332,7 +334,7 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
                 </span>
               </div>
 
-              {showFileFormat && !isZipImport && (
+              {showAdvancedOptions && !isZipImport && (
                 <div className="mt-4">
                   <label htmlFor="format" className="flex items-center font-medium">
                     File Format
@@ -356,6 +358,24 @@ const ImportCollectionLocation = ({ onClose, handleSubmit, rawData, format, sour
                     <option value="yml">OpenCollection (YAML)</option>
                     <option value="bru">BRU Format (.bru)</option>
                   </select>
+                </div>
+              )}
+
+              {showAdvancedOptions && isPostman && (
+                <div className="mt-4">
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={preserveScripts}
+                      onChange={(e) => setPreserveScripts(e.target.checked)}
+                      className="checkbox cursor-pointer"
+                      data-testid="preserve-scripts-toggle"
+                    />
+                    <span className="preserve-scripts-label">Preserve scripts</span>
+                  </label>
+                  <p className="preserve-scripts-description">
+                    Imports pm.* scripts as-is, without translating them to bru.*.
+                  </p>
                 </div>
               )}
             </div>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2685,6 +2685,17 @@ export const browseFiles = (filters, properties) => (_dispatch, _getState) => {
   });
 };
 
+export const exportCollectionToPostman = (location, fileName, content, overwrite = false) => (_dispatch, _getState) => {
+  const { ipcRenderer } = window;
+
+  return new Promise((resolve, reject) => {
+    ipcRenderer
+      .invoke('renderer:export-collection-postman', location, fileName, content, overwrite)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
 export const saveCollectionSettings = (collectionUid, brunoConfig = null, silent = false) => (dispatch, getState) => {
   const state = getState();
   const collection = findCollectionByUid(state.collections.collections, collectionUid);

--- a/packages/bruno-app/src/utils/exporters/postman-collection.js
+++ b/packages/bruno-app/src/utils/exporters/postman-collection.js
@@ -1,17 +1,13 @@
-import * as FileSaver from 'file-saver';
 import { brunoToPostman } from '@usebruno/converters';
 import { filterTransientItems } from 'utils/collections';
 
-export const exportCollection = (collection) => {
+export const exportPostmanCollection = (collection, { preserveScripts = false } = {}) => {
   // Filter out transient items before export
   collection.items = filterTransientItems(collection.items);
 
-  const collectionToExport = brunoToPostman(collection);
+  const collectionToExport = brunoToPostman(collection, { preserveScripts });
 
-  const fileName = `${collection.name}.json`;
-  const fileBlob = new Blob([JSON.stringify(collectionToExport, null, 2)], { type: 'application/json' });
-
-  FileSaver.saveAs(fileBlob, fileName);
+  return JSON.stringify(collectionToExport, null, 2);
 };
 
-export default exportCollection;
+export default exportPostmanCollection;

--- a/packages/bruno-app/src/utils/importers/postman-collection.js
+++ b/packages/bruno-app/src/utils/importers/postman-collection.js
@@ -11,9 +11,9 @@ const readFile = (files) => {
   });
 };
 
-const postmanToBruno = (collection) => {
+const postmanToBruno = (collection, options = {}) => {
   return new Promise((resolve, reject) => {
-    window.ipcRenderer.invoke('renderer:convert-postman-to-bruno', collection)
+    window.ipcRenderer.invoke('renderer:convert-postman-to-bruno', collection, options)
       .then((result) => resolve(result))
       .catch((err) => {
         console.error('Error converting Postman to Bruno via Electron:', err);

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -147,7 +147,7 @@ export const sanitizeUrl = (url) => {
   return sanitizedUrl;
 };
 
-export const brunoToPostman = (collection) => {
+export const brunoToPostman = (collection, { preserveScripts = false } = {}) => {
   delete collection.uid;
   delete collection.processEnvVariables;
   deleteUidsInItems(collection.items);
@@ -214,6 +214,11 @@ export const brunoToPostman = (collection) => {
     return Array.from(finalVarsMap.values());
   };
   const translateScriptSafely = (script = '') => {
+    // When preserving scripts option is enabled, return the
+    // script as-is without any bru.* -> pm.* translation
+    if (preserveScripts) {
+      return script;
+    }
     try {
       return translateBruToPostman(script);
     } catch (err) {

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -186,7 +186,10 @@ const constructUrl = (url) => {
   return '';
 };
 
-const importScriptsFromEvents = (events, requestObject) => {
+const translateOrPreserve = (exec, preserveScripts) =>
+  preserveScripts ? (Array.isArray(exec) ? exec.join('\n') : exec) : postmanTranslation(exec);
+
+const importScriptsFromEvents = (events, requestObject, preserveScripts = false) => {
   events.forEach((event) => {
     if (event.script && event.script.exec) {
       if (event.listen === 'prerequest') {
@@ -195,7 +198,7 @@ const importScriptsFromEvents = (events, requestObject) => {
         }
 
         if (event.script.exec && event.script.exec.length > 0) {
-          requestObject.script.req = postmanTranslation(event.script.exec);
+          requestObject.script.req = translateOrPreserve(event.script.exec, preserveScripts);
         } else {
           requestObject.script.req = '';
           console.warn('Unexpected event.script.exec type', typeof event.script.exec);
@@ -208,7 +211,7 @@ const importScriptsFromEvents = (events, requestObject) => {
         }
 
         if (event.script.exec && event.script.exec.length > 0) {
-          requestObject.script.res = postmanTranslation(event.script.exec);
+          requestObject.script.res = translateOrPreserve(event.script.exec, preserveScripts);
         } else {
           requestObject.script.res = '';
           console.warn('Unexpected event.script.exec type', typeof event.script.exec);
@@ -399,7 +402,7 @@ export const processAuth = (auth, requestObject, isCollection = false) => {
   }
 };
 
-const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false } = {}, scriptMap, issues = [], parentPath = '') => {
+const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false, preserveScripts = false } = {}, scriptMap, issues = [], parentPath = '') => {
   brunoParent.items = brunoParent.items || [];
   const folderMap = {};
   const requestMap = {};
@@ -459,17 +462,17 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
       processAuth(i.auth, brunoFolderItem.root.request);
 
       if (i.item && i.item.length) {
-        importPostmanV2CollectionItem(brunoFolderItem, i.item, { useWorkers }, scriptMap, issues, itemPath);
+        importPostmanV2CollectionItem(brunoFolderItem, i.item, { useWorkers, preserveScripts }, scriptMap, issues, itemPath);
       }
 
       if (i.event) {
-        if (useWorkers) {
+        if (useWorkers && !preserveScripts) {
           scriptMap.set(brunoFolderItem.uid, {
             events: i.event,
             request: brunoFolderItem.root.request
           });
         } else {
-          importScriptsFromEvents(i.event, brunoFolderItem.root.request);
+          importScriptsFromEvents(i.event, brunoFolderItem.root.request, preserveScripts);
         }
       }
 
@@ -543,7 +546,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
         brunoRequestItem.settings = settings;
 
         if (i.event) {
-          if (useWorkers) {
+          if (useWorkers && !preserveScripts) {
             scriptMap.set(brunoRequestItem.uid, {
               events: i.event,
               request: brunoRequestItem.request
@@ -555,7 +558,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
                   brunoRequestItem.request.script = {};
                 }
                 if (event.script.exec && event.script.exec.length > 0) {
-                  brunoRequestItem.request.script.req = postmanTranslation(event.script.exec);
+                  brunoRequestItem.request.script.req = translateOrPreserve(event.script.exec, preserveScripts);
                 } else {
                   brunoRequestItem.request.script.req = '';
                   console.warn('Unexpected event.script.exec type', typeof event.script.exec);
@@ -566,7 +569,7 @@ const importPostmanV2CollectionItem = (brunoParent, item, { useWorkers = false }
                   brunoRequestItem.request.script = {};
                 }
                 if (event.script.exec && event.script.exec.length > 0) {
-                  brunoRequestItem.request.script.res = postmanTranslation(event.script.exec);
+                  brunoRequestItem.request.script.res = translateOrPreserve(event.script.exec, preserveScripts);
                 } else {
                   brunoRequestItem.request.script.res = '';
                   console.warn('Unexpected event.script.exec type', typeof event.script.exec);
@@ -966,7 +969,7 @@ const rewriteRequiresInBrunoCollection = (brunoCollection) => {
   return Array.from(injected);
 };
 
-const importPostmanV2Collection = async (collection, { useWorkers = false }) => {
+const importPostmanV2Collection = async (collection, { useWorkers = false, preserveScripts = false }) => {
   const brunoCollection = {
     name: collection.info.name || 'Untitled Collection',
     uid: uuid(),
@@ -998,7 +1001,7 @@ const importPostmanV2Collection = async (collection, { useWorkers = false }) => 
   };
 
   if (collection.event) {
-    importScriptsFromEvents(collection.event, brunoCollection.root.request);
+    importScriptsFromEvents(collection.event, brunoCollection.root.request, preserveScripts);
   }
 
   const issues = [];
@@ -1015,9 +1018,9 @@ const importPostmanV2Collection = async (collection, { useWorkers = false }) => 
   processAuth(collection.auth, brunoCollection.root.request, true);
 
   // Create a single scriptMap for all items
-  const scriptMap = useWorkers ? new Map() : null;
+  const scriptMap = useWorkers && !preserveScripts ? new Map() : null;
 
-  importPostmanV2CollectionItem(brunoCollection, collection.item, { useWorkers }, scriptMap, issues);
+  importPostmanV2CollectionItem(brunoCollection, collection.item, { useWorkers, preserveScripts }, scriptMap, issues);
 
   // Process all scripts in a single call at the top level
   if (useWorkers && scriptMap && scriptMap.size > 0) {
@@ -1079,7 +1082,7 @@ const importPostmanV2Collection = async (collection, { useWorkers = false }) => 
   return { collection: brunoCollection, issues };
 };
 
-const parsePostmanCollection = async (collection, { useWorkers = false }) => {
+const parsePostmanCollection = async (collection, { useWorkers = false, preserveScripts = false }) => {
   try {
     // Newer Postman exports wrap the collection in a { collection: { ... } } envelope
     const parsedCollection = collection.collection?.info ? collection.collection : collection;
@@ -1094,7 +1097,7 @@ const parsePostmanCollection = async (collection, { useWorkers = false }) => {
     ];
 
     if (v2Schemas.includes(schema)) {
-      return await importPostmanV2Collection(parsedCollection, { useWorkers });
+      return await importPostmanV2Collection(parsedCollection, { useWorkers, preserveScripts });
     }
 
     throw new Error('Unsupported Postman schema version. Only Postman Collection v2.0 and v2.1 are supported.');
@@ -1108,7 +1111,7 @@ const parsePostmanCollection = async (collection, { useWorkers = false }) => {
   }
 };
 
-const postmanToBruno = async (postmanCollection, { useWorkers = false } = {}) => {
+const postmanToBruno = async (postmanCollection, { useWorkers = false, preserveScripts = false } = {}) => {
   try {
     // Resolve the actual collection envelope (Postman wraps newer exports
     // in a `{ collection: {...} }` shell) so the raw scan sees real events.
@@ -1117,20 +1120,21 @@ const postmanToBruno = async (postmanCollection, { useWorkers = false } = {}) =>
       : postmanCollection;
     const rawPackages = collectPackagesFromPostmanCollection(rawCollectionForScan);
 
-    const { collection: parsedCollection, issues } = await parsePostmanCollection(postmanCollection, { useWorkers });
+    const { collection: parsedCollection, issues } = await parsePostmanCollection(postmanCollection, { useWorkers, preserveScripts });
     const transformedCollection = transformItemsInCollection(parsedCollection);
     const hydratedCollection = hydrateSeqInCollection(transformedCollection);
     // Apply backward compatibility transformation for string status to number
     const statusTransformedCollection = transformExampleStatusInCollection(hydratedCollection);
     const validatedCollection = validateSchema(statusTransformedCollection);
 
-    // Rewrite any pm.require() calls that survived the Bruno-side translator
+    // When preserving script option is enabled, skip any rewrite.
+    // Otherwise rewrite any pm.require() calls that survived the Bruno-side translator
     // so the imported scripts use plain require(). The post-scan also picks
     // up translator-injected globals (cheerio, tv4, ...) - packages Postman
     // exposed as sandbox globals that the raw pre-scan can't see. The
     // schema is strict + noUnknown so we attach the report by mutating
     // the already-validated collection.
-    const injectedPackages = rewriteRequiresInBrunoCollection(validatedCollection);
+    const injectedPackages = preserveScripts ? [] : rewriteRequiresInBrunoCollection(validatedCollection);
     validatedCollection.packageReport = buildPackageReport([...rawPackages, ...injectedPackages]);
 
     return { collection: validatedCollection, issues };

--- a/packages/bruno-converters/tests/postman/preserve-scripts.spec.js
+++ b/packages/bruno-converters/tests/postman/preserve-scripts.spec.js
@@ -1,0 +1,303 @@
+import { describe, it, expect } from '@jest/globals';
+import postmanToBruno from '../../src/postman/postman-to-bruno';
+import { brunoToPostman } from '../../src/postman/bruno-to-postman';
+
+const postmanCollectionWithScripts = {
+  info: {
+    _postman_id: 'preserve-scripts-test',
+    name: 'Preserve Scripts Collection',
+    schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+  },
+  variable: [{ key: 'token', value: 'abc123' }],
+  item: [
+    {
+      name: 'Get User',
+      request: { method: 'GET', url: 'https://example.com/users' },
+      event: [
+        {
+          listen: 'prerequest',
+          script: { type: 'text/javascript', exec: ['pm.environment.set(\'token\', \'123\')', 'console.log(\'pre\')'] }
+        },
+        {
+          listen: 'test',
+          script: { type: 'text/javascript', exec: ['pm.test(\'status is 200\', function () {', '  pm.response.to.have.status(200);', '});'] }
+        }
+      ]
+    }
+  ]
+};
+
+describe('preserve scripts option is enabled when importing a Postman collection', () => {
+  it('should keep pre-request and test scripts as-is instead of translating pm.* to bru.*', async () => {
+    const { collection } = await postmanToBruno(postmanCollectionWithScripts, { preserveScripts: true });
+    const request = collection.items[0].request;
+
+    // scripts are preserved exactly as in the imported postman collection
+    expect(request.script.req).toBe('pm.environment.set(\'token\', \'123\')\nconsole.log(\'pre\')');
+    expect(request.script.res).toBe('pm.test(\'status is 200\', function () {\n  pm.response.to.have.status(200);\n});');
+
+    // no pm.* -> bru.* translation occurred
+    expect(request.script.req).not.toContain('bru.');
+    expect(request.script.res).not.toContain('bru.');
+  });
+
+  it('should convert the collection metadata, requests, and variables', async () => {
+    const { collection } = await postmanToBruno(postmanCollectionWithScripts, { preserveScripts: true });
+
+    expect(collection.name).toBe('Preserve Scripts Collection');
+    expect(collection.items).toHaveLength(1);
+    expect(collection.items[0].name).toBe('Get User');
+    expect(collection.items[0].request.method).toBe('GET');
+    expect(collection.items[0].request.url).toBe('https://example.com/users');
+    expect(collection.root.request.vars.req).toMatchObject([{ name: 'token', value: 'abc123', enabled: true }]);
+  });
+
+  it('should translate scripts to bru.* by default when the option is not enabled', async () => {
+    const { collection } = await postmanToBruno(postmanCollectionWithScripts);
+    const request = collection.items[0].request;
+
+    expect(request.script.req).toContain('bru.setEnvVar(\'token\', \'123\')');
+    expect(request.script.req).not.toContain('pm.environment.set');
+  });
+
+  it('should keep scripts as is even when the worker path is used', async () => {
+    const { collection } = await postmanToBruno(postmanCollectionWithScripts, {
+      useWorkers: true,
+      preserveScripts: true
+    });
+    const request = collection.items[0].request;
+
+    expect(request.script.req).toBe('pm.environment.set(\'token\', \'123\')\nconsole.log(\'pre\')');
+    expect(request.script.res).toBe('pm.test(\'status is 200\', function () {\n  pm.response.to.have.status(200);\n});');
+    expect(request.script.req).not.toContain('bru.');
+  });
+
+  it('should leave pm.require() and require() calls untouched', async () => {
+    const collectionWithRequire = {
+      info: {
+        _postman_id: 'preserve-require-test',
+        name: 'Require Collection',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'Uses packages',
+          request: { method: 'GET', url: 'https://example.com' },
+          event: [
+            {
+              listen: 'prerequest',
+              script: { type: 'text/javascript', exec: ['const _ = pm.require(\'lodash\');', 'const axios = require(\'axios\');'] }
+            }
+          ]
+        }
+      ]
+    };
+
+    const { collection } = await postmanToBruno(collectionWithRequire, { preserveScripts: true });
+    const request = collection.items[0].request;
+
+    // require rewriting is skipped in preserve mode
+    expect(request.script.req).toBe('const _ = pm.require(\'lodash\');\nconst axios = require(\'axios\');');
+  });
+});
+
+describe('preserve scripts for collection and folder level scripts', () => {
+  const postmanCollectionWithNestedScripts = {
+    info: {
+      _postman_id: 'preserve-nested-test',
+      name: 'Nested Scripts Collection',
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+    },
+    event: [
+      { listen: 'prerequest', script: { type: 'text/javascript', exec: ['pm.environment.set(\'collectionVar\', \'1\')'] } },
+      { listen: 'test', script: { type: 'text/javascript', exec: ['pm.test(\'collection-level test\', function () {});'] } }
+    ],
+    item: [
+      {
+        name: 'Auth Folder',
+        event: [
+          { listen: 'prerequest', script: { type: 'text/javascript', exec: ['pm.variables.set(\'folderVar\', \'2\')'] } },
+          { listen: 'test', script: { type: 'text/javascript', exec: ['pm.expect(true).to.be.true;'] } }
+        ],
+        item: [{ name: 'Login', request: { method: 'POST', url: 'https://example.com/login' } }]
+      }
+    ]
+  };
+
+  it('should keep collection level scripts as is', async () => {
+    const { collection } = await postmanToBruno(postmanCollectionWithNestedScripts, { preserveScripts: true });
+    const rootScript = collection.root.request.script;
+
+    expect(rootScript.req).toBe('pm.environment.set(\'collectionVar\', \'1\')');
+    expect(rootScript.res).toBe('pm.test(\'collection-level test\', function () {});');
+    expect(rootScript.req).not.toContain('bru.');
+  });
+
+  it('should keep folder level scripts as is', async () => {
+    const { collection } = await postmanToBruno(postmanCollectionWithNestedScripts, { preserveScripts: true });
+    const folder = collection.items.find((i) => i.type === 'folder');
+    const folderScript = folder.root.request.script;
+
+    expect(folderScript.req).toBe('pm.variables.set(\'folderVar\', \'2\')');
+    expect(folderScript.res).toBe('pm.expect(true).to.be.true;');
+    expect(folderScript.req).not.toContain('bru.');
+  });
+});
+
+describe('Preserve scripts option when exporting a collection to Postman', () => {
+  const brunoCollectionWithScripts = {
+    name: 'Bruno Collection',
+    items: [
+      {
+        name: 'Get User',
+        type: 'http-request',
+        request: {
+          method: 'GET',
+          url: 'https://example.com/users',
+          script: {
+            req: 'bru.setEnvVar(\'token\', \'123\')',
+            res: 'test(\'status is 200\', function () {\n  expect(res.getStatus()).to.equal(200);\n});'
+          }
+        }
+      }
+    ]
+  };
+
+  it('should keep scripts as is instead of translating bru.* to pm.*', () => {
+    const result = brunoToPostman(brunoCollectionWithScripts, { preserveScripts: true });
+    const events = result.item[0].event;
+
+    const prerequest = events.find((e) => e.listen === 'prerequest');
+    const test = events.find((e) => e.listen === 'test');
+
+    expect(prerequest.script.exec).toEqual(['bru.setEnvVar(\'token\', \'123\')']);
+    expect(test.script.exec).toEqual(['test(\'status is 200\', function () {', '  expect(res.getStatus()).to.equal(200);', '});']);
+    expect(prerequest.script.exec.join('\n')).not.toContain('pm.');
+  });
+
+  it('should translate scripts to pm.* by default when the option is not enabled', () => {
+    const result = brunoToPostman(brunoCollectionWithScripts);
+    const prerequest = result.item[0].event.find((e) => e.listen === 'prerequest');
+
+    expect(prerequest.script.exec.join('\n')).toContain('pm.environment.set');
+  });
+
+  it('should keep the tests block as is instead of translating it', () => {
+    const brunoCollectionWithTests = {
+      name: 'Bruno Collection',
+      items: [
+        {
+          name: 'Get User',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com/users',
+            tests: 'test(\'is ok\', function () {\n  expect(res.getStatus()).to.equal(200);\n});'
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(brunoCollectionWithTests, { preserveScripts: true });
+    // A request's `tests` field is exported into the Postman test event
+    const testEvent = result.item[0].event.find((e) => e.listen === 'test');
+
+    expect(testEvent.script.exec.join('\n')).toContain('test(\'is ok\', function () {');
+    expect(testEvent.script.exec.join('\n')).toContain('expect(res.getStatus()).to.equal(200)');
+    expect(testEvent.script.exec.join('\n')).not.toContain('pm.');
+  });
+
+  it('should merge a post-response script and a tests block into one test event without translating either', () => {
+    const brunoCollectionWithResAndTests = {
+      name: 'Bruno Collection',
+      items: [
+        {
+          name: 'Get User',
+          type: 'http-request',
+          request: {
+            method: 'GET',
+            url: 'https://example.com/users',
+            script: {
+              res: 'bru.setVar(\'userId\', \'42\');'
+            },
+            tests: 'test(\'is ok\', function () {\n  expect(bru.getVar(\'userId\')).to.equal(\'42\');\n});'
+          }
+        }
+      ]
+    };
+
+    const result = brunoToPostman(brunoCollectionWithResAndTests, { preserveScripts: true });
+    const testEvent = result.item[0].event.find((e) => e.listen === 'test');
+
+    // res and tests bodies are carried verbatim
+    expect(testEvent.script.exec).toEqual([
+      'bru.setVar(\'userId\', \'42\');',
+      '',
+      '// Tests',
+      'test(\'is ok\', function () {',
+      '  expect(bru.getVar(\'userId\')).to.equal(\'42\');',
+      '});'
+    ]);
+    expect(testEvent.script.exec.join('\n')).not.toContain('pm.');
+  });
+});
+
+describe('Preserve scripts option across a full round trip', () => {
+  const prerequestExec = [
+    '// Fetch an auth token before the request runs',
+    'const token = pm.environment.get(\'authToken\');',
+    '',
+    'if (!token) {',
+    '  pm.sendRequest({',
+    '    url: pm.environment.get(\'baseUrl\') + \'/auth/login\',',
+    '    method: \'POST\'',
+    '  }, function (err, res) {',
+    '    pm.environment.set(\'authToken\', res.json().token);',
+    '  });',
+    '}'
+  ];
+  const testExec = [
+    'pm.test(\'status is 200\', function () {',
+    '  pm.response.to.have.status(200);',
+    '});',
+    '',
+    'pm.test(\'has user id\', function () {',
+    '  const body = pm.response.json();',
+    '  pm.expect(body).to.have.property(\'id\');',
+    '});'
+  ];
+
+  const postmanCollectionWithRealisticScripts = {
+    info: {
+      _postman_id: 'preserve-roundtrip-test',
+      name: 'Round Trip Collection',
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+    },
+    item: [
+      {
+        name: 'Login',
+        request: { method: 'POST', url: 'https://example.com/login' },
+        event: [
+          { listen: 'prerequest', script: { type: 'text/javascript', exec: prerequestExec } },
+          { listen: 'test', script: { type: 'text/javascript', exec: testExec } }
+        ]
+      }
+    ]
+  };
+
+  it('should keep a multi-line script identical after a round trip conversion', async () => {
+    const { collection } = await postmanToBruno(postmanCollectionWithRealisticScripts, { preserveScripts: true });
+    const brunoRequest = collection.items[0].request;
+
+    expect(brunoRequest.script.req).toBe(prerequestExec.join('\n'));
+    expect(brunoRequest.script.res).toBe(testExec.join('\n'));
+
+    const result = brunoToPostman(collection, { preserveScripts: true });
+    const events = result.item[0].event;
+    const prerequest = events.find((e) => e.listen === 'prerequest');
+    const test = events.find((e) => e.listen === 'test');
+
+    expect(prerequest.script.exec).toEqual(prerequestExec);
+    expect(test.script.exec).toEqual(testExec);
+  });
+});

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -2342,11 +2342,15 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
   });
 
   // Implement the Postman to Bruno conversion handler
-  ipcMain.handle('renderer:convert-postman-to-bruno', async (event, postmanCollection) => {
+  ipcMain.handle('renderer:convert-postman-to-bruno', async (event, postmanCollection, options = {}) => {
     try {
       // Convert Postman collection to Bruno format
       // Returns { collection, issues } where issues tracks items that were skipped or degraded
-      const result = await postmanToBruno(postmanCollection, { useWorkers: true });
+      const result = await postmanToBruno(postmanCollection, {
+        useWorkers: true,
+        // preserve scripts without any pm.* -> bru.* translation
+        preserveScripts: !!options.preserveScripts
+      });
 
       return result;
     } catch (error) {
@@ -2542,6 +2546,26 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       return { success: true, filePath };
     } catch (error) {
       throw error;
+    }
+  });
+
+  ipcMain.handle('renderer:export-collection-postman', async (event, dirPath, fileName, content, overwrite = false) => {
+    try {
+      if (!dirPath || !fs.existsSync(dirPath)) {
+        throw new Error('Export location does not exist');
+      }
+
+      const filePath = path.join(dirPath, fileName);
+
+      if (!overwrite && fs.existsSync(filePath)) {
+        throw new Error(`path: ${filePath} already exists`);
+      }
+
+      await writeFile(filePath, content);
+
+      return { success: true, filePath };
+    } catch (error) {
+      return Promise.reject(error);
     }
   });
 

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -2555,7 +2555,12 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         throw new Error('Export location does not exist');
       }
 
-      const filePath = path.join(dirPath, fileName);
+      // ensure the resolved path is inside the export directory
+      const resolvedDir = path.resolve(dirPath);
+      const filePath = path.resolve(resolvedDir, fileName);
+      if (!filePath.startsWith(resolvedDir + path.sep) && filePath !== resolvedDir) {
+        throw new Error('Invalid file name');
+      }
 
       if (!overwrite && fs.existsSync(filePath)) {
         throw new Error(`path: ${filePath} already exists`);

--- a/tests/export/postman/export-preserve-scripts.spec.ts
+++ b/tests/export/postman/export-preserve-scripts.spec.ts
@@ -1,61 +1,15 @@
-import { test, expect, Page } from '../../../playwright';
-import { closeAllCollections, openCollection } from '../../utils/page';
-import { buildCommonLocators } from '../../utils/page/locators';
+import { test, expect } from '../../../playwright';
+import {
+  closeAllCollections,
+  buildCommonLocators,
+  openExportToPostmanModal,
+  closeExportToPostmanModal,
+  exportCollectionToPostman
+} from '../../utils/page';
 import * as fs from 'fs';
 import * as nodePath from 'path';
 
 const COLLECTION_NAME = 'Export Scripts Collection';
-
-const openExportToPostmanModal = async (page: Page) => {
-  const locators = buildCommonLocators(page);
-
-  await openCollection(page, COLLECTION_NAME);
-
-  const collectionAction = locators.actions.collectionActions(COLLECTION_NAME);
-  await locators.sidebar.collection(COLLECTION_NAME).hover();
-  await expect(collectionAction).toBeVisible({ timeout: 2000 });
-  await collectionAction.click();
-  await locators.dropdown.item('Share').click();
-  await expect(locators.modal.title('Share Collection')).toBeVisible();
-
-  await page.getByTestId('export-format-postman').click();
-  await locators.modal.button('Proceed').click();
-  await expect(locators.modal.title('Export to Postman')).toBeVisible();
-};
-
-// export a collection via Share -> Export to Postman into outputDir and read the file
-const exportPostmanCollection = async (
-  page: Page,
-  outputDir: string,
-  { preserveScripts }: { preserveScripts: boolean }
-) => {
-  const locators = buildCommonLocators(page);
-
-  await openExportToPostmanModal(page);
-
-  await test.step('Set the export location', async () => {
-    await page.getByLabel('Location', { exact: true }).fill(outputDir);
-  });
-
-  await test.step('Configure preserve scripts', async () => {
-    if (preserveScripts) {
-      // 'Preserve scripts' lives under the modal footer's advanced options
-      await page.getByRole('button', { name: 'Options' }).click();
-      await page.getByTestId('show-advanced-options-toggle').click();
-      const checkbox = page.getByTestId('preserve-scripts-toggle');
-      await expect(checkbox).toBeVisible();
-      await checkbox.check();
-      await expect(checkbox).toBeChecked();
-    }
-  });
-
-  return await test.step('Export and read the written file', async () => {
-    await locators.modal.button('Export').click();
-    const filePath = nodePath.join(outputDir, `${COLLECTION_NAME}.json`);
-    await expect.poll(() => fs.existsSync(filePath), { timeout: 5000 }).toBe(true);
-    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  });
-};
 
 const findLoginEvents = (exported: any) => {
   const login = exported.item.find((i: any) => i.name === 'Login');
@@ -66,13 +20,13 @@ const findLoginEvents = (exported: any) => {
 };
 
 test.describe('Export Postman Collection - Preserve scripts option', () => {
-  test.afterAll(async ({ pageWithUserData: page }) => {
+  test.afterEach(async ({ pageWithUserData: page }) => {
     await closeAllCollections(page);
   });
 
   test('should export scripts as is when preserve scripts is enabled', async ({ pageWithUserData: page, createTmpDir }) => {
     const outputDir = await createTmpDir('postman-export');
-    const exported = await exportPostmanCollection(page, outputDir, { preserveScripts: true });
+    const exported = await exportCollectionToPostman(page, COLLECTION_NAME, outputDir, { preserveScripts: true });
     const { prerequest, test: testEvent } = findLoginEvents(exported);
 
     expect(prerequest.script.exec.join('\n')).toContain('bru.setEnvVar(\'token\', \'abc\')');
@@ -83,7 +37,7 @@ test.describe('Export Postman Collection - Preserve scripts option', () => {
 
   test('should translate scripts to pm.* by default when preserve scripts is disabled', async ({ pageWithUserData: page, createTmpDir }) => {
     const outputDir = await createTmpDir('postman-export');
-    const exported = await exportPostmanCollection(page, outputDir, { preserveScripts: false });
+    const exported = await exportCollectionToPostman(page, COLLECTION_NAME, outputDir, { preserveScripts: false });
     const { prerequest } = findLoginEvents(exported);
 
     expect(prerequest.script.exec.join('\n')).toContain('pm.environment.set');
@@ -98,10 +52,10 @@ test.describe('Export Postman Collection - Preserve scripts option', () => {
     // Pre seed a conflicting file so the export hits the "already exists" path
     fs.writeFileSync(filePath, '{"stale":true}', 'utf-8');
 
-    await openExportToPostmanModal(page);
+    await openExportToPostmanModal(page, COLLECTION_NAME);
 
     await test.step('Exporting over an existing file prompts to replace', async () => {
-      await page.getByLabel('Location', { exact: true }).fill(outputDir);
+      await locators.export.locationInput().fill(outputDir);
       await locators.modal.button('Export').click();
       await expect(page.getByText('Name already exists in this location')).toBeVisible();
       await expect(locators.modal.button('Replace')).toBeVisible();
@@ -123,10 +77,10 @@ test.describe('Export Postman Collection - Preserve scripts option', () => {
   test('should require a name and location before exporting', async ({ pageWithUserData: page }) => {
     const locators = buildCommonLocators(page);
 
-    await openExportToPostmanModal(page);
+    await openExportToPostmanModal(page, COLLECTION_NAME);
 
     await test.step('Clearing the name and location blocks export with validation errors', async () => {
-      await page.getByLabel('Name', { exact: true }).fill('');
+      await locators.export.nameInput().fill('');
       await locators.modal.button('Export').click();
 
       await expect(page.getByText('Name is required')).toBeVisible();
@@ -135,13 +89,24 @@ test.describe('Export Postman Collection - Preserve scripts option', () => {
       await expect(locators.modal.title('Export to Postman')).toBeVisible();
     });
 
-    // Close both modals to cleanup the app state for the next test
-    await test.step('Close the export and share modals', async () => {
-      await locators.export.postmanModal().getByTestId('modal-close-button').click();
-      await expect(locators.modal.title('Export to Postman')).toBeHidden();
-      await locators.modal.byTitle('Share Collection').getByTestId('modal-close-button').click();
-      await expect(locators.modal.title('Share Collection')).toBeHidden();
+    await closeExportToPostmanModal(page);
+  });
+
+  test('should block export when the name has invalid characters', async ({ pageWithUserData: page }) => {
+    const locators = buildCommonLocators(page);
+
+    await openExportToPostmanModal(page, COLLECTION_NAME);
+
+    await test.step('An invalid name shows a validation error and blocks export', async () => {
+      await locators.export.nameInput().fill('foo/bar');
+      await locators.modal.button('Export').click();
+
+      await expect(page.getByText('Special characters aren\'t allowed in the name')).toBeVisible();
+      // The modal stays open and the export did not proceed
+      await expect(locators.modal.title('Export to Postman')).toBeVisible();
     });
+
+    await closeExportToPostmanModal(page);
   });
 
   test('should let the user rename to avoid overwriting an existing file', async ({ pageWithUserData: page, createTmpDir }) => {
@@ -151,17 +116,17 @@ test.describe('Export Postman Collection - Preserve scripts option', () => {
     // Pre-seed a conflicting file for the default (collection) name
     fs.writeFileSync(nodePath.join(outputDir, `${COLLECTION_NAME}.json`), '{"stale":true}', 'utf-8');
 
-    await openExportToPostmanModal(page);
+    await openExportToPostmanModal(page, COLLECTION_NAME);
 
     await test.step('Exporting over an existing file prompts to replace', async () => {
-      await page.getByLabel('Location', { exact: true }).fill(outputDir);
+      await locators.export.locationInput().fill(outputDir);
       await locators.modal.button('Export').click();
       await expect(page.getByText('Name already exists in this location')).toBeVisible();
       await expect(locators.modal.button('Replace')).toBeVisible();
     });
 
     await test.step('Renaming clears the conflict and restores Export', async () => {
-      await page.getByLabel('Name', { exact: true }).fill('Renamed Export');
+      await locators.export.nameInput().fill('Renamed Export');
       await expect(page.getByText('Name already exists in this location')).toBeHidden();
       await expect(locators.modal.button('Export')).toBeVisible();
     });

--- a/tests/export/postman/export-preserve-scripts.spec.ts
+++ b/tests/export/postman/export-preserve-scripts.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect, Page } from '../../../playwright';
+import { closeAllCollections, openCollection } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+import * as fs from 'fs';
+import * as nodePath from 'path';
+
+const COLLECTION_NAME = 'Export Scripts Collection';
+
+const openExportToPostmanModal = async (page: Page) => {
+  const locators = buildCommonLocators(page);
+
+  await openCollection(page, COLLECTION_NAME);
+
+  const collectionAction = locators.actions.collectionActions(COLLECTION_NAME);
+  await locators.sidebar.collection(COLLECTION_NAME).hover();
+  await expect(collectionAction).toBeVisible({ timeout: 2000 });
+  await collectionAction.click();
+  await locators.dropdown.item('Share').click();
+  await expect(locators.modal.title('Share Collection')).toBeVisible();
+
+  await page.getByTestId('export-format-postman').click();
+  await locators.modal.button('Proceed').click();
+  await expect(locators.modal.title('Export to Postman')).toBeVisible();
+};
+
+// export a collection via Share -> Export to Postman into outputDir and read the file
+const exportPostmanCollection = async (
+  page: Page,
+  outputDir: string,
+  { preserveScripts }: { preserveScripts: boolean }
+) => {
+  const locators = buildCommonLocators(page);
+
+  await openExportToPostmanModal(page);
+
+  await test.step('Set the export location', async () => {
+    await page.getByLabel('Location', { exact: true }).fill(outputDir);
+  });
+
+  await test.step('Configure preserve scripts', async () => {
+    if (preserveScripts) {
+      // 'Preserve scripts' lives under the modal footer's advanced options
+      await page.getByRole('button', { name: 'Options' }).click();
+      await page.getByTestId('show-advanced-options-toggle').click();
+      const checkbox = page.getByTestId('preserve-scripts-toggle');
+      await expect(checkbox).toBeVisible();
+      await checkbox.check();
+      await expect(checkbox).toBeChecked();
+    }
+  });
+
+  return await test.step('Export and read the written file', async () => {
+    await locators.modal.button('Export').click();
+    const filePath = nodePath.join(outputDir, `${COLLECTION_NAME}.json`);
+    await expect.poll(() => fs.existsSync(filePath), { timeout: 5000 }).toBe(true);
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  });
+};
+
+const findLoginEvents = (exported: any) => {
+  const login = exported.item.find((i: any) => i.name === 'Login');
+  return {
+    prerequest: login.event.find((e: any) => e.listen === 'prerequest'),
+    test: login.event.find((e: any) => e.listen === 'test')
+  };
+};
+
+test.describe('Export Postman Collection - Preserve scripts option', () => {
+  test.afterAll(async ({ pageWithUserData: page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('should export scripts as is when preserve scripts is enabled', async ({ pageWithUserData: page, createTmpDir }) => {
+    const outputDir = await createTmpDir('postman-export');
+    const exported = await exportPostmanCollection(page, outputDir, { preserveScripts: true });
+    const { prerequest, test: testEvent } = findLoginEvents(exported);
+
+    expect(prerequest.script.exec.join('\n')).toContain('bru.setEnvVar(\'token\', \'abc\')');
+    expect(prerequest.script.exec.join('\n')).not.toContain('pm.');
+    expect(testEvent.script.exec.join('\n')).toContain('bru.setVar(\'userId\', \'42\')');
+    expect(testEvent.script.exec.join('\n')).not.toContain('pm.');
+  });
+
+  test('should translate scripts to pm.* by default when preserve scripts is disabled', async ({ pageWithUserData: page, createTmpDir }) => {
+    const outputDir = await createTmpDir('postman-export');
+    const exported = await exportPostmanCollection(page, outputDir, { preserveScripts: false });
+    const { prerequest } = findLoginEvents(exported);
+
+    expect(prerequest.script.exec.join('\n')).toContain('pm.environment.set');
+    expect(prerequest.script.exec.join('\n')).not.toContain('bru.setEnvVar');
+  });
+
+  test('should overwrite an existing file when Replace is confirmed', async ({ pageWithUserData: page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const outputDir = await createTmpDir('postman-export');
+    const filePath = nodePath.join(outputDir, `${COLLECTION_NAME}.json`);
+
+    // Pre seed a conflicting file so the export hits the "already exists" path
+    fs.writeFileSync(filePath, '{"stale":true}', 'utf-8');
+
+    await openExportToPostmanModal(page);
+
+    await test.step('Exporting over an existing file prompts to replace', async () => {
+      await page.getByLabel('Location', { exact: true }).fill(outputDir);
+      await locators.modal.button('Export').click();
+      await expect(page.getByText('Name already exists in this location')).toBeVisible();
+      await expect(locators.modal.button('Replace')).toBeVisible();
+    });
+
+    await test.step('Confirming Replace overwrites the file', async () => {
+      await locators.modal.button('Replace').click();
+      // The stale sentinel is gone once the real collection is written
+      await expect
+        .poll(() => JSON.parse(fs.readFileSync(filePath, 'utf-8')).stale ?? false, { timeout: 5000 })
+        .toBe(false);
+    });
+
+    const exported = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    const { prerequest } = findLoginEvents(exported);
+    expect(prerequest).toBeTruthy();
+  });
+
+  test('should require a name and location before exporting', async ({ pageWithUserData: page }) => {
+    const locators = buildCommonLocators(page);
+
+    await openExportToPostmanModal(page);
+
+    await test.step('Clearing the name and location blocks export with validation errors', async () => {
+      await page.getByLabel('Name', { exact: true }).fill('');
+      await locators.modal.button('Export').click();
+
+      await expect(page.getByText('Name is required')).toBeVisible();
+      await expect(page.getByText('Location is required')).toBeVisible();
+      // The modal stays open and the export did not proceed
+      await expect(locators.modal.title('Export to Postman')).toBeVisible();
+    });
+
+    // Close both modals to cleanup the app state for the next test
+    await test.step('Close the export and share modals', async () => {
+      await locators.export.postmanModal().getByTestId('modal-close-button').click();
+      await expect(locators.modal.title('Export to Postman')).toBeHidden();
+      await locators.modal.byTitle('Share Collection').getByTestId('modal-close-button').click();
+      await expect(locators.modal.title('Share Collection')).toBeHidden();
+    });
+  });
+
+  test('should let the user rename to avoid overwriting an existing file', async ({ pageWithUserData: page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const outputDir = await createTmpDir('postman-export');
+
+    // Pre-seed a conflicting file for the default (collection) name
+    fs.writeFileSync(nodePath.join(outputDir, `${COLLECTION_NAME}.json`), '{"stale":true}', 'utf-8');
+
+    await openExportToPostmanModal(page);
+
+    await test.step('Exporting over an existing file prompts to replace', async () => {
+      await page.getByLabel('Location', { exact: true }).fill(outputDir);
+      await locators.modal.button('Export').click();
+      await expect(page.getByText('Name already exists in this location')).toBeVisible();
+      await expect(locators.modal.button('Replace')).toBeVisible();
+    });
+
+    await test.step('Renaming clears the conflict and restores Export', async () => {
+      await page.getByLabel('Name', { exact: true }).fill('Renamed Export');
+      await expect(page.getByText('Name already exists in this location')).toBeHidden();
+      await expect(locators.modal.button('Export')).toBeVisible();
+    });
+
+    await test.step('Export writes the new file and leaves the original untouched', async () => {
+      await locators.modal.button('Export').click();
+      const renamedPath = nodePath.join(outputDir, 'Renamed Export.json');
+      await expect.poll(() => fs.existsSync(renamedPath), { timeout: 5000 }).toBe(true);
+      // The pre-seeded file was not overwritten
+      expect(JSON.parse(fs.readFileSync(nodePath.join(outputDir, `${COLLECTION_NAME}.json`), 'utf-8')).stale).toBe(true);
+    });
+  });
+});

--- a/tests/export/postman/export-preserve-scripts.spec.ts
+++ b/tests/export/postman/export-preserve-scripts.spec.ts
@@ -4,6 +4,7 @@ import {
   buildCommonLocators,
   openExportToPostmanModal,
   closeExportToPostmanModal,
+  dismissModalIfOpen,
   exportCollectionToPostman
 } from '../../utils/page';
 import * as fs from 'fs';
@@ -21,6 +22,10 @@ const findLoginEvents = (exported: any) => {
 
 test.describe('Export Postman Collection - Preserve scripts option', () => {
   test.afterEach(async ({ pageWithUserData: page }) => {
+    await dismissModalIfOpen(page);
+  });
+
+  test.afterAll(async ({ pageWithUserData: page }) => {
     await closeAllCollections(page);
   });
 

--- a/tests/export/postman/export-preserve-scripts.spec.ts
+++ b/tests/export/postman/export-preserve-scripts.spec.ts
@@ -29,10 +29,8 @@ test.describe('Export Postman Collection - Preserve scripts option', () => {
     const exported = await exportCollectionToPostman(page, COLLECTION_NAME, outputDir, { preserveScripts: true });
     const { prerequest, test: testEvent } = findLoginEvents(exported);
 
-    expect(prerequest.script.exec.join('\n')).toContain('bru.setEnvVar(\'token\', \'abc\')');
-    expect(prerequest.script.exec.join('\n')).not.toContain('pm.');
-    expect(testEvent.script.exec.join('\n')).toContain('bru.setVar(\'userId\', \'42\')');
-    expect(testEvent.script.exec.join('\n')).not.toContain('pm.');
+    expect(prerequest.script.exec).toEqual(['bru.setEnvVar(\'token\', \'abc\');']);
+    expect(testEvent.script.exec).toEqual(['bru.setVar(\'userId\', \'42\');']);
   });
 
   test('should translate scripts to pm.* by default when preserve scripts is disabled', async ({ pageWithUserData: page, createTmpDir }) => {

--- a/tests/export/postman/fixtures/collection/bruno.json
+++ b/tests/export/postman/fixtures/collection/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "Export Scripts Collection",
+  "type": "collection"
+}

--- a/tests/export/postman/fixtures/collection/login.bru
+++ b/tests/export/postman/fixtures/collection/login.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Login
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://example.com/login
+}
+
+script:pre-request {
+  bru.setEnvVar('token', 'abc');
+}
+
+script:post-response {
+  bru.setVar('userId', '42');
+}

--- a/tests/export/postman/init-user-data/preferences.json
+++ b/tests/export/postman/init-user-data/preferences.json
@@ -1,0 +1,11 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}"
+  ],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/import/postman/fixtures/postman-with-scripts.json
+++ b/tests/import/postman/fixtures/postman-with-scripts.json
@@ -1,0 +1,46 @@
+{
+  "info": {
+    "_postman_id": "b7e2f1a0-1c2d-4e3f-9a8b-scriptscollection",
+    "name": "Scripts Collection",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Login",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.environment.set('token', 'abc');",
+              "console.log('pre');"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('status is 200', function () {",
+              "  pm.response.to.have.status(200);",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://example.com/login",
+          "protocol": "https",
+          "host": ["example", "com"],
+          "path": ["login"]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/tests/import/postman/import-file-format-options.spec.ts
+++ b/tests/import/postman/import-file-format-options.spec.ts
@@ -31,7 +31,7 @@ test.describe('Import Collection File Format Options toggle', () => {
 
     await test.step('Options toggle reveals the File Format selector defaulting to OpenCollection (YAML)', async () => {
       await locationModal.getByRole('button', { name: 'Options' }).click();
-      await page.getByTestId('show-file-format-toggle').click();
+      await page.getByTestId('show-advanced-options-toggle').click();
 
       const formatSelect = locationModal.locator('#format');
       await expect(formatSelect).toBeVisible();
@@ -49,11 +49,16 @@ test.describe('Import Collection File Format Options toggle', () => {
       await expect(formatSelect).toHaveValue('bru');
 
       await locationModal.getByRole('button', { name: 'Options' }).click();
-      const toggle = page.getByTestId('show-file-format-toggle');
-      await expect(toggle).toHaveText('Hide File Format');
+      const toggle = page.getByTestId('show-advanced-options-toggle');
+      await expect(toggle).toHaveText('Hide Advanced Options');
       await toggle.click();
 
       await expect(locationModal.locator('#format')).toHaveCount(0);
+    });
+
+    await test.step('Close the import modal', async () => {
+      await locators.modal.closeButton().click();
+      await expect(locators.import.locationModal()).toBeHidden();
     });
   });
 });

--- a/tests/import/postman/import-preserve-scripts.spec.ts
+++ b/tests/import/postman/import-preserve-scripts.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '../../../playwright';
+import * as path from 'path';
+import { closeAllCollections, importCollection, selectScriptSubTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const postmanFile = path.resolve(__dirname, 'fixtures', 'postman-with-scripts.json');
+
+test.describe('Import Postman Collection with preserve scripts option enabled', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('should hide the preserve scripts checkbox until advanced options is shown', async ({ page }) => {
+    const locators = buildCommonLocators(page);
+
+    await test.step('Open import modal and upload the Postman collection', async () => {
+      await locators.plusMenu.button().click();
+      await locators.plusMenu.importCollection().click();
+      await locators.import.fileInput().setInputFiles(postmanFile);
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 10000 });
+    });
+
+    await test.step('Checkbox is hidden until Advanced Options is shown', async () => {
+      await expect(page.getByTestId('preserve-scripts-toggle')).toHaveCount(0);
+    });
+
+    await test.step('Advanced Options toggle reveals the Preserve scripts checkbox', async () => {
+      const locationModal = locators.import.locationModal();
+      await locationModal.getByRole('button', { name: 'Options' }).click();
+      await page.getByTestId('show-advanced-options-toggle').click();
+      await expect(page.getByTestId('preserve-scripts-toggle')).toBeVisible();
+    });
+
+    await test.step('Close the import modal', async () => {
+      await locators.modal.closeButton().click();
+      await expect(locators.import.locationModal()).toBeHidden();
+    });
+  });
+
+  test('should preserve pm.* scripts as is when the option is enabled', async ({ page, createTmpDir }) => {
+    const importDir = await createTmpDir('preserve-scripts-on');
+    const locators = buildCommonLocators(page);
+
+    await importCollection(page, postmanFile, importDir, {
+      expectedCollectionName: 'Scripts Collection',
+      preserveScripts: true
+    });
+
+    await test.step('Open the imported request', async () => {
+      await locators.sidebar.request('Login').click();
+      await expect(locators.request.pane()).toBeVisible();
+    });
+
+    await test.step('Pre-request script keeps pm.* untranslated', async () => {
+      await selectScriptSubTab(page, 'pre-request');
+      const editor = locators.codeMirror.byTestId('pre-request-script-editor');
+      await expect(editor).toContainText('pm.environment.set(\'token\', \'abc\');');
+      await expect(editor).not.toContainText('bru.');
+    });
+
+    await test.step('Post-response script keeps pm.* untranslated', async () => {
+      await selectScriptSubTab(page, 'post-response');
+      const editor = locators.codeMirror.byTestId('post-response-script-editor');
+      await expect(editor).toContainText('pm.test(');
+      await expect(editor).toContainText('pm.response.to.have.status(200)');
+      await expect(editor).not.toContainText('expect(res.getStatus())');
+    });
+  });
+
+  test('should translate pm.* scripts to bru.* by default when the option is disabled', async ({ page, createTmpDir }) => {
+    const importDir = await createTmpDir('preserve-scripts-off');
+    const locators = buildCommonLocators(page);
+
+    await importCollection(page, postmanFile, importDir, {
+      expectedCollectionName: 'Scripts Collection'
+    });
+
+    await test.step('Open the imported request', async () => {
+      await locators.sidebar.request('Login').click();
+      await expect(locators.request.pane()).toBeVisible();
+    });
+
+    await test.step('Pre-request script is translated to bru.*', async () => {
+      await selectScriptSubTab(page, 'pre-request');
+      const editor = locators.codeMirror.byTestId('pre-request-script-editor');
+      await expect(editor).toContainText('bru.setEnvVar(\'token\', \'abc\')');
+      await expect(editor).not.toContainText('pm.environment.set');
+    });
+
+    await test.step('Post-response script is translated to bru.* / expect', async () => {
+      await selectScriptSubTab(page, 'post-response');
+      const editor = locators.codeMirror.byTestId('post-response-script-editor');
+      await expect(editor).toContainText('expect(res.getStatus()).to.equal(200)');
+      await expect(editor).not.toContainText('pm.response.to.have.status');
+    });
+  });
+});

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -157,13 +157,13 @@ const createCollection = async (
 
     if (format) {
       const advancedBtn = createCollectionModal.locator('.advanced-options .btn-advanced');
-      const showFileFormatToggle = page.getByTestId('show-file-format-toggle');
+      const showAdvancedOptionsToggle = page.getByTestId('show-advanced-options-toggle');
       const formatSelect = createCollectionModal.locator('#format');
 
       await expect(async () => {
         if (!(await formatSelect.isVisible())) {
           await advancedBtn.click();
-          await showFileFormatToggle.click({ timeout: 2000 });
+          await showAdvancedOptionsToggle.click({ timeout: 2000 });
         }
         await expect(formatSelect).toBeVisible({ timeout: 2000 });
       }).toPass({ timeout: 15000 });
@@ -476,6 +476,7 @@ type ImportCollectionOptions = {
   expectedCollectionName?: string;
   expectIssues?: boolean;
   sidebarTimeout?: number;
+  preserveScripts?: boolean;
 };
 
 const importCollection = async (
@@ -506,6 +507,15 @@ const importCollection = async (
     // Verify expected collection name if provided
     if (options.expectedCollectionName) {
       await expect(locationModal.getByText(options.expectedCollectionName)).toBeVisible();
+    }
+
+    // Enable 'Preserve scripts' option via the Advanced Options toggle
+    if (options.preserveScripts) {
+      await locationModal.getByRole('button', { name: 'Options' }).click();
+      await page.getByTestId('show-advanced-options-toggle').click();
+      const preserveScriptsCheckbox = page.getByTestId('preserve-scripts-toggle');
+      await preserveScriptsCheckbox.check();
+      await expect(preserveScriptsCheckbox).toBeChecked();
     }
 
     // Set location and import

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page, Locator, ElectronApplication, waitForReadyPage as waitForReadyPageImpl } from '../../../playwright';
 import process from 'node:process';
 import * as path from 'path';
+import * as fs from 'fs';
 import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators, buildWebsocketCommonLocators } from './locators';
 import { waitForCollectionMount } from './mounting';
 
@@ -2145,6 +2146,68 @@ const generateCollectionDocs = async (
   });
 };
 
+const openExportToPostmanModal = async (page: Page, collectionName: string) => {
+  await test.step(`Open Export to Postman for "${collectionName}"`, async () => {
+    const locators = buildCommonLocators(page);
+
+    await openCollection(page, collectionName);
+
+    const collectionAction = locators.actions.collectionActions(collectionName);
+    await locators.sidebar.collection(collectionName).hover();
+    await expect(collectionAction).toBeVisible({ timeout: 2000 });
+    await collectionAction.click();
+    await locators.dropdown.item('Share').click();
+    await expect(locators.modal.title('Share Collection')).toBeVisible();
+
+    await locators.export.postmanFormatCard().click();
+    await locators.modal.button('Proceed').click();
+    await expect(locators.modal.title('Export to Postman')).toBeVisible();
+  });
+};
+
+const closeExportToPostmanModal = async (page: Page) => {
+  await test.step('Close the export modal', async () => {
+    const locators = buildCommonLocators(page);
+
+    await locators.export.postmanModal().getByTestId('modal-close-button').click();
+    await expect(locators.modal.title('Export to Postman')).toBeHidden();
+    await expect(locators.modal.title('Share Collection')).toBeHidden();
+  });
+};
+
+const exportCollectionToPostman = async (
+  page: Page,
+  collectionName: string,
+  outputDir: string,
+  { preserveScripts = false }: { preserveScripts?: boolean } = {}
+) => {
+  const locators = buildCommonLocators(page);
+
+  await openExportToPostmanModal(page, collectionName);
+
+  await test.step('Set the export location', async () => {
+    await locators.export.locationInput().fill(outputDir);
+  });
+
+  await test.step('Configure preserve scripts', async () => {
+    if (preserveScripts) {
+      await locators.export.optionsButton().click();
+      await locators.export.advancedOptionsToggle().click();
+      const checkbox = locators.export.preserveScriptsToggle();
+      await expect(checkbox).toBeVisible();
+      await checkbox.check();
+      await expect(checkbox).toBeChecked();
+    }
+  });
+
+  return await test.step('Export and read the written file', async () => {
+    await locators.modal.button('Export').click();
+    const filePath = path.join(outputDir, `${collectionName}.json`);
+    await expect.poll(() => fs.existsSync(filePath), { timeout: 5000 }).toBe(true);
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  });
+};
+
 /**
  * Toggle the "Enable App" request setting idempotently (Settings tab).
  * Enabling exposes the App tab and the Request/App/File view-mode toggle.
@@ -2482,6 +2545,9 @@ export {
   openRequestInFolder,
   setUrlEncoding,
   generateCollectionDocs,
+  openExportToPostmanModal,
+  closeExportToPostmanModal,
+  exportCollectionToPostman,
   openFolderSettings,
   setTableRowDescriptionValue,
   setAppCode,

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -513,8 +513,8 @@ const importCollection = async (
     // Enable 'Preserve scripts' option via the Advanced Options toggle
     if (options.preserveScripts) {
       await locationModal.getByRole('button', { name: 'Options' }).click();
-      await page.getByTestId('show-advanced-options-toggle').click();
-      const preserveScriptsCheckbox = page.getByTestId('preserve-scripts-toggle');
+      await locators.import.advancedOptionsToggle().click();
+      const preserveScriptsCheckbox = locators.import.preserveScriptsToggle();
       await preserveScriptsCheckbox.check();
       await expect(preserveScriptsCheckbox).toBeChecked();
     }

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -2175,6 +2175,15 @@ const closeExportToPostmanModal = async (page: Page) => {
   });
 };
 
+// Dismiss an open modal if one is present
+const dismissModalIfOpen = async (page: Page) => {
+  const { modal } = buildCommonLocators(page);
+  if (await modal.closeButton().isVisible()) {
+    await modal.closeButton().click({ force: true });
+    await expect(modal.card()).toBeHidden();
+  }
+};
+
 const exportCollectionToPostman = async (
   page: Page,
   collectionName: string,
@@ -2547,6 +2556,7 @@ export {
   generateCollectionDocs,
   openExportToPostmanModal,
   closeExportToPostmanModal,
+  dismissModalIfOpen,
   exportCollectionToPostman,
   openFolderSettings,
   setTableRowDescriptionValue,

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -301,7 +301,13 @@ export const buildCommonLocators = (page: Page) => ({
     })()
   },
   export: {
-    postmanModal: () => page.getByTestId('export-to-postman-modal')
+    postmanModal: () => page.getByTestId('export-to-postman-modal'),
+    postmanFormatCard: () => page.getByTestId('export-format-postman'),
+    nameInput: () => page.getByLabel('Name', { exact: true }),
+    locationInput: () => page.getByLabel('Location', { exact: true }),
+    optionsButton: () => page.getByRole('button', { name: 'Options' }),
+    advancedOptionsToggle: () => page.getByTestId('show-advanced-options-toggle'),
+    preserveScriptsToggle: () => page.getByTestId('preserve-scripts-toggle')
   },
   /**
    * Build generic table locators for any table with a testId

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -300,6 +300,9 @@ export const buildCommonLocators = (page: Page) => ({
       };
     })()
   },
+  export: {
+    postmanModal: () => page.getByTestId('export-to-postman-modal')
+  },
   /**
    * Build generic table locators for any table with a testId
    * @param testId - The testId of the table

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -279,6 +279,8 @@ export const buildCommonLocators = (page: Page) => ({
     locationModal: () => page.locator('[data-testid="import-collection-location-modal"]'),
     locationInput: () => page.locator('#collection-location'),
     fileInput: () => page.locator('input[type="file"]'),
+    advancedOptionsToggle: () => page.getByTestId('show-advanced-options-toggle'),
+    preserveScriptsToggle: () => page.getByTestId('preserve-scripts-toggle'),
     bulkModal: () => page.getByTestId('bulk-import-collection-location-modal'),
     bulkFormatSelect: () => page.getByTestId('bulk-import-collection-location-modal').getByTestId('bulk-import-collection-format-selector'),
     bulkLocationInput: () => page.getByTestId('bulk-import-collection-location-modal').getByTestId('bulk-import-collection-location-input'),


### PR DESCRIPTION
### Description

Adds support for preserving Postman scripts during import and export instead of translating them into Bruno scripts.
Introduce an optional preserve scripts mode that skips script translation while continuing to convert the rest of the collection collection structure, requests, variables, and settings.

Ref: BRU-2573

When enabled:
- Pre-request and test scripts are preserved exactly as they exist in the source collection.
- Collection structure, requests, variables, folders, and settings continue to be converted normally.
- Users can toggle between translated scripts (existing behavior - default) and preserved scripts depending on their use case.

#### Screen Recording
- Import flow
 

https://github.com/user-attachments/assets/353f8b5a-431c-4916-8643-c7c1fa9d2945




- Export flow

https://github.com/user-attachments/assets/4f0aca6b-97f3-4250-8679-a5e97f6d5c9f




#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an “Export to Postman” modal flow with destination selection, filename validation, and an overwrite/replace experience.
  * Added “Preserve scripts” support for both Postman import and Postman export.
  * Unified Postman-related “File Format” controls under “Advanced Options”.

* **Bug Fixes**
  * Improved handling of existing export files with correct replace/conflict behavior.

* **Tests**
  * Added/updated Jest and Playwright coverage for preserve-scripts behavior, advanced options toggles, validation, and overwrite flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->