### PR TITLE
fix(keybindings): new request in active tab based on active collection

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -8,7 +8,7 @@ import { clearGlobalEnvironmentDraft } from 'providers/ReduxStore/slices/global-
 import { saveGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import { useTheme } from 'providers/Theme';
 import { useDispatch, useSelector } from 'react-redux';
-import { findItemInCollection, findItemInCollectionByPathname, hasRequestChanges, areItemsLoading, isItemTransientRequest } from 'utils/collections';
+import { findItemInCollection, findItemInCollectionByPathname, findParentItemInCollectionByPathname, hasRequestChanges, areItemsLoading, isItemTransientRequest, isScratchCollection } from 'utils/collections';
 import ConfirmRequestClose from './ConfirmRequestClose';
 import ConfirmCollectionClose from './ConfirmCollectionClose';
 import ConfirmFolderClose from './ConfirmFolderClose';
@@ -39,6 +39,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   const [showConfirmFolderClose, setShowConfirmFolderClose] = useState(false);
   const [showConfirmEnvironmentClose, setShowConfirmEnvironmentClose] = useState(false);
   const [showConfirmGlobalEnvironmentClose, setShowConfirmGlobalEnvironmentClose] = useState(false);
+  const [newRequestTarget, setNewRequestTarget] = useState(null);
 
   const menuDropdownRef = useRef();
 
@@ -206,6 +207,10 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
 
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const isActive = tab.uid === activeTabUid;
+  // Truthy only when a sidebar folder/collection is focused; those own the
+  // new-request shortcut (with folder targeting), so the tab handler yields to them.
+  const focusedSidebarPath = useSelector((state) => state.app.focusedSidebarPath);
+  const workspaces = useSelector((state) => state.workspaces.workspaces);
 
   // Close tab shortcut — draft-aware, only active for the focused tab
   useKeybinding('closeTab', () => {
@@ -289,6 +294,35 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
     }
     return false;
   }, { enabled: isActive, deps: [isActive, tab, item, collection, folder, globalEnvironmentDraft] });
+
+  useKeybinding('newRequest', () => {
+    // console.log({tab})
+    const requestTypes = ['request', 'http-request', 'graphql-request', 'grpc-request', 'ws-request'];
+
+    // No collection in context at all (e.g. global preferences) — nothing to target.
+    if (!collection) return false;
+
+    // Only the workspace's hidden scratch collection is active (overview, workspace
+    // environments, preferences). There's no sidebar-visible collection selected, so
+    // create a transient request the user can later persist via the transient-save flow.
+    if (isScratchCollection(collection, workspaces)) {
+      setNewRequestTarget({ collectionUid: collection.uid, item: null, isTransient: true });
+      return false;
+    }
+
+    if (requestTypes.includes(tab.type)) {
+      const parentFolder = item?.pathname ? findParentItemInCollectionByPathname(collection, item.pathname) : null;
+      setNewRequestTarget({ collectionUid: collection.uid, item: parentFolder || null });
+    } else if (tab.type === 'folder-settings' && folder) {
+      setNewRequestTarget({ collectionUid: collection.uid, item: folder });
+    } else {
+      // Any other collection-scoped tab (settings, overview, runner, variables, …)
+      // creates a request at the active collection's root.
+      setNewRequestTarget({ collectionUid: collection.uid, item: null });
+    }
+
+    return false;
+  }, { enabled: isActive && !focusedSidebarPath, deps: [isActive, focusedSidebarPath, tab, item, collection, folder, workspaces] });
 
   const handleCloseEnvironmentSettings = (event) => {
     if (!collection?.environmentsDraft) {
@@ -474,6 +508,14 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
             }}
           />
         )}
