### PR TITLE
fix(size/S):Minor bug fix in the version edit popup for the new version input box

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/StyledWrapper.js
@@ -69,40 +69,11 @@ const StyledWrapper = styled.div`
       flex-shrink: 0;
     }
 
-    .input-wrap {
-      position: relative;
-
-      .textbox {
-        padding-right: 2.25rem;
-        color: ${(props) => props.theme.text};
-        font-weight: 400;
-        font-size: ${(props) => props.theme.font.size.sm};
-        line-height: 20px;
-      }
-
-      .copy-btn {
-        position: absolute;
-        top: 50%;
-        right: 0.5rem;
-        transform: translateY(-50%);
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0.25rem;
-        background: transparent;
-        border: none;
-        cursor: pointer;
-        color: ${(props) => props.theme.colors.text.muted};
-
-        &:hover:not(:disabled) {
-          color: ${(props) => props.theme.text};
-        }
-
-        &:disabled {
-          opacity: 0.5;
-          cursor: default;
-        }
-      }
+    .new-version-input {
+      color: ${(props) => props.theme.text};
+      font-weight: 400;
+      font-size: ${(props) => props.theme.font.size.sm};
+      line-height: 20px;
     }
   }
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { IconArrowRight, IconCopy, IconCheck, IconAlertTriangle } from '@tabler/icons';
+import { IconArrowRight, IconAlertTriangle } from '@tabler/icons';
 
 import Modal from 'components/Modal';
 import Portal from 'components/Portal';
@@ -30,14 +30,12 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
   const isYml = isOpenCollectionFormat(collection);
   const targetKey = isYml ? 'info.version' : 'collectionVersion';
   const targetFile = isYml ? 'opencollection.yml' : 'bruno.json';
-  const [newVersion, setNewVersion] = useState(currentVersion);
+  const [newVersion, setNewVersion] = useState('');
   const [isSaving, setIsSaving] = useState(false);
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.focus();
-      inputRef.current.select();
     }
   }, []);
 
@@ -53,15 +51,6 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
     dispatch(saveCollectionVersion(collectionUid, trimmedVersion))
       .then(() => onClose())
       .catch(() => setIsSaving(false));
-  };
-
-  const handleCopy = () => {
-    if (!trimmedVersion || !navigator.clipboard) return;
-    navigator.clipboard.writeText(trimmedVersion)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      }).catch(() => {});
   };
 
   if (!collection) {
@@ -98,32 +87,20 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
 
               <div className="version-col">
                 <div className="col-label">New Version</div>
-                <div className="input-wrap">
-                  <input
-                    ref={inputRef}
-                    type="text"
-                    className="textbox w-full"
-                    autoComplete="off"
-                    autoCorrect="off"
-                    autoCapitalize="off"
-                    spellCheck="false"
-                    placeholder="e.g. v1.0.0"
-                    maxLength={50}
-                    value={newVersion}
-                    onChange={(e) => setNewVersion(e.target.value)}
-                    data-testid="change-version-input"
-                  />
-                  <button
-                    type="button"
-                    className="copy-btn"
-                    aria-label={copied ? 'Copied' : 'Copy version'}
-                    onClick={handleCopy}
-                    disabled={!trimmedVersion}
-                    data-testid="change-version-copy"
-                  >
-                    {copied ? <IconCheck size={15} stroke={1.5} /> : <IconCopy size={15} stroke={1.5} />}
-                  </button>
-                </div>
+                <input
+                  ref={inputRef}
+                  type="text"
+                  className="textbox w-full new-version-input"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  spellCheck="false"
+                  placeholder="e.g. v1.0.0"
+                  maxLength={50}
+                  value={newVersion}
+                  onChange={(e) => setNewVersion(e.target.value)}
+                  data-testid="change-version-input"
+                />
               </div>
             </div>
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.spec.js
@@ -66,6 +66,12 @@ beforeEach(() => {
 });
 
 describe('ChangeCollectionVersion', () => {
+  it('opens with an empty new-version input, even when the collection already has a version', () => {
+    renderModal(buildCollection());
+    expect(screen.getByTestId('change-version-input')).toHaveValue('');
+    expect(screen.getByTestId('change-version-submit-btn')).toBeDisabled();
+  });
+
   it('lets you save only when the new version is different from the current one', () => {
     renderModal(buildCollection());
     const submit = screen.getByTestId('change-version-submit-btn');

--- a/tests/collection/change-version/change-version.spec.ts
+++ b/tests/collection/change-version/change-version.spec.ts
@@ -30,7 +30,7 @@ test.describe('Change Collection Version (yml collection)', () => {
     await test.step('open the Change Collection Version modal', async () => {
       await page.getByTestId('info-version-change').click();
       await expect(page.getByTestId('change-version-current')).toHaveText('1.0.0');
-      await expect(page.getByTestId('change-version-input')).toHaveValue('1.0.0');
+      await expect(page.getByTestId('change-version-input')).toHaveValue('');
     });
 
     await test.step('the Update button stays off until the version is changed', async () => {


### PR DESCRIPTION
### Description
Impact
In the Collection overview, changing the version name updates the version line dynamically. However, when users close and reopen it, the same number is shown again. This is confusing for users.

Fix:
Removed the version when opening the edit version modal.
Removed the copy button from the new version input box as well.

BRU-3951

<img width="1690" height="848" alt="image" src="https://github.com/user-attachments/assets/0055d52b-033a-4f60-888e-8deabf33ddd3" />


<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Simplified the collection version dialog with a cleaner version input.
  * Updated input typography to match existing theme-based styles.
  * Removed the clipboard copy control from the version field.
  * The version field now opens empty (not pre-filled), focuses on load, and keeps the submit button disabled until a value is entered.

* **Tests**
  * Added/updated assertions to verify the dialog’s initial empty-input and disabled-submit states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->