### PR TITLE
feat(collections): add description text to open collection selection modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/StyledWrapper.js
@@ -6,6 +6,11 @@ const StyledWrapper = styled.div`
   max-width: 100%;
   min-width: 0;
   box-sizing: border-box;
+
+  .modal-description {
+    color: ${(props) => props.theme.text};
+    margin-bottom: 12px;
+  }
 `;
 
 export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
@@ -176,6 +176,9 @@ const OpenCollectionModal = ({ onClose }) => {
         )}
       >
         <StyledWrapper>
+          <p className="modal-description">
+            These collections were found inside your selection. Choose which ones to open.
+          </p>
           <div className="w-full min-w-0 flex flex-col gap-3">
             <SkippedPathsWarning paths={skippedCollectionPaths} itemNoun="collections" />
             <SelectionList

--- a/tests/collection/open/open-collection-selection.spec.ts
+++ b/tests/collection/open/open-collection-selection.spec.ts
@@ -143,6 +143,7 @@ test.describe('Open Collection - selection flow', () => {
     await openViaSidebar(page);
 
     await expect(openCollectionModal(page)).toBeVisible();
+    await expect(openCollectionModal(page).getByText(/found inside your selection/)).toBeVisible();
     await expect(locators.openCollectionPicker.count()).toHaveText('2');
     await expect(listTitles(page)).toHaveCount(2);
 
@@ -174,6 +175,7 @@ test.describe('Open Collection - selection flow', () => {
     await openViaSidebar(page);
 
     await expect(openCollectionModal(page)).toBeVisible();
+    await expect(openCollectionModal(page).getByText(/found inside your selection/)).toBeVisible();
     await expect(listTitles(page)).toHaveText('Picked Collection');
 
     await toggleOpenCollectionItem(page, 'Picked Collection');


### PR DESCRIPTION
### Description

Adds a description to the Open Collection selection modal so users immediately understand what the list of collections represents and what action to take.

Follow up PR: https://github.com/usebruno/bruno/pull/8724  Ref: BRU-141

### Problem

When the Open Collection modal appears after scanning nested or mixed folder selections, there is no contextual text explaining what the listed collections are or why they're being shown. 

### Fix

Gives users immediate context about what they're looking at when the modal appears after scanning nested folder selections. Added a static description "These collections were found inside your selection. Choose which ones to open." above the collection list in the selection modal


### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  <img width="681" height="703" alt="image" src="https://github.com/user-attachments/assets/0bda1e5a-1769-4a51-a1e7-b5d3f40bba5d" /> |  <img width="681" height="703" alt="image" src="https://github.com/user-attachments/assets/c78b74b4-4819-4ad1-8d45-a990b9399a37" /> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
