### PR TITLE
feat(tests): enhance Playwright configuration for sharded CI runs

### DIFF
--- a/.github/actions/tests/run-e2e-tests/action.yml
+++ b/.github/actions/tests/run-e2e-tests/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Shell to use (bash, pwsh)'
     required: false
     default: 'bash'
+  shard:
+    description: 'Optional Playwright shard, e.g. 1/4'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -16,11 +20,21 @@ runs:
       run: npm ci --prefix packages/bruno-tests/collection
 
     - name: Run Playwright Tests (Ubuntu)
-      if: inputs.os == 'ubuntu'
+      if: inputs.os == 'ubuntu' && inputs.shard == ''
       shell: bash
       run: xvfb-run dbus-run-session -- npm run test:e2e
 
+    - name: Run Playwright Tests (Ubuntu, sharded)
+      if: inputs.os == 'ubuntu' && inputs.shard != ''
+      shell: bash
+      run: xvfb-run dbus-run-session -- npm run test:e2e -- --shard=${{ inputs.shard }}
+
     - name: Run Playwright Tests
-      if: inputs.os != 'ubuntu'
+      if: inputs.os != 'ubuntu' && inputs.shard == ''
       shell: ${{ inputs.shell }}
       run: npm run test:e2e
+
+    - name: Run Playwright Tests (sharded)
+      if: inputs.os != 'ubuntu' && inputs.shard != ''
+      shell: ${{ inputs.shell }}
+      run: npm run test:e2e -- --shard=${{ inputs.shard }}

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -52,9 +52,14 @@ jobs:
           check_run: false
 
   e2e-test:
-    name: Playwright E2E Tests (Linux)
+    name: Playwright E2E Tests (Linux) ${{ matrix.shard }}/${{ matrix.shardTotal }}
     timeout-minutes: 240
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shardTotal: [4]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
 
@@ -81,10 +86,41 @@ jobs:
         uses: ./.github/actions/tests/run-e2e-tests
         with:
           os: ubuntu
+          shard: ${{ matrix.shard }}/${{ matrix.shardTotal }}
 
-      - name: Upload Playwright Report
+      - name: Upload blob report
         uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
+        with:
+          name: blob-report-linux-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 7
+
+  e2e-test-report:
+    name: Merge Playwright Reports (Linux)
+    if: ${{ !cancelled() }}
+    needs: [e2e-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/common/setup-node-deps
+        with:
+          skip-build: 'true'
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v6
+        with:
+          path: all-blob-reports
+          pattern: blob-report-linux-*
+          merge-multiple: true
+
+      - name: Merge into HTML report
+        run: npx playwright merge-reports --config=playwright.merge.config.ts ./all-blob-reports
+
+      - name: Upload merged Playwright report
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report-linux
           path: playwright-report/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,8 @@ const reporter: any[] = [['list'], ['html'], ['json', { outputFile: 'playwright-
 
 if (process.env.CI) {
   reporter.push(['github']);
+  // Blob reports are mergeable across shards (see tests-linux.yml e2e-test-report).
+  reporter.push(['blob']);
 }
 
 export default defineConfig({

--- a/playwright.merge.config.ts
+++ b/playwright.merge.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+/** Reporter config for `playwright merge-reports` after sharded CI runs. */
+export default defineConfig({
+  reporter: [
+    ['html'],
+    ['json', { outputFile: 'playwright-report/results.json' }]
+  ]
+});


### PR DESCRIPTION
### Description

Move linux CI to shards to chunk the amount of tests run since we have an abundance of linux runners now

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end tests now run in four parallel shards in Linux CI.
  * Sharded test results are automatically combined into a single HTML and JSON report.
  * CI test reports now include consolidated results for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->