### PR TITLE
feat(ai): implement immediate security settings save

### DIFF
--- a/packages/bruno-app/src/components/Preferences/AI/index.js
+++ b/packages/bruno-app/src/components/Preferences/AI/index.js
@@ -179,6 +179,13 @@ const AI = () => {
 
   useEffect(() => () => debouncedSave.flush(), [debouncedSave]);
 
+  const saveSecurityImmediate = useCallback((patch) => {
+    const nextSecurity = { ...formik.values.security, ...patch };
+    formik.setFieldValue('security', nextSecurity);
+    debouncedSave.cancel();
+    handleSaveRef.current({ ...formik.values, security: nextSecurity }).catch(() => {});
+  }, [formik, debouncedSave]);
+
   const modelsByProvider = useMemo(() => {
     const grouped = {};
     (status?.models || []).forEach((model) => {
@@ -497,12 +504,12 @@ const AI = () => {
             redactResponse={formik.values.security?.redactResponse !== false}
             customRedactedHeaders={formik.values.security?.customRedactedHeaders || []}
             customRedactedVariables={formik.values.security?.customRedactedVariables || []}
-            onToggleRedactHeaders={(next) => formik.setFieldValue('security.redactHeaders', next)}
-            onToggleRedactBody={(next) => formik.setFieldValue('security.redactBody', next)}
-            onToggleRedactVariables={(next) => formik.setFieldValue('security.redactVariables', next)}
-            onToggleRedactResponse={(next) => formik.setFieldValue('security.redactResponse', next)}
-            onChangeCustomRedactedHeaders={(next) => formik.setFieldValue('security.customRedactedHeaders', next)}
-            onChangeCustomRedactedVariables={(next) => formik.setFieldValue('security.customRedactedVariables', next)}
+            onToggleRedactHeaders={(next) => saveSecurityImmediate({ redactHeaders: next })}
+            onToggleRedactBody={(next) => saveSecurityImmediate({ redactBody: next })}
+            onToggleRedactVariables={(next) => saveSecurityImmediate({ redactVariables: next })}
+            onToggleRedactResponse={(next) => saveSecurityImmediate({ redactResponse: next })}
+            onChangeCustomRedactedHeaders={(next) => saveSecurityImmediate({ customRedactedHeaders: next })}
+            onChangeCustomRedactedVariables={(next) => saveSecurityImmediate({ customRedactedVariables: next })}
           />
         </div>
       )}

--- a/packages/bruno-app/src/components/Preferences/AI/index.js
+++ b/packages/bruno-app/src/components/Preferences/AI/index.js
@@ -179,13 +179,18 @@ const AI = () => {
 
   useEffect(() => () => debouncedSave.flush(), [debouncedSave]);
 
-  const saveSecurityImmediate = useCallback((patch) => {
+  const saveSecurityImmediate = (patch) => {
     const nextSecurity = { ...formik.values.security, ...patch };
+    const nextValues = { ...formik.values, security: nextSecurity };
+
     formik.setFieldValue('security', nextSecurity);
     debouncedSave.cancel();
-    handleSaveRef.current({ ...formik.values, security: nextSecurity }).catch(() => {});
-  }, [formik, debouncedSave]);
 
+    aiPreferencesSchema
+      .validate(nextValues, { abortEarly: true })
+      .then((validated) => handleSaveRef.current(validated))
+      .catch(() => {});
+  };
   const modelsByProvider = useMemo(() => {
     const grouped = {};
     (status?.models || []).forEach((model) => {


### PR DESCRIPTION
### Description

JIRA: https://usebruno.atlassian.net/browse/BRU-3900

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Security preference changes now persist immediately when updating redaction toggles or custom redacted header/variable lists.
  * Prevented pending/deferred security saves from overwriting recently updated security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->