### PR TITLE
fix(mount): redact large text blocks so big .bru files parse fast

### DIFF
--- a/packages/bruno-electron/src/services/pool/jobs/parse-file.js
+++ b/packages/bruno-electron/src/services/pool/jobs/parse-file.js
@@ -5,23 +5,25 @@ const filestore = require('@usebruno/filestore');
 
 const sha256 = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
 
-const REDACT_BODY_THRESHOLD = 512 * 1024;
+const LARGE_FILE_REDACT_THRESHOLD = 64 * 1024;
 
-const parseLargeBruRequest = (content, format) => {
-  const { bruFileStringWithRedactedBody, extractedBodyContent } = filestore.parseRequestAndRedactBody(content, { format });
-  const data = filestore.parseRequest(bruFileStringWithRedactedBody, { format });
-  data.request = data.request || {};
-  data.request.body = data.request.body || {};
-  const body = extractedBodyContent || {};
-  if (body.json) data.request.body.json = body.json;
-  if (body.text) data.request.body.text = body.text;
-  if (body.xml) data.request.body.xml = body.xml;
-  if (body.sparql) data.request.body.sparql = body.sparql;
-  if (body.graphql) {
-    data.request.body.graphql = data.request.body.graphql || {};
-    data.request.body.graphql.query = body.graphql;
+const parseLargeBru = (content, format, type) => {
+  const { skeleton, blocks } = filestore.redactLargeBruTextBlocks(content);
+  let data;
+  switch (type) {
+    case 'request':
+      data = filestore.parseRequest(skeleton, { format });
+      break;
+    case 'collection':
+      data = filestore.parseCollection(skeleton, { format });
+      break;
+    case 'folder':
+      data = filestore.parseFolder(skeleton, { format });
+      break;
+    default:
+      return null;
   }
-  return data;
+  return filestore.restoreRedactedBlocks(data, blocks);
 };
 
 const extractBruMeta = (content) => {
@@ -45,13 +47,16 @@ const extractBruMeta = (content) => {
 const parseContent = (content, format, type, byteSize) => {
   if (type === 'config' || format === 'json') return JSON.parse(content);
   const options = { format };
+  const isLargeBru = format === 'bru' && byteSize >= LARGE_FILE_REDACT_THRESHOLD;
   switch (type) {
     case 'request':
-      if (format === 'bru' && byteSize >= REDACT_BODY_THRESHOLD) return parseLargeBruRequest(content, format);
+      if (isLargeBru) return parseLargeBru(content, format, type);
       return filestore.parseRequest(content, options);
     case 'collection':
+      if (isLargeBru) return parseLargeBru(content, format, type);
       return filestore.parseCollection(content, options);
     case 'folder':
+      if (isLargeBru) return parseLargeBru(content, format, type);
       return filestore.parseFolder(content, options);
     case 'environment':
       return filestore.parseEnvironment(content, options);

--- a/packages/bruno-filestore/src/formats/bru/tests/redact-large-text-blocks.spec.js
+++ b/packages/bruno-filestore/src/formats/bru/tests/redact-large-text-blocks.spec.js
@@ -1,0 +1,313 @@
+const { redactLargeBruTextBlocks, restoreRedactedBlocks } = require('../utils/redact-large-text-blocks');
+const { parseBruRequest, parseBruCollection } = require('../index');
+
+const parseViaRedaction = (content, parser) => {
+  const { skeleton, blocks } = redactLargeBruTextBlocks(content);
+  return restoreRedactedBlocks(parser(skeleton), blocks);
+};
+
+const toCRLF = (content) => content.replace(/\n/g, '\r\n');
+
+const requestBru = `meta {
+  name: Redaction Test
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://example.com/api
+  body: json
+}
+
+headers {
+  content-type: application/json
+}
+
+body:json {
+  {
+    "hello": "world",
+    "nested": {
+      "a": 1,
+      "b": [1, 2, 3]
+    }
+  }
+}
+
+body:text {
+  This is a text body
+  spanning multiple lines
+}
+
+script:pre-request {
+  const x = 1;
+  if (x) {
+    console.log("hi");
+  }
+}
+
+script:post-response {
+  bru.setVar("y", 2);
+}
+
+tests {
+  test("ok", function() {
+    expect(1).to.equal(1);
+  });
+}
+
+docs {
+  # Title
+
+  Some **markdown** docs with a fenced block:
+
+      code line stays indented
+}
+`;
+
+const graphqlBru = `meta {
+  name: GraphQL Test
+  type: graphql
+  seq: 1
+}
+
+post {
+  url: https://example.com/graphql
+  body: graphql
+}
+
+body:graphql {
+  {
+    launchesPast {
+      launch_site {
+        site_name
+      }
+    }
+  }
+}
+
+body:graphql:vars {
+  {
+    "limit": 10
+  }
+}
+`;
+
+const xmlSparqlBru = `meta {
+  name: Others
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://example.com
+  body: xml
+}
+
+body:xml {
+  <xml>
+    <name>John</name>
+  </xml>
+}
+
+body:sparql {
+  SELECT * WHERE {
+    ?s ?p ?o .
+  }
+  LIMIT 10
+}
+`;
+
+const collectionBru = `headers {
+  x-trace: enabled
+}
+
+script:pre-request {
+  bru.setEnvVar("base", "https://example.com");
+}
+
+tests {
+  test("collection level", function() {
+    expect(true).to.equal(true);
+  });
+}
+
+docs {
+  # Collection docs
+
+  Notes for the whole collection.
+}
+`;
+
+const folderBru = `meta {
+  name: My Folder
+  seq: 2
+}
+
+docs {
+  # Folder docs
+}
+`;
+
+const blankLinesBru = `meta {
+  name: Blanks
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://example.com
+  body: json
+}
+
+body:json {
+
+  {
+    "a": 1
+  }
+
+
+}
+`;
+
+describe('redactLargeBruTextBlocks', () => {
+  describe('matches a normal parse (ohm oracle)', () => {
+    const requestCases = [
+      ['request with bodies, scripts, tests, docs', requestBru],
+      ['graphql query + variables', graphqlBru],
+      ['xml + sparql bodies', xmlSparqlBru],
+      ['CRLF request', toCRLF(requestBru)],
+      ['leading + trailing blank lines in body', blankLinesBru],
+      ['CRLF leading + trailing blank lines', toCRLF(blankLinesBru)]
+    ];
+
+    it.each(requestCases)('%s', (_name, content) => {
+      expect(parseViaRedaction(content, parseBruRequest)).toEqual(parseBruRequest(content));
+    });
+
+    const collectionCases = [
+      ['collection', collectionBru],
+      ['folder', folderBru],
+      ['CRLF collection', toCRLF(collectionBru)]
+    ];
+
+    it.each(collectionCases)('%s', (_name, content) => {
+      expect(parseViaRedaction(content, parseBruCollection)).toEqual(parseBruCollection(content));
+    });
+  });
+
+  it('extracts each large text block and shrinks the skeleton', () => {
+    const { skeleton, blocks } = redactLargeBruTextBlocks(requestBru);
+    expect(blocks.length).toBe(6);
+    expect(skeleton.length).toBeLessThan(requestBru.length);
+    blocks.forEach((block) => {
+      expect(skeleton).toContain(block.token);
+      expect(skeleton).not.toContain(block.value);
+    });
+  });
+
+  it('keeps the skeleton bounded regardless of block size', () => {
+    const blob = 'x'.repeat(4 * 1024 * 1024);
+    const bru = `meta {
+  name: Huge
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://example.com
+  body: json
+}
+
+body:json {
+  { "blob": "${blob}" }
+}
+`;
+    const { skeleton, blocks } = redactLargeBruTextBlocks(bru);
+    expect(bru.length).toBeGreaterThan(4 * 1024 * 1024);
+    expect(skeleton.length).toBeLessThan(1024);
+    expect(blocks[0].value).toContain(blob);
+  });
+
+  it('leaves dictionary body blocks untouched', () => {
+    const multipart = `meta {
+  name: Multipart
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://example.com
+  body: multipartForm
+}
+
+body:multipart-form {
+  field: value
+}
+`;
+    const { blocks } = redactLargeBruTextBlocks(multipart);
+    expect(blocks.length).toBe(0);
+    expect(parseViaRedaction(multipart, parseBruRequest)).toEqual(parseBruRequest(multipart));
+  });
+
+  it('captures nested braces in content without ending the block early', () => {
+    const nested = `body:json {
+  {
+    "a": {
+      "b": [ { "c": 1 } ],
+      "d": {}
+    }
+  }
+}
+
+script:pre-request {
+  function outer() {
+    if (true) {
+      return { ok: 1 };
+    }
+  }
+}
+`;
+    const { blocks } = redactLargeBruTextBlocks(nested);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0].value).toContain('"c": 1');
+    expect(blocks[0].value).toContain('"d": {}');
+    expect(blocks[1].value).toContain('return { ok: 1 };');
+    expect(parseViaRedaction(nested, parseBruRequest)).toEqual(parseBruRequest(nested));
+  });
+
+  it('only redacts blocks at column 0, never indented tags', () => {
+    const indented = `docs {
+  Nested pseudo-block should be treated as content:
+    body:json {
+      { "a": 1 }
+    }
+}
+`;
+    const { blocks } = redactLargeBruTextBlocks(indented);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].value).toContain('body:json {');
+  });
+
+  it('returns content unchanged when no large text blocks are present', () => {
+    const minimal = `meta {
+  name: Bare
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://example.com
+}
+`;
+    const { skeleton, blocks } = redactLargeBruTextBlocks(minimal);
+    expect(blocks).toEqual([]);
+    expect(skeleton).toBe(minimal);
+  });
+});
+
+describe('restoreRedactedBlocks', () => {
+  it('returns the parsed object unchanged when there are no blocks', () => {
+    const parsed = { request: { body: { json: 'x' } } };
+    expect(restoreRedactedBlocks(parsed, [])).toBe(parsed);
+  });
+});

--- a/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
+++ b/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
@@ -1,0 +1,102 @@
+import { createHash } from 'node:crypto';
+import { outdentString } from '@usebruno/lang';
+
+export interface RedactedBlock {
+  token: string;
+  value: string;
+}
+
+export interface RedactionResult {
+  skeleton: string;
+  blocks: RedactedBlock[];
+}
+
+const BLOCK_TAGS = [
+  'body:graphql:vars',
+  'body:graphql',
+  'body:json',
+  'body:text',
+  'body:xml',
+  'body:sparql',
+  'script:pre-request',
+  'script:post-response',
+  'tests',
+  'docs',
+  'body'
+];
+
+const BLOCK_OPENING = new RegExp(`^(${BLOCK_TAGS.join('|')})[ \\t]*\\{\\r?$`);
+
+const isOpening = (line: string): boolean => BLOCK_OPENING.test(line);
+
+// A top-level block's closing brace sits at column 0; braces inside the content are indented, so
+// nested braces are correctly treated as content rather than ending the block early.
+const isClosing = (line: string): boolean => line.startsWith('}');
+
+const tokenFor = (content: string): string => {
+  const hash = createHash('sha256').update(content).digest('hex').slice(0, 16);
+  return `__BRU_REDACTED_TEXT_BLOCK_${hash}__`;
+};
+
+const blockValue = (content: string[]): string =>
+  outdentString(content.join('\n').replace(/^(?:\r?\n)+/, '').replace(/\r$/, ''));
+
+export const redactLargeBruTextBlocks = (content: string): RedactionResult => {
+  const source = content || '';
+  const skeleton: string[] = [];
+  const blocks: RedactedBlock[] = [];
+
+  let openTag: string | null = null;
+  let openContent: string[] = [];
+
+  for (const line of source.split('\n')) {
+    if (openTag === null && isOpening(line)) {
+      openTag = line;
+      openContent = [];
+      continue;
+    }
+
+    if (openTag !== null && isClosing(line)) {
+      const token = tokenFor(openContent.join('\n'));
+      blocks.push({ token, value: blockValue(openContent) });
+      skeleton.push(openTag, `  ${token}`, line);
+      openTag = null;
+      continue;
+    }
+
+    (openTag === null ? skeleton : openContent).push(line);
+  }
+
+  if (openTag !== null) {
+    skeleton.push(openTag, ...openContent);
+  }
+
+  if (blocks.some((block) => source.includes(block.token))) {
+    console.warn('[bruno-filestore] Token collision detected; skipping redaction');
+    return { skeleton: source, blocks: [] };
+  }
+
+  return { skeleton: skeleton.join('\n'), blocks };
+};
+
+export const restoreRedactedBlocks = <T>(parsed: T, blocks: RedactedBlock[]): T => {
+  if (!blocks.length) {
+    return parsed;
+  }
+
+  const valueByToken = new Map(blocks.map((block) => [block.token, block.value]));
+
+  const walk = (node: any): any => {
+    if (typeof node === 'string') {
+      return valueByToken.get(node) ?? node;
+    }
+    if (node && typeof node === 'object') {
+      for (const key of Object.keys(node)) {
+        node[key] = walk(node[key]);
+      }
+    }
+    return node;
+  };
+
+  return walk(parsed);
+};

--- a/packages/bruno-filestore/src/index.ts
+++ b/packages/bruno-filestore/src/index.ts
@@ -27,6 +27,7 @@ import {
 } from './types';
 import { DEFAULT_COLLECTION_FORMAT } from './constants';
 import { bruRequestParseAndRedactBodyData } from './formats/bru/utils/request-parse-and-redact-body-data';
+import { redactLargeBruTextBlocks, restoreRedactedBlocks } from './formats/bru/utils/redact-large-text-blocks';
 
 // request
 export const parseRequest = (content: string, options: ParseOptions = { format: DEFAULT_COLLECTION_FORMAT }): any => {
@@ -135,6 +136,8 @@ export const parseDotEnv = (content: string): Record<string, string> => {
   return dotenvToJson(content);
 };
 
+export { redactLargeBruTextBlocks, restoreRedactedBlocks };
+export type { RedactedBlock, RedactionResult } from './formats/bru/utils/redact-large-text-blocks';
 export { BruParserWorker };
 export * from './types';
 export * from './constants';

--- a/packages/bruno-filestore/src/types/bruno-lang.d.ts
+++ b/packages/bruno-filestore/src/types/bruno-lang.d.ts
@@ -6,4 +6,5 @@ declare module '@usebruno/lang' {
   export function collectionBruToJson(bruContent: string): any;
   export function jsonToCollectionBru(jsonData: any): string;
   export function dotenvToJson(envContent: string): Record<string, string>;
+  export function outdentString(str: string, spaces?: number): string;
 }

--- a/packages/bruno-lang/src/index.js
+++ b/packages/bruno-lang/src/index.js
@@ -6,6 +6,7 @@ const dotenvToJson = require('../v2/src/dotenvToJson');
 
 const collectionBruToJson = require('../v2/src/collectionBruToJson');
 const jsonToCollectionBru = require('../v2/src/jsonToCollectionBru');
+const { outdentString } = require('../v2/src/utils');
 
 // Todo: remove V2 suffixes
 // Changes will have to be made to the CLI and GUI
@@ -19,5 +20,7 @@ module.exports = {
   collectionBruToJson,
   jsonToCollectionBru,
 
-  dotenvToJson
+  dotenvToJson,
+
+  outdentString
 };


### PR DESCRIPTION
## Problem

Large `.bru` files (>= 64KB) are fed whole to the ohm parser when mounting a collection, which is slow and memory-heavy. A ~900KB request takes ~860ms to parse and scales badly.

## Approach

Add a redaction pass that splits the unbounded flat text blocks out of the file before parsing, so ohm only ever sees a small structural skeleton:

- **`redactLargeBruTextBlocks(content)`** — line-by-line scan that replaces each top-level text block's content (`body:json/text/xml/sparql/graphql`, `body:graphql:vars`, `script:pre-request`, `script:post-response`, `tests`, `docs`, legacy `body`) with a content-hash sentinel token, returning the skeleton plus the extracted values.
- **`restoreRedactedBlocks(parsed, blocks)`** — re-attaches the extracted values wherever their tokens land in the parsed object (no hard-coded AST paths).
- `parse-file` uses this for **request, collection and folder** `.bru` above the size threshold.

Extracted values are byte-identical to a normal parse — leading blank lines, the CRLF terminator's stray `\r`, and the 2-space outdent are all reproduced to match ohm's grammar boundaries. This is enforced by round-trip tests that deep-equal the redacted path against a normal parse (bodies, scripts, tests, docs, graphql vars, nested braces, leading/trailing blank lines, CRLF, collection, folder).

## Result

A 900KB `.bru` drops from **~860ms → ~0.6ms** to parse, with output identical to the normal path. Examples and `'''`-delimited dictionary values (grpc/ws content, app code) are intentionally out of scope.

Ticket - BRU-3891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved handling of large Bruno files for requests, collections, and folders based on size.
  * Added utilities to redact and restore large text blocks during parsing (covering JSON/XML/GraphQL/script and more).
  * Exposed `outdentString` as a new formatting helper.

* **Tests**
  * Added comprehensive Jest coverage for redaction/restoration round-trips, nested/edge cases, and scenarios with no large text blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->