### PR TITLE
ci(tests-macos): disable mac runners on each PR

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -2,12 +2,10 @@ name: macOS Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, 'release/v*']
-  pull_request:
-    branches: [main, 'release/v*']
+    branches: [main, 'release/*']
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Description

Disabling macos runners on each PR and instead just run them on the `main` instead of everywhere

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS test workflow triggers for pushes to `main` and `release/*`.
  * Removed pull request-triggered runs while retaining manual workflow dispatch.
  * Improved concurrent run handling by canceling older runs for the same workflow and branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->