### PR TITLE
fix:sanitize item names before appending file extension on import

### DIFF
--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -575,7 +575,7 @@ const createCollectionFromBrunoObject = async (collection, dirPath, options = {}
 
     for (const env of collection.environments) {
       const content = stringifyEnvironment(env, { format });
-      const filename = format === 'bru' ? sanitizeName(`${env.name}.bru`) : sanitizeName(`${env.name}.yml`);
+      const filename = format === 'bru' ? `${sanitizeName(env.name)}.bru` : `${sanitizeName(env.name)}.yml`;
       fs.writeFileSync(path.join(envDirPath, filename), content);
     }
   }
@@ -622,12 +622,12 @@ const processCollectionItems = async (items = [], currentPath, options = {}) => 
       // Create request file
       let sanitizedFilename;
       if (format == 'yml') {
-        sanitizedFilename = sanitizeName(item?.filename || `${item.name}.yml`);
+        sanitizedFilename = item?.filename ? sanitizeName(item.filename) : `${sanitizeName(item.name)}.yml`;
         if (!sanitizedFilename.endsWith('.yml')) {
           sanitizedFilename += '.yml';
         }
       } else {
-        sanitizedFilename = sanitizeName(item?.filename || `${item.name}.bru`);
+        sanitizedFilename = item?.filename ? sanitizeName(item.filename) : `${sanitizeName(item.name)}.bru`;
         if (!sanitizedFilename.endsWith('.bru')) {
           sanitizedFilename += '.bru';
         }

--- a/packages/bruno-cli/tests/utils/collection/create-collection-from-bruno-object.spec.js
+++ b/packages/bruno-cli/tests/utils/collection/create-collection-from-bruno-object.spec.js
@@ -200,4 +200,78 @@ describe('createCollectionFromBrunoObject', () => {
       )
     ).rejects.toThrow('Unsupported item type: unsupported-type');
   });
+
+  it('strips a trailing period from request and environment names before appending the .bru extension', async () => {
+    createOutputDir();
+
+    await createCollectionFromBrunoObject(
+      {
+        name: 'trailing-period-collection',
+        items: [
+          {
+            type: 'http-request',
+            name: 'Add a new pet to the store.',
+            seq: 1,
+            request: {
+              method: 'POST',
+              url: 'https://api.example.com/pet'
+            }
+          }
+        ],
+        environments: [
+          {
+            name: 'Production.',
+            variables: []
+          }
+        ]
+      },
+      outputDir,
+      { format: 'bru' }
+    );
+
+    const files = fs.readdirSync(outputDir);
+    expect(files).toContain('Add a new pet to the store.bru');
+    expect(files).not.toContain('Add a new pet to the store..bru');
+
+    const envFiles = fs.readdirSync(path.join(outputDir, 'environments'));
+    expect(envFiles).toContain('Production.bru');
+    expect(envFiles).not.toContain('Production..bru');
+  });
+
+  it('strips a trailing period from request and environment names before appending the .yml extension', async () => {
+    createOutputDir();
+
+    await createCollectionFromBrunoObject(
+      {
+        name: 'trailing-period-collection',
+        items: [
+          {
+            type: 'http-request',
+            name: 'Add a new pet to the store.',
+            seq: 1,
+            request: {
+              method: 'POST',
+              url: 'https://api.example.com/pet'
+            }
+          }
+        ],
+        environments: [
+          {
+            name: 'Production.',
+            variables: []
+          }
+        ]
+      },
+      outputDir,
+      { format: 'yml' }
+    );
+
+    const files = fs.readdirSync(outputDir);
+    expect(files).toContain('Add a new pet to the store.yml');
+    expect(files).not.toContain('Add a new pet to the store..yml');
+
+    const envFiles = fs.readdirSync(path.join(outputDir, 'environments'));
+    expect(envFiles).toContain('Production.yml');
+    expect(envFiles).not.toContain('Production..yml');
+  });
 });

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -1337,18 +1337,18 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           if (item?.filename) {
             const ext = path.extname(item.filename);
             if (ext === '.bru' || ext === '.yml') {
-              return item.filename.replace(ext, `.${format}`);
+              return sanitizeName(item.filename.replace(ext, `.${format}`));
             }
-            return item.filename;
+            return sanitizeName(item.filename);
           }
