### PR TITLE
ci: enable Windows Unit Tests

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   unit-test:
     name: Unit Tests (Windows)
-    if: false # @TODO: Temporarily disabled. Remove this once the tests are fixed.
     timeout-minutes: 60
     runs-on: windows-latest
     permissions:

--- a/packages/bruno-app/src/utils/common/path.host.spec.js
+++ b/packages/bruno-app/src/utils/common/path.host.spec.js
@@ -1,0 +1,20 @@
+// These tests resolve against the real host cwd,
+// so results are asserted in the host's native path format.
+import path from 'path';
+import { getRelativePathWithinBasePath } from './path';
+
+describe('Path Utilities - cwd-relative resolution (host platform)', () => {
+  it('should treat relative collection path as cwd-relative when file path is absolute', () => {
+    const collectionPath = 'collections/api';
+    const filePath = path.resolve(collectionPath, 'files/payload.txt');
+    const result = getRelativePathWithinBasePath(collectionPath, filePath);
+    expect(result).toBe(path.join('files', 'payload.txt'));
+  });
+
+  it('should treat relative file path as cwd-relative when collection path is absolute', () => {
+    const collectionPath = path.resolve('collections/api');
+    const filePath = 'collections/api/files/payload.txt';
+    const result = getRelativePathWithinBasePath(collectionPath, filePath);
+    expect(result).toBe(path.join('files', 'payload.txt'));
+  });
+});

--- a/packages/bruno-app/src/utils/common/path.host.spec.js
+++ b/packages/bruno-app/src/utils/common/path.host.spec.js
@@ -1,0 +1,27 @@
+// These tests resolve against the real host cwd,
+// so results are asserted in the host's native path format.
+// Mock platform module from process.platform since jsdom's user agent doesn't reflect the real OS
+jest.mock('platform', () => ({
+  os: {
+    family: process.platform === 'win32' ? 'Windows' : 'Linux'
+  }
+}));
+
+import path from 'path';
+import { getRelativePathWithinBasePath } from './path';
+
+describe('Path Utilities - cwd-relative resolution (host platform)', () => {
+  it('should treat relative collection path as cwd-relative when file path is absolute', () => {
+    const collectionPath = 'collections/api';
+    const filePath = path.resolve(collectionPath, 'files/payload.txt');
+    const result = getRelativePathWithinBasePath(collectionPath, filePath);
+    expect(result).toBe(path.join('files', 'payload.txt'));
+  });
+
+  it('should treat relative file path as cwd-relative when collection path is absolute', () => {
+    const collectionPath = path.resolve('collections/api');
+    const filePath = 'collections/api/files/payload.txt';
+    const result = getRelativePathWithinBasePath(collectionPath, filePath);
+    expect(result).toBe(path.join('files', 'payload.txt'));
+  });
+});

--- a/packages/bruno-app/src/utils/common/path.spec.js
+++ b/packages/bruno-app/src/utils/common/path.spec.js
@@ -5,7 +5,6 @@ jest.mock('platform', () => ({
   }
 }));
 
