### PR TITLE
feat(size/M):Default to no environments selected in the Generate Documentation modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/EnvironmentSelectionList/index.spec.js
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EnvironmentSelectionList from './index';
+
+const ENVIRONMENTS = [
+  { uid: 'env-1', name: 'Production' },
+  { uid: 'env-2', name: 'Development' },
+  { uid: 'env-3', name: 'Staging' }
+];
+
+describe('EnvironmentSelectionList', () => {
+  it('renders a zero count and an empty, non-indeterminate "Select All" when nothing is selected', () => {
+    render(<EnvironmentSelectionList environments={ENVIRONMENTS} selectedUids={[]} />);
+
+    // The modal opens with no environments selected (safe-by-default, opt-in inclusion).
+    expect(screen.getByTestId('env-selected-count')).toHaveTextContent('(0/3 selected)');
+
+    const selectAll = screen.getByTestId('env-select-all');
+    expect(selectAll).not.toBeChecked();
+    expect(selectAll.indeterminate).toBe(false);
+  });
+
+  it('checks "Select All" and shows a full count when every environment is selected', () => {
+    render(
+      <EnvironmentSelectionList environments={ENVIRONMENTS} selectedUids={ENVIRONMENTS.map((env) => env.uid)} />
+    );
+
+    expect(screen.getByTestId('env-selected-count')).toHaveTextContent('(3/3 selected)');
+
+    const selectAll = screen.getByTestId('env-select-all');
+    expect(selectAll).toBeChecked();
+    expect(selectAll.indeterminate).toBe(false);
+  });
+
+  it('shows a partial count and an indeterminate "Select All" when some are selected', () => {
+    render(<EnvironmentSelectionList environments={ENVIRONMENTS} selectedUids={['env-2']} />);
+
+    expect(screen.getByTestId('env-selected-count')).toHaveTextContent('(1/3 selected)');
+    expect(screen.getByTestId('env-select-all').indeterminate).toBe(true);
+  });
+
+  it('requests selecting all when "Select All" is clicked from the empty default', () => {
+    const onToggleAll = jest.fn();
+    render(<EnvironmentSelectionList environments={ENVIRONMENTS} selectedUids={[]} onToggleAll={onToggleAll} />);
+
+    fireEvent.click(screen.getByTestId('env-select-all'));
+    expect(onToggleAll).toHaveBeenCalledWith(true);
+  });
+
+  it('requests deselecting all when "Select All" is clicked while fully selected', () => {
+    const onToggleAll = jest.fn();
+    render(
+      <EnvironmentSelectionList
+        environments={ENVIRONMENTS}
+        selectedUids={ENVIRONMENTS.map((env) => env.uid)}
+        onToggleAll={onToggleAll}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('env-select-all'));
+    expect(onToggleAll).toHaveBeenCalledWith(false);
+  });
+
+  it('renders nothing when the collection has no environments', () => {
+    const { container } = render(<EnvironmentSelectionList environments={[]} selectedUids={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
@@ -83,6 +83,21 @@ const StyledWrapper = styled.div`
           accent-color: ${(props) => props.theme.primary.solid};
         }
 
+        .env-checkbox:indeterminate {
+          appearance: none;
+          -webkit-appearance: none;
+          background-color: ${(props) => props.theme.primary.solid};
+          border: 1px solid ${(props) => props.theme.primary.solid};
+          border-radius: 0.15rem;
+          background-image: linear-gradient(
+            ${(props) => props.theme.bg},
+            ${(props) => props.theme.bg}
+          );
+          background-size: 0.55rem 2px;
+          background-position: center;
+          background-repeat: no-repeat;
+        }
+
         .env-section-header {
           display: flex;
           align-items: center;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -86,16 +86,15 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
 
   const environments = useMemo(() => collection?.environments || [], [collection?.environments]);
 
-  // Track *deselected* environments so all environments — including any that load
-  // after mount — stay selected by default, matching the design.
-  const [deselectedEnvUids, setDeselectedEnvUids] = useState(() => new Set());
+  // Track *selected* environments, starting empty, so nothing is included by default.
+  const [selectedEnvUidsSet, setSelectedEnvUidsSet] = useState(() => new Set());
   const selectedEnvUids = useMemo(
-    () => environments.filter((env) => !deselectedEnvUids.has(env.uid)).map((env) => env.uid),
-    [environments, deselectedEnvUids]
+    () => environments.filter((env) => selectedEnvUidsSet.has(env.uid)).map((env) => env.uid),
+    [environments, selectedEnvUidsSet]
   );
 
   const toggleEnv = useCallback((uid) => {
-    setDeselectedEnvUids((prev) => {
+    setSelectedEnvUidsSet((prev) => {
       const next = new Set(prev);
       if (next.has(uid)) {
         next.delete(uid);
@@ -106,9 +105,9 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
     });
   }, []);
 
-  // Select all -> nothing deselected; deselect all -> every environment deselected.
+  // Select all -> every environment selected; deselect all -> nothing selected.
   const toggleAllEnvs = useCallback(
-    (selectAll) => setDeselectedEnvUids(selectAll ? new Set() : new Set(environments.map((env) => env.uid))),
+    (selectAll) => setSelectedEnvUidsSet(selectAll ? new Set(environments.map((env) => env.uid)) : new Set()),
     [environments]
   );
 
@@ -120,7 +119,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
       // ) at every depth, so the generated docs match the collection shown in the sidebar.
       collectionCopy.items = sortItemsBySidebarOrder(collectionCopy.items);
 
-      // Only include the environments the user kept selected in the generated docs.
+      // Only include the environments the user explicitly selected in the generated docs.
       const selectedSet = new Set(selectedEnvUids);
       collectionCopy.environments = (collectionCopy.environments || []).filter((env) => selectedSet.has(env.uid));
 

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -79,7 +79,8 @@ const sidebarItemsToNameTree = (items: CollectionTreeItem[] = []): NameTree[] =>
 
 /**
  * Environments defined in the fixture collection (one `.bru` file each under
- * `environments/`). All of them should be selected by default in the modal.
+ * `environments/`). None of them are selected by default in the modal — inclusion
+ * is opt-in.
  */
 const EXPECTED_ENVIRONMENTS = ['Production', 'Development', 'Staging'];
 
@@ -193,7 +194,7 @@ test.describe('Generate Documentation', () => {
     await expect(modal).toBeHidden();
   });
 
-  test('lists every environment under "Environments to include", all selected by default', async ({
+  test('lists every environment under "Environments to include", none selected by default', async ({
     pageWithUserData: page
   }) => {
     const locators = buildCommonLocators(page);
@@ -208,108 +209,112 @@ test.describe('Generate Documentation', () => {
 
     for (const name of EXPECTED_ENVIRONMENTS) {
       await expect(locators.generateDocs.environmentRow(name)).toBeVisible();
-      await expect(locators.generateDocs.environmentCheckbox(name)).toBeChecked();
+      await expect(locators.generateDocs.environmentCheckbox(name)).not.toBeChecked();
     }
 
     // Exactly the fixture's environments are listed — nothing more.
     await expect(locators.generateDocs.environmentRows()).toHaveCount(EXPECTED_ENVIRONMENTS.length);
 
+    await expect(locators.generateDocs.selectAllCheckbox()).not.toBeChecked();
+    await expect(locators.generateDocs.selectedCount()).toHaveText(selectedCountText(0));
+
     await locators.generateDocs.cancelButton().click();
     await expect(modal).toBeHidden();
   });
 
-  test('includes every environment in the generated docs by default', async ({
+  test('includes no environments in the generated docs by default', async ({
     pageWithUserData: page
   }) => {
     const locators = buildCommonLocators(page);
 
-    // Ensure all environments have loaded (and stay checked) before generating.
     const { content } = await generateCollectionDocs(page, COLLECTION_NAME, async () => {
-      for (const name of EXPECTED_ENVIRONMENTS) {
-        await expect(locators.generateDocs.environmentCheckbox(name)).toBeChecked();
-      }
+      await expect(locators.generateDocs.environmentRows()).toHaveCount(EXPECTED_ENVIRONMENTS.length);
+      await expect(locators.generateDocs.selectedCount()).toHaveText(selectedCountText(0));
     });
 
-    expect(generatedEnvironmentNames(content).sort()).toEqual([...EXPECTED_ENVIRONMENTS].sort());
+    expect(generatedEnvironmentNames(content)).toEqual([]);
   });
 
-  test('excludes a deselected environment from the generated docs', async ({
+  test('includes only the environments the user explicitly selects', async ({
     pageWithUserData: page
   }) => {
     const locators = buildCommonLocators(page);
 
     const { content } = await generateCollectionDocs(page, COLLECTION_NAME, async () => {
-      // Wait for all environments to load, then deselect a single one.
-      for (const name of EXPECTED_ENVIRONMENTS) {
-        await expect(locators.generateDocs.environmentCheckbox(name)).toBeChecked();
-      }
-      await locators.generateDocs.environmentCheckbox('Development').uncheck();
-      await expect(locators.generateDocs.environmentCheckbox('Development')).not.toBeChecked();
+      // Wait for all environments to load, then opt a single one in.
+      await expect(locators.generateDocs.environmentRows()).toHaveCount(EXPECTED_ENVIRONMENTS.length);
+      await locators.generateDocs.environmentCheckbox('Development').check();
+      await expect(locators.generateDocs.environmentCheckbox('Development')).toBeChecked();
     });
 
     const envNames = generatedEnvironmentNames(content);
-    expect(envNames).toContain('Production');
-    expect(envNames).toContain('Staging');
-    expect(envNames).not.toContain('Development');
+    expect(envNames).toContain('Development');
+    expect(envNames).not.toContain('Production');
+    expect(envNames).not.toContain('Staging');
   });
 
-  test('checks "Select All" and shows a full count when every environment is selected by default', async ({
+  test('shows an empty "Select All" and a zero count when nothing is selected by default', async ({
     pageWithUserData: page
   }) => {
     const { locators, modal } = await openDocsModalWithEnvironments(page);
 
     await expect(locators.generateDocs.selectAllLabel()).toContainText('Select All');
+    await expect(locators.generateDocs.selectAllCheckbox()).not.toBeChecked();
+    await expect(locators.generateDocs.selectedCount()).toHaveText(selectedCountText(0));
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('shows "Select All" as indeterminate with a partial count when one environment is selected', async ({
+    pageWithUserData: page
+  }) => {
+    const { locators, modal } = await openDocsModalWithEnvironments(page);
+
+    await locators.generateDocs.environmentCheckbox('Development').check();
+
+    // Some-but-not-all selected -> tri-state checkbox shows the indeterminate state.
+    await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked({ indeterminate: true });
+    await expect(locators.generateDocs.selectedCount()).toHaveText(selectedCountText(1));
+
+    const indeterminateStyles = await locators.generateDocs.selectAllCheckbox().evaluate((el) => {
+      const style = getComputedStyle(el);
+      return { appearance: style.appearance, backgroundColor: style.backgroundColor, accentColor: style.accentColor };
+    });
+    expect(indeterminateStyles.appearance).toBe('none');
+    expect(indeterminateStyles.backgroundColor).toBe(indeterminateStyles.accentColor);
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('clicking "Select All" selects every environment, filling the checkbox and count', async ({
+    pageWithUserData: page
+  }) => {
+    const { locators, modal } = await openDocsModalWithEnvironments(page);
+    await expect(locators.generateDocs.selectAllCheckbox()).not.toBeChecked();
+
+    await locators.generateDocs.selectAllCheckbox().click();
+
     await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked();
     await expect(locators.generateDocs.selectedCount()).toHaveText(
       selectedCountText(EXPECTED_ENVIRONMENTS.length)
     );
-
-    await locators.generateDocs.cancelButton().click();
-    await expect(modal).toBeHidden();
-  });
-
-  test('shows "Select All" as indeterminate with a partial count when one environment is deselected', async ({
-    pageWithUserData: page
-  }) => {
-    const { locators, modal } = await openDocsModalWithEnvironments(page);
-
-    await locators.generateDocs.environmentCheckbox('Development').uncheck();
-
-    // Some-but-not-all selected -> tri-state checkbox shows the indeterminate state.
-    await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked({ indeterminate: true });
-    await expect(locators.generateDocs.selectedCount()).toHaveText(
-      selectedCountText(EXPECTED_ENVIRONMENTS.length - 1)
-    );
-
-    await locators.generateDocs.cancelButton().click();
-    await expect(modal).toBeHidden();
-  });
-
-  test('clicking "Select All" deselects every environment, emptying the checkbox and count', async ({
-    pageWithUserData: page
-  }) => {
-    const { locators, modal } = await openDocsModalWithEnvironments(page);
-    await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked();
-
-    await locators.generateDocs.selectAllCheckbox().click();
-
-    await expect(locators.generateDocs.selectAllCheckbox()).not.toBeChecked();
-    await expect(locators.generateDocs.selectedCount()).toHaveText(selectedCountText(0));
     for (const name of EXPECTED_ENVIRONMENTS) {
-      await expect(locators.generateDocs.environmentCheckbox(name)).not.toBeChecked();
+      await expect(locators.generateDocs.environmentCheckbox(name)).toBeChecked();
     }
 
     await locators.generateDocs.cancelButton().click();
     await expect(modal).toBeHidden();
   });
 
-  test('clicking "Select All" from a partial selection re-selects every environment', async ({
+  test('clicking "Select All" from a partial selection selects every environment', async ({
     pageWithUserData: page
   }) => {
     const { locators, modal } = await openDocsModalWithEnvironments(page);
 
     // Drop into the partial (indeterminate) state first.
-    await locators.generateDocs.environmentCheckbox('Development').uncheck();
+    await locators.generateDocs.environmentCheckbox('Development').check();
     await expect(locators.generateDocs.selectAllCheckbox()).toBeChecked({ indeterminate: true });
 
     // Clicking the tri-state checkbox while partial selects everything.
@@ -327,7 +332,7 @@ test.describe('Generate Documentation', () => {
     await expect(modal).toBeHidden();
   });
 
-  test('deselecting everything via "Select All" excludes all environments from the generated docs', async ({
+  test('selecting everything via "Select All" includes all environments in the generated docs', async ({
     pageWithUserData: page
   }) => {
     const locators = buildCommonLocators(page);
@@ -335,9 +340,11 @@ test.describe('Generate Documentation', () => {
     const { content } = await generateCollectionDocs(page, COLLECTION_NAME, async () => {
       await expect(locators.generateDocs.environmentRows()).toHaveCount(EXPECTED_ENVIRONMENTS.length);
       await locators.generateDocs.selectAllCheckbox().click();
-      await expect(locators.generateDocs.selectedCount()).toHaveText(selectedCountText(0));
+      await expect(locators.generateDocs.selectedCount()).toHaveText(
+        selectedCountText(EXPECTED_ENVIRONMENTS.length)
+      );
     });
 
-    expect(generatedEnvironmentNames(content)).toEqual([]);
+    expect(generatedEnvironmentNames(content).sort()).toEqual([...EXPECTED_ENVIRONMENTS].sort());
   });
 });


### PR DESCRIPTION
### Description

Problem
The Generate Documentation modal opens with all environments selected (Select All). Generating docs therefore embeds every environment's variables into the standalone HTML unless the user notices and manually deselects them. That risks leaking sensitive environment data (secrets, prod URLs, tokens) into a file meant to be shared or hosted. It also diverges from the CLI's opt-in environment model (inclusion is explicit) and from the docs-distribution decision that mandates no environments or secrets in generated output unless explicitly opted in.

Proposed Solution
Flip the modal's default so no environments are selected on open. The user explicitly checks the environments to include (or uses Select All). Nothing else about the feature changes. In code, the state tracks to selected uids from an empty set to fix this issue.

BRU - 4002

<img width="1232" height="1016" alt="image" src="https://github.com/user-attachments/assets/6a519f56-4845-4e5b-85d0-ff9878db62cb" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment selection for generated documentation is now opt-in; no environments are selected by default.
  * Added clear selection counts and tri-state “Select All” behavior for unchecked, partially selected, and fully selected states.
  * Generated documentation includes only the environments explicitly selected.

* **Style**
  * Improved the visual appearance of the indeterminate selection state.

* **Tests**
  * Added coverage for default, partial, full, and empty environment selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->