### PR TITLE
fix(ui): update size of cancel button in unsaved changes modal

### DIFF
--- a/packages/bruno-app/src/components/Environments/ConfirmCloseEnvironment/index.js
+++ b/packages/bruno-app/src/components/Environments/ConfirmCloseEnvironment/index.js
@@ -38,7 +38,7 @@ const ConfirmCloseEnvironment = ({ onCancel, onCloseWithoutSave, onSaveAndClose,
             </Button>
           </div>
           <div className="flex gap-2">
-            <Button size="sm" color="secondary" variant="ghost" onClick={onCancel} data-testid="env-unsaved-cancel">
+            <Button color="secondary" variant="ghost" onClick={onCancel} data-testid="env-unsaved-cancel">
               Cancel
             </Button>
             <Button onClick={onSaveAndClose} data-testid="env-unsaved-save-and-close">

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmCollectionClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmCollectionClose/index.js
@@ -35,7 +35,7 @@ const ConfirmCollectionClose = ({ collection, onCancel, onCloseWithoutSave, onSa
           </Button>
         </div>
         <div className="flex gap-2">
-          <Button size="sm" color="secondary" variant="ghost" onClick={onCancel}>
+          <Button color="secondary" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
           <Button onClick={onSaveAndClose}>

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmFolderClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmFolderClose/index.js
@@ -35,7 +35,7 @@ const ConfirmFolderClose = ({ folder, onCancel, onCloseWithoutSave, onSaveAndClo
           </Button>
         </div>
         <div className="flex gap-2">
-          <Button size="sm" color="secondary" variant="ghost" onClick={onCancel}>
+          <Button color="secondary" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
           <Button onClick={onSaveAndClose}>

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
@@ -39,7 +39,7 @@ const ConfirmRequestClose = ({ item, example, onCancel, onCloseWithoutSave, onSa
           </Button>
         </div>
         <div className="flex gap-2">
-          <Button size="sm" color="secondary" variant="ghost" onClick={onCancel}>
+          <Button color="secondary" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
           <Button onClick={onSaveAndClose}>Save</Button>


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated “Cancel” buttons in close-confirmation dialogs to use the standard button sizing for a more consistent appearance.
  * Preserved existing button actions, colors, and dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->