### PR TITLE
feat(request): warn when binary body file is missing on disk

### DIFF
--- a/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
@@ -76,6 +76,26 @@ const StyledWrapper = styled.div`
       margin-right: 4px;
     }
 
+    &.has-warning {
+      background-color: #BB931B1A;
+      font-weight: 500;
+      border-radius: 4px;
+      padding: 4px;
+    }
+
+    .warning-icon {
+      color: #BB931B;
+      margin-right: 4px;
+    }
+
+    .warning-tooltip {
+      background-color: #BB931B1A;
+      color: #856404; 
+      margin: 2px;
+      border-radius: 6px;
+      padding: 4px;
+    }
+
     .file-name {
       flex: 1;
       font-size: 12px;

--- a/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
@@ -16,7 +16,7 @@ const StyledWrapper = styled.div`
     background: transparent;
     border: none;
     cursor: pointer;
-    border-radius: 4px;
+    border-radius: ${(props) => props.theme.border.radius.sm};
     transition: color 0.15s ease;
     font-size: 12px;
     white-space: nowrap;
@@ -79,7 +79,7 @@ const StyledWrapper = styled.div`
     &.has-warning {
       background-color: ${(props) => props.theme.status.warning.background};
       font-weight: 500;
-      border-radius: 4px;
+      border-radius: ${(props) => props.theme.border.radius.sm};
       padding: 4px;
     }
 
@@ -89,11 +89,14 @@ const StyledWrapper = styled.div`
     }
 
     .warning-tooltip {
-      background-color: ${(props) => props.theme.status.warning.background};
-      color: ${(props) => props.theme.status.warning.text};
-      margin: 2px;
-      border-radius: 6px;
-      padding: 4px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+
+      svg {
+        color: ${(props) => props.theme.status.warning.text};
+        flex-shrink: 0;
+      }
     }
 
     .file-name {
@@ -116,7 +119,7 @@ const StyledWrapper = styled.div`
       background: transparent;
       border: none;
       cursor: pointer;
-      border-radius: 4px;
+      border-radius: ${(props) => props.theme.border.radius.sm};
       transition: color 0.15s ease;
       flex-shrink: 0;
 

--- a/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/StyledWrapper.js
@@ -77,20 +77,20 @@ const StyledWrapper = styled.div`
     }
 
     &.has-warning {
-      background-color: #BB931B1A;
+      background-color: ${(props) => props.theme.status.warning.background};
       font-weight: 500;
       border-radius: 4px;
       padding: 4px;
     }
 
     .warning-icon {
-      color: #BB931B;
+      color: ${(props) => props.theme.status.warning.text};
       margin-right: 4px;
     }
 
     .warning-tooltip {
-      background-color: #BB931B1A;
-      color: #856404; 
+      background-color: ${(props) => props.theme.status.warning.background};
+      color: ${(props) => props.theme.status.warning.text};
       margin: 2px;
       border-radius: 6px;
       padding: 4px;

--- a/packages/bruno-app/src/components/FilePickerEditor/index.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/index.js
@@ -40,7 +40,9 @@ const FilePickerEditor = ({
   const hasMissingFiles = status === 'ready' && missingPaths.length > 0;
 
   // title is shown when hovering over the button
-  const title = filenames.map((v) => `- ${v}`).join('\n');
+  const title = filenames.length > 1
+    ? filenames.map((v) => `- ${v}`).join('\n')
+    : filenames[0] ?? '';
 
   const browse = () => {
     if (readOnly) return;
@@ -100,7 +102,6 @@ const FilePickerEditor = ({
       <StyledWrapper>
         <div
           className={`file-picker-selected ${readOnly ? 'read-only' : ''} ${hasMissingFiles ? 'has-warning' : ''}`}
-          title={title}
           onClick={!readOnly ? browse : undefined}
         >
           {hasMissingFiles ? (
@@ -112,7 +113,7 @@ const FilePickerEditor = ({
           ) : (
             <IconFile size={16} className="file-icon" />
           )}
-          <span className="file-name">
+          <span className="file-name" title={title}>
             {renderButtonText(filenames)}
           </span>
           {!readOnly && (
@@ -132,7 +133,8 @@ const FilePickerEditor = ({
               place="bottom-end"
             >
               <div className="warning-tooltip" data-testid="file-picker-warning-tooltip">
-                The file above is not in the given directory, please upload it again.
+                <IconAlertTriangleFilled size={14} />
+                <span>The file above is not in the given directory, please upload it again.</span>
               </div>
             </Tooltip>
           )}

--- a/packages/bruno-app/src/components/FilePickerEditor/index.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/index.js
@@ -36,10 +36,7 @@ const FilePickerEditor = ({
   const [hasMissingFiles, setHasMissingFiles] = useState(false);
 
   const filePaths = (isSingleFilePicker ? [value] : value || []).filter((v) => v != null && v != '');
-  const filenames = filePaths.map((v) => {
-    const separator = isWindowsOS() ? '\\' : '/';
-    return v.split(separator).pop();
-  });
+  const filenames = filePaths.map((v) => v.split(/[\\/]/).pop());
 
   // title is shown when hovering over the button
   const title = filenames.map((v) => `- ${v}`).join('\n');

--- a/packages/bruno-app/src/components/FilePickerEditor/index.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/index.js
@@ -1,8 +1,10 @@
-import React from 'react';
-import { getRelativePathWithinBasePath } from 'utils/common/path';
+import React, { useEffect, useId, useState } from 'react';
+import { getRelativePathWithinBasePath, getAbsoluteFilePath } from 'utils/common/path';
+import { existsSync } from 'utils/filesystem';
 import { useDispatch } from 'react-redux';
 import { browseFiles } from 'providers/ReduxStore/slices/collections/actions';
 import { IconX, IconUpload, IconFile } from '@tabler/icons';
+import { Tooltip } from 'react-tooltip';
 import { isWindowsOS } from 'utils/common/platform';
 import StyledWrapper from './StyledWrapper';
 
@@ -30,15 +32,54 @@ const FilePickerEditor = ({
   icon: CustomIcon
 }) => {
   const dispatch = useDispatch();
-  const filenames = (isSingleFilePicker ? [value] : value || [])
-    .filter((v) => v != null && v != '')
-    .map((v) => {
-      const separator = isWindowsOS() ? '\\' : '/';
-      return v.split(separator).pop();
-    });
+  const warningTooltipId = `file-picker-warning-${useId().replace(/:/g, '')}`;
+  const [hasMissingFiles, setHasMissingFiles] = useState(false);
+
+  const filePaths = (isSingleFilePicker ? [value] : value || []).filter((v) => v != null && v != '');
+  const filenames = filePaths.map((v) => {
+    const separator = isWindowsOS() ? '\\' : '/';
+    return v.split(separator).pop();
+  });
 
   // title is shown when hovering over the button
   const title = filenames.map((v) => `- ${v}`).join('\n');
+
+  // Verify that the selected file(s) still exist on disk and warn the user otherwise
+  useEffect(() => {
+    let isMounted = true;
+
+    if (filePaths.length === 0) {
+      setHasMissingFiles(false);
+      return;
+    }
+
+    Promise.all(
+      filePaths.map(async (filePath) => {
+        try {
+          const absolutePath = collection?.pathname
+            ? getAbsoluteFilePath(collection.pathname, filePath)
+            : filePath;
+          return await existsSync(absolutePath);
+        } catch (error) {
+          return false;
+        }
+      })
+    )
+      .then((results) => {
+        if (isMounted) {
+          setHasMissingFiles(results.some((exists) => !exists));
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setHasMissingFiles(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [JSON.stringify(filePaths), collection?.pathname]);
 
   const browse = () => {
     if (readOnly) return;
@@ -97,11 +138,28 @@ const FilePickerEditor = ({
     return (
       <StyledWrapper>
         <div
-          className={`file-picker-selected ${readOnly ? 'read-only' : ''}`}
+          className={`file-picker-selected ${readOnly ? 'read-only' : ''} ${hasMissingFiles ? 'has-warning' : ''}`}
           title={title}
           onClick={!readOnly ? browse : undefined}
         >
-          <IconFile size={16} className="file-icon" />
+          {hasMissingFiles ? (
+            <>
+              <svg
+                data-tooltip-id={warningTooltipId}
+                className="warning-icon"
+                xmlns="http://www.w3.org/2000/svg"
+                width={16}
+                height={16}
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M12 1.67c.955 0 1.845 .467 2.39 1.247l.105 .16l8.114 13.548a2.914 2.914 0 0 1 -2.307 4.363l-.195 .008h-16.225a2.914 2.914 0 0 1 -2.582 -4.2l.099 -.185l8.11 -13.538a2.914 2.914 0 0 1 2.491 -1.401zm.01 13.33l-.127 .007a1 1 0 0 0 0 1.986l.117 .007l.127 -.007a1 1 0 0 0 0 -1.986l-.117 -.007zm-.01 -7a1 1 0 0 0 -.993 .883l-.007 .117v4l.007 .117a1 1 0 0 0 1.986 0l.007 -.117v-4l-.007 -.117a1 1 0 0 0 -.993 -.883z" />
+              </svg>
+
+            </>
+          ) : (
+            <IconFile size={16} className="file-icon" />
+          )}
           <span className="file-name">
             {renderButtonText(filenames)}
           </span>
@@ -114,6 +172,15 @@ const FilePickerEditor = ({
             >
               <IconX size={16} />
             </button>
+          )}
+          {hasMissingFiles && (
+            <Tooltip
+              id={warningTooltipId}
+              className="tooltip-mod max-w-lg"
+              place="bottom-end"
+            >
+              <div className="warning-tooltip">The file above is not in the given directory, please upload it again.</div>
+            </Tooltip>
           )}
         </div>
       </StyledWrapper>

--- a/packages/bruno-app/src/components/FilePickerEditor/index.js
+++ b/packages/bruno-app/src/components/FilePickerEditor/index.js
@@ -1,11 +1,11 @@
-import React, { useEffect, useId, useState } from 'react';
-import { getRelativePathWithinBasePath, getAbsoluteFilePath } from 'utils/common/path';
-import { existsSync } from 'utils/filesystem';
+import React, { useId } from 'react';
+import { getRelativePathWithinBasePath, getBasename } from 'utils/common/path';
 import { useDispatch } from 'react-redux';
 import { browseFiles } from 'providers/ReduxStore/slices/collections/actions';
 import { IconX, IconUpload, IconFile } from '@tabler/icons';
 import { Tooltip } from 'react-tooltip';
-import { isWindowsOS } from 'utils/common/platform';
+import IconAlertTriangleFilled from 'components/Icons/IconAlertTriangleFilled';
+import useMissingFileCheck from 'hooks/useMissingFileCheck';
 import StyledWrapper from './StyledWrapper';
 
 /**
@@ -33,50 +33,14 @@ const FilePickerEditor = ({
 }) => {
   const dispatch = useDispatch();
   const warningTooltipId = `file-picker-warning-${useId().replace(/:/g, '')}`;
-  const [hasMissingFiles, setHasMissingFiles] = useState(false);
 
   const filePaths = (isSingleFilePicker ? [value] : value || []).filter((v) => v != null && v != '');
-  const filenames = filePaths.map((v) => v.split(/[\\/]/).pop());
+  const filenames = filePaths.map((v) => getBasename(collection.pathname, v));
+  const { status, missingPaths } = useMissingFileCheck(filePaths, collection?.pathname);
+  const hasMissingFiles = status === 'ready' && missingPaths.length > 0;
 
   // title is shown when hovering over the button
   const title = filenames.map((v) => `- ${v}`).join('\n');
-
-  // Verify that the selected file(s) still exist on disk and warn the user otherwise
-  useEffect(() => {
-    let isMounted = true;
-
-    if (filePaths.length === 0) {
-      setHasMissingFiles(false);
-      return;
-    }
-
-    Promise.all(
-      filePaths.map(async (filePath) => {
-        try {
-          const absolutePath = collection?.pathname
-            ? getAbsoluteFilePath(collection.pathname, filePath)
-            : filePath;
-          return await existsSync(absolutePath);
-        } catch (error) {
-          return false;
-        }
-      })
-    )
-      .then((results) => {
-        if (isMounted) {
-          setHasMissingFiles(results.some((exists) => !exists));
-        }
-      })
-      .catch(() => {
-        if (isMounted) {
-          setHasMissingFiles(false);
-        }
-      });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [JSON.stringify(filePaths), collection?.pathname]);
 
   const browse = () => {
     if (readOnly) return;
@@ -140,20 +104,11 @@ const FilePickerEditor = ({
           onClick={!readOnly ? browse : undefined}
         >
           {hasMissingFiles ? (
-            <>
-              <svg
-                data-tooltip-id={warningTooltipId}
-                className="warning-icon"
-                xmlns="http://www.w3.org/2000/svg"
-                width={16}
-                height={16}
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path d="M12 1.67c.955 0 1.845 .467 2.39 1.247l.105 .16l8.114 13.548a2.914 2.914 0 0 1 -2.307 4.363l-.195 .008h-16.225a2.914 2.914 0 0 1 -2.582 -4.2l.099 -.185l8.11 -13.538a2.914 2.914 0 0 1 2.491 -1.401zm.01 13.33l-.127 .007a1 1 0 0 0 0 1.986l.117 .007l.127 -.007a1 1 0 0 0 0 -1.986l-.117 -.007zm-.01 -7a1 1 0 0 0 -.993 .883l-.007 .117v4l.007 .117a1 1 0 0 0 1.986 0l.007 -.117v-4l-.007 -.117a1 1 0 0 0 -.993 -.883z" />
-              </svg>
-
-            </>
+            <IconAlertTriangleFilled
+              data-tooltip-id={warningTooltipId}
+              className="warning-icon"
+              size={16}
+            />
           ) : (
             <IconFile size={16} className="file-icon" />
           )}
@@ -176,7 +131,9 @@ const FilePickerEditor = ({
               className="tooltip-mod max-w-lg"
               place="bottom-end"
             >
-              <div className="warning-tooltip">The file above is not in the given directory, please upload it again.</div>
+              <div className="warning-tooltip" data-testid="file-picker-warning-tooltip">
+                The file above is not in the given directory, please upload it again.
+              </div>
             </Tooltip>
           )}
         </div>

--- a/packages/bruno-app/src/hooks/useMissingFileCheck/index.js
+++ b/packages/bruno-app/src/hooks/useMissingFileCheck/index.js
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
+import { getAbsoluteFilePath } from 'utils/common/path';
+import { existsSync } from 'utils/filesystem';
+
+/**
+ * Checks whether the given file paths (resolved against `basePath`) exist on disk.
+ *
+ * The hook only reports what it observed — callers own the "should I warn" policy.
+ * A sequence counter discards results from superseded runs so rapid input changes
+ * can't leave stale results on screen.
+ *
+ * @param {string[]} paths - Relative or absolute file paths to check.
+ * @param {string} basePath - Base directory that relative paths are resolved against.
+ *   When falsy, the hook stays in the 'idle' state without issuing any check.
+ * @returns {{ status: 'idle' | 'checking' | 'ready' | 'error', missingPaths: string[] }}
+ *   - `'idle'`     — nothing to check (empty input or no `basePath`)
+ *   - `'checking'` — a check is in flight; `missingPaths` is empty
+ *   - `'ready'`    — check completed; `missingPaths` lists paths that don't exist
+ *   - `'error'`    — the check itself failed (e.g. IPC threw); `missingPaths` is empty
+ */
+const useMissingFileCheck = (paths, basePath) => {
+  const [state, setState] = useState({ status: 'idle', missingPaths: [] });
+  const seqRef = useRef(0);
+  const pathsRef = useRef(paths);
+  pathsRef.current = paths;
+
+  // Content-based key so re-renders that pass a fresh array with the same
+  // contents don't retrigger the check.
+  const pathsKey = paths.join('\0');
+
+  useEffect(() => {
+    const currentPaths = pathsRef.current;
+    if (!currentPaths.length || !basePath) {
+      setState({ status: 'idle', missingPaths: [] });
+      return;
+    }
+
+    const seq = ++seqRef.current;
+    setState({ status: 'checking', missingPaths: [] });
+
+    Promise.all(
+      currentPaths.map(async (filePath) => {
+        const exists = await existsSync(getAbsoluteFilePath(basePath, filePath));
+        return { filePath, exists };
+      })
+    ).then(
+      (results) => {
+        if (seq !== seqRef.current) return;
+        setState({
+          status: 'ready',
+          missingPaths: results.filter((r) => !r.exists).map((r) => r.filePath)
+        });
+      },
+      () => {
+        if (seq !== seqRef.current) return;
+        setState({ status: 'error', missingPaths: [] });
+      }
+    );
+  }, [pathsKey, basePath]);
+
+  return state;
+};
+
+export default useMissingFileCheck;

--- a/tests/request/binary-file/binary-file-missing-warning.spec.ts
+++ b/tests/request/binary-file/binary-file-missing-warning.spec.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, openCollection, selectRequestPaneTab } from '../../utils/page';
+import { closeAllCollections, mockBrowseFiles, openCollection, selectRequestPaneTab } from '../../utils/page';
 import { buildCommonLocators } from '../../utils/page/locators';
 
 const MISSING_FILE_WARNING = 'The file above is not in the given directory, please upload it again.';
@@ -16,16 +16,7 @@ test.describe('File / Binary body missing-file warning', () => {
 
     const importDir = await createTmpDir('imported-collection');
 
-    await electronApp.evaluate(({ dialog }, { importDir }) => {
-      const originalShowOpenDialog = dialog.showOpenDialog;
-      dialog.showOpenDialog = async () => {
-        dialog.showOpenDialog = originalShowOpenDialog;
-        return {
-          canceled: false,
-          filePaths: [importDir]
-        };
-      };
-    }, { importDir });
+    await mockBrowseFiles(electronApp, [importDir]);
 
     await test.step('Import collection', async () => {
       await locators.plusMenu.button().click();
@@ -39,8 +30,8 @@ test.describe('File / Binary body missing-file warning', () => {
       await locators.import.browseLink(locationModal).click();
       await locators.import.importButton(locationModal).click();
       await locationModal.waitFor({ state: 'hidden' });
-      await openCollection(page, 'Binary body type');
       await expect(locators.sidebar.collection('Binary body type')).toBeVisible();
+      await openCollection(page, 'Binary body type');
     });
 
     await test.step('shows a warning when the binary file does not exist on disk', async () => {
@@ -58,7 +49,7 @@ test.describe('File / Binary body missing-file warning', () => {
       await expect(warningIcon).toBeVisible();
 
       await warningIcon.hover();
-      const tooltip = page.locator('.tooltip-mod');
+      const tooltip = locators.filePicker.warningTooltip();
       await expect(tooltip).toBeVisible();
       await expect(tooltip).toContainText(MISSING_FILE_WARNING);
     });

--- a/tests/request/binary-file/binary-file-missing-warning.spec.ts
+++ b/tests/request/binary-file/binary-file-missing-warning.spec.ts
@@ -1,0 +1,66 @@
+import * as path from 'path';
+import { test, expect } from '../../../playwright';
+import { closeAllCollections, openCollection, selectRequestPaneTab } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const MISSING_FILE_WARNING = 'The file above is not in the given directory, please upload it again.';
+
+test.describe('File / Binary body missing-file warning', () => {
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('should show warning for missing binary file', async ({ page, electronApp, createTmpDir }) => {
+    const collectionFile = path.resolve(__dirname, 'fixtures', 'binary-file-missing-warning.yml');
+    const locators = buildCommonLocators(page);
+
+    const importDir = await createTmpDir('imported-collection');
+
+    await electronApp.evaluate(({ dialog }, { importDir }) => {
+      const originalShowOpenDialog = dialog.showOpenDialog;
+      dialog.showOpenDialog = async () => {
+        dialog.showOpenDialog = originalShowOpenDialog;
+        return {
+          canceled: false,
+          filePaths: [importDir]
+        };
+      };
+    }, { importDir });
+
+    await test.step('Import collection', async () => {
+      await locators.plusMenu.button().click();
+      await locators.plusMenu.importCollection().click();
+      const importModal = locators.import.modal();
+      await importModal.waitFor({ state: 'visible' });
+      await locators.import.fileInput().setInputFiles(collectionFile);
+      await locators.import.locationModal().waitFor({ state: 'visible', timeout: 5000 });
+      const locationModal = locators.import.locationModal();
+      await expect(locationModal.getByText('Binary body type')).toBeVisible();
+      await locators.import.browseLink(locationModal).click();
+      await locators.import.importButton(locationModal).click();
+      await locationModal.waitFor({ state: 'hidden' });
+      await openCollection(page, 'Binary body type');
+      await expect(locators.sidebar.collection('Binary body type')).toBeVisible();
+    });
+
+    await test.step('shows a warning when the binary file does not exist on disk', async () => {
+      await locators.sidebar.request('Binary body - missing file').click();
+      await expect(locators.request.pane()).toBeVisible();
+      await selectRequestPaneTab(page, 'Body');
+
+      const filePicker = page.locator('.file-picker-selected').first();
+      await expect(filePicker).toBeVisible({ timeout: 5000 });
+      await expect(filePicker.locator('.file-name')).toHaveText('missing-payload.bin');
+
+      // Warning: the missing-file styling, icon and tooltip must be present.
+      await expect(filePicker).toHaveClass(/has-warning/);
+      const warningIcon = filePicker.locator('.warning-icon');
+      await expect(warningIcon).toBeVisible();
+
+      await warningIcon.hover();
+      const tooltip = page.locator('.tooltip-mod');
+      await expect(tooltip).toBeVisible();
+      await expect(tooltip).toContainText(MISSING_FILE_WARNING);
+    });
+  });
+});

--- a/tests/request/binary-file/fixtures/binary-file-missing-warning.yml
+++ b/tests/request/binary-file/fixtures/binary-file-missing-warning.yml
@@ -1,0 +1,41 @@
+opencollection: 1.0.0
+info:
+  name: Binary body type
+config:
+  proxy:
+    inherit: true
+    config:
+      protocol: http
+      hostname: ''
+      port: ''
+      auth:
+        username: ''
+        password: ''
+      bypassProxy: ''
+items:
+  - info:
+      name: Binary body - missing file
+      type: http
+      seq: 2
+    http:
+      method: POST
+      url: https://api.com/users
+      body:
+        type: file
+        data:
+          - filePath: ./missing-payload.bin
+            contentType: ''
+            selected: true
+      auth: inherit
+    settings:
+      encodeUrl: true
+      timeout: 0
+      followRedirects: true
+      maxRedirects: 5
+bundled: true
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git
+    exportedUsing: Bruno

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -174,6 +174,9 @@ export const buildCommonLocators = (page: Page) => ({
     },
     pane: () => page.getByTestId('request-pane')
   },
+  filePicker: {
+    warningTooltip: () => page.getByTestId('file-picker-warning-tooltip')
+  },
   // The variable-info popup shown when hovering a `{{var}}` token in an editor.
   varInfoPopup: {
     all: () => page.getByTestId('var-info-popup'),


### PR DESCRIPTION
JIRA: BRU-3118
Extension of https://github.com/usebruno/bruno/pull/8276

<img width="667" height="229" alt="Screenshot 2026-07-23 at 8 00 45 PM" src="https://github.com/user-attachments/assets/1299665b-83c9-4246-a0f5-e4eb6832f8e7" />


### Description

Warn when a request's binary body points to a file that no longer exists on disk.

- `FilePickerEditor` shows a warning icon and tooltip when the selected file is missing.
- New `useMissingFileCheck(paths, basePath)` hook returns `{ status, missingPaths }` and uses a sequence counter to discard superseded results.
- Filename extraction switched to `getBasename` for correct handling of trailing separators, `.`/`..`, and mixed separators on Windows.
- Inline warning SVG replaced with the existing `IconAlertTriangleFilled` component.
- New Playwright spec: `tests/request/binary-file/binary-file-missing-warning.spec.ts`.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File pickers now identify selected files that are missing from the collection directory.
  * Missing files display a warning icon and an explanatory tooltip.

* **Bug Fixes**
  * Improved filename handling across different path formats.

* **Tests**
  * Added coverage for missing binary payload file warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->