### PR TITLE
fix(devtools): prevent console panel from bleeding over modals

### DIFF
--- a/packages/bruno-app/src/components/Devtools/index.js
+++ b/packages/bruno-app/src/components/Devtools/index.js
@@ -77,13 +77,12 @@ const Devtools = ({ mainSectionRef }) => {
           cursor: 'row-resize',
           backgroundColor: isResizingDevtools ? dragHandleColor : 'transparent',
           transition: 'background-color 0.2s ease',
-          zIndex: 20,
           position: 'relative'
         }}
         onMouseEnter={(e) => e.target.style.backgroundColor = dragHandleColor}
         onMouseLeave={(e) => e.target.style.backgroundColor = isResizingDevtools ? dragHandleColor : 'transparent'}
       />
-      <div style={{ height: `${devtoolsHeight}px`, overflow: 'hidden', position: 'relative' }}>
+      <div style={{ height: `${devtoolsHeight}px`, overflow: 'hidden', position: 'relative', isolation: 'isolate' }}>
         <Console />
       </div>
     </>


### PR DESCRIPTION
### Description

Fixes the Devtools console panel and its resize handle rendering on top of modals when the console is open. Removed the explicit `z-index: 20` from the resize handle so it no longer floats above the modal's stacking context.  

Also added `isolation: isolate` to the console content container so any `z-index` descendants inside `<Console />` are contained and can't bleed over modals.

Ref: BRU-3968


#### Screenshot 
<img width="1469" height="858" alt="image" src="https://github.com/user-attachments/assets/adf4216a-6446-4d7f-965f-71f156a9960d" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Devtools panel resizing behavior.
  - Prevented layout and layering issues when interacting with the resize handle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->