### PR TITLE
fix: persist additional request values in preferences general tab save

### DIFF
--- a/packages/bruno-app/src/components/Preferences/General/index.js
+++ b/packages/bruno-app/src/components/Preferences/General/index.js
@@ -101,6 +101,7 @@ const General = () => {
       savePreferences({
         ...preferences,
         request: {
+          ...preferences.request,
           sslVerification: newPreferences.sslVerification,
           customCaCertificate: {
             enabled: newPreferences.customCaCertificate.enabled,


### PR DESCRIPTION
### Description

The Preferences general tab currently only saves the values present in the tab to the electron store. currently client certificates are dropped on autosave in general tab. This PR also solves any new attributes added to the request object from dropped.

### Problem

Keys apart from general tab are dropped on General Save

### Fix

Added a spread on request key, on General save, so other values are persisted.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing request preferences when saving General settings, preventing unrelated request options from being unintentionally reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->