### PR TITLE
fix(converters): default enabled to true when importing Postman environment variables

### DIFF
--- a/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
+++ b/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
@@ -14,7 +14,7 @@ const importPostmanEnvironmentVariables = (brunoEnvironment, values = []) => {
       uid: uuid(),
       name: (i.key ?? '').replace(invalidVariableCharacterRegex, '_'),
       value: i.value ?? '',
-      enabled: i.enabled,
+      enabled: i.enabled ?? true,
       type: 'text',
       secret: isSecret(i.type)
     };

--- a/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
@@ -112,6 +112,52 @@ describe('postmanToBrunoEnvironment Function', () => {
     expect(brunoEnvironment).toEqual(expectedEnvironment);
   });
 
+  it('should default enabled to true when Postman omits or nulls it', async () => {
+    const postmanEnvironment = {
+      id: 'some-id',
+      name: 'My Environment',
+      values: [
+        {
+          key: 'noEnabled',
+          value: 'value1',
+          type: 'default'
+        },
+        {
+          key: 'nullEnabled',
+          value: 'value2',
+          enabled: null,
+          type: 'default'
+        }
+      ]
+    };
+
+    const brunoEnvironment = await postmanToBrunoEnvironment(postmanEnvironment);
+
+    const expectedEnvironment = {
+      name: 'My Environment',
+      variables: [
+        {
+          name: 'noEnabled',
+          value: 'value1',
+          enabled: true,
+          secret: false,
+          type: 'text',
+          uid: 'mockeduuidvalue123456'
+        },
+        {
+          name: 'nullEnabled',
+          value: 'value2',
+          enabled: true,
+          secret: false,
+          type: 'text',
+          uid: 'mockeduuidvalue123456'
+        }
+      ]
+    };
+
+    expect(brunoEnvironment).toEqual(expectedEnvironment);
+  });
+
   it.skip('should throw Error when JSON parsing fails', async () => {
     const invalidBrunoEnvironment = {
       id: 'some-id',


### PR DESCRIPTION
### Description


Closes #8680
Internal - [BRU-3960]

**Cause:** When importing a Postman environment, `postmanToBrunoEnvironment` mapped `enabled: i.enabled` verbatim. Postman omits the `enabled` field on some variables (or sets it to `null`), so the resulting Bruno variable had `enabled: undefined`.

The environment schema declares `enabled: Yup.boolean().defined()`, which is validated on the **global** environment save path (`store/global-environments.js`), so the whole import aborted with `variables[N].enabled must be defined`. Collection-level import appeared to work only because it doesn't run that same validation — an inconsistency between the two import paths.

**Resolution:** Default `enabled` to `true` when Postman doesn't provide it (`enabled: i.enabled ?? true`), matching Postman's own semantics that a variable without the flag is enabled. This handles both the missing and `null` cases and fixes both import paths at the source (the converter). Added a regression test covering the omitted/`null` `enabled` cases.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**


### Evidence

#### Before

<img width="500" height="auto" alt="Screenshot 2026-07-20 at 15 52 51" src="https://github.com/user-attachments/assets/b043ff94-291a-4021-942b-9077cfbdc87a" />

#### After

<img width="500" height="auto" alt="Screenshot 2026-07-20 at 16 21 30" src="https://github.com/user-attachments/assets/8b3914a3-70a1-4df1-8d59-0fa93b3e1c25" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Postman environment variables without an `enabled` value, or with a null value, are now enabled by default during conversion.
  * Other converted variable properties remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->