### PR TITLE
respected the redact-secret-variables toggle for name-pattern variables

### DIFF
--- a/packages/bruno-app/src/utils/ai/index.js
+++ b/packages/bruno-app/src/utils/ai/index.js
@@ -134,13 +134,23 @@ const isSensitiveName = (name) => {
  * Scope + secret metadata is attached by walking each named source. A name
  * marked secret by ANY source stays secret in the output.
  *
- * - `secret: true` => value is replaced by `<redacted>` here, not sent in the
- *   clear over IPC.
- * - The backend re-applies redaction in `formatVariableLine`, so even if a
- *   secret slipped through here it wouldn't reach the provider.
+ * Redaction mirrors the backend's `isSecretVariable`:
+ * - Variables EXPLICITLY marked secret (env `secret` flag, globalEnvSecrets,
+ *   OAuth2 creds) are ALWAYS redacted, regardless of the toggle.
+ * - Names that only LOOK secret by pattern are redacted only when
+ *   `redactVariables` (the "Redact secret variable values" setting) is on.
+ *
+ * `redactVariables` is read live from the store so call sites don't have to
+ * thread it; `redactVariablesOverride` lets tests drive both states.
  */
-export const buildAiVariablesPayload = (collection, item) => {
+export const buildAiVariablesPayload = (collection, item, redactVariablesOverride) => {
   if (!collection) return [];
+
+  // Lazy-require the store so merely importing this module (widely done via
+  // aiGhostText / CodeEditor / AIAssist) doesn't pull in providers/ReduxStore.
+  const redactVariables = redactVariablesOverride === undefined
+    ? get(require('providers/ReduxStore').default.getState(), 'app.preferences.ai.security.redactVariables', true)
+    : redactVariablesOverride;
 
   const REDACTED = '<redacted>';
 
@@ -193,9 +203,9 @@ export const buildAiVariablesPayload = (collection, item) => {
     // Default scope for names not claimed by any explicit source — these come
     // from collection/folder/request-level vars that don't carry a secret
     // flag of their own, so we rely on `isSensitiveName` to catch token-like
-    // names by pattern.
+    // names by pattern (only when the redact toggle is on).
     const scope = m?.scope || 'collection';
-    const isSecret = Boolean(m?.secret) || isSensitiveName(name);
+    const isSecret = Boolean(m?.secret) || (redactVariables && isSensitiveName(name));
     const value = resolved[name];
     out.push({
       name,
@@ -211,9 +221,9 @@ export const buildAiVariablesPayload = (collection, item) => {
  * Single entry point for chat + generation. Returns the same payload shape
  * for both so the backend formatters / tools behave identically.
  */
-export const buildAiContextPayload = (item, collection) => ({
+export const buildAiContextPayload = (item, collection, redactVariablesOverride) => ({
   requestContext: buildAiRequestContext(item),
-  variables: collection ? buildAiVariablesPayload(collection, item) : []
+  variables: collection ? buildAiVariablesPayload(collection, item, redactVariablesOverride) : []
 });
 
 const summarizeDocsItems = (items = []) => {

--- a/packages/bruno-app/src/utils/ai/index.spec.js
+++ b/packages/bruno-app/src/utils/ai/index.spec.js
@@ -1,3 +1,5 @@
+jest.mock('providers/ReduxStore', () => ({ __esModule: true, default: { getState: () => ({}) } }));
+
 import {
   buildAiContextPayload,
   buildAiRequestContext,
@@ -197,6 +199,34 @@ describe('utils/ai', () => {
       const result = buildAiVariablesPayload(collectionWithRuntimeSecret, null);
       const v = result.find((x) => x.name === 'access_token');
       expect(v).toEqual({ name: 'access_token', value: '<redacted>', scope: 'runtime', secret: true });
+    });
+
+    it('sends the real value for a pattern-only name when redactVariables is off', () => {
+      const collectionWithRuntimeSecret = {
+        activeEnvironmentUid: null,
+        environments: [],
+        globalEnvironmentVariables: {},
+        globalEnvSecrets: [],
+        runtimeVariables: { access_token: 'real-value' }
+      };
+      const result = buildAiVariablesPayload(collectionWithRuntimeSecret, null, false);
+      const v = result.find((x) => x.name === 'access_token');
+      expect(v).toEqual({ name: 'access_token', value: 'real-value', scope: 'runtime', secret: false });
+    });
+
+    it('keeps explicitly-secret vars redacted even when redactVariables is off', () => {
+      const collectionWithExplicitSecret = {
+        activeEnvironmentUid: 'env-1',
+        environments: [
+          { uid: 'env-1', variables: [{ name: 'MY_SECRET', value: 'v', enabled: true, secret: true }] }
+        ],
+        globalEnvironmentVariables: {},
+        globalEnvSecrets: [],
+        runtimeVariables: {}
+      };
+      const result = buildAiVariablesPayload(collectionWithExplicitSecret, null, false);
+      const v = result.find((x) => x.name === 'MY_SECRET');
+      expect(v).toEqual({ name: 'MY_SECRET', value: '<redacted>', scope: 'env', secret: true });
     });
 
     it('does not duplicate a name across scopes (env wins over global)', () => {


### PR DESCRIPTION
**JIRA: BRU-3902**
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

**Cause:** The renderer redacted name-pattern "secret-looking" variables unconditionally and stamped secret: true before IPC, so the backend short-circuited on that flag and never applied the toggle — turning it OFF did nothing.

**Resolution:** Gated the renderer's pattern redaction on the toggle (read live from the store): explicit secrets always redacted; pattern-matched ones redacted only when the toggle is ON, real values when OFF.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

**Redact secret variable values -> Disabled**
<img width="350" height="244" alt="Screenshot 2026-07-17 at 4 34 01 PM" src="https://github.com/user-attachments/assets/03621886-af01-4b46-9653-ecfa57ac27b6" />

**Redact secret variable values -> Enabled**
<img width="363" height="240" alt="Screenshot 2026-07-17 at 4 34 10 PM" src="https://github.com/user-attachments/assets/ae9e1b2c-3c7b-46c8-b20e-e47caaab89da" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to control whether AI requests redact pattern-matched sensitive variable values (default: on).
  * Variables explicitly marked as secret are always redacted, even if the setting is turned off.
  * When redaction is disabled, token-like runtime variables (e.g., access tokens) are sent with their actual values.
* **Tests**
  * Expanded AI payload tests to cover the new redaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->