### PR TITLE
fix(lang): escape triple quotes in multiline request values

### DIFF
--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -4,6 +4,7 @@ const {
   safeParseJson,
   outdentString,
   unescapeAnnotationDoubleQuotedArg,
+  unescapeMultilineValue,
   parseAnnotationMultilineTextBlock,
   applyDescriptionFromAnnotations,
   extractTypedAnnotations
@@ -506,7 +507,7 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     return '';
   },
   multilinetextblock(_1, content, _2, _3, contentType) {
-    const multilineString = content.sourceString
+    const multilineString = unescapeMultilineValue(content.sourceString)
       .split('\n')
       .map((line) => line.slice(4))
       .join('\n');

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -1,6 +1,17 @@
 const _ = require('lodash');
-const { indentString, getValueString, getKeyString, getValueUrl, serializeVar, serializeAnnotations, buildAnnotationsFromKVItem } = require('./utils');
+const {
+  indentString,
+  getValueString: getBaseValueString,
+  getKeyString,
+  getValueUrl,
+  serializeVar: serializeBaseVar,
+  serializeAnnotations,
+  buildAnnotationsFromKVItem
+} = require('./utils');
 const jsonToExampleBru = require('./example/jsonToBru');
+
+const getValueString = (value) => getBaseValueString(value, { escapeMultiline: true });
+const serializeVar = (item, prefix = '') => serializeBaseVar(item, prefix, { escapeMultiline: true });
 
 const enabled = (items = [], key = 'enabled') => items.filter((item) => item[key]);
 const disabled = (items = [], key = 'enabled') => items.filter((item) => !item[key]);

--- a/packages/bruno-lang/v2/src/utils.js
+++ b/packages/bruno-lang/v2/src/utils.js
@@ -109,16 +109,28 @@ const unescapeAnnotationDoubleQuotedArg = (value) =>
 const escapeAnnotationDoubleQuotedArg = (value) =>
   value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
-// Escapes a multiline description's own delimiter (''') so it can safely round-trip
+const multilineDelimiterRun = /'{3,}/g;
+const escapedMultilineDelimiterRun = /\\+'(?:\\'){2,}/g;
+
+// Escapes a multiline value's own delimiter (''') so it can safely round-trip
 // inside a '''...''' block. Any pre-existing \' must be doubled first so decoding
 // can tell it apart from the backslashes introduced by escaping '''.
-const escapeMultilineDescription = (value) =>
-  value.split('\\\'').join('\\\\\'').split('\'\'\'').join('\\\'\\\'\\\'');
+const escapeMultilineValue = (value) =>
+  value
+    .split('\\\'')
+    .join('\\\\\'')
+    .replace(multilineDelimiterRun, (quotes) => quotes.replace(/'/g, '\\\''));
 
-const unescapeMultilineDescription = (value) =>
-  value.split('\\\'\\\'\\\'').join('\'\'\'').split('\\\\\'').join('\\\'');
+const unescapeMultilineValue = (value) =>
+  value
+    .replace(escapedMultilineDelimiterRun, (escapedQuotes) => escapedQuotes.replace(/\\'/g, '\''))
+    .split('\\\\\'')
+    .join('\\\'');
 
