### PR TITLE
feat(sidebar): resizable sidebar sections draft

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
@@ -1,41 +1,51 @@
 import { setActiveApiSpecUid } from 'providers/ReduxStore/slices/apiSpec';
 import { showApiSpecPage as _showApiSpecPage } from 'providers/ReduxStore/slices/app';
-import Dropdown from 'components/Dropdown';
+import MenuDropdown from 'ui/MenuDropdown';
+import ActionIcon from 'ui/ActionIcon';
 import { IconDots, IconX } from '@tabler/icons';
 import { useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import CloseApiSpec from '../CloseApiSpec/index';
-import { forwardRef } from 'react';
+import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
 
 const ApiSpecItem = ({ apiSpec }) => {
   const dispatch = useDispatch();
+  const { dropdownContainerRef } = useSidebarAccordion();
 
   const activeApiSpecUid = useSelector((state) => state.apiSpec.activeApiSpecUid);
   const showApiSpecPage = useSelector((state) => state.app.showApiSpecPage);
 
   const [closeApiSpecModal, setCloseApiSpecModal] = useState(false);
-
-  const dropdownTippyRef = useRef();
-  const onDropdownCreate = (ref) => (dropdownTippyRef.current = ref);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuDropdownRef = useRef(null);
 
   const handleOpenApiSpec = (apiSpec) => (e) => {
     dispatch(_showApiSpecPage());
     dispatch(setActiveApiSpecUid({ uid: apiSpec.uid }));
   };
 
-  const MenuIcon = forwardRef((props, ref) => {
-    return (
-      <div ref={ref}>
-        <IconDots size={22} />
-      </div>
-    );
-  });
+  const handleContextMenu = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    menuDropdownRef.current?.show();
+  };
+
+  const menuItems = [
+    {
+      id: 'remove',
+      leftSection: IconX,
+      label: 'Remove',
+      className: 'delete-item',
+      onClick: () => setCloseApiSpecModal(true)
+    }
+  ];
 
   return (
     <div
       className={`flex flex-grow api-spec-item items-center h-full overflow-hidden w-full justify-between ${
         showApiSpecPage && apiSpec?.uid == activeApiSpecUid ? 'active' : ''
-      }`}
+      } ${menuOpen ? 'menu-open' : ''}`}
+      onContextMenu={handleContextMenu}
     >
       {closeApiSpecModal && <CloseApiSpec apiSpec={apiSpec} onClose={() => setCloseApiSpecModal(false)} />}
       <div
@@ -44,21 +54,21 @@ const ApiSpecItem = ({ apiSpec }) => {
       >
         <span className="flex-nowrap whitespace-nowrap overflow-ellipsis overflow-hidden w-full">{apiSpec?.name}</span>
       </div>
-      <div className="menu-icon pr-2">
-        <Dropdown onCreate={onDropdownCreate} icon={<MenuIcon />} placement="bottom-start">
-          <div
-            className="dropdown-item close-item"
-            onClick={(e) => {
-              dropdownTippyRef.current.hide();
-              setCloseApiSpecModal(true);
-            }}
-          >
-            <span className="dropdown-icon">
-              <IconX size={16} strokeWidth={2} />
-            </span>
-            Remove
-          </div>
-        </Dropdown>
+      <div className="pr-2">
+        <MenuDropdown
+          ref={menuDropdownRef}
+          items={menuItems}
+          opened={menuOpen}
+          onChange={setMenuOpen}
+          placement="bottom-start"
+          data-testid="api-spec-item-menu"
+          popperOptions={{ strategy: 'fixed' }}
+          appendTo={dropdownContainerRef?.current || document.body}
+        >
+          <ActionIcon className="menu-icon">
+            <IconDots size={18} className="api-spec-item-menu-icon" />
+          </ActionIcon>
+        </MenuDropdown>
       </div>
     </div>
   );

--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/StyledWrapper.js
@@ -22,38 +22,41 @@ const Wrapper = styled.div`
   .api-spec-item {
     height: 1.6rem;
     cursor: pointer;
+    position: relative;
+
+    .menu-icon {
+      color: ${(props) => props.theme.sidebar.dropdownIcon.color};
+      visibility: hidden;
+    }
+
+    .api-spec-item-menu-icon {
+      visibility: hidden;
+    }
+
     &.active {
       background: ${(props) => props.theme.sidebar.collection.item.bg};
     }
-    &:hover {
+
+    &:hover,
+    &.menu-open {
       background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
-      .menu-icon {
-        .dropdown {
-          div[aria-expanded='false'] {
-            visibility: visible;
-          }
-        }
-      }
     }
-  }
 
-  .menu-icon {
-    cursor: pointer;
-    color: ${(props) => props.theme.sidebar.dropdownIcon.color};
+    &.menu-open {
+      border-top: 1px solid ${(props) => props.theme.sidebar.collection.item.focusBorder};
+      border-bottom: 1px solid ${(props) => props.theme.sidebar.collection.item.focusBorder};
+      outline: none;
+    }
 
-    .dropdown {
-      div[aria-expanded='true'] {
+    &:hover,
+    &.active,
+    &.menu-open {
+      .menu-icon,
+      .api-spec-item-menu-icon {
         visibility: visible;
-      }
-      div[aria-expanded='false'] {
-        visibility: hidden;
+        background-color: transparent !important;
       }
     }
-  }
-
-  div.tippy-box {
-    position: relative;
-    top: -0.625rem;
   }
 
   .placeholder {

--- a/packages/bruno-app/src/components/Sidebar/SidebarAccordionContext.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarAccordionContext.js
@@ -1,4 +1,6 @@
-import React, { createContext, useContext, useState, useCallback, useRef } from 'react';
+import React, { createContext, useContext, useCallback, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { setSidebarSectionExpanded } from 'providers/ReduxStore/slices/app';
 
 const SidebarAccordionContext = createContext();
 
@@ -10,40 +12,29 @@ export const useSidebarAccordion = () => {
   return context;
 };
 
-export const SidebarAccordionProvider = ({ children, defaultExpanded = ['collections'] }) => {
-  const [expandedSections, setExpandedSections] = useState(new Set(defaultExpanded));
+// Expansion state lives in the redux `app` slice so it persists across restarts
+// through the snapshot (alongside sidebarSectionSizes). This provider is a thin
+// wrapper exposing the same imperative API the sidebar already consumed, plus a
+// ref used to anchor sidebar dropdowns.
+export const SidebarAccordionProvider = ({ children }) => {
+  const dispatch = useDispatch();
+  const expandedSections = useSelector((state) => state.app.sidebarExpandedSections);
   const dropdownContainerRef = useRef(null);
 
   const toggleSection = useCallback((sectionId) => {
-    setExpandedSections((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(sectionId)) {
-        newSet.delete(sectionId);
-      } else {
-        newSet.add(sectionId);
-      }
-      return newSet;
-    });
-  }, []);
+    dispatch(setSidebarSectionExpanded({ id: sectionId, expanded: !expandedSections.includes(sectionId) }));
+  }, [dispatch, expandedSections]);
 
   const setSectionExpanded = useCallback((sectionId, expanded) => {
-    setExpandedSections((prev) => {
-      const newSet = new Set(prev);
-      if (expanded) {
-        newSet.add(sectionId);
-      } else {
-        newSet.delete(sectionId);
-      }
-      return newSet;
-    });
-  }, []);
+    dispatch(setSidebarSectionExpanded({ id: sectionId, expanded }));
+  }, [dispatch]);
 
   const isExpanded = useCallback((sectionId) => {
-    return expandedSections.has(sectionId);
+    return expandedSections.includes(sectionId);
   }, [expandedSections]);
 
   const getExpandedCount = useCallback(() => {
-    return expandedSections.size;
+    return expandedSections.length;
   }, [expandedSections]);
 
   return (

--- a/packages/bruno-app/src/components/Sidebar/SidebarContent.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarContent.js
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useSidebarAccordion } from './SidebarAccordionContext';
 import { updateSidebarSectionSizes, removeSidebarSectionSize } from 'providers/ReduxStore/slices/app';
@@ -34,7 +34,9 @@ const SidebarContent = ({ sections }) => {
   // shared area, taking that space from the neighbour above it (cascading outward),
   // while the other sections keep their heights. Sizes are stored as target pixel
   // heights; flexGrowFor normalizes them back into flex-grow at render time.
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so the measure-and-resize happens before paint —
+  // otherwise the new section flashes at its min height for one frame.
+  useLayoutEffect(() => {
     const unsized = expandedIds.filter((id) => !(id in sizes));
     if (unsized.length === 0) return;
 
@@ -164,7 +166,8 @@ const SidebarContent = ({ sections }) => {
             <div
               className={wrapperClassName}
               ref={(node) => {
-                wrapperRefs.current[section.id] = node;
+                if (node) wrapperRefs.current[section.id] = node;
+                else delete wrapperRefs.current[section.id];
               }}
               style={expanded ? { flexGrow: flexGrowFor(section.id), flexBasis: 0 } : undefined}
             >

--- a/packages/bruno-app/src/components/Sidebar/SidebarContent.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarContent.js
@@ -5,8 +5,8 @@ import { updateSidebarSectionSizes, removeSidebarSectionSize } from 'providers/R
 import SidebarSectionSash from './SidebarSectionSash';
 import {
   DEFAULT_SECTION_WEIGHT,
-  NEW_SECTION_FRACTION,
-  computeExpandWeight,
+  MIN_SECTION_PX,
+  resolveExpandHeights,
   resolveSashDrag
 } from './sidebarSectionSizing';
 
@@ -26,24 +26,60 @@ const SidebarContent = ({ sections }) => {
 
   const expandedIds = sections.filter((s) => isExpanded(s.id)).map((s) => s.id);
 
-  // Assign a ~20% default weight to any newly-expanded, never-sized section.
+  const weightFor = (id) => liveSizes?.[id] ?? sizes[id] ?? DEFAULT_SECTION_WEIGHT;
+
+  // Size a newly-expanded, never-sized section VSCode-style: it opens at 1/N of the
+  // shared area, taking that space from the neighbour above it (cascading outward),
+  // while the other sections keep their heights. Sizes are stored as target pixel
+  // heights; flexGrowFor normalizes them back into flex-grow at render time.
   useEffect(() => {
     const unsized = expandedIds.filter((id) => !(id in sizes));
     if (unsized.length === 0) return;
 
-    const runningWeights = expandedIds
-      .filter((id) => id in sizes)
-      .map((id) => sizes[id]);
-    const updates = {};
-    unsized.forEach((id) => {
-      const weight = computeExpandWeight(runningWeights, NEW_SECTION_FRACTION);
-      updates[id] = weight;
-      runningWeights.push(weight);
+    // With more than one unsized section at once (e.g. restored from a snapshot),
+    // seed the extra ones first so the cascade below always runs against fully
+    // sized neighbours; the primary new section is then sized on the next pass.
+    const [newId, ...extraUnsized] = unsized;
+    if (extraUnsized.length > 0) {
+      const seed = {};
+      extraUnsized.forEach((id) => { seed[id] = DEFAULT_SECTION_WEIGHT; });
+      dispatch(updateSidebarSectionSizes(seed));
+      return;
+    }
+
+    const oldIds = expandedIds.filter((id) => id !== newId);
+    // The only expanded section fills on its own — no neighbour to take space from.
+    if (oldIds.length === 0) {
+      dispatch(updateSidebarSectionSizes({ [newId]: DEFAULT_SECTION_WEIGHT }));
+      return;
+    }
+
+    // Shared area = the height currently filled by the expanded sections.
+    const areaPx = expandedIds.reduce(
+      (sum, id) => sum + (wrapperRefs.current[id]?.getBoundingClientRect().height || 0),
+      0
+    );
+    if (areaPx <= 0) {
+      dispatch(updateSidebarSectionSizes({ [newId]: DEFAULT_SECTION_WEIGHT }));
+      return;
+    }
+
+    // Reconstruct the neighbours' pre-expand heights from their weights (avoids the
+    // transient height the new section briefly takes before this effect runs).
+    const oldWeightSum = oldIds.reduce((sum, id) => sum + weightFor(id), 0) || 1;
+    const oldHeights = oldIds.map((id) => (weightFor(id) / oldWeightSum) * areaPx);
+
+    const heights = resolveExpandHeights({
+      oldHeights,
+      newIndex: expandedIds.indexOf(newId),
+      areaPx,
+      minPx: MIN_SECTION_PX
     });
+
+    const updates = {};
+    expandedIds.forEach((id, i) => { updates[id] = heights[i]; });
     dispatch(updateSidebarSectionSizes(updates));
   }, [expandedIds.join('|'), sizes, dispatch]);
-
-  const weightFor = (id) => liveSizes?.[id] ?? sizes[id] ?? DEFAULT_SECTION_WEIGHT;
 
   // Normalize the rendered flex-grow across expanded sections so it always sums
   // to the expanded count (>= 1). CSS distributes only a fraction of the free

--- a/packages/bruno-app/src/components/Sidebar/SidebarContent.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarContent.js
@@ -8,6 +8,7 @@ import {
   DEFAULT_SECTION_WEIGHT,
   MIN_SECTION_PX,
   NEW_SECTION_FRACTION,
+  TOP_MIN_FRACTION,
   computeExpandWeight,
   computeSashTransfer
 } from './sidebarSectionSizing';
@@ -58,7 +59,7 @@ const SidebarContent = ({ sections }) => {
     return classes.join(' ');
   };
 
-  const makeSashHandlers = (aboveId, belowId) => {
+  const makeSashHandlers = (aboveId, belowId, aboveIsTop) => {
     // Captured once at drag start. The drag delta is measured from the start
     // position, so it must apply to the heights as they were then — re-reading
     // the live (already-resized) heights each move would compound the delta.
@@ -87,14 +88,20 @@ const SidebarContent = ({ sections }) => {
           setSectionExpanded(id, false);
         };
         if (belowPx - deltaPx < COLLAPSE_THRESHOLD_PX) return collapse(belowId);
-        if (abovePx + deltaPx < COLLAPSE_THRESHOLD_PX) return collapse(aboveId);
+        // The top section never collapses via drag — it floors at TOP_MIN_FRACTION
+        // of the shared area so the sash stays reachable.
+        if (!aboveIsTop && abovePx + deltaPx < COLLAPSE_THRESHOLD_PX) return collapse(aboveId);
 
+        const minAbovePx = aboveIsTop
+          ? Math.max(MIN_SECTION_PX, TOP_MIN_FRACTION * (abovePx + belowPx))
+          : MIN_SECTION_PX;
         const { weightAbove, weightBelow } = computeSashTransfer({
           abovePx,
           belowPx,
           deltaPx,
           combinedWeight,
-          minPx: MIN_SECTION_PX
+          minAbovePx,
+          minBelowPx: MIN_SECTION_PX
         });
         setLiveSizes({ [aboveId]: weightAbove, [belowId]: weightBelow });
       },
@@ -123,7 +130,7 @@ const SidebarContent = ({ sections }) => {
         return (
           <Fragment key={section.id}>
             {showSashBefore && (
-              <SidebarSectionSash {...makeSashHandlers(prevSection.id, section.id)} />
+              <SidebarSectionSash {...makeSashHandlers(prevSection.id, section.id, index - 1 === 0)} />
             )}
             <div
               className={wrapperClassName}

--- a/packages/bruno-app/src/components/Sidebar/SidebarContent.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarContent.js
@@ -6,17 +6,19 @@ import SidebarSectionSash from './SidebarSectionSash';
 import {
   DEFAULT_SECTION_WEIGHT,
   MIN_SECTION_PX,
-  resolveExpandHeights,
-  resolveSashDrag
+  computeSashTransfer,
+  resolveExpandHeights
 } from './sidebarSectionSizing';
 
 /**
  * Renders the stacked sidebar sections. Expanded sections divide the available
  * height in proportion to their persisted weights (app.sidebarSectionSizes);
- * a draggable sash between two adjacent expanded sections resizes them.
+ * a draggable sash between two adjacent expanded sections resizes them. Dragging
+ * only shrinks a section to its minimum — closing a section is done by clicking
+ * its header (which clears its stored size so it reopens at the 1/N default).
  */
 const SidebarContent = ({ sections }) => {
-  const { isExpanded, setSectionExpanded } = useSidebarAccordion();
+  const { isExpanded } = useSidebarAccordion();
   const dispatch = useDispatch();
   const sizes = useSelector((state) => state.app.sidebarSectionSizes);
 
@@ -81,6 +83,14 @@ const SidebarContent = ({ sections }) => {
     dispatch(updateSidebarSectionSizes(updates));
   }, [expandedIds.join('|'), sizes, dispatch]);
 
+  // A section closed from its header drops its stored size, so it reopens at the
+  // 1/N default rather than its last dragged height.
+  useEffect(() => {
+    Object.keys(sizes).forEach((id) => {
+      if (!expandedIds.includes(id)) dispatch(removeSidebarSectionSize(id));
+    });
+  }, [expandedIds.join('|'), sizes, dispatch]);
+
   // Normalize the rendered flex-grow across expanded sections so it always sums
   // to the expanded count (>= 1). CSS distributes only a fraction of the free
   // space when the flex-grow values sum to less than 1, which would leave a
@@ -95,7 +105,7 @@ const SidebarContent = ({ sections }) => {
     return classes.join(' ');
   };
 
-  const makeSashHandlers = (aboveId, belowId, aboveIsTop) => {
+  const makeSashHandlers = (aboveId, belowId) => {
     // Captured once at drag start. The drag delta is measured from the start
     // position, so it must apply to the heights as they were then — re-reading
     // the live (already-resized) heights each move would compound the delta.
@@ -114,20 +124,15 @@ const SidebarContent = ({ sections }) => {
       onDrag: (deltaPx) => {
         if (!startRef.current) return;
         const { abovePx, belowPx, combinedWeight } = startRef.current;
-
-        const result = resolveSashDrag({ abovePx, belowPx, deltaPx, combinedWeight, aboveIsTop });
-
-        // Dragging a neighbor past its minimum, into the collapse zone, closes
-        // that section (header only) instead of flooring at the min height.
-        if (result.action === 'collapse') {
-          const id = result.side === 'below' ? belowId : aboveId;
-          startRef.current = null;
-          setLiveSizes(null);
-          dispatch(removeSidebarSectionSize(id));
-          setSectionExpanded(id, false);
-          return;
-        }
-        setLiveSizes({ [aboveId]: result.weightAbove, [belowId]: result.weightBelow });
+        // Clamps at the minimum height — dragging never collapses a section.
+        const { weightAbove, weightBelow } = computeSashTransfer({
+          abovePx,
+          belowPx,
+          deltaPx,
+          combinedWeight,
+          minPx: MIN_SECTION_PX
+        });
+        setLiveSizes({ [aboveId]: weightAbove, [belowId]: weightBelow });
       },
       onDragEnd: () => {
         startRef.current = null;
@@ -154,7 +159,7 @@ const SidebarContent = ({ sections }) => {
         return (
           <Fragment key={section.id}>
             {showSashBefore && (
-              <SidebarSectionSash {...makeSashHandlers(prevSection.id, section.id, index - 1 === 0)} />
+              <SidebarSectionSash {...makeSashHandlers(prevSection.id, section.id)} />
             )}
             <div
               className={wrapperClassName}

--- a/packages/bruno-app/src/components/Sidebar/SidebarContent.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarContent.js
@@ -1,9 +1,10 @@
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useSidebarAccordion } from './SidebarAccordionContext';
-import { updateSidebarSectionSizes } from 'providers/ReduxStore/slices/app';
+import { updateSidebarSectionSizes, removeSidebarSectionSize } from 'providers/ReduxStore/slices/app';
 import SidebarSectionSash from './SidebarSectionSash';
 import {
+  COLLAPSE_THRESHOLD_PX,
   DEFAULT_SECTION_WEIGHT,
   MIN_SECTION_PX,
   NEW_SECTION_FRACTION,
@@ -17,7 +18,7 @@ import {
  * a draggable sash between two adjacent expanded sections resizes them.
  */
 const SidebarContent = ({ sections }) => {
-  const { isExpanded } = useSidebarAccordion();
+  const { isExpanded, setSectionExpanded } = useSidebarAccordion();
   const dispatch = useDispatch();
   const sizes = useSelector((state) => state.app.sidebarSectionSizes);
 
@@ -76,6 +77,18 @@ const SidebarContent = ({ sections }) => {
       onDrag: (deltaPx) => {
         if (!startRef.current) return;
         const { abovePx, belowPx, combinedWeight } = startRef.current;
+
+        // Dragging a neighbor past its minimum, into the collapse zone, closes
+        // that section (header only) instead of flooring at the min height.
+        const collapse = (id) => {
+          startRef.current = null;
+          setLiveSizes(null);
+          dispatch(removeSidebarSectionSize(id));
+          setSectionExpanded(id, false);
+        };
+        if (belowPx - deltaPx < COLLAPSE_THRESHOLD_PX) return collapse(belowId);
+        if (abovePx + deltaPx < COLLAPSE_THRESHOLD_PX) return collapse(aboveId);
+
         const { weightAbove, weightBelow } = computeSashTransfer({
           abovePx,
           belowPx,

--- a/packages/bruno-app/src/components/Sidebar/SidebarContent.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarContent.js
@@ -4,13 +4,10 @@ import { useSidebarAccordion } from './SidebarAccordionContext';
 import { updateSidebarSectionSizes, removeSidebarSectionSize } from 'providers/ReduxStore/slices/app';
 import SidebarSectionSash from './SidebarSectionSash';
 import {
-  COLLAPSE_THRESHOLD_PX,
   DEFAULT_SECTION_WEIGHT,
-  MIN_SECTION_PX,
   NEW_SECTION_FRACTION,
-  TOP_MIN_FRACTION,
   computeExpandWeight,
-  computeSashTransfer
+  resolveSashDrag
 } from './sidebarSectionSizing';
 
 /**
@@ -48,14 +45,17 @@ const SidebarContent = ({ sections }) => {
 
   const weightFor = (id) => liveSizes?.[id] ?? sizes[id] ?? DEFAULT_SECTION_WEIGHT;
 
-  const getWrapperClassName = (section, sectionIndex) => {
+  // Normalize the rendered flex-grow across expanded sections so it always sums
+  // to the expanded count (>= 1). CSS distributes only a fraction of the free
+  // space when the flex-grow values sum to less than 1, which would leave a
+  // single low-weight section short of filling. Ratios are preserved.
+  const expandedWeightSum = expandedIds.reduce((sum, id) => sum + weightFor(id), 0);
+  const flexGrowFor = (id) =>
+    (expandedWeightSum > 0 ? (weightFor(id) / expandedWeightSum) * expandedIds.length : 1);
+
+  const getWrapperClassName = (section) => {
     const classes = ['accordion-section-wrapper'];
-    if (isExpanded(section.id)) {
-      classes.push('expanded-wrapper');
-    } else {
-      const hasExpandedAbove = sections.slice(0, sectionIndex).some((s) => isExpanded(s.id));
-      if (hasExpandedAbove) classes.push('pinned-to-bottom');
-    }
+    if (isExpanded(section.id)) classes.push('expanded-wrapper');
     return classes.join(' ');
   };
 
@@ -79,31 +79,19 @@ const SidebarContent = ({ sections }) => {
         if (!startRef.current) return;
         const { abovePx, belowPx, combinedWeight } = startRef.current;
 
+        const result = resolveSashDrag({ abovePx, belowPx, deltaPx, combinedWeight, aboveIsTop });
+
         // Dragging a neighbor past its minimum, into the collapse zone, closes
         // that section (header only) instead of flooring at the min height.
-        const collapse = (id) => {
+        if (result.action === 'collapse') {
+          const id = result.side === 'below' ? belowId : aboveId;
           startRef.current = null;
           setLiveSizes(null);
           dispatch(removeSidebarSectionSize(id));
           setSectionExpanded(id, false);
-        };
-        if (belowPx - deltaPx < COLLAPSE_THRESHOLD_PX) return collapse(belowId);
-        // The top section never collapses via drag — it floors at TOP_MIN_FRACTION
-        // of the shared area so the sash stays reachable.
-        if (!aboveIsTop && abovePx + deltaPx < COLLAPSE_THRESHOLD_PX) return collapse(aboveId);
-
-        const minAbovePx = aboveIsTop
-          ? Math.max(MIN_SECTION_PX, TOP_MIN_FRACTION * (abovePx + belowPx))
-          : MIN_SECTION_PX;
-        const { weightAbove, weightBelow } = computeSashTransfer({
-          abovePx,
-          belowPx,
-          deltaPx,
-          combinedWeight,
-          minAbovePx,
-          minBelowPx: MIN_SECTION_PX
-        });
-        setLiveSizes({ [aboveId]: weightAbove, [belowId]: weightBelow });
+          return;
+        }
+        setLiveSizes({ [aboveId]: result.weightAbove, [belowId]: result.weightBelow });
       },
       onDragEnd: () => {
         startRef.current = null;
@@ -119,7 +107,7 @@ const SidebarContent = ({ sections }) => {
     <>
       {sections.map((section, index) => {
         const SectionComponent = section.component;
-        const wrapperClassName = getWrapperClassName(section, index);
+        const wrapperClassName = getWrapperClassName(section);
         const expanded = isExpanded(section.id);
 
         // A sash sits before this section when both it and the previous
@@ -137,7 +125,7 @@ const SidebarContent = ({ sections }) => {
               ref={(node) => {
                 wrapperRefs.current[section.id] = node;
               }}
-              style={expanded ? { flexGrow: weightFor(section.id), flexBasis: 0 } : undefined}
+              style={expanded ? { flexGrow: flexGrowFor(section.id), flexBasis: 0 } : undefined}
             >
               <SectionComponent />
             </div>

--- a/packages/bruno-app/src/components/Sidebar/SidebarContent.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarContent.js
@@ -1,53 +1,90 @@
+import { Fragment, useEffect, useRef, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { useSidebarAccordion } from './SidebarAccordionContext';
+import { updateSidebarSectionSizes } from 'providers/ReduxStore/slices/app';
+import SidebarSectionSash from './SidebarSectionSash';
+import {
+  DEFAULT_SECTION_WEIGHT,
+  MIN_SECTION_PX,
+  NEW_SECTION_FRACTION,
+  computeExpandWeight,
+  computeSashTransfer
+} from './sidebarSectionSizing';
 
 /**
- * Sections configuration
- *
- * All sections use the same generic accordion behavior with the class 'accordion-section-wrapper'.
- * Layout behavior is fully automatic based on section order and expansion state:
- * - Single expanded: When only one section is expanded, it fills available space
- * - Multi-expanded: When multiple sections are expanded, they split space equally
- * - Automatic pinning: Sections below an expanded section are automatically pinned to bottom
- *
- * To add a new section, simply add a new entry to this array:
- *
- * {
- *   id: 'my-section',                    // Unique identifier
- *   component: MySectionComponent,       // React component to render
- *   getProps: (context) => ({ ... })     // Function to get props for component
- * }
+ * Renders the stacked sidebar sections. Expanded sections divide the available
+ * height in proportion to their persisted weights (app.sidebarSectionSizes);
+ * a draggable sash between two adjacent expanded sections resizes them.
  */
-
 const SidebarContent = ({ sections }) => {
-  const { isExpanded, getExpandedCount } = useSidebarAccordion();
+  const { isExpanded } = useSidebarAccordion();
+  const dispatch = useDispatch();
+  const sizes = useSelector((state) => state.app.sidebarSectionSizes);
 
-  const expandedCount = getExpandedCount();
+  // Live weights during a sash drag (committed to redux on mouseup).
+  const [liveSizes, setLiveSizes] = useState(null);
+  const wrapperRefs = useRef({});
+
+  const expandedIds = sections.filter((s) => isExpanded(s.id)).map((s) => s.id);
+
+  // Assign a ~20% default weight to any newly-expanded, never-sized section.
+  useEffect(() => {
+    const unsized = expandedIds.filter((id) => !(id in sizes));
+    if (unsized.length === 0) return;
+
+    const runningWeights = expandedIds
+      .filter((id) => id in sizes)
+      .map((id) => sizes[id]);
+    const updates = {};
+    unsized.forEach((id) => {
+      const weight = computeExpandWeight(runningWeights, NEW_SECTION_FRACTION);
+      updates[id] = weight;
+      runningWeights.push(weight);
+    });
+    dispatch(updateSidebarSectionSizes(updates));
+  }, [expandedIds.join('|'), sizes, dispatch]);
+
+  const weightFor = (id) => liveSizes?.[id] ?? sizes[id] ?? DEFAULT_SECTION_WEIGHT;
 
   const getWrapperClassName = (section, sectionIndex) => {
-    const sectionExpanded = isExpanded(section.id);
-    // Use generic accordion-section-wrapper class for all sections
     const classes = ['accordion-section-wrapper'];
-
-    // Multi-expanded: when multiple sections are expanded
-    if (expandedCount > 1 && sectionExpanded) {
-      classes.push('multi-expanded');
-    }
-
-    // Single expanded wrapper behavior: when only one section is expanded, it fills space
-    if (sectionExpanded && expandedCount === 1) {
-      classes.push('single-expanded-wrapper');
-    }
-
-    // Automatic pinning: if section is not expanded and any section above it (earlier in array) is expanded
-    if (!sectionExpanded) {
-      // Check if any section before this one (earlier in array) is expanded
+    if (isExpanded(section.id)) {
+      classes.push('expanded-wrapper');
+    } else {
       const hasExpandedAbove = sections.slice(0, sectionIndex).some((s) => isExpanded(s.id));
-      if (hasExpandedAbove) {
-        classes.push('pinned-to-bottom');
-      }
+      if (hasExpandedAbove) classes.push('pinned-to-bottom');
     }
-
     return classes.join(' ');
+  };
+
+  const makeSashHandlers = (aboveId, belowId) => {
+    const combinedRef = { current: 0 };
+    return {
+      onDragStart: () => {
+        combinedRef.current = weightFor(aboveId) + weightFor(belowId);
+      },
+      onDrag: (deltaPx) => {
+        const aboveEl = wrapperRefs.current[aboveId];
+        const belowEl = wrapperRefs.current[belowId];
+        if (!aboveEl || !belowEl) return;
+        const abovePx = aboveEl.getBoundingClientRect().height;
+        const belowPx = belowEl.getBoundingClientRect().height;
+        const { weightAbove, weightBelow } = computeSashTransfer({
+          abovePx,
+          belowPx,
+          deltaPx,
+          combinedWeight: combinedRef.current,
+          minPx: MIN_SECTION_PX
+        });
+        setLiveSizes({ [aboveId]: weightAbove, [belowId]: weightBelow });
+      },
+      onDragEnd: () => {
+        setLiveSizes((current) => {
+          if (current) dispatch(updateSidebarSectionSizes(current));
+          return null;
+        });
+      }
+    };
   };
 
   return (
@@ -55,11 +92,28 @@ const SidebarContent = ({ sections }) => {
       {sections.map((section, index) => {
         const SectionComponent = section.component;
         const wrapperClassName = getWrapperClassName(section, index);
+        const expanded = isExpanded(section.id);
+
+        // A sash sits before this section when both it and the previous
+        // section are expanded (two adjacent expanded neighbors).
+        const prevSection = sections[index - 1];
+        const showSashBefore = expanded && prevSection && isExpanded(prevSection.id);
 
         return (
-          <div key={section.id} className={wrapperClassName}>
-            <SectionComponent />
-          </div>
+          <Fragment key={section.id}>
+            {showSashBefore && (
+              <SidebarSectionSash {...makeSashHandlers(prevSection.id, section.id)} />
+            )}
+            <div
+              className={wrapperClassName}
+              ref={(node) => {
+                wrapperRefs.current[section.id] = node;
+              }}
+              style={expanded ? { flexGrow: weightFor(section.id), flexBasis: 0 } : undefined}
+            >
+              <SectionComponent />
+            </div>
+          </Fragment>
         );
       })}
     </>

--- a/packages/bruno-app/src/components/Sidebar/SidebarContent.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarContent.js
@@ -58,27 +58,35 @@ const SidebarContent = ({ sections }) => {
   };
 
   const makeSashHandlers = (aboveId, belowId) => {
-    const combinedRef = { current: 0 };
+    // Captured once at drag start. The drag delta is measured from the start
+    // position, so it must apply to the heights as they were then — re-reading
+    // the live (already-resized) heights each move would compound the delta.
+    const startRef = { current: null };
     return {
       onDragStart: () => {
-        combinedRef.current = weightFor(aboveId) + weightFor(belowId);
-      },
-      onDrag: (deltaPx) => {
         const aboveEl = wrapperRefs.current[aboveId];
         const belowEl = wrapperRefs.current[belowId];
         if (!aboveEl || !belowEl) return;
-        const abovePx = aboveEl.getBoundingClientRect().height;
-        const belowPx = belowEl.getBoundingClientRect().height;
+        startRef.current = {
+          abovePx: aboveEl.getBoundingClientRect().height,
+          belowPx: belowEl.getBoundingClientRect().height,
+          combinedWeight: weightFor(aboveId) + weightFor(belowId)
+        };
+      },
+      onDrag: (deltaPx) => {
+        if (!startRef.current) return;
+        const { abovePx, belowPx, combinedWeight } = startRef.current;
         const { weightAbove, weightBelow } = computeSashTransfer({
           abovePx,
           belowPx,
           deltaPx,
-          combinedWeight: combinedRef.current,
+          combinedWeight,
           minPx: MIN_SECTION_PX
         });
         setLiveSizes({ [aboveId]: weightAbove, [belowId]: weightBelow });
       },
       onDragEnd: () => {
+        startRef.current = null;
         setLiveSizes((current) => {
           if (current) dispatch(updateSidebarSectionSizes(current));
           return null;

--- a/packages/bruno-app/src/components/Sidebar/SidebarSection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarSection/StyledWrapper.js
@@ -17,11 +17,6 @@ const StyledWrapper = styled.div`
     &:not(.expanded) {
       flex: 0 0 auto;
     }
-
-    &.multi-expanded {
-      flex: 1 1 0%;
-      margin-bottom: 0;
-    }
   }
 
   .section-header {

--- a/packages/bruno-app/src/components/Sidebar/SidebarSectionSash/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarSectionSash/StyledWrapper.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  flex: 0 0 4px;
+  height: 4px;
+  width: 100%;
+  cursor: row-resize;
+  background: transparent;
+  transition: background-color 0.15s ease;
+  z-index: 1;
+
+  &:hover,
+  &.dragging {
+    background: ${(props) => props.theme.sidebar.dragbar.activeBorder};
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/SidebarSectionSash/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarSectionSash/StyledWrapper.js
@@ -7,7 +7,18 @@ const StyledWrapper = styled.div`
   cursor: row-resize;
   background: transparent;
   transition: background-color 0.15s ease;
-  z-index: 1;
+  position: relative;
+  z-index: 2;
+
+  /* Extend the grab area beyond the 4px line without affecting layout. */
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: -3px;
+    bottom: -3px;
+  }
 
   &:hover,
   &.dragging {

--- a/packages/bruno-app/src/components/Sidebar/SidebarSectionSash/index.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarSectionSash/index.js
@@ -1,9 +1,20 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import StyledWrapper from './StyledWrapper';
 
 const SidebarSectionSash = ({ onDragStart, onDrag, onDragEnd }) => {
   const startYRef = useRef(0);
+  const listenersRef = useRef(null);
   const [dragging, setDragging] = useState(false);
+
+  const teardown = () => {
+    if (!listenersRef.current) return;
+    document.removeEventListener('mousemove', listenersRef.current.move);
+    document.removeEventListener('mouseup', listenersRef.current.up);
+    listenersRef.current = null;
+  };
+
+  // Remove any still-attached drag listeners if the sash unmounts mid-drag.
+  useEffect(() => teardown, []);
 
   const handleMouseDown = (e) => {
     e.preventDefault();
@@ -11,18 +22,18 @@ const SidebarSectionSash = ({ onDragStart, onDrag, onDragEnd }) => {
     setDragging(true);
     onDragStart?.();
 
-    const handleMove = (ev) => {
+    const move = (ev) => {
       ev.preventDefault();
       onDrag?.(ev.clientY - startYRef.current);
     };
-    const handleUp = () => {
+    const up = () => {
       setDragging(false);
-      document.removeEventListener('mousemove', handleMove);
-      document.removeEventListener('mouseup', handleUp);
+      teardown();
       onDragEnd?.();
     };
-    document.addEventListener('mousemove', handleMove);
-    document.addEventListener('mouseup', handleUp);
+    listenersRef.current = { move, up };
+    document.addEventListener('mousemove', move);
+    document.addEventListener('mouseup', up);
   };
 
   return (

--- a/packages/bruno-app/src/components/Sidebar/SidebarSectionSash/index.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarSectionSash/index.js
@@ -1,0 +1,36 @@
+import { useRef, useState } from 'react';
+import StyledWrapper from './StyledWrapper';
+
+const SidebarSectionSash = ({ onDragStart, onDrag, onDragEnd }) => {
+  const startYRef = useRef(0);
+  const [dragging, setDragging] = useState(false);
+
+  const handleMouseDown = (e) => {
+    e.preventDefault();
+    startYRef.current = e.clientY;
+    setDragging(true);
+    onDragStart?.();
+
+    const handleMove = (ev) => {
+      ev.preventDefault();
+      onDrag?.(ev.clientY - startYRef.current);
+    };
+    const handleUp = () => {
+      setDragging(false);
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleUp);
+      onDragEnd?.();
+    };
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleUp);
+  };
+
+  return (
+    <StyledWrapper
+      className={`sidebar-section-sash ${dragging ? 'dragging' : ''}`}
+      onMouseDown={handleMouseDown}
+    />
+  );
+};
+
+export default SidebarSectionSash;

--- a/packages/bruno-app/src/components/Sidebar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/StyledWrapper.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { MIN_SECTION_PX } from './sidebarSectionSizing';
 
 const Wrapper = styled.div`
   color: ${(props) => props.theme.sidebar.color};
@@ -20,7 +21,8 @@ const Wrapper = styled.div`
       height: 100%;
     }
 
-    /* Expanded sections grow to fill available space but are constrained */
+    /* Expanded section fills its wrapper; the wrapper's inline flex-grow (the
+       section weight) decides how much of the sidebar the wrapper gets. */
     .sidebar-section.expanded {
       flex: 1 1 0%;
       min-height: 0;
@@ -28,24 +30,6 @@ const Wrapper = styled.div`
       .section-header {
         border-bottom: 1px solid ${(props) => props.theme.sidebar.collection.item.hoverBg};
       }
-    }
-
-    /* Single expanded section: add margin-bottom to push others down */
-    .sidebar-section.single-expanded {
-      margin-bottom: auto !important;
-      flex: 1 1 0% !important;
-      min-height: 0;
-      max-height: 100%;
-    }
-
-    /* Multiple expanded sections: equal split, no margin-bottom */
-    .sidebar-section.multi-expanded {
-      margin-bottom: 0;
-      flex: 1 1 0% !important;
-
-      min-height: 0;
-      overflow: hidden;
-      max-height: 100%;
     }
 
     /* Collapsed sections only take header height */
@@ -74,30 +58,22 @@ const Wrapper = styled.div`
       border-top: 1px solid ${(props) => props.theme.sidebar.collection.item.hoverBg};
     }
 
-    /* When a section is single expanded, wrapper should fill space but respect pinned sections */
-    .accordion-section-wrapper.single-expanded-wrapper {
-      flex: 1 1 0% !important;
-      min-height: 0;
+    /* Expanded wrappers fill in proportion to their inline flex-grow (weight),
+       floored so a section can't be crushed below a usable height. */
+    .accordion-section-wrapper.expanded-wrapper {
+      min-height: ${MIN_SECTION_PX}px;
       overflow: hidden;
     }
 
-    /* Normal flow: sections not pinned and not multi-expanded */
-    .accordion-section-wrapper:not(.pinned-to-bottom):not(.multi-expanded) {
+    /* Collapsed wrappers take only header height */
+    .accordion-section-wrapper:not(.expanded-wrapper) {
       flex: 0 0 auto;
     }
 
-    /* When a section is pinned to bottom */
+    /* Collapsed sections below an expanded one stick to the bottom */
     .accordion-section-wrapper.pinned-to-bottom {
       flex: 0 0 auto;
       margin-top: auto;
-    }
-
-    /* When multiple sections are expanded, split space equally */
-    .accordion-section-wrapper.multi-expanded {
-      flex: 1 1 0% !important;
-      min-height: 0;
-      margin-top: 0 !important;
-      height: auto !important;
     }
 
   }

--- a/packages/bruno-app/src/components/Sidebar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/StyledWrapper.js
@@ -65,15 +65,11 @@ const Wrapper = styled.div`
       overflow: hidden;
     }
 
-    /* Collapsed wrappers take only header height */
+    /* Collapsed wrappers take only header height. An expanded section fills the
+       remaining space and pushes trailing collapsed headers to the bottom, so no
+       auto margin is needed (and it would otherwise starve the flex-grow). */
     .accordion-section-wrapper:not(.expanded-wrapper) {
       flex: 0 0 auto;
-    }
-
-    /* Collapsed sections below an expanded one stick to the bottom */
-    .accordion-section-wrapper.pinned-to-bottom {
-      flex: 0 0 auto;
-      margin-top: auto;
     }
 
   }

--- a/packages/bruno-app/src/components/Sidebar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/index.js
@@ -98,7 +98,7 @@ const Sidebar = () => {
   }, [leftSidebarWidth]);
 
   return (
-    <SidebarAccordionProvider defaultExpanded={['collections']}>
+    <SidebarAccordionProvider>
       <StyledWrapper className="flex relative h-full">
         <aside className="sidebar" style={{ width: currentWidth, transition: dragging ? 'none' : 'width 0.2s ease-in-out' }}>
           <div className="flex flex-row h-full w-full">

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
@@ -1,5 +1,4 @@
 export const DEFAULT_SECTION_WEIGHT = 1;
-export const NEW_SECTION_FRACTION = 0.25;
 export const MIN_SECTION_PX = 64;
 // Dragging a neighbor's height below this (past its min) collapses the section.
 export const COLLAPSE_THRESHOLD_PX = 32;
@@ -7,12 +6,39 @@ export const COLLAPSE_THRESHOLD_PX = 32;
 // the shared area so the sash remains reachable (matches VSCode).
 export const TOP_MIN_FRACTION = 0.25;
 
-// Weight for a section that should occupy `fraction` of the area shared with its
-// already-expanded siblings, leaving the siblings' relative proportions intact.
-export const computeExpandWeight = (expandedSiblingWeights, fraction = NEW_SECTION_FRACTION) => {
-  const sum = expandedSiblingWeights.reduce((total, weight) => total + (weight > 0 ? weight : 0), 0);
-  if (sum <= 0) return DEFAULT_SECTION_WEIGHT;
-  return (fraction / (1 - fraction)) * sum;
+// Lays out the expanded sections when a new one is opened, VSCode-style: the new
+// section opens at an equal 1/N share of the shared area, and that space is
+// reclaimed from the other sections' slack (height above the minimum) starting
+// with the neighbour directly above the new section and cascading outward — up
+// first, then down. A section already at its minimum gives nothing; if the total
+// available slack is less than the new section's share, the new section opens
+// smaller (whatever slack allowed).
+//
+// `oldHeights` are the existing expanded sections' pixel heights in visual order;
+// `newIndex` is the position the new section takes in the resulting order.
+// Returns the full ordered list of N heights (new section inserted at newIndex).
+export const resolveExpandHeights = ({ oldHeights, newIndex, areaPx, minPx = MIN_SECTION_PX }) => {
+  const count = oldHeights.length + 1;
+  const target = areaPx / count;
+
+  const reduced = [...oldHeights];
+  // Reclaim order: nearest neighbour above the new section first, then further up,
+  // then the neighbours below.
+  const order = [];
+  for (let i = newIndex - 1; i >= 0; i--) order.push(i);
+  for (let i = newIndex; i < reduced.length; i++) order.push(i);
+
+  let remaining = target;
+  for (const i of order) {
+    if (remaining <= 0) break;
+    const slack = Math.max(0, reduced[i] - minPx);
+    const give = Math.min(slack, remaining);
+    reduced[i] -= give;
+    remaining -= give;
+  }
+
+  const newHeight = target - remaining; // short of target if slack ran out
+  return [...reduced.slice(0, newIndex), newHeight, ...reduced.slice(newIndex)];
 };
 
 // Given the two neighbors' pixel heights and a drag delta, return new weights that

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
@@ -3,6 +3,9 @@ export const NEW_SECTION_FRACTION = 0.25;
 export const MIN_SECTION_PX = 64;
 // Dragging a neighbor's height below this (past its min) collapses the section.
 export const COLLAPSE_THRESHOLD_PX = 32;
+// The top section never collapses via drag; it stays at least this fraction of
+// the shared area so the sash remains reachable (matches VSCode).
+export const TOP_MIN_FRACTION = 0.25;
 
 // Weight for a section that should occupy `fraction` of the area shared with its
 // already-expanded siblings, leaving the siblings' relative proportions intact.
@@ -15,10 +18,18 @@ export const computeExpandWeight = (expandedSiblingWeights, fraction = NEW_SECTI
 // Given the two neighbors' pixel heights and a drag delta, return new weights that
 // preserve their combined weight. The delta is clamped so neither neighbor goes
 // below `minPx`.
-export const computeSashTransfer = ({ abovePx, belowPx, deltaPx, combinedWeight, minPx = MIN_SECTION_PX }) => {
+export const computeSashTransfer = ({
+  abovePx,
+  belowPx,
+  deltaPx,
+  combinedWeight,
+  minPx = MIN_SECTION_PX,
+  minAbovePx = minPx,
+  minBelowPx = minPx
+}) => {
   const totalPx = abovePx + belowPx;
-  const minDelta = minPx - abovePx;
-  const maxDelta = belowPx - minPx;
+  const minDelta = minAbovePx - abovePx;
+  const maxDelta = belowPx - minBelowPx;
   const clampedDelta = Math.max(minDelta, Math.min(maxDelta, deltaPx));
   const newAbovePx = abovePx + clampedDelta;
   const weightAbove = combinedWeight * (newAbovePx / totalPx);

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
@@ -1,5 +1,5 @@
 export const DEFAULT_SECTION_WEIGHT = 1;
-export const NEW_SECTION_FRACTION = 0.2;
+export const NEW_SECTION_FRACTION = 0.25;
 export const MIN_SECTION_PX = 64;
 
 // Weight for a section that should occupy `fraction` of the area shared with its

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
@@ -1,10 +1,7 @@
 export const DEFAULT_SECTION_WEIGHT = 1;
-export const MIN_SECTION_PX = 64;
-// Dragging a neighbor's height below this (past its min) collapses the section.
-export const COLLAPSE_THRESHOLD_PX = 32;
-// The top section never collapses via drag; it stays at least this fraction of
-// the shared area so the sash remains reachable (matches VSCode).
-export const TOP_MIN_FRACTION = 0.25;
+// A section can be dragged down to this height but no further; dragging never
+// collapses a section (matches VSCode — close it by clicking its header).
+export const MIN_SECTION_PX = 100;
 
 // Lays out the expanded sections when a new one is opened, VSCode-style: the new
 // section opens at an equal 1/N share of the shared area, and that space is
@@ -41,50 +38,17 @@ export const resolveExpandHeights = ({ oldHeights, newIndex, areaPx, minPx = MIN
   return [...reduced.slice(0, newIndex), newHeight, ...reduced.slice(newIndex)];
 };
 
-// Given the two neighbors' pixel heights and a drag delta, return new weights that
-// preserve their combined weight. The delta is clamped so neither neighbor goes
-// below `minPx`.
-export const computeSashTransfer = ({
-  abovePx,
-  belowPx,
-  deltaPx,
-  combinedWeight,
-  minPx = MIN_SECTION_PX,
-  minAbovePx = minPx,
-  minBelowPx = minPx
-}) => {
+// Given the two neighbours' pixel heights and a cumulative drag delta, return new
+// weights that preserve their combined weight. The delta is clamped so neither
+// neighbour drops below `minPx` — dragging never collapses a section.
+// Positive delta drags the sash down (grows `above`, shrinks `below`).
+export const computeSashTransfer = ({ abovePx, belowPx, deltaPx, combinedWeight, minPx = MIN_SECTION_PX }) => {
   const totalPx = abovePx + belowPx;
-  const minDelta = minAbovePx - abovePx;
-  const maxDelta = belowPx - minBelowPx;
+  const minDelta = minPx - abovePx;
+  const maxDelta = belowPx - minPx;
   const clampedDelta = Math.max(minDelta, Math.min(maxDelta, deltaPx));
   const newAbovePx = abovePx + clampedDelta;
   const weightAbove = combinedWeight * (newAbovePx / totalPx);
   const weightBelow = combinedWeight - weightAbove;
   return { weightAbove, weightBelow };
-};
-
-// Decides what a sash drag does given the neighbours' start heights and the
-// cumulative delta. Returns either a collapse of one side, or the new weights.
-// Positive delta drags the sash down (grows `above`, shrinks `below`).
-export const resolveSashDrag = ({ abovePx, belowPx, deltaPx, combinedWeight, aboveIsTop }) => {
-  if (belowPx - deltaPx < COLLAPSE_THRESHOLD_PX) {
-    return { action: 'collapse', side: 'below' };
-  }
-  // The top section never collapses via drag; it floors instead (see below).
-  if (!aboveIsTop && abovePx + deltaPx < COLLAPSE_THRESHOLD_PX) {
-    return { action: 'collapse', side: 'above' };
-  }
-
-  const minAbovePx = aboveIsTop
-    ? Math.max(MIN_SECTION_PX, TOP_MIN_FRACTION * (abovePx + belowPx))
-    : MIN_SECTION_PX;
-  const { weightAbove, weightBelow } = computeSashTransfer({
-    abovePx,
-    belowPx,
-    deltaPx,
-    combinedWeight,
-    minAbovePx,
-    minBelowPx: MIN_SECTION_PX
-  });
-  return { action: 'resize', weightAbove, weightBelow };
 };

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
@@ -36,3 +36,29 @@ export const computeSashTransfer = ({
   const weightBelow = combinedWeight - weightAbove;
   return { weightAbove, weightBelow };
 };
+
+// Decides what a sash drag does given the neighbours' start heights and the
+// cumulative delta. Returns either a collapse of one side, or the new weights.
+// Positive delta drags the sash down (grows `above`, shrinks `below`).
+export const resolveSashDrag = ({ abovePx, belowPx, deltaPx, combinedWeight, aboveIsTop }) => {
+  if (belowPx - deltaPx < COLLAPSE_THRESHOLD_PX) {
+    return { action: 'collapse', side: 'below' };
+  }
+  // The top section never collapses via drag; it floors instead (see below).
+  if (!aboveIsTop && abovePx + deltaPx < COLLAPSE_THRESHOLD_PX) {
+    return { action: 'collapse', side: 'above' };
+  }
+
+  const minAbovePx = aboveIsTop
+    ? Math.max(MIN_SECTION_PX, TOP_MIN_FRACTION * (abovePx + belowPx))
+    : MIN_SECTION_PX;
+  const { weightAbove, weightBelow } = computeSashTransfer({
+    abovePx,
+    belowPx,
+    deltaPx,
+    combinedWeight,
+    minAbovePx,
+    minBelowPx: MIN_SECTION_PX
+  });
+  return { action: 'resize', weightAbove, weightBelow };
+};

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
@@ -19,11 +19,17 @@ export const resolveExpandHeights = ({ oldHeights, newIndex, areaPx, minPx = MIN
   const target = areaPx / count;
 
   const reduced = [...oldHeights];
-  // Reclaim order: nearest neighbour above the new section first, then further up,
-  // then the neighbours below.
+  // Reclaim from the nearest neighbours first, fanning outward from the new
+  // section — the section directly above, then directly below, then the next
+  // ones out (above preferred at equal distance). `reduced[newIndex-1]` is the
+  // neighbour above, `reduced[newIndex]` the neighbour below.
   const order = [];
-  for (let i = newIndex - 1; i >= 0; i--) order.push(i);
-  for (let i = newIndex; i < reduced.length; i++) order.push(i);
+  let up = newIndex - 1;
+  let down = newIndex;
+  while (up >= 0 || down < reduced.length) {
+    if (up >= 0) order.push(up--);
+    if (down < reduced.length) order.push(down++);
+  }
 
   let remaining = target;
   for (const i of order) {

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
@@ -1,0 +1,25 @@
+export const DEFAULT_SECTION_WEIGHT = 1;
+export const NEW_SECTION_FRACTION = 0.2;
+export const MIN_SECTION_PX = 64;
+
+// Weight for a section that should occupy `fraction` of the area shared with its
+// already-expanded siblings, leaving the siblings' relative proportions intact.
+export const computeExpandWeight = (expandedSiblingWeights, fraction = NEW_SECTION_FRACTION) => {
+  const sum = expandedSiblingWeights.reduce((total, weight) => total + (weight > 0 ? weight : 0), 0);
+  if (sum <= 0) return DEFAULT_SECTION_WEIGHT;
+  return (fraction / (1 - fraction)) * sum;
+};
+
+// Given the two neighbors' pixel heights and a drag delta, return new weights that
+// preserve their combined weight. The delta is clamped so neither neighbor goes
+// below `minPx`.
+export const computeSashTransfer = ({ abovePx, belowPx, deltaPx, combinedWeight, minPx = MIN_SECTION_PX }) => {
+  const totalPx = abovePx + belowPx;
+  const minDelta = minPx - abovePx;
+  const maxDelta = belowPx - minPx;
+  const clampedDelta = Math.max(minDelta, Math.min(maxDelta, deltaPx));
+  const newAbovePx = abovePx + clampedDelta;
+  const weightAbove = combinedWeight * (newAbovePx / totalPx);
+  const weightBelow = combinedWeight - weightAbove;
+  return { weightAbove, weightBelow };
+};

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.js
@@ -1,6 +1,8 @@
 export const DEFAULT_SECTION_WEIGHT = 1;
 export const NEW_SECTION_FRACTION = 0.25;
 export const MIN_SECTION_PX = 64;
+// Dragging a neighbor's height below this (past its min) collapses the section.
+export const COLLAPSE_THRESHOLD_PX = 32;
 
 // Weight for a section that should occupy `fraction` of the area shared with its
 // already-expanded siblings, leaving the siblings' relative proportions intact.

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
@@ -42,4 +42,13 @@ describe('computeSashTransfer', () => {
     expect(weightAbove).toBeCloseTo(3 * (64 / 300), 5);
     expect(weightBelow).toBeCloseTo(3 * (236 / 300), 5);
   });
+
+  it('honors a larger minAbovePx floor for the top section', () => {
+    // container 800px, top floored at 25% = 200px; big up-drag should stop there
+    const { weightAbove, weightBelow } = computeSashTransfer({
+      abovePx: 600, belowPx: 200, deltaPx: -1000, combinedWeight: 4, minAbovePx: 200, minBelowPx: 64
+    });
+    expect(weightAbove).toBeCloseTo(4 * (200 / 800), 5); // top stays at 200px
+    expect(weightBelow).toBeCloseTo(4 * (600 / 800), 5);
+  });
 });

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
@@ -27,6 +27,14 @@ describe('resolveExpandHeights', () => {
     expect(heights).toEqual([300, 375, 225]);
   });
 
+  it('a middle insert pulls from its nearest neighbours, leaving far sections untouched', () => {
+    // 4 sections at 300 each; open a 5th in the middle (index 2), target = 1500/5 = 300.
+    const heights = resolveExpandHeights({ oldHeights: [300, 300, 300, 300], newIndex: 2, areaPx: 1500, minPx: 100 });
+    // above-adjacent drains to min (200 given), below-adjacent gives the rest (100);
+    // the outermost sections keep their 300.
+    expect(heights).toEqual([300, 100, 300, 200, 300]);
+  });
+
   it('opens smaller than 1/N when the other sections have no slack to give', () => {
     // both existing already at min 100; area only 900, target 300 but no slack
     const heights = resolveExpandHeights({ oldHeights: [100, 100], newIndex: 2, areaPx: 900, minPx: 100 });

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
@@ -1,28 +1,37 @@
 import {
-  DEFAULT_SECTION_WEIGHT,
-  NEW_SECTION_FRACTION,
-  computeExpandWeight,
   computeSashTransfer,
+  resolveExpandHeights,
   resolveSashDrag
 } from './sidebarSectionSizing';
 
-describe('computeExpandWeight', () => {
-  it('returns the default weight when there are no expanded siblings', () => {
-    expect(computeExpandWeight([], 0.2)).toBe(DEFAULT_SECTION_WEIGHT);
+describe('resolveExpandHeights', () => {
+  it('opens the second section at 50% of a two-section sidebar', () => {
+    // one section fills the 900px area; expanding a second below it
+    const heights = resolveExpandHeights({ oldHeights: [900], newIndex: 1, areaPx: 900, minPx: 64 });
+    expect(heights).toEqual([450, 450]);
   });
 
-  it('gives the new section ~20% of the combined area (single sibling)', () => {
-    const w = computeExpandWeight([1], 0.2);
-    expect(w).toBeCloseTo(0.25, 5); // 0.25 / (0.25 + 1) = 0.2
+  it('takes the new section (1/3) from the neighbour above, leaving the far section untouched', () => {
+    // Collections 225, API Specs 675; open a third below -> 3rd takes 300 from API Specs
+    const heights = resolveExpandHeights({ oldHeights: [225, 675], newIndex: 2, areaPx: 900, minPx: 100 });
+    expect(heights).toEqual([225, 375, 300]);
   });
 
-  it('gives the new section ~20% with multiple siblings, keeping their proportions', () => {
-    const w = computeExpandWeight([2, 2], 0.2);
-    expect(w).toBeCloseTo(1, 5); // 1 / (1 + 4) = 0.2
+  it('cascades past a neighbour that is already at its minimum', () => {
+    // API Specs pinned at min 100; the third opens taking its space from Collections instead
+    const heights = resolveExpandHeights({ oldHeights: [700, 100], newIndex: 2, areaPx: 900, minPx: 100 });
+    expect(heights).toEqual([400, 100, 300]);
   });
 
-  it('ignores non-positive sibling weights', () => {
-    expect(computeExpandWeight([0, -3], 0.2)).toBe(DEFAULT_SECTION_WEIGHT);
+  it('takes from the neighbour below when the new section opens at the top', () => {
+    const heights = resolveExpandHeights({ oldHeights: [675, 225], newIndex: 0, areaPx: 900, minPx: 100 });
+    expect(heights).toEqual([300, 375, 225]);
+  });
+
+  it('opens smaller than 1/N when the other sections have no slack to give', () => {
+    // both existing already at min 100; area only 900, target 300 but no slack
+    const heights = resolveExpandHeights({ oldHeights: [100, 100], newIndex: 2, areaPx: 900, minPx: 100 });
+    expect(heights).toEqual([100, 100, 0]); // new gets whatever slack allowed (none)
   });
 });
 
@@ -87,12 +96,5 @@ describe('resolveSashDrag', () => {
   it('still collapses the bottom even when the above is the top section', () => {
     const r = resolveSashDrag({ abovePx: 400, belowPx: 400, deltaPx: 390, combinedWeight: 2, aboveIsTop: true });
     expect(r).toEqual({ action: 'collapse', side: 'below' });
-  });
-});
-
-describe('NEW_SECTION_FRACTION default', () => {
-  it('opens a newly expanded section at 25% next to one existing section', () => {
-    const w = computeExpandWeight([1], NEW_SECTION_FRACTION);
-    expect(w / (w + 1)).toBeCloseTo(0.25, 5);
   });
 });

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
@@ -1,7 +1,6 @@
 import {
   computeSashTransfer,
-  resolveExpandHeights,
-  resolveSashDrag
+  resolveExpandHeights
 } from './sidebarSectionSizing';
 
 describe('resolveExpandHeights', () => {
@@ -54,47 +53,12 @@ describe('computeSashTransfer', () => {
     expect(weightBelow).toBeCloseTo(3 * (236 / 300), 5);
   });
 
-  it('honors a larger minAbovePx floor for the top section', () => {
-    // container 800px, top floored at 25% = 200px; big up-drag should stop there
+  it('clamps a large up-drag at the minimum instead of collapsing', () => {
+    // above 600, below 200, min 100; a huge up-drag can only shrink above to 100
     const { weightAbove, weightBelow } = computeSashTransfer({
-      abovePx: 600, belowPx: 200, deltaPx: -1000, combinedWeight: 4, minAbovePx: 200, minBelowPx: 64
+      abovePx: 600, belowPx: 200, deltaPx: -1000, combinedWeight: 4, minPx: 100
     });
-    expect(weightAbove).toBeCloseTo(4 * (200 / 800), 5); // top stays at 200px
-    expect(weightBelow).toBeCloseTo(4 * (600 / 800), 5);
-  });
-});
-
-describe('resolveSashDrag', () => {
-  const base = { abovePx: 400, belowPx: 400, combinedWeight: 2 };
-
-  it('resizes proportionally on a normal drag', () => {
-    const r = resolveSashDrag({ ...base, deltaPx: 100, aboveIsTop: false });
-    expect(r.action).toBe('resize');
-    expect(r.weightAbove).toBeCloseTo(2 * (500 / 800), 5); // above 400->500
-    expect(r.weightBelow).toBeCloseTo(2 * (300 / 800), 5);
-  });
-
-  it('collapses the bottom section when dragged down past the threshold', () => {
-    // below 400 - 390 = 10px < 32 collapse threshold
-    const r = resolveSashDrag({ ...base, deltaPx: 390, aboveIsTop: false });
-    expect(r).toEqual({ action: 'collapse', side: 'below' });
-  });
-
-  it('collapses a non-top above section when dragged up past the threshold', () => {
-    // above 400 + (-390) = 10px < 32
-    const r = resolveSashDrag({ ...base, deltaPx: -390, aboveIsTop: false });
-    expect(r).toEqual({ action: 'collapse', side: 'above' });
-  });
-
-  it('never collapses the top section — it floors at 25% of the shared area', () => {
-    const r = resolveSashDrag({ abovePx: 600, belowPx: 200, deltaPx: -1000, combinedWeight: 4, aboveIsTop: true });
-    expect(r.action).toBe('resize');
-    expect(r.weightAbove).toBeCloseTo(4 * (200 / 800), 5); // floored at 25% = 200px
-    expect(r.weightBelow).toBeCloseTo(4 * (600 / 800), 5);
-  });
-
-  it('still collapses the bottom even when the above is the top section', () => {
-    const r = resolveSashDrag({ abovePx: 400, belowPx: 400, deltaPx: 390, combinedWeight: 2, aboveIsTop: true });
-    expect(r).toEqual({ action: 'collapse', side: 'below' });
+    expect(weightAbove).toBeCloseTo(4 * (100 / 800), 5); // above floored at 100px
+    expect(weightBelow).toBeCloseTo(4 * (700 / 800), 5);
   });
 });

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
@@ -1,7 +1,9 @@
 import {
   DEFAULT_SECTION_WEIGHT,
+  NEW_SECTION_FRACTION,
   computeExpandWeight,
-  computeSashTransfer
+  computeSashTransfer,
+  resolveSashDrag
 } from './sidebarSectionSizing';
 
 describe('computeExpandWeight', () => {
@@ -50,5 +52,47 @@ describe('computeSashTransfer', () => {
     });
     expect(weightAbove).toBeCloseTo(4 * (200 / 800), 5); // top stays at 200px
     expect(weightBelow).toBeCloseTo(4 * (600 / 800), 5);
+  });
+});
+
+describe('resolveSashDrag', () => {
+  const base = { abovePx: 400, belowPx: 400, combinedWeight: 2 };
+
+  it('resizes proportionally on a normal drag', () => {
+    const r = resolveSashDrag({ ...base, deltaPx: 100, aboveIsTop: false });
+    expect(r.action).toBe('resize');
+    expect(r.weightAbove).toBeCloseTo(2 * (500 / 800), 5); // above 400->500
+    expect(r.weightBelow).toBeCloseTo(2 * (300 / 800), 5);
+  });
+
+  it('collapses the bottom section when dragged down past the threshold', () => {
+    // below 400 - 390 = 10px < 32 collapse threshold
+    const r = resolveSashDrag({ ...base, deltaPx: 390, aboveIsTop: false });
+    expect(r).toEqual({ action: 'collapse', side: 'below' });
+  });
+
+  it('collapses a non-top above section when dragged up past the threshold', () => {
+    // above 400 + (-390) = 10px < 32
+    const r = resolveSashDrag({ ...base, deltaPx: -390, aboveIsTop: false });
+    expect(r).toEqual({ action: 'collapse', side: 'above' });
+  });
+
+  it('never collapses the top section — it floors at 25% of the shared area', () => {
+    const r = resolveSashDrag({ abovePx: 600, belowPx: 200, deltaPx: -1000, combinedWeight: 4, aboveIsTop: true });
+    expect(r.action).toBe('resize');
+    expect(r.weightAbove).toBeCloseTo(4 * (200 / 800), 5); // floored at 25% = 200px
+    expect(r.weightBelow).toBeCloseTo(4 * (600 / 800), 5);
+  });
+
+  it('still collapses the bottom even when the above is the top section', () => {
+    const r = resolveSashDrag({ abovePx: 400, belowPx: 400, deltaPx: 390, combinedWeight: 2, aboveIsTop: true });
+    expect(r).toEqual({ action: 'collapse', side: 'below' });
+  });
+});
+
+describe('NEW_SECTION_FRACTION default', () => {
+  it('opens a newly expanded section at 25% next to one existing section', () => {
+    const w = computeExpandWeight([1], NEW_SECTION_FRACTION);
+    expect(w / (w + 1)).toBeCloseTo(0.25, 5);
   });
 });

--- a/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/sidebarSectionSizing.spec.js
@@ -1,0 +1,45 @@
+import {
+  DEFAULT_SECTION_WEIGHT,
+  computeExpandWeight,
+  computeSashTransfer
+} from './sidebarSectionSizing';
+
+describe('computeExpandWeight', () => {
+  it('returns the default weight when there are no expanded siblings', () => {
+    expect(computeExpandWeight([], 0.2)).toBe(DEFAULT_SECTION_WEIGHT);
+  });
+
+  it('gives the new section ~20% of the combined area (single sibling)', () => {
+    const w = computeExpandWeight([1], 0.2);
+    expect(w).toBeCloseTo(0.25, 5); // 0.25 / (0.25 + 1) = 0.2
+  });
+
+  it('gives the new section ~20% with multiple siblings, keeping their proportions', () => {
+    const w = computeExpandWeight([2, 2], 0.2);
+    expect(w).toBeCloseTo(1, 5); // 1 / (1 + 4) = 0.2
+  });
+
+  it('ignores non-positive sibling weights', () => {
+    expect(computeExpandWeight([0, -3], 0.2)).toBe(DEFAULT_SECTION_WEIGHT);
+  });
+});
+
+describe('computeSashTransfer', () => {
+  it('transfers height between neighbors and preserves the combined weight', () => {
+    const { weightAbove, weightBelow } = computeSashTransfer({
+      abovePx: 800, belowPx: 200, deltaPx: -100, combinedWeight: 5, minPx: 64
+    });
+    expect(weightAbove).toBeCloseTo(3.5, 5); // 5 * 700/1000
+    expect(weightBelow).toBeCloseTo(1.5, 5);
+    expect(weightAbove + weightBelow).toBeCloseTo(5, 5);
+  });
+
+  it('clamps the drag so neither neighbor drops below minPx', () => {
+    const { weightAbove, weightBelow } = computeSashTransfer({
+      abovePx: 100, belowPx: 200, deltaPx: -100, combinedWeight: 3, minPx: 64
+    });
+    // delta clamped to (64 - 100) = -36 -> above 64px, below 236px of 300px total
+    expect(weightAbove).toBeCloseTo(3 * (64 / 300), 5);
+    expect(weightBelow).toBeCloseTo(3 * (236 / 300), 5);
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.js
@@ -119,7 +119,8 @@ export const serializeSnapshot = async (state, options = {}) => {
         }
       },
       sidebar: {
-        sectionSizes: state.app?.sidebarSectionSizes || {}
+        sectionSizes: state.app?.sidebarSectionSizes || {},
+        expandedSections: state.app?.sidebarExpandedSections || []
       }
     },
     workspaces: [],

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.js
@@ -117,6 +117,9 @@ export const serializeSnapshot = async (state, options = {}) => {
           ...existingDevToolsTabs,
           [resolvedDevToolsActiveTab]: existingDevToolsTabs[resolvedDevToolsActiveTab] ?? {}
         }
+      },
+      sidebar: {
+        sectionSizes: state.app?.sidebarSectionSizes || {}
       }
     },
     workspaces: [],

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.spec.js
@@ -265,4 +265,15 @@ describe('serializeSnapshot sidebar section sizes', () => {
     expect(snapshot.extras.sidebar.sectionSizes).toEqual({ 'collections': 4, 'api-specs': 1 });
     expect(snapshot.extras.devTools).toBeDefined();
   });
+
+  it('persists the expanded section list', async () => {
+    const state = makeState();
+    state.app.sidebarExpandedSections = ['collections', 'api-specs'];
+
+    const snapshot = await serializeSnapshot(state, {
+      getExistingSnapshot: async () => null
+    });
+
+    expect(snapshot.extras.sidebar.expandedSections).toEqual(['collections', 'api-specs']);
+  });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.spec.js
@@ -252,3 +252,17 @@ describe('serializeSnapshot collection environment preservation', () => {
     });
   });
 });
+
+describe('serializeSnapshot sidebar section sizes', () => {
+  it('persists sidebar section sizes without clobbering devTools extras', async () => {
+    const state = makeState();
+    state.app.sidebarSectionSizes = { 'collections': 4, 'api-specs': 1 };
+
+    const snapshot = await serializeSnapshot(state, {
+      getExistingSnapshot: async () => null
+    });
+
+    expect(snapshot.extras.sidebar.sectionSizes).toEqual({ 'collections': 4, 'api-specs': 1 });
+    expect(snapshot.extras.devTools).toBeDefined();
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -16,6 +16,7 @@ const initialState = {
     startedAt: null
   },
   leftSidebarWidth: 250,
+  sidebarSectionSizes: {},
   sidebarCollapsed: false,
   showSidebarSearch: false,
   focusedSidebarPath: null,
@@ -165,6 +166,13 @@ export const appSlice = createSlice({
     updateLeftSidebarWidth: (state, action) => {
       state.leftSidebarWidth = action.payload.leftSidebarWidth;
     },
+    updateSidebarSectionSizes: (state, action) => {
+      Object.entries(action.payload || {}).forEach(([sectionId, weight]) => {
+        if (typeof weight === 'number' && Number.isFinite(weight) && weight > 0) {
+          state.sidebarSectionSizes[sectionId] = weight;
+        }
+      });
+    },
     updateIsDragging: (state, action) => {
       state.isDragging = action.payload.isDragging;
     },
@@ -286,6 +294,7 @@ export const {
   clearSnapshotHydrationSession,
   refreshScreenWidth,
   updateLeftSidebarWidth,
+  updateSidebarSectionSizes,
   updateIsDragging,
   showHomePage,
   hideHomePage,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -173,6 +173,9 @@ export const appSlice = createSlice({
         }
       });
     },
+    removeSidebarSectionSize: (state, action) => {
+      delete state.sidebarSectionSizes[action.payload];
+    },
     updateIsDragging: (state, action) => {
       state.isDragging = action.payload.isDragging;
     },
@@ -295,6 +298,7 @@ export const {
   refreshScreenWidth,
   updateLeftSidebarWidth,
   updateSidebarSectionSizes,
+  removeSidebarSectionSize,
   updateIsDragging,
   showHomePage,
   hideHomePage,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.js
@@ -17,6 +17,7 @@ const initialState = {
   },
   leftSidebarWidth: 250,
   sidebarSectionSizes: {},
+  sidebarExpandedSections: ['collections'],
   sidebarCollapsed: false,
   showSidebarSearch: false,
   focusedSidebarPath: null,
@@ -176,6 +177,20 @@ export const appSlice = createSlice({
     removeSidebarSectionSize: (state, action) => {
       delete state.sidebarSectionSizes[action.payload];
     },
+    setSidebarSectionExpanded: (state, action) => {
+      const { id, expanded } = action.payload;
+      const has = state.sidebarExpandedSections.includes(id);
+      if (expanded && !has) {
+        state.sidebarExpandedSections.push(id);
+      } else if (!expanded && has) {
+        state.sidebarExpandedSections = state.sidebarExpandedSections.filter((sectionId) => sectionId !== id);
+      }
+    },
+    setSidebarExpandedSections: (state, action) => {
+      if (Array.isArray(action.payload)) {
+        state.sidebarExpandedSections = action.payload.filter((id) => typeof id === 'string');
+      }
+    },
     updateIsDragging: (state, action) => {
       state.isDragging = action.payload.isDragging;
     },
@@ -299,6 +314,8 @@ export const {
   updateLeftSidebarWidth,
   updateSidebarSectionSizes,
   removeSidebarSectionSize,
+  setSidebarSectionExpanded,
+  setSidebarExpandedSections,
   updateIsDragging,
   showHomePage,
   hideHomePage,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.spec.js
@@ -1,0 +1,23 @@
+import appReducer, { updateSidebarSectionSizes } from './app';
+
+const baseState = () => appReducer(undefined, { type: '@@INIT' });
+
+describe('app slice — sidebarSectionSizes', () => {
+  it('starts empty', () => {
+    expect(baseState().sidebarSectionSizes).toEqual({});
+  });
+
+  it('merges id→weight pairs without dropping existing keys', () => {
+    let state = appReducer(baseState(), updateSidebarSectionSizes({ collections: 4 }));
+    state = appReducer(state, updateSidebarSectionSizes({ 'api-specs': 1 }));
+    expect(state.sidebarSectionSizes).toEqual({ 'collections': 4, 'api-specs': 1 });
+  });
+
+  it('ignores non-finite or non-positive weights', () => {
+    const state = appReducer(
+      baseState(),
+      updateSidebarSectionSizes({ a: 0, b: -2, c: NaN, d: Infinity, e: 3 })
+    );
+    expect(state.sidebarSectionSizes).toEqual({ e: 3 });
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.spec.js
@@ -1,4 +1,4 @@
-import appReducer, { updateSidebarSectionSizes } from './app';
+import appReducer, { updateSidebarSectionSizes, removeSidebarSectionSize } from './app';
 
 const baseState = () => appReducer(undefined, { type: '@@INIT' });
 
@@ -19,5 +19,11 @@ describe('app slice — sidebarSectionSizes', () => {
       updateSidebarSectionSizes({ a: 0, b: -2, c: NaN, d: Infinity, e: 3 })
     );
     expect(state.sidebarSectionSizes).toEqual({ e: 3 });
+  });
+
+  it('removes a section size by id (leaving the rest)', () => {
+    let state = appReducer(baseState(), updateSidebarSectionSizes({ 'collections': 4, 'api-specs': 1 }));
+    state = appReducer(state, removeSidebarSectionSize('api-specs'));
+    expect(state.sidebarSectionSizes).toEqual({ collections: 4 });
   });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/app.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/app.spec.js
@@ -1,4 +1,9 @@
-import appReducer, { updateSidebarSectionSizes, removeSidebarSectionSize } from './app';
+import appReducer, {
+  updateSidebarSectionSizes,
+  removeSidebarSectionSize,
+  setSidebarSectionExpanded,
+  setSidebarExpandedSections
+} from './app';
 
 const baseState = () => appReducer(undefined, { type: '@@INIT' });
 
@@ -25,5 +30,31 @@ describe('app slice — sidebarSectionSizes', () => {
     let state = appReducer(baseState(), updateSidebarSectionSizes({ 'collections': 4, 'api-specs': 1 }));
     state = appReducer(state, removeSidebarSectionSize('api-specs'));
     expect(state.sidebarSectionSizes).toEqual({ collections: 4 });
+  });
+});
+
+describe('app slice — sidebarExpandedSections', () => {
+  it('starts with collections expanded', () => {
+    expect(baseState().sidebarExpandedSections).toEqual(['collections']);
+  });
+
+  it('adds and removes a section id without duplicating', () => {
+    let state = appReducer(baseState(), setSidebarSectionExpanded({ id: 'api-specs', expanded: true }));
+    expect(state.sidebarExpandedSections).toEqual(['collections', 'api-specs']);
+    // expanding again is a no-op (no duplicate)
+    state = appReducer(state, setSidebarSectionExpanded({ id: 'api-specs', expanded: true }));
+    expect(state.sidebarExpandedSections).toEqual(['collections', 'api-specs']);
+    state = appReducer(state, setSidebarSectionExpanded({ id: 'collections', expanded: false }));
+    expect(state.sidebarExpandedSections).toEqual(['api-specs']);
+  });
+
+  it('replaces the list from a hydrated array, dropping non-strings', () => {
+    const state = appReducer(baseState(), setSidebarExpandedSections(['api-specs', 'dummy', 5, null]));
+    expect(state.sidebarExpandedSections).toEqual(['api-specs', 'dummy']);
+  });
+
+  it('ignores a non-array payload', () => {
+    const state = appReducer(baseState(), setSidebarExpandedSections('nope'));
+    expect(state.sidebarExpandedSections).toEqual(['collections']);
   });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -18,7 +18,8 @@ import {
   setSnapshotReady,
   startSnapshotHydrationSession,
   markSnapshotCollectionHydrated,
-  clearSnapshotHydrationSession
+  clearSnapshotHydrationSession,
+  updateSidebarSectionSizes
 } from '../app';
 import { openConsole, closeConsole, setActiveTab as setActiveDevToolsTab, TAB_IDENFIERS as DEVTOOL_TABS } from '../logs';
 import { normalizePath } from 'utils/common/path';
@@ -882,6 +883,10 @@ export const workspaceOpenedEvent = (workspacePath, workspaceUid, workspaceConfi
         }
         const { activeTab = 'terminal' } = snapshot.extras.devTools;
         dispatch(setActiveDevToolsTab(activeTab));
+      }
+
+      if (!currentState.app.snapshotReady && snapshot?.extras?.sidebar?.sectionSizes) {
+        dispatch(updateSidebarSectionSizes(snapshot.extras.sidebar.sectionSizes));
       }
     } catch (err) {
     }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -19,7 +19,8 @@ import {
   startSnapshotHydrationSession,
   markSnapshotCollectionHydrated,
   clearSnapshotHydrationSession,
-  updateSidebarSectionSizes
+  updateSidebarSectionSizes,
+  setSidebarExpandedSections
 } from '../app';
 import { openConsole, closeConsole, setActiveTab as setActiveDevToolsTab, TAB_IDENFIERS as DEVTOOL_TABS } from '../logs';
 import { normalizePath } from 'utils/common/path';
@@ -883,6 +884,10 @@ export const workspaceOpenedEvent = (workspacePath, workspaceUid, workspaceConfi
         }
         const { activeTab = 'terminal' } = snapshot.extras.devTools;
         dispatch(setActiveDevToolsTab(activeTab));
+      }
+
+      if (!currentState.app.snapshotReady && Array.isArray(snapshot?.extras?.sidebar?.expandedSections)) {
+        dispatch(setSidebarExpandedSections(snapshot.extras.sidebar.expandedSections));
       }
 
       if (!currentState.app.snapshotReady && snapshot?.extras?.sidebar?.sectionSizes) {

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -40,6 +40,7 @@ export const WORKSPACE_TAB_TYPES = new Set(Object.keys(WORKSPACE_TAB_UID_SUFFIX_
 
 export const SAVE_TRIGGERS = new Map([
   ['app/setSnapshotReady', null],
+  ['app/updateSidebarSectionSizes', null],
   ['tabs/addTab', null],
   ['tabs/closeTabs', null],
   ['tabs/focusTab', null],

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -42,6 +42,7 @@ export const SAVE_TRIGGERS = new Map([
   ['app/setSnapshotReady', null],
   ['app/updateSidebarSectionSizes', null],
   ['app/removeSidebarSectionSize', null],
+  ['app/setSidebarSectionExpanded', null],
   ['tabs/addTab', null],
   ['tabs/closeTabs', null],
   ['tabs/focusTab', null],

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -41,6 +41,7 @@ export const WORKSPACE_TAB_TYPES = new Set(Object.keys(WORKSPACE_TAB_UID_SUFFIX_
 export const SAVE_TRIGGERS = new Map([
   ['app/setSnapshotReady', null],
   ['app/updateSidebarSectionSizes', null],
+  ['app/removeSidebarSectionSize', null],
   ['tabs/addTab', null],
   ['tabs/closeTabs', null],
   ['tabs/focusTab', null],

--- a/packages/bruno-electron/src/services/snapshot/index.js
+++ b/packages/bruno-electron/src/services/snapshot/index.js
@@ -91,11 +91,17 @@ const devToolsSchema = yup.object({
   })
 });
 
+const sidebarSchema = yup.object({
+  sectionSizes: yup.object().optional(),
+  expandedSections: yup.array().of(yup.string()).optional()
+});
+
 const snapshotSchema = yup.object({
   version: yup.string().defined(),
   activeWorkspacePath: yup.string().nullable(),
   extras: yup.object({
-    devTools: devToolsSchema.required()
+    devTools: devToolsSchema.required(),
+    sidebar: sidebarSchema.optional()
   }).required(),
   workspaces: yup.array().of(workspaceSchema).required(),
   collections: yup.array().of(collectionSchema).required()
@@ -397,7 +403,8 @@ class SnapshotManager {
       version: snapshot.version ?? SNAPSHOT_VERSION,
       activeWorkspacePath: typeof snapshot.activeWorkspacePath === 'string' ? snapshot.activeWorkspacePath : null,
       extras: {
-        devTools: this._normalizeDevTools(snapshot?.extras?.devTools)
+        devTools: this._normalizeDevTools(snapshot?.extras?.devTools),
+        sidebar: this._normalizeSidebar(snapshot?.extras?.sidebar)
       },
       workspaces: this._normalizeWorkspaceList(snapshot.workspaces),
       collections: this._normalizeCollectionList(snapshot.collections, snapshot.tabs)
@@ -426,6 +433,22 @@ class SnapshotManager {
     });
 
     return _snapshotEntry;
+  }
+
+  _normalizeSidebar(sidebar = {}) {
+    const sectionSizes = {};
+    if (isObject(sidebar?.sectionSizes)) {
+      Object.entries(sidebar.sectionSizes).forEach(([id, size]) => {
+        if (typeof size === 'number' && Number.isFinite(size) && size > 0) {
+          sectionSizes[id] = size;
+        }
+      });
+    }
+    const expandedSections = Array.isArray(sidebar?.expandedSections)
+      ? sidebar.expandedSections.filter((id) => typeof id === 'string')
+      : [];
+
+    return { sectionSizes, expandedSections };
   }
 
   _normalizeWorkspaceList(workspaces) {


### PR DESCRIPTION
### Description

Makes the left sidebar's stacked sections (**Collections**, **API Specs**, and any future section) behave like VS Code's Explorer, and brings the **API Spec** item's options menu in line with Collection items.

#### Behavioural changes

**1. API Spec item options menu — parity with Collection items**
- The per-item "⋮" menu now uses the same `MenuDropdown` + `ActionIcon` primitives as Collection items (was the legacy `Dropdown`), with the matching 18px icon.
- Right-click anywhere on an API Spec row opens the same menu.
- Hover/selection styling matches Collections: the dots reveal on hover, on the active spec, and while the menu is open; the row highlights and draws focus-border lines while its menu is open.
- No functional change to the action itself — the only item remains **Remove** (via the existing confirmation modal).

**2. Resizable sidebar sections (VS Code-style)**
- A draggable **sash** sits between two adjacent expanded sections; drag it to redistribute height between those two neighbours.
- Opening a section gives it an equal **1/N** share of the shared area (50% with two sections, 33% with three, …); that space is taken from the neighbour directly above it, cascading outward only when a neighbour hits its minimum — the other sections keep their sizes.
- Dragging can shrink a section down to a **100px minimum but never collapses it**. To close a section you click its header (same as before); a closed section reopens at the 1/N default.
- A single expanded section fills the remaining space; collapsed sections show only their header.
- **Section sizes and expansion state now persist across restarts** (via the UI-state snapshot).
- The layout math is generalised to **N sections**, so a future sidebar section slots in with no extra work.

#### Implementation notes
- Sizing/expansion state lives in the `app` Redux slice and is persisted through the existing snapshot mechanism (`extras.sidebar`), including a matching schema/normalizer update in the Electron snapshot service (which previously stripped unknown `extras` keys on save).
- Core layout logic is extracted into pure, unit-tested helpers (`sidebarSectionSizing.js`): the 1/N neighbour-cascade on expand and the min-clamped sash transfer on drag.

#### Testing
- Unit tests: sizing helpers (1/N cascade, neighbour reclaim, min clamp), the `app` slice reducers, and snapshot round-trip (renderer serialize + Electron normalizer).
- Manual/E2E-style verification via CDP for drag, close-via-header, reopen-at-1/N, and size + expansion persistence across a real app restart.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.** <!-- Bundles two closely-related sidebar changes (menu parity + resizable sections). Happy to split if preferred. -->
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** <!-- to add -->
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.** <!-- to link -->