### PR TITLE
feat(converters): add support for script execution flow in yml configuration

### DIFF
--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -154,6 +154,7 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
   const brunoExtension: {
     ignore?: string[];
     presets?: BrunoPresets;
+    scripts?: { flow?: 'sandwich' | 'sequential' };
   } = {};
 
   if (brunoConfig?.ignore?.length) {
@@ -169,6 +170,11 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
     if (presets.requestUrl) {
       brunoExtension.presets.requestUrl = presets.requestUrl;
     }
+  }
+
+  const scriptFlow = brunoConfig?.scripts?.flow;
+  if (scriptFlow === 'sandwich' || scriptFlow === 'sequential') {
+    brunoExtension.scripts = { flow: scriptFlow };
   }
 
   if (Object.keys(brunoExtension).length > 0) {

--- a/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
+++ b/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
@@ -10,6 +10,7 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
   const brunoExtension = oc.extensions?.bruno as {
     ignore?: string[];
     presets?: BrunoPresets;
+    scripts?: { flow?: unknown };
   } | undefined;
 
   const ignoreList = brunoExtension && Array.isArray(brunoExtension.ignore)
@@ -34,6 +35,11 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
     if (brunoExtension.presets.requestUrl) {
       brunoConfig.presets.requestUrl = brunoExtension.presets.requestUrl;
     }
+  }
+
+  const scriptFlow = brunoExtension?.scripts?.flow;
+  if (scriptFlow === 'sandwich' || scriptFlow === 'sequential') {
+    brunoConfig.scripts = { flow: scriptFlow };
   }
 
   const config = oc.config;

--- a/packages/bruno-converters/src/opencollection/types.ts
+++ b/packages/bruno-converters/src/opencollection/types.ts
@@ -212,6 +212,7 @@ export interface BrunoConfig {
   };
   scripts?: {
     additionalContextRoots?: string[];
+    flow?: 'sandwich' | 'sequential';
   };
   openapi?: Array<{
     sourceUrl: string;

--- a/packages/bruno-converters/tests/opencollection/scripts-flow.spec.js
+++ b/packages/bruno-converters/tests/opencollection/scripts-flow.spec.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from '@jest/globals';
+import { brunoToOpenCollection } from '../../src/opencollection/bruno-to-opencollection';
+import { openCollectionToBruno } from '../../src/opencollection/opencollection-to-bruno';
+
+describe('brunoToOpenCollection (export): scripts.flow', () => {
+  it('writes flow: sequential under extensions.bruno.scripts', () => {
+    const oc = brunoToOpenCollection({
+      name: 'API',
+      brunoConfig: { scripts: { flow: 'sequential' } },
+      items: []
+    });
+    expect(oc.extensions?.bruno?.scripts?.flow).toBe('sequential');
+  });
+
+  it('writes flow: sandwich under extensions.bruno.scripts', () => {
+    const oc = brunoToOpenCollection({
+      name: 'API',
+      brunoConfig: { scripts: { flow: 'sandwich' } },
+      items: []
+    });
+    expect(oc.extensions?.bruno?.scripts?.flow).toBe('sandwich');
+  });
+
+  it('writes nothing when the collection has no flow', () => {
+    const oc = brunoToOpenCollection({ name: 'API', brunoConfig: {}, items: [] });
+    expect(oc.extensions?.bruno?.scripts).toBeUndefined();
+  });
+
+  it('drops an unrecognized flow value', () => {
+    const oc = brunoToOpenCollection({
+      name: 'API',
+      brunoConfig: { scripts: { flow: 'parallel' } },
+      items: []
+    });
+    expect(oc.extensions?.bruno?.scripts).toBeUndefined();
+  });
+});
+
+describe('openCollectionToBruno (import): scripts.flow', () => {
+  it('reads flow: sequential from extensions.bruno.scripts', () => {
+    const { brunoConfig } = openCollectionToBruno({
+      opencollection: '1.0.0',
+      info: { name: 'API' },
+      extensions: { bruno: { scripts: { flow: 'sequential' } } }
+    });
+    expect(brunoConfig.scripts?.flow).toBe('sequential');
+  });
+
+  it('ignores an unrecognized flow value', () => {
+    const { brunoConfig } = openCollectionToBruno({
+      opencollection: '1.0.0',
+      info: { name: 'API' },
+      extensions: { bruno: { scripts: { flow: 'parallel' } } }
+    });
+    expect(brunoConfig.scripts).toBeUndefined();
+  });
+});
+
+describe('scripts.flow: export then import keeps it the same', () => {
+  it('preserves flow across a round trip', () => {
+    const oc = brunoToOpenCollection({
+      name: 'API',
+      brunoConfig: { scripts: { flow: 'sequential' } },
+      items: []
+    });
+    const { brunoConfig } = openCollectionToBruno(oc);
+    expect(brunoConfig.scripts?.flow).toBe('sequential');
+  });
+});

--- a/packages/bruno-filestore/src/formats/yml/parseCollection.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseCollection.spec.ts
@@ -52,6 +52,52 @@ request:
   });
 });
 