-          return `${item.name}.${format}`;
+          return `${sanitizeName(item.name)}.${format}`;
         };
 
         // Recursive function to parse the collection items and create files/folders
         const parseCollectionItems = async (items = [], currentPath) => {
           await Promise.all(items.map(async (item) => {
             if (['http-request', 'graphql-request', 'grpc-request', 'ws-request'].includes(item.type)) {
-              let sanitizedFilename = sanitizeName(getFilenameWithFormat(item, format));
+              let sanitizedFilename = getFilenameWithFormat(item, format);
               const content = await stringifyRequestViaWorker(item, { format });
               const filePath = path.join(currentPath, sanitizedFilename);
               safeWriteFileSync(filePath, content);
@@ -1371,7 +1371,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             }
             // Handle items of type 'js'
             if (item.type === 'js') {
-              let sanitizedFilename = sanitizeName(item?.filename || `${item.name}.js`);
+              let sanitizedFilename = item?.filename ? sanitizeName(item.filename) : `${sanitizeName(item.name)}.js`;
               const filePath = path.join(currentPath, sanitizedFilename);
               safeWriteFileSync(filePath, item.fileContent);
             }
@@ -1386,7 +1386,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
           await Promise.all(environments.map(async (env) => {
             const content = await stringifyEnvironment(env, { format });
-            let sanitizedEnvFilename = sanitizeName(`${env.name}.${format}`);
+            let sanitizedEnvFilename = `${sanitizeName(env.name)}.${format}`;
             const filePath = path.join(envDirPath, sanitizedEnvFilename);
             safeWriteFileSync(filePath, content);
           }));

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -38,7 +38,7 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
   const parseCollectionItems = async (items = [], currentPath) => {
     for (const item of items) {
       if (['http-request', 'graphql-request', 'grpc-request'].includes(item.type)) {
-        let sanitizedFilename = sanitizeName(item.filename || `${item.name}.${format}`);
+        let sanitizedFilename = item.filename ? sanitizeName(item.filename) : `${sanitizeName(item.name)}.${format}`;
         const content = await stringifyRequestViaWorker(item, { format });
         const filePath = path.join(currentPath, sanitizedFilename);
         safeWriteFileSync(filePath, content);
@@ -61,7 +61,7 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
       }
       // Handle items of type 'js'
       if (item.type === 'js') {
-        let sanitizedFilename = sanitizeName(item.filename || `${item.name}.js`);
+        let sanitizedFilename = item.filename ? sanitizeName(item.filename) : `${sanitizeName(item.name)}.js`;
         const filePath = path.join(currentPath, sanitizedFilename);
         safeWriteFileSync(filePath, item.fileContent);
       }
@@ -76,7 +76,7 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
 
     for (const env of environments) {
       const content = await stringifyEnvironment(env, { format });
-      let sanitizedEnvFilename = sanitizeName(`${env.name}.${format}`);
+      let sanitizedEnvFilename = `${sanitizeName(env.name)}.${format}`;
       const filePath = path.join(envDirPath, sanitizedEnvFilename);
       safeWriteFileSync(filePath, content);
     }


### PR DESCRIPTION
### Description
REF:BRU-3250
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Cause:Filenames were built by appending the extension and then running the results through sanitizeName(),which stripped trailing dots 
Fix:Sanitize the name first and then append the extension 
#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collection import and export filename handling.
  - Request and environment names are now sanitized consistently while preserving their file extensions.
  - Removed trailing periods from generated filenames before adding `.bru`, `.yml`, or `.js` extensions.
  - Ensured exported YAML files consistently receive the correct `.yml` extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->