+        {newRequestTarget && (
+          <NewRequest
+            collectionUid={newRequestTarget.collectionUid}
+            item={newRequestTarget.item}
+            isTransient={newRequestTarget.isTransient}
+            onClose={() => setNewRequestTarget(null)}
+          />
+        )}
         {tab.type === 'folder-settings' && !folder ? (
           tab.name && isItemsLoading
             ? <RequestTabLoading handleCloseClick={handleCloseClick} name={tab.name} />
@@ -572,6 +614,14 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
                 console.log('err', err);
               });
           }}
+        />
+      )}
+      {newRequestTarget && (
+        <NewRequest
+          collectionUid={newRequestTarget.collectionUid}
+          item={newRequestTarget.item}
+          isTransient={newRequestTarget.isTransient}
+          onClose={() => setNewRequestTarget(null)}
         />
       )}
       <div

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -8,7 +8,8 @@ import { clearGlobalEnvironmentDraft } from 'providers/ReduxStore/slices/global-
 import { saveGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import { useTheme } from 'providers/Theme';
 import { useDispatch, useSelector } from 'react-redux';
-import { findItemInCollection, findItemInCollectionByPathname, findParentItemInCollectionByPathname, hasRequestChanges, areItemsLoading, isItemTransientRequest, isScratchCollection } from 'utils/collections';
+import { findItemInCollection, findItemInCollectionByPathname, hasRequestChanges, areItemsLoading, isItemTransientRequest } from 'utils/collections';
+import { resolveNewRequestTarget } from './resolveNewRequestTarget';
 import ConfirmRequestClose from './ConfirmRequestClose';
 import ConfirmCollectionClose from './ConfirmCollectionClose';
 import ConfirmFolderClose from './ConfirmFolderClose';
@@ -210,7 +211,6 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   // Truthy only when a sidebar folder/collection is focused; those own the
   // new-request shortcut (with folder targeting), so the tab handler yields to them.
   const focusedSidebarPath = useSelector((state) => state.app.focusedSidebarPath);
-  const workspaces = useSelector((state) => state.workspaces.workspaces);
 
   // Close tab shortcut — draft-aware, only active for the focused tab
   useKeybinding('closeTab', () => {
@@ -296,33 +296,12 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
   }, { enabled: isActive, deps: [isActive, tab, item, collection, folder, globalEnvironmentDraft] });
 
   useKeybinding('newRequest', () => {
-    // console.log({tab})
-    const requestTypes = ['request', 'http-request', 'graphql-request', 'grpc-request', 'ws-request'];
-
-    // No collection in context at all (e.g. global preferences) — nothing to target.
-    if (!collection) return false;
-
-    // Only the workspace's hidden scratch collection is active (overview, workspace
-    // environments, preferences). There's no sidebar-visible collection selected, so
-    // create a transient request the user can later persist via the transient-save flow.
-    if (isScratchCollection(collection, workspaces)) {
-      setNewRequestTarget({ collectionUid: collection.uid, item: null, isTransient: true });
-      return false;
+    const target = resolveNewRequestTarget({ tab, item, collection, folder });
+    if (target) {
+      setNewRequestTarget(target);
     }
-
-    if (requestTypes.includes(tab.type)) {
-      const parentFolder = item?.pathname ? findParentItemInCollectionByPathname(collection, item.pathname) : null;
-      setNewRequestTarget({ collectionUid: collection.uid, item: parentFolder || null });
-    } else if (tab.type === 'folder-settings' && folder) {
-      setNewRequestTarget({ collectionUid: collection.uid, item: folder });
-    } else {
-      // Any other collection-scoped tab (settings, overview, runner, variables, …)
-      // creates a request at the active collection's root.
-      setNewRequestTarget({ collectionUid: collection.uid, item: null });
-    }
-
     return false;
-  }, { enabled: isActive && !focusedSidebarPath, deps: [isActive, focusedSidebarPath, tab, item, collection, folder, workspaces] });
+  }, { enabled: isActive && !focusedSidebarPath, deps: [isActive, focusedSidebarPath, tab, item, collection, folder] });
 
   const handleCloseEnvironmentSettings = (event) => {
     if (!collection?.environmentsDraft) {
@@ -343,6 +322,14 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
     event.preventDefault();
     setShowConfirmGlobalEnvironmentClose(true);
   };
+
+  const newRequestModal = newRequestTarget ? (
+    <NewRequest
+      collectionUid={newRequestTarget.collectionUid}
+      item={newRequestTarget.item}
+      onClose={() => setNewRequestTarget(null)}
+    />
+  ) : null;
 
   if (specialTabs.includes(tab.type)) {
     return (
@@ -508,14 +495,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
             }}
           />
         )}
