### PR TITLE
fix(size/L): Export/Import OpenCollection YAML drops collection and folder-level post-response variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9691,9 +9691,9 @@
       }
     },
     "node_modules/@opencollection/types": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@opencollection/types/-/types-0.10.0.tgz",
-      "integrity": "sha512-DlMSme/DRkogHwikowtIJmSrPpjSIgTsi8jPliFSuOUgjw9Kla/cmAaVYEC9tKz7WvoZ7J5UNzgC9JppIVY8bg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@opencollection/types/-/types-0.12.0.tgz",
+      "integrity": "sha512-ya41pdpUcfLDQ6uc/7MipWVcqeCW0VLYSdbOch93UH+hzolw3AZmjJQB+qUpRGqwTWE5EJ6Csv7o6E7EsehH9g==",
       "dev": true,
       "license": "MIT"
     },
@@ -35681,7 +35681,7 @@
         "@babel/core": "^7.25.2",
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-typescript": "^7.25.0",
-        "@opencollection/types": "0.10.0",
+        "@opencollection/types": "0.12.0",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -36388,7 +36388,7 @@
       "devDependencies": {
         "@babel/preset-env": "^7.22.0",
         "@babel/preset-typescript": "^7.22.0",
-        "@opencollection/types": "0.10.0",
+        "@opencollection/types": "0.12.0",
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/bruno-converters/package.json
+++ b/packages/bruno-converters/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.4",
     "@babel/preset-typescript": "^7.25.0",
-    "@opencollection/types": "0.10.0",
+    "@opencollection/types": "0.12.0",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -1,4 +1,4 @@
-import { toOpenCollectionAuth, toOpenCollectionHeaders, toOpenCollectionScripts, toOpenCollectionVariables } from "./common";
+import { toOpenCollectionActions, toOpenCollectionAuth, toOpenCollectionHeaders, toOpenCollectionScripts, toOpenCollectionVariables } from "./common";
 import { toOpenCollectionEnvironments } from "./environment";
 import { toOpenCollectionFolder } from "./folder";
 import { toOpenCollectionItems } from "./items";
@@ -78,6 +78,7 @@ const hasRequestDefaults = (root: BrunoCollectionRoot | undefined): boolean => {
   return Boolean(
     request?.headers?.length ||
     request?.vars?.req?.length ||
+    request?.vars?.res?.length ||
     request?.script?.req ||
     request?.script?.res ||
     request?.tests ||
@@ -134,6 +135,11 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
     const variables = toOpenCollectionVariables(request?.vars);
     if (variables) {
       openCollection.request.variables = variables;
+    }
+
+    const actions = toOpenCollectionActions(request?.vars?.res);
+    if (actions) {
+      openCollection.request.actions = actions;
     }
 
     const scripts = toOpenCollectionScripts(request as any);

--- a/packages/bruno-converters/src/opencollection/folder.ts
+++ b/packages/bruno-converters/src/opencollection/folder.ts
@@ -7,7 +7,9 @@ import {
   fromOpenCollectionScripts,
   toOpenCollectionScripts,
   fromOpenCollectionVariables,
-  toOpenCollectionVariables
+  fromOpenCollectionActions,
+  toOpenCollectionVariables,
+  toOpenCollectionActions
 } from './common';
 import { fromOpenCollectionItems, toOpenCollectionItems } from './items';
 import type {
@@ -39,7 +41,10 @@ export const fromOpenCollectionFolder = (folder: Folder): BrunoItem => {
         headers: fromOpenCollectionHeaders(folder.request.headers),
         auth: fromOpenCollectionAuth(folder.request.auth as Auth),
         script: scripts?.script,
-        vars: fromOpenCollectionVariables(folder.request.variables),
+        vars: {
+          ...fromOpenCollectionVariables(folder.request.variables),
+          res: fromOpenCollectionActions(folder.request.actions)
+        },
         tests: scripts?.tests
       };
     }
@@ -96,8 +101,9 @@ export const toOpenCollectionFolder = (folder: BrunoItem): Folder => {
     const auth = toOpenCollectionAuth(folderRequest.auth);
     const scripts = toOpenCollectionScripts(folderRequest as { script?: { req: string | null; res: string | null } | null; tests?: string | null });
     const variables = toOpenCollectionVariables(folderRequest.vars);
+    const actions = toOpenCollectionActions(folderRequest.vars?.res);
 
-    if (headers || auth || scripts || variables) {
+    if (headers || auth || scripts || variables || actions) {
       const request: RequestDefaults = {};
 
       if (headers) {
@@ -114,6 +120,10 @@ export const toOpenCollectionFolder = (folder: BrunoItem): Folder => {
 
       if (variables) {
         request.variables = variables;
+      }
+
+      if (actions) {
+        request.actions = actions;
       }
 
       ocFolder.request = request;

--- a/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
+++ b/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
@@ -1,6 +1,6 @@
 import { OpenCollection } from "@opencollection/types";
 import { BrunoCollection, BrunoCollectionRoot, BrunoConfig, BrunoPresets, PemCertificate, Pkcs12Certificate } from "./types";
-import { fromOpenCollectionAuth, fromOpenCollectionHeaders, fromOpenCollectionScripts, fromOpenCollectionVariables } from "./common";
+import { fromOpenCollectionActions, fromOpenCollectionAuth, fromOpenCollectionHeaders, fromOpenCollectionScripts, fromOpenCollectionVariables } from "./common";
 import { uuid } from "../common";
 import { fromOpenCollectionItems } from "./items";
 import { fromOpenCollectionFolder } from "./folder";
@@ -108,7 +108,10 @@ const fromOpenCollectionRoot = (oc: OpenCollection): BrunoCollectionRoot => {
       headers: fromOpenCollectionHeaders(oc.request.headers),
       auth: fromOpenCollectionAuth(oc.request.auth),
       script: scripts?.script,
-      vars: fromOpenCollectionVariables(oc.request.variables),
+      vars: {
+        ...fromOpenCollectionVariables(oc.request.variables),
+        res: fromOpenCollectionActions(oc.request.actions)
+      },
       tests: scripts?.tests
     };
   }

--- a/packages/bruno-converters/tests/opencollection/post-response-vars.spec.js
+++ b/packages/bruno-converters/tests/opencollection/post-response-vars.spec.js
@@ -1,0 +1,224 @@
+import { describe, it, expect } from '@jest/globals';
+import { brunoToOpenCollection } from '../../src/opencollection/bruno-to-opencollection';
+import { openCollectionToBruno } from '../../src/opencollection/opencollection-to-bruno';
+
+describe('opencollection post-response variables (actions)', () => {
+  it('round-trips collection, folder, and request pre- and post-response vars (Bruno -> OpenCollection -> Bruno)', () => {
+    const brunoCollection = {
+      uid: 'c1',
+      name: 'Vars',
+      version: '1',
+      root: {
+        request: {
+          vars: {
+            req: [{ uid: 'cr1', name: 'baseUrl', value: 'https://api.example.com', enabled: true }],
+            res: [
+              { uid: 'cp1', name: 'token', value: 'res.body.token', enabled: true, description: 'Auth token' },
+              { uid: 'cp2', name: 'userId', value: 'res.body.id', enabled: false, local: true }
+            ]
+          }
+        }
+      },
+      items: [
+        {
+          uid: 'f1',
+          type: 'folder',
+          name: 'Auth',
+          seq: 1,
+          root: {
+            request: {
+              vars: {
+                req: [{ uid: 'fr1', name: 'authPath', value: '/oauth', enabled: true }],
+                res: [{ uid: 'fp1', name: 'refresh', value: 'res.body.refresh', enabled: true }]
+              }
+            }
+          },
+          items: [
+            {
+              uid: 'r1',
+              type: 'http-request',
+              name: 'Login',
+              seq: 1,
+              request: {
+                method: 'POST',
+                url: 'https://api.example.com/login',
+                headers: [],
+                vars: {
+                  req: [{ uid: 'rr1', name: 'grant', value: 'password', enabled: true }],
+                  res: [{ uid: 'rp1', name: 'sessionId', value: 'res.body.session', enabled: true }]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const oc = brunoToOpenCollection(brunoCollection);
+
+    expect(oc.request.variables).toEqual([{ name: 'baseUrl', value: 'https://api.example.com' }]);
+    expect(oc.request.actions).toEqual([
+      {
+        type: 'set-variable',
+        phase: 'after-response',
+        selector: { expression: 'res.body.token', method: 'jsonq' },
+        variable: { name: 'token', scope: 'runtime' },
+        description: 'Auth token'
+      },
+      {
+        type: 'set-variable',
+        phase: 'after-response',
+        selector: { expression: 'res.body.id', method: 'jsonq' },
+        variable: { name: 'userId', scope: 'request' },
+        disabled: true
+      }
+    ]);
+
+    expect(oc.items[0].request.variables).toEqual([{ name: 'authPath', value: '/oauth' }]);
+    expect(oc.items[0].request.actions).toEqual([
+      {
+        type: 'set-variable',
+        phase: 'after-response',
+        selector: { expression: 'res.body.refresh', method: 'jsonq' },
+        variable: { name: 'refresh', scope: 'runtime' }
+      }
+    ]);
+
+    const back = openCollectionToBruno(oc);
+
+    expect(back.root.request.vars.req[0]).toMatchObject({ name: 'baseUrl', value: 'https://api.example.com' });
+    expect(back.root.request.vars.res).toHaveLength(2);
+    expect(back.root.request.vars.res[0]).toMatchObject({
+      name: 'token',
+      value: 'res.body.token',
+      enabled: true,
+      local: false,
+      description: 'Auth token'
+    });
+    expect(back.root.request.vars.res[1]).toMatchObject({
+      name: 'userId',
+      value: 'res.body.id',
+      enabled: false,
+      local: true
+    });
+
+    const folder = back.items[0];
+    expect(folder.root.request.vars.req[0]).toMatchObject({ name: 'authPath', value: '/oauth' });
+    expect(folder.root.request.vars.res).toHaveLength(1);
+    expect(folder.root.request.vars.res[0]).toMatchObject({ name: 'refresh', value: 'res.body.refresh', enabled: true });
+
+    const request = folder.items[0];
+    expect(request.request.vars.req[0]).toMatchObject({ name: 'grant', value: 'password' });
+    expect(request.request.vars.res).toHaveLength(1);
+    expect(request.request.vars.res[0]).toMatchObject({ name: 'sessionId', value: 'res.body.session', enabled: true });
+  });
+
+  it('emits the request block when a root has only post-response vars (no pre-request vars/headers/auth/scripts)', () => {
+    const brunoCollection = {
+      uid: 'c2',
+      name: 'OnlyRes',
+      version: '1',
+      root: {
+        request: {
+          vars: {
+            req: [],
+            res: [{ uid: 'cp1', name: 'token', value: 'res.body.token', enabled: true }]
+          }
+        }
+      },
+      items: [
+        {
+          uid: 'f2',
+          type: 'folder',
+          name: 'F',
+          seq: 1,
+          root: {
+            request: {
+              vars: {
+                req: [],
+                res: [{ uid: 'fp1', name: 'fv', value: 'res.body.fv', enabled: true }]
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const oc = brunoToOpenCollection(brunoCollection);
+
+    expect(oc.request).toBeDefined();
+    expect(oc.request.actions).toHaveLength(1);
+    expect(oc.request.variables).toBeUndefined();
+
+    expect(oc.items[0].request).toBeDefined();
+    expect(oc.items[0].request.actions).toHaveLength(1);
+    expect(oc.items[0].request.variables).toBeUndefined();
+
+    const back = openCollectionToBruno(oc);
+
+    expect(back.root.request.vars.res).toHaveLength(1);
+    expect(back.root.request.vars.res[0]).toMatchObject({ name: 'token', value: 'res.body.token', enabled: true });
+    expect(back.items[0].root.request.vars.res).toHaveLength(1);
+    expect(back.items[0].root.request.vars.res[0]).toMatchObject({ name: 'fv', value: 'res.body.fv', enabled: true });
+  });
+
+  it('restores post-response vars from actions and re-exports them (OpenCollection -> Bruno -> OpenCollection)', () => {
+    const openCollection = {
+      opencollection: '1.0.0',
+      info: { name: 'OC' },
+      request: {
+        actions: [
+          {
+            type: 'set-variable',
+            phase: 'after-response',
+            selector: { expression: 'res.body.token', method: 'jsonq' },
+            variable: { name: 'token', scope: 'runtime' }
+          }
+        ]
+      },
+      items: [
+        {
+          info: { name: 'F', type: 'folder' },
+          request: {
+            actions: [
+              {
+                type: 'set-variable',
+                phase: 'after-response',
+                selector: { expression: 'res.body.fv', method: 'jsonq' },
+                variable: { name: 'fv', scope: 'request' },
+                disabled: true
+              }
+            ]
+          }
+        }
+      ]
+    };
+
+    const bruno = openCollectionToBruno(openCollection);
+
+    expect(bruno.root.request.vars.res).toHaveLength(1);
+    expect(bruno.root.request.vars.res[0]).toMatchObject({ name: 'token', value: 'res.body.token', enabled: true, local: false });
+    expect(bruno.items[0].root.request.vars.res).toHaveLength(1);
+    expect(bruno.items[0].root.request.vars.res[0]).toMatchObject({ name: 'fv', value: 'res.body.fv', enabled: false, local: true });
+
+    const backOC = brunoToOpenCollection(bruno);
+
+    expect(backOC.request.actions).toEqual([
+      {
+        type: 'set-variable',
+        phase: 'after-response',
+        selector: { expression: 'res.body.token', method: 'jsonq' },
+        variable: { name: 'token', scope: 'runtime' }
+      }
+    ]);
+    expect(backOC.items[0].request.actions).toEqual([
+      {
+        type: 'set-variable',
+        phase: 'after-response',
+        selector: { expression: 'res.body.fv', method: 'jsonq' },
+        variable: { name: 'fv', scope: 'request' },
+        disabled: true
+      }
+    ]);
+  });
+});

--- a/packages/bruno-filestore/package.json
+++ b/packages/bruno-filestore/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^29.5.11",
     "@types/lodash": "^4.14.191",
     "@types/node": "^24.1.0",
-    "@opencollection/types": "0.10.0",
+    "@opencollection/types": "0.12.0",
     "@usebruno/schema-types": "0.0.1",
     "babel-jest": "^29.7.0",
     "jest": "^29.2.0",


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
Ref: BRU-4001

Problem: When converting a collection to/from OpenCollection YAML via @usebruno/converters — the app's Export Collection to .yml and Generate Documentation flows — post-response variables (vars.res) defined at the collection root and folder roots were silently dropped. The root and folder mappers wrote pre-request vars to request.variables but never mapped post-response vars to request.actions, import never read actions back, and hasRequestDefaults ignored vars.res (so a root whose only customization was a post-response var lost its entire request block). Request- and item-level vars were unaffected, and the on-disk .bru↔.yml path (@usebruno/filestore) was already correct — the defect was specific to the converters path at the collection and folder roots.

Fix: Wire the existing toOpenCollectionActions/fromOpenCollectionActions helpers (already used by request items) into the collection root (bruno-to-opencollection.ts / opencollection-to-bruno.ts) and folder root (folder.ts) in both directions, add vars.res to the hasRequestDefaults guard and the folder-export condition so request.actions is emitted even when post-response vars are the only customization, and bump @opencollection/types to 0.12.0 (which declares RequestDefaults.actions). A new round-trip test covers pre- and post-response vars at the collection, folder, and request levels, and the full opencollection suite passes 

<img width="2422" height="1518" alt="image" src="https://github.com/user-attachments/assets/d01bdc6b-fd90-4d53-a469-83f12aa00fba" />

<img width="3114" height="1140" alt="image" src="https://github.com/user-attachments/assets/a19ed482-5f00-4547-a517-23fd2d64eafd" />


| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting post-response variables between Bruno and OpenCollection formats.
  * Preserved variable expressions, scopes, enabled/disabled states, and local settings during conversion.
  * Supported post-response actions at collection, folder, and request levels.

* **Bug Fixes**
  * Ensured request sections are generated when post-response variables are present.

* **Tests**
  * Added coverage for post-response variable and action conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->