+describe('parseCollection — script execution flow', () => {
+  it('reads flow: sequential from the bruno extension', () => {
+    const yml = `opencollection: "1.0.0"
+info:
+  name: c
+extensions:
+  bruno:
+    scripts:
+      flow: sequential
+`;
+    const { brunoConfig } = parseCollection(yml);
+    expect(brunoConfig.scripts?.flow).toBe('sequential');
+  });
+
+  it('reads flow: sandwich from the bruno extension', () => {
+    const yml = `opencollection: "1.0.0"
+info:
+  name: c
+extensions:
+  bruno:
+    scripts:
+      flow: sandwich
+`;
+    const { brunoConfig } = parseCollection(yml);
+    expect(brunoConfig.scripts?.flow).toBe('sandwich');
+  });
+
+  it('ignores an unrecognized flow value', () => {
+    const yml = `opencollection: "1.0.0"
+info:
+  name: c
+extensions:
+  bruno:
+    scripts:
+      flow: parallel
+`;
+    const { brunoConfig } = parseCollection(yml);
+    expect(brunoConfig.scripts?.flow).toBeUndefined();
+  });
+
+  it('has no scripts.flow when the file does not set one', () => {
+    const { brunoConfig } = parseCollection('opencollection: "1.0.0"\ninfo:\n  name: c\n');
+    expect(brunoConfig.scripts?.flow).toBeUndefined();
+  });
+});
+
 describe('parseCollection — reading the collection version', () => {
   it('reads the version from the file as text', () => {
     const { brunoConfig } = parseCollection('opencollection: "1.0.0"\ninfo:\n  name: c\n  version: v1.0.0\n');

--- a/packages/bruno-filestore/src/formats/yml/parseCollection.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseCollection.ts
@@ -59,6 +59,14 @@ const parseCollection = (ymlString: string): ParsedCollection => {
         };
       }
     }
+    // scripts.flow controls collection/folder/request script execution order
+    // ('sandwich' | 'sequential'); unrecognized values fall back to the runtime default.
+    if (brunoExtensions?.scripts?.flow === 'sandwich' || brunoExtensions?.scripts?.flow === 'sequential') {
+      brunoConfig.scripts = {
+        ...brunoConfig.scripts,
+        flow: brunoExtensions.scripts.flow
+      };
+    }
     if (Array.isArray(brunoExtensions?.openapi) && brunoExtensions.openapi.length > 0) {
       brunoConfig.openapi = brunoExtensions.openapi.map((entry: any) => ({
         sourceUrl: entry.sourceUrl,

--- a/packages/bruno-filestore/src/formats/yml/stringifyCollection.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyCollection.spec.ts
@@ -48,6 +48,46 @@ describe('stringifyCollection — typed request.variables', () => {
   });
 });
 
+describe('stringifyCollection — script execution flow', () => {
+  const baseRoot = {
+    meta: null,
+    request: { headers: [], auth: { mode: 'none' }, script: { req: null, res: null }, tests: null, vars: { req: [], res: [] } },
+    docs: null
+  } as any;
+
+  it('round-trips flow: sequential through the bruno extension', () => {
+    const yml = stringifyCollection(baseRoot, { name: 'c', scripts: { flow: 'sequential' } });
+    expect(yml).toMatch(/flow:\s*sequential/);
+    expect(parseCollection(yml).brunoConfig.scripts?.flow).toBe('sequential');
+  });
+
+  it('round-trips flow: sandwich through the bruno extension', () => {
+    const yml = stringifyCollection(baseRoot, { name: 'c', scripts: { flow: 'sandwich' } });
+    expect(parseCollection(yml).brunoConfig.scripts?.flow).toBe('sandwich');
+  });
+
+  it('writes no flow when the collection has none', () => {
+    const yml = stringifyCollection(baseRoot, { name: 'c' });
+    expect(yml).not.toMatch(/flow:/);
+    expect(parseCollection(yml).brunoConfig.scripts?.flow).toBeUndefined();
+  });
+
+  it('drops an unrecognized flow value on write', () => {
+    const yml = stringifyCollection(baseRoot, { name: 'c', scripts: { flow: 'parallel' } });
+    expect(yml).not.toMatch(/flow:/);
+  });
+
+  it('preserves additionalContextRoots alongside a written flow value', () => {
+    const yml = stringifyCollection(baseRoot, {
+      name: 'c',
+      scripts: { flow: 'sequential', additionalContextRoots: ['../libs'] }
+    });
+    const { brunoConfig } = parseCollection(yml);
+    expect(brunoConfig.scripts?.flow).toBe('sequential');
+    expect(brunoConfig.scripts?.additionalContextRoots).toEqual(['../libs']);
+  });
+});
+
 describe('stringifyCollection — writing the collection version', () => {
   const baseRoot = {
     meta: null,

--- a/packages/bruno-filestore/src/formats/yml/stringifyCollection.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyCollection.ts
@@ -257,13 +257,18 @@ const stringifyCollection = (collectionRoot: any, brunoConfig: any): string => {
     }
 
     // bruno-specific script extensions
+    const brunoScripts: Record<string, unknown> = {};
     if (brunoConfig.scripts?.additionalContextRoots?.length) {
+      brunoScripts.additionalContextRoots = brunoConfig.scripts.additionalContextRoots;
+    }
+    if (brunoConfig.scripts?.flow === 'sandwich' || brunoConfig.scripts?.flow === 'sequential') {
+      brunoScripts.flow = brunoConfig.scripts.flow;
+    }
+    if (Object.keys(brunoScripts).length > 0) {
       if (!oc.extensions.bruno) {
         oc.extensions.bruno = {};
       }
-      (oc.extensions.bruno as any).scripts = {
-        additionalContextRoots: brunoConfig.scripts.additionalContextRoots
-      };
+      (oc.extensions.bruno as any).scripts = brunoScripts;
     }
 
     // bruno-specific extensions


### PR DESCRIPTION


### Description

JIRA: BRU-3877

- Introduced 'flow' property in scripts to handle 'sandwich' and 'sequential' execution orders.
- Updated conversion functions to read and write the new flow property.
- Added tests to ensure correct parsing and stringification of flow values in YAML format.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Script execution flow settings (`sequential` or `sandwich`) are now preserved when importing, exporting, and saving collections.
  * Supported flow settings round-trip correctly between collection formats.

* **Bug Fixes**
  * Unsupported flow values are now ignored instead of being saved.

* **Tests**
  * Added coverage for flow setting conversion, YAML parsing, serialization, and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->