### PR TITLE
Fix: Description missing for the import export yml for the environments

### DIFF
--- a/packages/bruno-converters/src/opencollection/environment.ts
+++ b/packages/bruno-converters/src/opencollection/environment.ts
@@ -44,9 +44,11 @@ export const fromOpenCollectionEnvironments = (environments: Environment[] | und
       if (isSecret) {
         // Secret values are not present in the source; never carry a dataType.
         if (variable.description) {
-          result.description = typeof variable.description === 'string'
-            ? variable.description
-            : (variable.description as { content?: string })?.content || '';
+          result.description = 
+          	typeof variable.description === 'string'
+            	? variable.description
+	            : (variable.description as { content?: string })?.content || '';
+	      
         }
         return result;
       }

--- a/packages/bruno-converters/src/opencollection/environment.ts
+++ b/packages/bruno-converters/src/opencollection/environment.ts
@@ -43,6 +43,11 @@ export const fromOpenCollectionEnvironments = (environments: Environment[] | und
 
       if (isSecret) {
         // Secret values are not present in the source; never carry a dataType.
+        if (variable.description) {
+          result.description = typeof variable.description === 'string'
+            ? variable.description
+            : (variable.description as { content?: string })?.content || '';
+        }
         return result;
       }
 
@@ -90,6 +95,10 @@ export const toOpenCollectionEnvironments = (environments: BrunoEnvironment[] | 
 
         if (v.enabled === false) {
           ocVar.disabled = true;
+        }
+
+        if (v.description && typeof v.description === 'string' && v.description.trim().length) {
+          ocVar.description = v.description;
         }
 
         return ocVar;

--- a/packages/bruno-converters/tests/opencollection/environment.spec.js
+++ b/packages/bruno-converters/tests/opencollection/environment.spec.js
@@ -94,3 +94,46 @@ describe('OpenCollection environment round-trip', () => {
     expect(out).toEqual(ocEnvs);
   });
 });
+
+describe('toOpenCollectionEnvironments — exports environment variable descriptions', () => {
+  it('exports the description for both plain and secret variables, and skips it when empty or only whitespace', () => {
+    const envs = [
+      {
+        uid: 'e1',
+        name: 'staging',
+        variables: [
+          { uid: 'v1', name: 'baseUrl', value: 'https://api.example.com', type: 'text', enabled: true, secret: false, description: 'Base API URL' },
+          { uid: 'v2', name: 'apiKey', value: '', type: 'text', enabled: true, secret: true, description: 'Secret auth key' },
+          { uid: 'v3', name: 'plain', value: 'v', type: 'text', enabled: true, secret: false },
+          { uid: 'v4', name: 'ws', value: 'v', type: 'text', enabled: true, secret: false, description: '   ' }
+        ],
+        color: null
+      }
+    ];
+
+    const [env] = toOpenCollectionEnvironments(envs);
+
+    expect(env.variables[0]).toMatchObject({ name: 'baseUrl', value: 'https://api.example.com', description: 'Base API URL' });
+    expect(env.variables[1]).toMatchObject({ name: 'apiKey', secret: true, description: 'Secret auth key' });
+    expect(env.variables[2]).not.toHaveProperty('description');
+    expect(env.variables[3]).not.toHaveProperty('description');
+  });
+});
+
+describe('OpenCollection environment round-trip — variable descriptions', () => {
+  it('keeps plain and secret variable descriptions when converting OpenCollection to Bruno and back', () => {
+    const ocEnvs = [
+      {
+        name: 'staging',
+        color: undefined,
+        variables: [
+          { name: 'baseUrl', value: 'https://api.example.com', description: 'Base API URL' },
+          { name: 'apiKey', secret: true, description: 'Secret auth key' }
+        ]
+      }
+    ];
+
+    const out = toOpenCollectionEnvironments(fromOpenCollectionEnvironments(ocEnvs));
+    expect(out).toEqual(ocEnvs);
+  });
+});

--- a/packages/bruno-converters/tests/opencollection/environment.spec.js
+++ b/packages/bruno-converters/tests/opencollection/environment.spec.js
@@ -105,7 +105,9 @@ describe('toOpenCollectionEnvironments — exports environment variable descript
           { uid: 'v1', name: 'baseUrl', value: 'https://api.example.com', type: 'text', enabled: true, secret: false, description: 'Base API URL' },
           { uid: 'v2', name: 'apiKey', value: '', type: 'text', enabled: true, secret: true, description: 'Secret auth key' },
           { uid: 'v3', name: 'plain', value: 'v', type: 'text', enabled: true, secret: false },
-          { uid: 'v4', name: 'ws', value: 'v', type: 'text', enabled: true, secret: false, description: '   ' }
+          { uid: 'v4', name: 'ws', value: 'v', type: 'text', enabled: true, secret: false, description: '   ' },
+          { uid: 'v5', name: 'port', value: 8080, type: 'text', enabled: true, secret: false, dataType: 'number', description: 'Server port' },
+          { uid: 'v6', name: 'config', value: { region: 'us' }, type: 'text', enabled: true, secret: false, dataType: 'object', description: 'Service config' }
         ],
         color: null
       }
@@ -117,6 +119,8 @@ describe('toOpenCollectionEnvironments — exports environment variable descript
     expect(env.variables[1]).toMatchObject({ name: 'apiKey', secret: true, description: 'Secret auth key' });
     expect(env.variables[2]).not.toHaveProperty('description');
     expect(env.variables[3]).not.toHaveProperty('description');
+    expect(env.variables[4]).toMatchObject({ name: 'port', value: { type: 'number', data: '8080' }, description: 'Server port' });
+    expect(env.variables[5]).toMatchObject({ name: 'config', value: { type: 'object', data: '{\n  "region": "us"\n}' }, description: 'Service config' });
   });
 });
 


### PR DESCRIPTION
Ref: BRU-4073

### Description

Problem: Environment variable descriptions were dropped when exporting/sharing a collection as .yml or generating docs, because the converter's toOpenCollectionEnvironments never wrote the description field (its import side also skipped it for secret variables). The normal on-disk save was fine — only the @usebruno/converters export path lost it.

Fix: toOpenCollectionEnvironments now writes description for plain, secret, and typed variables (omitting empty/whitespace, matching the sibling mappers), and the import side reads it for secret variables too so descriptions round-trip. Applied to both bruno and bruno-enterprise-edition with new export + round-trip tests.

### Screenshots

<img width="2724" height="1274" alt="image" src="https://github.com/user-attachments/assets/bdfedf05-8162-460b-8296-e9690c951613" />

<img width="1812" height="1176" alt="image" src="https://github.com/user-attachments/assets/4ce5c9d6-baf0-45a8-8a4f-b9ee97b71feb" />


| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved environment variable `description` when converting between OpenCollection and Bruno formats, including secret variables.
  * Export now omits `description` when it’s missing or only whitespace.
* **Tests**
  * Added Jest coverage for `description` handling, including typed variables and a full round-trip conversion check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->