### PR TITLE
fix(app): correct new request shortcut label in response placeholder

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Placeholder/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Placeholder/index.js
@@ -7,7 +7,7 @@ import { isMacOS } from 'utils/common/platform';
 const Placeholder = () => {
   const isMac = isMacOS();
   const sendRequestShortcut = isMac ? 'Cmd + Enter' : 'Ctrl + Enter';
-  const newRequestShortcut = isMac ? 'Cmd + B' : 'Ctrl + B';
+  const newRequestShortcut = isMac ? 'Cmd + N' : 'Ctrl + N';
   const editEnvironmentShortcut = isMac ? 'Cmd + E' : 'Ctrl + E';
   const preferences = useSelector((state) => state.app.preferences);
   const isVerticalLayout = preferences?.layout?.responsePaneOrientation === 'vertical';


### PR DESCRIPTION
### Description

The response pane placeholder displayed "Cmd/Ctrl + B" for the new request shortcut, but the actual hotkey is "Cmd/Ctrl + N". This label was only wrong in the response pane placeholder; updated it to match the real binding.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3931)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<img width="620" height="465" alt="image" src="https://github.com/user-attachments/assets/b3b117e3-4bb5-4442-a50c-b86f20fc09c9" />
