### PR TITLE
fix(ai): improve script types and clarify res restrictions in pre scripts

### DIFF
--- a/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.js
@@ -34,7 +34,7 @@ ${blocks.map((block) => API_BLOCKS[block]).join('\n\n')}`;
 
 const SCRIPT_CONTEXTS = {
   'tests': `Tests run AFTER the response. Globals: bru, req, res, test, expect. Assertions go inside test("name", () => { ... }) blocks. Don't call bru.setEnvVar / setVar — keep tests pure.`,
-  'pre-request': `Pre-request scripts run BEFORE the HTTP request is sent. Globals: bru, req. res is NOT available. Don't use test() / expect() — those belong in the Tests tab.`,
+  'pre-request': `Pre-request scripts run BEFORE the HTTP request is sent — the response does not exist yet. Globals: bru, req only. Do NOT emit res.status / res.headers / res.body / res(...) or any other res.* member — the res global is not defined here and referencing it throws. Don't use test() / expect() either — those belong in the Tests tab.`,
   'post-response': `Post-response scripts run AFTER the response is received, before tests. Globals: bru, req, res. Don't use test() / expect() — those belong in the Tests tab.`
 };
 
@@ -62,6 +62,7 @@ ${context}
 - If the cursor is at the end of a \`//\` comment line and you are generating CODE (not finishing the comment's text), begin your output with a newline — anything emitted on the comment line itself would be commented out. A comment like \`// test that status is 200\` is an instruction: put the implementing code on the following line(s).
 - Stop at a natural break (end of statement, end of block) — do not rewrite code that already exists after the cursor.
 - Prefer real variable names from the provided lists over placeholders.
+- This is Bruno, not Postman. Never emit \`pm.*\` calls such as \`pm.environment.get\`, \`pm.variables.get\`, \`pm.response.json\`, \`pm.test\`, or \`pm.sendRequest\` — \`pm\` is not a global in Bruno. Use only the Bruno globals listed above.
 - Return an empty string if you have nothing useful to add.`;
 };
 
@@ -199,8 +200,18 @@ const ensureNewlineAfterComment = (prefix, suggestion) => {
   return '\n' + suggestion;
 };
 