-const getValueString = (value) => {
+const escapeMultilineDescription = escapeMultilineValue;
+const unescapeMultilineDescription = unescapeMultilineValue;
+
+const getValueString = (value, { escapeMultiline = false } = {}) => {
   // Handle null, undefined, and empty strings
   if (!value && value !== 0 && value !== false) {
     return '';
@@ -136,7 +148,8 @@ const getValueString = (value) => {
   }
 
   // Wrap multiline values in triple quotes with 2-space indentation
-  return `'''\n${indentString(value)}\n'''`;
+  const blockValue = escapeMultiline ? escapeMultilineValue(value) : value;
+  return `'''\n${indentString(blockValue)}\n'''`;
 };
 
 const getKeyString = (key) => {
@@ -157,7 +170,7 @@ const getValueUrl = (url) => {
   }
 
   // Wrap multiline values in triple quotes with 4-space indentation (2 levels)
-  return `'''\n${indentString(url, 2)}\n'''`;
+  return `'''\n${indentString(escapeMultilineValue(url), 2)}\n'''`;
 };
 
 const formatAnnotationArg = (strValue) => {
@@ -220,8 +233,8 @@ const extractTypedAnnotations = (rawAnnotations, result) => {
   result.value = parseValueByDataType(result.value, result.dataType);
 };
 
-const serializeVar = (item, prefix = '') => {
-  return `${serializeAnnotations(buildAnnotationsFromVariable(item))}${prefix}${item.name}: ${getValueString(item.value)}`;
+const serializeVar = (item, prefix = '', options) => {
+  return `${serializeAnnotations(buildAnnotationsFromVariable(item))}${prefix}${item.name}: ${getValueString(item.value, options)}`;
 };
 
 const applyDescriptionFromAnnotations = (result, annotations) => {
@@ -245,6 +258,8 @@ module.exports = {
   unescapeAnnotationDoubleQuotedArg,
   escapeMultilineDescription,
   unescapeMultilineDescription,
+  escapeMultilineValue,
+  unescapeMultilineValue,
   parseAnnotationMultilineTextBlock,
   getValueString,
   getKeyString,

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -1,4 +1,5 @@
 const stringify = require('../src/jsonToBru');
+const parse = require('../src/bruToJson');
 
 describe('jsonToBru stringify', () => {
   describe('body:ws', () => {
@@ -196,6 +197,38 @@ describe('jsonToBru stringify', () => {
         }
         "
       `);
+    });
+
+    it.each([
+      ['one delimiter', 'line1\ncontains \'\'\'\nline3', 'line1\ncontains \'\'\'\nline3'],
+      ['overlapping delimiters', 'line1\n\'\'\'\'\'\nline3', 'line1\n\'\'\'\'\'\nline3'],
+      ['multiple delimiters', 'line1\n\'\'\' and \'\'\'\nline3', 'line1\n\'\'\' and \'\'\'\nline3'],
+      ['backslash-quotes', 'line1\nit\\\'s \'\'\' here\nline3', 'line1\nit\\\'s \'\'\' here\nline3'],
+      ['CRLF newlines', 'line1\r\ncontains \'\'\'\r\nline3', 'line1\ncontains \'\'\'\nline3']
+    ])('round-trips %s in multiline request values', (_case, value, expected) => {
+      const input = {
+        meta: { name: 'triple-quote-value', type: 'http', seq: 1 },
+        http: { method: 'get', url: 'https://example.com', body: 'none' },
+        params: [{ name: 'query', value, enabled: true, type: 'query' }],
+        headers: [{ name: 'X-Test', value, enabled: true }],
+        vars: { req: [{ name: 'test-var', value, enabled: true }] }
+      };
+
+      const parsed = parse(stringify(input));
+
+      expect(parsed.params[0].value).toBe(expected);
+      expect(parsed.headers[0].value).toBe(expected);
+      expect(parsed.vars.req[0].value).toBe(expected);
+    });
+
+    it('round-trips triple quotes in a multiline URL', () => {
+      const value = 'https://example.com/search\n?q=\'\'\'';
+      const input = {
+        meta: { name: 'triple-quote-url', type: 'http', seq: 1 },
+        http: { method: 'get', url: value, body: 'none' }
+      };
+
+      expect(parse(stringify(input)).http.url).toBe(value);
     });
   });
 


### PR DESCRIPTION
### Description

Fixes serialization of multiline request values that contain triple quotes. These values could close their `'''` block early and produce invalid or incorrectly parsed Bruno files.

This change escapes delimiter runs when serializing multiline URLs, query parameters, headers, and request variables, then restores the original value while parsing. Existing backslash-quote sequences remain distinguishable from generated escapes.

Regression coverage includes:

- a single triple-quote delimiter
- overlapping and repeated delimiter runs
- multiple delimiters in one value
- existing backslash-quote sequences
- CRLF normalization
- multiline URLs

### Validation

```text
npm test --workspace=packages/bruno-lang -- --runInBand
```

Result: 32 test suites passed, with 467 tests and 2 snapshots passing.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Screenshots are not applicable because this change only affects Bruno language serialization and parsing.

Fixes #8691.
