### PR TITLE
feat(ai): add request handling to ai chatbar

### DIFF
--- a/packages/bruno-app/src/components/AiChatSidebar/index.js
+++ b/packages/bruno-app/src/components/AiChatSidebar/index.js
@@ -50,7 +50,7 @@ import {
 } from 'providers/ReduxStore/slices/collections';
 import { updateIsDragging } from 'providers/ReduxStore/slices/app';
 import { findItemInCollection, findItemInCollectionByPathname, isItemAFolder, isItemARequest } from 'utils/collections';
-import { buildAiVariablesPayload, getAiStatus } from 'utils/ai';
+import { buildAiVariablesPayload, buildAiRequestsPayload, getAiStatus } from 'utils/ai';
 
 import StyledWrapper from './StyledWrapper';
 import DiffView from './DiffView';
@@ -428,6 +428,8 @@ const AiChatSidebar = ({ collection, variant = 'sidebar' }) => {
     return buildAiVariablesPayload(collection, null);
   }, [collection, aiContext]);
 
+  const aiRequests = useMemo(() => buildAiRequestsPayload(collection), [collection]);
+
   const chatsWithMessages = useMemo(() => {
     if (!collection) return [];
     return Object.entries(allChats)
@@ -543,7 +545,7 @@ const AiChatSidebar = ({ collection, variant = 'sidebar' }) => {
     if (textareaRef.current) textareaRef.current.style.height = 'auto';
 
     try {
-      await dispatch(sendAiMessage(activeTabUid, text, allContent, requestContext, selectedModel, contentType, aiVariables, appEnabled));
+      await dispatch(sendAiMessage(activeTabUid, text, allContent, requestContext, selectedModel, contentType, aiVariables, appEnabled, aiRequests));
       setProcessingStage('applying');
       setTimeout(() => setProcessingStage(null), 500);
     } catch (err) {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/chat.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/chat.js
@@ -253,7 +253,8 @@ export const sendAiMessage = (
   model,
   contentType = 'app',
   variables = [],
-  appEnabled = true
+  appEnabled = true,
+  requests = []
 ) => async (dispatch, getState) => {
   const { ipcRenderer } = window;
 
@@ -390,6 +391,7 @@ export const sendAiMessage = (
       contentType,
       requestContext,
       variables,
+      requests,
       requestId,
       model,
       appEnabled

--- a/packages/bruno-app/src/utils/ai/index.js
+++ b/packages/bruno-app/src/utils/ai/index.js
@@ -217,13 +217,42 @@ export const buildAiVariablesPayload = (collection, item, redactVariablesOverrid
   return out;
 };
 
+export const buildAiRequestsPayload = (collection) => {
+  if (!collection) return [];
+  const out = [];
+  const walk = (items, folderPath) => {
+    const ordered = sortItemsBySidebarOrder(items || []);
+    for (const item of ordered) {
+      if (item.isTransient) continue;
+      if (isItemAFolder(item)) {
+        const nested = folderPath ? `${folderPath}/${item.name || ''}` : (item.name || '');
+        walk(item.items || [], nested);
+        continue;
+      }
+      if (!isItemARequest(item)) continue;
+      const req = item.draft?.request || item.request || {};
+      out.push({
+        name: item.name || '',
+        pathname: item.pathname || '',
+        folderPath: folderPath || '',
+        type: item.type,
+        method: req.method || 'GET',
+        url: req.url || ''
+      });
+    }
+  };
+  walk(collection.items || [], '');
+  return out;
+};
+
 /**
  * Single entry point for chat + generation. Returns the same payload shape
  * for both so the backend formatters / tools behave identically.
  */
 export const buildAiContextPayload = (item, collection, redactVariablesOverride) => ({
   requestContext: buildAiRequestContext(item),
-  variables: collection ? buildAiVariablesPayload(collection, item, redactVariablesOverride) : []
+  variables: collection ? buildAiVariablesPayload(collection, item, redactVariablesOverride) : [],
+  requests: buildAiRequestsPayload(collection)
 });
 
 const summarizeDocsItems = (items = []) => {

--- a/packages/bruno-app/src/utils/ai/index.spec.js
+++ b/packages/bruno-app/src/utils/ai/index.spec.js
@@ -326,9 +326,9 @@ describe('utils/ai', () => {
   });
 
   describe('buildAiContextPayload', () => {
-    it('combines request context and variables into a single payload', () => {
+    it('combines request context, variables, and the collection request list into a single payload', () => {
       const result = buildAiContextPayload(null, null);
-      expect(result).toEqual({ requestContext: null, variables: [] });
+      expect(result).toEqual({ requestContext: null, variables: [], requests: [] });
     });
   });
 });

--- a/packages/bruno-electron/src/ipc/ai/chat-prompts.js
+++ b/packages/bruno-electron/src/ipc/ai/chat-prompts.js
@@ -125,7 +125,7 @@ bru.ctx.onTestsChange       = (tests) => { ... }
 bru.ctx.onVariablesChange   = (variables) => { ... }
 \`\`\`
 
-### Collection-/folder-level app (edited from the collection's own app editor — mentioned here only so you can answer questions about it)
+### Collection-/folder-level app (edited from the collection's own app editor)
 \`\`\`js
 bru.ctx.theme / bru.ctx.variables / bru.ctx.variables.runtime.set / bru.ctx.log / bru.ctx.onInit   // as above
 bru.ctx.collection                        // { name, pathname } | null
@@ -135,6 +135,8 @@ bru.ctx.onThemeChange / bru.ctx.onVariablesChange / bru.ctx.onCollectionChange
 \`\`\`
 There is NO \`bru.ctx.http\` / \`bru.ctx.submitRequest\` / \`bru.ctx.assertions\` / \`bru.ctx.tests\` at collection level. Reference requests by the \`pathname\` from \`bru.ctx.listRequests()\`, not by name.
 
+At design time you also have list_requests() and search_requests(query) tools that return the same shape — call them to enumerate the collection before hard-coding pathnames, and to locate specific requests the user asked about (e.g. "create an app for the login request"). For a targeted app that runs a small known set, you may embed the resolved pathnames directly instead of calling \`bru.ctx.listRequests()\` at runtime.
+
 ## RULES
 1. Generate a single self-contained HTML document (inline styles and scripts are fine — no external CDN)
 2. Use ONLY the \`bru.ctx\` APIs listed above for the app's level — do not invent \`bru.ctx\` methods, do not use \`fetch\` to call the API directly, and do not rely on Bruno internals beyond \`bru.ctx\`
@@ -142,7 +144,8 @@ There is NO \`bru.ctx.http\` / \`bru.ctx.submitRequest\` / \`bru.ctx.assertions\
 4. Always handle loading and error states around \`bru.ctx.submitRequest\` / \`bru.ctx.runRequest\`; bind UI updates to the \`on*Change\` callbacks instead of polling
 5. Theme changes toggle a \`light\`/\`dark\` class on \`document.body\` (from \`bru.ctx.theme.mode\`) — style both states; \`bru.ctx.theme.config\` is the full resolved theme object
 6. Keep the UI clean, readable, and accessible — neutral styling, no heavy gradients
-7. Write the COMPLETE document when using write_content`
+7. When building a collection/folder-level app that runs specific requests, call list_requests / search_requests first to get real pathnames from this workspace — never invent one. Pass the returned \`pathname\` verbatim to \`bru.ctx.runRequest\`.
+8. Write the COMPLETE document when using write_content`
 };
 
 const SCOPE_GUARD = `## Scope
@@ -182,6 +185,8 @@ This means:
 - read_response(): returns the redacted shape (keys + types) of the last response body. No parameters. Use it to learn paths and types — not to read actual values.
 - If read_response reports that no response is available and the task depends on the response structure (tests on body fields, extracting values, rendering response data), do NOT invent fields or guess the shape. Ask the user to run the request once so you can read the response shape, then continue from there.
 - search_variables(query?): search environment / collection / global / runtime variables by name (case-insensitive substring). Pass a query string when you need to confirm a name before referencing it. Values come back redacted for secrets — never hard-code a returned value. Each result has a \`scope\` field — use it to pick the right runtime accessor: \`bru.getEnvVar\` for \`env\`, \`bru.getGlobalEnvVar\` for \`global\`, \`bru.getCollectionVar\` / \`bru.getFolderVar\` / \`bru.getRequestVar\` for \`collection\`, \`bru.getVar\` for \`runtime\`, and \`bru.getSecretVar\` for any value that came back redacted. Use this when the inline variables list is truncated.
+- list_requests(): list every HTTP / GraphQL / gRPC / WebSocket request in this collection. Returns each request's name, method, url, folder path, and \`pathname\`. Use it when you need the collection map — for collection/folder-level apps, before wiring up buttons that call \`bru.ctx.runRequest\`, or when the user asks "what's in this collection". Prefer search_requests when you already know a keyword.
+- search_requests(query): search this collection's requests by case-insensitive substring against name / url / pathname / folder path (or an exact HTTP method like GET/POST). Returns the same shape as list_requests. Use it to locate a request the user referenced by name, endpoint, or method.
 
 ### Rules
 - ALWAYS call read_content before write_content for the same type
@@ -208,7 +213,9 @@ const TOOL_LABELS = {
     'docs': 'Writing documentation'
   },
   read_response: { default: 'Reading response data' },
-  search_variables: { default: 'Searching variables' }
+  search_variables: { default: 'Searching variables' },
+  list_requests: { default: 'Listing collection requests' },
+  search_requests: { default: 'Searching collection requests' }
 };
 
 const buildSystemPrompt = (contentType, hasMultipleContent) => {

--- a/packages/bruno-electron/src/ipc/ai/chat.js
+++ b/packages/bruno-electron/src/ipc/ai/chat.js
@@ -8,7 +8,10 @@ const {
   formatResponseShape,
   formatVariablesList,
   searchVariables,
-  formatSearchVariablesResult
+  formatSearchVariablesResult,
+  formatRequestsList,
+  searchRequests,
+  formatSearchRequestsResult
 } = require('./context');
 const { getPreferences } = require('../../store/preferences');
 const { isBuiltInModelId } = require('./providers');
@@ -27,7 +30,7 @@ const CONTENT_LABELS = {
 
 const APP_DISABLED_NOTICE = 'App mode is currently DISABLED for this request. The App tab is hidden and any code written to \'app\' will not be visible or runnable. Do NOT call write_content(\'app\'); instead, tell the user to open the request\'s Settings tab and turn on "Enable App" first, then ask them to run the request again.';
 
-const buildContextMessage = (contentType, allContent, requestContext, variables, security, appEnabled) => {
+const buildContextMessage = (contentType, allContent, requestContext, variables, security, appEnabled, requests) => {
   const parts = [];
   if (appEnabled === false) {
     parts.push(`Note: ${APP_DISABLED_NOTICE}`);
@@ -40,6 +43,11 @@ const buildContextMessage = (contentType, allContent, requestContext, variables,
   const varsStr = formatVariablesList(variables, { security });
   if (varsStr) {
     parts.push(`Available Variables (names only — call search_variables(query) for a value):\n${varsStr}`);
+  }
+
+  const requestsStr = formatRequestsList(requests);
+  if (requestsStr) {
+    parts.push(`Requests in this collection (preview — call list_requests / search_requests for full details, use \`pathname\` with bru.ctx.runRequest):\n${requestsStr}`);
   }
 
   const activeLabel = CONTENT_LABELS[contentType] || 'Code';
@@ -85,6 +93,12 @@ const SEARCH_VARS_PARAMS = z.object({
     .optional()
     .describe('Substring to match against variable names (case-insensitive). Omit to list the first 50 variables.')
 });
+const LIST_REQUESTS_PARAMS = z.object({});
+const SEARCH_REQUESTS_PARAMS = z.object({
+  query: z
+    .string()
+    .describe('Substring to match against request name, URL, pathname, folder path (case-insensitive), or an exact HTTP method like GET/POST.')
+});
 
 const registerChatIpc = ({ mainWindow, resolveModel, pickDefaultModelId, isAiEnabled }) => {
   ipcMain.on('renderer:ai-chat-stop', (_event, { requestId } = {}) => {
@@ -96,7 +110,7 @@ const registerChatIpc = ({ mainWindow, resolveModel, pickDefaultModelId, isAiEna
   });
 
   ipcMain.on('renderer:ai-chat-stream', async (_event, payload) => {
-    const { messages, allContent, contentType, requestContext, variables, requestId, model: modelId, appEnabled } = payload || {};
+    const { messages, allContent, contentType, requestContext, variables, requests, requestId, model: modelId, appEnabled } = payload || {};
 
     const send = (channel, data) => {
       if (mainWindow?.webContents && !mainWindow.webContents.isDestroyed()) {
@@ -213,11 +227,32 @@ const registerChatIpc = ({ mainWindow, resolveModel, pickDefaultModelId, isAiEna
           const result = searchVariables(variables, query);
           return formatSearchVariablesResult(result, query, { security });
         }
+      },
+      list_requests: {
+        description: 'List every HTTP / GraphQL / gRPC / WebSocket request in this collection. Returns each request\'s name, method, url, folder path, and `pathname`. Use `pathname` — never the name — when generating code that calls `bru.ctx.runRequest(pathname)` (collection/folder-level apps) or when telling the user which file to open. Prefer search_requests when the collection is large or you already know a keyword.',
+        inputSchema: LIST_REQUESTS_PARAMS,
+        execute: async () => {
+          if (!Array.isArray(requests) || requests.length === 0) {
+            return '(No requests in this collection.)';
+          }
+          return formatSearchRequestsResult(searchRequests(requests, ''), '');
+        }
+      },
+      search_requests: {
+        description: 'Search this collection\'s requests by a case-insensitive substring matched against name / url / pathname / folder path (or an exact HTTP method like GET/POST). Returns each match\'s name, method, url, folder path, and `pathname`. Use `pathname` verbatim when generating `bru.ctx.runRequest(pathname)` calls for a collection/folder-level app.',
+        inputSchema: SEARCH_REQUESTS_PARAMS,
+        execute: async ({ query }) => {
+          if (!Array.isArray(requests) || requests.length === 0) {
+            return '(No requests in this collection.)';
+          }
+          const result = searchRequests(requests, query);
+          return formatSearchRequestsResult(result, query);
+        }
       }
     };
 
     const allMessages = [
-      { role: 'user', content: buildContextMessage(effectiveType, normalizedContent, requestContext, variables, security, appEnabled) },
+      { role: 'user', content: buildContextMessage(effectiveType, normalizedContent, requestContext, variables, security, appEnabled, requests) },
       ...messages.map((m) => ({ role: m.role, content: m.content }))
     ];
 

--- a/packages/bruno-electron/src/ipc/ai/context.js
+++ b/packages/bruno-electron/src/ipc/ai/context.js
@@ -403,6 +403,62 @@ const formatSearchVariablesResult = ({ items, totalMatched, limit }, query, opts
   return `${heading}\n${lines.join('\n')}${trailer}`;
 };
 
+const REQUESTS_PREVIEW_LIMIT = 25;
+const REQUESTS_SEARCH_LIMIT = 50;
+
+const methodOf = (r) => String(r?.method || (r?.type === 'app' ? 'APP' : 'GET')).toUpperCase();
+
+const labelOf = (r) => (r?.folderPath ? `${r.folderPath}/${r.name || ''}` : r?.name || '');
+
+const formatRequestsList = (requests) => {
+  if (!Array.isArray(requests) || !requests.length) return '';
+  const total = requests.length;
+  const preview = requests.slice(0, REQUESTS_PREVIEW_LIMIT);
+  const lines = preview.map((r) => {
+    const url = r.url ? ` — ${r.url}` : '';
+    return `  ${methodOf(r)} ${labelOf(r)}${url}`;
+  });
+  const trailer = total > preview.length
+    ? `\n(+${total - preview.length} more — call search_requests to find them)`
+    : '';
+  return `${lines.join('\n')}${trailer}`;
+};
+
+const searchRequests = (requests, rawQuery, limit = REQUESTS_SEARCH_LIMIT) => {
+  if (!Array.isArray(requests) || !requests.length) {
+    return { items: [], totalMatched: 0, limit };
+  }
+  const query = String(rawQuery || '').toLowerCase().trim();
+  const filtered = query
+    ? requests.filter((r) => {
+        const hay = `${r?.name || ''} ${r?.url || ''} ${r?.pathname || ''} ${r?.folderPath || ''}`.toLowerCase();
+        if (hay.includes(query)) return true;
+        // Method matches only on exact token to avoid `get` matching every URL.
+        return String(r?.method || '').toLowerCase() === query;
+      })
+    : requests.slice();
+  return { items: filtered.slice(0, limit), totalMatched: filtered.length, limit };
+};
+
+const formatSearchRequestsResult = ({ items, totalMatched, limit }, query) => {
+  if (!items.length) {
+    return query
+      ? `No requests match "${query}".`
+      : 'No requests in this collection.';
+  }
+  const lines = items.map((r) => {
+    const url = r.url || '(no url)';
+    return `  ${methodOf(r)} ${labelOf(r)}\n    url: ${url}\n    pathname: ${r.pathname || ''}`;
+  });
+  const heading = query
+    ? `Found ${items.length}${totalMatched > items.length ? ` of ${totalMatched}` : ''} request(s) matching "${query}":`
+    : `Requests (${items.length}${totalMatched > items.length ? ` of ${totalMatched}` : ''}):`;
+  const trailer = totalMatched > items.length
+    ? `\n\n(${totalMatched - items.length} more match — narrow the query to see them.)`
+    : '';
+  return `${heading}\n${lines.join('\n')}${trailer}`;
+};
+
 module.exports = {
   // patterns + helpers
   SENSITIVE_HEADER_PATTERNS,
@@ -421,5 +477,9 @@ module.exports = {
   isSecretVariable,
   formatVariablesList,
   searchVariables,
-  formatSearchVariablesResult
+  formatSearchVariablesResult,
+  // requests (collection tree)
+  formatRequestsList,
+  searchRequests,
+  formatSearchRequestsResult
 };

--- a/packages/bruno-electron/src/ipc/ai/context.spec.js
+++ b/packages/bruno-electron/src/ipc/ai/context.spec.js
@@ -6,7 +6,10 @@ const {
   formatRequestContext,
   formatVariablesList,
   searchVariables,
-  formatSearchVariablesResult
+  formatSearchVariablesResult,
+  formatRequestsList,
+  searchRequests,
+  formatSearchRequestsResult
 } = require('./context');
 
 describe('ipc/ai/context', () => {
@@ -350,6 +353,61 @@ describe('ipc/ai/context', () => {
       const out = formatSearchVariablesResult(searchVariables(many, 'token', 50), 'token');
       expect(out).toContain('Found 50 of 60');
       expect(out).toContain('(10 more match');
+    });
+  });
+
+  describe('searchRequests / formatRequestsList / formatSearchRequestsResult', () => {
+    const requests = [
+      { name: 'Login', method: 'POST', url: 'https://api/login', pathname: '/coll/Auth/Login.bru', folderPath: 'Auth', type: 'http-request' },
+      { name: 'Logout', method: 'POST', url: 'https://api/logout', pathname: '/coll/Auth/Logout.bru', folderPath: 'Auth', type: 'http-request' },
+      { name: 'GetUser', method: 'GET', url: 'https://api/users/{id}', pathname: '/coll/Users/GetUser.bru', folderPath: 'Users', type: 'http-request' },
+      { name: 'GraphQL Query', method: 'POST', url: 'https://api/gql', pathname: '/coll/gql.bru', folderPath: '', type: 'graphql-request' }
+    ];
+
+    it('formats the inline preview with method + folder-qualified name', () => {
+      const out = formatRequestsList(requests);
+      expect(out).toContain('POST Auth/Login');
+      expect(out).toContain('GET Users/GetUser');
+      expect(out).toContain('POST GraphQL Query');
+    });
+
+    it('adds a trailer when the collection exceeds the preview limit', () => {
+      const many = Array.from({ length: 40 }, (_, i) => ({
+        name: 'Req' + i, method: 'GET', url: '/r/' + i, pathname: '/p/' + i, folderPath: '', type: 'http-request'
+      }));
+      const out = formatRequestsList(many);
+      expect(out).toContain('(+15 more');
+    });
+
+    it('returns case-insensitive substring matches across name, url, pathname, folder', () => {
+      expect(searchRequests(requests, 'login').totalMatched).toBe(1);
+      expect(searchRequests(requests, 'auth').totalMatched).toBe(2);
+      expect(searchRequests(requests, 'users').totalMatched).toBe(1);
+      expect(searchRequests(requests, 'GQL').totalMatched).toBe(1);
+    });
+
+    it('exact-matches HTTP methods without letting "get" match every URL', () => {
+      const result = searchRequests(requests, 'get');
+      expect(result.totalMatched).toBe(1);
+      expect(result.items[0].name).toBe('GetUser');
+    });
+
+    it('returns every request for an empty query, capped at the limit', () => {
+      const result = searchRequests(requests, '', 50);
+      expect(result.items).toHaveLength(4);
+      expect(result.totalMatched).toBe(4);
+    });
+
+    it('formats matches with pathname so the model can pass it to bru.ctx.runRequest', () => {
+      const out = formatSearchRequestsResult(searchRequests(requests, 'login'), 'login');
+      expect(out).toContain('Found 1');
+      expect(out).toContain('POST Auth/Login');
+      expect(out).toContain('pathname: /coll/Auth/Login.bru');
+    });
+
+    it('says "no matches" when nothing matched the query', () => {
+      expect(formatSearchRequestsResult(searchRequests(requests, 'zzz'), 'zzz'))
+        .toBe('No requests match "zzz".');
     });
   });
 });


### PR DESCRIPTION
### Description

- Introduced `buildAiRequestsPayload` to construct request payloads from the collection.
- Updated `sendAiMessage` to accept and dispatch requests alongside existing parameters.
- Enhanced `buildContextMessage` to include a preview of requests in the chat context.
- Implemented search and formatting functions for requests in the context module.
- Added tests for new request handling functionalities.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI chat now receives context about requests in the active collection.
  * Added request browsing and search capabilities, including filtering by name, URL, path, folder, or HTTP method.
  * AI responses can reference request paths and provide clearer collection-level guidance.

* **Bug Fixes**
  * Improved request context accuracy by preventing the AI from inventing request pathnames.

* **Tests**
  * Added coverage for request previews, searching, result formatting, limits, and empty matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->