### PR TITLE
fix(workspace): heal legacy object entries in lastOpenedWorkspaces

### DIFF
--- a/packages/bruno-electron/src/store/last-opened-workspaces.js
+++ b/packages/bruno-electron/src/store/last-opened-workspaces.js
@@ -1,4 +1,31 @@
+const _ = require('lodash');
 const Store = require('electron-store');
+
+/**
+* Older/experimental builds persisted some entries as a workspace object (`{ pathname, ... }`)
+* instead of a plain path string. Recover the path from `pathname`, drop anything unusable, and
+* de-duplicate so callers only ever see a string-only list.
+*/
+
+const normalizeWorkspaceEntry = (entry) => {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+
+  if (entry && typeof entry === 'object' && typeof entry.pathname === 'string') {
+    return entry.pathname;
+  }
+
+  return null;
+};
+
+const normalizeWorkspaceEntries = (entries) => {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return _.uniq(entries.map(normalizeWorkspaceEntry).filter(Boolean));
+};
 
 class LastOpenedWorkspaces {
   constructor() {
@@ -6,10 +33,26 @@ class LastOpenedWorkspaces {
       name: 'preferences',
       defaults: {}
     });
+    this.migrate();
+  }
+
+  /**
+  * migrate()
+  * One-shot heal on load: recover the path from any legacy object entries and scrub the objects
+  * from preferences.json so only string paths persist. Runs once at construction, before any read.
+  */
+
+  migrate() {
+    const rawWorkspaces = this.store.get('workspaces.lastOpenedWorkspaces', []);
+    const normalized = normalizeWorkspaceEntries(rawWorkspaces);
+
+    if (!_.isEqual(rawWorkspaces, normalized)) {
+      this.store.set('workspaces.lastOpenedWorkspaces', normalized);
+    }
   }
 
   getAll() {
-    return this.store.get('workspaces.lastOpenedWorkspaces', []);
+    return normalizeWorkspaceEntries(this.store.get('workspaces.lastOpenedWorkspaces', []));
   }
 
   add(workspacePath) {

--- a/packages/bruno-electron/src/utils/workspace-startup.js
+++ b/packages/bruno-electron/src/utils/workspace-startup.js
@@ -36,6 +36,10 @@ const prioritizeActiveWorkspacePath = (workspacePaths, activeWorkspacePath) => {
 };
 
 const isValidWorkspacePathOnDisk = (workspacePath, { validateConfig = false } = {}) => {
+  if (typeof workspacePath !== 'string' || !workspacePath.length) {
+    return false;
+  }
+
   const workspaceYmlPath = path.join(workspacePath, 'workspace.yml');
 
   if (!fs.existsSync(workspaceYmlPath)) {

--- a/packages/bruno-electron/tests/utils/workspace-startup.spec.js
+++ b/packages/bruno-electron/tests/utils/workspace-startup.spec.js
@@ -116,6 +116,14 @@ describe('isValidWorkspacePathOnDisk', () => {
     expect(isValidWorkspacePathOnDisk(workspacePath, { validateConfig: true })).toBe(false);
   });
 
+  test('returns false for non-string input instead of throwing from path.join', () => {
+    expect(isValidWorkspacePathOnDisk(undefined)).toBe(false);
+    expect(isValidWorkspacePathOnDisk(null)).toBe(false);
+    expect(isValidWorkspacePathOnDisk('')).toBe(false);
+    expect(isValidWorkspacePathOnDisk({ pathname: '/tmp/ws' })).toBe(false);
+    expect(isValidWorkspacePathOnDisk({ pathname: '/tmp/ws' }, { validateConfig: true })).toBe(false);
+  });
+
   test('returns true when workspace.yml exists and config validation is disabled', () => {
     const workspacePath = createWorkspaceDir(rootDir, 'exists-only');
 


### PR DESCRIPTION
### Description

**Issue:**

Workspaces disappearing after upgrade when `preferences.json` →`workspaces.lastOpenedWorkspaces` contains legacy object entries mixed with string paths. Startup code assumed every entry was a string and called
`path.join(entry, 'workspace.yml')`. On an object entry, this threw a `TypeError`, which aborted workspace resolution and made the handler return an empty list. So one bad entry wiped out every workspace, leaving only the default "My Workspace".

**Fix:** 

- Normalise entries in the store: keep strings, recover the path from an
  object's `pathname`, drop anything unusable, and de-duplicate. So callers
  only ever see a string-only list.

- `migrate()` runs once on load and rewrites `preferences.json` to the clean string-only array, scrubbing the legacy/experimental build-related objects from disk.

- Guard `isValidWorkspacePathOnDisk` against non-string input as defense.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of previously saved workspaces by removing duplicates and ignoring invalid entries.
  * Added compatibility for older saved workspace formats.
  * Prevented workspace validation errors when invalid or empty paths are provided.

* **Tests**
  * Added coverage for invalid workspace path inputs across supported validation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->