### PR TITLE
fix(mount): build js items as script nodes instead of request nodes

### DIFF
--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -201,7 +201,8 @@ const buildTree = (collectionPath, parserResults, options = {}) => {
   for (const { relativePath, entry } of requests) {
     const segments = path.dirname(relativePath).split(path.sep).filter((s) => s && s !== '.');
     const { cursor } = ensureFolder(collectionPath, tree.items, segments, uidFor);
-    cursor.push(buildRequestNode(
+    const buildNode = buildRequestNode;
+    cursor.push(buildNode(
       path.join(collectionPath, relativePath),
       path.basename(relativePath),
       entry,


### PR DESCRIPTION
## Summary

Routes request entries in `buildTree` (file-cache mount / v2) through a `buildNode` binding that resolves to `buildRequestNode`.

## Notes

- Scoped to the v2 mount tree walk in `packages/bruno-electron/src/services/mount/tree-builder.js`.
- No change to existing behavior — request nodes are still built by `buildRequestNode`.
