### PR TITLE
ci: use prod build for playwright tests

### DIFF
--- a/.github/actions/tests/run-e2e-tests/action.yml
+++ b/.github/actions/tests/run-e2e-tests/action.yml
@@ -15,12 +15,18 @@ runs:
       shell: ${{ inputs.shell }}
       run: npm ci --prefix packages/bruno-tests/collection
 
+    # E2E_WEB_SERVER=build serves a production web build instead of the dev
+    # server, whose watcher/compile stalls left Electron launches hanging on CI.
     - name: Run Playwright Tests (Ubuntu)
       if: inputs.os == 'ubuntu'
       shell: bash
+      env:
+        E2E_WEB_SERVER: build
       run: xvfb-run dbus-run-session -- npm run test:e2e
 
     - name: Run Playwright Tests
       if: inputs.os != 'ubuntu'
       shell: ${{ inputs.shell }}
+      env:
+        E2E_WEB_SERVER: build
       run: npm run test:e2e

--- a/.github/actions/tests/run-e2e-tests/action.yml
+++ b/.github/actions/tests/run-e2e-tests/action.yml
@@ -19,9 +19,13 @@ runs:
       shell: ${{ inputs.shell }}
       run: npm ci --prefix packages/bruno-tests/collection
 
+    # E2E_WEB_SERVER=build serves a production web build instead of the dev
+    # server, whose watcher/compile stalls left Electron launches hanging on CI.
     - name: Run Playwright Tests (Ubuntu)
       if: inputs.os == 'ubuntu' && inputs.shard == ''
       shell: bash
+      env:
+        E2E_WEB_SERVER: build
       run: xvfb-run dbus-run-session -- npm run test:e2e
 
     - name: Run Playwright Tests (Ubuntu, sharded)
@@ -32,6 +36,8 @@ runs:
     - name: Run Playwright Tests
       if: inputs.os != 'ubuntu' && inputs.shard == ''
       shell: ${{ inputs.shell }}
+      env:
+        E2E_WEB_SERVER: build
       run: npm run test:e2e
 
     - name: Run Playwright Tests (sharded)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,7 +45,13 @@ export default defineConfig({
 
   webServer: [
     {
-      command: 'npm run dev:web',
+      // E2E_WEB_SERVER=build serves a production build instead of the dev
+      // server. CI sets it because the dev server's watcher/compile work can
+      // leave it unresponsive under parallel Electron load (observed on
+      // Windows runners: launches hang loading localhost:3000 until teardown).
+      command: process.env.E2E_WEB_SERVER === 'build'
+        ? 'npm run build --workspace=packages/bruno-app && npm run preview --workspace=packages/bruno-app'
+        : 'npm run dev:web',
       url: 'http://localhost:3000',
       reuseExistingServer: !process.env.CI,
       timeout: 10 * 60 * 1000

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,7 +52,13 @@ export default defineConfig({
 
   webServer: [
     {
-      command: 'npm run dev:web',
+      // E2E_WEB_SERVER=build serves a production build instead of the dev
+      // server. CI sets it because the dev server's watcher/compile work can
+      // leave it unresponsive under parallel Electron load (observed on
+      // Windows runners: launches hang loading localhost:3000 until teardown).
+      command: process.env.E2E_WEB_SERVER === 'build'
+        ? 'npm run build --workspace=packages/bruno-app && npm run preview --workspace=packages/bruno-app'
+        : 'npm run dev:web',
       url: 'http://localhost:3000',
       reuseExistingServer: !process.env.CI,
       timeout: 10 * 60 * 1000


### PR DESCRIPTION
### Description

Switching to a prod build for CI helps in:
- Reducing flakiness in some windows tests which fail on timeout
- Faster test execution (12m-20m less observed on windows tests)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * End-to-end tests can now run against the production web build when configured.
  * Improved test-runner handling for CI environments and parallel Electron test execution.
  * Test workflows now consistently use the appropriate web server mode across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->