### PR TITLE
fix(snapshot): environment loss of some workspaces

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -3291,8 +3291,10 @@ export const mountCollection
             dispatch(addTransientDirectory({ collectionUid, pathname: transientDirPath }));
 
             const collection = getState().collections.collections.find((c) => c.uid === collectionUid);
-            if (!skipTabRestore && collection?.pathname) {
-              await hydrateCollectionTabs(collection, dispatch, restoreTabs, null, workspacePathname);
+            if (collection?.pathname) {
+              if (!skipTabRestore) {
+                await hydrateCollectionTabs(collection, dispatch, restoreTabs, null, workspacePathname);
+              }
 
               const collectionSnapshotState = await window.ipcRenderer
                 .invoke('renderer:snapshot:get-collection', collection.pathname, workspacePathname)

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/mount-environment-restore.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/mount-environment-restore.spec.js
@@ -1,0 +1,239 @@
+const { describe, it, expect } = require('@jest/globals');
+const { configureStore } = require('@reduxjs/toolkit');
+
+jest.mock('@usebruno/schema', () => ({
+  collectionSchema: { validate: () => Promise.resolve() },
+  environmentSchema: { validate: () => Promise.resolve() },
+  itemSchema: { validate: () => Promise.resolve() }
+}));
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+const {
+  findCollectionEnvironmentFromSnapshot
+} = require('../../../../utils/snapshot');
+const {
+  shouldPreserveCollectionEnvironmentInSnapshot,
+  serializeSnapshot
+} = require('providers/ReduxStore/middlewares/snapshot/serializeSnapshot');
+const collectionsReducer = require('providers/ReduxStore/slices/collections').default;
+const {
+  mountCollection
+} = require('providers/ReduxStore/slices/collections/actions');
+
+const COLLECTION_PATH = 'C:/Users/abhis/Documents/Bruno/Dark knight/collections/YamlBased';
+const WORKSPACE_PATH = 'C:/Users/abhis/Documents/Bruno/Dark knight';
+const ENV_PATH = `${COLLECTION_PATH}/environments/abhi.yml`;
+const ENV_UID = 'env-abhi-uid';
+
+const snapshotData = {
+  environmentPath: ENV_PATH,
+  selectedEnvironment: 'abhi'
+};
+
+const makeExistingSnapshot = () => ({
+  version: '0.0.1',
+  activeWorkspacePath: WORKSPACE_PATH,
+  extras: { devTools: { open: false, activeTab: 'terminal', tabs: {} } },
+  workspaces: [
+    {
+      pathname: WORKSPACE_PATH,
+      sorting: 'default',
+      collections: [COLLECTION_PATH]
+    }
+  ],
+  collections: [
+    {
+      pathname: COLLECTION_PATH,
+      workspacePathname: WORKSPACE_PATH,
+      environment: {
+        collection: ENV_PATH,
+        global: '18b6ltc00000000000000'
+      },
+      environmentPath: ENV_PATH,
+      selectedEnvironment: 'abhi',
+      isOpen: true,
+      isMounted: true,
+      tabs: []
+    }
+  ]
+});
+
+const makeState = (collectionOverrides = {}) => ({
+  app: {
+    snapshotHydration: {
+      pendingCollectionPathnames: []
+    }
+  },
+  workspaces: {
+    activeWorkspaceUid: 'ws-dark-knight',
+    workspaces: [
+      {
+        uid: 'ws-dark-knight',
+        pathname: WORKSPACE_PATH,
+        collections: [{ path: COLLECTION_PATH }]
+      }
+    ]
+  },
+  collections: {
+    collectionSortOrder: 'default',
+    collections: [
+      {
+        uid: 'col-yamlbased',
+        pathname: COLLECTION_PATH,
+        mountStatus: 'unmounted',
+        environments: [],
+        activeEnvironmentUid: null,
+        collapsed: false,
+        ...collectionOverrides
+      }
+    ],
+    tempDirectories: {}
+  },
+  tabs: {
+    tabs: [],
+    activeTabUid: null
+  },
+  logs: {
+    isConsoleOpen: false,
+    activeTab: 'terminal'
+  },
+  globalEnvironments: {
+    activeGlobalEnvironmentUid: null
+  }
+});
+
+const createMountStore = () => configureStore({
+  reducer: {
+    app: (state = {
+      preferences: { cache: { file: { enabled: false } } }
+    }) => state,
+    collections: collectionsReducer
+  },
+  preloadedState: {
+    app: {
+      preferences: { cache: { file: { enabled: false } } }
+    },
+    collections: {
+      collectionSortOrder: 'default',
+      collections: [
+        {
+          uid: 'col-yamlbased',
+          pathname: COLLECTION_PATH,
+          mountStatus: 'unmounted',
+          environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }],
+          activeEnvironmentUid: null,
+          collapsed: false,
+          items: []
+        }
+      ],
+      activeConnections: [],
+      tempDirectories: {},
+      saveTransientRequestModals: []
+    }
+  }
+});
+
+describe('environment restore race', () => {
+  describe('pre-mount hydrate (switchWorkspace step before mount)', () => {
+    it('cannot resolve selected environment when environments are not loaded yet', () => {
+      const environment = findCollectionEnvironmentFromSnapshot(
+        { pathname: COLLECTION_PATH, environments: [] },
+        snapshotData
+      );
+      expect(environment).toBeNull();
+    });
+
+    it('resolves selected environment once environments are loaded', () => {
+      const environment = findCollectionEnvironmentFromSnapshot(
+        {
+          pathname: COLLECTION_PATH,
+          environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }]
+        },
+        snapshotData
+      );
+      expect(environment).toMatchObject({ uid: ENV_UID, name: 'abhi' });
+    });
+  });
+
+  describe('post-mount serialize after failed restore', () => {
+    it('treats mounted+hydrated+null selection as cleared and does not preserve snapshot env', () => {
+      expect(shouldPreserveCollectionEnvironmentInSnapshot({
+        collection: {
+          mountStatus: 'mounted',
+          environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }]
+        },
+        environmentPathFromRedux: '',
+        selectedEnvironmentFromRedux: '',
+        existingEnvironmentPath: ENV_PATH,
+        existingSelectedEnvironment: 'abhi'
+      })).toBe(false);
+    });
+
+    it('overwrites snapshot selectedEnvironment to empty after the race', async () => {
+      const snapshot = await serializeSnapshot(
+        makeState({
+          mountStatus: 'mounted',
+          activeEnvironmentUid: null,
+          environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }]
+        }),
+        { getExistingSnapshot: async () => makeExistingSnapshot() }
+      );
+
+      expect(snapshot.collections[0]).toMatchObject({
+        pathname: COLLECTION_PATH,
+        environmentPath: '',
+        selectedEnvironment: ''
+      });
+    });
+  });
+
+  describe('mountCollection skipTabRestore behavior', () => {
+    it('skips tab restore but still restores the saved collection environment after mount', async () => {
+      const store = createMountStore();
+      window.ipcRenderer = {
+        invoke: jest.fn((channel) => {
+          if (channel === 'renderer:mount-collection') {
+            return Promise.resolve('/tmp/bruno-transient');
+          }
+
+          if (channel === 'renderer:snapshot:get-collection') {
+            return Promise.resolve(snapshotData);
+          }
+
+          if (channel === 'renderer:snapshot:get-tabs') {
+            return Promise.resolve({ tabs: [{ uid: 'tab-1' }], activeTab: { accessor: 'uid', value: 'tab-1' } });
+          }
+
+          return Promise.resolve(null);
+        })
+      };
+
+      await store.dispatch(mountCollection({
+        collectionUid: 'col-yamlbased',
+        collectionPathname: COLLECTION_PATH,
+        brunoConfig: {},
+        skipTabRestore: true,
+        workspacePathname: WORKSPACE_PATH
+      }));
+
+      expect(store.getState().collections.collections[0]).toMatchObject({
+        mountStatus: 'mounted',
+        activeEnvironmentUid: ENV_UID
+      });
+      expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
+        'renderer:snapshot:get-collection',
+        COLLECTION_PATH,
+        WORKSPACE_PATH
+      );
+      expect(window.ipcRenderer.invoke).not.toHaveBeenCalledWith(
+        'renderer:snapshot:get-tabs',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/mount-environment-restore.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/mount-environment-restore.spec.js
@@ -86,4 +86,73 @@ describe('mountCollection skipTabRestore behavior', () => {
       expect.anything()
     );
   });
+
+  it('restores tabs and the saved collection environment when skipTabRestore is false', async () => {
+    const store = configureStore({
+      reducer: {
+        app: (state = { preferences: { cache: { file: { enabled: false } } } }) => state,
+        collections: collectionsReducer
+      },
+      preloadedState: {
+        app: { preferences: { cache: { file: { enabled: false } } } },
+        collections: {
+          collectionSortOrder: 'default',
+          collections: [{
+            uid: 'col-yamlbased',
+            pathname: COLLECTION_PATH,
+            mountStatus: 'unmounted',
+            environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }],
+            activeEnvironmentUid: null,
+            collapsed: false,
+            items: []
+          }],
+          tempDirectories: {}
+        }
+      }
+    });
+
+    window.ipcRenderer = {
+      invoke: jest.fn((channel) => {
+        if (channel === 'renderer:mount-collection') {
+          return Promise.resolve('/tmp/bruno-transient');
+        }
+
+        if (channel === 'renderer:snapshot:get-collection') {
+          return Promise.resolve({ environmentPath: ENV_PATH, selectedEnvironment: 'abhi' });
+        }
+
+        if (channel === 'renderer:snapshot:get-tabs') {
+          return Promise.resolve({
+            tabs: [{ type: 'http-request', accessor: 'uid', uid: 'tab-1', permanent: true }],
+            activeTab: { accessor: 'uid', value: 'tab-1' }
+          });
+        }
+
+        return Promise.resolve(null);
+      })
+    };
+
+    await store.dispatch(mountCollection({
+      collectionUid: 'col-yamlbased',
+      collectionPathname: COLLECTION_PATH,
+      brunoConfig: {},
+      skipTabRestore: false,
+      workspacePathname: WORKSPACE_PATH
+    }));
+
+    expect(store.getState().collections.collections[0]).toMatchObject({
+      mountStatus: 'mounted',
+      activeEnvironmentUid: ENV_UID
+    });
+    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
+      'renderer:snapshot:get-tabs',
+      COLLECTION_PATH,
+      WORKSPACE_PATH
+    );
+    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
+      'renderer:snapshot:get-collection',
+      COLLECTION_PATH,
+      WORKSPACE_PATH
+    );
+  });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/mount-environment-restore.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/mount-environment-restore.spec.js
@@ -12,228 +12,78 @@ jest.mock('react-hot-toast', () => ({
   error: jest.fn()
 }));
 
