### PR TITLE
fix(security): overflow on chip list styling

### DIFF
--- a/packages/bruno-app/src/components/Preferences/AI/SecurityPane.js
+++ b/packages/bruno-app/src/components/Preferences/AI/SecurityPane.js
@@ -89,7 +89,7 @@ const ChipListEditor = ({ list, placeholder, onChange, addTestId, inputTestId, r
       {values.length > 0 && (
         <ul className="security-chip-list flex flex-wrap gap-1.5">
           {values.map((name) => (
-            <li key={name} className="security-chip inline-flex items-center gap-1">
+            <li key={name} className="security-chip inline-flex items-center gap-1 min-w-0 max-w-full">
               <span className="security-chip-text">{name}</span>
               <button
                 type="button"

--- a/packages/bruno-app/src/components/Preferences/AI/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Preferences/AI/StyledWrapper.js
@@ -544,7 +544,14 @@ const StyledWrapper = styled.div`
     color: ${(props) => props.theme.text};
   }
 
+  .security-chip-text {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
   .security-chip-remove {
+    flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
### Description

JIRA: BRU-3822

<img width="1582" height="1035" alt="Screenshot 2026-07-23 at 4 51 19 PM" src="https://github.com/user-attachments/assets/46778fb6-9e0a-4848-89df-4e7f93adfd2e" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI security chip layout so long text wraps correctly instead of overflowing.
  * Preserved the visibility and alignment of chip removal controls on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->