### PR TITLE
Skip Ohm.js parsing large bodies

### DIFF
--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -1262,16 +1262,134 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   }
 });
 
-const parser = (input) => {
+const matchAndBuildAst = (input) => {
   const match = grammar.match(input);
 
   if (match.succeeded()) {
-    const ast = sem(match).ast;
-
-    return ast;
+    return sem(match).ast;
   } else {
     throw new Error(match.message);
   }
+};
+
+/**
+ * Performance: ohm matches the grammar character-by-character over the whole
+ * file, including large opaque body/script/docs/tests content — which the
+ * grammar just returns verbatim via outdentString(textblock.sourceString).
+ * That content can be >99% of a request file and dominates parse time.
+ *
+ * So before handing the file to ohm we replace each text block's content with
+ * a short sentinel, parse the resulting (tiny) skeleton, then splice the real
+ * content back into the AST. This is faithful to the grammar: ohm's
+ * `tagend = nl "}"` requires the closing brace at column 0, which is exactly
+ * the boundary the pre-pass uses, and `"{" nl* textblock` means the captured
+ * sourceString is the content after the run of newlines following `{`.
+ *
+ * Safety: if anything is unexpected — the skeleton fails to parse, or a
+ * sentinel did not land as a standalone value (e.g. a text-block opener nested
+ * inside an `example` block, whose content ohm treats as opaque) — we fall
+ * back to a full parse of the original input. Output is therefore never wrong,
+ * only (in those rare cases) as slow as before.
+ */
+
+// Text-block openers whose action is outdentString(textblock.sourceString).
+// Deliberately excludes dictionary blocks (meta/headers/auth/vars/params/
+// body:grpc/body:ws/body:form-*/body:file) and `example` (re-parsed content).
+// Longest-first so `body` cannot shadow `body:json` etc.
+const TEXT_BLOCK_OPENERS = [
+  'body:graphql:vars',
+  'body:json',
+  'body:text',
+  'body:xml',
+  'body:sparql',
+  'body:graphql',
+  'script:pre-request',
+  'script:post-response',
+  'body',
+  'tests',
+  'docs'
+].sort((a, b) => b.length - a.length);
+
+const escapeRegExp = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const TEXT_BLOCK_REGEX = new RegExp(
+  `(^|\\n)((?:${TEXT_BLOCK_OPENERS.map(escapeRegExp).join('|')})[ \\t]*\\{)((?:\\r?\\n)+)([\\s\\S]*?)(\\r?\\n\\})`,
+  'g'
+);
+
+const SENTINEL_DELIM = String.fromCharCode(0); // NUL — never present in .bru content
+
+const extractTextBlocks = (input) => {
+  const blocks = new Map();
+  let index = 0;
+  const skeleton = input.replace(TEXT_BLOCK_REGEX, (_match, before, opener, _newlines, content, close) => {
+    // NUL-delimited sentinel: a NUL byte never appears in .bru content, so it
+    // cannot collide with a real value and survives outdentString and ohm
+    // matching unchanged (it is a single, unindented line).
+    const sentinel = `${SENTINEL_DELIM}${index++}${SENTINEL_DELIM}`;
+    blocks.set(sentinel, outdentString(content));
+    return `${before}${opener}\n${sentinel}${close}`;
+  });
+  return { skeleton, blocks };
+};
+
+const spliceTextBlocks = (node, blocks, stats) => {
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      const value = node[i];
+      if (typeof value === 'string') {
+        if (blocks.has(value)) {
+          node[i] = blocks.get(value);
+          stats.replaced++;
+        }
+      } else if (value && typeof value === 'object') {
+        spliceTextBlocks(value, blocks, stats);
+      }
+    }
+  } else if (node && typeof node === 'object') {
+    for (const key of Object.keys(node)) {
+      const value = node[key];
+      if (typeof value === 'string') {
+        if (blocks.has(value)) {
+          node[key] = blocks.get(value);
+          stats.replaced++;
+        }
+      } else if (value && typeof value === 'object') {
+        spliceTextBlocks(value, blocks, stats);
+      }
+    }
+  }
+  return node;
+};
+
+const parser = (input) => {
+  // Non-string input (e.g. a Buffer) is handled by ohm directly, as before.
+  if (typeof input !== 'string') {
+    return matchAndBuildAst(input);
+  }
+
+  const { skeleton, blocks } = extractTextBlocks(input);
+
+  // No hoistable text blocks — nothing to gain, parse directly.
+  if (blocks.size === 0) {
+    return matchAndBuildAst(input);
+  }
+
+  try {
+    const ast = matchAndBuildAst(skeleton);
+    const stats = { replaced: 0 };
+    spliceTextBlocks(ast, blocks, stats);
+
+    // Every sentinel must have been replaced as a standalone value. If not,
+    // a sentinel leaked into an unexpected position — bail to a full parse.
+    if (stats.replaced === blocks.size) {
+      return ast;
+    }
+  } catch (err) {
+    // fall through to the full parse below
+  }
+
+  return matchAndBuildAst(input);
 };
 
 module.exports = parser;