-        {newRequestTarget && (
-          <NewRequest
-            collectionUid={newRequestTarget.collectionUid}
-            item={newRequestTarget.item}
-            isTransient={newRequestTarget.isTransient}
-            onClose={() => setNewRequestTarget(null)}
-          />
-        )}
+        {newRequestModal}
         {tab.type === 'folder-settings' && !folder ? (
           tab.name && isItemsLoading
             ? <RequestTabLoading handleCloseClick={handleCloseClick} name={tab.name} />
@@ -616,14 +596,7 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
           }}
         />
       )}
-      {newRequestTarget && (
-        <NewRequest
-          collectionUid={newRequestTarget.collectionUid}
-          item={newRequestTarget.item}
-          isTransient={newRequestTarget.isTransient}
-          onClose={() => setNewRequestTarget(null)}
-        />
-      )}
+      {newRequestModal}
       <div
         ref={tabLabelRef}
         className={`flex items-baseline tab-label ${tab.preview ? 'italic' : ''}`}

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/resolveNewRequestTarget.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/resolveNewRequestTarget.js
@@ -1,0 +1,29 @@
+import { findParentItemInCollectionByPathname } from 'utils/collections';
+
+const REQUEST_TAB_TYPES = ['request', 'http-request', 'graphql-request', 'grpc-request', 'ws-request'];
+
+/**
+ * Resolves where a new request should be created when Cmd/Ctrl+N is pressed
+ * from the active request tab (sidebar folder/collection focus yields separately).
+ *
+ * @returns {{ collectionUid: string, item: object|null }|null}
+ */
+export const resolveNewRequestTarget = ({ tab, item, collection, folder }) => {
+  if (!collection) {
+    return null;
+  }
+
+  if (REQUEST_TAB_TYPES.includes(tab.type)) {
+    const parentFolder = item?.pathname
+      ? findParentItemInCollectionByPathname(collection, item.pathname)
+      : null;
+    return { collectionUid: collection.uid, item: parentFolder || null };
+  }
+
+  if (tab.type === 'folder-settings' && folder) {
+    return { collectionUid: collection.uid, item: folder };
+  }
+
+  // collection-settings, overview, runner, variables, etc. → collection root
+  return { collectionUid: collection.uid, item: null };
+};

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/resolveNewRequestTarget.spec.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/resolveNewRequestTarget.spec.js
@@ -1,0 +1,79 @@
+const { resolveNewRequestTarget } = require('./resolveNewRequestTarget');
+
+describe('resolveNewRequestTarget', () => {
+  const collection = {
+    uid: 'col-1',
+    items: [
+      {
+        uid: 'folder-1',
+        type: 'folder',
+        pathname: '/col/folder',
+        items: [
+          { uid: 'req-nested', type: 'http-request', pathname: '/col/folder/req.bru' }
+        ]
+      },
+      { uid: 'req-root', type: 'http-request', pathname: '/col/req.bru' }
+    ]
+  };
+
+  const folder = { uid: 'folder-1', type: 'folder', pathname: '/col/folder' };
+
+  it('returns null when there is no collection', () => {
+    expect(resolveNewRequestTarget({
+      tab: { type: 'http-request' },
+      item: null,
+      collection: null,
+      folder: null
+    })).toBeNull();
+  });
+
+  it('targets collection root for a root-level request tab', () => {
+    expect(resolveNewRequestTarget({
+      tab: { type: 'http-request' },
+      item: { uid: 'req-root', pathname: '/col/req.bru' },
+      collection,
+      folder: null
+    })).toEqual({ collectionUid: 'col-1', item: null });
+  });
+
+  it('targets parent folder for a nested request tab', () => {
+    const result = resolveNewRequestTarget({
+      tab: { type: 'http-request' },
+      item: { uid: 'req-nested', pathname: '/col/folder/req.bru' },
+      collection,
+      folder: null
+    });
+
+    expect(result).toEqual({
+      collectionUid: 'col-1',
+      item: expect.objectContaining({ uid: 'folder-1', type: 'folder', pathname: '/col/folder' })
+    });
+  });
+
+  it('targets the folder for folder-settings tab', () => {
+    expect(resolveNewRequestTarget({
+      tab: { type: 'folder-settings' },
+      item: null,
+      collection,
+      folder
+    })).toEqual({ collectionUid: 'col-1', item: folder });
+  });
+
+  it('targets collection root for folder-settings without a folder', () => {
+    expect(resolveNewRequestTarget({
+      tab: { type: 'folder-settings' },
+      item: null,
+      collection,
+      folder: null
+    })).toEqual({ collectionUid: 'col-1', item: null });
+  });
+
+  it('targets collection root for collection-settings tab', () => {
+    expect(resolveNewRequestTarget({
+      tab: { type: 'collection-settings' },
+      item: null,
+      collection,
+      folder: null
+    })).toEqual({ collectionUid: 'col-1', item: null });
+  });
+});

