### PR TITLE
fix:resolver error for reference schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -9113,6 +9130,12 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@jsep-plugin/assignment": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
@@ -12976,7 +12999,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
@@ -35198,6 +35220,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.15",
         "@ai-sdk/openai": "3.0.12",
+        "@apidevtools/json-schema-ref-parser": "^11.7.3",
         "@aws-sdk/credential-providers": "3.1019.0",
         "@grpc/grpc-js": "^1.13.2",
         "@grpc/proto-loader": "^0.7.13",

--- a/packages/bruno-app/src/components/ApiSpecPanel/ApiSpecPanelErrorBoundary.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/ApiSpecPanelErrorBoundary.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { IconAlertTriangle } from '@tabler/icons';
+import { useDispatch } from 'react-redux';
+import { setActiveApiSpecUid } from 'providers/ReduxStore/slices/apiSpec';
+import Button from 'ui/Button';
+import { useTheme } from 'providers/Theme';
+
+class ApiSpecPanelErrorBoundaryInner extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('[ApiSpecPanelErrorBoundary] Unexpected render error:', error, errorInfo);
+  }
+
+  render() {
+    const { theme, onClose } = this.props;
+
+    if (this.state.hasError) {
+      const errorMessage = this.state.error?.message;
+
+      return (
+        <div className="h-full flex flex-col items-center justify-center gap-3 px-6 text-center">
+          <IconAlertTriangle size={36} strokeWidth={1.5} style={{ color: theme?.status?.warning?.text }} />
+          <h2 className="text-lg font-medium">Something went wrong</h2>
+          <p className="text-sm opacity-70 max-w-md">
+            This spec preview encountered an unexpected error, likely from an unresolvable
+            reference in the spec. Close it and try reopening.
+          </p>
+          {errorMessage && (
+            <p className="text-xs font-mono opacity-50 max-w-md break-all">{errorMessage}</p>
+          )}
+          <Button size="md" data-testid="api-spec-panel-error-boundary-close" color="primary" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const ApiSpecPanelErrorBoundary = ({ children }) => {
+  const dispatch = useDispatch();
+  const { theme } = useTheme();
+
+  const handleClose = () => {
+    dispatch(setActiveApiSpecUid({ uid: null }));
+  };
+
+  return (
+    <ApiSpecPanelErrorBoundaryInner onClose={handleClose} theme={theme}>
+      {children}
+    </ApiSpecPanelErrorBoundaryInner>
+  );
+};
+
+export default ApiSpecPanelErrorBoundary;

--- a/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.js
@@ -38,12 +38,16 @@ const MIN_RIGHT_PANE_WIDTH = 450;
  *
  * Props:
  *  - content               (string)  The spec content (YAML/JSON string)
+ *  - specFilePath          (string|undefined) Absolute path of the spec file on disk, if any.
+ *                          When set, every `$ref` (external and internal) is resolved in the main
+ *                          process, which has a real base path to resolve them against, before
+ *                          the preview ever mounts.
  *  - readOnly              (boolean) If true, editor is not editable and save icon is hidden
  *  - onSave                (fn)      Called with current editor content on save (editable mode only)
  *  - leftPaneWidth         (number|null) Persisted left pane width in px; null = use 50/50 default
  *  - onLeftPaneWidthChange (fn)      Persist the new width (called on mouseup / double-click / resize-clamp)
  */
-const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthChange }) => {
+const SpecViewer = ({ content, specFilePath, readOnly, onSave, leftPaneWidth, onLeftPaneWidthChange }) => {
   const { displayedTheme, theme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
 
@@ -75,10 +79,12 @@ const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthC
 
   const [swaggerReady, setSwaggerReady] = useState(false);
   const [previewError, setPreviewError] = useState(null);
+  const [specForRender, setSpecForRender] = useState(null);
   const previewTimeoutRef = useRef(null);
 
   useEffect(() => {
     setSwaggerReady(false);
+    setSpecForRender(null);
     clearTimeout(previewTimeoutRef.current);
 
     if (!content || !content.trim()) {
@@ -96,9 +102,29 @@ const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthC
     previewTimeoutRef.current = setTimeout(() => {
       setPreviewError(SPEC_PREVIEW_ERRORS.TIMEOUT);
     }, PREVIEW_TIMEOUT_MS);
+    let cancelled = false;
+    if (specFilePath) {
+      window.ipcRenderer.invoke('renderer:resolve-openapi-spec-refs', specFilePath)
+        .then((result) => {
+          if (cancelled) return;
+          if (result?.error) {
+            console.warn('[SpecViewer] $ref resolution failed, falling back to raw content:', result.error);
+          }
+          setSpecForRender(result?.spec || content);
+        })
+        .catch((err) => {
+          console.warn('[SpecViewer] $ref resolution IPC call failed, falling back to raw content:', err);
+          if (!cancelled) setSpecForRender(content);
+        });
+    } else {
+      setSpecForRender(content);
+    }
 
-    return () => clearTimeout(previewTimeoutRef.current);
-  }, [content]);
+    return () => {
+      cancelled = true;
+      clearTimeout(previewTimeoutRef.current);
+    };
+  }, [content, specFilePath]);
 
   const handleSwaggerComplete = useCallback(() => {
     // Double rAF: wait for one full paint cycle so Swagger is actually on screen
@@ -160,9 +186,11 @@ const SpecViewer = ({ content, readOnly, onSave, leftPaneWidth, onLeftPaneWidthC
           </div>
         ) : (
           <>
-            <div style={{ visibility: swaggerReady ? 'visible' : 'hidden', height: '100%' }}>
-              <Swagger spec={content} onComplete={handleSwaggerComplete} />
-            </div>
+            {specForRender != null && (
+              <div style={{ visibility: swaggerReady ? 'visible' : 'hidden', height: '100%' }}>
+                <Swagger spec={specForRender} onComplete={handleSwaggerComplete} />
+              </div>
+            )}
             {!swaggerReady && (
               <div
                 className="absolute inset-0 flex items-center justify-center gap-2"

--- a/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.spec.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/SpecViewer.spec.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+jest.mock('providers/Theme', () => ({
+  useTheme: () => ({
+    theme: { bg: '#fff', draftColor: '#000', requestTabs: { icon: { color: '#000' } } },
+    displayedTheme: 'light'
+  })
+}));
+
+jest.mock('./FileEditor/CodeEditor/index', () => () => <div data-testid="code-editor" />);
+
+const swaggerSpecs = [];
+jest.mock('./Renderers/Swagger', () => ({ spec, onComplete }) => {
+  swaggerSpecs.push(spec);
+  onComplete?.();
+  return <div data-testid="swagger">{typeof spec === 'string' ? spec : JSON.stringify(spec)}</div>;
+});
+
+import SpecViewer from './SpecViewer';
+
+const OPENAPI_CONTENT = JSON.stringify({
+  openapi: '3.1.0',
+  info: { title: 't', version: '1' },
+  paths: { '/pet': { get: { responses: { 200: { description: 'ok' } } } } }
+});
+
+const mockStore = configureStore({
+  reducer: {
+    app: (state = { preferences: {} }) => state
+  }
+});
+
+const renderSpecViewer = (props) => render(
+  <Provider store={mockStore}>
+    <SpecViewer content={OPENAPI_CONTENT} {...props} />
+  </Provider>
+);
+
+describe('SpecViewer $ref-resolution gating', () => {
+  beforeEach(() => {
+    swaggerSpecs.length = 0;
+    window.ipcRenderer = { invoke: jest.fn() };
+  });
+
+  test('does not mount Swagger until the main-process resolution call settles', async () => {
+    let resolveIpc;
+    window.ipcRenderer.invoke.mockReturnValue(new Promise((resolve) => { resolveIpc = resolve; }));
+
+    render(
+      <Provider store={mockStore}>
+        <SpecViewer content={OPENAPI_CONTENT} specFilePath="/collections/petstore.yaml" />
+      </Provider>
+    );
+
+    expect(swaggerSpecs).toHaveLength(0);
+
+    const resolvedSpec = { openapi: '3.1.0', paths: {} };
+    await act(async () => {
+      resolveIpc({ spec: resolvedSpec });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(swaggerSpecs).toHaveLength(1));
+    expect(swaggerSpecs[0]).toEqual(resolvedSpec);
+  });
+
+  test('falls back to raw content when the resolution call fails', async () => {
+    window.ipcRenderer.invoke.mockRejectedValue(new Error('boom'));
+
+    render(
+      <Provider store={mockStore}>
+        <SpecViewer content={OPENAPI_CONTENT} specFilePath="/collections/petstore.yaml" />
+      </Provider>
+    );
+
+    await waitFor(() => expect(swaggerSpecs).toHaveLength(1));
+    expect(swaggerSpecs[0]).toBe(OPENAPI_CONTENT);
+  });
+
+  test('renders raw content immediately when there is no spec file path', async () => {
+    renderSpecViewer({});
+
+    await waitFor(() => expect(swaggerSpecs).toHaveLength(1));
+    expect(swaggerSpecs[0]).toBe(OPENAPI_CONTENT);
+    expect(window.ipcRenderer.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-app/src/components/ApiSpecPanel/index.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/index.js
@@ -87,6 +87,7 @@ const ApiSpecPanel = () => {
       </div>
       <SpecViewer
         content={raw}
+        specFilePath={pathname}
         onSave={(content) => dispatch(saveApiSpecToFile({ uid, content }))}
         leftPaneWidth={leftPaneWidth ?? null}
         onLeftPaneWidthChange={handleLeftPaneWidthChange}

--- a/packages/bruno-app/src/pages/Bruno/index.js
+++ b/packages/bruno-app/src/pages/Bruno/index.js
@@ -10,6 +10,7 @@ import Sidebar from 'components/Sidebar';
 import StatusBar from 'components/StatusBar';
 import AppTitleBar from 'components/AppTitleBar';
 import ApiSpecPanel from 'components/ApiSpecPanel';
+import ApiSpecPanelErrorBoundary from 'components/ApiSpecPanel/ApiSpecPanelErrorBoundary';
 import TabPanelErrorBoundary from 'components/RequestTabPanel/TabPanelErrorBoundary';
 // import ErrorCapture from 'components/ErrorCapture';
 import { useSelector } from 'react-redux';
@@ -160,7 +161,9 @@ export default function Main() {
           <Sidebar />
           <section className="flex flex-grow flex-col overflow-hidden">
             {showApiSpecPage && activeApiSpecUid ? (
-              <ApiSpecPanel key={activeApiSpecUid} />
+              <ApiSpecPanelErrorBoundary key={activeApiSpecUid}>
+                <ApiSpecPanel key={activeApiSpecUid} />
+              </ApiSpecPanelErrorBoundary>
             ) : showManageWorkspacePage ? (
               <ManageWorkspace />
             ) : (

--- a/packages/bruno-electron/package.json
+++ b/packages/bruno-electron/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.15",
     "@ai-sdk/openai": "3.0.12",
+    "@apidevtools/json-schema-ref-parser": "^11.7.3",
     "@aws-sdk/credential-providers": "3.1019.0",
     "@grpc/grpc-js": "^1.13.2",
     "@grpc/proto-loader": "^0.7.13",

--- a/packages/bruno-electron/src/ipc/apiSpec.js
+++ b/packages/bruno-electron/src/ipc/apiSpec.js
@@ -6,6 +6,7 @@ const { removeApiSpecFromWorkspace } = require('../utils/workspace-config');
 const { getCertsAndProxyConfig } = require('./network/cert-utils');
 const { makeAxiosInstance } = require('./network/axios-instance');
 const { proxySwaggerFetch } = require('./swagger-fetch');
+const { resolveOpenApiSpecRefs } = require('./openapi-ref-resolver');
 const path = require('path');
 const fs = require('fs');
 
@@ -91,6 +92,10 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedApiSpecs) 
 
   ipcMain.handle('renderer:swagger-fetch', async (event, req) => {
     return proxySwaggerFetch(req);
+  });
+
+  ipcMain.handle('renderer:resolve-openapi-spec-refs', async (event, pathname) => {
+    return resolveOpenApiSpecRefs(pathname);
   });
 
   ipcMain.handle('renderer:ensure-apispec-folder', async (event, workspacePath) => {

--- a/packages/bruno-electron/src/ipc/openapi-ref-resolver.js
+++ b/packages/bruno-electron/src/ipc/openapi-ref-resolver.js
@@ -1,0 +1,118 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const jsyaml = require('js-yaml');
+const { dereference } = require('@apidevtools/json-schema-ref-parser');
+
+const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const arrayToJsonPointer = (tokens) => `/${tokens.map((t) => String(t).replace(/~/g, '~0').replace(/\//g, '~1')).join('/')}`;
+
+const collectIdsAndAnchors = (node, currentPath, currentId, idMap, anchorMap) => {
+  if (Array.isArray(node)) {
+    node.forEach((item, index) => collectIdsAndAnchors(item, [...currentPath, index], currentId, idMap, anchorMap));
+    return;
+  }
+  if (!isPlainObject(node)) return;
+
+  if (typeof node.$id === 'string') {
+    idMap.set(node.$id, currentPath);
+    currentId = node.$id;
+  }
+  if (typeof node.$anchor === 'string' && currentId) {
+    anchorMap.set(`${currentId}#${node.$anchor}`, currentPath);
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    collectIdsAndAnchors(value, [...currentPath, key], currentId, idMap, anchorMap);
+  }
+};
+
+const isRemoteUri = (value) => /^([a-z][a-z0-9+.-]*:)?\/\//i.test(value);
+
+const rewriteIdBasedRefs = (node, idMap, anchorMap) => {
+  if (Array.isArray(node)) {
+    return node.map((item) => rewriteIdBasedRefs(item, idMap, anchorMap));
+  }
+  if (!isPlainObject(node)) return node;
+
+  const result = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && typeof value === 'string' && !value.startsWith('#') && !isRemoteUri(value)) {
+      const hashIndex = value.indexOf('#');
+      const base = hashIndex === -1 ? value : value.slice(0, hashIndex);
+      const fragment = hashIndex === -1 ? null : value.slice(hashIndex + 1);
+
+      if (fragment == null && idMap.has(base)) {
+        result[key] = `#${arrayToJsonPointer(idMap.get(base))}`;
+        continue;
+      }
+      if (fragment != null && anchorMap.has(`${base}#${fragment}`)) {
+        result[key] = `#${arrayToJsonPointer(anchorMap.get(`${base}#${fragment}`))}`;
+        continue;
+      }
+    }
+    result[key] = rewriteIdBasedRefs(value, idMap, anchorMap);
+  }
+  return result;
+};
+
+const IDENTIFYING_SCHEMA_FIELDS = ['type', 'title', 'description'];
+
+const truncateCycles = (value, ancestors = new Set()) => {
+  if (value === null || typeof value !== 'object') return value;
+
+  if (ancestors.has(value)) {
+    if (Array.isArray(value)) return [];
+    const stub = {};
+    for (const field of IDENTIFYING_SCHEMA_FIELDS) {
+      if (typeof value[field] === 'string') stub[field] = value[field];
+    }
+    return stub;
+  }
+
+  const nextAncestors = new Set(ancestors);
+  nextAncestors.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => truncateCycles(item, nextAncestors));
+  }
+  const result = {};
+  for (const [key, val] of Object.entries(value)) {
+    result[key] = truncateCycles(val, nextAncestors);
+  }
+  return result;
+};
+
+const resolveOpenApiSpecRefs = async (pathname) => {
+  if (!pathname || !fs.existsSync(pathname)) {
+    return { error: 'Spec file not found' };
+  }
+
+  let normalizedPathname = pathname;
+  try {
+    const parsed = jsyaml.load(fs.readFileSync(pathname, 'utf8'));
+    const idMap = new Map();
+    const anchorMap = new Map();
+    collectIdsAndAnchors(parsed, [], null, idMap, anchorMap);
+
+    if (idMap.size > 0) {
+      normalizedPathname = path.join(
+        path.dirname(pathname),
+        `.bruno-openapi-resolve-${crypto.randomUUID()}.json`
+      );
+      fs.writeFileSync(normalizedPathname, JSON.stringify(rewriteIdBasedRefs(parsed, idMap, anchorMap)));
+    }
+
+    const spec = await dereference(normalizedPathname);
+    return { spec: truncateCycles(spec) };
+  } catch (error) {
+    return { error: error.message || 'Failed to resolve spec references' };
+  } finally {
+    if (normalizedPathname !== pathname) {
+      fs.rmSync(normalizedPathname, { force: true });
+    }
+  }
+};
+
+module.exports = { resolveOpenApiSpecRefs, truncateCycles, rewriteIdBasedRefs, collectIdsAndAnchors };

--- a/packages/bruno-electron/tests/openapi-ref-resolver.test.js
+++ b/packages/bruno-electron/tests/openapi-ref-resolver.test.js
@@ -1,0 +1,426 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { resolveOpenApiSpecRefs, truncateCycles, collectIdsAndAnchors, rewriteIdBasedRefs } = require('../src/ipc/openapi-ref-resolver');
+
+describe('collectIdsAndAnchors / rewriteIdBasedRefs', () => {
+  test('rewrites a $ref matching a same-document $id into a JSON pointer', () => {
+    const doc = {
+      components: {
+        schemas: {
+          Pet: { properties: { details: { $ref: '/api/v31/components/schemas/petdetails' } } },
+          PetDetails: { $id: '/api/v31/components/schemas/petdetails', type: 'object' }
+        }
+      }
+    };
+    const idMap = new Map();
+    const anchorMap = new Map();
+    collectIdsAndAnchors(doc, [], null, idMap, anchorMap);
+    const result = rewriteIdBasedRefs(doc, idMap, anchorMap);
+    expect(result.components.schemas.Pet.properties.details.$ref).toBe('#/components/schemas/PetDetails');
+  });
+
+  test('rewrites a $ref matching an $id + $anchor pair, scoped to the nearest $id', () => {
+    const doc = {
+      components: {
+        schemas: {
+          Pet: { petDetailsId: { $ref: '/api/v31/components/schemas/petdetails#pet_details_id' } },
+          PetDetails: {
+            $id: '/api/v31/components/schemas/petdetails',
+            properties: { id: { $anchor: 'pet_details_id', type: 'integer' } }
+          }
+        }
+      }
+    };
+    const idMap = new Map();
+    const anchorMap = new Map();
+    collectIdsAndAnchors(doc, [], null, idMap, anchorMap);
+    const result = rewriteIdBasedRefs(doc, idMap, anchorMap);
+    expect(result.components.schemas.Pet.petDetailsId.$ref).toBe('#/components/schemas/PetDetails/properties/id');
+  });
+
+  test('leaves a $ref alone when it does not match any known $id', () => {
+    const doc = { a: { $ref: '/some/unrelated/path' } };
+    const result = rewriteIdBasedRefs(doc, new Map(), new Map());
+    expect(result.a.$ref).toBe('/some/unrelated/path');
+  });
+
+  test('leaves plain JSON-pointer and remote-URL $refs untouched', () => {
+    const doc = {
+      a: { $ref: '#/components/schemas/Foo' },
+      b: { $ref: 'https://example.com/schema.json#/Foo' }
+    };
+    const result = rewriteIdBasedRefs(doc, new Map([['x', ['y']]]), new Map());
+    expect(result.a.$ref).toBe('#/components/schemas/Foo');
+    expect(result.b.$ref).toBe('https://example.com/schema.json#/Foo');
+  });
+});
+
+describe('truncateCycles', () => {
+  test('leaves non-circular data untouched', () => {
+    const input = { a: 1, b: [1, 2, { c: 'x' }], d: null };
+    expect(truncateCycles(input)).toEqual(input);
+  });
+
+  test('lets the same object appear at unrelated sibling locations without truncating it', () => {
+    const shared = { type: 'string' };
+    const input = { a: shared, b: shared };
+    const result = truncateCycles(input);
+    expect(result).toEqual({ a: { type: 'string' }, b: { type: 'string' } });
+  });
+
+  test('cuts off a direct self-reference with a finite stub', () => {
+    const node = { type: 'object', title: 'Self' };
+    node.self = node;
+    const result = truncateCycles(node);
+    expect(result.self).toEqual({ type: 'object', title: 'Self' });
+    expect(result.self.self).toBeUndefined();
+  });
+
+  test('cuts off a cycle that loops back through an array with an empty array, not {}', () => {
+    // A $ref with a sibling keyword (e.g. `{ $ref: '#/definitions/User', 'x-nullable': true }`)
+    // gets merged with its target's own keys during dereferencing. If that target is
+    // itself shaped like `{ allOf: [...] }`, the cyclic slot ends up being the array
+    // itself, not a plain object -- swagger-ui-react's own validation rejects
+    // `allOf: {}` outright ("allOf must be an array"), so the stub must stay an array.
+    const user = { allOf: [{ type: 'object' }] };
+    user.allOf.push({ type: 'object', properties: { manager: { 'x-nullable': true } } });
+    user.allOf[1].properties.manager.allOf = user.allOf;
+
+    const result = truncateCycles(user);
+    const truncatedAllOf = result.allOf[1].properties.manager.allOf;
+    expect(Array.isArray(truncatedAllOf)).toBe(true);
+    expect(truncatedAllOf).toEqual([]);
+  });
+
+  test('terminates on a deep, indirect cycle instead of recursing forever', () => {
+    const a = { type: 'object' };
+    const b = { type: 'object' };
+    a.b = b;
+    b.a = a;
+    const result = truncateCycles(a);
+    expect(result).toEqual({ type: 'object', b: { type: 'object', a: { type: 'object' } } });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+});
+
+describe('resolveOpenApiSpecRefs', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-openapi-ref-resolver-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3 });
+  });
+
+  test('returns an error when the spec file does not exist', async () => {
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'missing.yaml'));
+
+    expect(result.error).toBe('Spec file not found');
+    expect(result.spec).toBeUndefined();
+  });
+
+  test('returns an error when called with no pathname', async () => {
+    const result = await resolveOpenApiSpecRefs(undefined);
+
+    expect(result.error).toBe('Spec file not found');
+  });
+
+  test('resolves an external $ref against the spec file directory, not cwd', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'root.yaml'),
+      [
+        'openapi: 3.0.0',
+        'info:',
+        '  title: t',
+        '  version: \'1\'',
+        'paths:',
+        '  /foo:',
+        '    get:',
+        '      responses:',
+        '        \'200\':',
+        '          description: ok',
+        '          content:',
+        '            application/json:',
+        '              schema:',
+        '                $ref: \'./external.yaml#/User\''
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'external.yaml'),
+      ['User:', '  type: object', '  properties:', '    name:', '      type: string'].join('\n')
+    );
+
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'root.yaml'));
+
+    expect(result.error).toBeUndefined();
+    const schema = result.spec.paths['/foo'].get.responses['200'].content['application/json'].schema;
+    expect(schema.$ref).toBeUndefined();
+    expect(schema).toEqual({ type: 'object', properties: { name: { type: 'string' } } });
+  });
+
+  test('inlines an internal (same-document) $ref, leaving no $ref behind', async () => {
+    // This is the actual reported bug: swagger-ui-react's OpenAPI 3.1 resolver
+    // re-resolves refs lazily when a request is opened, and that pass fails on
+    // *any* unresolved $ref under a packaged app's file:// origin — including a
+    // same-document ref like '#/components/schemas/Pet'.
+    fs.writeFileSync(
+      path.join(tmpDir, 'petstore.yaml'),
+      [
+        'openapi: 3.1.0',
+        'paths:',
+        '  /pet:',
+        '    post:',
+        '      requestBody:',
+        '        content:',
+        '          application/json:',
+        '            schema:',
+        '              $ref: \'#/components/schemas/Pet\'',
+        'components:',
+        '  schemas:',
+        '    Pet:',
+        '      type: object',
+        '      properties:',
+        '        name:',
+        '          type: string'
+      ].join('\n')
+    );
+
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'petstore.yaml'));
+
+    expect(result.error).toBeUndefined();
+    const schema = result.spec.paths['/pet'].post.requestBody.content['application/json'].schema;
+    expect(schema.$ref).toBeUndefined();
+    expect(schema).toEqual({ type: 'object', properties: { name: { type: 'string' } } });
+  });
+
+  test('truncates a genuinely self-referential schema instead of leaving a $ref or crashing', async () => {
+    // A tree-shaped schema (Category with sub-Categories) can't be inlined without
+    // creating a real circular JS object, which breaks JSON serialization. But
+    // leaving a $ref for just that one schema isn't safe either -- any unresolved
+    // $ref, anywhere, re-triggers the exact resolver bug this module exists to
+    // avoid. So the cycle must be cut off with a finite, $ref-free stub instead.
+    fs.writeFileSync(
+      path.join(tmpDir, 'tree.yaml'),
+      [
+        'Category:',
+        '  type: object',
+        '  properties:',
+        '    subcategories:',
+        '      type: array',
+        '      items:',
+        '        $ref: \'#/Category\''
+      ].join('\n')
+    );
+
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'tree.yaml'));
+
+    expect(result.error).toBeUndefined();
+    expect(() => JSON.stringify(result.spec)).not.toThrow();
+    const truncated = result.spec.Category.properties.subcategories.items;
+    expect(truncated.$ref).toBeUndefined();
+    expect(truncated).toEqual({ type: 'object' });
+  });
+
+  test('keeps allOf an array when a $ref-with-sibling cycle loops back through it', async () => {
+    // Real Swagger 2.0 pattern: a nullable circular self-reference is written as
+    // `$ref` plus a sibling vendor extension (`x-nullable`), and the referenced
+    // schema (User) is itself defined as `allOf: [...]`.
+    fs.writeFileSync(
+      path.join(tmpDir, 'nullable-cycle.yaml'),
+      [
+        'User:',
+        '  allOf:',
+        '    - type: object',
+        '    - type: object',
+        '      properties:',
+        '        manager:',
+        '          $ref: \'#/User\'',
+        '          x-nullable: true'
+      ].join('\n')
+    );
+
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'nullable-cycle.yaml'));
+
+    expect(result.error).toBeUndefined();
+    expect(() => JSON.stringify(result.spec)).not.toThrow();
+    const manager = result.spec.User.allOf[1].properties.manager;
+    expect(manager['x-nullable']).toBe(true);
+    expect(Array.isArray(manager.allOf)).toBe(true);
+  });
+
+  test('resolves discriminator/oneOf polymorphism, a parameter $ref with a sibling override, and additionalProperties $ref', async () => {
+    // A broader proactive sweep, not a reported bug -- covers three common
+    // real-world patterns (Stripe/GitHub-style polymorphism, parameter reuse
+    // with per-use overrides, and a $ref as a map's value type) that hadn't
+    // been exercised by any prior fixture in this file.
+    fs.writeFileSync(
+      path.join(tmpDir, 'discriminator.yaml'),
+      [
+        'openapi: 3.0.3',
+        'paths:',
+        '  /pets:',
+        '    get:',
+        '      parameters:',
+        '        - $ref: \'#/components/parameters/LimitParam\'',
+        '          description: Overridden via sibling on a parameter $ref',
+        '      responses:',
+        '        \'200\':',
+        '          description: ok',
+        '          content:',
+        '            application/json:',
+        '              schema:',
+        '                $ref: \'#/components/schemas/Pet\'',
+        'components:',
+        '  parameters:',
+        '    LimitParam:',
+        '      name: limit',
+        '      in: query',
+        '      schema:',
+        '        type: integer',
+        '  schemas:',
+        '    Pet:',
+        '      oneOf:',
+        '        - $ref: \'#/components/schemas/Cat\'',
+        '        - $ref: \'#/components/schemas/Dog\'',
+        '      discriminator:',
+        '        propertyName: petType',
+        '    Cat:',
+        '      type: object',
+        '      properties:',
+        '        toy:',
+        '          $ref: \'#/components/schemas/Toy\'',
+        '    Dog:',
+        '      type: object',
+        '    Toy:',
+        '      type: object',
+        '      additionalProperties:',
+        '        $ref: \'#/components/schemas/ToyAttribute\'',
+        '    ToyAttribute:',
+        '      type: string'
+      ].join('\n')
+    );
+
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'discriminator.yaml'));
+
+    expect(result.error).toBeUndefined();
+    expect(JSON.stringify(result.spec)).not.toMatch(/"\$ref"/);
+    const param = result.spec.paths['/pets'].get.parameters[0];
+    expect(param.description).toBe('Overridden via sibling on a parameter $ref');
+    expect(param.name).toBe('limit');
+    const pet = result.spec.components.schemas.Pet;
+    expect(pet.discriminator).toEqual({ propertyName: 'petType' });
+    expect(pet.oneOf[0].properties.toy.additionalProperties).toEqual({ type: 'string' });
+  });
+
+  test('truncates a circular external $ref instead of leaving a $ref or hanging', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'a.yaml'),
+      ['A:', '  type: object', '  properties:', '    b:', '      $ref: \'./b.yaml#/B\''].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'b.yaml'),
+      ['B:', '  type: object', '  properties:', '    a:', '      $ref: \'./a.yaml#/A\''].join('\n')
+    );
+
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'a.yaml'));
+
+    expect(result.error).toBeUndefined();
+    expect(() => JSON.stringify(result.spec)).not.toThrow();
+    const truncated = result.spec.A.properties.b.properties.a;
+    expect(truncated.$ref).toBeUndefined();
+    expect(truncated).toEqual({ type: 'object' });
+  });
+
+  test('resolves $id/$anchor-based refs (the real Swagger Petstore 3.1 sample pattern)', async () => {
+    // @apidevtools/json-schema-ref-parser only understands plain JSON pointers
+    // and http(s)/file URLs -- an $id-style $ref like this one gets treated as
+    // a filesystem path, throws ENOENT, and previously aborted resolving the
+    // *entire* document (breaking even plain #/... refs elsewhere in the spec).
+    fs.writeFileSync(
+      path.join(tmpDir, 'petstore-3.1.json'),
+      JSON.stringify({
+        openapi: '3.1.0',
+        paths: {
+          '/pet': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      properties: {
+                        petDetailsId: { $ref: '/api/v31/components/schemas/petdetails#pet_details_id' },
+                        petDetails: { $ref: '/api/v31/components/schemas/petdetails' }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        components: {
+          schemas: {
+            PetDetails: {
+              $id: '/api/v31/components/schemas/petdetails',
+              type: 'object',
+              properties: {
+                id: { $anchor: 'pet_details_id', type: 'integer' }
+              }
+            }
+          }
+        }
+      })
+    );
+
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'petstore-3.1.json'));
+
+    expect(result.error).toBeUndefined();
+    expect(JSON.stringify(result.spec)).not.toMatch(/"\$ref"/);
+    const schema = result.spec.paths['/pet'].post.requestBody.content['application/json'].schema;
+    expect(schema.properties.petDetails).toEqual(result.spec.components.schemas.PetDetails);
+    expect(schema.properties.petDetailsId).toEqual({ $anchor: 'pet_details_id', type: 'integer' });
+  });
+
+  test('does not leave a temp rewrite file behind after resolving $id-based refs', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'with-id.json'),
+      JSON.stringify({
+        a: { $ref: '/x' },
+        b: { $id: '/x', type: 'string' }
+      })
+    );
+
+    await resolveOpenApiSpecRefs(path.join(tmpDir, 'with-id.json'));
+
+    const leftoverFiles = fs.readdirSync(tmpDir).filter((f) => f.startsWith('.bruno-openapi-resolve-'));
+    expect(leftoverFiles).toEqual([]);
+  });
+
+  test('returns an error when an external $ref points at a missing file', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'broken.yaml'),
+      [
+        'openapi: 3.0.0',
+        'paths:',
+        '  /x:',
+        '    get:',
+        '      responses:',
+        '        \'200\':',
+        '          description: ok',
+        '          content:',
+        '            application/json:',
+        '              schema:',
+        '                $ref: \'./does-not-exist.yaml#/Foo\''
+      ].join('\n')
+    );
+
+    const result = await resolveOpenApiSpecRefs(path.join(tmpDir, 'broken.yaml'));
+
+    expect(result.spec).toBeUndefined();
+    expect(result.error).toMatch(/does-not-exist\.yaml/);
+  });
+});


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI previews now resolve internal and external `$ref` references for more complete documentation rendering.
  * Added graceful error handling for API specification previews, including an option to close the affected view.

* **Bug Fixes**
  * Preview rendering now falls back to the original specification if reference resolution fails.
  * Circular references are safely handled to prevent rendering failures.

* **Tests**
  * Added coverage for reference resolution, circular schemas, anchors, external files, fallbacks, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->