### PR TITLE
fix(workspace): notify about collections that fail to open in Workspa…

### DIFF
--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -14,6 +14,7 @@ import {
 } from '@tabler/icons';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import { mountCollection, showInFolder } from 'providers/ReduxStore/slices/collections/actions';
+import { removeCollectionFromWorkspaceAction } from 'providers/ReduxStore/slices/workspaces/actions';
 import { getRevealInFolderLabel } from 'utils/common/platform';
 import { normalizePath } from 'utils/common/path';
 import toast from 'react-hot-toast';
@@ -76,6 +77,8 @@ const CollectionsList = ({ workspace }) => {
         environments: [],
         isGitBacked: !!wc.remote,
         isLoaded: false,
+        failedToOpen: !!wc.failedToOpen,
+        failureReason: wc.failureReason,
         gitRemoteUrl: wc.remote,
         git: { gitRootPath: null },
         brunoConfig: {},
@@ -95,6 +98,15 @@ const CollectionsList = ({ workspace }) => {
 
   const handleOpenCollectionClick = (collection, event) => {
     if (event.target.closest('.collection-menu')) {
+      return;
+    }
+
+    if (collection.failedToOpen) {
+      if (collection.failureReason === 'not-found') {
+        toast.error(`Collection "${collection.name}" could not be opened — not found at ${collection.pathname}`);
+      } else {
+        toast.error(`Collection "${collection.name}" could not be opened — no valid collection found at ${collection.pathname}`);
+      }
       return;
     }
 
@@ -155,6 +167,12 @@ const CollectionsList = ({ workspace }) => {
 
   const handleRemoveCollection = (collection) => {
     dropdownRefs.current[collection.uid]?.hide();
+    if (collection.failedToOpen) {
+      dispatch(removeCollectionFromWorkspaceAction(workspace.uid, collection.pathname))
+        .then(() => toast.success('Collection removed from workspace'))
+        .catch(() => toast.error('An error occurred while removing the collection'));
+      return;
+    }
     if (collection.isLoaded === false) {
       toast.error('Cannot remove collections that are not loaded');
       return;
@@ -312,7 +330,12 @@ const CollectionsList = ({ workspace }) => {
                       Git
                     </StatusBadge>
                   )}
-                  {!isDefaultWorkspace && collection.isLoaded === false && (
+                  {collection.failedToOpen && (
+                    <StatusBadge status="danger" size="xs">
+                      {collection.failureReason === 'not-found' ? 'Missing' : 'Failed to open'}
+                    </StatusBadge>
+                  )}
+                  {!isDefaultWorkspace && collection.isLoaded === false && !collection.failedToOpen && (
                     <StatusBadge status="warning" size="xs">Not cloned</StatusBadge>
                   )}
                 </div>

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -61,7 +61,7 @@ const CollectionsList = ({ workspace }) => {
         (c) => normalizePath(c.pathname) === normalizePath(wc.path)
       );
 
-      if (loadedCollection) {
+      if (loadedCollection && !wc.failedToOpen) {
         return {
           ...loadedCollection,
           isGitBacked: !!wc.remote,

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -102,11 +102,7 @@ const CollectionsList = ({ workspace }) => {
     }
 
     if (collection.failedToOpen) {
-      if (collection.failureReason === 'not-found') {
-        toast.error(`Collection "${collection.name}" could not be opened — not found at ${collection.pathname}`);
-      } else {
-        toast.error(`Collection "${collection.name}" could not be opened — no valid collection found at ${collection.pathname}`);
-      }
+      toast.error(`Collection could not be opened: ${collection.pathname}`);
       return;
     }
 
@@ -313,6 +309,7 @@ const CollectionsList = ({ workspace }) => {
             <div
               key={collection.uid || index}
               className="collection-card"
+              data-testid="collection-card"
               onClick={(e) => handleOpenCollectionClick(collection, e)}
             >
               <div className="collection-info">
@@ -325,18 +322,21 @@ const CollectionsList = ({ workspace }) => {
                     <StatusBadge
                       status="info"
                       size="xs"
+                      dataTestId="collection-git-badge"
                       leftSection={<IconBrandGit size={11} strokeWidth={2} />}
                     >
                       Git
                     </StatusBadge>
                   )}
                   {collection.failedToOpen && (
-                    <StatusBadge status="danger" size="xs">
+                    <StatusBadge status="danger" size="xs" dataTestId="collection-failed-badge">
                       {collection.failureReason === 'not-found' ? 'Missing' : 'Failed to open'}
                     </StatusBadge>
                   )}
                   {!isDefaultWorkspace && collection.isLoaded === false && !collection.failedToOpen && (
-                    <StatusBadge status="warning" size="xs">Not cloned</StatusBadge>
+                    <StatusBadge status="warning" size="xs" dataTestId="collection-not-cloned-badge">
+                      Not cloned
+                    </StatusBadge>
                   )}
                 </div>
                 <div className="collection-path">{collection.pathname}</div>

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -322,19 +322,19 @@ const CollectionsList = ({ workspace }) => {
                     <StatusBadge
                       status="info"
                       size="xs"
-                      dataTestId="collection-git-badge"
+                      data-testid="collection-git-badge"
                       leftSection={<IconBrandGit size={11} strokeWidth={2} />}
                     >
                       Git
                     </StatusBadge>
                   )}
                   {collection.failedToOpen && (
-                    <StatusBadge status="danger" size="xs" dataTestId="collection-failed-badge">
+                    <StatusBadge status="danger" size="xs" data-testid="collection-failed-badge">
                       {collection.failureReason === 'not-found' ? 'Missing' : 'Failed to open'}
                     </StatusBadge>
                   )}
                   {!isDefaultWorkspace && collection.isLoaded === false && !collection.failedToOpen && (
-                    <StatusBadge status="warning" size="xs" dataTestId="collection-not-cloned-badge">
+                    <StatusBadge status="warning" size="xs" data-testid="collection-not-cloned-badge">
                       Not cloned
                     </StatusBadge>
                   )}

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -371,8 +371,12 @@ const loadWorkspaceCollectionsForSwitch = async (dispatch, workspace) => {
         getState().collections.collections.map((c) => normalizePath(c.pathname))
       );
 
+      const unopened = updatedWorkspace.collections
+        .filter((wc) => wc.failedToOpen)
+        .map((wc) => wc.path);
+
       const collectionPaths = updatedWorkspace.collections
-        .filter((wc) => !wc.notFoundLocally)
+        .filter((wc) => !wc.notFoundLocally && !wc.failedToOpen)
         .map((wc) => wc.path)
         .filter((p) => p && !alreadyOpenCollections.includes(normalizePath(p)));
 
@@ -388,11 +392,20 @@ const loadWorkspaceCollectionsForSwitch = async (dispatch, workspace) => {
 
         if (Array.isArray(openResult?.failed) && openResult.failed.length > 0) {
           console.warn('Some workspace collections failed to open during switch:', openResult.failed);
+          unopened.push(...openResult.failed.map((f) => f.path));
         }
 
         if (Array.isArray(openResult?.invalid) && openResult.invalid.length > 0) {
           console.warn('Some workspace collection paths were invalid during switch:', openResult.invalid);
+          unopened.push(...openResult.invalid);
         }
+      }
+
+      if (unopened.length > 0) {
+        const message = unopened.length === 1
+          ? `Collection could not be opened: ${unopened[0]}`
+          : `${unopened.length} collections could not be opened`;
+        toast.error(message);
       }
     }
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -952,7 +952,7 @@ export const workspaceConfigUpdatedEvent = (workspacePath, workspaceUid, workspa
 
         if (workspace?.collections?.length > 0) {
           const newCollectionPaths = workspace.collections
-            .filter((workspaceCollection) => !workspaceCollection.notFoundLocally)
+            .filter((workspaceCollection) => !workspaceCollection.notFoundLocally && !workspaceCollection.failedToOpen)
             .map((workspaceCollection) => workspaceCollection.path)
             .filter((collectionPath) => collectionPath && !openCollections.includes(normalizePath(collectionPath)));
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.spec.js
@@ -9,10 +9,18 @@ jest.mock('react-hot-toast', () => ({
   error: jest.fn()
 }));
 
+jest.mock('../collections/actions', () => ({
+  createCollection: jest.fn(() => () => Promise.resolve()),
+  openMultipleCollections: jest.fn(() => () => Promise.resolve({ opened: [], failed: [], invalid: [] })),
+  openScratchCollectionEvent: jest.fn(() => () => Promise.resolve()),
+  mountCollection: jest.fn(() => () => Promise.resolve()),
+  hydrateCollectionWithUiStateSnapshot: jest.fn(() => () => Promise.resolve())
+}));
+
 import os from 'os';
 import path from 'path';
 import { configureStore } from '@reduxjs/toolkit';
-import workspacesReducer from './index';
+import workspacesReducer, { updateWorkspace } from './index';
 import collectionsReducer from '../collections';
 import chatReducer, { openAiSidebar } from '../chat';
 import appReducer from '../app';
@@ -114,5 +122,46 @@ describe('switchWorkspace', () => {
 
     expect(store.getState().chat.isOpen).toBe(false);
     expect(store.getState().workspaces.activeWorkspaceUid).toBe(WS_B);
+  });
+});
+
+describe('workspaceConfigUpdatedEvent', () => {
+  let workspaceConfigUpdatedEvent;
+  let openMultipleCollections;
+
+  const WS_A_PATH = path.join(os.tmpdir(), 'ws-a');
+  const GOOD_COLL = path.join(os.tmpdir(), 'good-coll');
+  const FAILED_COLL = path.join(os.tmpdir(), 'failed-coll');
+
+  beforeAll(async () => {
+    ({ openMultipleCollections } = await import('../collections/actions'));
+    ({ workspaceConfigUpdatedEvent } = await import('./actions'));
+  });
+
+  beforeEach(() => {
+    openMultipleCollections.mockClear();
+    // actions.js captures `const { ipcRenderer } = window` at import time, so mutate
+    // the existing object's `invoke` rather than reassigning window.ipcRenderer.
+    window.ipcRenderer.invoke = jest.fn((channel) => {
+      if (channel === 'renderer:load-workspace-collections') {
+        return Promise.resolve([
+          { name: 'Good', path: GOOD_COLL },
+          { name: 'Failed', path: FAILED_COLL, failedToOpen: true, failureReason: 'invalid' }
+        ]);
+      }
+      return mockIpcInvoke(channel);
+    });
+  });
+
+  it('does not re-attempt to open failed-to-open collections on a config update', async () => {
+    const store = createStore();
+    store.dispatch(updateWorkspace({ uid: WS_A, pathname: WS_A_PATH }));
+
+    await store.dispatch(workspaceConfigUpdatedEvent(WS_A_PATH, WS_A, { collections: [], docs: '' }));
+
+    expect(openMultipleCollections).toHaveBeenCalledTimes(1);
+    const attemptedPaths = openMultipleCollections.mock.calls[0][0];
+    expect(attemptedPaths).toContain(GOOD_COLL);
+    expect(attemptedPaths).not.toContain(FAILED_COLL);
   });
 });

--- a/packages/bruno-app/src/ui/StatusBadge/index.js
+++ b/packages/bruno-app/src/ui/StatusBadge/index.js
@@ -13,6 +13,7 @@ import StyledWrapper from './StyledWrapper';
  * - leftSection:  ReactNode rendered before children (e.g. icon)
  * - rightSection: ReactNode rendered after children (e.g. Help tooltip)
  * - className:    passthrough for additional styling
+ * - dataTestId:   passthrough for the data-testid attribute
  *
  * @example
  * <StatusBadge status="danger">Error</StatusBadge>
@@ -27,7 +28,8 @@ const StatusBadge = ({
   radius,
   leftSection,
   rightSection,
-  className = ''
+  className = '',
+  dataTestId
 }) => {
   return (
     <StyledWrapper
@@ -36,6 +38,7 @@ const StatusBadge = ({
       $size={size}
       $radius={radius}
       className={className}
+      data-testid={dataTestId}
     >
       {leftSection}
       {children}

--- a/packages/bruno-app/src/ui/StatusBadge/index.js
+++ b/packages/bruno-app/src/ui/StatusBadge/index.js
@@ -13,7 +13,7 @@ import StyledWrapper from './StyledWrapper';
  * - leftSection:  ReactNode rendered before children (e.g. icon)
  * - rightSection: ReactNode rendered after children (e.g. Help tooltip)
  * - className:    passthrough for additional styling
- * - dataTestId:   passthrough for the data-testid attribute
+ * - ...rest:      forwarded to the root element (e.g. data-testid)
  *
  * @example
  * <StatusBadge status="danger">Error</StatusBadge>
@@ -29,7 +29,7 @@ const StatusBadge = ({
   leftSection,
   rightSection,
   className = '',
-  dataTestId
+  ...rest
 }) => {
   return (
     <StyledWrapper
@@ -38,7 +38,7 @@ const StatusBadge = ({
       $size={size}
       $radius={radius}
       className={className}
-      data-testid={dataTestId}
+      {...rest}
     >
       {leftSection}
       {children}

--- a/packages/bruno-electron/src/utils/workspace-config.js
+++ b/packages/bruno-electron/src/utils/workspace-config.js
@@ -569,7 +569,7 @@ const getCollectionFailureReason = (collectionPath) => {
       return 'not-found';
     }
   } catch (err) {
-    return 'not-found';
+    return err.code === 'ENOENT' || err.code === 'ENOTDIR' ? 'not-found' : 'invalid';
   }
   return 'invalid';
 };

--- a/packages/bruno-electron/src/utils/workspace-config.js
+++ b/packages/bruno-electron/src/utils/workspace-config.js
@@ -563,6 +563,17 @@ const reorderWorkspaceCollections = async (workspacePath, collectionPaths) => {
   });
 };
 
+const getCollectionFailureReason = (collectionPath) => {
+  try {
+    if (!fs.existsSync(collectionPath) || !fs.statSync(collectionPath).isDirectory()) {
+      return 'not-found';
+    }
+  } catch (err) {
+    return 'not-found';
+  }
+  return 'invalid';
+};
+
 const resolveAndFilterWorkspaceCollections = (workspacePath, rawCollections) => {
   const seenPaths = new Set();
 
@@ -583,7 +594,7 @@ const resolveAndFilterWorkspaceCollections = (workspacePath, rawCollections) => 
 
       if (isValidCollectionDirectory(collection.path)) return collection;
       if (collection.remote) return { ...collection, notFoundLocally: true };
-      return null;
+      return { ...collection, failedToOpen: true, failureReason: getCollectionFailureReason(collection.path) };
     })
     .filter(Boolean);
 };

--- a/packages/bruno-electron/tests/utils/workspace-config.spec.js
+++ b/packages/bruno-electron/tests/utils/workspace-config.spec.js
@@ -179,9 +179,26 @@ describe('Git remote on workspace collections', () => {
     expect(missing.remote).toBe('https://github.com/x/missing');
   });
 
-  test('getWorkspaceCollections still drops missing entries that have no remote', () => {
+  test('getWorkspaceCollections keeps local entries that fail to open and flags them', () => {
     writeYml([collection('Missing', 'collections/missing')]);
-    expect(getWorkspaceCollections(workspacePath)).toHaveLength(0);
+
+    const result = getWorkspaceCollections(workspacePath);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Missing');
+    expect(result[0].failedToOpen).toBe(true);
+    expect(result[0].failureReason).toBe('not-found');
+  });
+
+  test('getWorkspaceCollections flags existing directories without a collection config as failed', () => {
+    fs.mkdirSync(path.join(workspacePath, 'collections/empty'), { recursive: true });
+    writeYml([collection('Empty', 'collections/empty')]);
+
+    const result = getWorkspaceCollections(workspacePath);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].failedToOpen).toBe(true);
+    expect(result[0].failureReason).toBe('invalid');
   });
 
   test('setCollectionGitRemote adds the collection path to .gitignore', async () => {

--- a/tests/utils/page/index.ts
+++ b/tests/utils/page/index.ts
@@ -4,6 +4,7 @@ export * from './file-mode';
 export * from './runner';
 export * from './locators';
 export * from './sidebar';
+export * from './workspace-overview';
 export * from './mounting';
 export * from './preferences';
 export * from './ai';

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -9,6 +9,7 @@ import { buildSidebarLocators } from './sidebar';
 import { buildDeleteCollectionItemModalLocators } from './collection/delete-collection-item';
 import { buildWebsocketCommonLocators } from './websocket';
 import { buildRequestLocators } from '../request';
+import { buildWorkspaceOverviewLocators } from './workspace-overview';
 
 export const buildCommonLocators = (page: Page) => ({
   runner: () => page.getByTestId('run-button'),
@@ -26,6 +27,7 @@ export const buildCommonLocators = (page: Page) => ({
   settingsSaveButton: () => page.getByRole('button', { name: 'Save' }),
   openPreferences: () => page.getByRole('button', { name: 'Open Preferences' }),
   sidebar: buildSidebarLocators(page),
+  workspaceOverview: buildWorkspaceOverviewLocators(page),
   deleteCollectionItemModal: buildDeleteCollectionItemModalLocators(page),
   actions: {
     collectionActions: (collectionName: string) =>

--- a/tests/utils/page/workspace-overview.ts
+++ b/tests/utils/page/workspace-overview.ts
@@ -1,0 +1,43 @@
+import { test, Page } from '../../../playwright';
+
+/**
+ * Locators for the Workspace Home overview (the collection cards grid).
+ */
+export const buildWorkspaceOverviewLocators = (page: Page) => {
+  const card = (collectionName: string) =>
+    page.getByTestId('collection-card').filter({ hasText: collectionName });
+
+  return {
+    homeButton: () => page.locator('.titlebar-left .home-button'),
+    card,
+    cardMenu: (collectionName: string) => card(collectionName).locator('.collection-menu'),
+    gitBadge: (collectionName: string) => card(collectionName).getByTestId('collection-git-badge'),
+    failedBadge: (collectionName: string) => card(collectionName).getByTestId('collection-failed-badge'),
+    notClonedBadge: (collectionName: string) => card(collectionName).getByTestId('collection-not-cloned-badge')
+  };
+};
+
+/**
+ * Navigate to the Workspace Home overview via the title bar home button
+ * @param page - The page object
+ */
+const openWorkspaceOverview = async (page: Page) => {
+  await test.step('Open the workspace overview', async () => {
+    await buildWorkspaceOverviewLocators(page).homeButton().click();
+  });
+};
+
+/**
+ * Open a collection card's "..." menu and click one of its entries
+ * @param page - The page object
+ * @param collectionName - The name of the collection whose card menu to open
+ * @param itemLabel - The exact label of the dropdown entry to click
+ */
+const selectCollectionCardMenuItem = async (page: Page, collectionName: string, itemLabel: string) => {
+  await test.step(`Select "${itemLabel}" from the "${collectionName}" card menu`, async () => {
+    await buildWorkspaceOverviewLocators(page).cardMenu(collectionName).click();
+    await page.locator('.dropdown-item').getByText(itemLabel, { exact: true }).click();
+  });
+};
+
+export { openWorkspaceOverview, selectCollectionCardMenuItem };

--- a/tests/workspace/failed-collections/failed-collections.spec.ts
+++ b/tests/workspace/failed-collections/failed-collections.spec.ts
@@ -146,4 +146,19 @@ test.describe('Collections that fail to open', () => {
 
     await closeElectronApp(app);
   });
+
+  test('switching into a workspace with unopenable collections surfaces an aggregated error toast', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createTmpDir('failed-coll-switch-toast');
+    await fs.promises.cp(fixturePath, workspacePath, { recursive: true });
+
+    const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
+    const page = await waitForReadyPage(app);
+
+    await test.step('The switch reports how many collections could not be opened', async () => {
+      await switchWorkspace(page, WORKSPACE_NAME);
+      await expect(page.getByText('2 collections could not be opened')).toBeVisible({ timeout: 10000 });
+    });
+
+    await closeElectronApp(app);
+  });
 });

--- a/tests/workspace/failed-collections/failed-collections.spec.ts
+++ b/tests/workspace/failed-collections/failed-collections.spec.ts
@@ -67,7 +67,7 @@ test.describe('Collections that fail to open', () => {
   test('clicking a missing collection reports the failure and opens no tab', async ({ launchElectronApp, createTmpDir }) => {
     const workspacePath = await createTmpDir('failed-coll-click-missing');
     const { app, page } = await openBrokenWorkspaceOverview(launchElectronApp, workspacePath);
-    const overview = buildCommonLocators(page).workspaceOverview;
+    const { workspaceOverview: overview, tabs } = buildCommonLocators(page);
 
     await test.step('Click the missing collection card', async () => {
       await expect(overview.card(MISSING_COLL)).toBeVisible({ timeout: 10000 });
@@ -79,7 +79,7 @@ test.describe('Collections that fail to open', () => {
     });
 
     await test.step('No collection tab is opened and the card stays on the overview', async () => {
-      await expect(page.locator('.request-tab').filter({ hasText: MISSING_COLL })).toHaveCount(0);
+      await expect(tabs.requestTab(MISSING_COLL)).toHaveCount(0);
       await expect(overview.card(MISSING_COLL)).toBeVisible();
     });
 
@@ -89,7 +89,7 @@ test.describe('Collections that fail to open', () => {
   test('clicking a folder without a collection config reports the failure', async ({ launchElectronApp, createTmpDir }) => {
     const workspacePath = await createTmpDir('failed-coll-click-empty');
     const { app, page } = await openBrokenWorkspaceOverview(launchElectronApp, workspacePath);
-    const overview = buildCommonLocators(page).workspaceOverview;
+    const { workspaceOverview: overview, tabs } = buildCommonLocators(page);
 
     await test.step('Click the collection card whose folder has no bruno.json', async () => {
       await expect(overview.card(EMPTY_COLL)).toBeVisible({ timeout: 10000 });
@@ -98,7 +98,7 @@ test.describe('Collections that fail to open', () => {
 
     await test.step('An error toast reports the collection could not be opened', async () => {
       await expect(page.getByText(/Collection could not be opened:.*empty-coll/)).toBeVisible();
-      await expect(page.locator('.request-tab').filter({ hasText: EMPTY_COLL })).toHaveCount(0);
+      await expect(tabs.requestTab(EMPTY_COLL)).toHaveCount(0);
     });
 
     await closeElectronApp(app);
@@ -124,7 +124,7 @@ test.describe('Collections that fail to open', () => {
   test('removing a failed collection prunes it from workspace.yml without a confirmation modal', async ({ launchElectronApp, createTmpDir }) => {
     const workspacePath = await createTmpDir('failed-coll-remove');
     const { app, page } = await openBrokenWorkspaceOverview(launchElectronApp, workspacePath);
-    const overview = buildCommonLocators(page).workspaceOverview;
+    const { workspaceOverview: overview, modal } = buildCommonLocators(page);
 
     await test.step('Choose Remove from the failed collection card menu', async () => {
       await expect(overview.card(MISSING_COLL)).toBeVisible({ timeout: 10000 });
@@ -133,7 +133,7 @@ test.describe('Collections that fail to open', () => {
 
     await test.step('The collection is removed straight away, with no confirmation modal', async () => {
       await expect(page.getByText('Collection removed from workspace')).toBeVisible();
-      await expect(page.locator('.bruno-modal-card').filter({ hasText: 'Remove Collection' })).toHaveCount(0);
+      await expect(modal.byTitle('Remove Collection')).toHaveCount(0);
       await expect(overview.card(MISSING_COLL)).toHaveCount(0, { timeout: 5000 });
     });
 

--- a/tests/workspace/failed-collections/failed-collections.spec.ts
+++ b/tests/workspace/failed-collections/failed-collections.spec.ts
@@ -1,0 +1,149 @@
+import path from 'path';
+import fs from 'fs';
+import yaml from 'js-yaml';
+import { test, expect, closeElectronApp, ElectronApplication, Page } from '../../../playwright';
+import {
+  switchWorkspace,
+  waitForReadyPage,
+  buildCommonLocators,
+  openWorkspaceOverview,
+  selectCollectionCardMenuItem
+} from '../../utils/page';
+
+type CollectionEntry = { name?: string; path?: string; remote?: string };
+type WorkspaceConfig = { collections?: CollectionEntry[] };
+
+const initUserDataPath = path.join(__dirname, 'init-user-data');
+const fixturePath = path.join(__dirname, 'fixtures', 'workspace-with-broken-collections');
+
+const WORKSPACE_NAME = 'Broken WS';
+const HEALTHY_COLL = 'Healthy Coll';
+const MISSING_COLL = 'Missing Coll';
+const EMPTY_COLL = 'Empty Coll';
+const GHOST_COLL = 'Ghost Coll';
+
+function readWorkspaceYml(workspacePath: string): WorkspaceConfig {
+  const raw = fs.readFileSync(path.join(workspacePath, 'workspace.yml'), 'utf8');
+  return yaml.load(raw) as WorkspaceConfig;
+}
+
+async function openBrokenWorkspaceOverview(
+  launchElectronApp: (opts?: any) => Promise<ElectronApplication>,
+  workspacePath: string
+): Promise<{ app: ElectronApplication; page: Page }> {
+  await fs.promises.cp(fixturePath, workspacePath, { recursive: true });
+
+  const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
+  const page = await waitForReadyPage(app);
+
+  await switchWorkspace(page, WORKSPACE_NAME);
+  await openWorkspaceOverview(page);
+
+  return { app, page };
+}
+
+test.describe('Collections that fail to open', () => {
+  test('badges distinguish a missing folder from a folder without a collection config', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createTmpDir('failed-coll-badges');
+    const { app, page } = await openBrokenWorkspaceOverview(launchElectronApp, workspacePath);
+    const overview = buildCommonLocators(page).workspaceOverview;
+
+    await test.step('An entry whose folder does not exist is badged as Missing', async () => {
+      await expect(overview.failedBadge(MISSING_COLL)).toHaveText('Missing', { timeout: 10000 });
+    });
+
+    await test.step('An entry whose folder has no collection config is badged as Failed to open', async () => {
+      await expect(overview.failedBadge(EMPTY_COLL)).toHaveText('Failed to open');
+    });
+
+    await test.step('A collection that opens fine carries no failure badge', async () => {
+      await expect(overview.card(HEALTHY_COLL)).toBeVisible();
+      await expect(overview.failedBadge(HEALTHY_COLL)).toHaveCount(0);
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('clicking a missing collection reports the failure and opens no tab', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createTmpDir('failed-coll-click-missing');
+    const { app, page } = await openBrokenWorkspaceOverview(launchElectronApp, workspacePath);
+    const overview = buildCommonLocators(page).workspaceOverview;
+
+    await test.step('Click the missing collection card', async () => {
+      await expect(overview.card(MISSING_COLL)).toBeVisible({ timeout: 10000 });
+      await overview.card(MISSING_COLL).click();
+    });
+
+    await test.step('An error toast reports the collection could not be opened', async () => {
+      await expect(page.getByText(/Collection could not be opened:.*missing-coll/)).toBeVisible();
+    });
+
+    await test.step('No collection tab is opened and the card stays on the overview', async () => {
+      await expect(page.locator('.request-tab').filter({ hasText: MISSING_COLL })).toHaveCount(0);
+      await expect(overview.card(MISSING_COLL)).toBeVisible();
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('clicking a folder without a collection config reports the failure', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createTmpDir('failed-coll-click-empty');
+    const { app, page } = await openBrokenWorkspaceOverview(launchElectronApp, workspacePath);
+    const overview = buildCommonLocators(page).workspaceOverview;
+
+    await test.step('Click the collection card whose folder has no bruno.json', async () => {
+      await expect(overview.card(EMPTY_COLL)).toBeVisible({ timeout: 10000 });
+      await overview.card(EMPTY_COLL).click();
+    });
+
+    await test.step('An error toast reports the collection could not be opened', async () => {
+      await expect(page.getByText(/Collection could not be opened:.*empty-coll/)).toBeVisible();
+      await expect(page.locator('.request-tab').filter({ hasText: EMPTY_COLL })).toHaveCount(0);
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('a git-backed entry with a missing folder is Not cloned rather than Missing', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createTmpDir('failed-coll-ghost');
+    const { app, page } = await openBrokenWorkspaceOverview(launchElectronApp, workspacePath);
+    const overview = buildCommonLocators(page).workspaceOverview;
+
+    await test.step('The card shows the Git and Not cloned badges', async () => {
+      await expect(overview.notClonedBadge(GHOST_COLL)).toHaveText('Not cloned', { timeout: 10000 });
+      await expect(overview.gitBadge(GHOST_COLL)).toBeVisible();
+    });
+
+    await test.step('The failure badge is not rendered alongside Not cloned', async () => {
+      await expect(overview.failedBadge(GHOST_COLL)).toHaveCount(0);
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('removing a failed collection prunes it from workspace.yml without a confirmation modal', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createTmpDir('failed-coll-remove');
+    const { app, page } = await openBrokenWorkspaceOverview(launchElectronApp, workspacePath);
+    const overview = buildCommonLocators(page).workspaceOverview;
+
+    await test.step('Choose Remove from the failed collection card menu', async () => {
+      await expect(overview.card(MISSING_COLL)).toBeVisible({ timeout: 10000 });
+      await selectCollectionCardMenuItem(page, MISSING_COLL, 'Remove');
+    });
+
+    await test.step('The collection is removed straight away, with no confirmation modal', async () => {
+      await expect(page.getByText('Collection removed from workspace')).toBeVisible();
+      await expect(page.locator('.bruno-modal-card').filter({ hasText: 'Remove Collection' })).toHaveCount(0);
+      await expect(overview.card(MISSING_COLL)).toHaveCount(0, { timeout: 5000 });
+    });
+
+    await test.step('workspace.yml no longer lists the entry, and the other entries survive', async () => {
+      const config = readWorkspaceYml(workspacePath);
+      const names = config.collections?.map((c) => c.name);
+      expect(names).not.toContain(MISSING_COLL);
+      expect(names).toEqual(expect.arrayContaining([HEALTHY_COLL, EMPTY_COLL, GHOST_COLL]));
+    });
+
+    await closeElectronApp(app);
+  });
+});

--- a/tests/workspace/failed-collections/fixtures/workspace-with-broken-collections/collections/healthy-coll/bruno.json
+++ b/tests/workspace/failed-collections/fixtures/workspace-with-broken-collections/collections/healthy-coll/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "Healthy Coll",
+  "type": "collection"
+}

--- a/tests/workspace/failed-collections/fixtures/workspace-with-broken-collections/workspace.yml
+++ b/tests/workspace/failed-collections/fixtures/workspace-with-broken-collections/workspace.yml
@@ -1,0 +1,19 @@
+opencollection: 1.0.0
+info:
+  name: "Broken WS"
+  type: workspace
+
+collections:
+  - name: "Healthy Coll"
+    path: "collections/healthy-coll"
+  - name: "Missing Coll"
+    path: "collections/missing-coll"
+  - name: "Empty Coll"
+    path: "collections/empty-coll"
+  - name: "Ghost Coll"
+    path: "collections/ghost-coll"
+    remote: "https://github.com/usebruno/sample-collection.git"
+
+specs:
+
+docs: ''

--- a/tests/workspace/failed-collections/init-user-data/preferences.json
+++ b/tests/workspace/failed-collections/init-user-data/preferences.json
@@ -1,0 +1,11 @@
+{
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  },
+  "workspaces": {
+    "lastOpenedWorkspaces": ["{{workspacePath}}"]
+  }
+}


### PR DESCRIPTION
[JIRA - BRU-2508]

### Problem:
Workspace collections that fail to open folder moved or deleted, or no valid collection config are silently dropped: nothing in Workspace Home, no notification, no way to remove them.

### Fix:
They're now tracked separately from the collection list, listed with a Failed to open badge, removable, with one aggregate notification.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Screenshots/Videos

**Before:** 


https://github.com/user-attachments/assets/1ff664e2-7a7e-4011-98d4-3dcf665902b2



**After:**

https://github.com/user-attachments/assets/631707f2-0445-4998-b512-4f706b109362


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace overview now displays un-openable collections with clear “Missing” or “Failed to open” status, including improved test-friendly identifiers on collection cards.
  * Added Playwright/Electron test helpers and a new broken-collections test suite covering badging, toasts, and tab behavior.
* **Bug Fixes**
  * Failed collections are now preserved with specific failure reasons instead of being dropped.
  * Clicking and removing failed collections now shows the correct toast and prevents opening request tabs.
  * Workspace switching skips failed collections and reports any that couldn’t be opened.
* **Chores**
  * StatusBadge now forwards extra root props (e.g., `data-testid`) for easier testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->