### PR TITLE
fix: preserve elapsed time for streaming requests

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
@@ -1,27 +1,41 @@
 import React, { useState, useEffect } from 'react';
 import StyledWrapper from './StyledWrapper';
 
-const ResponseStopWatch = ({ startMillis }) => {
-  const [milliseconds, setMilliseconds] = useState(startMillis);
+const TICK_INTERVAL = 100;
 
-  const tickInterval = 100;
-  const tick = () => {
-    setMilliseconds((_milliseconds) => _milliseconds + tickInterval);
-  };
+const isValidStartTime = (startTime) => Number.isFinite(startTime);
+
+const getElapsedTime = (startTime, startMillis) => (
+  isValidStartTime(startTime)
+    ? Math.max(0, Date.now() - startTime)
+    : startMillis
+);
+
+const ResponseStopWatch = ({ startTime, startMillis = 0 }) => {
+  const [milliseconds, setMilliseconds] = useState(() => getElapsedTime(startTime, startMillis));
 
   useEffect(() => {
-    let timerID = setInterval(() => {
-      tick();
-    }, tickInterval);
-    return () => {
-      clearInterval(timerID);
-    };
-  }, []);
+    setMilliseconds(getElapsedTime(startTime, startMillis));
 
-  let seconds = milliseconds / 1000;
-  let secondsFormatted = `${seconds.toFixed(1)}s`;
-  let width = secondsFormatted.length * 0.4; // Calculate width manually to stop parent layout from "flickering" by changing width too fast
-  return <StyledWrapper className="ml-2" style={{ width: `${width}rem` }}>{secondsFormatted}</StyledWrapper>;
+    const timerId = setInterval(() => {
+      setMilliseconds((currentMilliseconds) => (
+        isValidStartTime(startTime)
+          ? Math.max(0, Date.now() - startTime)
+          : currentMilliseconds + TICK_INTERVAL
+      ));
+    }, TICK_INTERVAL);
+
+    return () => clearInterval(timerId);
+  }, [startTime, startMillis]);
+
+  const secondsFormatted = `${(milliseconds / 1000).toFixed(1)}s`;
+  const width = secondsFormatted.length * 0.4;
+
+  return (
+    <StyledWrapper className="ml-2" style={{ width: `${width}rem` }}>
+      {secondsFormatted}
+    </StyledWrapper>
+  );
 };
 
 export default React.memo(ResponseStopWatch);

--- a/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.spec.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import ResponseStopWatch from './index';
+
+const theme = {
+  font: { size: { sm: '0.875rem' } },
+  requestTabPanel: { responseStatus: '#000' }
+};
+
+const renderStopWatch = (props) => render(
+  <ThemeProvider theme={theme}>
+    <ResponseStopWatch {...props} />
+  </ThemeProvider>
+);
+
+describe('ResponseStopWatch', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-28T10:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('derives elapsed time from the request start timestamp', () => {
+    const startTime = Date.now() - 1500;
+
+    renderStopWatch({ startTime, startMillis: 200 });
+
+    expect(screen.getByText('1.5s')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText('2.0s')).toBeInTheDocument();
+  });
+
+  it('preserves elapsed time after unmounting and remounting', () => {
+    const startTime = Date.now() - 1000;
+    const firstRender = renderStopWatch({ startTime, startMillis: 100 });
+
+    expect(screen.getByText('1.0s')).toBeInTheDocument();
+    firstRender.unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    renderStopWatch({ startTime, startMillis: 100 });
+
+    expect(screen.getByText('3.0s')).toBeInTheDocument();
+  });
+
+  it('continues from the supplied duration when start time is unavailable', () => {
+    renderStopWatch({ startMillis: 400 });
+
+    expect(screen.getByText('0.4s')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByText('0.7s')).toBeInTheDocument();
+  });
+
+  it('does not display a negative duration for a future start timestamp', () => {
+    renderStopWatch({ startTime: Date.now() + 1000, startMillis: 400 });
+
+    expect(screen.getByText('0.0s')).toBeInTheDocument();
+  });
+
+  it('uses a request start timestamp received after the initial render', () => {
+    const { rerender } = renderStopWatch({ startMillis: 200 });
+
+    expect(screen.getByText('0.2s')).toBeInTheDocument();
+
+    const startTime = Date.now() - 1500;
+    rerender(
+      <ThemeProvider theme={theme}>
+        <ResponseStopWatch startTime={startTime} startMillis={200} />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('1.5s')).toBeInTheDocument();
+  });
+});

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -262,7 +262,12 @@ const ResponsePane = ({ item, collection }) => {
       <div className="flex items-center response-pane-status">
         <StatusCode status={response.status} isStreaming={item.response?.stream?.running} />
         {item.response?.stream?.running
-          ? <ResponseStopWatch startMillis={response.duration} />
+          ? (
+              <ResponseStopWatch
+                startTime={item.requestSent?.timestamp}
+                startMillis={response.duration}
+              />
+            )
           : <ResponseTime duration={response.duration} />}
         <ResponseSize size={responseSize} />
       </div>


### PR DESCRIPTION
Internal - [BRU-4095]

### Description

Preserves the elapsed-time counter for active streaming HTTP responses when navigating away from and back to the request.

### Problem

`ResponseStopWatch` kept elapsed time only in component-local state. Switching requests unmounted the component, so returning to a still-running stream initialized the counter from the original response duration and appeared to reset it.

Fixes #8792.

### Fix

- Derive elapsed time from the stable `requestSent.timestamp` when available.
- Keep the existing duration-based ticking as a compatibility fallback.
- Synchronize immediately when the request-sent event arrives after the initial render.
- Clamp future timestamps to zero.
- Add focused regression coverage for navigation/remounting and event ordering.

### Screenshots

Not applicable; this changes timer continuity rather than layout or styling.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

### Testing

- `ResponseStopWatch`: 5/5 tests passed
- ResponsePane scope: 48/48 tests passed
- ESLint on all three changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response timing display accuracy when requests are actively running.
  * Preserved elapsed time across component updates and remounts.
  * Prevented future timestamps from showing negative durations.
  * Updated timing when request start information becomes available after rendering.

* **Tests**
  * Added coverage for elapsed-time calculation, fallback timing, timer progression, and future timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->