### PR TITLE
fix(converters): default env variable enabled to true when missing in postman env import

### DIFF
--- a/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
+++ b/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
@@ -14,7 +14,7 @@ const importPostmanEnvironmentVariables = (brunoEnvironment, values = []) => {
       uid: uuid(),
       name: (i.key ?? '').replace(invalidVariableCharacterRegex, '_'),
       value: i.value ?? '',
-      enabled: i.enabled,
+      enabled: i.enabled !== false,
       type: 'text',
       secret: isSecret(i.type)
     };

--- a/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
@@ -112,6 +112,52 @@ describe('postmanToBrunoEnvironment Function', () => {
     expect(brunoEnvironment).toEqual(expectedEnvironment);
   });
 
+  it('should default enabled to true when the field is missing and preserve an explicit false', async () => {
+    const postmanEnvironment = {
+      id: 'some-id',
+      name: 'My Environment',
+      values: [
+        { key: 'api_url', value: 'https://api.example.com', enabled: true },
+        { key: 'gymfinder-backend-url', value: 'https://example.com', type: 'default' },
+        { key: 'disabled_var', value: 'off', enabled: false }
+      ]
+    };
+
+    const brunoEnvironment = await postmanToBrunoEnvironment(postmanEnvironment);
+
+    const expectedEnvironment = {
+      name: 'My Environment',
+      variables: [
+        {
+          name: 'api_url',
+          value: 'https://api.example.com',
+          enabled: true,
+          secret: false,
+          type: 'text',
+          uid: 'mockeduuidvalue123456'
+        },
+        {
+          name: 'gymfinder-backend-url',
+          value: 'https://example.com',
+          enabled: true,
+          secret: false,
+          type: 'text',
+          uid: 'mockeduuidvalue123456'
+        },
+        {
+          name: 'disabled_var',
+          value: 'off',
+          enabled: false,
+          secret: false,
+          type: 'text',
+          uid: 'mockeduuidvalue123456'
+        }
+      ]
+    };
+
+    expect(brunoEnvironment).toEqual(expectedEnvironment);
+  });
+
   it.skip('should throw Error when JSON parsing fails', async () => {
     const invalidBrunoEnvironment = {
       id: 'some-id',

--- a/tests/environments/import-environment/fixtures/global-env-missing-enabled.json
+++ b/tests/environments/import-environment/fixtures/global-env-missing-enabled.json
@@ -1,0 +1,26 @@
+{
+  "id": "missing-enabled-global-env-id",
+  "name": "Missing Enabled Global Environment",
+  "values": [
+    {
+      "key": "api_url",
+      "value": "https://api.example.com",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "backend_url",
+      "value": "https://backend.example.com",
+      "type": "default"
+    },
+    {
+      "key": "disabled_var",
+      "value": "off",
+      "enabled": false,
+      "type": "text"
+    }
+  ],
+  "_postman_variable_scope": "globals",
+  "_postman_exported_at": "2024-01-01T00:00:00.000Z",
+  "_postman_exported_using": "Postman/10.0.0"
+}

--- a/tests/environments/import-environment/global-env-import-missing-enabled.spec.ts
+++ b/tests/environments/import-environment/global-env-import-missing-enabled.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '../../../playwright';
+import path from 'path';
+import { importCollection, deleteAllGlobalEnvironments, closeAllCollections } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+test.describe('Global Environment Import - missing enabled field', () => {
+  test.afterEach(async ({ page }) => {
+    await deleteAllGlobalEnvironments(page);
+    await closeAllCollections(page);
+  });
+
+  test('imports a postman global environment when a variable omits the enabled field', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionFile = path.join(__dirname, 'fixtures', 'collection.json');
+    const globalEnvFile = path.join(__dirname, 'fixtures', 'global-env-missing-enabled.json');
+    const locators = buildCommonLocators(page);
+
+    await test.step('Import collection', async () => {
+      await importCollection(page, collectionFile, await createTmpDir('global-env-missing-enabled'), {
+        expectedCollectionName: 'Environment Test Collection'
+      });
+    });
+
+    await test.step('Import postman global environment with a variable missing enabled', async () => {
+      await locators.environment.selector().click();
+      await locators.environment.globalTab().click();
+      await page.getByText('Import', { exact: true }).click();
+
+      const importModal = page.locator('[data-testid="import-global-environment-modal"]');
+      await expect(importModal).toBeVisible();
+
+      const fileChooserPromise = page.waitForEvent('filechooser');
+      await page.locator('[data-testid="import-global-environment"]').click();
+      const fileChooser = await fileChooserPromise;
+      await fileChooser.setFiles(globalEnvFile);
+    });
+
+    await test.step('Environment is created and variables are present', async () => {
+      await expect(locators.environment.currentEnvironment()).toContainText('Missing Enabled Global Environment');
+
+      const envTab = locators.environment.globalEnvTab();
+      await expect(envTab).toBeVisible();
+
+      const variablesTable = page.locator('.table-container');
+      await expect(variablesTable.locator('input[name$=".name"][value="api_url"]')).toBeVisible();
+      await expect(variablesTable.locator('input[name$=".name"][value="backend_url"]')).toBeVisible();
+      await expect(variablesTable.locator('input[name$=".name"][value="disabled_var"]')).toBeVisible();
+    });
+
+    await test.step('The variable that omitted enabled is imported enabled; explicit false stays disabled', async () => {
+      await expect(locators.environment.varRow('backend_url').locator('input[name$=".enabled"]')).toBeChecked();
+      await expect(locators.environment.varRow('disabled_var').locator('input[name$=".enabled"]')).not.toBeChecked();
+    });
+  });
+});


### PR DESCRIPTION
[JIRA: BRU-3960]

### Description
Importing a Postman environment fails with variables[N].enabled must be defined and aborts the import whenever a variable has no enabled field  which Postman legitimately exports. No environment gets created.

### Cause
The Postman environment converter copied enabled straight from the source, producing an undefined value when the field was absent. Environment validation requires enabled to be defined, so the import threw and aborted.

### Resolution
Default enabled to true when it's missing (matching Postman, where a variable with no enabled field is treated as enabled) while still preserving an explicit false. Added a regression test covering both cases.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Postman environment variables that omit an explicit enabled setting are now treated as enabled by default during conversion.
  * Variables marked explicitly as disabled remain disabled in the converted Bruno environment.

* **Tests**
  * Added test coverage for conversion and UI import behavior when enabled is missing, including fixture-based validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->