-import path from 'path';
 import { getRelativePath, getBasename, getAbsoluteFilePath, getRelativePathWithinBasePath, isPathExternalToBasePath } from './path';
 
 describe('Path Utilities - Unix Platform', () => {
@@ -166,20 +165,6 @@ describe('Path Utilities - Unix Platform', () => {
     it('should keep the original file path when inputs are missing', () => {
       expect(getRelativePathWithinBasePath('', '/users/john/downloads/payload.txt')).toBe('/users/john/downloads/payload.txt');
       expect(getRelativePathWithinBasePath('/users/john/collections/api', '')).toBe('');
-    });
-
-    it('should treat relative collection path as cwd-relative when file path is absolute', () => {
-      const collectionPath = 'collections/api';
-      const filePath = path.resolve(collectionPath, 'files/payload.txt');
-      const result = getRelativePathWithinBasePath(collectionPath, filePath);
-      expect(result).toBe('files/payload.txt');
-    });
-
-    it('should treat relative file path as cwd-relative when collection path is absolute', () => {
-      const collectionPath = path.resolve('collections/api');
-      const filePath = 'collections/api/files/payload.txt';
-      const result = getRelativePathWithinBasePath(collectionPath, filePath);
-      expect(result).toBe('files/payload.txt');
     });
 
     it('should treat both relative paths as cwd-relative for containment checks', () => {

--- a/packages/bruno-converters/jest.setup.js
+++ b/packages/bruno-converters/jest.setup.js
@@ -1,3 +1,11 @@
+// The Postman translators reprint code via recast, whose toSource() takes its
+// line terminator from os.EOL, so translated output is CRLF on Windows while the
+// spec expectations (and collection files, per .gitattributes) are LF. Pin os.EOL
+// to LF for the test process so output is identical on every platform. recast
+// reads os.EOL once at load, and setupFiles run before any spec requires a
+// translator, so this lands first.
+Object.defineProperty(require('os'), 'EOL', { value: '\n', configurable: true, writable: true });
+
 // Mock the uuid function
 jest.mock('./src/common', () => {
   // Import the original module to keep other functions intact

--- a/packages/bruno-electron/src/store/tests/system-proxy.spec.js
+++ b/packages/bruno-electron/src/store/tests/system-proxy.spec.js
@@ -8,20 +8,30 @@ jest.mock('@usebruno/requests', () => ({
 
 const PROXY_ENV_KEYS = ['http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY', 'no_proxy', 'NO_PROXY', 'all_proxy', 'ALL_PROXY'];
 
+// The shell-env refresh no-ops on win32, so tests exercising that branch are
+// skipped on Windows hosts instead of faking the platform.
+const itIf = (condition) => (condition ? it : it.skip);
+const isWindows = process.platform === 'win32';
+
 describe('system-proxy refresh', () => {
   let fetchSystemProxy;
   const originalPlatform = process.platform;
 
   beforeEach(() => {
     jest.resetModules();
-    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     mockFetchShellEnv = jest.fn(() => Promise.resolve({}));
     mockGetSystemProxy = jest.fn(() => Promise.resolve({ source: 'environment' }));
     for (const key of PROXY_ENV_KEYS) delete process.env[key];
     ({ fetchSystemProxy } = require('../system-proxy'));
   });
 
-  it('updates proxy env vars from shell config', async () => {
+  // process is shared across spec files in a worker; a leaked fake platform
+  // would poison unrelated suites.
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  itIf(!isWindows)('updates proxy env vars from shell config', async () => {
     process.env.http_proxy = 'http://old-proxy:8080';
     mockFetchShellEnv = jest.fn(() => Promise.resolve({ http_proxy: 'http://new-proxy:8080' }));
     ({ fetchSystemProxy } = require('../system-proxy'));
@@ -31,7 +41,7 @@ describe('system-proxy refresh', () => {
     expect(process.env.http_proxy).toBe('http://new-proxy:8080');
   });
 
-  it('removes proxy env vars missing from shell config (user removed the export)', async () => {
+  itIf(!isWindows)('removes proxy env vars missing from shell config (user removed the export)', async () => {
     process.env.http_proxy = 'http://old-proxy:8080';
     process.env.no_proxy = 'localhost';
     mockFetchShellEnv = jest.fn(() => Promise.resolve({}));
@@ -43,7 +53,7 @@ describe('system-proxy refresh', () => {
     expect(process.env.no_proxy).toBeUndefined();
   });
 
-  it('restores prior proxy vars when the shell fetch fails', async () => {
+  itIf(!isWindows)('restores prior proxy vars when the shell fetch fails', async () => {
     // fetchShellEnv never rejects - it resolves null on subprocess failure (see shell-env.ts).
     process.env.http_proxy = 'http://existing:8080';
     mockFetchShellEnv = jest.fn(() => Promise.resolve(null));
@@ -77,7 +87,7 @@ describe('system-proxy refresh', () => {
     beforeEach(() => jest.useFakeTimers());
     afterEach(() => jest.useRealTimers());
 
-    it('restores prior proxy vars if the shell fetch hangs past 60s', async () => {
+    itIf(!isWindows)('restores prior proxy vars if the shell fetch hangs past 60s', async () => {
       process.env.http_proxy = 'http://existing:8080';
       mockFetchShellEnv = jest.fn(() => new Promise(() => {})); // never resolves
       ({ fetchSystemProxy } = require('../system-proxy'));

--- a/packages/bruno-electron/tests/utils/collection.spec.js
+++ b/packages/bruno-electron/tests/utils/collection.spec.js
@@ -436,9 +436,8 @@ describe('mergeScripts metadata', () => {
 
     expect(request.script.reqMetadata.segments).toHaveLength(2);
     expect(request.script.reqMetadata.segments[0].displayPath).toBe('collection.bru');
-    expect(request.script.reqMetadata.segments[1].displayPath).toBe(
-      path.join('subfolder', 'folder.bru')
-    );
+    // displayPath is posixified by mergeScripts regardless of platform
+    expect(request.script.reqMetadata.segments[1].displayPath).toBe('subfolder/folder.bru');
   });
 
   test('non-sequential flow reverses post-res segment order', () => {
@@ -452,7 +451,7 @@ describe('mergeScripts metadata', () => {
     const segments = request.script.resMetadata.segments;
     expect(segments).toHaveLength(2);
     // Folder should come before collection in reversed order
-    expect(segments[0].displayPath).toBe(path.join('subfolder', 'folder.bru'));
+    expect(segments[0].displayPath).toBe('subfolder/folder.bru');
     expect(segments[1].displayPath).toBe('collection.bru');
   });
 

--- a/packages/bruno-electron/tests/utils/workspace-config.spec.js
+++ b/packages/bruno-electron/tests/utils/workspace-config.spec.js
@@ -83,22 +83,19 @@ describe('reorderWorkspaceCollections', () => {
 describe('Git remote on workspace collections', () => {
   let workspacePath;
 
+  // Serialized with yaml.dump: hand-built double-quoted scalars break on
+  // Windows tmp paths, whose backslashes read as YAML escapes.
   const writeYml = (collections) => {
-    const lines = [
-      'opencollection: 1.0.0',
-      'info:',
-      '  name: Test',
-      '  type: workspace',
-      'collections:'
-    ];
-    for (const c of collections) {
-      lines.push(`  - name: "${c.name}"`);
-      lines.push(`    path: "${c.path}"`);
-      if (c.remote) lines.push(`    remote: "${c.remote}"`);
-    }
-    lines.push('specs: []');
-    lines.push('docs: \'\'');
-    fs.writeFileSync(path.join(workspacePath, 'workspace.yml'), lines.join('\n'));
+    const config = {
+      opencollection: '1.0.0',
+      info: { name: 'Test', type: 'workspace' },
+      collections: collections.map(({ name, path: collectionPath, remote }) =>
+        remote ? { name, path: collectionPath, remote } : { name, path: collectionPath }
+      ),
+      specs: [],
+      docs: ''
+    };
+    fs.writeFileSync(path.join(workspacePath, 'workspace.yml'), yaml.dump(config));
   };
 
   const readCollectionsFromYml = () => {

--- a/packages/bruno-js/src/utils/error-formatter.js
+++ b/packages/bruno-js/src/utils/error-formatter.js
@@ -747,5 +747,6 @@ module.exports = {
   findYmlScriptBlockStartLine,
   findYmlScriptBlockEndLine,
   adjustStackTrace,
-  getErrorTypeName
+  getErrorTypeName,
+  posixifyPath
 };

--- a/packages/bruno-js/src/utils/error-formatter.spec.js
+++ b/packages/bruno-js/src/utils/error-formatter.spec.js
@@ -11,7 +11,8 @@ const {
   parseErrorLocation,
   getSourceContextFromContent,
   adjustStackTrace,
-  buildStackFromCallSites
+  buildStackFromCallSites,
+  posixifyPath
 } = require('./error-formatter');
 const fs = require('fs');
 const path = require('path');
@@ -804,7 +805,9 @@ get {
         const result = formatErrorWithContextV2(error, 'pre-request');
 
         expect(result).not.toBeNull();
-        expect(result.filePath).toBe(bruFilePath);
+        // display paths are posixified, so the Windows path.join backslashes
+        // must be normalized before comparing
+        expect(result.filePath).toBe(posixifyPath(bruFilePath));
       });
     });
 

--- a/packages/bruno-requests/src/network/system-proxy/index.spec.js
+++ b/packages/bruno-requests/src/network/system-proxy/index.spec.js
@@ -15,7 +15,12 @@ describe('SystemProxyResolver Integration', () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     detector = new SystemProxyResolver();
-    originalEnv = { ...process.env };
+    // Swap the real env object for a plain copy: the OS-backed env is
+    // case-insensitive on Windows (setting HTTP_PROXY overwrites http_proxy),
+    // while a plain object keeps distinct-cased keys distinct on every host.
+    // afterEach restores the real object, untouched by the tests.
+    originalEnv = process.env;
+    process.env = { ...process.env };
 
     // Clear environment variables
     delete process.env.http_proxy;

--- a/packages/bruno-requests/src/utils/shell-env.spec.ts
+++ b/packages/bruno-requests/src/utils/shell-env.spec.ts
@@ -9,12 +9,17 @@ jest.mock('shell-env', () => ({
 
 const originalPlatform = process.platform;
 
+// initializeShellEnv no-ops on win32, so the unix-branch tests below are
+// skipped on Windows hosts instead of faking the platform.
+const itIf = (condition: boolean) => (condition ? it : it.skip);
+const isWindows = process.platform === 'win32';
+
 afterEach(() => {
-  Object.defineProperty(process, 'platform', { value: originalPlatform });
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
 });
 
 describe('initializeShellEnv', () => {
-  test('should add shell env vars that are not in process.env', async () => {
+  itIf(!isWindows)('should add shell env vars that are not in process.env', async () => {
     delete process.env.TEST_SHELL_VAR;
     mockShellEnvResult = { TEST_SHELL_VAR: 'from_shell_config' };
 
@@ -24,7 +29,7 @@ describe('initializeShellEnv', () => {
     delete process.env.TEST_SHELL_VAR;
   });
 
-  test('should not overwrite existing process.env values', async () => {
+  itIf(!isWindows)('should not overwrite existing process.env values', async () => {
     process.env.http_proxy = 'updated_value';
     mockShellEnvResult = { http_proxy: 'config_file_value' };
 
@@ -34,7 +39,7 @@ describe('initializeShellEnv', () => {
     delete process.env.http_proxy;
   });
 
-  test('should prepend shell PATH to existing process.env.PATH', async () => {
+  itIf(!isWindows)('should prepend shell PATH to existing process.env.PATH', async () => {
     const shellNodeBin = path.join('fixtures', 'shell-env', 'node-bin');
     const systemBin = path.join('fixtures', 'shell-env', 'system-bin');
     const otherBin = path.join('fixtures', 'shell-env', 'other-bin');
@@ -49,7 +54,7 @@ describe('initializeShellEnv', () => {
     delete process.env.PATH;
   });
 
-  test('should set PATH from shell when not in process.env', async () => {
+  itIf(!isWindows)('should set PATH from shell when not in process.env', async () => {
     const shellBin = path.join('fixtures', 'shell-env', 'shell-bin');
     delete process.env.PATH;
     mockShellEnvResult = { PATH: shellBin };
@@ -60,7 +65,7 @@ describe('initializeShellEnv', () => {
     delete process.env.PATH;
   });
 
-  test('should preserve multiple existing env vars while adding new ones', async () => {
+  itIf(!isWindows)('should preserve multiple existing env vars while adding new ones', async () => {
     process.env.EXISTING_VAR = 'existing';
     delete process.env.NEW_VAR;
     mockShellEnvResult = { EXISTING_VAR: 'overwritten', NEW_VAR: 'new_value' };
@@ -73,7 +78,7 @@ describe('initializeShellEnv', () => {
     delete process.env.NEW_VAR;
   });
 
-  test('should return the shell env vars (not the merged result)', async () => {
+  itIf(!isWindows)('should return the shell env vars (not the merged result)', async () => {
     mockShellEnvResult = { SOME_VAR: 'value' };
 
     const result = await initializeShellEnv();
@@ -83,7 +88,7 @@ describe('initializeShellEnv', () => {
   });
 
   test('should return empty object on Windows', async () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' });
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
     mockShellEnvResult = { SHOULD_NOT_APPEAR: 'value' };
 
     const result = await initializeShellEnv();


### PR DESCRIPTION
### Description

Internal - BRU-4506

This PR enables Windows Unit Tests and also fixes the failing ones.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported `posixifyPath` from the error-formatting utilities for external use.

* **Bug Fixes**
  * Improved consistency of displayed paths across platforms (including posix-normalized “display path” behavior).

* **Tests**
  * Enabled Windows unit-test execution and removed hard-disabled guards.
  * Updated platform-aware tests to skip where appropriate, avoid `process.platform`/`process.env` leakage, and standardize line endings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->