### PR TITLE
fix(converters): populate collection & folder docs on OpenAPI/Swagger…

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-common.js
+++ b/packages/bruno-converters/src/openapi/openapi-common.js
@@ -534,6 +534,27 @@ export const groupRequestsByTags = (requests, options = {}) => {
 };
 
 /**
+ * Builds a lookup of tag description keyed by sanitized tag name.
+ * Folders are named from the sanitized first tag (see groupRequestsByTags), so the
+ * spec's top-level tags[] descriptions are keyed the same way to line up with folder names.
+ * @param {Array} tags - The spec's top-level tags array (each { name, description })
+ * @param {Object} options - Sanitization options (forwarded to sanitizeTag)
+ * @returns {Object} Map of sanitized tag name -> description
+ */
+export const getTagDescriptions = (tags, options = {}) => {
+  const descriptions = {};
+  each(tags || [], (tag) => {
+    if (tag && typeof tag === 'object' && tag.name && tag.description) {
+      const key = sanitizeTag(tag.name, options);
+      if (key) {
+        descriptions[key] = tag.description;
+      }
+    }
+  });
+  return descriptions;
+};
+
+/**
  * Groups requests by URL path segments and builds nested folder structures
  * @param {Array} requests - Array of parsed request objects
  * @param {Function} transformFn - Function to transform a request into a Bruno item: (request, usedNames, options) => brunoItem

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -9,7 +9,8 @@ import {
   getExampleFromSchema,
   createBrunoExample,
   groupRequestsByTags,
-  groupRequestsByPath
+  groupRequestsByPath,
+  getTagDescriptions
 } from './openapi-common';
 
 const getContentLevelExample = (bodyContent) => {
@@ -890,8 +891,9 @@ export const parseOpenApiCollection = (data, options = {}) => {
     } else {
       // Default tag-based grouping
       let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
+      const tagDescriptions = getTagDescriptions(collectionData.tags, options);
       let brunoFolders = groups.map((group) => {
-        return {
+        const folder = {
           uid: uuid(),
           name: group.name,
           type: 'folder',
@@ -912,6 +914,11 @@ export const parseOpenApiCollection = (data, options = {}) => {
           },
           items: group.requests.map((req) => transformOpenapiRequestItem(req, usedNames, options))
         };
+        const docs = tagDescriptions[group.name];
+        if (docs) {
+          folder.root.docs = docs;
+        }
+        return folder;
       });
 
       let ungroupedItems = ungroupedRequests.map((req) => transformOpenapiRequestItem(req, usedNames, options));
@@ -1012,7 +1019,8 @@ export const parseOpenApiCollection = (data, options = {}) => {
       },
       meta: {
         name: brunoCollection.name
-      }
+      },
+      docs: collectionData.info?.description
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
@@ -11,7 +11,8 @@ import {
   getExampleFromSchema,
   createBrunoExample,
   groupRequestsByTags,
-  groupRequestsByPath
+  groupRequestsByPath,
+  getTagDescriptions
 } from './openapi-common';
 
 /**
@@ -610,19 +611,27 @@ export const parseSwagger2Collection = (data, options = {}) => {
     if (groupingType === 'path') {
       brunoCollection.items = groupRequestsByPath(allRequests, transformSwaggerRequestItem, options);
     } else {
-      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests);
-      let brunoFolders = groups.map((group) => ({
-        uid: uuid(),
-        name: group.name,
-        type: 'folder',
-        root: {
-          request: {
-            auth: { mode: 'inherit', basic: null, bearer: null, digest: null, apikey: null, oauth2: null }
+      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
+      const tagDescriptions = getTagDescriptions(collectionData.tags, options);
+      let brunoFolders = groups.map((group) => {
+        const folder = {
+          uid: uuid(),
+          name: group.name,
+          type: 'folder',
+          root: {
+            request: {
+              auth: { mode: 'inherit', basic: null, bearer: null, digest: null, apikey: null, oauth2: null }
+            },
+            meta: { name: group.name }
           },
-          meta: { name: group.name }
-        },
-        items: group.requests.map((req) => transformSwaggerRequestItem(req, usedNames, options))
-      }));
+          items: group.requests.map((req) => transformSwaggerRequestItem(req, usedNames, options))
+        };
+        const docs = tagDescriptions[group.name];
+        if (docs) {
+          folder.root.docs = docs;
+        }
+        return folder;
+      });
 
       let ungroupedItems = ungroupedRequests.map((req) => transformSwaggerRequestItem(req, usedNames, options));
       brunoCollection.items = brunoFolders.concat(ungroupedItems);
@@ -632,7 +641,8 @@ export const parseSwagger2Collection = (data, options = {}) => {
     let collectionAuth = buildCollectionAuth(securityConfig.supported[0]);
     brunoCollection.root = {
       request: { auth: collectionAuth },
-      meta: { name: brunoCollection.name }
+      meta: { name: brunoCollection.name },
+      docs: collectionData.info?.description
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from '@jest/globals';
+import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
+
+const findRequestByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'http-request' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findRequestByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const findFolderByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'folder' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findFolderByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const buildSpec = (overrides = {}) => ({
+  openapi: '3.0.0',
+  info: {
+    title: 'Petstore',
+    description: '# Pet Store API\n\nThis is the **collection-level** description.',
+    ...overrides.info
+  },
+  tags: overrides.tags ?? [
+    { name: 'pets', description: 'Everything about your _Pets_.' },
+    { name: 'store', description: '## Store\n\nAccess to Petstore **orders**.' }
+  ],
+  servers: [{ url: 'https://api.example.com' }],
+  paths: {
+    '/pets': {
+      get: {
+        tags: ['pets'],
+        summary: 'List pets',
+        description: 'Returns all pets.',
+        responses: { 200: { description: 'OK' } }
+      }
+    },
+    '/store/orders': {
+      post: {
+        tags: ['store'],
+        summary: 'Place order',
+        responses: { 201: { description: 'Created' } }
+      }
+    }
+  }
+});
+
+describe('OpenAPI Import - Docs (collection & folder descriptions)', () => {
+  it('populates collection Docs from info.description', () => {
+    const result = openApiToBruno(buildSpec());
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+
+  it('populates each folder Docs from the matching top-level tags[] description', () => {
+    const result = openApiToBruno(buildSpec());
+
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBe('Everything about your _Pets_.');
+
+    const storeFolder = findFolderByName(result.items, 'store');
+    expect(storeFolder.root.docs).toBe('## Store\n\nAccess to Petstore **orders**.');
+  });
+
+  it('preserves markdown formatting verbatim', () => {
+    const md = '# Title\n\n- one\n- two\n\n`code` and **bold**';
+    const result = openApiToBruno(buildSpec({ info: { description: md } }));
+    expect(result.root.docs).toBe(md);
+  });
+
+  it('matches folder docs after tag-name sanitization (spaces -> underscores)', () => {
+    const spec = buildSpec({ tags: [{ name: 'Pet Store', description: 'Pet store docs.' }] });
+    spec.paths = {
+      '/pets': {
+        get: { tags: ['Pet Store'], summary: 'List pets', responses: { 200: { description: 'OK' } } }
+      }
+    };
+    const result = openApiToBruno(spec);
+
+    const folder = findFolderByName(result.items, 'Pet_Store');
+    expect(folder).toBeDefined();
+    expect(folder.root.docs).toBe('Pet store docs.');
+  });
+
+  it('does not regress request-level Docs', () => {
+    const result = openApiToBruno(buildSpec());
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request.request.docs).toBe('Returns all pets.');
+  });
+
+  it('leaves docs unset when the spec has no info.description or tag descriptions', () => {
+    const result = openApiToBruno(
+      buildSpec({ info: { title: 'No Docs', description: undefined }, tags: [{ name: 'pets' }] })
+    );
+    expect(result.root.docs == null || result.root.docs === '').toBe(true);
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBeUndefined();
+  });
+
+  it('still sets collection docs under path-based grouping (no tag folders to describe)', () => {
+    const result = openApiToBruno(buildSpec(), { groupBy: 'path' });
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+});

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from '@jest/globals';
+import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
+
+const findRequestByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'http-request' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findRequestByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const findFolderByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'folder' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findFolderByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const buildSpec = (overrides = {}) => ({
+  swagger: '2.0',
+  info: {
+    title: 'Petstore',
+    description: '# Pet Store API\n\nThis is the **collection-level** description.',
+    ...overrides.info
+  },
+  tags: overrides.tags ?? [
+    { name: 'pets', description: 'Everything about your _Pets_.' },
+    { name: 'store', description: '## Store\n\nAccess to Petstore **orders**.' }
+  ],
+  host: 'api.example.com',
+  basePath: '/v1',
+  schemes: ['https'],
+  paths: {
+    '/pets': {
+      get: {
+        tags: ['pets'],
+        summary: 'List pets',
+        description: 'Returns all pets.',
+        responses: { 200: { description: 'OK' } }
+      }
+    },
+    '/store/orders': {
+      post: {
+        tags: ['store'],
+        summary: 'Place order',
+        responses: { 201: { description: 'Created' } }
+      }
+    }
+  }
+});
+
+describe('Swagger 2.0 Import - Docs (collection & folder descriptions)', () => {
+  it('populates collection Docs from info.description', () => {
+    const result = openApiToBruno(buildSpec());
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+
+  it('populates each folder Docs from the matching top-level tags[] description', () => {
+    const result = openApiToBruno(buildSpec());
+
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBe('Everything about your _Pets_.');
+
+    const storeFolder = findFolderByName(result.items, 'store');
+    expect(storeFolder.root.docs).toBe('## Store\n\nAccess to Petstore **orders**.');
+  });
+
+  it('does not regress request-level Docs', () => {
+    const result = openApiToBruno(buildSpec());
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request.request.docs).toBe('Returns all pets.');
+  });
+
+  it('leaves docs unset when the spec has no info.description or tag descriptions', () => {
+    const result = openApiToBruno(
+      buildSpec({ info: { title: 'No Docs', description: undefined }, tags: [{ name: 'pets' }] })
+    );
+    expect(result.root.docs == null || result.root.docs === '').toBe(true);
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBeUndefined();
+  });
+});


### PR DESCRIPTION
… import
REF:BRU-1429
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
OpenAPI import only copied request-level descriptions into Docs tabs,info.description (collection) and top-level tags[].description (folders)were never read, leaving those Docs tabs empty.

Read info.description into collection root docs and match top-level tags[] descriptions to their folders via a shared getTagDescriptions helper (keyed by sanitized tag name so it lines up with folder names).Applied to both the OpenAPI 3.x and Swagger 2.0 converters.
#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
Collection-Level:
<img width="1176" height="674" alt="image" src="https://github.com/user-attachments/assets/488ff956-8117-46ab-a04a-2c7177825739" />
Folder-Level:
<img width="782" height="366" alt="image" src="https://github.com/user-attachments/assets/72662035-39ec-4366-95cd-3c44bc0fd51b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenAPI and Swagger 2.0 imports now preserve collection descriptions from `info.description`.
  - Tag descriptions are added to their corresponding generated folders.
  - Markdown formatting in collection documentation is preserved.
  - Documentation remains correctly associated when grouping requests by path or tags.
  - Existing request-level documentation is preserved.

- **Tests**
  - Added coverage for collection, folder, and request documentation, including missing descriptions and sanitized tag names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->