### PR TITLE
fix(openapi): sync enabled query params into the URL + enableOptionalParameters option

### DIFF
--- a/packages/bruno-app/src/utils/exporters/openapi-spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.js
@@ -119,21 +119,24 @@ export const exportApiSpec = ({ variables, items, name, environments }) => {
       if (baseUrlOverride) {
         const reqVarsMap = {};
         requestVars.filter((v) => v.enabled).forEach((v) => { reqVarsMap[v.name] = v.value; });
-        const path = rawUrl.slice('{{baseUrl}}'.length) || '/';
+        // A saved request keeps its enabled query params in the URL (e.g.
+        // "{{baseUrl}}/users?status=active"); the OpenAPI path must exclude the
+        // query string — query params are exported from the params array below.
+        const path = rawUrl.slice('{{baseUrl}}'.length).split('?')[0] || '/';
         return { url: interpolate(path, reqVarsMap), operationLevelServer: buildServerEntry(baseUrlOverride.value, reqVarsMap) };
       }
     }
 
     // URL uses {{baseUrl}} placeholder — strip it and resolve remaining path
     if (rawUrl.startsWith('{{baseUrl}}')) {
-      const path = rawUrl.slice('{{baseUrl}}'.length) || '/';
+      const path = rawUrl.slice('{{baseUrl}}'.length).split('?')[0] || '/';
       return { url: interpolate(path, {}), operationLevelServer: null };
     }
 
     // URL matches a known baseUrl value directly (e.g. user typed template vars inline)
     for (const source of baseUrlSources) {
       if (rawUrl.startsWith(source.baseUrl)) {
-        const rawPath = rawUrl.slice(source.baseUrl.length);
+        const rawPath = rawUrl.slice(source.baseUrl.length).split('?')[0];
         const path = rawPath.startsWith('/') ? rawPath : `/${rawPath}`;
         return { url: interpolate(path, {}), operationLevelServer: null };
       }

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -35,7 +35,7 @@ const getSchemaPropertyExampleValue = (prop, propName, parentExample = {}) => {
  * @param {Object} param - The OpenAPI parameter object
  * @returns {Array} - Array of objects with value and enabled properties
  */
-const getParameterEntries = (param) => {
+const computeParameterEntries = (param) => {
   const schema = param.schema || {};
   const entries = [];
 
@@ -158,6 +158,27 @@ const getParameterEntries = (param) => {
   return [{ value, enabled }];
 };
 
+/**
+ * Wraps computeParameterEntries with the enableOptionalParameters option.
+ * The base logic enables every required parameter, plus any optional one that
+ * carries an example/default value, so whether an optional parameter is ticked
+ * depends on how thoroughly the spec documents it. When importers pass
+ * enableOptionalParameters: false (mirroring the option exposed by other
+ * OpenAPI importers), every entry for a non-required parameter is disabled so
+ * that only required parameters are ticked. Defaults to the existing behaviour
+ * when unset.
+ * @param {Object} param - The OpenAPI parameter object
+ * @param {Object} options - Conversion options
+ * @returns {Array} - Array of objects with value and enabled properties
+ */
+const getParameterEntries = (param, options = {}) => {
+  const entries = computeParameterEntries(param);
+  if (options.enableOptionalParameters === false && !param.required) {
+    return entries.map((entry) => ({ ...entry, enabled: false }));
+  }
+  return entries;
+};
+
 const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {}) => {
   let _operationObject = request.operationObject;
 
@@ -259,7 +280,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
           ? { ...prop, example: schemaExample[propName] }
           : prop;
         const tempParam = { ...param, example: undefined, examples: undefined, name: propName, schema: propSchema, required: isRequired };
-        const entries = getParameterEntries(tempParam);
+        const entries = getParameterEntries(tempParam, options);
 
         entries.forEach((entry) => {
           if (param.in === 'query' || param.in === 'querystring') {
@@ -292,7 +313,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
         });
       });
     } else {
-      const entries = getParameterEntries(param);
+      const entries = getParameterEntries(param, options);
 
       entries.forEach((entry) => {
         if (param.in === 'query' || param.in === 'querystring') {
@@ -431,6 +452,22 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
         autoRefreshToken: true
       };
     }
+  }
+
+  // Keep the request URL in sync with the enabled query params. Bruno derives
+  // the query string it sends from the URL, so an enabled param that is absent
+  // from the URL is shown ticked but is not actually applied until the user
+  // toggles it. Appending the enabled query params mirrors how Bruno persists a
+  // saved request (URL and params:query stay in sync) so an imported request
+  // works on first open.
+  const enabledQueryParams = brunoRequestItem.request.params.filter(
+    (param) => param.type === 'query' && param.enabled
+  );
+  if (enabledQueryParams.length > 0) {
+    const queryString = enabledQueryParams
+      .map((param) => `${param.name}=${param.value ?? ''}`)
+      .join('&');
+    brunoRequestItem.request.url += `?${queryString}`;
   }
 
   // TODO: handle allOf/anyOf/oneOf

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-query-parameters.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-query-parameters.spec.js
@@ -1,0 +1,145 @@
+import { describe, it, expect } from '@jest/globals';
+import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
+
+const specWith = (params) => `
+openapi: '3.0.0'
+info:
+  title: 'Query Params API'
+  version: '1.0.0'
+servers:
+  - url: 'https://api.example.com'
+paths:
+  /search:
+    get:
+      summary: 'Search'
+      operationId: 'search'
+      parameters:
+${params}
+      responses:
+        '200':
+          description: 'OK'
+`;
+
+const search = (spec, options) =>
+  openApiToBruno(spec, options).items.find((i) => i.name === 'Search').request;
+
+describe('openapi query parameter import', () => {
+  describe('syncing enabled query params into the URL', () => {
+    it('appends enabled query params to the request URL', () => {
+      const request = search(
+        specWith(`        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+            example: hello`)
+      );
+
+      expect(request.url).toBe('{{baseUrl}}/search?q=hello');
+    });
+
+    it('keeps disabled query params out of the URL', () => {
+      const request = search(
+        specWith(`        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+            example: hello
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: string`)
+      );
+
+      expect(request.url).toContain('q=hello');
+      expect(request.url).not.toContain('page');
+      expect(request.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'page', type: 'query', enabled: false })
+        ])
+      );
+    });
+  });
+
+  describe('enableOptionalParameters option', () => {
+    const spec = specWith(`        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+            example: hello
+        - name: normalise
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true`);
+
+    it('ticks optional params carrying a default by default (unchanged behaviour)', () => {
+      const request = search(spec);
+
+      expect(request.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'normalise', enabled: true })
+        ])
+      );
+      expect(request.url).toContain('normalise=true');
+    });
+
+    it('unticks optional params and drops them from the URL when disabled', () => {
+      const request = search(spec, { enableOptionalParameters: false });
+
+      expect(request.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'q', enabled: true }),
+          expect.objectContaining({ name: 'normalise', enabled: false })
+        ])
+      );
+      expect(request.url).toBe('{{baseUrl}}/search?q=hello');
+    });
+
+    it('unticks every entry of an optional enum param when disabled', () => {
+      const request = search(
+        specWith(`        - name: mode
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [a, b, c]
+            default: b`),
+        { enableOptionalParameters: false }
+      );
+
+      const modeParams = request.params.filter((p) => p.name === 'mode');
+      expect(modeParams.length).toBeGreaterThan(0);
+      expect(modeParams.every((p) => p.enabled === false)).toBe(true);
+      expect(request.url).not.toContain('mode');
+    });
+
+    it('keeps required params ticked while unticking optional ones', () => {
+      const request = search(
+        specWith(`        - name: reqd
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: opt
+          in: query
+          required: false
+          schema:
+            type: string
+            example: something`),
+        { enableOptionalParameters: false }
+      );
+
+      expect(request.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'reqd', enabled: true }),
+          expect.objectContaining({ name: 'opt', enabled: false })
+        ])
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Description

