### PR TITLE
task (migration) : hiding migration options and the respective test

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Overview/Info/index.js
@@ -175,7 +175,7 @@ const Info = ({ collection }) => {
           </div>
           {showGenerateDocumentationModal && <GenerateDocumentation collectionUid={collection.uid} onClose={() => setShowGenerateDocumentationModal(false)} />}
 
-          <Migration collection={collection} />
+          {/* <Migration collection={collection} /> */}
         </div>
       </div>
     </StyledWrapper>

--- a/packages/bruno-app/src/components/RequestTabs/CollectionHeader/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionHeader/index.js
@@ -714,7 +714,7 @@ const CollectionHeader = ({ collection, isScratchCollection }) => {
                   </ActionIcon>
                 </ToolHint>
               )}
-              {collection.format === 'bru' && !migratePillDismissed && (
+              {/* {collection.format === 'bru' && !migratePillDismissed && (
                 <div
                   className="migrate-yml-pill"
                   data-testid="migrate-yml-pill"
@@ -738,7 +738,7 @@ const CollectionHeader = ({ collection, isScratchCollection }) => {
                     <IconX size={12} strokeWidth={2} />
                   </button>
                 </div>
-              )}
+              )} */}
               {/* OpenAPI Sync - standalone only when configured and beta enabled */}
               {hasOpenApiSyncConfigured && (
                 <ToolHint

--- a/tests/collection/migrate-to-yml-nested-multi/migrate-to-yml-nested-multi.spec.ts
+++ b/tests/collection/migrate-to-yml-nested-multi/migrate-to-yml-nested-multi.spec.ts
@@ -1,85 +1,85 @@
-// import fs from 'fs';
-// import path from 'path';
-// import { test, expect } from '../../../playwright';
-// import { closeAllCollections, openCollection, buildCommonLocators } from '../../utils/page';
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, openCollection, buildCommonLocators } from '../../utils/page';
 
-// test.describe('Migrating one collection to yml preserves nested tabs & expanded folders and leaves other collections untouched', () => {
-//   test.afterAll(async ({ page }) => {
-//     await closeAllCollections(page);
-//   });
+test.describe.skip('Migrating one collection to yml preserves nested tabs & expanded folders and leaves other collections untouched', () => {
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
 
-//   test('nested tabs stay open, nested folders stay expanded, other collection is untouched', async ({ pageWithUserData: page, collectionFixturePath }) => {
-//     const collectionPath = collectionFixturePath!;
-//     const loc = buildCommonLocators(page);
+  test('nested tabs stay open, nested folders stay expanded, other collection is untouched', async ({ pageWithUserData: page, collectionFixturePath }) => {
+    const collectionPath = collectionFixturePath!;
+    const loc = buildCommonLocators(page);
 
-//     const pageErrors: Error[] = [];
-//     page.on('pageerror', (error) => pageErrors.push(error));
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
 
-//     await test.step('Both collections are open', async () => {
-//       await expect(loc.sidebar.collection('migrate-source')).toBeVisible({ timeout: 15000 });
-//       await expect(loc.sidebar.collection('keep-open')).toBeVisible();
-//     });
+    await test.step('Both collections are open', async () => {
+      await expect(loc.sidebar.collection('migrate-source')).toBeVisible({ timeout: 15000 });
+      await expect(loc.sidebar.collection('keep-open')).toBeVisible();
+    });
 
-//     await test.step('Expand nested folders and open nested requests as permanent tabs in the source collection', async () => {
-//       await openCollection(page, 'migrate-source');
-//       await loc.folder.chevron('api').click();
-//       await loc.folder.chevron('v2').click();
+    await test.step('Expand nested folders and open nested requests as permanent tabs in the source collection', async () => {
+      await openCollection(page, 'migrate-source');
+      await loc.folder.chevron('api').click();
+      await loc.folder.chevron('v2').click();
 
-//       await loc.sidebar.request('root-req').dblclick();
-//       await loc.sidebar.request('users').dblclick();
-//       await loc.sidebar.request('deep').dblclick();
+      await loc.sidebar.request('root-req').dblclick();
+      await loc.sidebar.request('users').dblclick();
+      await loc.sidebar.request('deep').dblclick();
 
-//       await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/api/v2/deep');
-//     });
+      await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/api/v2/deep');
+    });
 
-//     await test.step('Open a request tab in the other collection', async () => {
-//       await openCollection(page, 'keep-open');
-//       await loc.sidebar.request('Keep Me').dblclick();
-//       await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/keep');
-//     });
+    await test.step('Open a request tab in the other collection', async () => {
+      await openCollection(page, 'keep-open');
+      await loc.sidebar.request('Keep Me').dblclick();
+      await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/keep');
+    });
 
-//     await test.step('Migrate the source collection to yml', async () => {
-//       await loc.sidebar.collection('migrate-source').click();
-//       await page.getByTestId('collection-settings-tab-overview').click();
-//       await page.getByRole('button', { name: 'Convert to YML' }).click();
+    await test.step('Migrate the source collection to yml', async () => {
+      await loc.sidebar.collection('migrate-source').click();
+      await page.getByTestId('collection-settings-tab-overview').click();
+      await page.getByRole('button', { name: 'Convert to YML' }).click();
 
-//       const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
-//       await modal.waitFor({ state: 'visible', timeout: 5000 });
-//       await modal.getByRole('button', { name: 'Migrate' }).click();
+      const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
+      await modal.waitFor({ state: 'visible', timeout: 5000 });
+      await modal.getByRole('button', { name: 'Migrate' }).click();
 
-//       await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
-//     });
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
 
-//     await test.step('Files migrated on disk, including the deeply nested request', async () => {
-//       expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'v2', 'deep.yml'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'v2', 'deep.bru'))).toBe(false);
-//       expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'users.yml'))).toBe(true);
-//     });
+    await test.step('Files migrated on disk, including the deeply nested request', async () => {
+      expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'v2', 'deep.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'v2', 'deep.bru'))).toBe(false);
+      expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'users.yml'))).toBe(true);
+    });
 
-//     await test.step('All nested request tabs stay open (no "Request no longer exists")', async () => {
-//       await expect(page.getByText('Request no longer exists')).not.toBeVisible();
+    await test.step('All nested request tabs stay open (no "Request no longer exists")', async () => {
+      await expect(page.getByText('Request no longer exists')).not.toBeVisible();
 
-//       for (const name of ['root-req', 'users', 'deep']) {
-//         await expect(page.locator('.request-tab .tab-label').filter({ hasText: name })).toBeVisible({ timeout: 15000 });
-//       }
-//     });
+      for (const name of ['root-req', 'users', 'deep']) {
+        await expect(page.locator('.request-tab .tab-label').filter({ hasText: name })).toBeVisible({ timeout: 15000 });
+      }
+    });
 
-//     await test.step('A migrated tab resolves to a real request (not a broken not-found tab)', async () => {
-//       await page.locator('.request-tab').filter({ hasText: 'deep' }).click({ force: true });
-//       await expect(page.getByText('Request no longer exists')).not.toBeVisible();
-//       await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/api/v2/deep');
-//     });
+    await test.step('A migrated tab resolves to a real request (not a broken not-found tab)', async () => {
+      await page.locator('.request-tab').filter({ hasText: 'deep' }).click({ force: true });
+      await expect(page.getByText('Request no longer exists')).not.toBeVisible();
+      await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/api/v2/deep');
+    });
 
-//     await test.step('Nested folders remain expanded (nested request rows still visible in the tree)', async () => {
-//       await expect(loc.sidebar.request('users')).toBeVisible();
-//       await expect(loc.sidebar.request('deep')).toBeVisible();
-//     });
+    await test.step('Nested folders remain expanded (nested request rows still visible in the tree)', async () => {
+      await expect(loc.sidebar.request('users')).toBeVisible();
+      await expect(loc.sidebar.request('deep')).toBeVisible();
+    });
 
-//     await test.step('The other collection tab is untouched by the migration', async () => {
-//       await loc.sidebar.collection('keep-open').click();
-//       await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'Keep Me' })).toBeVisible();
-//     });
+    await test.step('The other collection tab is untouched by the migration', async () => {
+      await loc.sidebar.collection('keep-open').click();
+      await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'Keep Me' })).toBeVisible();
+    });
 
-//     expect(pageErrors).toHaveLength(0);
-//   });
-// });
+    expect(pageErrors).toHaveLength(0);
+  });
+});

