### PR TITLE
fix: broken sse event rendering in ui

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -38,6 +38,7 @@ const { cookiesStore } = require('../../store/cookies');
 const registerGrpcEventHandlers = require('./grpc-event-handlers');
 const { registerWsEventHandlers } = require('./ws-event-handlers');
 const { getCertsAndProxyConfig, buildCertsAndProxyConfig } = require('./cert-utils');
+const { createSseEventBuffer } = require('./sse-event-buffer');
 const { easterEggResponse } = require('../../utils/woof');
 const { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType } = require('@usebruno/common').utils;
 
@@ -1347,12 +1348,12 @@ const registerNetworkIpc = (mainWindow) => {
       const stream = response.stream;
       response.stream = { running: response.status >= 200 && response.status < 300 };
 
-      stream.on('data', (newData) => {
-        // Collect the raw chunk so runRequest can rebuild the full body on stream close.
-        response.sseChunks?.push(newData);
+      const sseEventBuffer = createSseEventBuffer();
+
+      const sendSseEvent = (rawEvent) => {
         seq += 1;
 
-        const parsed = parseDataFromResponse({ data: newData, headers: {} });
+        const parsed = parseDataFromResponse({ data: rawEvent, headers: {} });
 
         mainWindow.webContents.send('main:http-stream-new-data', {
           collectionUid,
@@ -1361,9 +1362,20 @@ const registerNetworkIpc = (mainWindow) => {
           timestamp: Date.now(),
           data: parsed
         });
+      };
+
+      stream.on('data', (newData) => {
+        // Collect the raw chunk so runRequest can rebuild the full body on stream close.
+        response.sseChunks?.push(newData);
+        sseEventBuffer.push(newData).forEach(sendSseEvent);
       });
 
       stream.on('close', () => {
+        const remaining = sseEventBuffer.flush();
+        if (remaining) {
+          sendSseEvent(remaining);
+        }
+
         if (!cancelTokens[response.cancelTokenUid]) return;
 
         mainWindow.webContents.send('main:http-stream-end', {

--- a/packages/bruno-electron/src/ipc/network/sse-event-buffer.js
+++ b/packages/bruno-electron/src/ipc/network/sse-event-buffer.js
@@ -1,0 +1,49 @@
+const { StringDecoder } = require('string_decoder');
+
+// A single SSE event (terminated by a blank line) can arrive split across multiple network
+// chunks, so incoming bytes must be buffered and only handed off once a full event is available,
+// rather than parsing each raw chunk in isolation.
+const createSseEventBuffer = () => {
+  let buffer = '';
+  // True when the previous chunk ended in a lone \r whose \n pair (if any) may still be
+  // in transit - a \r\n terminator split across chunks must not be read as two line breaks.
+  let pendingCr = false;
+  const decoder = new StringDecoder('utf8');
+
+  const push = (chunk) => {
+    let text = decoder.write(chunk);
+    if (!text) return [];
+
+    if (pendingCr) {
+      pendingCr = false;
+      if (text[0] === '\n') {
+        text = text.slice(1);
+      }
+    }
+
+    if (text.endsWith('\r')) {
+      pendingCr = true;
+    }
+
+    buffer += text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+    const events = [];
+    let eventEnd;
+    while ((eventEnd = buffer.indexOf('\n\n')) !== -1) {
+      events.push(buffer.slice(0, eventEnd));
+      buffer = buffer.slice(eventEnd + 2);
+    }
+    return events;
+  };
+
+  // Flushes any buffered, non-terminated event left over once the stream closes.
+  const flush = () => {
+    const remaining = buffer + decoder.end();
+    buffer = '';
+    return remaining || null;
+  };
+
+  return { push, flush };
+};
+
+module.exports = { createSseEventBuffer };

--- a/packages/bruno-electron/src/ipc/network/sse-event-buffer.spec.js
+++ b/packages/bruno-electron/src/ipc/network/sse-event-buffer.spec.js
@@ -1,0 +1,173 @@
+const http = require('http');
+const { createSseEventBuffer } = require('./sse-event-buffer');
+const { makeAxiosInstance } = require('./axios-instance');
+
+describe('createSseEventBuffer', () => {
+  test('emits nothing until a full event (blank-line terminated) is received', () => {
+    const sseEventBuffer = createSseEventBuffer();
+
+    expect(sseEventBuffer.push(Buffer.from('event: response.created\n'))).toEqual([]);
+    expect(sseEventBuffer.push(Buffer.from('data: {"foo":"bar"}\n'))).toEqual([]);
+    expect(sseEventBuffer.push(Buffer.from('\n'))).toEqual(['event: response.created\ndata: {"foo":"bar"}']);
+  });
+
+  test('reassembles a data payload split mid-string across network chunk boundaries', () => {
+    // Mirrors the reported bug: a long `data:` JSON line arriving split across two
+    // TCP/HTTP2 reads, with the split landing in the middle of a string value.
+    const fullEvent = 'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_02c1","max_tool_calls":null,"model":"gpt-5"}}\n\n';
+    const splitIndex = fullEvent.indexOf('max_tool_') + 'max_tool_'.length;
+    const firstChunk = fullEvent.slice(0, splitIndex);
+    const secondChunk = fullEvent.slice(splitIndex);
+
+    const sseEventBuffer = createSseEventBuffer();
+
+    expect(sseEventBuffer.push(Buffer.from(firstChunk))).toEqual([]);
+    const events = sseEventBuffer.push(Buffer.from(secondChunk));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toBe(fullEvent.trim());
+    expect(() => JSON.parse(events[0].split('data: ')[1])).not.toThrow();
+  });
+
+  test('emits multiple events that arrive in a single chunk', () => {
+    const sseEventBuffer = createSseEventBuffer();
+
+    const events = sseEventBuffer.push(Buffer.from('event: a\ndata: 1\n\nevent: b\ndata: 2\n\n'));
+
+    expect(events).toEqual(['event: a\ndata: 1', 'event: b\ndata: 2']);
+  });
+
+  test('normalizes CRLF line endings within a single chunk before detecting event boundaries', () => {
+    const sseEventBuffer = createSseEventBuffer();
+
+    const events = sseEventBuffer.push(Buffer.from('event: a\r\ndata: 1\r\n\r\n'));
+
+    expect(events).toEqual(['event: a\ndata: 1']);
+  });
+
+  test('normalizes lone CR line endings within a single chunk before detecting event boundaries', () => {
+    const sseEventBuffer = createSseEventBuffer();
+
+    const events = sseEventBuffer.push(Buffer.from('event: a\rdata: 1\r\r'));
+
+    expect(events).toEqual(['event: a\ndata: 1']);
+  });
+
+  test('does not misread a CRLF terminator split across chunks as an extra blank line', () => {
+    // If \r and \n were normalized independently per chunk before concatenating, a chunk
+    // boundary landing between them would turn one line break into two, splitting a single
+    // event into two (or worse, emitting a bogus event early).
+    const sseEventBuffer = createSseEventBuffer();
+
+    expect(sseEventBuffer.push(Buffer.from('event: a\r'))).toEqual([]);
+    const events = sseEventBuffer.push(Buffer.from('\ndata: 1\r\n\r\n'));
+
+    expect(events).toEqual(['event: a\ndata: 1']);
+  });
+
+  test('treats a lone CR followed by an unrelated CR as two separate line breaks', () => {
+    const sseEventBuffer = createSseEventBuffer();
+
+    expect(sseEventBuffer.push(Buffer.from('event: a\r'))).toEqual([]);
+    const events = sseEventBuffer.push(Buffer.from('\rdata: 1\r\r'));
+
+    expect(events).toEqual(['event: a', 'data: 1']);
+  });
+
+  test('does not split a multi-byte UTF-8 character across chunks', () => {
+    const payload = 'event: msg\ndata: "€"\n\n';
+    const payloadBytes = Buffer.from(payload, 'utf8');
+    // Split inside the 3-byte UTF-8 encoding of '€'.
+    const euroIndex = payloadBytes.indexOf(Buffer.from('€', 'utf8'));
+    const firstChunk = payloadBytes.subarray(0, euroIndex + 1);
+    const secondChunk = payloadBytes.subarray(euroIndex + 1);
+
+    const sseEventBuffer = createSseEventBuffer();
+
+    expect(sseEventBuffer.push(firstChunk)).toEqual([]);
+    const events = sseEventBuffer.push(secondChunk);
+
+    expect(events).toEqual(['event: msg\ndata: "€"']);
+  });
+
+  test('flush returns a trailing event that never received a closing blank line', () => {
+    const sseEventBuffer = createSseEventBuffer();
+
+    sseEventBuffer.push(Buffer.from('event: done\ndata: {"ok":true}'));
+
+    expect(sseEventBuffer.flush()).toBe('event: done\ndata: {"ok":true}');
+  });
+
+  test('flush returns null when nothing is left buffered', () => {
+    const sseEventBuffer = createSseEventBuffer();
+
+    sseEventBuffer.push(Buffer.from('event: a\ndata: 1\n\n'));
+
+    expect(sseEventBuffer.flush()).toBeNull();
+  });
+});
+
+// Spins up a plain HTTP server on loopback for exercising real timeout behavior end to end.
+const createServer = (handler) =>
+  new Promise((resolve) => {
+    const server = http.createServer(handler);
+    const sockets = new Set();
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}/`,
+        close: () =>
+          new Promise((closeResolve) => {
+            sockets.forEach((socket) => socket.destroy());
+            server.close(closeResolve);
+          })
+      });
+    });
+  });
+
+describe('SSE requests respect the configured timeout for the initial response', () => {
+  test('resolves once the SSE stream starts responding before the timeout elapses', async () => {
+    const { url, close } = await createServer((_, res) => {
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.write('event: ping\ndata: {}\n\n');
+    });
+
+    try {
+      const instance = makeAxiosInstance();
+      const response = await instance.get(url, { responseType: 'stream', timeout: 500 });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toBe('text/event-stream');
+      response.data.on('error', () => {});
+      response.data.destroy();
+    } finally {
+      await close();
+    }
+  }, 8000);
+
+  test('aborts the SSE request if the server never responds within the configured timeout', async () => {
+    const { url, close } = await createServer(() => {
+      // Accept the connection but never write headers or end the response.
+    });
+
+    try {
+      const instance = makeAxiosInstance();
+      const start = Date.now();
+
+      await expect(instance.get(url, { responseType: 'stream', timeout: 300 })).rejects.toMatchObject({
+        code: expect.stringMatching(/ECONNABORTED|ETIMEDOUT/)
+      });
+
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(250);
+      expect(elapsed).toBeLessThan(2000);
+    } finally {
+      await close();
+    }
+  }, 8000);
+});


### PR DESCRIPTION
### Description

Added `sse-event-buffer.js` (`createSseEventBuffer`), which buffers incoming bytes, decoding with StringDecoder so multi-byte UTF-8 characters are never split across chunks, and normalizing CRLF/CR line endings until a full SSE event (blank-line terminated) is available, only then handing it off to the renderer. `flush()` emits any trailing event left over when the stream closes without a final blank line. The send-http-request handler now pushes each chunk through this buffer instead of parsing raw chunks in isolation. The raw-byte accumulation used to rebuild the final persisted response body is untouched, so that stays byte-accurate.

Added unit tests in `sse-event-buffer.spec.js` covering: buffering until a full event arrives, reassembling a data: payload split mid-string (the reported bug), multiple events in one chunk, CRLF/CR normalization, multi-byte UTF-8 characters split across chunks, and `flush()` behavior.

Before:

<img width="1253" height="802" alt="Image" src="https://github.com/user-attachments/assets/7e116bc4-eef8-4793-85bf-bad225efe515" />

<img width="1253" height="802" alt="Image" src="https://github.com/user-attachments/assets/23100dc7-92e9-4468-aaeb-49d2cb18a74c" />

After:

<img width="1253" height="761" alt="Screenshot 2026-07-24 at 14 39 41" src="https://github.com/user-attachments/assets/1717ba0c-2d37-45a6-a760-378b4b75be4d" />

<img width="1253" height="761" alt="Screenshot 2026-07-24 at 14 39 58" src="https://github.com/user-attachments/assets/0ed8b0a6-368e-4442-bfa7-bf6e11802beb" />

Closes #8762 

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time SSE streaming by buffering incoming data until complete events are formed before dispatching to the renderer.
  * Improved handling of event boundaries across chunk splits, including `\r\n`/`\r` normalization and UTF-8 multi-byte boundaries.
  * Flushes any remaining buffered SSE content on connection close so no partial event is lost.
  * Enhanced behavior for SSE requests that connect successfully but don’t begin sending headers/stream within the expected timeout.
* **Tests**
  * Added Jest coverage for SSE buffering, termination/flush behavior, encoding and boundary edge cases, plus end-to-end SSE timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->