### PR TITLE
fix(environments): keep secret values on the secret row when a variable shares its name

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1239,10 +1239,11 @@ export const getEnvironmentVariables = (collection) => {
   if (collection) {
     const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
     if (environment) {
-      each(environment.variables, (variable) => {
-        if (variable.name && variable.enabled) {
-          variables[variable.name] = variable.value;
-        }
+      // Apply secrets last so a secret wins over a plain variable of the same name,
+      // regardless of their order in the array.
+      const enabledVars = (environment.variables || []).filter((v) => v.name && v.enabled);
+      [...enabledVars.filter((v) => !v.secret), ...enabledVars.filter((v) => v.secret)].forEach((variable) => {
+        variables[variable.name] = variable.value;
       });
     }
   }
@@ -1726,7 +1727,11 @@ export const getVariableScope = (variableName, collection, item) => {
   if (collection.activeEnvironmentUid) {
     const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
     if (environment && environment.variables) {
-      const envVar = environment.variables.find((v) => v.name === variableName && v.enabled);
+      // A name can exist as both a plain variable and a secret. The secret takes
+      // precedence (matching interpolation), so the resolved value and the secret
+      // flag stay in sync instead of coming from different entries.
+      const envVars = environment.variables.filter((v) => v.name === variableName && v.enabled);
+      const envVar = envVars.find((v) => v.secret) || envVars[0];
       if (envVar) {
         return {
           type: 'environment',

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -141,7 +141,7 @@ const addEnvironmentFile = async (win, pathname, collectionUid, collectionPath) 
     if (envHasSecrets(file.data)) {
       const envSecrets = environmentSecretsStore.getEnvSecrets(collectionPath, file.data);
       _.each(envSecrets, (secret) => {
-        const variable = _.find(file.data.variables, (v) => v.name === secret.name);
+        const variable = _.find(file.data.variables, (v) => v.name === secret.name && v.secret);
         if (variable && secret.value) {
           const decryptionResult = decryptStringSafe(secret.value);
           variable.value = parseValueByDataType(decryptionResult.value, variable.dataType);
@@ -182,7 +182,8 @@ const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPat
     if (envHasSecrets(file.data)) {
       const envSecrets = environmentSecretsStore.getEnvSecrets(collectionPath, file.data);
       _.each(envSecrets, (secret) => {
-        const variable = _.find(file.data.variables, (v) => v.name === secret.name);
+        // Match the secret flag too: a non-secret variable can share a name with a secret.
+        const variable = _.find(file.data.variables, (v) => v.name === secret.name && v.secret);
         if (variable && secret.value) {
           const decryptionResult = decryptStringSafe(secret.value);
           variable.value = parseValueByDataType(decryptionResult.value, variable.dataType);

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -182,7 +182,6 @@ const changeEnvironmentFile = async (win, pathname, collectionUid, collectionPat
     if (envHasSecrets(file.data)) {
       const envSecrets = environmentSecretsStore.getEnvSecrets(collectionPath, file.data);
       _.each(envSecrets, (secret) => {
-        // Match the secret flag too: a non-secret variable can share a name with a secret.
         const variable = _.find(file.data.variables, (v) => v.name === secret.name && v.secret);
         if (variable && secret.value) {
           const decryptionResult = decryptStringSafe(secret.value);

--- a/packages/bruno-electron/src/app/workspace-watcher.js
+++ b/packages/bruno-electron/src/app/workspace-watcher.js
@@ -76,7 +76,7 @@ const parseGlobalEnvironmentFile = async (pathname, workspacePath, workspaceUid)
   if (envHasSecrets(file.data)) {
     const envSecrets = environmentSecretsStore.getEnvSecrets(workspacePath, file.data);
     _.each(envSecrets, (secret) => {
-      const variable = _.find(file.data.variables, (v) => v.name === secret.name);
+      const variable = _.find(file.data.variables, (v) => v.name === secret.name && v.secret);
       if (variable && secret.value) {
         const decryptionResult = decryptStringSafe(secret.value);
         variable.value = parseValueByDataType(decryptionResult.value, variable.dataType);

--- a/packages/bruno-electron/src/services/mount/manager.js
+++ b/packages/bruno-electron/src/services/mount/manager.js
@@ -31,7 +31,7 @@ const hydrateEnvironments = (collectionPath, environments) => {
     try {
       const envSecrets = getEnvSecretsStore().getEnvSecrets(collectionPath, env);
       for (const secret of envSecrets || []) {
-        const variable = env.variables.find((v) => v.name === secret.name);
+        const variable = env.variables.find((v) => v.name === secret.name && v.secret);
         if (variable && secret.value) {
           const decrypted = decryptStringSafe(secret.value);
           variable.value = decrypted.value;

--- a/packages/bruno-electron/src/store/workspace-environments.js
+++ b/packages/bruno-electron/src/store/workspace-environments.js
@@ -71,7 +71,7 @@ class GlobalEnvironmentsManager {
     if (this.envHasSecrets(environment)) {
       const envSecrets = environmentSecretsStore.getEnvSecrets(workspacePath, environment);
       _.each(envSecrets, (secret) => {
-        const variable = _.find(environment.variables, (v) => v.name === secret.name);
+        const variable = _.find(environment.variables, (v) => v.name === secret.name && v.secret);
         if (variable && secret.value) {
           const decryptionResult = decryptStringSafe(secret.value);
           variable.value = parseValueByDataType(decryptionResult.value, variable.dataType);

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -786,10 +786,10 @@ const getEnvVars = (environment = {}) => {
   }
 
   const envVars = {};
-  each(variables, (variable) => {
-    if (variable.enabled) {
-      envVars[variable.name] = resolveTypedValue(variable);
-    }
+  // Apply secrets last so a secret wins over a plain variable of the same name.
+  const enabledVars = variables.filter((variable) => variable.enabled);
+  [...enabledVars.filter((v) => !v.secret), ...enabledVars.filter((v) => v.secret)].forEach((variable) => {
+    envVars[variable.name] = resolveTypedValue(variable);
   });
 
   return {

--- a/tests/environments/environment-tabs/environment-tabs.spec.ts
+++ b/tests/environments/environment-tabs/environment-tabs.spec.ts
@@ -372,6 +372,50 @@ test.describe('Environment Variables / Secrets tab separation', () => {
       await expect(varRow(page, 'host')).toBeVisible();
     });
   });
+
+  test('a secret keeps its own value when a plain variable shares its name', async ({
+    page,
+    createTmpDir
+  }) => {
+    const ENV_NAME = 'Collision Env';
+    const SHARED_KEY = 'token';
+    const PLAIN_VALUE = 'plain-variable-value';
+    const SECRET_VALUE = 'super-secret-value-98765';
+
+    const collectionDir = await createTmpDir('var-secret-name-collision');
+    await importCollection(page, collectionFile, collectionDir, {
+      expectedCollectionName: 'test_collection'
+    });
+
+    await createEnvironment(page, ENV_NAME, 'collection');
+
+    await test.step('Add a plain variable and a secret that share the name `token`', async () => {
+      await expect(variablesTab(page)).toHaveClass(/active/);
+      await addRowToActiveTab(page, SHARED_KEY, PLAIN_VALUE);
+      await expect(varRowValueLine(page, SHARED_KEY)).toHaveText(PLAIN_VALUE);
+
+      await secretsTab(page).click();
+      await addRowToActiveTab(page, SHARED_KEY, SECRET_VALUE);
+      await expect(varRow(page, SHARED_KEY)).toBeVisible();
+    });
+
+    await test.step('Save both tabs at once', async () => {
+      await saveEnvironment(page);
+      await expect(page.getByText('Changes saved successfully').last()).toBeVisible();
+    });
+
+    await test.step('The secret still reveals its own value (not blanked)', async () => {
+      await secretsTab(page).click();
+      await expect(varRow(page, SHARED_KEY)).toBeVisible();
+      await envLocators(page).varRowEyeToggle(SHARED_KEY).click();
+      await expect(envLocators(page).varRowValueEditor(SHARED_KEY)).toContainText(SECRET_VALUE);
+    });
+
+    await test.step('The plain variable kept its own value (not overwritten by the secret)', async () => {
+      await variablesTab(page).click();
+      await expect(varRowValueLine(page, SHARED_KEY)).toHaveText(PLAIN_VALUE);
+    });
+  });
 });
 
 test.describe('Global Environment Variables / Secrets tab separation', () => {
@@ -681,6 +725,49 @@ test.describe('Global Environment Variables / Secrets tab separation', () => {
     await test.step('The variable on the Variables tab is untouched', async () => {
       await variablesTab(page).click();
       await expect(varRow(page, 'host')).toBeVisible();
+    });
+  });
+
+  test('a secret keeps its own value when a plain variable shares its name', async ({
+    page,
+    createTmpDir
+  }) => {
+    const ENV_NAME = 'Global Collision Env';
+    const SHARED_KEY = 'token';
+    const PLAIN_VALUE = 'plain-variable-value';
+    const SECRET_VALUE = 'super-secret-value-98765';
+
+    await importCollection(page, collectionFile, await createTmpDir('global-var-secret-name-collision'), {
+      expectedCollectionName: 'test_collection'
+    });
+
+    await createEnvironment(page, ENV_NAME, 'global');
+
+    await test.step('Add a plain variable and a secret that share the name `token`', async () => {
+      await expect(variablesTab(page)).toHaveClass(/active/);
+      await addRowToActiveTab(page, SHARED_KEY, PLAIN_VALUE);
+      await expect(varRowValueLine(page, SHARED_KEY)).toHaveText(PLAIN_VALUE);
+
+      await secretsTab(page).click();
+      await addRowToActiveTab(page, SHARED_KEY, SECRET_VALUE);
+      await expect(varRow(page, SHARED_KEY)).toBeVisible();
+    });
+
+    await test.step('Save both tabs at once', async () => {
+      await saveEnvironment(page);
+      await expect(page.getByText('Changes saved successfully').last()).toBeVisible();
+    });
+
+    await test.step('The secret still reveals its own value (not blanked)', async () => {
+      await secretsTab(page).click();
+      await expect(varRow(page, SHARED_KEY)).toBeVisible();
+      await envLocators(page).varRowEyeToggle(SHARED_KEY).click();
+      await expect(envLocators(page).varRowValueEditor(SHARED_KEY)).toContainText(SECRET_VALUE);
+    });
+
+    await test.step('The plain variable kept its own value (not overwritten by the secret)', async () => {
+      await variablesTab(page).click();
+      await expect(varRowValueLine(page, SHARED_KEY)).toHaveText(PLAIN_VALUE);
     });
   });
 });


### PR DESCRIPTION
### Description

**Bug:** In collection and global environments, if a **variable** and a **secret** have the **same key name**, saving the secret made its value disappear (and it could overwrite the variable's value).

**Fix:** Match on the `secret` flag as well as the name when re-attaching secret values, so the value always lands on the secret row. Applied in all five places that re-hydrate secrets (collection watcher, workspace watcher, workspace-environments store, and mount manager), covering both collection and global environments.

[JIRA](https://usebruno.atlassian.net/browse/BRU-3952)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved environment/secret name collisions by ensuring secret values hydrate only into variables explicitly marked as secrets.
  * Updated environment variable resolution so secret entries consistently override plain entries with the same name.
  * Prevented decrypted secret values from overwriting non-secret variable values during initial load and updates.
* **Tests**
  * Added Playwright regression coverage for both collection and global environment tabs to verify reveal behavior and that plain variables remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->