--- a/tests/collection/migrate-to-yml-nested-multi/migrate-to-yml-nested-multi.spec.ts
+++ b/tests/collection/migrate-to-yml-nested-multi/migrate-to-yml-nested-multi.spec.ts
@@ -1,85 +1,85 @@
-import fs from 'fs';
-import path from 'path';
-import { test, expect } from '../../../playwright';
-import { closeAllCollections, openCollection, buildCommonLocators } from '../../utils/page';
+// import fs from 'fs';
+// import path from 'path';
+// import { test, expect } from '../../../playwright';
+// import { closeAllCollections, openCollection, buildCommonLocators } from '../../utils/page';
 
-test.describe('Migrating one collection to yml preserves nested tabs & expanded folders and leaves other collections untouched', () => {
-  test.afterAll(async ({ page }) => {
-    await closeAllCollections(page);
-  });
+// test.describe('Migrating one collection to yml preserves nested tabs & expanded folders and leaves other collections untouched', () => {
+//   test.afterAll(async ({ page }) => {
+//     await closeAllCollections(page);
+//   });
 
-  test('nested tabs stay open, nested folders stay expanded, other collection is untouched', async ({ pageWithUserData: page, collectionFixturePath }) => {
-    const collectionPath = collectionFixturePath!;
-    const loc = buildCommonLocators(page);
+//   test('nested tabs stay open, nested folders stay expanded, other collection is untouched', async ({ pageWithUserData: page, collectionFixturePath }) => {
+//     const collectionPath = collectionFixturePath!;
+//     const loc = buildCommonLocators(page);
 
-    const pageErrors: Error[] = [];
-    page.on('pageerror', (error) => pageErrors.push(error));
+//     const pageErrors: Error[] = [];
+//     page.on('pageerror', (error) => pageErrors.push(error));
 
-    await test.step('Both collections are open', async () => {
-      await expect(loc.sidebar.collection('migrate-source')).toBeVisible({ timeout: 15000 });
-      await expect(loc.sidebar.collection('keep-open')).toBeVisible();
-    });
+//     await test.step('Both collections are open', async () => {
+//       await expect(loc.sidebar.collection('migrate-source')).toBeVisible({ timeout: 15000 });
+//       await expect(loc.sidebar.collection('keep-open')).toBeVisible();
+//     });
 
-    await test.step('Expand nested folders and open nested requests as permanent tabs in the source collection', async () => {
-      await openCollection(page, 'migrate-source');
-      await loc.folder.chevron('api').click();
-      await loc.folder.chevron('v2').click();
+//     await test.step('Expand nested folders and open nested requests as permanent tabs in the source collection', async () => {
+//       await openCollection(page, 'migrate-source');
+//       await loc.folder.chevron('api').click();
+//       await loc.folder.chevron('v2').click();
 
-      await loc.sidebar.request('root-req').dblclick();
-      await loc.sidebar.request('users').dblclick();
-      await loc.sidebar.request('deep').dblclick();
+//       await loc.sidebar.request('root-req').dblclick();
+//       await loc.sidebar.request('users').dblclick();
+//       await loc.sidebar.request('deep').dblclick();
 
-      await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/api/v2/deep');
-    });
+//       await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/api/v2/deep');
+//     });
 
-    await test.step('Open a request tab in the other collection', async () => {
-      await openCollection(page, 'keep-open');
-      await loc.sidebar.request('Keep Me').dblclick();
-      await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/keep');
-    });
+//     await test.step('Open a request tab in the other collection', async () => {
+//       await openCollection(page, 'keep-open');
+//       await loc.sidebar.request('Keep Me').dblclick();
+//       await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/keep');
+//     });
 
-    await test.step('Migrate the source collection to yml', async () => {
-      await loc.sidebar.collection('migrate-source').click();
-      await page.getByTestId('collection-settings-tab-overview').click();
-      await page.getByRole('button', { name: 'Convert to YML' }).click();
+//     await test.step('Migrate the source collection to yml', async () => {
+//       await loc.sidebar.collection('migrate-source').click();
+//       await page.getByTestId('collection-settings-tab-overview').click();
+//       await page.getByRole('button', { name: 'Convert to YML' }).click();
 
-      const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
-      await modal.waitFor({ state: 'visible', timeout: 5000 });
-      await modal.getByRole('button', { name: 'Migrate' }).click();
+//       const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
+//       await modal.waitFor({ state: 'visible', timeout: 5000 });
+//       await modal.getByRole('button', { name: 'Migrate' }).click();
 
-      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
-    });
+//       await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+//     });
 
-    await test.step('Files migrated on disk, including the deeply nested request', async () => {
-      expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'v2', 'deep.yml'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'v2', 'deep.bru'))).toBe(false);
-      expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'users.yml'))).toBe(true);
-    });
+//     await test.step('Files migrated on disk, including the deeply nested request', async () => {
+//       expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'v2', 'deep.yml'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'v2', 'deep.bru'))).toBe(false);
+//       expect(fs.existsSync(path.join(collectionPath, 'source-collection', 'api', 'users.yml'))).toBe(true);
+//     });
 
-    await test.step('All nested request tabs stay open (no "Request no longer exists")', async () => {
-      await expect(page.getByText('Request no longer exists')).not.toBeVisible();
+//     await test.step('All nested request tabs stay open (no "Request no longer exists")', async () => {
+//       await expect(page.getByText('Request no longer exists')).not.toBeVisible();
 
-      for (const name of ['root-req', 'users', 'deep']) {
-        await expect(page.locator('.request-tab .tab-label').filter({ hasText: name })).toBeVisible({ timeout: 15000 });
-      }
-    });
+//       for (const name of ['root-req', 'users', 'deep']) {
+//         await expect(page.locator('.request-tab .tab-label').filter({ hasText: name })).toBeVisible({ timeout: 15000 });
+//       }
+//     });
 
-    await test.step('A migrated tab resolves to a real request (not a broken not-found tab)', async () => {
-      await page.locator('.request-tab').filter({ hasText: 'deep' }).click({ force: true });
-      await expect(page.getByText('Request no longer exists')).not.toBeVisible();
-      await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/api/v2/deep');
-    });
+//     await test.step('A migrated tab resolves to a real request (not a broken not-found tab)', async () => {
+//       await page.locator('.request-tab').filter({ hasText: 'deep' }).click({ force: true });
+//       await expect(page.getByText('Request no longer exists')).not.toBeVisible();
+//       await expect(page.locator('#request-url').locator('.CodeMirror')).toContainText('/api/v2/deep');
+//     });
 
-    await test.step('Nested folders remain expanded (nested request rows still visible in the tree)', async () => {
-      await expect(loc.sidebar.request('users')).toBeVisible();
-      await expect(loc.sidebar.request('deep')).toBeVisible();
-    });
+//     await test.step('Nested folders remain expanded (nested request rows still visible in the tree)', async () => {
+//       await expect(loc.sidebar.request('users')).toBeVisible();
+//       await expect(loc.sidebar.request('deep')).toBeVisible();
+//     });
 
-    await test.step('The other collection tab is untouched by the migration', async () => {
-      await loc.sidebar.collection('keep-open').click();
-      await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'Keep Me' })).toBeVisible();
-    });
+//     await test.step('The other collection tab is untouched by the migration', async () => {
+//       await loc.sidebar.collection('keep-open').click();
+//       await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'Keep Me' })).toBeVisible();
+//     });
 
-    expect(pageErrors).toHaveLength(0);
-  });
-});
+//     expect(pageErrors).toHaveLength(0);
+//   });
+// });

