### PR TITLE
fix(mountv2): give duplicate-named env variables distinct uids

### DIFF
--- a/packages/bruno-electron/src/services/mount/manager.js
+++ b/packages/bruno-electron/src/services/mount/manager.js
@@ -24,8 +24,7 @@ const hydrateEnvironments = (collectionPath, environments) => {
   for (const env of environments) {
     if (!Array.isArray(env.variables)) continue;
     env.variables.forEach((variable, i) => {
-      const key = variable.name || `index:${i}`;
-      variable.uid = uidForSeed(`${env.uid}#var#${key}`);
+      variable.uid = uidForSeed(`${env.uid}#var#${i}#${variable.name || ''}`);
     });
     if (!envHasSecrets(env)) continue;
     try {

--- a/packages/bruno-electron/src/services/mount/manager.spec.js
+++ b/packages/bruno-electron/src/services/mount/manager.spec.js
@@ -44,6 +44,7 @@ jest.mock('../../cache/requestUids', () => ({
 
 const { MountManager } = require('./manager');
 const collectionWatcher = require('../../app/collection-watcher');
+const treeBuilder = require('./tree-builder');
 
 const makeEmit = () => ({ loading: jest.fn(), tree: jest.fn(), config: jest.fn() });
 
@@ -99,6 +100,30 @@ describe('MountManager.remount', () => {
     expect(collectionWatcher.removeWatcher).not.toHaveBeenCalled();
     expect(collectionWatcher.addWatcher).not.toHaveBeenCalled();
     expect(collectionWatcher.addTempDirectoryWatcher).not.toHaveBeenCalled();
+  });
+
+  it('gives each environment variable a distinct uid when names collide', async () => {
+    treeBuilder.buildTree.mockReturnValueOnce({
+      items: [],
+      environments: [
+        {
+          uid: 'env-1',
+          name: 'Local',
+          variables: [
+            { name: 'TOKEN', value: 'a' },
+            { name: 'TOKEN', value: 'b' },
+            { name: 'TOKEN', value: 'c' }
+          ]
+        }
+      ]
+    });
+
+    const manager = new MountManager();
+    const { emit } = await mountCollection(manager, { collectionUid: 'col-1' });
+
+    const emittedTree = emit.tree.mock.calls[0][0];
+    const uids = emittedTree.environments[0].variables.map((v) => v.uid);
+    expect(new Set(uids).size).toBe(3);
   });
 
   it('propagates a watcher-removal failure without reattaching', async () => {


### PR DESCRIPTION
### Problem

In the mountv2 mount path, deleting one environment variable also deletes every other variable that shares the same name. Reproduces with an environment holding multiple variables with the same key but different values (e.g. 3 × `TOKEN`). Only occurs on mountv2 with the file cache enabled.

### Root cause

Cold-load environment hydration minted each variable's `uid` from the variable **name** only:

```js
const key = variable.name || `index:${i}`;
variable.uid = uidForSeed(`${env.uid}#var#${key}`);
```

`uidForSeed` is a pure hash of the seed, so variables sharing a name produced an identical `uid`. The renderer keys variable delete/edit (and its React row keys) on `uid`, so removing one duplicate filtered out all of them.

The legacy (non-mountv2) watcher path assigns a fresh `uuid()` per variable, which is why it was unaffected.

### Fix

Fold the array index into the seed so every variable gets a distinct `uid` regardless of duplicate names. Nothing depends on env-variable uid stability across reloads — secret hydration matches by name, and the legacy path already re-mints random uids each reload.

### Test

Added a regression test in `manager.spec.js` that mounts an environment with three same-named variables and asserts three distinct uids.

Ticket: BRU-3981


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable identification during remounts to ensure variables with identical names receive distinct identifiers.
  * Improved reliability when emitting environments containing duplicate variable names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->