### PR TITLE
fix(ws-replace)/add height for ws msgs to fix search overlap

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -7,6 +7,13 @@ const StyledWrapper = styled.div`
     }
   }
 
+  /* Ensure the search bar (position: absolute; top: 8px; ~66px tall with replace open)
+     never clips in a short editor that can grow freely (e.g. flex parent).
+     Fixed-height parents like SingleWSMessage handle this via onSearchBarVisibilityChange. */
+  &.search-bar-visible {
+    min-height: 90px;
+  }
+
   div.CodeMirror {
     background: ${(props) => props.theme.codemirror.bg};
     border: solid 1px ${(props) => props.theme.codemirror.border};

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -443,6 +443,12 @@ class CodeEditor extends React.Component {
 
       this.editor = null;
     }
+
+    // Notify the parent that the search bar is gone so it can reset any
+    // height reservation it made (e.g. SingleWSMessage accordion body).
+    if (this.state.searchBarVisible) {
+      this.props.onSearchBarVisibilityChange?.(false);
+    }
   }
 
   render() {
@@ -451,7 +457,7 @@ class CodeEditor extends React.Component {
     }
     return (
       <StyledWrapper
-        className={`h-full w-full flex flex-col relative graphiql-container ${this.props.readOnly ? 'read-only' : ''}`}
+        className={`h-full w-full flex flex-col relative graphiql-container ${this.props.readOnly ? 'read-only' : ''} ${this.state.searchBarVisible ? 'search-bar-visible' : ''}`}
         aria-label="Code Editor"
         data-testid={this.props.testId}
         font={this.props.font}
@@ -468,7 +474,7 @@ class CodeEditor extends React.Component {
           onClose={() => this.setState({ searchBarVisible: false })}
         />
         <div
-          className={`editor-container${this.state.searchBarVisible ? ' search-bar-visible' : ''}`}
+          className="editor-container"
           ref={(node) => { this._node = node; }}
           style={{ height: '100%', width: '100%' }}
         />

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -299,7 +299,13 @@ class CodeEditor extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
+    // Notify parent when the search bar opens or closes (e.g. so a fixed-height
+    // container like a WS message accordion can reserve enough room for the bar).
+    if (prevState.searchBarVisible !== this.state.searchBarVisible) {
+      this.props.onSearchBarVisibilityChange?.(this.state.searchBarVisible);
+    }
+
     // Ensure the changes caused by this update are not interpreted as
     // user-input changes which could otherwise result in an infinite
     // event loop.

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -54,7 +54,7 @@ export const SingleWSMessage = ({
 
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(displayName);
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isSearchBarVisible, setIsSearchBarVisible] = useState(false);
   const labelTooltipId = `ws-msg-label-${message.uid ?? index}`;
 
   // Auto-focus the name input when this is a newly created message
@@ -108,6 +108,7 @@ export const SingleWSMessage = ({
   const lineHeight = fontSize * 1.5;
 
   const HEADER_ALLOWANCE = 44;
+  const SEARCH_BAR_MIN_HEIGHT = 110;
   const maxEditorHeight = paneHeight
     ? Math.max(160, paneHeight - HEADER_ALLOWANCE)
     : Math.round((typeof window !== 'undefined' ? window.innerHeight : 900) * 0.6);
@@ -115,8 +116,9 @@ export const SingleWSMessage = ({
     const lineCount = (content || '').split('\n').length;
     const lines = lineCount + 1;
     const contentHeight = lines * lineHeight + 10;
-    return `${Math.min(contentHeight, maxEditorHeight)}px`;
-  }, [content, lineHeight, maxEditorHeight]);
+    const naturalHeight = Math.min(contentHeight, maxEditorHeight);
+    return `${isSearchBarVisible ? Math.max(naturalHeight, SEARCH_BAR_MIN_HEIGHT) : naturalHeight}px`;
+  }, [content, lineHeight, maxEditorHeight, isSearchBarVisible]);
 
   const onUpdateMessageType = (newMode) => {
     const currentMessages = [...(body.ws || [])];
@@ -257,11 +259,7 @@ export const SingleWSMessage = ({
         <div
           className="accordion-body"
           data-testid={`ws-message-body-${index}`}
-          style={{
-            height: isSearchOpen
-              ? `${Math.max(parseInt(editorHeight), 110)}px`
-              : editorHeight
-          }}
+          style={{ height: editorHeight }}
         >
           <CodeEditor
             collection={collection}
@@ -276,7 +274,7 @@ export const SingleWSMessage = ({
             enableVariableHighlighting={true}
             docKey={`${item.uid}:ws-msg:${message.uid ?? index}`}
             containScroll={true}
-            onSearchBarVisibilityChange={setIsSearchOpen}
+            onSearchBarVisibilityChange={setIsSearchBarVisible}
           />
         </div>
       )}

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -54,6 +54,7 @@ export const SingleWSMessage = ({
 
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(displayName);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
   const labelTooltipId = `ws-msg-label-${message.uid ?? index}`;
 
   // Auto-focus the name input when this is a newly created message
@@ -256,7 +257,11 @@ export const SingleWSMessage = ({
         <div
           className="accordion-body"
           data-testid={`ws-message-body-${index}`}
-          style={{ height: editorHeight }}
+          style={{
+            height: isSearchOpen
+              ? `${Math.max(parseInt(editorHeight), 110)}px`
+              : editorHeight
+          }}
         >
           <CodeEditor
             collection={collection}
@@ -271,6 +276,7 @@ export const SingleWSMessage = ({
             enableVariableHighlighting={true}
             docKey={`${item.uid}:ws-msg:${message.uid ?? index}`}
             containScroll={true}
+            onSearchBarVisibilityChange={setIsSearchOpen}
           />
         </div>
       )}

--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
@@ -166,6 +166,7 @@ const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
               enableLineWrapping={showHex ? false : true}
               font={preferences.codeFont || 'default'}
               value={showHex ? contentHexdump : parsedContent.content}
+              readOnly
             />
           </div>
         </>


### PR DESCRIPTION
### Description

BRU-2623

Related PR - https://github.com/usebruno/bruno/pull/8715

Fix `WSMessagesList` missing `readOnly` prop on the response viewer CodeEditor, and expand the WS message accordion body to fit the search bar when editor content is only 1–2 lines tall.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Problem

The WS response message viewer was missing `readOnly`, allowing users to type into received messages with changes silently dropped. When a WS message had only 1–2 lines of content, the search bar would overflow the accordion body and overlap the next message below it.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
Added `readOnly` to the `CodeEditor` in `WSMessagesList`. Added an `onSearchBarVisibilityChange` callback to `CodeEditor` (via `componentDidUpdate`) so `SingleWSMessage` can expand its accordion body height to at least 110px when the search bar is open.

Ensure the search bar (position: absolute; top: 8px; ~66px tall with replace open) never clips in a short editor that can grow freely (e.g. flex parent).
Fixed-height parents like SingleWSMessage handle this via onSearchBarVisibilityChange. 

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="567" height="155" alt="image" src="https://github.com/user-attachments/assets/a2a1a040-d1fb-4d8d-92ba-12fd03a26390" />| <img width="568" height="198" alt="image" src="https://github.com/user-attachments/assets/e49d5c60-ca72-4a86-b927-e0c3b97a0a7b" />|

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket message editor behavior by syncing search bar visibility between the editor and message container.
  * Ensured the editor container expands appropriately when the search bar is shown, avoiding clipped search controls.
  * Made WebSocket response message content/hexdump views read-only to prevent accidental edits.

* **Style**
  * Updated the editor wrapper styling with a search-bar-visible mode to maintain minimum height for reliable layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->