--- a/tests/collection/migrate-to-yml/keep-request-tab-open.spec.ts
+++ b/tests/collection/migrate-to-yml/keep-request-tab-open.spec.ts
@@ -1,67 +1,67 @@
-// import fs from 'fs';
-// import path from 'path';
-// import { test, expect } from '../../../playwright';
-// import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
 
-// test.describe('Migrate collection from bru to yml format — keep open request tab', () => {
-//   test.afterAll(async ({ page }) => {
-//     await closeAllCollections(page);
-//   });
+test.describe.skip('Migrate collection from bru to yml format — keep open request tab', () => {
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
 
-//   test('should keep a request tab open during migration functional (no "Request no longer exists")', async ({ pageWithUserData: page, collectionFixturePath }) => {
-//     const collectionPath = collectionFixturePath!;
+  test('should keep a request tab open during migration functional (no "Request no longer exists")', async ({ pageWithUserData: page, collectionFixturePath }) => {
+    const collectionPath = collectionFixturePath!;
 
-//     const pageErrors: Error[] = [];
-//     page.on('pageerror', (error) => pageErrors.push(error));
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
 
-//     await test.step('Open the ping request as a permanent tab', async () => {
-//       await openCollection(page, 'migration-test');
-//       await page.locator('.item-name').filter({ hasText: 'ping' }).dblclick();
+    await test.step('Open the ping request as a permanent tab', async () => {
+      await openCollection(page, 'migration-test');
+      await page.locator('.item-name').filter({ hasText: 'ping' }).dblclick();
 
-//       const urlContainer = page.locator('#request-url');
-//       await expect(urlContainer).toBeVisible();
-//       await expect(urlContainer.locator('.CodeMirror')).toContainText('/ping');
-//     });
+      const urlContainer = page.locator('#request-url');
+      await expect(urlContainer).toBeVisible();
+      await expect(urlContainer.locator('.CodeMirror')).toContainText('/ping');
+    });
 
-//     await test.step('Migrate the collection to yml', async () => {
-//       await page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' }).click();
+    await test.step('Migrate the collection to yml', async () => {
+      await page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' }).click();
 
-//       const overviewTab = page.getByTestId('collection-settings-tab-overview');
-//       await expect(overviewTab).toBeVisible();
-//       await overviewTab.click();
+      const overviewTab = page.getByTestId('collection-settings-tab-overview');
+      await expect(overviewTab).toBeVisible();
+      await overviewTab.click();
 
-//       const convertButton = page.getByRole('button', { name: 'Convert to YML' });
-//       await expect(convertButton).toBeVisible();
-//       await convertButton.click();
+      const convertButton = page.getByRole('button', { name: 'Convert to YML' });
+      await expect(convertButton).toBeVisible();
+      await convertButton.click();
 
-//       const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
-//       await modal.waitFor({ state: 'visible', timeout: 5000 });
-//       await modal.getByRole('button', { name: 'Migrate' }).click();
+      const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
+      await modal.waitFor({ state: 'visible', timeout: 5000 });
+      await modal.getByRole('button', { name: 'Migrate' }).click();
 
-//       await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
-//     });
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
 
-//     await test.step('The migrated files exist on disk', async () => {
-//       expect(fs.existsSync(path.join(collectionPath, 'ping.yml'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(false);
-//     });
+    await test.step('The migrated files exist on disk', async () => {
+      expect(fs.existsSync(path.join(collectionPath, 'ping.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(false);
+    });
 
-//     await test.step('The ping tab stays open and resolves to the yml request (no "Request no longer exists")', async () => {
-//       await expect(page.getByText('Request no longer exists')).not.toBeVisible();
+    await test.step('The ping tab stays open and resolves to the yml request (no "Request no longer exists")', async () => {
+      await expect(page.getByText('Request no longer exists')).not.toBeVisible();
 
-//       const pingTab = page.locator('.request-tab .tab-label').filter({ hasText: 'ping' });
-//       await expect(pingTab).toBeVisible({ timeout: 15000 });
-//       await page.locator('.request-tab').filter({ hasText: 'ping' }).click({ force: true });
+      const pingTab = page.locator('.request-tab .tab-label').filter({ hasText: 'ping' });
+      await expect(pingTab).toBeVisible({ timeout: 15000 });
+      await page.locator('.request-tab').filter({ hasText: 'ping' }).click({ force: true });
 
-//       await expect(page.getByText('Request no longer exists')).not.toBeVisible();
-//       const urlContainer = page.locator('#request-url');
-//       await expect(urlContainer).toBeVisible();
-//       await expect(urlContainer.locator('.CodeMirror')).toContainText('/ping');
+      await expect(page.getByText('Request no longer exists')).not.toBeVisible();
+      const urlContainer = page.locator('#request-url');
+      await expect(urlContainer).toBeVisible();
+      await expect(urlContainer.locator('.CodeMirror')).toContainText('/ping');
 
-//       await selectEnvironment(page, 'Local');
-//       await sendRequestAndWaitForResponse(page, 200);
-//     });
+      await selectEnvironment(page, 'Local');
+      await sendRequestAndWaitForResponse(page, 200);
+    });
 
-//     expect(pageErrors).toHaveLength(0);
-//   });
-// });
+    expect(pageErrors).toHaveLength(0);
+  });
+});

--- a/tests/collection/migrate-to-yml/keep-request-tab-open.spec.ts
+++ b/tests/collection/migrate-to-yml/keep-request-tab-open.spec.ts
@@ -1,67 +1,67 @@
-import fs from 'fs';
-import path from 'path';
-import { test, expect } from '../../../playwright';
-import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
+// import fs from 'fs';
+// import path from 'path';
+// import { test, expect } from '../../../playwright';
+// import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
 
-test.describe('Migrate collection from bru to yml format — keep open request tab', () => {
-  test.afterAll(async ({ page }) => {
-    await closeAllCollections(page);
-  });
+// test.describe('Migrate collection from bru to yml format — keep open request tab', () => {
+//   test.afterAll(async ({ page }) => {
+//     await closeAllCollections(page);
+//   });
 
-  test('should keep a request tab open during migration functional (no "Request no longer exists")', async ({ pageWithUserData: page, collectionFixturePath }) => {
-    const collectionPath = collectionFixturePath!;
+//   test('should keep a request tab open during migration functional (no "Request no longer exists")', async ({ pageWithUserData: page, collectionFixturePath }) => {
+//     const collectionPath = collectionFixturePath!;
 
-    const pageErrors: Error[] = [];
-    page.on('pageerror', (error) => pageErrors.push(error));
+//     const pageErrors: Error[] = [];
+//     page.on('pageerror', (error) => pageErrors.push(error));
 
-    await test.step('Open the ping request as a permanent tab', async () => {
-      await openCollection(page, 'migration-test');
-      await page.locator('.item-name').filter({ hasText: 'ping' }).dblclick();
+//     await test.step('Open the ping request as a permanent tab', async () => {
+//       await openCollection(page, 'migration-test');
+//       await page.locator('.item-name').filter({ hasText: 'ping' }).dblclick();
 
-      const urlContainer = page.locator('#request-url');
-      await expect(urlContainer).toBeVisible();
-      await expect(urlContainer.locator('.CodeMirror')).toContainText('/ping');
-    });
+//       const urlContainer = page.locator('#request-url');
+//       await expect(urlContainer).toBeVisible();
+//       await expect(urlContainer.locator('.CodeMirror')).toContainText('/ping');
+//     });
 
-    await test.step('Migrate the collection to yml', async () => {
-      await page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' }).click();
+//     await test.step('Migrate the collection to yml', async () => {
+//       await page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' }).click();
 
-      const overviewTab = page.getByTestId('collection-settings-tab-overview');
-      await expect(overviewTab).toBeVisible();
-      await overviewTab.click();
+//       const overviewTab = page.getByTestId('collection-settings-tab-overview');
+//       await expect(overviewTab).toBeVisible();
+//       await overviewTab.click();
 
-      const convertButton = page.getByRole('button', { name: 'Convert to YML' });
-      await expect(convertButton).toBeVisible();
-      await convertButton.click();
+//       const convertButton = page.getByRole('button', { name: 'Convert to YML' });
+//       await expect(convertButton).toBeVisible();
+//       await convertButton.click();
 
-      const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
-      await modal.waitFor({ state: 'visible', timeout: 5000 });
-      await modal.getByRole('button', { name: 'Migrate' }).click();
+//       const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
+//       await modal.waitFor({ state: 'visible', timeout: 5000 });
+//       await modal.getByRole('button', { name: 'Migrate' }).click();
 
-      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
-    });
+//       await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+//     });
 
-    await test.step('The migrated files exist on disk', async () => {
-      expect(fs.existsSync(path.join(collectionPath, 'ping.yml'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(false);
-    });
+//     await test.step('The migrated files exist on disk', async () => {
+//       expect(fs.existsSync(path.join(collectionPath, 'ping.yml'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(false);
+//     });
 
-    await test.step('The ping tab stays open and resolves to the yml request (no "Request no longer exists")', async () => {
-      await expect(page.getByText('Request no longer exists')).not.toBeVisible();
+//     await test.step('The ping tab stays open and resolves to the yml request (no "Request no longer exists")', async () => {
+//       await expect(page.getByText('Request no longer exists')).not.toBeVisible();
 
-      const pingTab = page.locator('.request-tab .tab-label').filter({ hasText: 'ping' });
-      await expect(pingTab).toBeVisible({ timeout: 15000 });
-      await page.locator('.request-tab').filter({ hasText: 'ping' }).click({ force: true });
+//       const pingTab = page.locator('.request-tab .tab-label').filter({ hasText: 'ping' });
+//       await expect(pingTab).toBeVisible({ timeout: 15000 });
+//       await page.locator('.request-tab').filter({ hasText: 'ping' }).click({ force: true });
 
-      await expect(page.getByText('Request no longer exists')).not.toBeVisible();
-      const urlContainer = page.locator('#request-url');
-      await expect(urlContainer).toBeVisible();
-      await expect(urlContainer.locator('.CodeMirror')).toContainText('/ping');
+//       await expect(page.getByText('Request no longer exists')).not.toBeVisible();
+//       const urlContainer = page.locator('#request-url');
+//       await expect(urlContainer).toBeVisible();
+//       await expect(urlContainer.locator('.CodeMirror')).toContainText('/ping');
 
-      await selectEnvironment(page, 'Local');
-      await sendRequestAndWaitForResponse(page, 200);
-    });
+//       await selectEnvironment(page, 'Local');
+//       await sendRequestAndWaitForResponse(page, 200);
+//     });
 
-    expect(pageErrors).toHaveLength(0);
-  });
-});
+//     expect(pageErrors).toHaveLength(0);
+//   });
+// });

--- a/tests/collection/migrate-to-yml/migrate-to-yml-pill.spec.ts
+++ b/tests/collection/migrate-to-yml/migrate-to-yml-pill.spec.ts
@@ -1,80 +1,80 @@
-import { test, expect } from '../../../playwright';
-import { closeAllCollections, openCollection } from '../../utils/page';
+// import { test, expect } from '../../../playwright';
+// import { closeAllCollections, openCollection } from '../../utils/page';
 
-const DISMISSED_LOCAL_STORAGE_KEY = 'bruno.migrateToYmlPill.dismissed';
+// const DISMISSED_LOCAL_STORAGE_KEY = 'bruno.migrateToYmlPill.dismissed';
 
-test.describe('Migrate-to-YML pill in collection toolbar', () => {
-  test.afterAll(async ({ page }) => {
-    await closeAllCollections(page);
-  });
+// test.describe('Migrate-to-YML pill in collection toolbar', () => {
+//   test.afterAll(async ({ page }) => {
+//     await closeAllCollections(page);
+//   });
 
-  test('should show the pill for bru collections, open settings on click, and persist dismissal', async ({
-    pageWithUserData: page,
-    collectionFixturePath
-  }) => {
-    const collectionPath = collectionFixturePath!;
+//   test('should show the pill for bru collections, open settings on click, and persist dismissal', async ({
+//     pageWithUserData: page,
+//     collectionFixturePath
+//   }) => {
+//     const collectionPath = collectionFixturePath!;
 
-    const pageErrors: Error[] = [];
-    page.on('pageerror', (error) => pageErrors.push(error));
+//     const pageErrors: Error[] = [];
+//     page.on('pageerror', (error) => pageErrors.push(error));
 
-    await test.step('Clear any prior dismissal state for this collection', async () => {
-      await page.evaluate((key) => {
-        localStorage.removeItem(key);
-      }, DISMISSED_LOCAL_STORAGE_KEY);
-    });
+//     await test.step('Clear any prior dismissal state for this collection', async () => {
+//       await page.evaluate((key) => {
+//         localStorage.removeItem(key);
+//       }, DISMISSED_LOCAL_STORAGE_KEY);
+//     });
 
-    await test.step('Open the bru collection', async () => {
-      await openCollection(page, 'migration-test');
-    });
+//     await test.step('Open the bru collection', async () => {
+//       await openCollection(page, 'migration-test');
+//     });
 
-    const pill = page.getByTestId('migrate-yml-pill');
-    const pillDismiss = page.getByTestId('migrate-yml-pill-dismiss');
+//     const pill = page.getByTestId('migrate-yml-pill');
+//     const pillDismiss = page.getByTestId('migrate-yml-pill-dismiss');
 
-    await test.step('Pill is visible in the collection toolbar with the expected label and dismiss icon', async () => {
-      await expect(pill).toBeVisible({ timeout: 10000 });
-      await expect(pill).toContainText('Migrate to YML');
-      await expect(pillDismiss).toBeVisible();
-    });
+//     await test.step('Pill is visible in the collection toolbar with the expected label and dismiss icon', async () => {
+//       await expect(pill).toBeVisible({ timeout: 10000 });
+//       await expect(pill).toContainText('Migrate to YML');
+//       await expect(pillDismiss).toBeVisible();
+//     });
 
-    await test.step('Clicking the pill body opens the migrate-to-yml modal without dismissing', async () => {
-      await pill.click();
-      const migrateModal = page.locator('.bruno-modal-card', { hasText: 'Migrate to YML format' });
-      await expect(migrateModal).toBeVisible();
-      // Pill should still be visible — clicking the body opens the modal, it should not dismiss
-      await expect(pill).toBeVisible();
-      // Close the modal so the next step can interact with the pill
-      await page.keyboard.press('Escape');
-      await expect(page.locator('.bruno-modal-backdrop')).toHaveCount(0);
-    });
+//     await test.step('Clicking the pill body opens the migrate-to-yml modal without dismissing', async () => {
+//       await pill.click();
+//       const migrateModal = page.locator('.bruno-modal-card', { hasText: 'Migrate to YML format' });
+//       await expect(migrateModal).toBeVisible();
+//       // Pill should still be visible — clicking the body opens the modal, it should not dismiss
+//       await expect(pill).toBeVisible();
+//       // Close the modal so the next step can interact with the pill
+//       await page.keyboard.press('Escape');
+//       await expect(page.locator('.bruno-modal-backdrop')).toHaveCount(0);
+//     });
 
-    await test.step('Dismiss the pill via the cross icon', async () => {
-      await pillDismiss.click();
-      await expect(pill).toBeHidden();
-    });
+//     await test.step('Dismiss the pill via the cross icon', async () => {
+//       await pillDismiss.click();
+//       await expect(pill).toBeHidden();
+//     });
 
-    await test.step('Dismissal is persisted to localStorage keyed by collection pathname', async () => {
-      const stored = await page.evaluate(
-        (key) => localStorage.getItem(key),
-        DISMISSED_LOCAL_STORAGE_KEY
-      );
-      expect(stored).not.toBeNull();
+//     await test.step('Dismissal is persisted to localStorage keyed by collection pathname', async () => {
+//       const stored = await page.evaluate(
+//         (key) => localStorage.getItem(key),
+//         DISMISSED_LOCAL_STORAGE_KEY
+//       );
+//       expect(stored).not.toBeNull();
 
-      const parsed = JSON.parse(stored!);
-      expect(Array.isArray(parsed)).toBe(true);
+//       const parsed = JSON.parse(stored!);
+//       expect(Array.isArray(parsed)).toBe(true);
 
-      // collection.pathname is stored as-is; normalise separators for the cross-platform check
-      const normalisedStored = parsed.map((p: string) => p.replace(/\\/g, '/'));
-      const normalisedCollectionPath = collectionPath.replace(/\\/g, '/');
-      expect(normalisedStored).toContain(normalisedCollectionPath);
-    });
+//       // collection.pathname is stored as-is; normalise separators for the cross-platform check
+//       const normalisedStored = parsed.map((p: string) => p.replace(/\\/g, '/'));
+//       const normalisedCollectionPath = collectionPath.replace(/\\/g, '/');
+//       expect(normalisedStored).toContain(normalisedCollectionPath);
+//     });
 
-    await test.step('Pill stays hidden when switching between collection settings tabs', async () => {
-      await page.getByTestId('collection-settings-tab-headers').click();
-      await expect(pill).toBeHidden();
-      await page.getByTestId('collection-settings-tab-overview').click();
-      await expect(pill).toBeHidden();
-    });
+//     await test.step('Pill stays hidden when switching between collection settings tabs', async () => {
+//       await page.getByTestId('collection-settings-tab-headers').click();
+//       await expect(pill).toBeHidden();
+//       await page.getByTestId('collection-settings-tab-overview').click();
+//       await expect(pill).toBeHidden();
+//     });
 
-    expect(pageErrors).toHaveLength(0);
-  });
-});
+//     expect(pageErrors).toHaveLength(0);
+//   });
+// });

--- a/tests/collection/migrate-to-yml/migrate-to-yml-pill.spec.ts
+++ b/tests/collection/migrate-to-yml/migrate-to-yml-pill.spec.ts
@@ -1,80 +1,80 @@
-// import { test, expect } from '../../../playwright';
-// import { closeAllCollections, openCollection } from '../../utils/page';
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, openCollection } from '../../utils/page';
 
-// const DISMISSED_LOCAL_STORAGE_KEY = 'bruno.migrateToYmlPill.dismissed';
+const DISMISSED_LOCAL_STORAGE_KEY = 'bruno.migrateToYmlPill.dismissed';
 
-// test.describe('Migrate-to-YML pill in collection toolbar', () => {
-//   test.afterAll(async ({ page }) => {
-//     await closeAllCollections(page);
-//   });
+test.describe.skip('Migrate-to-YML pill in collection toolbar', () => {
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
 
-//   test('should show the pill for bru collections, open settings on click, and persist dismissal', async ({
-//     pageWithUserData: page,
-//     collectionFixturePath
-//   }) => {
-//     const collectionPath = collectionFixturePath!;
+  test('should show the pill for bru collections, open settings on click, and persist dismissal', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    const collectionPath = collectionFixturePath!;
 
-//     const pageErrors: Error[] = [];
-//     page.on('pageerror', (error) => pageErrors.push(error));
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
 
-//     await test.step('Clear any prior dismissal state for this collection', async () => {
-//       await page.evaluate((key) => {
-//         localStorage.removeItem(key);
-//       }, DISMISSED_LOCAL_STORAGE_KEY);
-//     });
+    await test.step('Clear any prior dismissal state for this collection', async () => {
+      await page.evaluate((key) => {
+        localStorage.removeItem(key);
+      }, DISMISSED_LOCAL_STORAGE_KEY);
+    });
 
-//     await test.step('Open the bru collection', async () => {
-//       await openCollection(page, 'migration-test');
-//     });
+    await test.step('Open the bru collection', async () => {
+      await openCollection(page, 'migration-test');
+    });
 
-//     const pill = page.getByTestId('migrate-yml-pill');
-//     const pillDismiss = page.getByTestId('migrate-yml-pill-dismiss');
+    const pill = page.getByTestId('migrate-yml-pill');
+    const pillDismiss = page.getByTestId('migrate-yml-pill-dismiss');
 
-//     await test.step('Pill is visible in the collection toolbar with the expected label and dismiss icon', async () => {
-//       await expect(pill).toBeVisible({ timeout: 10000 });
-//       await expect(pill).toContainText('Migrate to YML');
-//       await expect(pillDismiss).toBeVisible();
-//     });
+    await test.step('Pill is visible in the collection toolbar with the expected label and dismiss icon', async () => {
+      await expect(pill).toBeVisible({ timeout: 10000 });
+      await expect(pill).toContainText('Migrate to YML');
+      await expect(pillDismiss).toBeVisible();
+    });
 
-//     await test.step('Clicking the pill body opens the migrate-to-yml modal without dismissing', async () => {
-//       await pill.click();
-//       const migrateModal = page.locator('.bruno-modal-card', { hasText: 'Migrate to YML format' });
-//       await expect(migrateModal).toBeVisible();
-//       // Pill should still be visible — clicking the body opens the modal, it should not dismiss
-//       await expect(pill).toBeVisible();
-//       // Close the modal so the next step can interact with the pill
-//       await page.keyboard.press('Escape');
-//       await expect(page.locator('.bruno-modal-backdrop')).toHaveCount(0);
-//     });
+    await test.step('Clicking the pill body opens the migrate-to-yml modal without dismissing', async () => {
+      await pill.click();
+      const migrateModal = page.locator('.bruno-modal-card', { hasText: 'Migrate to YML format' });
+      await expect(migrateModal).toBeVisible();
+      // Pill should still be visible — clicking the body opens the modal, it should not dismiss
+      await expect(pill).toBeVisible();
+      // Close the modal so the next step can interact with the pill
+      await page.keyboard.press('Escape');
+      await expect(page.locator('.bruno-modal-backdrop')).toHaveCount(0);
+    });
 
-//     await test.step('Dismiss the pill via the cross icon', async () => {
-//       await pillDismiss.click();
-//       await expect(pill).toBeHidden();
-//     });
+    await test.step('Dismiss the pill via the cross icon', async () => {
+      await pillDismiss.click();
+      await expect(pill).toBeHidden();
+    });
 
-//     await test.step('Dismissal is persisted to localStorage keyed by collection pathname', async () => {
-//       const stored = await page.evaluate(
-//         (key) => localStorage.getItem(key),
-//         DISMISSED_LOCAL_STORAGE_KEY
-//       );
-//       expect(stored).not.toBeNull();
+    await test.step('Dismissal is persisted to localStorage keyed by collection pathname', async () => {
+      const stored = await page.evaluate(
+        (key) => localStorage.getItem(key),
+        DISMISSED_LOCAL_STORAGE_KEY
+      );
+      expect(stored).not.toBeNull();
 
-//       const parsed = JSON.parse(stored!);
-//       expect(Array.isArray(parsed)).toBe(true);
+      const parsed = JSON.parse(stored!);
+      expect(Array.isArray(parsed)).toBe(true);
 
-//       // collection.pathname is stored as-is; normalise separators for the cross-platform check
-//       const normalisedStored = parsed.map((p: string) => p.replace(/\\/g, '/'));
-//       const normalisedCollectionPath = collectionPath.replace(/\\/g, '/');
-//       expect(normalisedStored).toContain(normalisedCollectionPath);
-//     });
+      // collection.pathname is stored as-is; normalise separators for the cross-platform check
+      const normalisedStored = parsed.map((p: string) => p.replace(/\\/g, '/'));
+      const normalisedCollectionPath = collectionPath.replace(/\\/g, '/');
+      expect(normalisedStored).toContain(normalisedCollectionPath);
+    });
 
-//     await test.step('Pill stays hidden when switching between collection settings tabs', async () => {
-//       await page.getByTestId('collection-settings-tab-headers').click();
-//       await expect(pill).toBeHidden();
-//       await page.getByTestId('collection-settings-tab-overview').click();
-//       await expect(pill).toBeHidden();
-//     });
+    await test.step('Pill stays hidden when switching between collection settings tabs', async () => {
+      await page.getByTestId('collection-settings-tab-headers').click();
+      await expect(pill).toBeHidden();
+      await page.getByTestId('collection-settings-tab-overview').click();
+      await expect(pill).toBeHidden();
+    });
 
-//     expect(pageErrors).toHaveLength(0);
-//   });
-// });
+    expect(pageErrors).toHaveLength(0);
+  });
+});

--- a/tests/collection/migrate-to-yml/migrate-to-yml.spec.ts
+++ b/tests/collection/migrate-to-yml/migrate-to-yml.spec.ts
@@ -1,139 +1,139 @@
-import fs from 'fs';
-import path from 'path';
-import jsyaml from 'js-yaml';
-import { test, expect } from '../../../playwright';
-import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
+// import fs from 'fs';
+// import path from 'path';
+// import jsyaml from 'js-yaml';
+// import { test, expect } from '../../../playwright';
+// import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
 
-test.describe('Migrate collection from bru to yml format', () => {
-  test.afterAll(async ({ page }) => {
-    await closeAllCollections(page);
-  });
+// test.describe('Migrate collection from bru to yml format', () => {
+//   test.afterAll(async ({ page }) => {
+//     await closeAllCollections(page);
+//   });
 
-  test('should migrate bru collection to yml and preserve all data', async ({ pageWithUserData: page, collectionFixturePath }) => {
-    const collectionPath = collectionFixturePath!;
+//   test('should migrate bru collection to yml and preserve all data', async ({ pageWithUserData: page, collectionFixturePath }) => {
+//     const collectionPath = collectionFixturePath!;
 
-    // Capture any uncaught errors during migration
-    const pageErrors: Error[] = [];
-    page.on('pageerror', (error) => pageErrors.push(error));
+//     // Capture any uncaught errors during migration
+//     const pageErrors: Error[] = [];
+//     page.on('pageerror', (error) => pageErrors.push(error));
 
-    await test.step('Verify collection is in bru format before migration', async () => {
-      expect(fs.existsSync(path.join(collectionPath, 'bruno.json'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'collection.bru'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'post-json.bru'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.bru'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.bru'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.bru'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.bru'))).toBe(true);
-    });
+//     await test.step('Verify collection is in bru format before migration', async () => {
+//       expect(fs.existsSync(path.join(collectionPath, 'bruno.json'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'collection.bru'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'post-json.bru'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.bru'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.bru'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.bru'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.bru'))).toBe(true);
+//     });
 
-    await test.step('Open collection and navigate to overview', async () => {
-      await openCollection(page, 'migration-test');
-      await page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' }).click();
-      await page.getByTestId('collection-settings-tab-overview').click();
-    });
+//     await test.step('Open collection and navigate to overview', async () => {
+//       await openCollection(page, 'migration-test');
+//       await page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' }).click();
+//       await page.getByTestId('collection-settings-tab-overview').click();
+//     });
 
-    await test.step('Verify migration section is visible for bru collection', async () => {
-      await expect(page.getByText('Migrate to YML file format')).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Convert to YML' })).toBeVisible();
-    });
+//     await test.step('Verify migration section is visible for bru collection', async () => {
+//       await expect(page.getByText('Migrate to YML file format')).toBeVisible();
+//       await expect(page.getByRole('button', { name: 'Convert to YML' })).toBeVisible();
+//     });
 
-    await test.step('Click Convert to YML and confirm migration', async () => {
-      await page.getByRole('button', { name: 'Convert to YML' }).click();
+//     await test.step('Click Convert to YML and confirm migration', async () => {
+//       await page.getByRole('button', { name: 'Convert to YML' }).click();
 
-      // Confirmation modal should appear
-      const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
-      await modal.waitFor({ state: 'visible', timeout: 5000 });
+//       // Confirmation modal should appear
+//       const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
+//       await modal.waitFor({ state: 'visible', timeout: 5000 });
 
-      // Verify modal content mentions the collection name
-      await expect(modal.getByText('migration-test')).toBeVisible();
+//       // Verify modal content mentions the collection name
+//       await expect(modal.getByText('migration-test')).toBeVisible();
 
-      // Confirm migration
-      await modal.getByRole('button', { name: 'Migrate' }).click();
-    });
+//       // Confirm migration
+//       await modal.getByRole('button', { name: 'Migrate' }).click();
+//     });
 
-    await test.step('Wait for migration to complete and collection to reload', async () => {
-      // Wait for success toast
-      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
-    });
+//     await test.step('Wait for migration to complete and collection to reload', async () => {
+//       // Wait for success toast
+//       await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+//     });
 
-    await test.step('Verify all bru files are removed from disk', async () => {
-      expect(fs.existsSync(path.join(collectionPath, 'bruno.json'))).toBe(false);
-      expect(fs.existsSync(path.join(collectionPath, 'collection.bru'))).toBe(false);
-      expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(false);
-      expect(fs.existsSync(path.join(collectionPath, 'post-json.bru'))).toBe(false);
-      expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.bru'))).toBe(false);
-      expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.bru'))).toBe(false);
-      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.bru'))).toBe(false);
-      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.bru'))).toBe(false);
-    });
+//     await test.step('Verify all bru files are removed from disk', async () => {
+//       expect(fs.existsSync(path.join(collectionPath, 'bruno.json'))).toBe(false);
+//       expect(fs.existsSync(path.join(collectionPath, 'collection.bru'))).toBe(false);
+//       expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(false);
+//       expect(fs.existsSync(path.join(collectionPath, 'post-json.bru'))).toBe(false);
+//       expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.bru'))).toBe(false);
+//       expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.bru'))).toBe(false);
+//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.bru'))).toBe(false);
+//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.bru'))).toBe(false);
+//     });
 
-    await test.step('Verify all yml files are created on disk', async () => {
-      expect(fs.existsSync(path.join(collectionPath, 'opencollection.yml'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'ping.yml'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'post-json.yml'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.yml'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.yml'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.yml'))).toBe(true);
-      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.yml'))).toBe(true);
-    });
+//     await test.step('Verify all yml files are created on disk', async () => {
+//       expect(fs.existsSync(path.join(collectionPath, 'opencollection.yml'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'ping.yml'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'post-json.yml'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.yml'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.yml'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.yml'))).toBe(true);
+//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.yml'))).toBe(true);
+//     });
 
-    await test.step('Verify opencollection.yml has correct config', async () => {
-      const ocContent = fs.readFileSync(path.join(collectionPath, 'opencollection.yml'), 'utf8');
-      expect(ocContent).toContain('opencollection');
-      expect(ocContent).toContain('migration-test');
+//     await test.step('Verify opencollection.yml has correct config', async () => {
+//       const ocContent = fs.readFileSync(path.join(collectionPath, 'opencollection.yml'), 'utf8');
+//       expect(ocContent).toContain('opencollection');
+//       expect(ocContent).toContain('migration-test');
 
-      const oc = jsyaml.load(ocContent) as { info?: { version?: string } };
-      expect(oc.info?.version).toBe('v9.9.9');
-    });
+//       const oc = jsyaml.load(ocContent) as { info?: { version?: string } };
+//       expect(oc.info?.version).toBe('v9.9.9');
+//     });
 
-    await test.step('Verify request yml files preserve data', async () => {
-      const pingContent = fs.readFileSync(path.join(collectionPath, 'ping.yml'), 'utf8');
-      expect(pingContent).toContain('ping');
-      expect(pingContent).toContain('/ping');
-      expect(pingContent).toContain('GET');
+//     await test.step('Verify request yml files preserve data', async () => {
+//       const pingContent = fs.readFileSync(path.join(collectionPath, 'ping.yml'), 'utf8');
+//       expect(pingContent).toContain('ping');
+//       expect(pingContent).toContain('/ping');
+//       expect(pingContent).toContain('GET');
 
-      const postContent = fs.readFileSync(path.join(collectionPath, 'post-json.yml'), 'utf8');
-      expect(postContent).toContain('post-json');
-      expect(postContent).toContain('POST');
-      expect(postContent).toContain('hello from migration test');
-    });
+//       const postContent = fs.readFileSync(path.join(collectionPath, 'post-json.yml'), 'utf8');
+//       expect(postContent).toContain('post-json');
+//       expect(postContent).toContain('POST');
+//       expect(postContent).toContain('hello from migration test');
+//     });
 
-    await test.step('Verify folder yml file preserves data', async () => {
-      const folderContent = fs.readFileSync(path.join(collectionPath, 'api', 'folder.yml'), 'utf8');
-      expect(folderContent).toContain('api');
-      expect(folderContent).toContain('X-Folder-Header');
-    });
+//     await test.step('Verify folder yml file preserves data', async () => {
+//       const folderContent = fs.readFileSync(path.join(collectionPath, 'api', 'folder.yml'), 'utf8');
+//       expect(folderContent).toContain('api');
+//       expect(folderContent).toContain('X-Folder-Header');
+//     });
 
-    await test.step('Verify environment yml files preserve data', async () => {
-      const localEnvContent = fs.readFileSync(path.join(collectionPath, 'environments', 'Local.yml'), 'utf8');
-      expect(localEnvContent).toContain('host');
-      expect(localEnvContent).toContain('http://localhost:8081');
+//     await test.step('Verify environment yml files preserve data', async () => {
+//       const localEnvContent = fs.readFileSync(path.join(collectionPath, 'environments', 'Local.yml'), 'utf8');
+//       expect(localEnvContent).toContain('host');
+//       expect(localEnvContent).toContain('http://localhost:8081');
 
-      const prodEnvContent = fs.readFileSync(path.join(collectionPath, 'environments', 'Production.yml'), 'utf8');
-      expect(prodEnvContent).toContain('host');
-      expect(prodEnvContent).toContain('https://api.example.com');
-    });
+//       const prodEnvContent = fs.readFileSync(path.join(collectionPath, 'environments', 'Production.yml'), 'utf8');
+//       expect(prodEnvContent).toContain('host');
+//       expect(prodEnvContent).toContain('https://api.example.com');
+//     });
 
-    await test.step('Verify collection items are loaded in sidebar', async () => {
-      await expect(page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' })).toBeVisible();
-      await expect(page.locator('.item-name').filter({ hasText: 'ping' })).toBeVisible({ timeout: 15000 });
-      await expect(page.locator('.item-name').filter({ hasText: 'post-json' })).toBeVisible();
-      await expect(page.locator('.item-name').filter({ hasText: 'api' })).toBeVisible();
-    });
+//     await test.step('Verify collection items are loaded in sidebar', async () => {
+//       await expect(page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' })).toBeVisible();
+//       await expect(page.locator('.item-name').filter({ hasText: 'ping' })).toBeVisible({ timeout: 15000 });
+//       await expect(page.locator('.item-name').filter({ hasText: 'post-json' })).toBeVisible();
+//       await expect(page.locator('.item-name').filter({ hasText: 'api' })).toBeVisible();
+//     });
 
-    await test.step('Verify migration section is hidden after migration', async () => {
-      await page.getByTestId('collection-settings-tab-overview').click();
-      await expect(page.getByText('Migrate to YML file format')).not.toBeVisible();
-    });
+//     await test.step('Verify migration section is hidden after migration', async () => {
+//       await page.getByTestId('collection-settings-tab-overview').click();
+//       await expect(page.getByText('Migrate to YML file format')).not.toBeVisible();
+//     });
 
-    await test.step('Verify migrated requests are functional', async () => {
-      await selectEnvironment(page, 'Local');
-      await page.locator('.item-name').filter({ hasText: 'ping' }).click();
-      await sendRequestAndWaitForResponse(page, 200);
-    });
+//     await test.step('Verify migrated requests are functional', async () => {
+//       await selectEnvironment(page, 'Local');
+//       await page.locator('.item-name').filter({ hasText: 'ping' }).click();
+//       await sendRequestAndWaitForResponse(page, 200);
+//     });
 
-    // Verify no uncaught JS errors occurred during migration
-    expect(pageErrors).toHaveLength(0);
-  });
-});
+//     // Verify no uncaught JS errors occurred during migration
+//     expect(pageErrors).toHaveLength(0);
+//   });
+// });

--- a/tests/collection/migrate-to-yml/migrate-to-yml.spec.ts
+++ b/tests/collection/migrate-to-yml/migrate-to-yml.spec.ts
@@ -1,139 +1,139 @@
-// import fs from 'fs';
-// import path from 'path';
-// import jsyaml from 'js-yaml';
-// import { test, expect } from '../../../playwright';
-// import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
+import fs from 'fs';
+import path from 'path';
+import jsyaml from 'js-yaml';
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, openCollection, selectEnvironment, sendRequestAndWaitForResponse } from '../../utils/page';
 
-// test.describe('Migrate collection from bru to yml format', () => {
-//   test.afterAll(async ({ page }) => {
-//     await closeAllCollections(page);
-//   });
+test.describe.skip('Migrate collection from bru to yml format', () => {
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
 
-//   test('should migrate bru collection to yml and preserve all data', async ({ pageWithUserData: page, collectionFixturePath }) => {
-//     const collectionPath = collectionFixturePath!;
+  test('should migrate bru collection to yml and preserve all data', async ({ pageWithUserData: page, collectionFixturePath }) => {
+    const collectionPath = collectionFixturePath!;
 
-//     // Capture any uncaught errors during migration
-//     const pageErrors: Error[] = [];
-//     page.on('pageerror', (error) => pageErrors.push(error));
+    // Capture any uncaught errors during migration
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
 
-//     await test.step('Verify collection is in bru format before migration', async () => {
-//       expect(fs.existsSync(path.join(collectionPath, 'bruno.json'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'collection.bru'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'post-json.bru'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.bru'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.bru'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.bru'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.bru'))).toBe(true);
-//     });
+    await test.step('Verify collection is in bru format before migration', async () => {
+      expect(fs.existsSync(path.join(collectionPath, 'bruno.json'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'collection.bru'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'post-json.bru'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.bru'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.bru'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.bru'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.bru'))).toBe(true);
+    });
 
-//     await test.step('Open collection and navigate to overview', async () => {
-//       await openCollection(page, 'migration-test');
-//       await page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' }).click();
-//       await page.getByTestId('collection-settings-tab-overview').click();
-//     });
+    await test.step('Open collection and navigate to overview', async () => {
+      await openCollection(page, 'migration-test');
+      await page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' }).click();
+      await page.getByTestId('collection-settings-tab-overview').click();
+    });
 
-//     await test.step('Verify migration section is visible for bru collection', async () => {
-//       await expect(page.getByText('Migrate to YML file format')).toBeVisible();
-//       await expect(page.getByRole('button', { name: 'Convert to YML' })).toBeVisible();
-//     });
+    await test.step('Verify migration section is visible for bru collection', async () => {
+      await expect(page.getByText('Migrate to YML file format')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Convert to YML' })).toBeVisible();
+    });
 
-//     await test.step('Click Convert to YML and confirm migration', async () => {
-//       await page.getByRole('button', { name: 'Convert to YML' }).click();
+    await test.step('Click Convert to YML and confirm migration', async () => {
+      await page.getByRole('button', { name: 'Convert to YML' }).click();
 
-//       // Confirmation modal should appear
-//       const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
-//       await modal.waitFor({ state: 'visible', timeout: 5000 });
+      // Confirmation modal should appear
+      const modal = page.locator('.bruno-modal').filter({ hasText: 'Migrate to YML format' });
+      await modal.waitFor({ state: 'visible', timeout: 5000 });
 
-//       // Verify modal content mentions the collection name
-//       await expect(modal.getByText('migration-test')).toBeVisible();
+      // Verify modal content mentions the collection name
+      await expect(modal.getByText('migration-test')).toBeVisible();
 
-//       // Confirm migration
-//       await modal.getByRole('button', { name: 'Migrate' }).click();
-//     });
+      // Confirm migration
+      await modal.getByRole('button', { name: 'Migrate' }).click();
+    });
 
-//     await test.step('Wait for migration to complete and collection to reload', async () => {
-//       // Wait for success toast
-//       await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
-//     });
+    await test.step('Wait for migration to complete and collection to reload', async () => {
+      // Wait for success toast
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
 
-//     await test.step('Verify all bru files are removed from disk', async () => {
-//       expect(fs.existsSync(path.join(collectionPath, 'bruno.json'))).toBe(false);
-//       expect(fs.existsSync(path.join(collectionPath, 'collection.bru'))).toBe(false);
-//       expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(false);
-//       expect(fs.existsSync(path.join(collectionPath, 'post-json.bru'))).toBe(false);
-//       expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.bru'))).toBe(false);
-//       expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.bru'))).toBe(false);
-//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.bru'))).toBe(false);
-//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.bru'))).toBe(false);
-//     });
+    await test.step('Verify all bru files are removed from disk', async () => {
+      expect(fs.existsSync(path.join(collectionPath, 'bruno.json'))).toBe(false);
+      expect(fs.existsSync(path.join(collectionPath, 'collection.bru'))).toBe(false);
+      expect(fs.existsSync(path.join(collectionPath, 'ping.bru'))).toBe(false);
+      expect(fs.existsSync(path.join(collectionPath, 'post-json.bru'))).toBe(false);
+      expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.bru'))).toBe(false);
+      expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.bru'))).toBe(false);
+      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.bru'))).toBe(false);
+      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.bru'))).toBe(false);
+    });
 
-//     await test.step('Verify all yml files are created on disk', async () => {
-//       expect(fs.existsSync(path.join(collectionPath, 'opencollection.yml'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'ping.yml'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'post-json.yml'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.yml'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.yml'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.yml'))).toBe(true);
-//       expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.yml'))).toBe(true);
-//     });
+    await test.step('Verify all yml files are created on disk', async () => {
+      expect(fs.existsSync(path.join(collectionPath, 'opencollection.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'ping.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'post-json.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'api', 'folder.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'api', 'get-users.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Local.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(collectionPath, 'environments', 'Production.yml'))).toBe(true);
+    });
 
-//     await test.step('Verify opencollection.yml has correct config', async () => {
-//       const ocContent = fs.readFileSync(path.join(collectionPath, 'opencollection.yml'), 'utf8');
-//       expect(ocContent).toContain('opencollection');
-//       expect(ocContent).toContain('migration-test');
+    await test.step('Verify opencollection.yml has correct config', async () => {
+      const ocContent = fs.readFileSync(path.join(collectionPath, 'opencollection.yml'), 'utf8');
+      expect(ocContent).toContain('opencollection');
+      expect(ocContent).toContain('migration-test');
 
-//       const oc = jsyaml.load(ocContent) as { info?: { version?: string } };
-//       expect(oc.info?.version).toBe('v9.9.9');
-//     });
+      const oc = jsyaml.load(ocContent) as { info?: { version?: string } };
+      expect(oc.info?.version).toBe('v9.9.9');
+    });
 
-//     await test.step('Verify request yml files preserve data', async () => {
-//       const pingContent = fs.readFileSync(path.join(collectionPath, 'ping.yml'), 'utf8');
-//       expect(pingContent).toContain('ping');
-//       expect(pingContent).toContain('/ping');
-//       expect(pingContent).toContain('GET');
+    await test.step('Verify request yml files preserve data', async () => {
+      const pingContent = fs.readFileSync(path.join(collectionPath, 'ping.yml'), 'utf8');
+      expect(pingContent).toContain('ping');
+      expect(pingContent).toContain('/ping');
+      expect(pingContent).toContain('GET');
 
-//       const postContent = fs.readFileSync(path.join(collectionPath, 'post-json.yml'), 'utf8');
-//       expect(postContent).toContain('post-json');
-//       expect(postContent).toContain('POST');
-//       expect(postContent).toContain('hello from migration test');
-//     });
+      const postContent = fs.readFileSync(path.join(collectionPath, 'post-json.yml'), 'utf8');
+      expect(postContent).toContain('post-json');
+      expect(postContent).toContain('POST');
+      expect(postContent).toContain('hello from migration test');
+    });
 
-//     await test.step('Verify folder yml file preserves data', async () => {
-//       const folderContent = fs.readFileSync(path.join(collectionPath, 'api', 'folder.yml'), 'utf8');
-//       expect(folderContent).toContain('api');
-//       expect(folderContent).toContain('X-Folder-Header');
-//     });
+    await test.step('Verify folder yml file preserves data', async () => {
+      const folderContent = fs.readFileSync(path.join(collectionPath, 'api', 'folder.yml'), 'utf8');
+      expect(folderContent).toContain('api');
+      expect(folderContent).toContain('X-Folder-Header');
+    });
 
-//     await test.step('Verify environment yml files preserve data', async () => {
-//       const localEnvContent = fs.readFileSync(path.join(collectionPath, 'environments', 'Local.yml'), 'utf8');
-//       expect(localEnvContent).toContain('host');
-//       expect(localEnvContent).toContain('http://localhost:8081');
+    await test.step('Verify environment yml files preserve data', async () => {
+      const localEnvContent = fs.readFileSync(path.join(collectionPath, 'environments', 'Local.yml'), 'utf8');
+      expect(localEnvContent).toContain('host');
+      expect(localEnvContent).toContain('http://localhost:8081');
 
-//       const prodEnvContent = fs.readFileSync(path.join(collectionPath, 'environments', 'Production.yml'), 'utf8');
-//       expect(prodEnvContent).toContain('host');
-//       expect(prodEnvContent).toContain('https://api.example.com');
-//     });
+      const prodEnvContent = fs.readFileSync(path.join(collectionPath, 'environments', 'Production.yml'), 'utf8');
+      expect(prodEnvContent).toContain('host');
+      expect(prodEnvContent).toContain('https://api.example.com');
+    });
 
-//     await test.step('Verify collection items are loaded in sidebar', async () => {
-//       await expect(page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' })).toBeVisible();
-//       await expect(page.locator('.item-name').filter({ hasText: 'ping' })).toBeVisible({ timeout: 15000 });
-//       await expect(page.locator('.item-name').filter({ hasText: 'post-json' })).toBeVisible();
-//       await expect(page.locator('.item-name').filter({ hasText: 'api' })).toBeVisible();
-//     });
+    await test.step('Verify collection items are loaded in sidebar', async () => {
+      await expect(page.locator('#sidebar-collection-name').filter({ hasText: 'migration-test' })).toBeVisible();
+      await expect(page.locator('.item-name').filter({ hasText: 'ping' })).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('.item-name').filter({ hasText: 'post-json' })).toBeVisible();
+      await expect(page.locator('.item-name').filter({ hasText: 'api' })).toBeVisible();
+    });
 
-//     await test.step('Verify migration section is hidden after migration', async () => {
-//       await page.getByTestId('collection-settings-tab-overview').click();
-//       await expect(page.getByText('Migrate to YML file format')).not.toBeVisible();
-//     });
+    await test.step('Verify migration section is hidden after migration', async () => {
+      await page.getByTestId('collection-settings-tab-overview').click();
+      await expect(page.getByText('Migrate to YML file format')).not.toBeVisible();
+    });
 
-//     await test.step('Verify migrated requests are functional', async () => {
-//       await selectEnvironment(page, 'Local');
-//       await page.locator('.item-name').filter({ hasText: 'ping' }).click();
-//       await sendRequestAndWaitForResponse(page, 200);
-//     });
+    await test.step('Verify migrated requests are functional', async () => {
+      await selectEnvironment(page, 'Local');
+      await page.locator('.item-name').filter({ hasText: 'ping' }).click();
+      await sendRequestAndWaitForResponse(page, 200);
+    });
 
-//     // Verify no uncaught JS errors occurred during migration
-//     expect(pageErrors).toHaveLength(0);
-//   });
-// });
+    // Verify no uncaught JS errors occurred during migration
+    expect(pageErrors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
cases

### Description

Hiding migration options and the respective test

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed the migration option from the Collection Settings overview.
  * Removed the “Migrate to YML” prompt from collection headers.

* **Tests**
  * Disabled automated tests covering collection migration, nested tabs, request-tab preservation, and the migration prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->