### PR TITLE
fix:populate collection & folder docs on OpenAPI/swagger imports

### DIFF
--- a/packages/bruno-converters/src/openapi/openapi-common.js
+++ b/packages/bruno-converters/src/openapi/openapi-common.js
@@ -544,6 +544,15 @@ export const groupRequestsByTags = (requests, options = {}) => {
 };
 
 /**
+ * Coerces a value into a string.
+ * The spec is unvalidated, so a description can arrive as any YAML type. A bad
+ * value is dropped rather than failing the whole import.
+ * @param {*} value - A value straight off the parsed spec
+ * @returns {string} The value, or '' when it isn't a usable string
+ */
+export const toSpecString = (value) => (typeof value === 'string' ? value : '');
+
+/**
  * Builds a lookup of tag description keyed by sanitized tag name.
  * Folders are named from the sanitized first tag (see groupRequestsByTags), so the
  * spec's top-level tags[] descriptions are keyed the same way to line up with folder names.
@@ -554,10 +563,11 @@ export const groupRequestsByTags = (requests, options = {}) => {
 export const getTagDescriptions = (tags, options = {}) => {
   const descriptions = Object.create(null);
   each(tags || [], (tag) => {
-    if (tag && typeof tag === 'object' && tag.name && tag.description) {
+    if (tag && typeof tag === 'object' && tag.name) {
+      const docs = toSpecString(tag.description);
       const key = sanitizeTag(tag.name, options);
-      if (key) {
-        descriptions[key] = tag.description;
+      if (key && docs) {
+        descriptions[key] = docs;
       }
     }
   });

--- a/packages/bruno-converters/src/openapi/openapi-common.js
+++ b/packages/bruno-converters/src/openapi/openapi-common.js
@@ -544,6 +544,27 @@ export const groupRequestsByTags = (requests, options = {}) => {
 };
 
 /**
+ * Builds a lookup of tag description keyed by sanitized tag name.
+ * Folders are named from the sanitized first tag (see groupRequestsByTags), so the
+ * spec's top-level tags[] descriptions are keyed the same way to line up with folder names.
+ * @param {Array} tags - The spec's top-level tags array (each { name, description })
+ * @param {Object} options - Sanitization options (forwarded to sanitizeTag)
+ * @returns {Object} Map of sanitized tag name -> description
+ */
+export const getTagDescriptions = (tags, options = {}) => {
+  const descriptions = Object.create(null);
+  each(tags || [], (tag) => {
+    if (tag && typeof tag === 'object' && tag.name && tag.description) {
+      const key = sanitizeTag(tag.name, options);
+      if (key) {
+        descriptions[key] = tag.description;
+      }
+    }
+  });
+  return descriptions;
+};
+
+/**
  * Groups requests by URL path segments and builds nested folder structures
  * @param {Array} requests - Array of parsed request objects
  * @param {Function} transformFn - Function to transform a request into a Bruno item: (request, usedNames, options) => brunoItem

--- a/packages/bruno-converters/src/openapi/openapi-common.js
+++ b/packages/bruno-converters/src/openapi/openapi-common.js
@@ -563,7 +563,7 @@ export const toSpecString = (value) => (typeof value === 'string' ? value : '');
 export const getTagDescriptions = (tags, options = {}) => {
   const descriptions = Object.create(null);
   each(tags || [], (tag) => {
-    if (tag && typeof tag === 'object' && tag.name) {
+    if (tag && typeof tag === 'object' && typeof tag.name === 'string') {
       const docs = toSpecString(tag.description);
       const key = sanitizeTag(tag.name, options);
       if (key && docs) {

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -11,7 +11,8 @@ import {
   groupRequestsByTags,
   groupRequestsByPath,
   normalizeItemName,
-  getTagDescriptions
+  getTagDescriptions,
+  toSpecString
 } from './openapi-common';
 
 const getContentLevelExample = (bodyContent) => {
@@ -163,7 +164,7 @@ const getParameterEntries = (param) => {
 const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {}) => {
   let _operationObject = request.operationObject;
 
-  let operationName = _operationObject.summary || _operationObject.operationId || _operationObject.description;
+  let operationName = _operationObject.summary || _operationObject.operationId || toSpecString(_operationObject.description);
   operationName = operationName ? normalizeItemName(operationName) : '';
   if (!operationName) {
     operationName = `${request.method} ${request.path}`;
@@ -197,7 +198,7 @@ const transformOpenapiRequestItem = (request, usedNames = new Set(), options = {
     },
     tags: sanitizeTags(request.operationObject.tags || [], options),
     request: {
-      docs: _operationObject.description,
+      docs: toSpecString(_operationObject.description),
       url: ensureUrl(request.global.server + path),
       method: request.method.toUpperCase(),
       auth: {
@@ -1038,7 +1039,7 @@ export const parseOpenApiCollection = (data, options = {}) => {
       meta: {
         name: brunoCollection.name
       },
-      docs: collectionData.info?.description
+      docs: toSpecString(collectionData.info?.description)
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/src/openapi/openapi-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/openapi-to-bruno.js
@@ -10,7 +10,8 @@ import {
   createBrunoExample,
   groupRequestsByTags,
   groupRequestsByPath,
-  normalizeItemName
+  normalizeItemName,
+  getTagDescriptions
 } from './openapi-common';
 
 const getContentLevelExample = (bodyContent) => {
@@ -908,8 +909,9 @@ export const parseOpenApiCollection = (data, options = {}) => {
     } else {
       // Default tag-based grouping
       let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
+      const tagDescriptions = getTagDescriptions(collectionData.tags, options);
       let brunoFolders = groups.map((group) => {
-        return {
+        const folder = {
           uid: uuid(),
           name: group.name,
           type: 'folder',
@@ -930,6 +932,11 @@ export const parseOpenApiCollection = (data, options = {}) => {
           },
           items: group.requests.map((req) => transformOpenapiRequestItem(req, usedNames, options))
         };
+        const docs = tagDescriptions[group.name];
+        if (docs) {
+          folder.root.docs = docs;
+        }
+        return folder;
       });
 
       let ungroupedItems = ungroupedRequests.map((req) => transformOpenapiRequestItem(req, usedNames, options));
@@ -1030,7 +1037,8 @@ export const parseOpenApiCollection = (data, options = {}) => {
       },
       meta: {
         name: brunoCollection.name
-      }
+      },
+      docs: collectionData.info?.description
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
@@ -13,7 +13,8 @@ import {
   groupRequestsByTags,
   groupRequestsByPath,
   normalizeItemName,
-  getTagDescriptions
+  getTagDescriptions,
+  toSpecString
 } from './openapi-common';
 
 /**
@@ -132,7 +133,7 @@ const transformSwaggerRequestItem = (request, usedNames = new Set(), options = {
   const produces = op.produces || request.global.produces || ['application/json'];
 
   // Determine operation name
-  let operationName = op.summary || op.operationId || op.description;
+  let operationName = op.summary || op.operationId || toSpecString(op.description);
   operationName = operationName ? normalizeItemName(operationName) : '';
   if (!operationName) operationName = `${request.method} ${request.path}`;
 
@@ -159,7 +160,7 @@ const transformSwaggerRequestItem = (request, usedNames = new Set(), options = {
     },
     tags: sanitizeTags(op.tags || [], options),
     request: {
-      docs: op.description,
+      docs: toSpecString(op.description),
       url: ensureUrl(request.global.server + path),
       method: request.method.toUpperCase(),
       auth: {
@@ -644,7 +645,7 @@ export const parseSwagger2Collection = (data, options = {}) => {
     brunoCollection.root = {
       request: { auth: collectionAuth },
       meta: { name: brunoCollection.name },
-      docs: collectionData.info?.description
+      docs: toSpecString(collectionData.info?.description)
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
+++ b/packages/bruno-converters/src/openapi/swagger2-to-bruno.js
@@ -12,7 +12,8 @@ import {
   createBrunoExample,
   groupRequestsByTags,
   groupRequestsByPath,
-  normalizeItemName
+  normalizeItemName,
+  getTagDescriptions
 } from './openapi-common';
 
 /**
@@ -612,19 +613,27 @@ export const parseSwagger2Collection = (data, options = {}) => {
     if (groupingType === 'path') {
       brunoCollection.items = groupRequestsByPath(allRequests, transformSwaggerRequestItem, options);
     } else {
-      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests);
-      let brunoFolders = groups.map((group) => ({
-        uid: uuid(),
-        name: group.name,
-        type: 'folder',
-        root: {
-          request: {
-            auth: { mode: 'inherit', basic: null, bearer: null, digest: null, apikey: null, oauth2: null }
+      let [groups, ungroupedRequests] = groupRequestsByTags(allRequests, options);
+      const tagDescriptions = getTagDescriptions(collectionData.tags, options);
+      let brunoFolders = groups.map((group) => {
+        const folder = {
+          uid: uuid(),
+          name: group.name,
+          type: 'folder',
+          root: {
+            request: {
+              auth: { mode: 'inherit', basic: null, bearer: null, digest: null, apikey: null, oauth2: null }
+            },
+            meta: { name: group.name }
           },
-          meta: { name: group.name }
-        },
-        items: group.requests.map((req) => transformSwaggerRequestItem(req, usedNames, options))
-      }));
+          items: group.requests.map((req) => transformSwaggerRequestItem(req, usedNames, options))
+        };
+        const docs = tagDescriptions[group.name];
+        if (docs) {
+          folder.root.docs = docs;
+        }
+        return folder;
+      });
 
       let ungroupedItems = ungroupedRequests.map((req) => transformSwaggerRequestItem(req, usedNames, options));
       brunoCollection.items = brunoFolders.concat(ungroupedItems);
@@ -634,7 +643,8 @@ export const parseSwagger2Collection = (data, options = {}) => {
     let collectionAuth = buildCollectionAuth(securityConfig.supported[0]);
     brunoCollection.root = {
       request: { auth: collectionAuth },
-      meta: { name: brunoCollection.name }
+      meta: { name: brunoCollection.name },
+      docs: collectionData.info?.description
     };
 
     return brunoCollection;

--- a/packages/bruno-converters/tests/common/find-items.js
+++ b/packages/bruno-converters/tests/common/find-items.js
@@ -1,0 +1,28 @@
+// Helpers to locate a request or folder by name in a converted collection.
+// Both search recursively, since imported items are often grouped into folders.
+
+export const findRequestByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'http-request' && item.name === name) {
+      return item;
+    }
+    if (item.type === 'folder' && item.items) {
+      const found = findRequestByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+export const findFolderByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'folder' && item.name === name) {
+      return item;
+    }
+    if (item.type === 'folder' && item.items) {
+      const found = findFolderByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from '@jest/globals';
+import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
+
+const findRequestByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'http-request' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findRequestByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const findFolderByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'folder' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findFolderByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const buildSpec = (overrides = {}) => ({
+  openapi: '3.0.0',
+  info: {
+    title: 'Petstore',
+    description: '# Pet Store API\n\nThis is the **collection-level** description.',
+    ...overrides.info
+  },
+  tags: overrides.tags ?? [
+    { name: 'pets', description: 'Everything about your _Pets_.' },
+    { name: 'store', description: '## Store\n\nAccess to Petstore **orders**.' }
+  ],
+  servers: [{ url: 'https://api.example.com' }],
+  paths: {
+    '/pets': {
+      get: {
+        tags: ['pets'],
+        summary: 'List pets',
+        description: 'Returns all pets.',
+        responses: { 200: { description: 'OK' } }
+      }
+    },
+    '/store/orders': {
+      post: {
+        tags: ['store'],
+        summary: 'Place order',
+        responses: { 201: { description: 'Created' } }
+      }
+    }
+  }
+});
+
+describe('OpenAPI Import - Docs (collection & folder descriptions)', () => {
+  it('populates collection Docs from info.description', () => {
+    const result = openApiToBruno(buildSpec());
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+
+  it('populates each folder Docs from the matching top-level tags[] description', () => {
+    const result = openApiToBruno(buildSpec());
+
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBe('Everything about your _Pets_.');
+
+    const storeFolder = findFolderByName(result.items, 'store');
+    expect(storeFolder.root.docs).toBe('## Store\n\nAccess to Petstore **orders**.');
+  });
+
+  it('preserves markdown formatting verbatim', () => {
+    const md = '# Title\n\n- one\n- two\n\n`code` and **bold**';
+    const result = openApiToBruno(buildSpec({ info: { description: md } }));
+    expect(result.root.docs).toBe(md);
+  });
+
+  it('matches folder docs after tag-name sanitization (spaces -> underscores)', () => {
+    const spec = buildSpec({ tags: [{ name: 'Pet Store', description: 'Pet store docs.' }] });
+    spec.paths = {
+      '/pets': {
+        get: { tags: ['Pet Store'], summary: 'List pets', responses: { 200: { description: 'OK' } } }
+      }
+    };
+    const result = openApiToBruno(spec);
+
+    const folder = findFolderByName(result.items, 'Pet_Store');
+    expect(folder).toBeDefined();
+    expect(folder.root.docs).toBe('Pet store docs.');
+  });
+
+  it('does not regress request-level Docs', () => {
+    const result = openApiToBruno(buildSpec());
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request.request.docs).toBe('Returns all pets.');
+  });
+
+  it('leaves docs unset when the spec has no info.description or tag descriptions', () => {
+    const result = openApiToBruno(
+      buildSpec({ info: { title: 'No Docs', description: undefined }, tags: [{ name: 'pets' }] })
+    );
+    expect(result.root.docs == null || result.root.docs === '').toBe(true);
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBeUndefined();
+  });
+
+  it('still sets collection docs under path-based grouping (no tag folders to describe)', () => {
+    const result = openApiToBruno(buildSpec(), { groupBy: 'path' });
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+});

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
@@ -1,27 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
-
-const findRequestByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'http-request' && item.name === name) return item;
-    if (item.type === 'folder' && item.items) {
-      const found = findRequestByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
-
-const findFolderByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'folder' && item.name === name) return item;
-    if (item.type === 'folder' && item.items) {
-      const found = findFolderByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
+import { findRequestByName, findFolderByName } from '../../common/find-items';
 
 const buildSpec = (overrides = {}) => ({
   openapi: '3.0.0',

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-docs.spec.js
@@ -105,6 +105,52 @@ describe('OpenAPI Import - Docs (collection & folder descriptions)', () => {
     expect(petsFolder.root.docs).toBeUndefined();
   });
 
+  it('imports the spec and skips docs when info.description is not a string', () => {
+    [{ en: 'A mapping, not a string' }, 42, ['a', 'b'], true].forEach((badDescription) => {
+      const result = openApiToBruno(buildSpec({ info: { description: badDescription } }));
+      expect(result.root.docs).toBe('');
+      expect(findRequestByName(result.items, 'List pets')).toBeDefined();
+    });
+  });
+
+  it('imports the spec and skips docs when a tag description is not a string', () => {
+    const result = openApiToBruno(
+      buildSpec({
+        tags: [
+          { name: 'pets', description: { en: 'A mapping, not a string' } },
+          { name: 'store', description: 'Access to Petstore orders.' }
+        ]
+      })
+    );
+
+    expect(findFolderByName(result.items, 'pets').root.docs).toBeUndefined();
+    expect(findFolderByName(result.items, 'store').root.docs).toBe('Access to Petstore orders.');
+  });
+
+  it('imports the request and skips docs when an operation description is not a string', () => {
+    const spec = buildSpec();
+    spec.paths['/pets'].get.description = { en: 'A mapping, not a string' };
+    const result = openApiToBruno(spec);
+
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request).toBeDefined();
+    expect(request.request.docs).toBe('');
+  });
+
+  it('falls back to method and path when a non-string description is the only name source', () => {
+    const spec = buildSpec();
+    spec.paths['/pets'].get = {
+      tags: ['pets'],
+      description: { en: 'A mapping, not a string' },
+      responses: { 200: { description: 'OK' } }
+    };
+    const result = openApiToBruno(spec);
+
+    const request = findRequestByName(result.items, 'get /pets');
+    expect(request).toBeDefined();
+    expect(request.request.docs).toBe('');
+  });
+
   it('still sets collection docs under path-based grouping (no tag folders to describe)', () => {
     const result = openApiToBruno(buildSpec(), { groupBy: 'path' });
     expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');

--- a/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-tags.spec.js
+++ b/packages/bruno-converters/tests/openapi/openapi-to-bruno/openapi-tags.spec.js
@@ -1,39 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import openApiToBruno from '../../../src/openapi/openapi-to-bruno';
-
-/**
- * Helper function to find a request by name in the collection.
- * Searches recursively through folders since requests with tags
- * are grouped into folders.
- */
-const findRequestByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'http-request' && item.name === name) {
-      return item;
-    }
-    if (item.type === 'folder' && item.items) {
-      const found = findRequestByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
-
-/**
- * Helper function to find a folder by name in the collection.
- */
-const findFolderByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'folder' && item.name === name) {
-      return item;
-    }
-    if (item.type === 'folder' && item.items) {
-      const found = findFolderByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
+import { findRequestByName, findFolderByName } from '../../common/find-items';
 
 describe('OpenAPI Import - Tag Sanitization', () => {
   it('should replace spaces with underscores in tags', () => {

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from '@jest/globals';
+import swagger2ToBruno from '../../../src/openapi/swagger2-to-bruno';
+
+const findRequestByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'http-request' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findRequestByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const findFolderByName = (items, name) => {
+  for (const item of items) {
+    if (item.type === 'folder' && item.name === name) return item;
+    if (item.type === 'folder' && item.items) {
+      const found = findFolderByName(item.items, name);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+const buildSpec = (overrides = {}) => ({
+  swagger: '2.0',
+  info: {
+    title: 'Petstore',
+    description: '# Pet Store API\n\nThis is the **collection-level** description.',
+    ...overrides.info
+  },
+  tags: overrides.tags ?? [
+    { name: 'pets', description: 'Everything about your _Pets_.' },
+    { name: 'store', description: '## Store\n\nAccess to Petstore **orders**.' }
+  ],
+  host: 'api.example.com',
+  basePath: '/v1',
+  schemes: ['https'],
+  paths: {
+    '/pets': {
+      get: {
+        tags: ['pets'],
+        summary: 'List pets',
+        description: 'Returns all pets.',
+        responses: { 200: { description: 'OK' } }
+      }
+    },
+    '/store/orders': {
+      post: {
+        tags: ['store'],
+        summary: 'Place order',
+        responses: { 201: { description: 'Created' } }
+      }
+    }
+  }
+});
+
+describe('Swagger 2.0 Import - Docs (collection & folder descriptions)', () => {
+  it('populates collection Docs from info.description', () => {
+    const result = swagger2ToBruno(buildSpec());
+    expect(result.root.docs).toBe('# Pet Store API\n\nThis is the **collection-level** description.');
+  });
+
+  it('populates each folder Docs from the matching top-level tags[] description', () => {
+    const result = swagger2ToBruno(buildSpec());
+
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBe('Everything about your _Pets_.');
+
+    const storeFolder = findFolderByName(result.items, 'store');
+    expect(storeFolder.root.docs).toBe('## Store\n\nAccess to Petstore **orders**.');
+  });
+
+  it('does not regress request-level Docs', () => {
+    const result = swagger2ToBruno(buildSpec());
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request.request.docs).toBe('Returns all pets.');
+  });
+
+  it('leaves docs unset when the spec has no info.description or tag descriptions', () => {
+    const result = swagger2ToBruno(
+      buildSpec({ info: { title: 'No Docs', description: undefined }, tags: [{ name: 'pets' }] })
+    );
+    expect(result.root.docs == null || result.root.docs === '').toBe(true);
+    const petsFolder = findFolderByName(result.items, 'pets');
+    expect(petsFolder.root.docs).toBeUndefined();
+  });
+});

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
@@ -86,4 +86,50 @@ describe('Swagger 2.0 Import - Docs (collection & folder descriptions)', () => {
     const petsFolder = findFolderByName(result.items, 'pets');
     expect(petsFolder.root.docs).toBeUndefined();
   });
+
+  it('imports the spec and skips docs when info.description is not a string', () => {
+    [{ en: 'A mapping, not a string' }, 42, ['a', 'b'], true].forEach((badDescription) => {
+      const result = swagger2ToBruno(buildSpec({ info: { description: badDescription } }));
+      expect(result.root.docs).toBe('');
+      expect(findRequestByName(result.items, 'List pets')).toBeDefined();
+    });
+  });
+
+  it('imports the request and skips docs when an operation description is not a string', () => {
+    const spec = buildSpec();
+    spec.paths['/pets'].get.description = { en: 'A mapping, not a string' };
+    const result = swagger2ToBruno(spec);
+
+    const request = findRequestByName(result.items, 'List pets');
+    expect(request).toBeDefined();
+    expect(request.request.docs).toBe('');
+  });
+
+  it('falls back to method and path when a non-string description is the only name source', () => {
+    const spec = buildSpec();
+    spec.paths['/pets'].get = {
+      tags: ['pets'],
+      description: { en: 'A mapping, not a string' },
+      responses: { 200: { description: 'OK' } }
+    };
+    const result = swagger2ToBruno(spec);
+
+    const request = findRequestByName(result.items, 'get /pets');
+    expect(request).toBeDefined();
+    expect(request.request.docs).toBe('');
+  });
+
+  it('imports the spec and skips docs when a tag description is not a string', () => {
+    const result = swagger2ToBruno(
+      buildSpec({
+        tags: [
+          { name: 'pets', description: { en: 'A mapping, not a string' } },
+          { name: 'store', description: 'Access to Petstore orders.' }
+        ]
+      })
+    );
+
+    expect(findFolderByName(result.items, 'pets').root.docs).toBeUndefined();
+    expect(findFolderByName(result.items, 'store').root.docs).toBe('Access to Petstore orders.');
+  });
 });

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-docs.spec.js
@@ -1,27 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import swagger2ToBruno from '../../../src/openapi/swagger2-to-bruno';
-
-const findRequestByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'http-request' && item.name === name) return item;
-    if (item.type === 'folder' && item.items) {
-      const found = findRequestByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
-
-const findFolderByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'folder' && item.name === name) return item;
-    if (item.type === 'folder' && item.items) {
-      const found = findFolderByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
+import { findRequestByName, findFolderByName } from '../../common/find-items';
 
 const buildSpec = (overrides = {}) => ({
   swagger: '2.0',

--- a/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-tags.spec.js
+++ b/packages/bruno-converters/tests/openapi/swagger2-to-bruno/swagger2-tags.spec.js
@@ -1,38 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { swagger2ToBruno } from '../../../src/openapi/swagger2-to-bruno';
-
-/**
- * Helper function to find a request by name in the collection.
- * Searches recursively through folders.
- */
-const findRequestByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'http-request' && item.name === name) {
-      return item;
-    }
-    if (item.type === 'folder' && item.items) {
-      const found = findRequestByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
-
-/**
- * Helper function to find a folder by name in the collection.
- */
-const findFolderByName = (items, name) => {
-  for (const item of items) {
-    if (item.type === 'folder' && item.name === name) {
-      return item;
-    }
-    if (item.type === 'folder' && item.items) {
-      const found = findFolderByName(item.items, name);
-      if (found) return found;
-    }
-  }
-  return undefined;
-};
+import { findRequestByName, findFolderByName } from '../../common/find-items';
 
 describe('Swagger 2.0 Import - Tag Sanitization', () => {
   it('should replace spaces with underscores in tags', () => {


### PR DESCRIPTION
### Description
REF:BRU-1429
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->

OpenAPI import only copied request-level descriptions into Docs tabs,info.description (collection) and top-level tags[].description (folders)were never read, leaving those Docs tabs empty.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
Read info.description into collection root docs and match top-level tags[] descriptions to their folders via a shared getTagDescriptions helper (keyed by sanitized tag name so it lines up with folder names).Applied to both the OpenAPI 3.x and Swagger 2.0 converters.
### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/36e2ee30-2d73-40bd-a9f6-9fbfb2877ff9" />
 | 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/c981f906-916b-472e-ac80-9f5262b38495" />
 |
| 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/41f919bb-ab15-485a-9ee5-24ce283e3e36" />
 |  
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/a13f134c-ef6c-433d-b731-4aaacbb46e03" />
|

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenAPI and Swagger imports now populate collection **docs** from the API `info.description`.
  - Tag-based folder **docs** are set from matching tag `description` values.
- **Bug Fixes**
  - Non-text documentation fields are safely ignored to avoid incorrect **docs** output.
  - Operation/derived request naming is now normalized for cleaner, consistent results.
  - Server-derived environment names are normalized to prevent filename collisions.
- **Tests**
  - Added Jest coverage for collection and tag-folder `docs` import behavior (including markdown preservation and edge cases) and reused shared recursive lookup helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->