### PR TITLE
Added the fix for bru.runner.stopExecution() while running collection run from tests

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -2137,12 +2137,14 @@ const registerNetworkIpc = (mainWindow) => {
         }
 
         deleteCancelToken(cancelTokenUid);
-        mainWindow.webContents.send('main:run-folder-event', {
-          type: 'testrun-ended',
-          collectionUid,
-          folderUid,
-          runCompletionTime: new Date().toISOString()
-        });
+        if (!stopRunnerExecution) {
+          mainWindow.webContents.send('main:run-folder-event', {
+            type: 'testrun-ended',
+            collectionUid,
+            folderUid,
+            runCompletionTime: new Date().toISOString()
+          });
+        }
       } catch (error) {
         console.log('error', error);
         deleteCancelToken(cancelTokenUid);

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -2069,6 +2069,10 @@ const registerNetworkIpc = (mainWindow) => {
                 nextRequestName = testResults.nextRequestName;
               }
 
+              if (testResults?.stopExecution) {
+                stopRunnerExecution = true;
+              }
+
               mainWindow.webContents.send('main:run-folder-event', {
                 type: 'test-results',
                 testResults: testResults.results,

--- a/packages/bruno-js/src/runtime/test-runtime.js
+++ b/packages/bruno-js/src/runtime/test-runtime.js
@@ -67,7 +67,8 @@ class TestRuntime {
         collectionVariables: null,
         globalEnvironmentVariables: null,
         results: __brunoTestResults.getResults(),
-        nextRequestName: bru.nextRequest
+        nextRequestName: bru.nextRequest,
+        stopExecution: bru.stopExecution
       };
     }
 
@@ -133,6 +134,7 @@ class TestRuntime {
       oauth2CredentialsToReset: bru.oauth2CredentialsToReset,
       results: cleanJson(__brunoTestResults.getResults()),
       nextRequestName: bru.nextRequest,
+      stopExecution: bru.stopExecution,
       scriptedRequestEntries: cleanJson(bru.scriptedRequestEntries || [])
     };
 

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -88,6 +88,57 @@ describe('runtime', () => {
         { description: 'format valid', status: 'pass' }
       ]);
     });
+
+    it('should return stopExecution when bru.runner.stopExecution() is called in tests (nodevm)', async () => {
+      const testFile = `bru.runner.stopExecution();`;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env
+      );
+      expect(result.stopExecution).toBe(true);
+    });
+
+    it('should return stopExecution when bru.runner.stopExecution() is called in tests (quickjs)', async () => {
+      const testFile = `bru.runner.stopExecution();`;
+
+      const runtime = new TestRuntime({ runtime: 'quickjs' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env
+      );
+      expect(result.stopExecution).toBe(true);
+    });
+
+    it('should not set stopExecution when bru.runner.stopExecution() is not called', async () => {
+      const testFile = `test('noop', () => { expect(true).to.be.true; });`;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env
+      );
+      expect(result.stopExecution).toBeFalsy();
+    });
   });
 
   describe('script-runtime', () => {


### PR DESCRIPTION
JIRA: BRU-3342

Fixes : #7928

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
#### Problem
**The Issue:** The built-in scripting method bru.runner.stopExecution() is failing to halt a Bruno collection run when it is invoked specifically within the Tests block of a request.

**The Discrepancy:** The method works exactly as expected (immediately halting the execution) when called inside either the Pre-Request or Post-Response script blocks. However, in the Tests block, the runner ignores the stop command and incorrectly continues running subsequent lines of code and moving on to the next requests in the collection.

**Impact:** Automation workflows and test suites cannot be aborted dynamically from the test stage when an unrecoverable assertion or validation failure occurs.

#### Solution
The Fix: A programmatic fix was introduced to ensure that the collection runner monitors and respects the execution stop signal triggered during the Tests evaluation phase, aligning it with the pre-request and post-response lifecycle hooks.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test scripts can now request an immediate stop to an ongoing collection run via the runner controls.
  * Stop requests are applied consistently across supported runtimes.

* **Bug Fixes**
  * Run termination handling is now more reliable, including correct “run ended” signaling when a stop is requested.
  * Stop status is surfaced in test execution results for clearer stop behavior.

* **Tests**
  * Added runtime tests validating `stopExecution` behavior for both NodeVM and QuickJS, including normal completion when not stopped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->