### PR TITLE
feature: sort path parameters table rows

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -716,7 +716,7 @@ export const collectionsSlice = createSlice({
       // Get current response state or create initial state
       const currentResponse = item.response || initiatedGrpcResponse;
       const timestamp = item?.requestSent?.timestamp;
-      const updatedResponse = { ...currentResponse, duration: Date.now() - (timestamp || Date.now()) };
+      let updatedResponse = { ...currentResponse, duration: Date.now() - (timestamp || Date.now()) };
 
       // Process based on event type
       switch (eventType) {
@@ -2508,7 +2508,7 @@ export const collectionsSlice = createSlice({
           folder.draft = cloneDeep(folder.root);
         }
         if (type === 'request') {
-          const vars = get(folder, 'draft.request.vars.req', []);
+          let vars = get(folder, 'draft.request.vars.req', []);
           const _var = find(vars, (h) => h.uid === action.payload.var.uid);
           if (_var) {
             _var.name = action.payload.var.name;
@@ -2518,7 +2518,7 @@ export const collectionsSlice = createSlice({
           }
           set(folder, 'draft.request.vars.req', vars);
         } else if (type === 'response') {
-          const vars = get(folder, 'draft.request.vars.res', []);
+          let vars = get(folder, 'draft.request.vars.res', []);
           const _var = find(vars, (h) => h.uid === action.payload.var.uid);
           if (_var) {
             _var.name = action.payload.var.name;
@@ -2772,7 +2772,7 @@ export const collectionsSlice = createSlice({
           };
         }
         if (type === 'request') {
-          const vars = get(collection, 'draft.root.request.vars.req', []);
+          let vars = get(collection, 'draft.root.request.vars.req', []);
           const _var = find(vars, (h) => h.uid === action.payload.var.uid);
           if (_var) {
             _var.name = action.payload.var.name;
@@ -2782,7 +2782,7 @@ export const collectionsSlice = createSlice({
           }
           set(collection, 'draft.root.request.vars.req', vars);
         } else if (type === 'response') {
-          const vars = get(collection, 'draft.root.request.vars.res', []);
+          let vars = get(collection, 'draft.root.request.vars.res', []);
           const _var = find(vars, (h) => h.uid === action.payload.var.uid);
           if (_var) {
             _var.name = action.payload.var.name;
@@ -3627,7 +3627,7 @@ export const collectionsSlice = createSlice({
       if (!collection.oauth2Credentials) {
         collection.oauth2Credentials = [];
       }
-      const collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
+      let collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
 
       // Remove existing credentials for the same combination
       const filteredOauth2Credentials = filter(
@@ -3684,7 +3684,7 @@ export const collectionsSlice = createSlice({
       if (!collection) return;
 
       if (collection.oauth2Credentials) {
-        const collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
+        let collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
         const filteredOauth2Credentials = filter(
           collectionOauth2Credentials,
           (creds) =>
@@ -3846,7 +3846,7 @@ export const collectionsSlice = createSlice({
       // Get current response state or create initial state
       const currentResponse = item.response || initiatedWsResponse;
       const timestamp = item?.requestSent?.timestamp;
-      const updatedResponse = {
+      let updatedResponse = {
         ...currentResponse,
         isError: false,
         error: '',

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -716,7 +716,7 @@ export const collectionsSlice = createSlice({
       // Get current response state or create initial state
       const currentResponse = item.response || initiatedGrpcResponse;
       const timestamp = item?.requestSent?.timestamp;
-      let updatedResponse = { ...currentResponse, duration: Date.now() - (timestamp || Date.now()) };
+      const updatedResponse = { ...currentResponse, duration: Date.now() - (timestamp || Date.now()) };
 
       // Process based on event type
       switch (eventType) {
@@ -1071,11 +1071,11 @@ export const collectionsSlice = createSlice({
             }
           });
 
-          const oldPathParams = filter(item?.draft?.request?.params, (p) => p.enabled && p.type === 'path');
+          let remainingPathParams = filter(item?.draft?.request?.params, (p) => p.enabled && p.type === 'path');
           const pathParamsInUrlOrder = urlPathParams.map((urlPath) => {
-            const existingPathParam = find(oldPathParams, (p) => p.name === urlPath.name);
-
+            const existingPathParam = find(remainingPathParams, (p) => p.name === urlPath.name);
             if (existingPathParam) {
+              remainingPathParams = filter(remainingPathParams, (p) => p.uid !== existingPathParam.uid);
               return {
                 ...existingPathParam,
                 uid: existingPathParam.uid,
@@ -1083,7 +1083,6 @@ export const collectionsSlice = createSlice({
                 type: 'path'
               };
             }
-
             return {
               ...urlPath,
               uid: uuid(),
@@ -2509,7 +2508,7 @@ export const collectionsSlice = createSlice({
           folder.draft = cloneDeep(folder.root);
         }
         if (type === 'request') {
-          let vars = get(folder, 'draft.request.vars.req', []);
+          const vars = get(folder, 'draft.request.vars.req', []);
           const _var = find(vars, (h) => h.uid === action.payload.var.uid);
           if (_var) {
             _var.name = action.payload.var.name;
@@ -2519,7 +2518,7 @@ export const collectionsSlice = createSlice({
           }
           set(folder, 'draft.request.vars.req', vars);
         } else if (type === 'response') {
-          let vars = get(folder, 'draft.request.vars.res', []);
+          const vars = get(folder, 'draft.request.vars.res', []);
           const _var = find(vars, (h) => h.uid === action.payload.var.uid);
           if (_var) {
             _var.name = action.payload.var.name;
@@ -2773,7 +2772,7 @@ export const collectionsSlice = createSlice({
           };
         }
         if (type === 'request') {
-          let vars = get(collection, 'draft.root.request.vars.req', []);
+          const vars = get(collection, 'draft.root.request.vars.req', []);
           const _var = find(vars, (h) => h.uid === action.payload.var.uid);
           if (_var) {
             _var.name = action.payload.var.name;
@@ -2783,7 +2782,7 @@ export const collectionsSlice = createSlice({
           }
           set(collection, 'draft.root.request.vars.req', vars);
         } else if (type === 'response') {
-          let vars = get(collection, 'draft.root.request.vars.res', []);
+          const vars = get(collection, 'draft.root.request.vars.res', []);
           const _var = find(vars, (h) => h.uid === action.payload.var.uid);
           if (_var) {
             _var.name = action.payload.var.name;
@@ -3628,7 +3627,7 @@ export const collectionsSlice = createSlice({
       if (!collection.oauth2Credentials) {
         collection.oauth2Credentials = [];
       }
-      let collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
+      const collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
 
       // Remove existing credentials for the same combination
       const filteredOauth2Credentials = filter(
@@ -3685,7 +3684,7 @@ export const collectionsSlice = createSlice({
       if (!collection) return;
 
       if (collection.oauth2Credentials) {
-        let collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
+        const collectionOauth2Credentials = cloneDeep(collection.oauth2Credentials);
         const filteredOauth2Credentials = filter(
           collectionOauth2Credentials,
           (creds) =>
@@ -3847,7 +3846,7 @@ export const collectionsSlice = createSlice({
       // Get current response state or create initial state
       const currentResponse = item.response || initiatedWsResponse;
       const timestamp = item?.requestSent?.timestamp;
-      let updatedResponse = {
+      const updatedResponse = {
         ...currentResponse,
         isError: false,
         error: '',

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1054,8 +1054,6 @@ export const collectionsSlice = createSlice({
 
           const disabledQueryParams = filter(item?.draft?.request?.params, (p) => !p.enabled && p.type === 'query');
           let enabledQueryParams = filter(item?.draft?.request?.params, (p) => p.enabled && p.type === 'query');
-          let oldPathParams = filter(item?.draft?.request?.params, (p) => p.enabled && p.type === 'path');
-          let newPathParams = [];
 
           // try and connect as much as old params uid's as possible
           each(urlQueryParams, (urlQueryParam) => {
@@ -1073,27 +1071,31 @@ export const collectionsSlice = createSlice({
             }
           });
 
-          // filter the newest path param and compare with previous data that already inserted
-          newPathParams = filter(urlPathParams, (urlPath) => {
+          const oldPathParams = filter(item?.draft?.request?.params, (p) => p.enabled && p.type === 'path');
+          const pathParamsInUrlOrder = urlPathParams.map((urlPath) => {
             const existingPathParam = find(oldPathParams, (p) => p.name === urlPath.name);
-            if (existingPathParam) {
-              return false;
-            }
-            urlPath.uid = uuid();
-            urlPath.enabled = true;
-            urlPath.type = 'path';
-            return true;
-          });
 
-          // remove path param that not used or deleted when typing url
-          oldPathParams = filter(oldPathParams, (urlPath) => {
-            return find(urlPathParams, (p) => p.name === urlPath.name);
+            if (existingPathParam) {
+              return {
+                ...existingPathParam,
+                uid: existingPathParam.uid,
+                enabled: existingPathParam.enabled ?? true,
+                type: 'path'
+              };
+            }
+
+            return {
+              ...urlPath,
+              uid: uuid(),
+              enabled: true,
+              type: 'path'
+            };
           });
 
           // ultimately params get replaced with params in url + the disabled ones that existed prior
           // the query params are the source of truth, the url in the queryurl input gets constructed using these params
           // we however are also storing the full url (with params) in the url itself
-          item.draft.request.params = concat(urlQueryParams, newPathParams, disabledQueryParams, oldPathParams);
+          item.draft.request.params = concat(urlQueryParams, pathParamsInUrlOrder, disabledQueryParams);
         }
       }
     },

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
@@ -5,7 +5,8 @@ const {
   setFolderVars,
   setCollectionVars,
   updateFile,
-  wsResponseReceived
+  wsResponseReceived,
+  requestUrlChanged
 } = collectionsSlice.actions;
 const reducer = collectionsSlice.reducer;
 
@@ -156,5 +157,31 @@ describe('wsResponseReceived — disconnecting', () => {
       status: 'DISCONNECTING',
       statusText: 'DISCONNECTING'
     });
+  });
+});
+
+describe('requestUrlChanged — preserves URL order for path params', () => {
+  it('orders existing and newly discovered path params according to the URL', () => {
+    const item = {
+      uid: 'item1',
+      type: 'http-request',
+      request: {
+        url: 'https://example.com/users/:id',
+        params: [
+          { uid: 'path-1', name: 'id', value: '123', enabled: true, type: 'path' }
+        ]
+      }
+    };
+
+    const next = reducer(
+      makeStateWith(item),
+      requestUrlChanged({ collectionUid: 'col1', itemUid: 'item1', url: 'https://example.com/users/:id/posts/:postId' })
+    );
+
+    const pathParams = next.collections[0].items[0].draft.request.params.filter((param) => param.type === 'path');
+
+    expect(pathParams.map((param) => param.name)).toEqual(['id', 'postId']);
+    expect(pathParams[0].uid).toBe('path-1');
+    expect(pathParams[1].uid).not.toBe('path-1');
   });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
@@ -161,7 +161,7 @@ describe('wsResponseReceived — disconnecting', () => {
 });
 
 describe('requestUrlChanged — preserves URL order for path params', () => {
-  it('orders existing and newly discovered path params according to the URL', () => {
+  it('orders existing and newly discovered path params according to the URL when new path parameter is added to end of URL', () => {
     const item = {
       uid: 'item1',
       type: 'http-request',
@@ -183,5 +183,33 @@ describe('requestUrlChanged — preserves URL order for path params', () => {
     expect(pathParams.map((param) => param.name)).toEqual(['id', 'postId']);
     expect(pathParams[0].uid).toBe('path-1');
     expect(pathParams[1].uid).not.toBe('path-1');
+  });
+});
+
+describe('requestUrlChanged — preserves URL order for path params', () => {
+  it('orders existing and newly discovered path params according to the URL when new path parameter is added between two existing ones', () => {
+    const item = {
+      uid: 'item1',
+      type: 'http-request',
+      request: {
+        url: 'https://example.com/users/:id/:postId',
+        params: [
+          { uid: 'path-1', name: 'id', value: '123', enabled: true, type: 'path' },
+          { uid: 'path-2', name: 'postId', value: '456', enabled: true, type: 'path' }
+        ]
+      }
+    };
+
+    const next = reducer(
+      makeStateWith(item),
+      requestUrlChanged({ collectionUid: 'col1', itemUid: 'item1', url: 'https://example.com/users/:id/:commentId/:postId' })
+    );
+
+    const pathParams = next.collections[0].items[0].draft.request.params.filter((param) => param.type === 'path');
+
+    expect(pathParams.map((param) => param.name)).toEqual(['id', 'commentId', 'postId']);
+    expect(pathParams[0].uid).toBe('path-1');
+    expect(pathParams[1].uid).not.toBe('path-2');
+    expect(pathParams[2].uid).toBe('path-2');
   });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
@@ -5,8 +5,8 @@ const {
   setFolderVars,
   setCollectionVars,
   updateFile,
-  wsResponseReceived,
-  requestUrlChanged
+  requestUrlChanged,
+  wsResponseReceived
 } = collectionsSlice.actions;
 const reducer = collectionsSlice.reducer;
 


### PR DESCRIPTION
### Description

Implements feature #8779

When path parameters are added to a URL then the new parameter is prepended to the path parameters table. 
I would expect the path parameters in the table to be in the same order as they appear in the URL.

Current behavior if I add first path parameter 1, then 2, 3 and 4. Also if a path parameter is added in between other parameters it's also prepended to the table.
<img width="457" height="496" alt="image" src="https://github.com/user-attachments/assets/806b4caa-5621-48a0-a60e-bf49b452bb1e" />

After my change path parameters are shown in the correct order and also if a new parameter is added in between others the order is correct:
<img width="457" height="496" alt="image" src="https://github.com/user-attachments/assets/802e0ef4-f046-4ffb-8d75-909861584747" />

This change improves user experience as the user does not need to search in a unsorted list of path parameters.


#### Contribution Checklist:

- [ X] **I've used AI significantly to create this pull request**
- [ X] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ X] **I have added screenshots or gifs to help explain the change if applicable.**
- [ X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL synchronization for path parameters.
  * Path parameters now appear in the same order as their URL segments.
  * Existing parameter settings are preserved when matching parameters are found.
  * Newly detected path parameters are added automatically.
  * Removed path parameters no longer remain in the parameter list.
  * WebSocket responses now correctly show a disconnecting status during disconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->