### PR TITLE
fix: disable encode url for http://localhost

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -1205,6 +1205,41 @@ describe('generateSnippet – encodeUrl setting', () => {
     const result = await generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
     expect(result).toBe(`curl -X GET '${rawUrl}'`);
   });
+
+  it('should preserve the host:port colon (not %3A) when encodeUrl is true', async () => {
+    // Local-dev `host:port` authority. The port colon must survive un-encoded:
+    // encodeUrl leaves the authority alone because the scheme is present (the
+    // codegen path prepends http:// upstream), so a bogus `localhost%3A6000`
+    // host can never reach the snippet.
+    const rawUrl = 'http://localhost:6000/echo-request';
+    const item = makeItem(rawUrl, { encodeUrl: true });
+
+    const result = await generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toContain('http://localhost:6000/echo-request');
+    expect(result).not.toContain('localhost%3A6000');
+  });
+
+  it('should preserve the host:port colon when encodeUrl is false', async () => {
+    const rawUrl = 'http://localhost:6000/echo-request';
+    const item = makeItem(rawUrl, { encodeUrl: false });
+
+    const result = await generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toContain('http://localhost:6000/echo-request');
+    expect(result).not.toContain('localhost%3A6000');
+  });
+
+  it('requires an explicit scheme — a bare host:port is rejected upstream of the snippet', async () => {
+    // generateSnippet expects the scheme already prepended: the GenerateCodeItem
+    // component runs interpolateUrlPathParams (which prepends http://) before
+    // calling it. Given a raw `host:port` with no scheme, buildHar's URL sanity
+    // gate rejects it and the error string surfaces. The schemeless→correct
+    // path (user types `localhost:6000`, snippet shows `http://localhost:6000`)
+    // is exercised end-to-end in tests/request/generate-code.
+    const item = makeItem('localhost:6000/echo-request', { encodeUrl: true });
+
+    const result = await generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toBe('Error generating code snippet');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -367,12 +367,12 @@ const runSingleRequest = async function (
       }
     }
 
-    if (request.settings?.encodeUrl) {
-      request.url = encodeUrl(request.url);
-    }
-
     if (!hasExplicitScheme(request.url)) {
       request.url = `http://${request.url}`;
+    }
+
+    if (request.settings?.encodeUrl) {
+      request.url = encodeUrl(request.url);
     }
 
     const insecure = get(options, 'insecure', false);

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -611,6 +611,14 @@ const registerNetworkIpc = (mainWindow) => {
     // interpolate variables inside request
     interpolateVars(request, envVars, runtimeVariables, processEnvVars, promptVariables);
 
+    if (!hasExplicitScheme(request.url)) {
+      // The scheme must be present before encoding. Without a `://`, encodeUrl
+      // treats a `host:port` authority as a path segment and percent-encodes the
+      // port colon (localhost:6000 → localhost%3A6000), which then resolves to a
+      // bogus host once configureRequest prepends http://.
+      request.url = `http://${request.url}`;
+    }
+
     if (request.settings?.encodeUrl) {
       request.url = encodeUrl(request.url);
     }

--- a/tests/request/generate-code/collection/requests/scheme-hostport.bru
+++ b/tests/request/generate-code/collection/requests/scheme-hostport.bru
@@ -1,0 +1,15 @@
+meta {
+  name: scheme-hostport
+  type: http
+  seq: 39
+}
+
+get {
+  url: http://localhost:8081/api/echo/anything/hostport
+  body: none
+  auth: none
+}
+
+settings {
+  encodeUrl: false
+}

--- a/tests/request/generate-code/collection/requests/schemeless-hostport.bru
+++ b/tests/request/generate-code/collection/requests/schemeless-hostport.bru
@@ -1,0 +1,15 @@
+meta {
+  name: schemeless-hostport
+  type: http
+  seq: 38
+}
+
+get {
+  url: localhost:8081/api/echo/anything/hostport
+  body: none
+  auth: none
+}
+
+settings {
+  encodeUrl: false
+}

--- a/tests/request/generate-code/send-vs-snippet.spec.ts
+++ b/tests/request/generate-code/send-vs-snippet.spec.ts
@@ -29,6 +29,9 @@ test.describe('Send Request — every fixture, ON and OFF', () => {
     'path-issues-fragment',
     'path-spa-route',
     'oauth-callback-fragment',
+    // scheme normalization
+    'schemeless-hostport',
+    'scheme-hostport',
     // params:path
     'params-path-odata',
     'params-path-space',
@@ -179,5 +182,45 @@ test.describe('Send Request — # encoding scenarios (local echo)', () => {
     // OAuth implicit-flow security property.
     await expectEchoReceived(page, 'http://localhost:8081/api/echo/anything/callback');
     await expectEchoDidNotReceive(page, 'access_token');
+  });
+});
+
+test.describe('Send Request — schemeless host:port normalization', () => {
+  // Regression: with encoding ON, a schemeless `host:port` must keep its port
+  // colon. The scheme is prepended before encodeUrl runs, so `localhost:8081`
+  // stays a valid authority instead of becoming a bogus `localhost%3A8081`
+  // host. This is the common local-dev shape that worked in v3.5.3.
+  test('schemeless — ON keeps the port colon, echo receives http://localhost:8081/...', async ({ pageWithUserData: page }) => {
+    await openCollection(page, COLLECTION);
+    await openRequestInFolder(page, FOLDER, 'schemeless-hostport');
+    await setUrlEncoding(page, true);
+    await sendRequest(page, 200);
+    await expectEchoReceived(page, 'http://localhost:8081/api/echo/anything/hostport');
+    await expectEchoDidNotReceive(page, 'localhost%3A8081');
+  });
+
+  test('explicit http:// scheme — unchanged with encoding ON', async ({ pageWithUserData: page }) => {
+    await openCollection(page, COLLECTION);
+    await openRequestInFolder(page, FOLDER, 'scheme-hostport');
+    await setUrlEncoding(page, true);
+    await sendRequest(page, 200);
+    await expectEchoReceived(page, 'http://localhost:8081/api/echo/anything/hostport');
+  });
+
+  test('schemeless — OFF keeps the port colon, echo receives http://localhost:8081/...', async ({ pageWithUserData: page }) => {
+    await openCollection(page, COLLECTION);
+    await openRequestInFolder(page, FOLDER, 'schemeless-hostport');
+    await setUrlEncoding(page, false);
+    await sendRequest(page, 200);
+    await expectEchoReceived(page, 'http://localhost:8081/api/echo/anything/hostport');
+    await expectEchoDidNotReceive(page, 'localhost%3A8081');
+  });
+
+  test('explicit http:// scheme — unchanged with encoding OFF', async ({ pageWithUserData: page }) => {
+    await openCollection(page, COLLECTION);
+    await openRequestInFolder(page, FOLDER, 'scheme-hostport');
+    await setUrlEncoding(page, false);
+    await sendRequest(page, 200);
+    await expectEchoReceived(page, 'http://localhost:8081/api/echo/anything/hostport');
   });
 });


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved `host:port` correctly when URL encoding is enabled or disabled, preventing `:` from being percent-encoded.
  * Improved URL normalization for requests missing an explicit scheme by applying the default `http://` scheme before any optional encoding.
  * Updated snippet generation to reject schemeless `host:port` inputs with an appropriate error.

* **Tests**
  * Added new fixtures and coverage for both schemeless and explicitly-schemed `host:port` cases across encoding modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->