### PR TITLE
fix(secrets): environment table

### DIFF
--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -68,16 +68,18 @@ const EnvVarValueCell = ({
 }) => {
   const editorRef = useRef(null);
   const [compact, setCompact] = useState(true);
-  const [masked, setMasked] = useState(variable.secret);
+
+  const showAsSecret = variable.secret && !isLastEmptyRow;
+  const [masked, setMasked] = useState(showAsSecret);
 
   useEffect(() => {
-    setMasked(variable.secret);
-  }, [variable.secret]);
+    setMasked(showAsSecret);
+  }, [showAsSecret]);
 
   return (
     <VarValueCell
       onCompactChange={setCompact}
-      trailingContent={variable.secret ? (
+      trailingContent={showAsSecret ? (
         <SecretEyeButton
           masked={masked}
           testId="secret-reveal-toggle"
@@ -97,8 +99,8 @@ const EnvVarValueCell = ({
             name={`${actualIndex}.value`}
             value={valueToString(variable.value, 2)}
             placeholder={variable.value == null || (typeof variable.value === 'string' && variable.value.trim() === '') ? 'Value' : ''}
-            isSecret={variable.secret}
-            hideSecretEye={variable.secret}
+            isSecret={showAsSecret}
+            hideSecretEye={showAsSecret}
             onMaskChange={setMasked}
             onChange={(newValue) => {
               formik.setFieldValue(`${actualIndex}.value`, newValue, true);
@@ -853,6 +855,7 @@ const EnvironmentVariablesTable = ({
                     actualIndex={actualIndex}
                     isLastRow={isLastRow}
                     isLastEmptyRow={isLastEmptyRow}
+                    isSecretTab={isSecretTab}
                     storedTheme={storedTheme}
                     collection={_collection}
                     formik={formik}

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -393,18 +393,6 @@ const EnvironmentVariablesTable = ({
     setPinnedData({ query: '', uids: new Set() });
   }, [savedValuesJson]);
 
-  // Keep the trailing empty "add new" row's secret flag in sync with the active
-  // tab, so typing into it creates a variable of the correct type. The empty row
-  // is filtered out of save/draft, so this never affects persisted data.
-  useEffect(() => {
-    const lastIndex = formik.values.length - 1;
-    const last = formik.values[lastIndex];
-    const isEmpty = !last?.name || (typeof last.name === 'string' && last.name.trim() === '');
-    if (last && isEmpty && !!last.secret !== isSecretTab) {
-      formik.setFieldValue(`${lastIndex}.secret`, isSecretTab, false);
-    }
-  }, [isSecretTab, formik.values]);
-
   // Sync modified state
   useEffect(() => {
     const currentValues = formik.values.filter((variable) => variable.name && variable.name.trim() !== '');

--- a/tests/environments/environment-tabs/environment-tabs.spec.ts
+++ b/tests/environments/environment-tabs/environment-tabs.spec.ts
@@ -1,13 +1,14 @@
 import { Page } from '@playwright/test';
 import path from 'path';
 import { expect, test } from '../../../playwright';
-import { addRowToActiveTab, closeAllCollections, createEnvironment, deleteAllGlobalEnvironments, importCollection, saveEnvironment } from '../../utils/page';
+import { addRowToActiveTab, closeAllCollections, createEnvironment, deleteAllGlobalEnvironments, importCollection, openCollection, saveEnvironment } from '../../utils/page';
 import { buildCommonLocators } from '../../utils/page/locators';
 
 const envLocators = (page: Page) => buildCommonLocators(page).environment;
 
 const variablesTab = (page: Page) => envLocators(page).variablesTab();
 const secretsTab = (page: Page) => envLocators(page).secretsTab();
+const collectionEnvTab = (page: Page) => envLocators(page).collectionEnvTab();
 const varRow = (page: Page, name: string) => envLocators(page).varRow(name);
 const varRowValueLine = (page: Page, name: string) => envLocators(page).varRowValueLine(name);
 const saveTab = (page: Page) => envLocators(page).saveTab();
@@ -414,6 +415,47 @@ test.describe('Environment Variables / Secrets tab separation', () => {
     await test.step('The plain variable kept its own value (not overwritten by the secret)', async () => {
       await variablesTab(page).click();
       await expect(varRowValueLine(page, SHARED_KEY)).toHaveText(PLAIN_VALUE);
+    });
+  });
+
+  test('keeps unsaved variable and secret drafts after navigating to the collection overview and back', async ({ page, createTmpDir }) => {
+    await importCollection(page, collectionFile, await createTmpDir('var-secret-draft-persist'), {
+      expectedCollectionName: 'test_collection'
+    });
+
+    await createEnvironment(page, 'Draft Persist Env', 'collection');
+
+    await test.step('Add an unsaved variable on the Variables tab', async () => {
+      await addRowToActiveTab(page, 'host', 'https://echo.usebruno.com');
+      await expect(varRow(page, 'host')).toBeVisible();
+    });
+
+    await test.step('Add an unsaved secret on the Secrets tab', async () => {
+      await secretsTab(page).click();
+      await addRowToActiveTab(page, 'apiToken', 'super-secret-token-12345');
+      await expect(varRow(page, 'apiToken')).toBeVisible();
+    });
+
+    await test.step('Navigate to the collection overview, then back to the environment tab', async () => {
+      // Env-var edits are written to the draft on a 300ms debounce, and the editor unmounts when its
+      // tab loses focus — wait for the draft to commit before navigating away (mirrors the snapshot suite).
+      await expect(tabDraftIcon(page)).toBeVisible();
+      await page.waitForTimeout(500);
+
+      await openCollection(page, 'test_collection');
+      await collectionEnvTab(page).click();
+    });
+
+    await test.step('The unsaved variable draft is restored on the Variables tab', async () => {
+      await variablesTab(page).click();
+      await expect(varRow(page, 'host')).toBeVisible();
+      await expect(varRow(page, 'apiToken')).toHaveCount(0);
+    });
+
+    await test.step('The unsaved secret draft is restored on the Secrets tab', async () => {
+      await secretsTab(page).click();
+      await expect(varRow(page, 'apiToken')).toBeVisible();
+      await expect(varRow(page, 'host')).toHaveCount(0);
     });
   });
 });

--- a/tests/proxy/system-pac/system-pac-proxy.spec.ts
+++ b/tests/proxy/system-pac/system-pac-proxy.spec.ts
@@ -31,7 +31,7 @@ function gnomeProxySchemaAvailable(): boolean {
   }
 }
 
-test.describe('System Proxy with PAC', () => {
+test.describe.serial('System Proxy with PAC', () => {
   test.skip(
     process.platform !== 'linux',
     'Linux-only: relies on gsettings to set OS-level PAC'


### PR DESCRIPTION
### Description

BRU-3853

#### Problem
On the environment editor, the Variables and Secrets tabs share one form with a single trailing "add new" row. That row keeps a persisted secret flag, and its value cell drove the masked-value eye icon straight off variable.secret. So after adding a secret, the trailing row's stale secret: true flag painted the closed-eye icon onto the Variables tab's Value column (and onto the empty placeholder row) where it doesn't belong.

#### Solution

Derive the eye/mask from the row's real identity instead of the shared placeholder's stale flag - render-only, no change to form/draft state:


const showAsSecret = variable.secret && !isLastEmptyRow;
The empty "add new" placeholder never shows the eye (on either tab); the icon appears only on a real row that's actually a secret. Because it touches only rendering (not formik.values), the draft/save behavior — and the "keeps unsaved variable and secret drafts after navigating…" test — is unaffected.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret-variable editing by disabling secret controls for the trailing “add new” row.
  * Updated secret toggle behavior so the secret UI is shown only for relevant rows.
* **Tests**
  * Added coverage to ensure unsaved environment variable and secret drafts persist when switching between environment and collection views.
  * Run “System Proxy with PAC” tests in serial mode for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->