### PR TITLE
fix(lang): guard ntlm domain on domainKey, not passwordKey

### DIFF
--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -794,7 +794,7 @@ const sem = grammar.createSemantics().addAttribute('ast', {
 
     const username = usernameKey ? usernameKey.value : '';
     const password = passwordKey ? passwordKey.value : '';
-    const domain = passwordKey ? domainKey.value : '';
+    const domain = domainKey ? domainKey.value : '';
 
     return {
       auth: {

--- a/packages/bruno-lang/v2/tests/bruToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/bruToJson.spec.js
@@ -1045,4 +1045,37 @@ headers {
       });
     });
   });
+
+  describe('auth:ntlm', () => {
+    it('should parse ntlm auth with a domain', () => {
+      const input = `
+auth:ntlm {
+  username: u
+  password: p
+  domain: d
+}`.trim();
+
+      const output = parser(input);
+      expect(output.auth.ntlm).toEqual({
+        username: 'u',
+        password: 'p',
+        domain: 'd'
+      });
+    });
+
+    it('should default domain to empty string when the domain line is absent', () => {
+      const input = `
+auth:ntlm {
+  username: u
+  password: p
+}`.trim();
+
+      const output = parser(input);
+      expect(output.auth.ntlm).toEqual({
+        username: 'u',
+        password: 'p',
+        domain: ''
+      });
+    });
+  });
 });


### PR DESCRIPTION
BRU-3988

## Summary

An `auth:ntlm` block with `username`/`password` but no `domain` line threw a `TypeError` and the `.bru` failed to parse. This guards the domain lookup on the correct key so it defaults to an empty string.

## Root cause

In `authNTLM` (`packages/bruno-lang/v2/src/bruToJson.js`), the domain line reads `domainKey.value` but guards on `passwordKey`:

```js
const password = passwordKey ? passwordKey.value : '';
const domain = passwordKey ? domainKey.value : '';
```

When a block has a password but no domain, `passwordKey` is truthy while `domainKey` is `undefined`, so `domainKey.value` throws `TypeError: Cannot read properties of undefined (reading 'value')`. A valid request `.bru` with NTLM auth and no explicit domain fails to parse.

## Fix

Guard the domain on `domainKey`, matching the `username` and `password` lines directly above:

```js
const domain = domainKey ? domainKey.value : '';
```

## Test plan

Added an `auth:ntlm` describe block to `packages/bruno-lang/v2/tests/bruToJson.spec.js`: one case with a domain line and one without. The no-domain case throws on the base branch and passes with the fix.

```
npx jest v2/tests/bruToJson.spec.js
Tests:       34 passed, 34 total

npx jest   # full bruno-lang suite
Test Suites: 32 passed, 32 total
Tests:       450 passed, 450 total
```

Fixes #8695.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  <img width="988" height="452" alt="Screenshot 2026-08-27 at 1 49 34 PM" src="https://github.com/user-attachments/assets/6854da46-751f-4a06-aae7-444f805bcfc6" /> |  <img width="988" height="452" alt="Screenshot 2026-08-27 at 1 50 18 PM" src="https://github.com/user-attachments/assets/00a12168-5b27-4f86-87c0-63ca78174dd5" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected NTLM authentication parsing so the domain is properly recognized when provided.
  * NTLM configurations without a domain now consistently default to an empty domain value.

* **Tests**
  * Added coverage for NTLM authentication with and without an explicit domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->