--- a/tests/shortcuts/helpers.ts
+++ b/tests/shortcuts/helpers.ts
@@ -7,6 +7,7 @@ import {
   openCollection,
   openRequest as openRequestBase
 } from '../utils/page';
+import { buildCommonLocators } from '../utils/page/locators';
 
 export const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
 export const collectionName = 'kb-collection';
@@ -176,7 +177,8 @@ export const focusTabWithoutSidebarFocus = async (page: Page, tabName: string | 
   await expect(tab).toHaveClass(/active/);
 
   // Blur sidebar so focusedSidebarPath is null and RequestTab's newRequest binding is enabled.
-  const requestUrl = page.getByTestId('request-url');
+  const locators = buildCommonLocators(page);
+  const requestUrl = locators.request.urlInput();
   if (await requestUrl.isVisible().catch(() => false)) {
     await requestUrl.click();
     return;
@@ -188,9 +190,10 @@ export const focusTabWithoutSidebarFocus = async (page: Page, tabName: string | 
 };
 
 export const fillAndCreateNewRequest = async (page: Page, requestName: string) => {
-  await expect(page.getByTestId('request-name')).toBeVisible();
-  await page.getByTestId('request-name').fill(requestName);
-  await page.getByTestId('new-request-url').locator('.CodeMirror').click();
+  const locators = buildCommonLocators(page);
+  await expect(locators.request.requestNameInput()).toBeVisible();
+  await locators.request.requestNameInput().fill(requestName);
+  await locators.request.newRequestUrl().click();
   await page.keyboard.type('https://echo.usebruno.com');
-  await page.getByTestId('create-new-request-button').click();
+  await locators.modal.button('Create').click();
 };

--- a/tests/shortcuts/helpers.ts
+++ b/tests/shortcuts/helpers.ts
@@ -168,3 +168,29 @@ export const getTabIndex = async (page: Page, name: string) => {
 
   return -1;
 };
+
+/** Activate a request/special tab and clear sidebar folder/collection focus so the tab owns shortcuts. */
+export const focusTabWithoutSidebarFocus = async (page: Page, tabName: string | RegExp) => {
+  const tab = page.locator('.request-tab').filter({ has: page.getByText(tabName, { exact: true }) });
+  await tab.click();
+  await expect(tab).toHaveClass(/active/);
+
+  // Blur sidebar so focusedSidebarPath is null and RequestTab's newRequest binding is enabled.
+  const requestUrl = page.getByTestId('request-url');
+  if (await requestUrl.isVisible().catch(() => false)) {
+    await requestUrl.click();
+    return;
+  }
+
+  // Special tabs (folder/collection settings, overview) have no request URL and no other
+  // focusable element to click — blur the sidebar row directly (it's the only thing focused).
+  await page.evaluate(() => (document.activeElement as HTMLElement)?.blur());
+};
+
+export const fillAndCreateNewRequest = async (page: Page, requestName: string) => {
+  await expect(page.getByTestId('request-name')).toBeVisible();
+  await page.getByTestId('request-name').fill(requestName);
+  await page.getByTestId('new-request-url').locator('.CodeMirror').click();
+  await page.keyboard.type('https://echo.usebruno.com');
+  await page.getByTestId('create-new-request-button').click();
+};

--- a/tests/shortcuts/new-request-from-tab.spec.ts
+++ b/tests/shortcuts/new-request-from-tab.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from '../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createRequest,
+  expandFolder,
+  openCollectionSettings,
+  openRequest
+} from '../utils/page';
+import {
+  collectionName,
+  fillAndCreateNewRequest,
+  focusTabWithoutSidebarFocus,
+  modifier,
+  openFolderSettingsTab,
+  pressShortcut,
+  resetKeybindings,
+  setupBoundActionsData
+} from './helpers';
+
+test.describe('Shortcut Keys - New Request from active tab', () => {
+  test.beforeEach(async ({ pageWithUserData: page, createTmpDir }) => {
+    await page.locator('[data-app-state="loaded"]').waitFor();
+    await setupBoundActionsData(page, createTmpDir);
+  });
+
+  test.afterEach(async ({ pageWithUserData: page }) => {
+    await resetKeybindings(page);
+    await closeAllCollections(page);
+  });
+
+  test('Cmd/Ctrl+N from a root request tab creates at collection root', async ({ pageWithUserData: page }) => {
+    await test.step('Arrange: open a root-level request and clear sidebar focus', async () => {
+      await createRequest(page, 'root-req', collectionName);
+      await openRequest(page, collectionName, 'root-req', { persist: true });
+      await focusTabWithoutSidebarFocus(page, 'root-req');
+    });
+
+    await test.step('Act: newRequest shortcut from the active tab', async () => {
+      await pressShortcut(page, modifier, 'KeyN');
+      await fillAndCreateNewRequest(page, 'from-root-tab');
+    });
+
+    await test.step('Assert: request lands at collection root', async () => {
+      const locators = buildCommonLocators(page);
+      await expect(locators.sidebar.request('from-root-tab')).toBeVisible();
+      await expect(locators.sidebar.folderRequest('kb-folder', 'from-root-tab')).toHaveCount(0);
+    });
+  });
+
+  test('Cmd/Ctrl+N from a nested request tab creates in the parent folder', async ({ pageWithUserData: page }) => {
+    await test.step('Arrange: request inside kb-folder, tab focused', async () => {
+      await expandFolder(page, 'kb-folder');
+      await createRequest(page, 'nested-req', 'kb-folder', { inFolder: true });
+      await openRequest(page, collectionName, 'nested-req', { persist: true });
+      await focusTabWithoutSidebarFocus(page, 'nested-req');
+    });
+
+    await test.step('Act: newRequest shortcut from the active tab', async () => {
+      await pressShortcut(page, modifier, 'KeyN');
+      await fillAndCreateNewRequest(page, 'from-nested-tab');
+    });
+
+    await test.step('Assert: request lands under parent folder', async () => {
+      const locators = buildCommonLocators(page);
+      await expect(locators.sidebar.folderRequest('kb-folder', 'from-nested-tab')).toBeVisible();
+    });
+  });
+
+  test('Cmd/Ctrl+N from folder-settings tab creates in that folder', async ({ pageWithUserData: page }) => {
+    await test.step('Arrange: open folder settings and clear sidebar focus', async () => {
+      await openFolderSettingsTab(page, 'kb-folder');
+      await focusTabWithoutSidebarFocus(page, 'kb-folder');
+    });
+
+    await test.step('Act: newRequest shortcut from folder-settings tab', async () => {
+      await pressShortcut(page, modifier, 'KeyN');
+      await fillAndCreateNewRequest(page, 'from-folder-settings');
+    });
+
+    await test.step('Assert: request lands under that folder', async () => {
+      const locators = buildCommonLocators(page);
+      await expect(locators.sidebar.folderRequest('kb-folder', 'from-folder-settings')).toBeVisible();
+    });
+  });
+
+  test('Cmd/Ctrl+N from collection-settings tab creates at collection root', async ({ pageWithUserData: page }) => {
+    await test.step('Arrange: open collection settings and clear sidebar focus', async () => {
+      await openCollectionSettings(page, collectionName, { persist: true });
+      await focusTabWithoutSidebarFocus(page, 'Collection');
+    });
+
+    await test.step('Act: newRequest shortcut from collection-settings tab', async () => {
+      await pressShortcut(page, modifier, 'KeyN');
+      await fillAndCreateNewRequest(page, 'from-collection-settings');
+    });
+
+    await test.step('Assert: request lands at collection root', async () => {
+      const locators = buildCommonLocators(page);
+      await expect(locators.sidebar.request('from-collection-settings')).toBeVisible();
+      await expect(locators.sidebar.folderRequest('kb-folder', 'from-collection-settings')).toHaveCount(0);
+    });
+  });
+
+  test('Cmd/Ctrl+N yields to sidebar when a folder is focused', async ({ pageWithUserData: page }) => {
+    await test.step('Arrange: active request tab + sidebar folder focus', async () => {
+      await createRequest(page, 'yield-req', collectionName);
+      await openRequest(page, collectionName, 'yield-req', { persist: true });
+      const locators = buildCommonLocators(page);
+      await locators.tabs.requestTab('yield-req').click();
+      await expect(locators.tabs.activeRequestTab()).toContainText('yield-req');
+
+      // Focus folder in sidebar — tab handler must yield (focusedSidebarPath truthy).
+      await locators.sidebar.folder('kb-folder').click();
+    });
+
+    await test.step('Act: newRequest shortcut while folder is focused', async () => {
+      await pressShortcut(page, modifier, 'KeyN');
+      await fillAndCreateNewRequest(page, 'from-sidebar-folder');
+    });
+
+    await test.step('Assert: request created in focused folder (sidebar wins)', async () => {
+      const locators = buildCommonLocators(page);
+      await expect(locators.sidebar.folderRequest('kb-folder', 'from-sidebar-folder')).toBeVisible();
+    });
+  });
+});

--- a/tests/shortcuts/new-request-from-tab.spec.ts
+++ b/tests/shortcuts/new-request-from-tab.spec.ts
@@ -20,7 +20,6 @@ import {
 
 test.describe('Shortcut Keys - New Request from active tab', () => {
   test.beforeEach(async ({ pageWithUserData: page, createTmpDir }) => {
-    await page.locator('[data-app-state="loaded"]').waitFor();
     await setupBoundActionsData(page, createTmpDir);
   });
 


### PR DESCRIPTION
### Description

BRU-3969

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a focused-tab keyboard shortcut (Cmd/Ctrl+N) to quickly create a new request from the active tab context.
  * The new request destination is automatically preselected based on the current tab type (root request, nested request, folder settings, or collection settings), and respects sidebar focus when present.
* **Tests**
  * Added unit tests to verify request targeting logic across tab and folder scenarios.
  * Added Playwright coverage to confirm the shortcut creates new requests in the correct destination for each UI context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->