### PR TITLE
test: fix the draft indicator tests for collection client certs

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/ClientCertSettings/index.js
@@ -45,7 +45,7 @@ const CertFileInput = ({ label, name, value, inputRef, onSelect, onClear, error,
         ref={inputRef}
       />
       {value ? (
-        <div className="file-chip">
+        <div className="file-chip" data-testid={`file-chip-${name}`}>
           <IconFile size={14} strokeWidth={1.5} className="flex-shrink-0" />
           <span className="truncate max-w-[260px]" title={value}>
             {path.basename(value)}
@@ -60,6 +60,7 @@ const CertFileInput = ({ label, name, value, inputRef, onSelect, onClear, error,
           variant="outline"
           icon={<IconUpload size={13} strokeWidth={1.5} />}
           onClick={() => inputRef.current?.click()}
+          data-testid={`choose-file-${name}`}
         >
           Choose file
         </Button>

--- a/packages/bruno-app/src/components/Preferences/ClientCertSettings/index.js
+++ b/packages/bruno-app/src/components/Preferences/ClientCertSettings/index.js
@@ -41,7 +41,7 @@ const CertFileInput = ({ label, name, value, inputRef, onSelect, onClear, error,
         ref={inputRef}
       />
       {value ? (
-        <div className="file-chip">
+        <div className="file-chip" data-testid={`file-chip-${name}`}>
           <IconFile size={14} strokeWidth={1.5} className="flex-shrink-0" />
           <span className="truncate max-w-[260px]" title={value}>
             {path.basename(value)}
@@ -56,6 +56,7 @@ const CertFileInput = ({ label, name, value, inputRef, onSelect, onClear, error,
           variant="outline"
           icon={<IconUpload size={13} strokeWidth={1.5} />}
           onClick={() => inputRef.current?.click()}
+          data-testid={`choose-file-${name}`}
         >
           Choose file
         </Button>

--- a/tests/collection/draft/draft-indicator.spec.ts
+++ b/tests/collection/draft/draft-indicator.spec.ts
@@ -128,8 +128,8 @@ test.describe.serial('Draft indicator in collection and folder settings', () => 
     await addCertModal.locator('#domain').fill('test.com');
 
     // The file inputs are hidden; the visible "Choose file" button next to each one opens the picker
-    const chooseFileButton = (inputId: string) =>
-      addCertModal.locator(`div:has(> input#${inputId})`).getByRole('button', { name: 'Choose file' });
+    const chooseFileButton = (field: string) => addCertModal.getByTestId(`choose-file-${field}`);
+    const fileChip = (field: string) => addCertModal.getByTestId(`file-chip-${field}`);
 
     // Select cert file using file picker (using grpcbin.proto as a dummy file)
     const certFileChooserPromise = page.waitForEvent('filechooser');
@@ -144,7 +144,8 @@ test.describe.serial('Draft indicator in collection and folder settings', () => 
     await keyFileChooser.setFiles('./tests/collection/draft/fixtures/grpcbin.proto');
 
     // Both file paths must land in the form before submitting, else validation blocks the add
-    await expect(addCertModal.locator('.file-chip').filter({ hasText: 'grpcbin.proto' })).toHaveCount(2);
+    await expect(fileChip('certFilePath')).toHaveText(/grpcbin\.proto/);
+    await expect(fileChip('keyFilePath')).toHaveText(/grpcbin\.proto/);
 
     // Add the certificate
     await page.getByTestId('add-client-cert-modal-submit-btn').click();

--- a/tests/collection/draft/draft-indicator.spec.ts
+++ b/tests/collection/draft/draft-indicator.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, createCollection } from '../../utils/page';
+import { buildCommonLocators, closeAllCollections, createCollection } from '../../utils/page';
 
 test.describe.serial('Draft indicator in collection and folder settings', () => {
   test.afterAll(async ({ page }) => {
@@ -117,7 +117,7 @@ test.describe.serial('Draft indicator in collection and folder settings', () => 
     await expect(collectionTab.locator('.has-changes-icon')).not.toBeVisible();
 
     // Click on Client Certificates tab
-    await page.getByTestId('collection-settings-tab-clientCert').click();
+    await buildCommonLocators(page).paneTabs.collectionSettingsTab('clientCert').click();
 
     // Open the add certificate modal
     await page.getByTestId('add-client-cert').click();

--- a/tests/collection/draft/draft-indicator.spec.ts
+++ b/tests/collection/draft/draft-indicator.spec.ts
@@ -117,32 +117,46 @@ test.describe.serial('Draft indicator in collection and folder settings', () => 
     await expect(collectionTab.locator('.has-changes-icon')).not.toBeVisible();
 
     // Click on Client Certificates tab
-    await page.locator('.tab.clientCert').click();
+    await page.getByTestId('collection-settings-tab-clientCert').click();
+
+    // Open the add certificate modal
+    await page.getByTestId('add-client-cert').click();
+    const addCertModal = page.getByTestId('add-client-cert-modal');
+    await expect(addCertModal).toBeVisible();
 
     // Fill domain
-    await page.locator('#domain').fill('test.com');
+    await addCertModal.locator('#domain').fill('test.com');
+
+    // The file inputs are hidden; the visible "Choose file" button next to each one opens the picker
+    const chooseFileButton = (inputId: string) =>
+      addCertModal.locator(`div:has(> input#${inputId})`).getByRole('button', { name: 'Choose file' });
 
     // Select cert file using file picker (using grpcbin.proto as a dummy file)
     const certFileChooserPromise = page.waitForEvent('filechooser');
-    await page.locator('input#certFilePath[type="file"]').click();
+    await chooseFileButton('certFilePath').click();
     const certFileChooser = await certFileChooserPromise;
     await certFileChooser.setFiles('./tests/collection/draft/fixtures/grpcbin.proto');
 
     // Select key file using file picker (using grpcbin.proto as a dummy file)
     const keyFileChooserPromise = page.waitForEvent('filechooser');
-    await page.locator('input#keyFilePath[type="file"]').click();
+    await chooseFileButton('keyFilePath').click();
     const keyFileChooser = await keyFileChooserPromise;
     await keyFileChooser.setFiles('./tests/collection/draft/fixtures/grpcbin.proto');
 
-    // Click Add button
-    await page.getByTestId('add-client-cert').click();
+    // Both file paths must land in the form before submitting, else validation blocks the add
+    await expect(addCertModal.locator('.file-chip').filter({ hasText: 'grpcbin.proto' })).toHaveCount(2);
+
+    // Add the certificate
+    await page.getByTestId('add-client-cert-modal-submit-btn').click();
+    await expect(addCertModal).not.toBeVisible();
+    await expect(page.locator('.listgroup-item').filter({ hasText: 'test.com' })).toBeVisible();
 
     // Verify draft indicator appears
     await expect(collectionTab.locator('.has-changes-icon')).toBeVisible();
     await expect(collectionTab.locator('.close-icon')).not.toBeVisible();
 
     // Save the changes
-    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByTestId('client-cert-save-btn').click();
 
     // Verify draft indicator is gone after saving
     await expect(collectionTab.locator('.close-icon')).toBeVisible();


### PR DESCRIPTION
### Description

The Draft indicator tests now has the revamped client certs UI components.

### Problem

The test cases were trying for the old UI components

### Fix

Add testIds for necessary fields and added new assertions as per convention and verified the draft indicator flow.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for client certificate configuration, including file selection, certificate creation, draft indicators, and saving.
  * Added stable UI test selectors for certificate file controls and selected-file displays, including dedicated selectors for the “choose file” button and the selected-file chip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->