-const {
-  findCollectionEnvironmentFromSnapshot
-} = require('../../../../utils/snapshot');
-const {
-  shouldPreserveCollectionEnvironmentInSnapshot,
-  serializeSnapshot
-} = require('providers/ReduxStore/middlewares/snapshot/serializeSnapshot');
 const collectionsReducer = require('providers/ReduxStore/slices/collections').default;
-const {
-  mountCollection
-} = require('providers/ReduxStore/slices/collections/actions');
+const { mountCollection } = require('providers/ReduxStore/slices/collections/actions');
 
 const COLLECTION_PATH = 'C:/Users/abhis/Documents/Bruno/Dark knight/collections/YamlBased';
 const WORKSPACE_PATH = 'C:/Users/abhis/Documents/Bruno/Dark knight';
 const ENV_PATH = `${COLLECTION_PATH}/environments/abhi.yml`;
 const ENV_UID = 'env-abhi-uid';
 
-const snapshotData = {
-  environmentPath: ENV_PATH,
-  selectedEnvironment: 'abhi'
-};
-
-const makeExistingSnapshot = () => ({
-  version: '0.0.1',
-  activeWorkspacePath: WORKSPACE_PATH,
-  extras: { devTools: { open: false, activeTab: 'terminal', tabs: {} } },
-  workspaces: [
-    {
-      pathname: WORKSPACE_PATH,
-      sorting: 'default',
-      collections: [COLLECTION_PATH]
-    }
-  ],
-  collections: [
-    {
-      pathname: COLLECTION_PATH,
-      workspacePathname: WORKSPACE_PATH,
-      environment: {
-        collection: ENV_PATH,
-        global: '18b6ltc00000000000000'
+describe('mountCollection skipTabRestore behavior', () => {
+  it('skips tab restore but still restores the saved collection environment after mount', async () => {
+    const store = configureStore({
+      reducer: {
+        app: (state = { preferences: { cache: { file: { enabled: false } } } }) => state,
+        collections: collectionsReducer
       },
-      environmentPath: ENV_PATH,
-      selectedEnvironment: 'abhi',
-      isOpen: true,
-      isMounted: true,
-      tabs: []
-    }
-  ]
-});
-
-const makeState = (collectionOverrides = {}) => ({
-  app: {
-    snapshotHydration: {
-      pendingCollectionPathnames: []
-    }
-  },
-  workspaces: {
-    activeWorkspaceUid: 'ws-dark-knight',
-    workspaces: [
-      {
-        uid: 'ws-dark-knight',
-        pathname: WORKSPACE_PATH,
-        collections: [{ path: COLLECTION_PATH }]
-      }
-    ]
-  },
-  collections: {
-    collectionSortOrder: 'default',
-    collections: [
-      {
-        uid: 'col-yamlbased',
-        pathname: COLLECTION_PATH,
-        mountStatus: 'unmounted',
-        environments: [],
-        activeEnvironmentUid: null,
-        collapsed: false,
-        ...collectionOverrides
-      }
-    ],
-    tempDirectories: {}
-  },
-  tabs: {
-    tabs: [],
-    activeTabUid: null
-  },
-  logs: {
-    isConsoleOpen: false,
-    activeTab: 'terminal'
-  },
-  globalEnvironments: {
-    activeGlobalEnvironmentUid: null
-  }
-});
-
-const createMountStore = () => configureStore({
-  reducer: {
-    app: (state = {
-      preferences: { cache: { file: { enabled: false } } }
-    }) => state,
-    collections: collectionsReducer
-  },
-  preloadedState: {
-    app: {
-      preferences: { cache: { file: { enabled: false } } }
-    },
-    collections: {
-      collectionSortOrder: 'default',
-      collections: [
-        {
-          uid: 'col-yamlbased',
-          pathname: COLLECTION_PATH,
-          mountStatus: 'unmounted',
-          environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }],
-          activeEnvironmentUid: null,
-          collapsed: false,
-          items: []
+      preloadedState: {
+        app: { preferences: { cache: { file: { enabled: false } } } },
+        collections: {
+          collectionSortOrder: 'default',
+          collections: [{
+            uid: 'col-yamlbased',
+            pathname: COLLECTION_PATH,
+            mountStatus: 'unmounted',
+            environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }],
+            activeEnvironmentUid: null,
+            collapsed: false,
+            items: []
+          }],
+          tempDirectories: {}
         }
-      ],
-      activeConnections: [],
-      tempDirectories: {},
-      saveTransientRequestModals: []
-    }
-  }
-});
-
-describe('environment restore race', () => {
-  describe('pre-mount hydrate (switchWorkspace step before mount)', () => {
-    it('cannot resolve selected environment when environments are not loaded yet', () => {
-      const environment = findCollectionEnvironmentFromSnapshot(
-        { pathname: COLLECTION_PATH, environments: [] },
-        snapshotData
-      );
-      expect(environment).toBeNull();
+      }
     });
 
-    it('resolves selected environment once environments are loaded', () => {
-      const environment = findCollectionEnvironmentFromSnapshot(
-        {
-          pathname: COLLECTION_PATH,
-          environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }]
-        },
-        snapshotData
-      );
-      expect(environment).toMatchObject({ uid: ENV_UID, name: 'abhi' });
+    window.ipcRenderer = {
+      invoke: jest.fn((channel) => {
+        if (channel === 'renderer:mount-collection') {
+          return Promise.resolve('/tmp/bruno-transient');
+        }
+
+        if (channel === 'renderer:snapshot:get-collection') {
+          return Promise.resolve({ environmentPath: ENV_PATH, selectedEnvironment: 'abhi' });
+        }
+
+        if (channel === 'renderer:snapshot:get-tabs') {
+          return Promise.resolve({ tabs: [{ uid: 'tab-1' }], activeTab: { accessor: 'uid', value: 'tab-1' } });
+        }
+
+        return Promise.resolve(null);
+      })
+    };
+
+    await store.dispatch(mountCollection({
+      collectionUid: 'col-yamlbased',
+      collectionPathname: COLLECTION_PATH,
+      brunoConfig: {},
+      skipTabRestore: true,
+      workspacePathname: WORKSPACE_PATH
+    }));
+
+    expect(store.getState().collections.collections[0]).toMatchObject({
+      mountStatus: 'mounted',
+      activeEnvironmentUid: ENV_UID
     });
-  });
-
-  describe('post-mount serialize after failed restore', () => {
-    it('treats mounted+hydrated+null selection as cleared and does not preserve snapshot env', () => {
-      expect(shouldPreserveCollectionEnvironmentInSnapshot({
-        collection: {
-          mountStatus: 'mounted',
-          environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }]
-        },
-        environmentPathFromRedux: '',
-        selectedEnvironmentFromRedux: '',
-        existingEnvironmentPath: ENV_PATH,
-        existingSelectedEnvironment: 'abhi'
-      })).toBe(false);
-    });
-
-    it('overwrites snapshot selectedEnvironment to empty after the race', async () => {
-      const snapshot = await serializeSnapshot(
-        makeState({
-          mountStatus: 'mounted',
-          activeEnvironmentUid: null,
-          environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }]
-        }),
-        { getExistingSnapshot: async () => makeExistingSnapshot() }
-      );
-
-      expect(snapshot.collections[0]).toMatchObject({
-        pathname: COLLECTION_PATH,
-        environmentPath: '',
-        selectedEnvironment: ''
-      });
-    });
-  });
-
-  describe('mountCollection skipTabRestore behavior', () => {
-    it('skips tab restore but still restores the saved collection environment after mount', async () => {
-      const store = createMountStore();
-      window.ipcRenderer = {
-        invoke: jest.fn((channel) => {
-          if (channel === 'renderer:mount-collection') {
-            return Promise.resolve('/tmp/bruno-transient');
-          }
-
-          if (channel === 'renderer:snapshot:get-collection') {
-            return Promise.resolve(snapshotData);
-          }
-
-          if (channel === 'renderer:snapshot:get-tabs') {
-            return Promise.resolve({ tabs: [{ uid: 'tab-1' }], activeTab: { accessor: 'uid', value: 'tab-1' } });
-          }
-
-          return Promise.resolve(null);
-        })
-      };
-
-      await store.dispatch(mountCollection({
-        collectionUid: 'col-yamlbased',
-        collectionPathname: COLLECTION_PATH,
-        brunoConfig: {},
-        skipTabRestore: true,
-        workspacePathname: WORKSPACE_PATH
-      }));
-
-      expect(store.getState().collections.collections[0]).toMatchObject({
-        mountStatus: 'mounted',
-        activeEnvironmentUid: ENV_UID
-      });
-      expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-        'renderer:snapshot:get-collection',
-        COLLECTION_PATH,
-        WORKSPACE_PATH
-      );
-      expect(window.ipcRenderer.invoke).not.toHaveBeenCalledWith(
-        'renderer:snapshot:get-tabs',
-        expect.anything(),
-        expect.anything()
-      );
-    });
+    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
+      'renderer:snapshot:get-collection',
+      COLLECTION_PATH,
+      WORKSPACE_PATH
+    );
+    expect(window.ipcRenderer.invoke).not.toHaveBeenCalledWith(
+      'renderer:snapshot:get-tabs',
+      expect.anything(),
+      expect.anything()
+    );
   });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/mount-environment-restore.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/mount-environment-restore.spec.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const os = require('os');
 const { describe, it, expect } = require('@jest/globals');
 const { configureStore } = require('@reduxjs/toolkit');
 
