### PR TITLE
fix(workspace): notify about collections that fail to open in Workspace Home

### DIFF
--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -14,6 +14,7 @@ import {
 } from '@tabler/icons';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import { mountCollection, showInFolder } from 'providers/ReduxStore/slices/collections/actions';
+import { removeCollectionFromWorkspaceAction } from 'providers/ReduxStore/slices/workspaces/actions';
 import { getRevealInFolderLabel } from 'utils/common/platform';
 import { normalizePath } from 'utils/common/path';
 import toast from 'react-hot-toast';
@@ -76,6 +77,8 @@ const CollectionsList = ({ workspace }) => {
         environments: [],
         isGitBacked: !!wc.remote,
         isLoaded: false,
+        failedToOpen: !!wc.failedToOpen,
+        failureReason: wc.failureReason,
         gitRemoteUrl: wc.remote,
         git: { gitRootPath: null },
         brunoConfig: {},
@@ -95,6 +98,15 @@ const CollectionsList = ({ workspace }) => {
 
   const handleOpenCollectionClick = (collection, event) => {
     if (event.target.closest('.collection-menu')) {
+      return;
+    }
+
+    if (collection.failedToOpen) {
+      if (collection.failureReason === 'not-found') {
+        toast.error(`Collection "${collection.name}" could not be opened — not found at ${collection.pathname}`);
+      } else {
+        toast.error(`Collection "${collection.name}" could not be opened — no valid collection found at ${collection.pathname}`);
+      }
       return;
     }
 
@@ -155,6 +167,12 @@ const CollectionsList = ({ workspace }) => {
 
   const handleRemoveCollection = (collection) => {
     dropdownRefs.current[collection.uid]?.hide();
+    if (collection.failedToOpen) {
+      dispatch(removeCollectionFromWorkspaceAction(workspace.uid, collection.pathname))
+        .then(() => toast.success('Collection removed from workspace'))
+        .catch(() => toast.error('An error occurred while removing the collection'));
+      return;
+    }
     if (collection.isLoaded === false) {
       toast.error('Cannot remove collections that are not loaded');
       return;
@@ -312,7 +330,12 @@ const CollectionsList = ({ workspace }) => {
                       Git
                     </StatusBadge>
                   )}
-                  {!isDefaultWorkspace && collection.isLoaded === false && (
+                  {collection.failedToOpen && (
+                    <StatusBadge status="danger" size="xs">
+                      {collection.failureReason === 'not-found' ? 'Missing' : 'Failed to open'}
+                    </StatusBadge>
+                  )}
+                  {!isDefaultWorkspace && collection.isLoaded === false && !collection.failedToOpen && (
                     <StatusBadge status="warning" size="xs">Not cloned</StatusBadge>
                   )}
                 </div>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -371,8 +371,12 @@ const loadWorkspaceCollectionsForSwitch = async (dispatch, workspace) => {
         getState().collections.collections.map((c) => normalizePath(c.pathname))
       );
 
+      const unopened = updatedWorkspace.collections
+        .filter((wc) => wc.failedToOpen)
+        .map((wc) => wc.path);
+
       const collectionPaths = updatedWorkspace.collections
-        .filter((wc) => !wc.notFoundLocally)
+        .filter((wc) => !wc.notFoundLocally && !wc.failedToOpen)
         .map((wc) => wc.path)
         .filter((p) => p && !alreadyOpenCollections.includes(normalizePath(p)));
 
@@ -388,11 +392,20 @@ const loadWorkspaceCollectionsForSwitch = async (dispatch, workspace) => {
 
         if (Array.isArray(openResult?.failed) && openResult.failed.length > 0) {
           console.warn('Some workspace collections failed to open during switch:', openResult.failed);
+          unopened.push(...openResult.failed.map((f) => f.path));
         }
 
         if (Array.isArray(openResult?.invalid) && openResult.invalid.length > 0) {
           console.warn('Some workspace collection paths were invalid during switch:', openResult.invalid);
+          unopened.push(...openResult.invalid);
         }
+      }
+
+      if (unopened.length > 0) {
+        const message = unopened.length === 1
+          ? `Collection could not be opened: ${unopened[0]}`
+          : `${unopened.length} collections could not be opened`;
+        toast.error(message);
       }
     }
 

--- a/packages/bruno-electron/src/utils/workspace-config.js
+++ b/packages/bruno-electron/src/utils/workspace-config.js
@@ -563,6 +563,17 @@ const reorderWorkspaceCollections = async (workspacePath, collectionPaths) => {
   });
 };
 
+const getCollectionFailureReason = (collectionPath) => {
+  try {
+    if (!fs.existsSync(collectionPath) || !fs.statSync(collectionPath).isDirectory()) {
+      return 'not-found';
+    }
+  } catch (err) {
+    return 'not-found';
+  }
+  return 'invalid';
+};
+
 const resolveAndFilterWorkspaceCollections = (workspacePath, rawCollections) => {
   const seenPaths = new Set();
 
@@ -583,7 +594,7 @@ const resolveAndFilterWorkspaceCollections = (workspacePath, rawCollections) => 
 
       if (isValidCollectionDirectory(collection.path)) return collection;
       if (collection.remote) return { ...collection, notFoundLocally: true };
-      return null;
+      return { ...collection, failedToOpen: true, failureReason: getCollectionFailureReason(collection.path) };
     })
     .filter(Boolean);
 };

--- a/packages/bruno-electron/tests/utils/workspace-config.spec.js
+++ b/packages/bruno-electron/tests/utils/workspace-config.spec.js
@@ -179,9 +179,26 @@ describe('Git remote on workspace collections', () => {
     expect(missing.remote).toBe('https://github.com/x/missing');
   });
 
-  test('getWorkspaceCollections still drops missing entries that have no remote', () => {
+  test('getWorkspaceCollections keeps local entries that fail to open and flags them', () => {
     writeYml([collection('Missing', 'collections/missing')]);
-    expect(getWorkspaceCollections(workspacePath)).toHaveLength(0);
+
+    const result = getWorkspaceCollections(workspacePath);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Missing');
+    expect(result[0].failedToOpen).toBe(true);
+    expect(result[0].failureReason).toBe('not-found');
+  });
+
+  test('getWorkspaceCollections flags existing directories without a collection config as failed', () => {
+    fs.mkdirSync(path.join(workspacePath, 'collections/empty'), { recursive: true });
+    writeYml([collection('Empty', 'collections/empty')]);
+
+    const result = getWorkspaceCollections(workspacePath);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].failedToOpen).toBe(true);
+    expect(result[0].failureReason).toBe('invalid');
   });
 
   test('setCollectionGitRemote adds the collection path to .gitignore', async () => {


### PR DESCRIPTION
[JIRA - BRU-2508]

**Cause:** When a workspace was opened, any local collection that couldn't be loaded, its folder had been moved or deleted, or the path held no valid collection config was silently discarded during resolution. Because it was dropped entirely, Workspace Home showed nothing, no notification fired, and the user had no way to see why it failed or to remove the stale entry.

**Resolution:** Instead of discarding the broken entry, it's now kept and flagged with a failure reason (either "not found" or "invalid"). On switching workspaces the user gets an error notification, the collection stays visible with a red "Missing" / "Failed to open" badge, clicking it explains the reason, and it can be removed from the workspace via the row menu. The flags are transient in-memory state, so nothing changes on disk.
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced collection status badges for cases where collections are missing or fail to open, including “Missing” vs “Failed to open”.
  * Added more specific error toasts explaining why a collection could not be opened.
  * Enabled removing collections that fail to open directly from the workspace.

* **Bug Fixes**
  * Improved workspace switching/opening logic to treat failed-to-open collections as unopened and surface appropriate error feedback instead of silently skipping or only warning.
  * Updated workspace collection resolution to correctly classify missing vs invalid collection paths and preserve them for recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->