### PR TITLE
fix(codegen): uppercase HTTP method in generated code snippets

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -53,7 +53,10 @@ const generateSnippet = async ({ language, item, collection, shouldInterpolate =
     const sourceUrl = item.rawUrl || request.url;
     const { har, rawUrl, encodedUrl, unhash } = await buildHar({
       request: {
-        method: request.method,
+        // HTTP methods are case-sensitive on the wire (RFC 7231); the request
+        // executor uppercases the method before sending, so the generated
+        // snippet must match or servers reject the verbatim lowercase verb.
+        method: (request.method || 'GET').toUpperCase(),
         url: sourceUrl,
         params: request.params,
         pathParams: [],

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -123,6 +123,29 @@ describe('Snippet Generator - Simple Tests', () => {
     expect(result).toBe('curl -X POST https://api.example.com/{{endpoint}} -H "Content-Type: application/json" -d \'{"message": "{{greeting}}", "count": {{number}}}\'');
   });
 
+  it('should uppercase a lowercase method so the snippet matches what is sent on the wire', async () => {
+    // Bru/yml files can store the method lowercase (e.g. `method: post`). The
+    // request executor uppercases before sending, so the snippet must too —
+    // otherwise the exported code sends a verbatim `post` that servers reject.
+    const lowercaseMethodRequest = {
+      ...testRequest,
+      request: {
+        ...testRequest.request,
+        method: 'post'
+      }
+    };
+
+    const result = await generateSnippet({
+      language: curlLanguage,
+      item: lowercaseMethodRequest,
+      collection: testCollection,
+      shouldInterpolate: false
+    });
+
+    expect(result).toContain('-X POST');
+    expect(result).not.toContain('-X post');
+  });
+
   it('should interpolate variables when enabled', async () => {
     const result = await generateSnippet({
       language: curlLanguage,


### PR DESCRIPTION
## Summary

Generated code snippets (Generate Code → curl/Python/etc.) emit the HTTP method exactly as stored in the collection file. Because a `.bru`/`.yml` request can store the method lowercase (e.g. `method: post`), the exported snippet becomes:

- curl: `curl --request post ...`
- Python: `conn.request("post", "/oauth/token", ...)`

HTTP methods are case-sensitive on the wire (RFC 7231 §4.1), so these run differently from the in-app request: many servers (e.g. Auth0's `/oauth/token`) reject the verbatim lowercase verb with **400 Bad Request**. The request works in Bruno but the copied code doesn't.

## Root cause

The request executor already normalizes the method to uppercase before sending:

```js
// packages/bruno-electron/src/ipc/network/index.js
method: (_item.request?.method || 'GET').toString().toUpperCase(),
```

…but the code generator passed it through verbatim:

```js
// packages/bruno-app/.../GenerateCodeItem/utils/snippet-generator.js
method: request.method,
```

So the runtime and codegen paths disagree on method casing.

## Fix

Uppercase the method in `snippet-generator.js` so exported code matches what Bruno sends on the wire, mirroring the executor's normalization.

## Testing

- Added a regression test in `snippet-generator.spec.js` asserting a lowercase `post` method produces `-X POST` in the snippet.
- `npm test --workspace=packages/bruno-app -- snippet-generator` → **55 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated cURL snippets now consistently use uppercase HTTP methods, preventing issues when requests use lowercase methods.

* **Tests**
  * Added coverage to verify lowercase request methods are converted to uppercase in generated snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->