### PR TITLE
feat(presets)/updated the requests to use segmented control

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Presets/constants.jsx
+++ b/packages/bruno-app/src/components/CollectionSettings/Presets/constants.jsx
@@ -1,30 +1,30 @@
 import React from 'react';
-import { IconWorld, IconBolt, IconCirclesRelation, IconPlugConnected } from '@tabler/icons';
+import { IconApi, IconBrandGraphql, IconCode, IconPlugConnected } from '@tabler/icons';
 import { PRESET_REQUEST_TYPES } from 'utils/common/constants';
 
 export const requestTypeItems = [
   {
     'value': PRESET_REQUEST_TYPES.HTTP,
     'label': 'HTTP',
-    'icon': <IconWorld size={15} strokeWidth={1.5} />,
+    'icon': <IconApi size={18} strokeWidth={1.5} />,
     'data-testid': 'presets-request-type-http'
   },
   {
     'value': PRESET_REQUEST_TYPES.GRAPHQL,
     'label': 'GraphQL',
-    'icon': <IconBolt size={15} strokeWidth={1.5} />,
+    'icon': <IconBrandGraphql size={16} strokeWidth={1.5} />,
     'data-testid': 'presets-request-type-graphql'
   },
   {
     'value': PRESET_REQUEST_TYPES.GRPC,
     'label': 'gRPC',
-    'icon': <IconCirclesRelation size={15} strokeWidth={1.5} />,
+    'icon': <IconCode size={16} strokeWidth={1.5} />,
     'data-testid': 'presets-request-type-grpc'
   },
   {
     'value': PRESET_REQUEST_TYPES.WS,
     'label': 'WebSocket',
-    'icon': <IconPlugConnected size={15} strokeWidth={1.5} />,
+    'icon': <IconPlugConnected size={16} strokeWidth={1.5} />,
     'data-testid': 'presets-request-type-ws'
   }
 ];

--- a/packages/bruno-app/src/components/CollectionSettings/Presets/constants.jsx
+++ b/packages/bruno-app/src/components/CollectionSettings/Presets/constants.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { IconWorld, IconBolt, IconCirclesRelation, IconPlugConnected } from '@tabler/icons';
+import { PRESET_REQUEST_TYPES } from 'utils/common/constants';
+
+export const requestTypeItems = [
+  {
+    'value': PRESET_REQUEST_TYPES.HTTP,
+    'label': 'HTTP',
+    'icon': <IconWorld size={15} strokeWidth={1.5} />,
+    'data-testid': 'presets-request-type-http'
+  },
+  {
+    'value': PRESET_REQUEST_TYPES.GRAPHQL,
+    'label': 'GraphQL',
+    'icon': <IconBolt size={15} strokeWidth={1.5} />,
+    'data-testid': 'presets-request-type-graphql'
+  },
+  {
+    'value': PRESET_REQUEST_TYPES.GRPC,
+    'label': 'gRPC',
+    'icon': <IconCirclesRelation size={15} strokeWidth={1.5} />,
+    'data-testid': 'presets-request-type-grpc'
+  },
+  {
+    'value': PRESET_REQUEST_TYPES.WS,
+    'label': 'WebSocket',
+    'icon': <IconPlugConnected size={15} strokeWidth={1.5} />,
+    'data-testid': 'presets-request-type-ws'
+  }
+];

--- a/packages/bruno-app/src/components/CollectionSettings/Presets/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Presets/index.js
@@ -7,8 +7,10 @@ import { get } from 'lodash';
 import Button from 'ui/Button';
 import Dropdown from 'components/Dropdown';
 import Help from 'components/Help';
+import SegmentedControl from 'ui/SegmentedControl';
 import { IconCaretDown, IconFilePlus, IconWorld } from '@tabler/icons';
-import { DEFAULT_PRESET_REQUEST_TYPE, PRESET_REQUEST_TYPES } from 'utils/common/constants';
+import { DEFAULT_PRESET_REQUEST_TYPE } from 'utils/common/constants';
+import { requestTypeItems } from './constants';
 
 const PresetsSettings = ({ collection }) => {
   const dispatch = useDispatch();
@@ -55,8 +57,8 @@ const PresetsSettings = ({ collection }) => {
 
   const handleSave = () => dispatch(saveCollectionSettings(collection.uid));
 
-  const handleRequestTypeChange = (e) => {
-    updatePresets({ requestType: e.target.value });
+  const handleRequestTypeChange = (value) => {
+    updatePresets({ requestType: value });
   };
 
   const handleRequestUrlChange = (e) => {
@@ -84,55 +86,13 @@ const PresetsSettings = ({ collection }) => {
                   New requests start with this type selected.
                 </Help>
               </div>
-              <div className="flex items-center">
-                <input
-                  id="http"
-                  data-testid="presets-request-type-http"
-                  className="cursor-pointer"
-                  type="radio"
-                  name="requestType"
-                  onChange={handleRequestTypeChange}
-                  value={PRESET_REQUEST_TYPES.HTTP}
-                  checked={requestType === PRESET_REQUEST_TYPES.HTTP}
-                />
-                <label htmlFor="http" className="ml-1 cursor-pointer select-none">HTTP</label>
-
-                <input
-                  id="graphql"
-                  data-testid="presets-request-type-graphql"
-                  className="ml-4 cursor-pointer"
-                  type="radio"
-                  name="requestType"
-                  onChange={handleRequestTypeChange}
-                  value={PRESET_REQUEST_TYPES.GRAPHQL}
-                  checked={requestType === PRESET_REQUEST_TYPES.GRAPHQL}
-                />
-                <label htmlFor="graphql" className="ml-1 cursor-pointer select-none">GraphQL</label>
-
-                <input
-                  id="grpc"
-                  data-testid="presets-request-type-grpc"
-                  className="ml-4 cursor-pointer"
-                  type="radio"
-                  name="requestType"
-                  onChange={handleRequestTypeChange}
-                  value={PRESET_REQUEST_TYPES.GRPC}
-                  checked={requestType === PRESET_REQUEST_TYPES.GRPC}
-                />
-                <label htmlFor="grpc" className="ml-1 cursor-pointer select-none">gRPC</label>
-
-                <input
-                  id="ws"
-                  data-testid="presets-request-type-ws"
-                  className="ml-4 cursor-pointer"
-                  type="radio"
-                  name="requestType"
-                  onChange={handleRequestTypeChange}
-                  value={PRESET_REQUEST_TYPES.WS}
-                  checked={requestType === PRESET_REQUEST_TYPES.WS}
-                />
-                <label htmlFor="ws" className="ml-1 cursor-pointer select-none">WebSocket</label>
-              </div>
+              <SegmentedControl
+                ariaLabel="Request Type"
+                name="requestType"
+                value={requestType}
+                onChange={handleRequestTypeChange}
+                items={requestTypeItems}
+              />
             </div>
 
             <div className="preset-field">


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Used Segmented control instead of input radios in presets requests.
BRU-2528

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="574" height="464" alt="image" src="https://github.com/user-attachments/assets/d4675ddb-7eab-4627-b6c5-8cae76f8a05e" />| <img width="531" height="409" alt="image" src="https://github.com/user-attachments/assets/8f2aa36b-0b07-415f-8def-890a64234656" />|

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the Request Type selector in collection presets to use a streamlined segmented control.
  * Refreshed the visual icons and sizing for HTTP, GraphQL, and gRPC request types.
  * Improved request type selection handling to work directly with the chosen segment value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->