### PR TITLE
test(environments): env tab eye icon

### DIFF
--- a/tests/environments/environment-tabs/environment-tabs.spec.ts
+++ b/tests/environments/environment-tabs/environment-tabs.spec.ts
@@ -76,6 +76,29 @@ test.describe('Environment Variables / Secrets tab separation', () => {
     });
   });
 
+  test.only('Secret value does not carry its reveal-eye toggle onto the Variables tab', async ({ page, createTmpDir }) => {
+    await importCollection(page, collectionFile, await createTmpDir('var-secret-eye-toggle'), {
+      expectedCollectionName: 'test_collection'
+    });
+
+    await createEnvironment(page, 'Eye Toggle Env', 'collection');
+
+    await test.step('Add a secret on the Secrets tab; its reveal-eye toggle is shown there', async () => {
+      await secretsTab(page).click();
+      await expect(secretsTab(page)).toHaveClass(/active/);
+      await addRowToActiveTab(page, 'apiToken', 'super-secret-token-12345');
+      await expect(envLocators(page).varRowEyeToggle('apiToken')).toBeVisible();
+    });
+
+    await test.step('Switching to the Variables tab hides the secret and its reveal-eye toggle', async () => {
+      await variablesTab(page).click();
+      await expect(variablesTab(page)).toHaveClass(/active/);
+      await expect(varRow(page, 'apiToken')).toHaveCount(0);
+      await expect(page.getByTestId('secret-reveal-toggle')).toHaveCount(0);
+    });
+    await page.pause();
+  });
+
   test('saves variables and secrets independently and persists both', async ({ page, createTmpDir }) => {
     await importCollection(page, collectionFile, await createTmpDir('var-secret-save'), {
       expectedCollectionName: 'test_collection'

--- a/tests/environments/environment-tabs/environment-tabs.spec.ts
+++ b/tests/environments/environment-tabs/environment-tabs.spec.ts
@@ -1,8 +1,7 @@
-import { test, expect } from '../../../playwright';
-import path from 'path';
-import fs from 'fs';
 import { Page } from '@playwright/test';
-import { importCollection, createEnvironment, closeAllCollections, addRowToActiveTab, saveEnvironment, deleteAllGlobalEnvironments } from '../../utils/page';
+import path from 'path';
+import { expect, test } from '../../../playwright';
+import { addRowToActiveTab, closeAllCollections, createEnvironment, deleteAllGlobalEnvironments, importCollection, saveEnvironment } from '../../utils/page';
 import { buildCommonLocators } from '../../utils/page/locators';
 
 const envLocators = (page: Page) => buildCommonLocators(page).environment;
@@ -76,7 +75,7 @@ test.describe('Environment Variables / Secrets tab separation', () => {
     });
   });
 
-  test.only('Secret value does not carry its reveal-eye toggle onto the Variables tab', async ({ page, createTmpDir }) => {
+  test('Secret value does not carry its reveal-eye toggle onto the Variables tab', async ({ page, createTmpDir }) => {
     await importCollection(page, collectionFile, await createTmpDir('var-secret-eye-toggle'), {
       expectedCollectionName: 'test_collection'
     });

--- a/tests/environments/environment-tabs/environment-tabs.spec.ts
+++ b/tests/environments/environment-tabs/environment-tabs.spec.ts
@@ -95,7 +95,6 @@ test.describe('Environment Variables / Secrets tab separation', () => {
       await expect(varRow(page, 'apiToken')).toHaveCount(0);
       await expect(page.getByTestId('secret-reveal-toggle')).toHaveCount(0);
     });
-    await page.pause();
   });
 
   test('saves variables and secrets independently and persists both', async ({ page, createTmpDir }) => {


### PR DESCRIPTION
### Description

Adds test for the env tab icon eye to only be visible on the secrets tab and not the variables tab

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added a Playwright test to ensure the per-row secret reveal toggle in the Secrets tab does not persist when switching to the Variables tab.
  * Confirmed that the secret row and the associated reveal controls are not displayed on the Variables tab.
* **Chores**
  * Updated test imports and consolidated shared page utilities to keep the suite organized without changing its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->