--- a/packages/bruno-lang/v2/tests/bruToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/bruToJson.spec.js
@@ -1045,4 +1045,159 @@ headers {
       });
     });
   });
+
+  // The v2 grammar matches the ohm grammar character-by-character across the
+  // whole file, including the large opaque body/script/docs/tests content that
+  // the grammar simply returns verbatim. That parse scales super-linearly with
+  // block size — a ~1MB JSON body takes several seconds, and larger bodies
+  // effectively freeze the parser. To avoid that, the parser hoists each text
+  // block behind a sentinel, parses the small remaining skeleton, then splices
+  // the real content back into the AST (falling back to a full parse if a
+  // sentinel does not land as a standalone value).
+  //
+  // These tests pin both halves of that contract: the output must be identical
+  // to a plain parse, and the parse time must no longer explode with body size.
+  describe('large text blocks (parse performance)', () => {
+    it('parses a ~1MB JSON body in a fraction of the time a full grammar parse needs', () => {
+      const rows = [];
+      for (let i = 0; i < 30000; i++) {
+        rows.push(`    { "id": ${i}, "name": "row ${i}" }`);
+      }
+      const json = `{\n  "rows": [\n${rows.join(',\n')}\n  ]\n}`;
+      // Bruno indents body content by 2 spaces; only the block's own closing
+      // brace sits at column 0, which is the boundary both the grammar and the
+      // hoisting pre-pass key off.
+      const indentedJson = json
+        .split('\n')
+        .map((line) => '  ' + line)
+        .join('\n');
+      const input = `get {\n  url: https://example.com\n}\n\nbody:json {\n${indentedJson}\n}\n`;
+
+      // Sanity: this really is a large body (the regression only bites at scale).
+      expect(input.length).toBeGreaterThan(1024 * 1024);
+
+      const start = process.hrtime.bigint();
+      const output = parser(input);
+      const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+
+      // Correctness: the body round-trips exactly to its outdented source form.
+      expect(output.http.method).toBe('get');
+      expect(output.body.json).toBe(json);
+
+      // Necessity: parsing this same input through the full grammar takes ~3s
+      // and grows super-linearly beyond it; the hoisting path is a few
+      // milliseconds. The 1s budget separates the two with a ~100x margin, so it
+      // flags a regression to the slow path without being timing-fragile.
+      expect(elapsedMs).toBeLessThan(1000);
+    }, 20000);
+
+    it('produces identical output for a large pretty-printed JSON body as for a small one', () => {
+      const json = `{\n  "rows": [\n${Array.from({ length: 2000 }, (_v, i) => `    { "id": ${i} }`).join(',\n')}\n  ]\n}`;
+      const indentedJson = json
+        .split('\n')
+        .map((line) => '  ' + line)
+        .join('\n');
+      const input = `get {\n  url: https://example.com\n}\n\nbody:json {\n${indentedJson}\n}\n`;
+
+      const output = parser(input);
+
+      expect(output).toEqual({
+        http: {
+          method: 'get',
+          url: 'https://example.com'
+        },
+        body: {
+          json
+        }
+      });
+      // The sentinel used internally must never leak into the result.
+      expect(JSON.stringify(output)).not.toContain('\u0000');
+    });
+
+    it('hoists and restores every text block when several appear in one file', () => {
+      const input = `get {
+  url: https://example.com
+}
+
+body:json {
+  {
+    "a": 1
+  }
+}
+
+script:pre-request {
+  console.log('hi');
+}
+
+docs {
+  # Title
+  some docs
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).toEqual({
+        http: {
+          method: 'get',
+          url: 'https://example.com'
+        },
+        body: {
+          json: '{\n  "a": 1\n}'
+        },
+        script: {
+          req: 'console.log(\'hi\');'
+        },
+        docs: '# Title\nsome docs'
+      });
+    });
+
+    it('handles CRLF line endings inside a text block', () => {
+      const input = 'get {\r\n  url: https://example.com\r\n}\r\n\r\nbody:json {\r\n  {\r\n    "a": 1\r\n  }\r\n}\r\n';
+
+      const output = parser(input);
+
+      expect(output).toEqual({
+        http: {
+          method: 'get',
+          url: 'https://example.com'
+        },
+        body: {
+          json: '{\n  "a": 1\n}'
+        }
+      });
+    });
+
+    it('falls back to a full parse and stays correct when a hoisted block is dropped by the reducer', () => {
+      // Duplicate text blocks are valid .bru: the grammar accepts them and the
+      // reducer keeps the last one. Both blocks get hoisted, but only the
+      // surviving block's sentinel remains in the merged AST, so the number of
+      // spliced sentinels no longer matches the number hoisted. That mismatch
+      // makes the parser discard the fast path and fall back to a full parse,
+      // which yields exactly the stock result — the optimization never changes
+      // the output, only (in this rare case) the speed.
+      const input = `get {
+  url: https://example.com
+}
+
+docs {
+  first docs
+}
+
+docs {
+  second docs
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).toEqual({
+        http: {
+          method: 'get',
+          url: 'https://example.com'
+        },
+        docs: 'second docs'
+      });
+    });
+  });
 });

