### PR TITLE
fix(app): chevron positioning and selector width

### DIFF
--- a/packages/bruno-app/src/components/DataTypeSelector/index.js
+++ b/packages/bruno-app/src/components/DataTypeSelector/index.js
@@ -75,7 +75,7 @@ const DataTypeSelector = ({ variable, onChange, compact = false }) => {
               size={16}
             />
             <Tooltip
-              positionStrategy="fixed"
+              positionStrategy="absolute"
               className="tooltip-mod"
               id={`type-error-${variable.uid}`}
               content={typeError}

--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -247,7 +247,8 @@ const StyledWrapper = styled.div`
     color: ${(props) => props.theme.text};
     border: none;
     outline: none;
-    padding: 2px 8px;
+    padding: 2px 2px;
+    width: 100%;
     font-size: 12px;
     cursor: pointer;
 

--- a/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EditableTable/StyledWrapper.js
@@ -249,6 +249,7 @@ const StyledWrapper = styled.div`
     outline: none;
     padding: 2px 2px;
     width: 100%;
+    box-sizing: border-box;
     font-size: 12px;
     cursor: pointer;
 


### PR DESCRIPTION
### Description

BRU-3907

Changes the padding used by the assertions selector and it's overall width.

**Before:**

https://github.com/user-attachments/assets/7a0c40c7-208d-4010-b591-b84f2d0d5316


**After:**

https://github.com/user-attachments/assets/3533e674-8972-447c-a001-2f5667442795



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved positioning for data type error tooltips.
  * Updated table dropdown styling so controls better fill available width and have more consistent padding/spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->