-const RES_API_USAGE_RE = /(?<![\w$.?])res\s*\??\s*[.([]/;
-const RES_BINDING_RE = /\b(?:const|let|var)\s+res\b|[(,]\s*res\s*[,)=]|\bres\s*=>/;
+// Match a bare `<name>` used as an API — followed by `.`, `[`, or `(`, and
+// NOT preceded by another identifier char or a `.` (so `myres`, `foo.res`
+// don't false-match). Optional chaining (`res?.`, `res?.[`, `res?.(`) counts.
+const buildApiUsageRe = (name) => new RegExp(`(?<![\\w$.?])${name}\\s*\\??\\s*[.([]`);
+// Match a user-declared binding of `<name>` (const/let/var, function param,
+// or arrow param) — in which case a suggestion referencing it is legitimate.
+const buildApiBindingRe = (name) =>
+  new RegExp(`\\b(?:const|let|var)\\s+${name}\\b|[(,]\\s*${name}\\s*[,)=]|\\b${name}\\s*=>`);
+
+const RES = { usage: buildApiUsageRe('res'), binding: buildApiBindingRe('res') };
+const PM = { usage: buildApiUsageRe('pm'), binding: buildApiBindingRe('pm') };
+
 const TRAILING_MEMBER_EXPR_RE = /[\w$.?[\]()]*$/;
 const TRAILING_WORD_RE = /[\w$]+$/;
 const PRECEDING_WORD_RE = /([\w$]+)\s+$/;
@@ -209,11 +220,17 @@ const LEADING_WORD_RE = /^[\w$]+/;
 const PREFIX_TAIL_LIMIT = 512;
 const prefixTail = (prefix) => prefix.slice(-PREFIX_TAIL_LIMIT);
 
-const stripDisallowedApis = (suggestion, scriptType, prefix = '') => {
-  if (!suggestion || scriptType !== 'pre-request') return suggestion;
-  if (RES_BINDING_RE.test(prefix)) return suggestion;
+const suggestionUsesBareName = (suggestion, prefix, { usage, binding }) => {
+  if (binding.test(prefix)) return false;
   const trailingExpr = (prefixTail(prefix).match(TRAILING_MEMBER_EXPR_RE) || [''])[0];
-  if (RES_API_USAGE_RE.test(suggestion) || RES_API_USAGE_RE.test(trailingExpr + suggestion)) return '';
+  return usage.test(suggestion) || usage.test(trailingExpr + suggestion);
+};
+
+const stripDisallowedApis = (suggestion, scriptType, prefix = '') => {
+  if (!suggestion) return suggestion;
+  if (suggestionUsesBareName(suggestion, prefix, PM)) return '';
+  // `res.*` is only unavailable in pre-request scripts (response not yet received).
+  if (scriptType === 'pre-request' && suggestionUsesBareName(suggestion, prefix, RES)) return '';
   return suggestion;
 };
 

--- a/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.spec.js
+++ b/packages/bruno-electron/src/ipc/ai/autocomplete-prompts.spec.js
@@ -68,6 +68,19 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('res:');
     expect(prompt).toContain('test/expect:');
   });
+
+  it('forbids Postman pm.* usage in every script type', () => {
+    for (const type of ['pre-request', 'post-response', 'tests']) {
+      const prompt = buildSystemPrompt(type);
+      expect(prompt).toMatch(/pm\.\*/);
+      expect(prompt.toLowerCase()).toContain('postman');
+    }
+  });
+
+  it('tells the model res is off-limits in pre-request', () => {
+    const prompt = buildSystemPrompt('pre-request');
+    expect(prompt).toContain('Do NOT emit res.status');
+  });
 });
 
 describe('stripDisallowedApis', () => {
@@ -113,6 +126,34 @@ describe('stripDisallowedApis', () => {
 
   it('handles empty suggestions', () => {
     expect(stripDisallowedApis('', 'pre-request')).toBe('');
+  });
+
+  it('drops pm.* suggestions in pre-request', () => {
+    expect(stripDisallowedApis('pm.environment.get("token");', 'pre-request')).toBe('');
+    expect(stripDisallowedApis('pm.variables.set("k", "v");', 'pre-request')).toBe('');
+  });
+
+  it('drops pm.* suggestions in post-response', () => {
+    expect(stripDisallowedApis('pm.response.json();', 'post-response')).toBe('');
+  });
+
+  it('drops pm.* suggestions in tests', () => {
+    expect(stripDisallowedApis('pm.test("status", () => {});', 'tests')).toBe('');
+    expect(stripDisallowedApis('pm.expect(res.getStatus()).to.equal(200);', 'tests')).toBe('');
+  });
+
+  it('drops optional-chained and bracket-access pm', () => {
+    expect(stripDisallowedApis('pm?.environment?.get("t");', 'tests')).toBe('');
+    expect(stripDisallowedApis('pm["environment"].get("t");', 'tests')).toBe('');
+  });
+
+  it('does not flag identifiers that merely contain pm', () => {
+    expect(stripDisallowedApis('const impl = 1;', 'pre-request')).toBe('const impl = 1;');
+    expect(stripDisallowedApis('foo.pm.get();', 'pre-request')).toBe('foo.pm.get();');
+  });
+
+  it('keeps pm when the user has declared it themselves', () => {
+    expect(stripDisallowedApis('.doThing();', 'tests', 'const pm = require("./pm")')).toBe('.doThing();');
   });
 });
 
@@ -197,6 +238,46 @@ describe('sanitizeSuggestion', () => {
   it('keeps a continuation of res in post-response', () => {
     expect(sanitizeSuggestion({ text: '.getStatus();', prefix: 'const status = res', scriptType: 'post-response' }))
       .toBe('.getStatus();');
+  });
+
+  it('drops pm.* suggestions in pre-request', () => {
+    expect(sanitizeSuggestion({ text: 'pm.environment.get("token");', prefix: 'const t = ', scriptType: 'pre-request' }))
+      .toBe('');
+  });
+
+  it('drops pm.* suggestions in post-response', () => {
+    expect(sanitizeSuggestion({ text: 'pm.response.json();', prefix: 'const body = ', scriptType: 'post-response' }))
+      .toBe('');
+  });
+
+  it('drops pm.* suggestions in tests', () => {
+    expect(sanitizeSuggestion({ text: 'pm.test("status", () => {});', prefix: '', scriptType: 'tests' }))
+      .toBe('');
+  });
+
+  it('drops pm.* even when the user already typed pm', () => {
+    expect(sanitizeSuggestion({ text: '.environment.get("t");', prefix: 'const t = pm', scriptType: 'tests' }))
+      .toBe('');
+  });
+
+  it('drops pm.* split across a partially typed prefix', () => {
+    expect(sanitizeSuggestion({ text: 'm.environment.get("t");', prefix: 'const t = p', scriptType: 'tests' }))
+      .toBe('');
+  });
+
+  it('drops pm.* when the accessor dot is already typed', () => {
+    expect(sanitizeSuggestion({ text: 'environment.get("t");', prefix: 'const t = pm.', scriptType: 'tests' }))
+      .toBe('');
+  });
+
+  it('does not drop when pm is a property of another object', () => {
+    expect(sanitizeSuggestion({ text: 'get("t");', prefix: 'const x = wrapper.pm.', scriptType: 'tests' }))
+      .toBe('get("t");');
+  });
+
+  it('does not drop when the trailing identifier merely ends in pm', () => {
+    expect(sanitizeSuggestion({ text: '.doThing();', prefix: 'const x = mypm', scriptType: 'tests' }))
+      .toBe('.doThing();');
   });
 
   it('allows res member access when the user declared res in a pre-request script', () => {


### PR DESCRIPTION


### Description

JIRA: BRU-3820

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved inline AI script suggestions by preventing unsupported Postman-style `pm.*` APIs across script types.
  * Clarified that response APIs are unavailable in pre-request scripts.
  * Reinforced that testing helpers belong only in the Tests tab.
* **Bug Fixes**
  * Prevented disallowed API references from appearing in autocomplete suggestions, including optional and bracket notation.
  * Improved handling of similarly named variables and user-defined identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->