### PR TITLE
fix:populate collection & folder docs on OpenAPI/swagger imports

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-common.js
+++ b/packages/bruno-converters/src/openapi/openapi-common.js
@@ -534,6 +534,27 @@ export const groupRequestsByTags = (requests, options = {}) => {
 };
 
 /**
+ * Builds a lookup of tag description keyed by sanitized tag name.
+ * Folders are named from the sanitized first tag (see groupRequestsByTags), so the
+ * spec's top-level tags[] descriptions are keyed the same way to line up with folder names.
+ * @param {Array} tags - The spec's top-level tags array (each { name, description })
+ * @param {Object} options - Sanitization options (forwarded to sanitizeTag)
+ * @returns {Object} Map of sanitized tag name -> description
+ */
+export const getTagDescriptions = (tags, options = {}) => {
+  const descriptions = Object.create(null);
+  each(tags || [], (tag) => {
+    if (tag && typeof tag === 'object' && tag.name && tag.description) {
+      const key = sanitizeTag(tag.name, options);
+      if (key) {
+        descriptions[key] = tag.description;
+      }
+    }
+  });
+  return descriptions;
+};
+
+/**
  * Groups requests by URL path segments and builds nested folder structures
  * @param {Array} requests - Array of parsed request objects
  * @param {Function} transformFn - Function to transform a request into a Bruno item: (request, usedNames, options) => brunoItem

--- a/packages/bruno-converters/src/openapi/openapi-common.js
+++ b/packages/bruno-converters/src/openapi/openapi-common.js
@@ -503,12 +503,12 @@ export const createBrunoExample = ({ brunoRequestItem, exampleValue, exampleName
  * @returns {Array} Tuple of [tagGroups, ungroupedRequests]
  */
 export const groupRequestsByTags = (requests, options = {}) => {
-  let _groups = {};
-  let ungrouped = [];
+  const _groups = {};
+  const ungrouped = [];
   each(requests, (request) => {
-    let tags = request.operationObject.tags || [];
+    const tags = request.operationObject.tags || [];
     if (tags.length > 0) {
-      let tag = sanitizeTag(tags[0].trim(), options); // take first tag, trim whitespace, and sanitize
+      const tag = sanitizeTag(tags[0].trim(), options); // take first tag, trim whitespace, and sanitize
 
       if (tag) {
         if (!_groups[tag]) {
@@ -523,7 +523,7 @@ export const groupRequestsByTags = (requests, options = {}) => {
     }
   });
 
-  let groups = Object.keys(_groups).map((groupName) => {
+  const groups = Object.keys(_groups).map((groupName) => {
     return {
       name: groupName,
       requests: _groups[groupName]
@@ -532,6 +532,15 @@ export const groupRequestsByTags = (requests, options = {}) => {
 
   return [groups, ungrouped];
 };
+
+/**
+ * Coerces a value into a string.
+ * The spec is unvalidated, so a description can arrive as any YAML type.A bad
+ * value is dropped rather than failing the whole import.
+ * @param {*} value - A value straight off the parsed spec
+ * @returns {string} The value, or '' when it isn't a usable string
+ */
+export const toSpecString = (value) => (typeof value === 'string' ? value : '');
 
 /**
  * Builds a lookup of tag description keyed by sanitized tag name.
@@ -544,10 +553,11 @@ export const groupRequestsByTags = (requests, options = {}) => {
 export const getTagDescriptions = (tags, options = {}) => {
   const descriptions = Object.create(null);
   each(tags || [], (tag) => {
-    if (tag && typeof tag === 'object' && tag.name && tag.description) {
+    if (tag && typeof tag === 'object' && tag.name) {
+      const docs = toSpecString(tag.description);
       const key = sanitizeTag(tag.name, options);
-      if (key) {
-        descriptions[key] = tag.description;
+      if (key && docs) {
+        descriptions[key] = docs;
       }
     }
   });
@@ -585,7 +595,7 @@ export const groupRequestsByPath = (requests, transformFn, options = {}) => {
     }
 
     // Use the first segment as the main group
-    let groupName = pathSegments[0];
+    const groupName = pathSegments[0];
 
     if (!pathGroups[groupName]) {
       pathGroups[groupName] = {
@@ -602,7 +612,7 @@ export const groupRequestsByPath = (requests, transformFn, options = {}) => {
       // For deeper paths, create sub-groups
       let currentGroup = pathGroups[groupName];
       for (let i = 1; i < pathSegments.length; i++) {
-        let subGroupName = pathSegments[i];
+        const subGroupName = pathSegments[i];
 
         if (!currentGroup.subGroups[subGroupName]) {
           currentGroup.subGroups[subGroupName] = {

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -9,7 +9,8 @@ import {
   getExampleFromSchema,
   createBrunoExample,
   groupRequestsByTags,
-  groupRequestsByPath
+  groupRequestsByPath,
+  getTagDescriptions
 } from './openapi-common';
 
 const getContentLevelExample = (bodyContent) => {
@@ -890,8 +891,9 @@ export const parseOpenApiCollection = (data, options = {}) => {
     } else {
       // Default tag-based grouping
       let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
+      const tagDescriptions = getTagDescriptions(collectionData.tags, options);
       let brunoFolders = groups.map((group) => {
-        return {
+        const folder = {
           uid: uuid(),
           name: group.name,
           type: 'folder',
@@ -912,6 +914,11 @@ export const parseOpenApiCollection = (data, options = {}) => {
           },
           items: group.requests.map((req) => transformOpenapiRequestItem(req, usedNames, options))
         };
+        const docs = tagDescriptions[group.name];
+        if (docs) {
+          folder.root.docs = docs;
+        }
+        return folder;
       });
 
       let ungroupedItems = ungroupedRequests.map((req) => transformOpenapiRequestItem(req, usedNames, options));
@@ -1012,7 +1019,8 @@ export const parseOpenApiCollection = (data, options = {}) => {
       },
       meta: {
         name: brunoCollection.name
-      }
+      },
+      docs: collectionData.info?.description
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -10,7 +10,8 @@ import {
   createBrunoExample,
   groupRequestsByTags,
   groupRequestsByPath,
-  getTagDescriptions
+  getTagDescriptions,
+  toSpecString
 } from './openapi-common';
 
 const getContentLevelExample = (bodyContent) => {
@@ -160,9 +161,9 @@ const getParameterEntries = (param) => {
 };
 
 const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {}) => {
-  let _operationObject = request.operationObject;
+  const _operationObject = request.operationObject;
 
-  let operationName = _operationObject.summary || _operationObject.operationId || _operationObject.description;
+  let operationName = _operationObject.summary || _operationObject.operationId || toSpecString(_operationObject.description);
   if (!operationName) {
     operationName = `${request.method} ${request.path}`;
   }
@@ -189,7 +190,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
   usedNames.add(operationName);
 
   // replace OpenAPI links in path by Bruno variables
-  let path = request.path.replace(/{([a-zA-Z]+)}/g, `{{${_operationObject.operationId}_$1}}`);
+  const path = request.path.replace(/{([a-zA-Z]+)}/g, `{{${_operationObject.operationId}_$1}}`);
 
   const brunoRequestItem = {
     uid: uuid(),
@@ -197,7 +198,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
     type: 'http-request',
     tags: sanitizeTags(request.operationObject.tags || [], options),
     request: {
-      docs: _operationObject.description,
+      docs: toSpecString(_operationObject.description),
       url: ensureUrl(request.global.server + path),
       method: request.method.toUpperCase(),
       auth: {
@@ -385,7 +386,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
       }
     } else if (auth.type === 'oauth2') {
       // Determine flow (grant type)
-      let flows = auth.flows || {};
+      const flows = auth.flows || {};
       let grantType = 'client_credentials';
       if (flows.authorizationCode) {
         grantType = 'authorization_code';
@@ -461,14 +462,14 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
 
   // build the extraction scripts from responses that have links
   // https://swagger.io/docs/specification/links/
-  let script = [];
+  const script = [];
   each(_operationObject.responses || [], (response, responseStatus) => {
     if (Object.hasOwn(response, 'links')) {
       // only extract if the status code matches the response
       script.push(`if (res.status === ${responseStatus}) {`);
       each(response.links, (link) => {
         each(link.parameters || [], (expression, parameter) => {
-          let value = openAPIRuntimeExpressionToScript(expression);
+          const value = openAPIRuntimeExpressionToScript(expression);
           script.push(`  bru.setVar('${link.operationId}_${parameter}', ${value});`);
         });
       });
@@ -735,7 +736,7 @@ const getDefaultUrl = (serverObject) => {
   let url = serverObject.url;
   if (serverObject.variables) {
     each(serverObject.variables, (variable, variableName) => {
-      let sub = variable.default !== undefined ? variable.default : (variable.enum ? variable.enum[0] : `{{${variableName}}}`);
+      const sub = variable.default !== undefined ? variable.default : (variable.enum ? variable.enum[0] : `{{${variableName}}}`);
       url = url.replaceAll(`{${variableName}}`, sub);
     });
   }
@@ -754,7 +755,7 @@ const extractServerVars = (server) => {
     baseUrlTemplate = baseUrlTemplate.endsWith('/') ? baseUrlTemplate.slice(0, -1) : baseUrlTemplate;
     vars.push({ name: 'baseUrl', value: baseUrlTemplate });
     each(server.variables, (variable, variableName) => {
-      let value = variable.default !== undefined ? variable.default : (variable.enum ? variable.enum[0] : '');
+      const value = variable.default !== undefined ? variable.default : (variable.enum ? variable.enum[0] : '');
       vars.push({ name: variableName, value: String(value) });
     });
   } else {
@@ -764,8 +765,8 @@ const extractServerVars = (server) => {
 };
 
 const getSecurity = (apiSpec) => {
-  let defaultSchemes = apiSpec.security || [];
-  let securitySchemes = get(apiSpec, 'components.securitySchemes', {});
+  const defaultSchemes = apiSpec.security || [];
+  const securitySchemes = get(apiSpec, 'components.securitySchemes', {});
 
   const hasSchemes = Object.keys(securitySchemes).length > 0;
 
@@ -785,7 +786,7 @@ const openAPIRuntimeExpressionToScript = (expression) => {
   if (expression === '$response.body') {
     return 'res.body';
   } else if (expression.startsWith('$response.body#')) {
-    let pointer = expression.substring(15);
+    const pointer = expression.substring(15);
     // could use https://www.npmjs.com/package/json-pointer for better support
     return `res.body${pointer.replace('/', '.')}`;
   }
@@ -813,11 +814,11 @@ export const parseOpenApiCollection = (data, options = {}) => {
 
     brunoCollection.name = collectionData.info?.title?.trim() || 'Untitled Collection';
 
-    let servers = collectionData.servers || [];
+    const servers = collectionData.servers || [];
 
     // Create environments based on the servers
     servers.forEach((server, index) => {
-      let environmentName = server.name || server.description || `Environment ${index + 1}`;
+      const environmentName = server.name || server.description || `Environment ${index + 1}`;
       const serverVars = extractServerVars(server);
       const variables = serverVars.map((sv) => ({
         uid: uuid(),
@@ -835,7 +836,7 @@ export const parseOpenApiCollection = (data, options = {}) => {
       });
     });
 
-    let securityConfig = getSecurity(collectionData);
+    const securityConfig = getSecurity(collectionData);
 
     // Merge path-item parameters with operation parameters.
     // Operation parameters override path-item parameters with the same name+in combination.
@@ -845,7 +846,7 @@ export const parseOpenApiCollection = (data, options = {}) => {
       return [...inheritedParams, ...operationParams];
     };
 
-    let allRequests = Object.entries(collectionData.paths)
+    const allRequests = Object.entries(collectionData.paths)
       .map(([path, pathItemObject]) => {
         // Extract path-item level parameters (per OpenAPI spec, these apply to all operations under this path)
         const pathItemParams = pathItemObject.parameters || [];
@@ -890,9 +891,9 @@ export const parseOpenApiCollection = (data, options = {}) => {
       brunoCollection.items = groupRequestsByPath(allRequests, transformOpenapiRequestItem, options);
     } else {
       // Default tag-based grouping
-      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
+      const [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
       const tagDescriptions = getTagDescriptions(collectionData.tags, options);
-      let brunoFolders = groups.map((group) => {
+      const brunoFolders = groups.map((group) => {
         const folder = {
           uid: uuid(),
           name: group.name,
@@ -921,8 +922,8 @@ export const parseOpenApiCollection = (data, options = {}) => {
         return folder;
       });
 
-      let ungroupedItems = ungroupedRequests.map((req) => transformOpenapiRequestItem(req, usedNames, options));
-      let brunoCollectionItems = brunoFolders.concat(ungroupedItems);
+      const ungroupedItems = ungroupedRequests.map((req) => transformOpenapiRequestItem(req, usedNames, options));
+      const brunoCollectionItems = brunoFolders.concat(ungroupedItems);
       brunoCollection.items = brunoCollectionItems;
     }
 
@@ -976,7 +977,7 @@ export const parseOpenApiCollection = (data, options = {}) => {
           }
         };
       } else if (scheme.type === 'oauth2') {
-        let flows = scheme.flows || {};
+        const flows = scheme.flows || {};
         let grantType = 'client_credentials';
         if (flows.authorizationCode) {
           grantType = 'authorization_code';
@@ -1011,7 +1012,7 @@ export const parseOpenApiCollection = (data, options = {}) => {
       return authTemplate;
     };
 
-    let collectionAuth = buildCollectionAuth(securityConfig.supported[0]);
+    const collectionAuth = buildCollectionAuth(securityConfig.supported[0]);
 
     brunoCollection.root = {
       request: {
@@ -1020,7 +1021,7 @@ export const parseOpenApiCollection = (data, options = {}) => {
       meta: {
         name: brunoCollection.name
       },
-      docs: collectionData.info?.description
+      docs: toSpecString(collectionData.info?.description)
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
@@ -11,7 +11,8 @@ import {
   getExampleFromSchema,
   createBrunoExample,
   groupRequestsByTags,
-  groupRequestsByPath
+  groupRequestsByPath,
+  getTagDescriptions
 } from './openapi-common';
 
 /**
@@ -610,19 +611,27 @@ export const parseSwagger2Collection = (data, options = {}) => {
     if (groupingType === 'path') {
       brunoCollection.items = groupRequestsByPath(allRequests, transformSwaggerRequestItem, options);
     } else {
-      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests);
-      let brunoFolders = groups.map((group) => ({
-        uid: uuid(),
-        name: group.name,
-        type: 'folder',
-        root: {
-          request: {
-            auth: { mode: 'inherit', basic: null, bearer: null, digest: null, apikey: null, oauth2: null }
+      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
+      const tagDescriptions = getTagDescriptions(collectionData.tags, options);
+      let brunoFolders = groups.map((group) => {
+        const folder = {
+          uid: uuid(),
+          name: group.name,
+          type: 'folder',
+          root: {
+            request: {
+              auth: { mode: 'inherit', basic: null, bearer: null, digest: null, apikey: null, oauth2: null }
+            },
+            meta: { name: group.name }
           },
-          meta: { name: group.name }
-        },
-        items: group.requests.map((req) => transformSwaggerRequestItem(req, usedNames, options))
-      }));
+          items: group.requests.map((req) => transformSwaggerRequestItem(req, usedNames, options))
+        };
+        const docs = tagDescriptions[group.name];
+        if (docs) {
+          folder.root.docs = docs;
+        }
+        return folder;
+      });
 
       let ungroupedItems = ungroupedRequests.map((req) => transformSwaggerRequestItem(req, usedNames, options));
       brunoCollection.items = brunoFolders.concat(ungroupedItems);
@@ -632,7 +641,8 @@ export const parseSwagger2Collection = (data, options = {}) => {
     let collectionAuth = buildCollectionAuth(securityConfig.supported[0]);
     brunoCollection.root = {
       request: { auth: collectionAuth },
-      meta: { name: brunoCollection.name }
+      meta: { name: brunoCollection.name },
+      docs: collectionData.info?.description
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
@@ -12,7 +12,8 @@ import {
   createBrunoExample,
   groupRequestsByTags,
   groupRequestsByPath,
-  getTagDescriptions
+  getTagDescriptions,
+  toSpecString
 } from './openapi-common';
 
 /**
@@ -78,7 +79,7 @@ const getParameterEntries = (param) => {
   }
 
   // Single value
-  let value = getParameterValue(param);
+  const value = getParameterValue(param);
   let enabled = param.required || false;
 
   if (value !== '') {
@@ -131,7 +132,7 @@ const transformSwaggerRequestItem = (request, usedNames = new Set(), options = {
   const produces = op.produces || request.global.produces || ['application/json'];
 
   // Determine operation name
-  let operationName = op.summary || op.operationId || op.description;
+  let operationName = op.summary || op.operationId || toSpecString(op.description);
   if (!operationName) operationName = `${request.method} ${request.path}`;
 
   // Sanitize operation name to prevent Bruno parsing issues
@@ -149,7 +150,7 @@ const transformSwaggerRequestItem = (request, usedNames = new Set(), options = {
   }
   usedNames.add(operationName);
 
-  let path = request.path;
+  const path = request.path;
 
   const brunoRequestItem = {
     uid: uuid(),
@@ -157,7 +158,7 @@ const transformSwaggerRequestItem = (request, usedNames = new Set(), options = {
     type: 'http-request',
     tags: sanitizeTags(op.tags || [], options),
     request: {
-      docs: op.description,
+      docs: toSpecString(op.description),
       url: ensureUrl(request.global.server + path),
       method: request.method.toUpperCase(),
       auth: {
@@ -582,7 +583,7 @@ export const parseSwagger2Collection = (data, options = {}) => {
       return [...inherited, ...operationParams];
     };
 
-    let allRequests = Object.entries(collectionData.paths || {})
+    const allRequests = Object.entries(collectionData.paths || {})
       .map(([path, pathItemObject]) => {
         const pathItemParams = pathItemObject.parameters || [];
         return Object.entries(pathItemObject)
@@ -611,9 +612,9 @@ export const parseSwagger2Collection = (data, options = {}) => {
     if (groupingType === 'path') {
       brunoCollection.items = groupRequestsByPath(allRequests, transformSwaggerRequestItem, options);
     } else {
-      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
+      const [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
       const tagDescriptions = getTagDescriptions(collectionData.tags, options);
-      let brunoFolders = groups.map((group) => {
+      const brunoFolders = groups.map((group) => {
         const folder = {
           uid: uuid(),
           name: group.name,
@@ -633,16 +634,16 @@ export const parseSwagger2Collection = (data, options = {}) => {
         return folder;
       });
 
-      let ungroupedItems = ungroupedRequests.map((req) => transformSwaggerRequestItem(req, usedNames, options));
+      const ungroupedItems = ungroupedRequests.map((req) => transformSwaggerRequestItem(req, usedNames, options));
       brunoCollection.items = brunoFolders.concat(ungroupedItems);
     }
 
     // Collection-level auth
-    let collectionAuth = buildCollectionAuth(securityConfig.supported[0]);
+    const collectionAuth = buildCollectionAuth(securityConfig.supported[0]);
     brunoCollection.root = {
       request: { auth: collectionAuth },
       meta: { name: brunoCollection.name },
-      docs: collectionData.info?.description
+      docs: toSpecString(collectionData.info?.description)
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/tests/common/find-items.js
+++ b/packages/bruno-converters/tests/common/find-items.js
@@ -1,0 +1,28 @@
+// Helpers to locate a request or folder by name in a converted collection.
+// Both search recursively, since imported items are often grouped into folders.
+
+export const findRequestByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'http-request' && item.name === name) {
+      return item;
+    }
+    if (item.type === 'folder' && item.items) {
+      const found = findRequestByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+export const findFolderByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'folder' && item.name === name) {
+      return item;
+    }
+    if (item.type === 'folder' && item.items) {
+      const found = findFolderByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from '@jest/globals';
+import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
+
+const findRequestByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'http-request' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findRequestByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const findFolderByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'folder' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findFolderByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const buildSpec = (overrides = {}) => ({
+  openapi: '3.0.0',
+  info: {
+    title: 'Petstore',
+    description: '# Pet Store API\n\nThis is the **collection-level** description.',
+    ...overrides.info
+  },
+  tags: overrides.tags ?? [
+    { name: 'pets', description: 'Everything about your _Pets_.' },
+    { name: 'store', description: '## Store\n\nAccess to Petstore **orders**.' }
+  ],
+  servers: [{ url: 'https://api.example.com' }],
+  paths: {
+    '/pets': {
+      get: {
+        tags: ['pets'],
+        summary: 'List pets',
+        description: 'Returns all pets.',
+        responses: { 200: { description: 'OK' } }
+      }
+    },
+    '/store/orders': {
+      post: {
+        tags: ['store'],
+        summary: 'Place order',
+        responses: { 201: { description: 'Created' } }
+      }
+    }
+  }
+});
+
+describe('OpenAPI Import - Docs (collection & folder descriptions)', () => {
+  it('populates collection Docs from info.description', () => {
+    const result = openApiToBruno(buildSpec());
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+
+  it('populates each folder Docs from the matching top-level tags[] description', () => {
+    const result = openApiToBruno(buildSpec());
+
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBe('Everything about your _Pets_.');
+
+    const storeFolder = findFolderByName(result.items, 'store');
+    expect(storeFolder.root.docs).toBe('## Store\n\nAccess to Petstore **orders**.');
+  });
+
+  it('preserves markdown formatting verbatim', () => {
+    const md = '# Title\n\n- one\n- two\n\n`code` and **bold**';
+    const result = openApiToBruno(buildSpec({ info: { description: md } }));
+    expect(result.root.docs).toBe(md);
+  });
+
+  it('matches folder docs after tag-name sanitization (spaces -> underscores)', () => {
+    const spec = buildSpec({ tags: [{ name: 'Pet Store', description: 'Pet store docs.' }] });
+    spec.paths = {
+      '/pets': {
+        get: { tags: ['Pet Store'], summary: 'List pets', responses: { 200: { description: 'OK' } } }
+      }
+    };
+    const result = openApiToBruno(spec);
+
+    const folder = findFolderByName(result.items, 'Pet_Store');
+    expect(folder).toBeDefined();
+    expect(folder.root.docs).toBe('Pet store docs.');
+  });
+
+  it('does not regress request-level Docs', () => {
+    const result = openApiToBruno(buildSpec());
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request.request.docs).toBe('Returns all pets.');
+  });
+
+  it('leaves docs unset when the spec has no info.description or tag descriptions', () => {
+    const result = openApiToBruno(
+      buildSpec({ info: { title: 'No Docs', description: undefined }, tags: [{ name: 'pets' }] })
+    );
+    expect(result.root.docs == null || result.root.docs === '').toBe(true);
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBeUndefined();
+  });
+
+  it('still sets collection docs under path-based grouping (no tag folders to describe)', () => {
+    const result = openApiToBruno(buildSpec(), { groupBy: 'path' });
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+});

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
@@ -1,27 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
-
-const findRequestByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'http-request' && item.name === name) return item;
-    if (item.type === 'folder' && item.items) {
-      const found = findRequestByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
-
-const findFolderByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'folder' && item.name === name) return item;
-    if (item.type === 'folder' && item.items) {
-      const found = findFolderByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
+import { findRequestByName, findFolderByName } from '../../common/find-items';
 
 const buildSpec = (overrides = {}) => ({
   openapi: '3.0.0',

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
@@ -105,6 +105,52 @@ describe('OpenAPI Import - Docs (collection & folder descriptions)', () => {
     expect(petsFolder.root.docs).toBeUndefined();
   });
 
+  it('imports the spec and skips docs when info.description is not a string', () => {
+    [{ en: 'A mapping, not a string' }, 42, ['a', 'b'], true].forEach((badDescription) => {
+      const result = openApiToBruno(buildSpec({ info: { description: badDescription } }));
+      expect(result.root.docs).toBe('');
+      expect(findRequestByName(result.items, 'List pets')).toBeDefined();
+    });
+  });
+
+  it('imports the spec and skips docs when a tag description is not a string', () => {
+    const result = openApiToBruno(
+      buildSpec({
+        tags: [
+          { name: 'pets', description: { en: 'A mapping, not a string' } },
+          { name: 'store', description: 'Access to Petstore orders.' }
+        ]
+      })
+    );
+
+    expect(findFolderByName(result.items, 'pets').root.docs).toBeUndefined();
+    expect(findFolderByName(result.items, 'store').root.docs).toBe('Access to Petstore orders.');
+  });
+
+  it('imports the request and skips docs when an operation description is not a string', () => {
+    const spec = buildSpec();
+    spec.paths['/pets'].get.description = { en: 'A mapping, not a string' };
+    const result = openApiToBruno(spec);
+
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request).toBeDefined();
+    expect(request.request.docs).toBe('');
+  });
+
+  it('falls back to method and path when a non-string description is the only name source', () => {
+    const spec = buildSpec();
+    spec.paths['/pets'].get = {
+      tags: ['pets'],
+      description: { en: 'A mapping, not a string' },
+      responses: { 200: { description: 'OK' } }
+    };
+    const result = openApiToBruno(spec);
+
+    const request = findRequestByName(result.items, 'get /pets');
+    expect(request).toBeDefined();
+    expect(request.request.docs).toBe('');
+  });
+
   it('still sets collection docs under path-based grouping (no tag folders to describe)', () => {
     const result = openApiToBruno(buildSpec(), { groupBy: 'path' });
     expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-tags.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-tags.spec.js
@@ -1,39 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
-
-/**
- * Helper function to find a request by name in the collection.
- * Searches recursively through folders since requests with tags
- * are grouped into folders.
- */
-const findRequestByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'http-request' && item.name === name) {
-      return item;
-    }
-    if (item.type === 'folder' && item.items) {
-      const found = findRequestByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
-
-/**
- * Helper function to find a folder by name in the collection.
- */
-const findFolderByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'folder' && item.name === name) {
-      return item;
-    }
-    if (item.type === 'folder' && item.items) {
-      const found = findFolderByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
+import { findRequestByName, findFolderByName } from '../../common/find-items';
 
 describe('OpenAPI Import - Tag Sanitization', () => {
   it('should replace spaces with underscores in tags', () => {

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from '@jest/globals';
+import swagger2ToBruno from '../../../src/openapi/swagger2-to-bruno';
+
+const findRequestByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'http-request' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findRequestByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const findFolderByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'folder' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findFolderByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const buildSpec = (overrides = {}) => ({
+  swagger: '2.0',
+  info: {
+    title: 'Petstore',
+    description: '# Pet Store API\n\nThis is the **collection-level** description.',
+    ...overrides.info
+  },
+  tags: overrides.tags ?? [
+    { name: 'pets', description: 'Everything about your _Pets_.' },
+    { name: 'store', description: '## Store\n\nAccess to Petstore **orders**.' }
+  ],
+  host: 'api.example.com',
+  basePath: '/v1',
+  schemes: ['https'],
+  paths: {
+    '/pets': {
+      get: {
+        tags: ['pets'],
+        summary: 'List pets',
+        description: 'Returns all pets.',
+        responses: { 200: { description: 'OK' } }
+      }
+    },
+    '/store/orders': {
+      post: {
+        tags: ['store'],
+        summary: 'Place order',
+        responses: { 201: { description: 'Created' } }
+      }
+    }
+  }
+});
+
+describe('Swagger 2.0 Import - Docs (collection & folder descriptions)', () => {
+  it('populates collection Docs from info.description', () => {
+    const result = swagger2ToBruno(buildSpec());
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+
+  it('populates each folder Docs from the matching top-level tags[] description', () => {
+    const result = swagger2ToBruno(buildSpec());
+
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBe('Everything about your _Pets_.');
+
+    const storeFolder = findFolderByName(result.items, 'store');
+    expect(storeFolder.root.docs).toBe('## Store\n\nAccess to Petstore **orders**.');
+  });
+
+  it('does not regress request-level Docs', () => {
+    const result = swagger2ToBruno(buildSpec());
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request.request.docs).toBe('Returns all pets.');
+  });
+
+  it('leaves docs unset when the spec has no info.description or tag descriptions', () => {
+    const result = swagger2ToBruno(
+      buildSpec({ info: { title: 'No Docs', description: undefined }, tags: [{ name: 'pets' }] })
+    );
+    expect(result.root.docs == null || result.root.docs === '').toBe(true);
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBeUndefined();
+  });
+});

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
@@ -86,4 +86,50 @@ describe('Swagger 2.0 Import - Docs (collection & folder descriptions)', () => {
     const petsFolder = findFolderByName(result.items, 'pets');
     expect(petsFolder.root.docs).toBeUndefined();
   });
+
+  it('imports the spec and skips docs when info.description is not a string', () => {
+    [{ en: 'A mapping, not a string' }, 42, ['a', 'b'], true].forEach((badDescription) => {
+      const result = swagger2ToBruno(buildSpec({ info: { description: badDescription } }));
+      expect(result.root.docs).toBe('');
+      expect(findRequestByName(result.items, 'List pets')).toBeDefined();
+    });
+  });
+
+  it('imports the request and skips docs when an operation description is not a string', () => {
+    const spec = buildSpec();
+    spec.paths['/pets'].get.description = { en: 'A mapping, not a string' };
+    const result = swagger2ToBruno(spec);
+
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request).toBeDefined();
+    expect(request.request.docs).toBe('');
+  });
+
+  it('falls back to method and path when a non-string description is the only name source', () => {
+    const spec = buildSpec();
+    spec.paths['/pets'].get = {
+      tags: ['pets'],
+      description: { en: 'A mapping, not a string' },
+      responses: { 200: { description: 'OK' } }
+    };
+    const result = swagger2ToBruno(spec);
+
+    const request = findRequestByName(result.items, 'get /pets');
+    expect(request).toBeDefined();
+    expect(request.request.docs).toBe('');
+  });
+
+  it('imports the spec and skips docs when a tag description is not a string', () => {
+    const result = swagger2ToBruno(
+      buildSpec({
+        tags: [
+          { name: 'pets', description: { en: 'A mapping, not a string' } },
+          { name: 'store', description: 'Access to Petstore orders.' }
+        ]
+      })
+    );
+
+    expect(findFolderByName(result.items, 'pets').root.docs).toBeUndefined();
+    expect(findFolderByName(result.items, 'store').root.docs).toBe('Access to Petstore orders.');
+  });
 });

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
@@ -1,27 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import swagger2ToBruno from '../../../src/openapi/swagger2-to-bruno';
-
-const findRequestByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'http-request' && item.name === name) return item;
-    if (item.type === 'folder' && item.items) {
-      const found = findRequestByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
-
-const findFolderByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'folder' && item.name === name) return item;
-    if (item.type === 'folder' && item.items) {
-      const found = findFolderByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
+import { findRequestByName, findFolderByName } from '../../common/find-items';
 
 const buildSpec = (overrides = {}) => ({
   swagger: '2.0',

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-tags.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-tags.spec.js
@@ -1,38 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { swagger2ToBruno } from '../../../src/openapi/swagger2-to-bruno';
-
-/**
- * Helper function to find a request by name in the collection.
- * Searches recursively through folders.
- */
-const findRequestByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'http-request' && item.name === name) {
-      return item;
-    }
-    if (item.type === 'folder' && item.items) {
-      const found = findRequestByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
-
-/**
- * Helper function to find a folder by name in the collection.
- */
-const findFolderByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'folder' && item.name === name) {
-      return item;
-    }
-    if (item.type === 'folder' && item.items) {
-      const found = findFolderByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
+import { findRequestByName, findFolderByName } from '../../common/find-items';
 
 describe('Swagger 2.0 Import - Tag Sanitization', () => {
   it('should replace spaces with underscores in tags', () => {


### PR DESCRIPTION
### Description
REF:BRU-1429
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
OpenAPI import only copied request-level descriptions into Docs tabs,info.description (collection) and top-level tags[].description (folders)were never read, leaving those Docs tabs empty.

Read info.description into collection root docs and match top-level tags[] descriptions to their folders via a shared getTagDescriptions helper (keyed by sanitized tag name so it lines up with folder names).Applied to both the OpenAPI 3.x and Swagger 2.0 converters.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
Collection-Level:
<img width="2352" height="1348" alt="image" src="https://github.com/user-attachments/assets/f7b35c6b-04c9-4b67-8966-8ceeed0adaef" />
Folder-Level:
<img width="1564" height="732" alt="image" src="https://github.com/user-attachments/assets/289cb482-04dd-457b-ad3c-fd0ae02aed6f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenAPI and Swagger 2.0 imports now populate collection/root documentation from `info.description`.
  - Tag `description` values are applied to matching generated folders, using the same tag name sanitization.
- **Bug Fixes**
  - Improved robustness for documentation fields: non-string `description` values no longer break conversion (they’re safely skipped or treated as empty).
  - Request-level `docs` are derived from operation `description`, with resilient naming/fallback behavior when `description` isn’t usable.
- **Tests**
  - Added Jest coverage for collection, folder, and request `docs` behavior (including sanitization and missing/non-string descriptions) for both OpenAPI and Swagger 2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->