@@ -15,10 +17,11 @@ jest.mock('react-hot-toast', () => ({
 const collectionsReducer = require('providers/ReduxStore/slices/collections').default;
 const { mountCollection } = require('providers/ReduxStore/slices/collections/actions');
 
-const COLLECTION_PATH = 'C:/Users/abhis/Documents/Bruno/Dark knight/collections/YamlBased';
-const WORKSPACE_PATH = 'C:/Users/abhis/Documents/Bruno/Dark knight';
-const ENV_PATH = `${COLLECTION_PATH}/environments/abhi.yml`;
-const ENV_UID = 'env-abhi-uid';
+const WORKSPACE_PATH = path.join(os.homedir(), 'Documents', 'Bruno', 'workspace');
+const COLLECTION_PATH = path.join(WORKSPACE_PATH, 'collections', 'YamlBased');
+const ENV_PATH = path.join(COLLECTION_PATH, 'environments', 'local.yml');
+const ENV_UID = 'env-local-uid';
+const TRANSIENT_DIR = path.join(os.tmpdir(), 'bruno-transient');
 
 describe('mountCollection skipTabRestore behavior', () => {
   it('skips tab restore but still restores the saved collection environment after mount', async () => {
@@ -35,7 +38,7 @@ describe('mountCollection skipTabRestore behavior', () => {
             uid: 'col-yamlbased',
             pathname: COLLECTION_PATH,
             mountStatus: 'unmounted',
-            environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }],
+            environments: [{ uid: ENV_UID, name: 'local', pathname: ENV_PATH }],
             activeEnvironmentUid: null,
             collapsed: false,
             items: []
@@ -48,11 +51,11 @@ describe('mountCollection skipTabRestore behavior', () => {
     window.ipcRenderer = {
       invoke: jest.fn((channel) => {
         if (channel === 'renderer:mount-collection') {
-          return Promise.resolve('/tmp/bruno-transient');
+          return Promise.resolve(TRANSIENT_DIR);
         }
 
         if (channel === 'renderer:snapshot:get-collection') {
-          return Promise.resolve({ environmentPath: ENV_PATH, selectedEnvironment: 'abhi' });
+          return Promise.resolve({ environmentPath: ENV_PATH, selectedEnvironment: 'local' });
         }
 
         if (channel === 'renderer:snapshot:get-tabs') {
@@ -101,7 +104,7 @@ describe('mountCollection skipTabRestore behavior', () => {
             uid: 'col-yamlbased',
             pathname: COLLECTION_PATH,
             mountStatus: 'unmounted',
-            environments: [{ uid: ENV_UID, name: 'abhi', pathname: ENV_PATH }],
+            environments: [{ uid: ENV_UID, name: 'local', pathname: ENV_PATH }],
             activeEnvironmentUid: null,
             collapsed: false,
             items: []
@@ -114,11 +117,11 @@ describe('mountCollection skipTabRestore behavior', () => {
     window.ipcRenderer = {
       invoke: jest.fn((channel) => {
         if (channel === 'renderer:mount-collection') {
-          return Promise.resolve('/tmp/bruno-transient');
+          return Promise.resolve(TRANSIENT_DIR);
         }
 
         if (channel === 'renderer:snapshot:get-collection') {
-          return Promise.resolve({ environmentPath: ENV_PATH, selectedEnvironment: 'abhi' });
+          return Promise.resolve({ environmentPath: ENV_PATH, selectedEnvironment: 'local' });
         }
 
         if (channel === 'renderer:snapshot:get-tabs') {

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -167,6 +167,11 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
   const workspacesByPath = {};
 
   if (Array.isArray(snapshot.collections)) {
+    const activeWorkspacePath = typeof snapshot.activeWorkspacePath === 'string'
+      ? normalizePath(snapshot.activeWorkspacePath)
+      : '';
+    const activeWorkspaceEntries = new Map();
+
     snapshot.collections.forEach((collectionEntry) => {
       if (!isObject(collectionEntry) || typeof collectionEntry.pathname !== 'string') {
         return;
@@ -211,6 +216,62 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
         };
 
         tabsByWorkspaceAndCollectionPath[workspaceCollectionKey] = {
+          pathname: collection.pathname,
+          workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
+          activeTab: collection.activeTab,
+          tabs: collection.tabs
+        };
+      }
+
+      const isActiveWorkspaceEntry = activeWorkspacePath
+        && normalizePath(collection.workspacePathname || '') === activeWorkspacePath;
+
+      if (isActiveWorkspaceEntry) {
+        const hasData = collection.selectedEnvironment || collection.environment?.collection;
+        if (hasData || !activeWorkspaceEntries.has(normalizedCollectionPathname)) {
+          activeWorkspaceEntries.set(normalizedCollectionPathname, collection);
+        }
+      }
+    });
+
+    // Prioritize the active workspace's collection data in the fallback collectionsByPath
+    // lookup. This mirrors the prioritization done by loadLastOpenedWorkspaces for the
+    // workspace list itself, so that a collection's last-known state from the active
+    // workspace is preferred over stale data from other workspaces.
+    activeWorkspaceEntries.forEach((collection, path) => {
+      collectionsByPath[path] = {
+        pathname: collection.pathname,
+        workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
+        environment: collection.environment,
+        environmentPath: collection.environmentPath,
+        selectedEnvironment: collection.selectedEnvironment,
+        isOpen: collection.isOpen,
+        isMounted: collection.isMounted
+      };
+
+      tabsByCollectionPath[path] = {
+        pathname: collection.pathname,
+        activeTab: collection.activeTab,
+        tabs: collection.tabs
+      };
+
+      const activeWorkspaceCollectionKey = getWorkspaceCollectionSnapshotKey(
+        collection.workspacePathname,
+        collection.pathname
+      );
+
+      if (activeWorkspaceCollectionKey) {
+        collectionsByWorkspaceAndPath[activeWorkspaceCollectionKey] = {
+          pathname: collection.pathname,
+          workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
+          environment: collection.environment,
+          environmentPath: collection.environmentPath,
+          selectedEnvironment: collection.selectedEnvironment,
+          isOpen: collection.isOpen,
+          isMounted: collection.isMounted
+        };
+
+        tabsByWorkspaceAndCollectionPath[activeWorkspaceCollectionKey] = {
           pathname: collection.pathname,
           workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
           activeTab: collection.activeTab,

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -166,6 +166,35 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
   const tabsByWorkspaceAndCollectionPath = {};
   const workspacesByPath = {};
 
+  const buildCollectionLookupEntry = (collection) => ({
+    pathname: collection.pathname,
+    workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
+    environment: collection.environment,
+    environmentPath: collection.environmentPath,
+    selectedEnvironment: collection.selectedEnvironment,
+    isOpen: collection.isOpen,
+    isMounted: collection.isMounted
+  });
+
+  const buildTabLookupEntry = (collection, includeWorkspace) => ({
+    pathname: collection.pathname,
+    ...(includeWorkspace
+      ? { workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '' }
+      : {}),
+    activeTab: collection.activeTab,
+    tabs: collection.tabs
+  });
+
+  const assignCollectionLookups = (path, workspaceKey, collection) => {
+    collectionsByPath[path] = buildCollectionLookupEntry(collection);
+    tabsByCollectionPath[path] = buildTabLookupEntry(collection, false);
+
+    if (workspaceKey) {
+      collectionsByWorkspaceAndPath[workspaceKey] = buildCollectionLookupEntry(collection);
+      tabsByWorkspaceAndCollectionPath[workspaceKey] = buildTabLookupEntry(collection, true);
+    }
+  };
+
   if (Array.isArray(snapshot.collections)) {
     const activeWorkspacePath = typeof snapshot.activeWorkspacePath === 'string'
       ? normalizePath(snapshot.activeWorkspacePath)
@@ -188,40 +217,7 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
         collection.pathname
       );
 
-      collectionsByPath[normalizedCollectionPathname] = {
-        pathname: collection.pathname,
-        workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
-        environment: collection.environment,
-        environmentPath: collection.environmentPath,
-        selectedEnvironment: collection.selectedEnvironment,
-        isOpen: collection.isOpen,
-        isMounted: collection.isMounted
-      };
-
-      tabsByCollectionPath[normalizedCollectionPathname] = {
-        pathname: collection.pathname,
-        activeTab: collection.activeTab,
-        tabs: collection.tabs
-      };
-
-      if (workspaceCollectionKey) {
-        collectionsByWorkspaceAndPath[workspaceCollectionKey] = {
-          pathname: collection.pathname,
-          workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
-          environment: collection.environment,
-          environmentPath: collection.environmentPath,
-          selectedEnvironment: collection.selectedEnvironment,
-          isOpen: collection.isOpen,
-          isMounted: collection.isMounted
-        };
-
-        tabsByWorkspaceAndCollectionPath[workspaceCollectionKey] = {
-          pathname: collection.pathname,
-          workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
-          activeTab: collection.activeTab,
-          tabs: collection.tabs
-        };
-      }
+      assignCollectionLookups(normalizedCollectionPathname, workspaceCollectionKey, collection);
 
       const isActiveWorkspaceEntry = activeWorkspacePath
         && normalizePath(collection.workspacePathname || '') === activeWorkspacePath;
@@ -239,45 +235,8 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
     // workspace list itself, so that a collection's last-known state from the active
     // workspace is preferred over stale data from other workspaces.
     activeWorkspaceEntries.forEach((collection, path) => {
-      collectionsByPath[path] = {
-        pathname: collection.pathname,
-        workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
-        environment: collection.environment,
-        environmentPath: collection.environmentPath,
-        selectedEnvironment: collection.selectedEnvironment,
-        isOpen: collection.isOpen,
-        isMounted: collection.isMounted
-      };
-
-      tabsByCollectionPath[path] = {
-        pathname: collection.pathname,
-        activeTab: collection.activeTab,
-        tabs: collection.tabs
-      };
-
-      const activeWorkspaceCollectionKey = getWorkspaceCollectionSnapshotKey(
-        collection.workspacePathname,
-        collection.pathname
-      );
-
-      if (activeWorkspaceCollectionKey) {
-        collectionsByWorkspaceAndPath[activeWorkspaceCollectionKey] = {
-          pathname: collection.pathname,
-          workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
-          environment: collection.environment,
-          environmentPath: collection.environmentPath,
-          selectedEnvironment: collection.selectedEnvironment,
-          isOpen: collection.isOpen,
-          isMounted: collection.isMounted
-        };
-
-        tabsByWorkspaceAndCollectionPath[activeWorkspaceCollectionKey] = {
-          pathname: collection.pathname,
-          workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
-          activeTab: collection.activeTab,
-          tabs: collection.tabs
-        };
-      }
+      const workspaceCollectionKey = getWorkspaceCollectionSnapshotKey(collection.workspacePathname, collection.pathname);
+      assignCollectionLookups(path, workspaceCollectionKey, collection);
     });
   }
 

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -166,32 +166,32 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
   const tabsByWorkspaceAndCollectionPath = {};
   const workspacesByPath = {};
 
-  const buildCollectionLookupEntry = (collection) => ({
-    pathname: collection.pathname,
-    workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '',
-    environment: collection.environment,
-    environmentPath: collection.environmentPath,
-    selectedEnvironment: collection.selectedEnvironment,
-    isOpen: collection.isOpen,
-    isMounted: collection.isMounted
-  });
-
-  const buildTabLookupEntry = (collection, includeWorkspace) => ({
-    pathname: collection.pathname,
-    ...(includeWorkspace
-      ? { workspacePathname: typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '' }
-      : {}),
-    activeTab: collection.activeTab,
-    tabs: collection.tabs
-  });
-
   const assignCollectionLookups = (path, workspaceKey, collection) => {
-    collectionsByPath[path] = buildCollectionLookupEntry(collection);
-    tabsByCollectionPath[path] = buildTabLookupEntry(collection, false);
+    const workspacePathname = typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '';
+    const collectionEntry = {
+      pathname: collection.pathname,
+      workspacePathname,
+      environment: collection.environment,
+      environmentPath: collection.environmentPath,
+      selectedEnvironment: collection.selectedEnvironment,
+      isOpen: collection.isOpen,
+      isMounted: collection.isMounted
+    };
+    const tabsEntry = {
+      pathname: collection.pathname,
+      activeTab: collection.activeTab,
+      tabs: collection.tabs
+    };
+
+    collectionsByPath[path] = collectionEntry;
+    tabsByCollectionPath[path] = tabsEntry;
 
     if (workspaceKey) {
-      collectionsByWorkspaceAndPath[workspaceKey] = buildCollectionLookupEntry(collection);
-      tabsByWorkspaceAndCollectionPath[workspaceKey] = buildTabLookupEntry(collection, true);
+      collectionsByWorkspaceAndPath[workspaceKey] = collectionEntry;
+      tabsByWorkspaceAndCollectionPath[workspaceKey] = {
+        ...tabsEntry,
+        workspacePathname
+      };
     }
   };
 
@@ -230,10 +230,6 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
       }
     });
 
-    // Prioritize the active workspace's collection data in the fallback collectionsByPath
-    // lookup. This mirrors the prioritization done by loadLastOpenedWorkspaces for the
-    // workspace list itself, so that a collection's last-known state from the active
-    // workspace is preferred over stale data from other workspaces.
     activeWorkspaceEntries.forEach((collection, path) => {
       const workspaceCollectionKey = getWorkspaceCollectionSnapshotKey(collection.workspacePathname, collection.pathname);
       assignCollectionLookups(path, workspaceCollectionKey, collection);

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -166,40 +166,10 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
   const tabsByWorkspaceAndCollectionPath = {};
   const workspacesByPath = {};
 
-  const assignCollectionLookups = (path, workspaceKey, collection) => {
-    const workspacePathname = typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '';
-    const collectionEntry = {
-      pathname: collection.pathname,
-      workspacePathname,
-      environment: collection.environment,
-      environmentPath: collection.environmentPath,
-      selectedEnvironment: collection.selectedEnvironment,
-      isOpen: collection.isOpen,
-      isMounted: collection.isMounted
-    };
-    const tabsEntry = {
-      pathname: collection.pathname,
-      activeTab: collection.activeTab,
-      tabs: collection.tabs
-    };
-
-    collectionsByPath[path] = collectionEntry;
-    tabsByCollectionPath[path] = tabsEntry;
-
-    if (workspaceKey) {
-      collectionsByWorkspaceAndPath[workspaceKey] = collectionEntry;
-      tabsByWorkspaceAndCollectionPath[workspaceKey] = {
-        ...tabsEntry,
-        workspacePathname
-      };
-    }
-  };
-
   if (Array.isArray(snapshot.collections)) {
     const activeWorkspacePath = typeof snapshot.activeWorkspacePath === 'string'
       ? normalizePath(snapshot.activeWorkspacePath)
       : '';
-    const activeWorkspaceEntries = new Map();
 
     snapshot.collections.forEach((collectionEntry) => {
       if (!isObject(collectionEntry) || typeof collectionEntry.pathname !== 'string') {
@@ -212,27 +182,50 @@ export const hydrateSnapshotLookups = (snapshot = {}) => {
         return;
       }
 
+      const workspacePathname = typeof collection.workspacePathname === 'string' ? collection.workspacePathname : '';
+      const collectionLookupEntry = {
+        pathname: collection.pathname,
+        workspacePathname,
+        environment: collection.environment,
+        environmentPath: collection.environmentPath,
+        selectedEnvironment: collection.selectedEnvironment,
+        isOpen: collection.isOpen,
+        isMounted: collection.isMounted
+      };
+      const tabsEntry = {
+        pathname: collection.pathname,
+        activeTab: collection.activeTab,
+        tabs: collection.tabs
+      };
+
+      const existing = collectionsByPath[normalizedCollectionPathname];
+      const incomingIsActive = Boolean(
+        activeWorkspacePath && normalizePath(workspacePathname) === activeWorkspacePath
+      );
+      const existingIsActive = Boolean(
+        existing && activeWorkspacePath && normalizePath(existing.workspacePathname || '') === activeWorkspacePath
+      );
+      const shouldWritePath = !existing
+        || (incomingIsActive && !existingIsActive)
+        || (incomingIsActive && existingIsActive && Boolean(collection.selectedEnvironment || collection.environment?.collection))
+        || (!incomingIsActive && !existingIsActive);
+
+      if (shouldWritePath) {
+        collectionsByPath[normalizedCollectionPathname] = collectionLookupEntry;
+        tabsByCollectionPath[normalizedCollectionPathname] = tabsEntry;
+      }
+
       const workspaceCollectionKey = getWorkspaceCollectionSnapshotKey(
         collection.workspacePathname,
         collection.pathname
       );
-
-      assignCollectionLookups(normalizedCollectionPathname, workspaceCollectionKey, collection);
-
-      const isActiveWorkspaceEntry = activeWorkspacePath
-        && normalizePath(collection.workspacePathname || '') === activeWorkspacePath;
-
-      if (isActiveWorkspaceEntry) {
-        const hasData = collection.selectedEnvironment || collection.environment?.collection;
-        if (hasData || !activeWorkspaceEntries.has(normalizedCollectionPathname)) {
-          activeWorkspaceEntries.set(normalizedCollectionPathname, collection);
-        }
+      if (workspaceCollectionKey) {
+        collectionsByWorkspaceAndPath[workspaceCollectionKey] = collectionLookupEntry;
+        tabsByWorkspaceAndCollectionPath[workspaceCollectionKey] = {
+          ...tabsEntry,
+          workspacePathname
+        };
       }
-    });
-
-    activeWorkspaceEntries.forEach((collection, path) => {
-      const workspaceCollectionKey = getWorkspaceCollectionSnapshotKey(collection.workspacePathname, collection.pathname);
-      assignCollectionLookups(path, workspaceCollectionKey, collection);
     });
   }
 

--- a/packages/bruno-app/src/utils/snapshot/index.spec.js
+++ b/packages/bruno-app/src/utils/snapshot/index.spec.js
@@ -228,6 +228,164 @@ describe('hydrateSnapshotLookups', () => {
     });
   });
 
+  it('prioritizes active workspace collection data in collectionsByPath when later non-active entries would otherwise overwrite it', () => {
+    const collectionPath = '/collections/shared';
+
+    const snapshot = {
+      activeWorkspacePath: '/workspaces/active',
+      workspaces: [
+        {
+          pathname: '/workspaces/active',
+          sorting: 'default',
+          collections: [collectionPath]
+        },
+        {
+          pathname: '/workspaces/other',
+          sorting: 'default',
+          collections: [collectionPath]
+        }
+      ],
+      collections: [
+        {
+          pathname: collectionPath,
+          workspacePathname: '/workspaces/active',
+          environment: {
+            collection: 'env-active',
+            global: ''
+          },
+          selectedEnvironment: 'env-active',
+          isOpen: true,
+          isMounted: false
+        },
+        {
+          pathname: collectionPath,
+          workspacePathname: '/workspaces/other',
+          environment: {
+            collection: '',
+            global: ''
+          },
+          selectedEnvironment: '',
+          isOpen: false,
+          isMounted: false
+        }
+      ]
+    };
+
+    const lookups = hydrateSnapshotLookups(snapshot);
+
+    // collectionsByPath should contain active workspace's data, not the later blank entry
+    expect(lookups.collectionsByPath[collectionPath]).toMatchObject({
+      selectedEnvironment: 'env-active',
+      environment: {
+        collection: 'env-active',
+        global: ''
+      }
+    });
+  });
+
+  it('falls back to active workspace data via collectionsByPath when workspace-scoped entry is missing', () => {
+    const collectionPath = '/collections/shared';
+    const activeWorkspacePath = '/workspaces/active';
+
+    const snapshot = {
+      activeWorkspacePath,
+      workspaces: [
+        {
+          pathname: activeWorkspacePath,
+          sorting: 'default',
+          collections: [collectionPath]
+        }
+      ],
+      collections: [
+        {
+          pathname: collectionPath,
+          workspacePathname: '',
+          environment: {
+            collection: 'env-active',
+            global: ''
+          },
+          selectedEnvironment: 'env-active',
+          isOpen: true,
+          isMounted: false
+        }
+      ]
+    };
+
+    const lookups = hydrateSnapshotLookups(snapshot);
+
+    // There is no workspace-scoped entry for the active workspace (workspacePathname is empty),
+    // so getCollectionSnapshotFromLookups falls back to collectionsByPath.
+    // The fallback should still return the active workspace's data.
+    expect(getCollectionSnapshotFromLookups(collectionPath, lookups, activeWorkspacePath)).toMatchObject({
+      selectedEnvironment: 'env-active',
+      environment: {
+        collection: 'env-active',
+        global: ''
+      }
+    });
+  });
+
+  it('overrides workspace-scoped entry with first non-blank active workspace data when a later blank entry shares the same workspacePathname', () => {
+    const collectionPath = '/collections/shared';
+    const activeWorkspacePath = '/workspaces/active';
+
+    const snapshot = {
+      activeWorkspacePath,
+      workspaces: [
+        {
+          pathname: activeWorkspacePath,
+          sorting: 'default',
+          collections: [collectionPath]
+        }
+      ],
+      collections: [
+        {
+          pathname: collectionPath,
+          workspacePathname: activeWorkspacePath,
+          environment: {
+            collection: 'env-active',
+            global: ''
+          },
+          selectedEnvironment: 'env-active',
+          isOpen: true,
+          isMounted: false
+        },
+        {
+          pathname: collectionPath,
+          workspacePathname: activeWorkspacePath,
+          environment: {
+            collection: '',
+            global: ''
+          },
+          selectedEnvironment: '',
+          isOpen: false,
+          isMounted: false
+        }
+      ]
+    };
+
+    const lookups = hydrateSnapshotLookups(snapshot);
+    const workspaceKey = `${activeWorkspacePath}::${collectionPath}`;
+
+    // The workspace-scoped lookup should be restored to the first non-blank entry
+    expect(lookups.collectionsByWorkspaceAndPath[workspaceKey]).toMatchObject({
+      selectedEnvironment: 'env-active',
+      environment: {
+        collection: 'env-active',
+        global: ''
+      }
+    });
+
+    // collectionsByPath should also be restored
+    expect(lookups.collectionsByPath[collectionPath]).toMatchObject({
+      selectedEnvironment: 'env-active',
+      environment: {
+        collection: 'env-active',
+        global: ''
+      }
+    });
+  });
+
   it('drops legacy v4 migration tabs from snapshot lookups', () => {
     const snapshot = {
       collections: [

--- a/packages/bruno-app/src/utils/snapshot/index.spec.js
+++ b/packages/bruno-app/src/utils/snapshot/index.spec.js
@@ -281,6 +281,160 @@ describe('hydrateSnapshotLookups', () => {
     });
   });
 
+  it('keeps workspace-scoped collection lookups distinct when active workspace preference is applied', () => {
+    const collectionPath = '/collections/shared';
+    const workspaceAPath = '/workspaces/a';
+    const workspaceBPath = '/workspaces/b';
+
+    const snapshot = {
+      activeWorkspacePath: workspaceAPath,
+      workspaces: [
+        { pathname: workspaceAPath, sorting: 'default', collections: [collectionPath] },
+        { pathname: workspaceBPath, sorting: 'default', collections: [collectionPath] }
+      ],
+      collections: [
+        {
+          pathname: collectionPath,
+          workspacePathname: workspaceAPath,
+          environment: { collection: 'env-a', global: '' },
+          selectedEnvironment: 'env-a',
+          isOpen: true,
+          isMounted: false
+        },
+        {
+          pathname: collectionPath,
+          workspacePathname: workspaceBPath,
+          environment: { collection: 'env-b', global: '' },
+          selectedEnvironment: 'env-b',
+          isOpen: true,
+          isMounted: false
+        }
+      ]
+    };
+
+    const lookups = hydrateSnapshotLookups(snapshot);
+
+    expect(lookups.collectionsByPath[collectionPath]).toMatchObject({
+      selectedEnvironment: 'env-a'
+    });
+    expect(getCollectionSnapshotFromLookups(collectionPath, lookups, workspaceAPath)).toMatchObject({
+      selectedEnvironment: 'env-a'
+    });
+    expect(getCollectionSnapshotFromLookups(collectionPath, lookups, workspaceBPath)).toMatchObject({
+      selectedEnvironment: 'env-b'
+    });
+  });
+
+  it('prefers blank active workspace collection data over a later non-active entry with environment data', () => {
+    const collectionPath = '/collections/shared';
+
+    const snapshot = {
+      activeWorkspacePath: '/workspaces/active',
+      workspaces: [
+        { pathname: '/workspaces/active', sorting: 'default', collections: [collectionPath] },
+        { pathname: '/workspaces/other', sorting: 'default', collections: [collectionPath] }
+      ],
+      collections: [
+        {
+          pathname: collectionPath,
+          workspacePathname: '/workspaces/active',
+          environment: { collection: '', global: '' },
+          selectedEnvironment: '',
+          isOpen: true,
+          isMounted: false
+        },
+        {
+          pathname: collectionPath,
+          workspacePathname: '/workspaces/other',
+          environment: { collection: 'env-other', global: '' },
+          selectedEnvironment: 'env-other',
+          isOpen: false,
+          isMounted: false
+        }
+      ]
+    };
+
+    const lookups = hydrateSnapshotLookups(snapshot);
+
+    expect(lookups.collectionsByPath[collectionPath]).toMatchObject({
+      selectedEnvironment: '',
+      environment: { collection: '', global: '' }
+    });
+  });
+
+  it('prefers an active workspace entry with environment data over an earlier blank active entry for the same path', () => {
+    const collectionPath = '/collections/shared';
+    const activeWorkspacePath = '/workspaces/active';
+
+    const snapshot = {
+      activeWorkspacePath,
+      workspaces: [
+        { pathname: activeWorkspacePath, sorting: 'default', collections: [collectionPath] }
+      ],
+      collections: [
+        {
+          pathname: collectionPath,
+          workspacePathname: activeWorkspacePath,
+          environment: { collection: '', global: '' },
+          selectedEnvironment: '',
+          isOpen: true,
+          isMounted: false
+        },
+        {
+          pathname: collectionPath,
+          workspacePathname: activeWorkspacePath,
+          environment: { collection: 'env-second', global: '' },
+          selectedEnvironment: 'env-second',
+          isOpen: true,
+          isMounted: false
+        }
+      ]
+    };
+
+    const lookups = hydrateSnapshotLookups(snapshot);
+
+    expect(lookups.collectionsByPath[collectionPath]).toMatchObject({
+      selectedEnvironment: 'env-second',
+      environment: { collection: 'env-second', global: '' }
+    });
+  });
+
+  it('uses last-write-wins for collectionsByPath when activeWorkspacePath is absent', () => {
+    const collectionPath = '/collections/shared';
+
+    const snapshot = {
+      workspaces: [
+        { pathname: '/workspaces/a', sorting: 'default', collections: [collectionPath] },
+        { pathname: '/workspaces/b', sorting: 'default', collections: [collectionPath] }
+      ],
+      collections: [
+        {
+          pathname: collectionPath,
+          workspacePathname: '/workspaces/a',
+          environment: { collection: 'env-a', global: '' },
+          selectedEnvironment: 'env-a',
+          isOpen: true,
+          isMounted: false
+        },
+        {
+          pathname: collectionPath,
+          workspacePathname: '/workspaces/b',
+          environment: { collection: 'env-b', global: '' },
+          selectedEnvironment: 'env-b',
+          isOpen: true,
+          isMounted: false
+        }
+      ]
+    };
+
+    const lookups = hydrateSnapshotLookups(snapshot);
+
+    expect(lookups.collectionsByPath[collectionPath]).toMatchObject({
+      selectedEnvironment: 'env-b',
+      environment: { collection: 'env-b', global: '' }
+    });
+  });
+
   it('drops legacy v4 migration tabs from snapshot lookups', () => {
     const snapshot = {
       collections: [

--- a/packages/bruno-app/src/utils/snapshot/index.spec.js
+++ b/packages/bruno-app/src/utils/snapshot/index.spec.js
@@ -219,7 +219,6 @@ describe('hydrateSnapshotLookups', () => {
 
     expect(lookups.hasWorkspaceScopedTabs).toBe(true);
 
-    // Each workspace should resolve to its own selected environment for the shared collection.
     expect(getCollectionSnapshotFromLookups(sharedCollectionPath, lookups, workspaceAPath)).toMatchObject({
       selectedEnvironment: 'env-a'
     });
@@ -273,110 +272,6 @@ describe('hydrateSnapshotLookups', () => {
 
     const lookups = hydrateSnapshotLookups(snapshot);
 
-    // collectionsByPath should contain active workspace's data, not the later blank entry
-    expect(lookups.collectionsByPath[collectionPath]).toMatchObject({
-      selectedEnvironment: 'env-active',
-      environment: {
-        collection: 'env-active',
-        global: ''
-      }
-    });
-  });
-
-  it('falls back to active workspace data via collectionsByPath when workspace-scoped entry is missing', () => {
-    const collectionPath = '/collections/shared';
-    const activeWorkspacePath = '/workspaces/active';
-
-    const snapshot = {
-      activeWorkspacePath,
-      workspaces: [
-        {
-          pathname: activeWorkspacePath,
-          sorting: 'default',
-          collections: [collectionPath]
-        }
-      ],
-      collections: [
-        {
-          pathname: collectionPath,
-          workspacePathname: '',
-          environment: {
-            collection: 'env-active',
-            global: ''
-          },
-          selectedEnvironment: 'env-active',
-          isOpen: true,
-          isMounted: false
-        }
-      ]
-    };
-
-    const lookups = hydrateSnapshotLookups(snapshot);
-
-    // There is no workspace-scoped entry for the active workspace (workspacePathname is empty),
-    // so getCollectionSnapshotFromLookups falls back to collectionsByPath.
-    // The fallback should still return the active workspace's data.
-    expect(getCollectionSnapshotFromLookups(collectionPath, lookups, activeWorkspacePath)).toMatchObject({
-      selectedEnvironment: 'env-active',
-      environment: {
-        collection: 'env-active',
-        global: ''
-      }
-    });
-  });
-
-  it('overrides workspace-scoped entry with first non-blank active workspace data when a later blank entry shares the same workspacePathname', () => {
-    const collectionPath = '/collections/shared';
-    const activeWorkspacePath = '/workspaces/active';
-
-    const snapshot = {
-      activeWorkspacePath,
-      workspaces: [
-        {
-          pathname: activeWorkspacePath,
-          sorting: 'default',
-          collections: [collectionPath]
-        }
-      ],
-      collections: [
-        {
-          pathname: collectionPath,
-          workspacePathname: activeWorkspacePath,
-          environment: {
-            collection: 'env-active',
-            global: ''
-          },
-          selectedEnvironment: 'env-active',
-          isOpen: true,
-          isMounted: false
-        },
-        {
-          pathname: collectionPath,
-          workspacePathname: activeWorkspacePath,
-          environment: {
-            collection: '',
-            global: ''
-          },
-          selectedEnvironment: '',
-          isOpen: false,
-          isMounted: false
-        }
-      ]
-    };
-
-    const lookups = hydrateSnapshotLookups(snapshot);
-    const workspaceKey = `${activeWorkspacePath}::${collectionPath}`;
-
-    // The workspace-scoped lookup should be restored to the first non-blank entry
-    expect(lookups.collectionsByWorkspaceAndPath[workspaceKey]).toMatchObject({
-      selectedEnvironment: 'env-active',
-      environment: {
-        collection: 'env-active',
-        global: ''
-      }
-    });
-
-    // collectionsByPath should also be restored
     expect(lookups.collectionsByPath[collectionPath]).toMatchObject({
       selectedEnvironment: 'env-active',
       environment: {

--- a/packages/bruno-electron/src/services/snapshot/index.js
+++ b/packages/bruno-electron/src/services/snapshot/index.js
@@ -683,7 +683,6 @@ class SnapshotManager {
     const activeWorkspacePath = typeof normalizedSnapshot.activeWorkspacePath === 'string'
       ? normalizeLookupKey(normalizedSnapshot.activeWorkspacePath)
       : null;
-    const activeWorkspaceEntries = new Map();
 
     normalizedSnapshot.workspaces.forEach((workspace) => {
       const normalizedPath = normalizeLookupKey(workspace.pathname);
@@ -694,12 +693,31 @@ class SnapshotManager {
       workspacesByPath[normalizedPath] = workspace;
     });
 
-    const assignCollectionLookups = (normalizedPath, collection) => {
-      collectionsByPath[normalizedPath] = collection;
-      tabsByCollectionPath[normalizedPath] = {
-        activeTab: collection.activeTab,
-        tabs: collection.tabs
-      };
+    normalizedSnapshot.collections.forEach((collection) => {
+      const normalizedPath = normalizeLookupKey(collection.pathname);
+      if (!normalizedPath) {
+        return;
+      }
+
+      const existing = collectionsByPath[normalizedPath];
+      const incomingIsActive = Boolean(
+        activeWorkspacePath && normalizeLookupKey(collection.workspacePathname || '') === activeWorkspacePath
+      );
+      const existingIsActive = Boolean(
+        existing && activeWorkspacePath && normalizeLookupKey(existing.workspacePathname || '') === activeWorkspacePath
+      );
+      const shouldWritePath = !existing
+        || (incomingIsActive && !existingIsActive)
+        || (incomingIsActive && existingIsActive && Boolean(collection.selectedEnvironment || collection.environment?.collection))
+        || (!incomingIsActive && !existingIsActive);
+
+      if (shouldWritePath) {
+        collectionsByPath[normalizedPath] = collection;
+        tabsByCollectionPath[normalizedPath] = {
+          activeTab: collection.activeTab,
+          tabs: collection.tabs
+        };
+      }
 
       const workspaceCollectionKey = buildWorkspaceCollectionLookupKey(collection.workspacePathname, collection.pathname);
       if (workspaceCollectionKey) {
@@ -709,28 +727,7 @@ class SnapshotManager {
           tabs: collection.tabs
         };
       }
-    };
-
-    normalizedSnapshot.collections.forEach((collection) => {
-      const normalizedPath = normalizeLookupKey(collection.pathname);
-      if (!normalizedPath) {
-        return;
-      }
-
-      assignCollectionLookups(normalizedPath, collection);
-
-      const isActiveWorkspaceEntry = activeWorkspacePath
-        && normalizeLookupKey(collection.workspacePathname || '') === activeWorkspacePath;
-
-      if (isActiveWorkspaceEntry) {
-        const hasData = collection.selectedEnvironment || collection.environment?.collection;
-        if (hasData || !activeWorkspaceEntries.has(normalizedPath)) {
-          activeWorkspaceEntries.set(normalizedPath, collection);
-        }
-      }
     });
-
-    activeWorkspaceEntries.forEach((collection, normalizedPath) => assignCollectionLookups(normalizedPath, collection));
 
     this._lookupCache = {
       workspacesByPath,

--- a/packages/bruno-electron/src/services/snapshot/index.js
+++ b/packages/bruno-electron/src/services/snapshot/index.js
@@ -680,6 +680,10 @@ class SnapshotManager {
     const collectionsByWorkspaceAndPath = {};
     const tabsByCollectionPath = {};
     const tabsByWorkspaceAndCollectionPath = {};
+    const activeWorkspacePath = typeof normalizedSnapshot.activeWorkspacePath === 'string'
+      ? normalizeLookupKey(normalizedSnapshot.activeWorkspacePath)
+      : null;
+    const activeWorkspaceEntries = new Map();
 
     normalizedSnapshot.workspaces.forEach((workspace) => {
       const normalizedPath = normalizeLookupKey(workspace.pathname);
@@ -696,6 +700,33 @@ class SnapshotManager {
         return;
       }
 
+      collectionsByPath[normalizedPath] = collection;
+      tabsByCollectionPath[normalizedPath] = {
+        activeTab: collection.activeTab,
+        tabs: collection.tabs
+      };
+
+      const workspaceCollectionKey = buildWorkspaceCollectionLookupKey(collection.workspacePathname, collection.pathname);
+      if (workspaceCollectionKey) {
+        collectionsByWorkspaceAndPath[workspaceCollectionKey] = collection;
+        tabsByWorkspaceAndCollectionPath[workspaceCollectionKey] = {
+          activeTab: collection.activeTab,
+          tabs: collection.tabs
+        };
+      }
+
+      const isActiveWorkspaceEntry = activeWorkspacePath
+        && normalizeLookupKey(collection.workspacePathname || '') === activeWorkspacePath;
+
+      if (isActiveWorkspaceEntry) {
+        const hasData = collection.selectedEnvironment || collection.environment?.collection;
+        if (hasData || !activeWorkspaceEntries.has(normalizedPath)) {
+          activeWorkspaceEntries.set(normalizedPath, collection);
+        }
+      }
+    });
+
+    activeWorkspaceEntries.forEach((collection, normalizedPath) => {
       collectionsByPath[normalizedPath] = collection;
       tabsByCollectionPath[normalizedPath] = {
         activeTab: collection.activeTab,

--- a/packages/bruno-electron/src/services/snapshot/index.js
+++ b/packages/bruno-electron/src/services/snapshot/index.js
@@ -694,12 +694,7 @@ class SnapshotManager {
       workspacesByPath[normalizedPath] = workspace;
     });
 
-    normalizedSnapshot.collections.forEach((collection) => {
-      const normalizedPath = normalizeLookupKey(collection.pathname);
-      if (!normalizedPath) {
-        return;
-      }
-
+    const assignCollectionLookups = (normalizedPath, collection) => {
       collectionsByPath[normalizedPath] = collection;
       tabsByCollectionPath[normalizedPath] = {
         activeTab: collection.activeTab,
@@ -714,6 +709,15 @@ class SnapshotManager {
           tabs: collection.tabs
         };
       }
+    };
+
+    normalizedSnapshot.collections.forEach((collection) => {
+      const normalizedPath = normalizeLookupKey(collection.pathname);
+      if (!normalizedPath) {
+        return;
+      }
+
+      assignCollectionLookups(normalizedPath, collection);
 
       const isActiveWorkspaceEntry = activeWorkspacePath
         && normalizeLookupKey(collection.workspacePathname || '') === activeWorkspacePath;
@@ -726,22 +730,7 @@ class SnapshotManager {
       }
     });
 
-    activeWorkspaceEntries.forEach((collection, normalizedPath) => {
-      collectionsByPath[normalizedPath] = collection;
-      tabsByCollectionPath[normalizedPath] = {
-        activeTab: collection.activeTab,
-        tabs: collection.tabs
-      };
-
-      const workspaceCollectionKey = buildWorkspaceCollectionLookupKey(collection.workspacePathname, collection.pathname);
-      if (workspaceCollectionKey) {
-        collectionsByWorkspaceAndPath[workspaceCollectionKey] = collection;
-        tabsByWorkspaceAndCollectionPath[workspaceCollectionKey] = {
-          activeTab: collection.activeTab,
-          tabs: collection.tabs
-        };
-      }
-    });
+    activeWorkspaceEntries.forEach((collection, normalizedPath) => assignCollectionLookups(normalizedPath, collection));
 
     this._lookupCache = {
       workspacesByPath,

--- a/packages/bruno-electron/tests/services/snapshot-remap.spec.js
+++ b/packages/bruno-electron/tests/services/snapshot-remap.spec.js
@@ -175,4 +175,224 @@ describe('SnapshotManager shared collection lookups', () => {
       selectedEnvironment: 'env-a'
     });
   });
+
+  it('keeps workspace-scoped getCollection results distinct when active workspace preference is applied', () => {
+    const workspaceAPath = '/workspaces/a';
+    const workspaceBPath = '/workspaces/b';
+    const sharedCollectionPath = '/collections/shared';
+
+    snapshotManager.saveSnapshot({
+      version: '0.0.1',
+      activeWorkspacePath: workspaceAPath,
+      extras: { devTools: { open: false, activeTab: '', tabs: {} } },
+      workspaces: [
+        {
+          pathname: workspaceAPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        },
+        {
+          pathname: workspaceBPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        }
+      ],
+      collections: [
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceAPath,
+          environment: { collection: 'env-a', global: '' },
+          environmentPath: 'env-a',
+          selectedEnvironment: 'env-a',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        },
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceBPath,
+          environment: { collection: 'env-b', global: '' },
+          environmentPath: 'env-b',
+          selectedEnvironment: 'env-b',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        }
+      ]
+    });
+
+    expect(snapshotManager.getCollection(sharedCollectionPath)).toMatchObject({
+      selectedEnvironment: 'env-a'
+    });
+    expect(snapshotManager.getCollection(sharedCollectionPath, workspaceAPath)).toMatchObject({
+      selectedEnvironment: 'env-a'
+    });
+    expect(snapshotManager.getCollection(sharedCollectionPath, workspaceBPath)).toMatchObject({
+      selectedEnvironment: 'env-b'
+    });
+  });
+
+  it('prefers blank active workspace collection data over a later non-active entry with environment data', () => {
+    const workspaceAPath = '/workspaces/a';
+    const workspaceBPath = '/workspaces/b';
+    const sharedCollectionPath = '/collections/shared';
+
+    snapshotManager.saveSnapshot({
+      version: '0.0.1',
+      activeWorkspacePath: workspaceAPath,
+      extras: { devTools: { open: false, activeTab: '', tabs: {} } },
+      workspaces: [
+        {
+          pathname: workspaceAPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        },
+        {
+          pathname: workspaceBPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        }
+      ],
+      collections: [
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceAPath,
+          environment: { collection: '', global: '' },
+          environmentPath: '',
+          selectedEnvironment: '',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        },
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceBPath,
+          environment: { collection: 'env-b', global: '' },
+          environmentPath: 'env-b',
+          selectedEnvironment: 'env-b',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        }
+      ]
+    });
+
+    expect(snapshotManager.getCollection(sharedCollectionPath)).toMatchObject({
+      workspacePathname: workspaceAPath,
+      selectedEnvironment: '',
+      environment: { collection: '', global: '' }
+    });
+  });
+
+  it('prefers an active workspace entry with environment data over an earlier blank active entry for the same path', () => {
+    const workspaceAPath = '/workspaces/a';
+    const sharedCollectionPath = '/collections/shared';
+
+    snapshotManager.saveSnapshot({
+      version: '0.0.1',
+      activeWorkspacePath: workspaceAPath,
+      extras: { devTools: { open: false, activeTab: '', tabs: {} } },
+      workspaces: [
+        {
+          pathname: workspaceAPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        }
+      ],
+      collections: [
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceAPath,
+          environment: { collection: '', global: '' },
+          environmentPath: '',
+          selectedEnvironment: '',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        },
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceAPath,
+          environment: { collection: 'env-second', global: '' },
+          environmentPath: 'env-second',
+          selectedEnvironment: 'env-second',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        }
+      ]
+    });
+
+    expect(snapshotManager.getCollection(sharedCollectionPath)).toMatchObject({
+      selectedEnvironment: 'env-second',
+      environment: { collection: 'env-second', global: '' }
+    });
+  });
+
+  it('uses last-write-wins for path lookup when activeWorkspacePath is absent', () => {
+    const workspaceAPath = '/workspaces/a';
+    const workspaceBPath = '/workspaces/b';
+    const sharedCollectionPath = '/collections/shared';
+
+    snapshotManager.saveSnapshot({
+      version: '0.0.1',
+      activeWorkspacePath: null,
+      extras: { devTools: { open: false, activeTab: '', tabs: {} } },
+      workspaces: [
+        {
+          pathname: workspaceAPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        },
+        {
+          pathname: workspaceBPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        }
+      ],
+      collections: [
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceAPath,
+          environment: { collection: 'env-a', global: '' },
+          environmentPath: 'env-a',
+          selectedEnvironment: 'env-a',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        },
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceBPath,
+          environment: { collection: 'env-b', global: '' },
+          environmentPath: 'env-b',
+          selectedEnvironment: 'env-b',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        }
+      ]
+    });
+
+    expect(snapshotManager.getCollection(sharedCollectionPath)).toMatchObject({
+      workspacePathname: workspaceBPath,
+      selectedEnvironment: 'env-b',
+      environment: { collection: 'env-b', global: '' }
+    });
+  });
 });

--- a/packages/bruno-electron/tests/services/snapshot-remap.spec.js
+++ b/packages/bruno-electron/tests/services/snapshot-remap.spec.js
@@ -113,3 +113,66 @@ describe('SnapshotManager.remapCollectionTabPaths', () => {
     expect(tabs.some((t) => t.pathname === `${collectionPath}/ping.bru`)).toBe(true);
   });
 });
+
+describe('SnapshotManager shared collection lookups', () => {
+  beforeEach(() => {
+    mockStoreData = {};
+  });
+
+  it('uses active workspace collection environment when a later shared collection entry is blank', () => {
+    const workspaceAPath = '/workspaces/a';
+    const workspaceBPath = '/workspaces/b';
+    const sharedCollectionPath = '/collections/shared';
+
+    snapshotManager.saveSnapshot({
+      version: '0.0.1',
+      activeWorkspacePath: workspaceAPath,
+      extras: { devTools: { open: false, activeTab: '', tabs: {} } },
+      workspaces: [
+        {
+          pathname: workspaceAPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        },
+        {
+          pathname: workspaceBPath,
+          environment: '',
+          sorting: 'default',
+          collections: [sharedCollectionPath]
+        }
+      ],
+      collections: [
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceAPath,
+          environment: { collection: 'env-a', global: '' },
+          environmentPath: 'env-a',
+          selectedEnvironment: 'env-a',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        },
+        {
+          pathname: sharedCollectionPath,
+          workspacePathname: workspaceBPath,
+          environment: { collection: '', global: '' },
+          environmentPath: '',
+          selectedEnvironment: '',
+          isOpen: true,
+          isMounted: true,
+          activeTab: null,
+          tabs: []
+        }
+      ]
+    });
+
+    expect(snapshotManager.getCollection(sharedCollectionPath)).toMatchObject({
+      workspacePathname: workspaceAPath,
+      environment: { collection: 'env-a', global: '' },
+      environmentPath: 'env-a',
+      selectedEnvironment: 'env-a'
+    });
+  });
+});


### PR DESCRIPTION
### Description

BRU-3963

Fixes 2 issues, 
- One is the active workspace lookup during hydration 
- Other is that the `if` condition would drop any environment restores if `skipTabRestore` was true
- Boatloads of tests for both scenarios

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collection environment restoration when tab restoration is disabled (environment is restored without requesting saved tabs).
  - Enhanced snapshot lookup hydration by normalizing the active workspace path and avoiding incorrect overwrites.
  - Improved reliability of environment/selection resolution for collections shared across multiple workspaces, with correct active-workspace precedence and fallbacks.

- **Tests**
  - Added/expanded Jest coverage for `skipTabRestore` behavior and active-workspace/shared-collection snapshot lookup resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->