--- a/packages/bruno-lang/v2/tests/bruToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/bruToJson.spec.js
@@ -1199,5 +1199,36 @@ docs {
         docs: 'second docs'
       });
     });
+
+    it('falls back to a full parse and stays correct when a hoisted opener is nested inside an example block', () => {
+      // An `example` block's content is opaque to the grammar (re-parsed by the
+      // dedicated example parser), so a text-block opener at column 0 inside it
+      // gets hoisted by the pre-pass but its sentinel lands buried in the example
+      // content string rather than as a standalone AST value. The count of
+      // replaced sentinels then falls short of the number hoisted, so the parser
+      // discards the fast path and falls back to a full parse — yielding exactly
+      // the stock result. (The example parser itself rejects a column-0 opener as
+      // invalid example syntax, which is why the client surfaces an error here
+      // rather than a parsed example; the optimization must not change that.)
+      const input = `get {
+  url: https://example.com
+}
+
+example {
+docs {
+inner documentation
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).toEqual({
+        http: {
+          method: 'get',
+          url: 'https://example.com'
+        },
+        examples: [{ error: expect.any(String) }]
+      });
+    });
   });
 });


### PR DESCRIPTION
### Description

The bru parser (bru-lang) is not performant when parsing large .bru files, especially due to large text blocks. For example, including Base64 data in an HTTP POST request makes the .bru parser crawl.

Since this text is not actually parsed by Ohm.js and is just forwarded as a string (`outdentString(sourceString)`), we can do a preprocessing step to remove large text blocks from .bru files, then parse with Ohm, and re-insert the text blocks. This improves parsing of small files slightly, and large files by many orders of magnitude. The parser falls back to the old (slow) method whenever necessary, adding a negligible time penalty in those cases.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** - N/A
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

### Potentially related issues:
#8529
#2416
#5840

### Benchmarks / proof:
| body size | old      | new     | speedup | output identical |
|-----------|---------:|--------:|--------:|:----------------:|
| ~169 KB   | 700 ms   | 1.5 ms  | 453×    | yes |
| ~569 KB   | 4,011 ms | 3.5 ms  | 1159×   | yes |
| ~1.75 MB  | 9,486 ms | 8.4 ms  | 1126×   | yes |
| ~3.5 MB   | 16,590 ms| 18.8 ms | 882×    | yes |

Also adds tests to measure parsing speed, and ensure the new parsing behavior is identical to the old.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved parsing speed for requests containing very large text blocks, including large JSON bodies.

* **Bug Fixes**
  * Preserved text block content and formatting across multiple blocks and CRLF line endings.
  * Added reliable fallback parsing for edge cases, preventing internal placeholder characters from appearing in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->