### PR TITLE
fix: colon in URL path segment incorrectly percent-encoded to %3A

### DIFF
--- a/packages/bruno-common/src/utils/url/index.ts
+++ b/packages/bruno-common/src/utils/url/index.ts
@@ -150,11 +150,6 @@ const encodePathSegments = (path: string): string =>
     .split('/')
     .map((segment) => {
       const encoded = encodeURIComponent(safeDecodeURIComponent(segment));
-      // RFC 3986 §3.3 pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
-      // Restore ':' and '@' which are legal unencoded in path segments
-      // but encodeURIComponent encodes them anyway.
-      // This preserves pre-4.0.0 behavior for routing layers that distinguish
-      // /foo:bar from /foo%3Abar.
       return encoded
         .replace(/%3A/g, ':')
         .replace(/%40/g, '@');

--- a/packages/bruno-common/src/utils/url/index.ts
+++ b/packages/bruno-common/src/utils/url/index.ts
@@ -148,7 +148,17 @@ const safeDecodeURIComponent = (s: string): string => {
 const encodePathSegments = (path: string): string =>
   path
     .split('/')
-    .map((segment) => encodeURIComponent(safeDecodeURIComponent(segment)))
+    .map((segment) => {
+      const encoded = encodeURIComponent(safeDecodeURIComponent(segment));
+      // RFC 3986 §3.3 pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
+      // Restore ':' and '@' which are legal unencoded in path segments
+      // but encodeURIComponent encodes them anyway.
+      // This preserves pre-4.0.0 behavior for routing layers that distinguish
+      // /foo:bar from /foo%3Abar.
+      return encoded
+        .replace(/%3A/g, ':')
+        .replace(/%40/g, '@');
+    })
     .join('/');
 
 // Encodes path segments and query name/value pairs when the URL Encoding toggle is on.


### PR DESCRIPTION
Fixes #8771
### Description
A colon (`:`) in a URL path segment (e.g. `/api/foo:bar`) was being
percent-encoded to `%3A` when sending a request or generating code,
even though this worked correctly before v4.0.0. This breaks any
server whose routing layer distinguishes the literal character from
its percent-encoded form.

**Root cause:** `encodePathSegments` (in `bruno-common/src/utils/url`)
runs `encodeURIComponent()` on each path segment. That function is
more aggressive than what RFC 3986 actually requires for a path -
per RFC 3986 §3.3, `:` and `@` are both legal, unencoded characters
within a path segment (`pchar = unreserved / pct-encoded / sub-delims
/ ":" / "@"`), but `encodeURIComponent()` doesn't make that
distinction and encodes both anyway.

**Fix:** after the existing `encodeURIComponent` pass, restore `%3A`
back to `:` and `%40` back to `@` - the two characters RFC 3986
explicitly permits unencoded in this context. Every other character
(spaces, unicode, brackets, quotes, pipes) stays encoded exactly as
before, with zero change to that existing, already-tested behavior.

#### Contribution Checklist:
- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [[contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md)](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Screenshot

Generated curl command after the fix - colon stays literal:
Before fix 
<img width="1029" height="753" alt="error" src="https://github.com/user-attachments/assets/1248ff8a-4d76-40ba-8c92-7401ca2afb2d" />
After Fix
<img width="1366" height="768" alt="Screenshot (5)" src="https://github.com/user-attachments/assets/762b8207-9e47-49b2-be40-15acfea0083c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated URL path encoding to preserve colon (`:`) and at-sign (`@`) characters in encoded path segments, improving compatibility for URLs containing these symbols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->