Fixes to the OpenAPI → Bruno importer (and a matching exporter fix), all about query parameters.

**1. Enabled query params are now written into the request URL (bug fix).**

The importer set a request's URL to the path only and listed query params separately in the `params:query` block. Bruno derives the query string it *sends* from the URL, so an imported query param that was ticked was shown enabled but not actually applied until the user toggled it off and back on (which rewrites the URL from the params table).

Example — `GET /api/v2/embeddings/product/average/` with a ticked `normalise` param imported as:

```
get {
  url: {{baseUrl}}/api/v2/embeddings/product/average/
}
params:query {
  normalise: true
}
```

`normalise` is ticked but never sent. After this change the URL is kept in sync with the enabled query params (matching how Bruno persists a saved request), so it works on first open:

```
get {
  url: {{baseUrl}}/api/v2/embeddings/product/average/?normalise=true
}
```

**2. New `enableOptionalParameters` option (opt-in, non-breaking).**

`getParameterEntries` ticks every required parameter, plus any optional one that carries an example/default value, so whether an *optional* param is ticked depends on how thoroughly the spec documents it — a single spec can end up with all / some / none of its optional params ticked. Passing `enableOptionalParameters: false` (mirroring the option other OpenAPI importers such as Postman expose) disables every non-required parameter, so only required params are ticked. Behaviour is unchanged when the option is unset.

**3. Exporter: exclude the query string from the exported OpenAPI path.**

Change 1 means a saved request URL now canonically carries its enabled query params (e.g. `{{baseUrl}}/users?status=active`). The Bruno → OpenAPI exporter derived the path by stripping `{{baseUrl}}` and using the remainder verbatim, so it produced a path like `/users?status=active` instead of `/users`. Query params are already exported from the request's `params` array, so the exporter now drops the query string when deriving the path. (This also fixes the existing round-trip unit test, which surfaced the exporter bug once the importer started producing canonical URLs.)

Covered by new tests in `openapi-query-parameters.spec.js` plus the existing exporter round-trip test; the full `tests/openapi` suite passes (218 tests).

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

> Note: this PR bundles a few closely-related query-parameter changes (importer URL sync, an opt-in option, and the matching exporter path fix). Happy to split if you'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI imports now provide control over whether optional query parameters are enabled by default.
  * Imported requests now synchronize their URL query string based on which query parameters are enabled (including example/default values).

* **Bug Fixes**
  * Disabled optional query parameters are omitted from the request URL while remaining present as disabled parameters.
  * OpenAPI URL paths derived from base URL templates now exclude any query string portion.

* **Tests**
  * Added Jest coverage for enabled/disabled query parameter URL inclusion rules, including optional parameters with enums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->