### PR TITLE
chore(eslint)/disable autofix for const

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,28 @@ const runESMImports = async () => {
   stylistic = await import('@stylistic/eslint-plugin').then((d) => d.default);
 };
 
+// Shared with the ESLINT_DISABLE_AUTOFIX override below - keep in one place
+// so adding a package here doesn't require remembering to update that block too.
+const mainLintFiles = [
+  './eslint.config.js',
+  'tests/**/*.{ts,js}',
+  'playwright/**/*.{js,ts}',
+  'packages/bruno-app/**/*.{js,jsx,ts}',
+  'packages/bruno-app/plugins/**/*.{js,cjs,mjs}',
+  'packages/bruno-app/src/test-utils/mocks/codemirror.js',
+  'packages/bruno-cli/**/*.js',
+  'packages/bruno-common/**/*.ts',
+  'packages/bruno-converters/**/*.js',
+  'packages/bruno-electron/**/*.js',
+  'packages/bruno-filestore/**/*.ts',
+  'packages/bruno-schema-types/**/*.ts',
+  'packages/bruno-js/**/*.js',
+  'packages/bruno-lang/**/*.js',
+  'packages/bruno-requests/**/*.ts',
+  'packages/bruno-requests/**/*.js',
+  'packages/bruno-tests/**/*.{js,ts}'
+];
+
 module.exports = runESMImports().then(() => defineConfig([
   // Global ignores - must be a standalone object with ONLY ignores
   {
@@ -35,25 +57,7 @@ module.exports = runESMImports().then(() => defineConfig([
         sourceType: 'module'
       }
     },
-    files: [
-      './eslint.config.js',
-      'tests/**/*.{ts,js}',
-      'playwright/**/*.{js,ts}',
-      'packages/bruno-app/**/*.{js,jsx,ts}',
-      'packages/bruno-app/plugins/**/*.{js,cjs,mjs}',
-      'packages/bruno-app/src/test-utils/mocks/codemirror.js',
-      'packages/bruno-cli/**/*.js',
-      'packages/bruno-common/**/*.ts',
-      'packages/bruno-converters/**/*.js',
-      'packages/bruno-electron/**/*.js',
-      'packages/bruno-filestore/**/*.ts',
-      'packages/bruno-schema-types/**/*.ts',
-      'packages/bruno-js/**/*.js',
-      'packages/bruno-lang/**/*.js',
-      'packages/bruno-requests/**/*.ts',
-      'packages/bruno-requests/**/*.js',
-      'packages/bruno-tests/**/*.{js,ts}'
-    ],
+    files: mainLintFiles,
     rules: {
       ...stylistic.configs.customize({
         indent: 2,
@@ -92,6 +96,16 @@ module.exports = runESMImports().then(() => defineConfig([
       'no-use-before-define': ['warn', { functions: false }]
     }
   },
+  // When running `eslint --fix` we don't want these two rules to silently
+  // rewrite existing code (they still run and warn under plain `npm run lint`).
+  // Toggle via ESLINT_DISABLE_AUTOFIX=true, set by the `lint:fix` script.
+  ...(process.env.ESLINT_DISABLE_AUTOFIX === 'true' ? [{
+    files: mainLintFiles,
+    rules: {
+      'eqeqeq': 'off',
+      'prefer-const': 'off'
+    }
+  }] : []),
   {
     files: ['packages/bruno-app/**/*.{js,jsx,ts}'],
     ignores: ['**/*.config.js', '**/public/**/*', '**/plugins/**/*'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -101,7 +101,7 @@ module.exports = runESMImports().then(() => defineConfig([
   // When running `eslint --fix` we don't want these two rules to silently
   // rewrite existing code (they still run and warn under plain `npm run lint`).
   // Toggle via ESLINT_DISABLE_AUTOFIX=true, set by the `lint:fix` script.
-  ...(!isFixMode ? [{
+  ...(isFixMode ? [{
     files: mainLintFiles,
     rules: {
       'eqeqeq': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,8 @@ const runESMImports = async () => {
   stylistic = await import('@stylistic/eslint-plugin').then((d) => d.default);
 };
 
+const isFixMode = process.argv.some(arg => arg === '--fix' || arg === '--fix-dry-run');
+
 // Shared with the ESLINT_DISABLE_AUTOFIX override below - keep in one place
 // so adding a package here doesn't require remembering to update that block too.
 const mainLintFiles = [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -101,7 +101,7 @@ module.exports = runESMImports().then(() => defineConfig([
   // When running `eslint --fix` we don't want these two rules to silently
   // rewrite existing code (they still run and warn under plain `npm run lint`).
   // Toggle via ESLINT_DISABLE_AUTOFIX=true, set by the `lint:fix` script.
-  ...(process.env.ESLINT_DISABLE_AUTOFIX === 'true' ? [{
+  ...(!isFixMode ? [{
     files: mainLintFiles,
     rules: {
       'eqeqeq': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ const runESMImports = async () => {
   stylistic = await import('@stylistic/eslint-plugin').then((d) => d.default);
 };
 
-const isFixMode = process.argv.some(arg => arg === '--fix' || arg === '--fix-dry-run');
+const isFixMode = process.argv.some((arg) => arg === '--fix' || arg === '--fix-dry-run');
 
 // Shared with the ESLINT_DISABLE_AUTOFIX override below - keep in one place
 // so adding a package here doesn't require remembering to update that block too.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,8 +12,6 @@ const runESMImports = async () => {
 
 const isFixMode = process.argv.some((arg) => arg === '--fix' || arg === '--fix-dry-run');
 
-// Shared with the ESLINT_DISABLE_AUTOFIX override below - keep in one place
-// so adding a package here doesn't require remembering to update that block too.
 const mainLintFiles = [
   './eslint.config.js',
   'tests/**/*.{ts,js}',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -88,8 +88,8 @@ module.exports = runESMImports().then(() => defineConfig([
       '@stylistic/no-mixed-operators': ['off'],
       'no-unused-vars': ['warn', { args: 'none', caughtErrors: 'none' }],
       'no-debugger': 'warn',
-      'eqeqeq': ['warn', 'always'],
-      'prefer-const': 'warn',
+      'eqeqeq': isFixMode ? 'off' : ['warn', 'always'],
+      'prefer-const': isFixMode ? 'off' : 'warn',
       'no-var': 'warn',
       'no-unreachable': 'warn',
       'no-duplicate-imports': 'warn',
@@ -98,16 +98,6 @@ module.exports = runESMImports().then(() => defineConfig([
       'no-use-before-define': ['warn', { functions: false }]
     }
   },
-  // When running `eslint --fix` we don't want these two rules to silently
-  // rewrite existing code (they still run and warn under plain `npm run lint`).
-  // Toggle via ESLINT_DISABLE_AUTOFIX=true, set by the `lint:fix` script.
-  ...(isFixMode ? [{
-    files: mainLintFiles,
-    rules: {
-      'eqeqeq': 'off',
-      'prefer-const': 'off'
-    }
-  }] : []),
   {
     files: ['packages/bruno-app/**/*.{js,jsx,ts}'],
     ignores: ['**/*.config.js', '**/public/**/*', '**/plugins/**/*'],

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "test:e2e:sanity": "playwright test --project=default --project=system-pac --grep @sanity",
     "test:benchmark": "playwright test --config=playwright.benchmark.config.ts",
     "lint": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" npx eslint",
-    "lint:fix": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" npx eslint --fix",
+    "lint:fix": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" npx eslint --fix --rule '{\"eqeqeq\":\"off\",\"prefer-const\":\"off\",\"no-var\":\"off\"}'",
     "prepare": "husky"
   },
   "nano-staged": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "test:e2e:sanity": "playwright test --project=default --project=system-pac --grep @sanity",
     "test:benchmark": "playwright test --config=playwright.benchmark.config.ts",
     "lint": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" npx eslint",
-    "lint:fix": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" ESLINT_DISABLE_AUTOFIX=true npx eslint --fix",
+    "lint:fix": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" npx eslint --fix",
     "prepare": "husky"
   },
   "nano-staged": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "test:e2e:sanity": "playwright test --project=default --project=system-pac --grep @sanity",
     "test:benchmark": "playwright test --config=playwright.benchmark.config.ts",
     "lint": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" npx eslint",
-    "lint:fix": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" npx eslint --fix --rule '{\"eqeqeq\":\"off\",\"prefer-const\":\"off\",\"no-var\":\"off\"}'",
+    "lint:fix": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" ESLINT_DISABLE_AUTOFIX=true npx eslint --fix",
     "prepare": "husky"
   },
   "nano-staged": {


### PR DESCRIPTION
### Description

In previous PR added warnings for `prefer-const` which `lint:fix` will autofix. This will create huge diff for existing PR when taking main pull.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

remove autofix for no var and use const. Warning will be there but these will not be lint fixable.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting behavior for fix and dry-run modes.
  * Centralized the primary linting file targets for more consistent checks.
  * Adjusted selected lint rules during automatic fixes to support smoother formatting workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->