### PR TITLE
fix(app): prevent runtime variables from leaking across environments

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -552,9 +552,11 @@ export const collectionsSlice = createSlice({
       }
     },
     runtimeVariablesUpdateEvent: (state, action) => {
-      const { collectionUid, runtimeVariables } = action.payload;
+      const { collectionUid, environmentUid, runtimeVariables } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
-      if (collection) {
+      const activeEnvironmentUid = collection?.activeEnvironmentUid || null;
+
+      if (collection && activeEnvironmentUid === (environmentUid || null)) {
         collection.runtimeVariables = runtimeVariables;
       }
     },

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -62,6 +62,16 @@ const deriveCollectionFormat = (brunoConfig) => {
   return brunoConfig?.opencollection ? 'yml' : brunoConfig?.format || 'bru';
 };
 
+const setActiveEnvironment = (collection, environmentUid) => {
+  const previousEnvironmentUid = collection.activeEnvironmentUid || null;
+  const nextEnvironmentUid = environmentUid || null;
+
+  collection.activeEnvironmentUid = nextEnvironmentUid;
+  if (previousEnvironmentUid !== nextEnvironmentUid) {
+    collection.runtimeVariables = {};
+  }
+};
+
 const mergeTreeItems = (existingItems, newItems) => {
   if (!Array.isArray(existingItems) || existingItems.length === 0) return newItems;
   const existingByUid = new Map();
@@ -407,21 +417,14 @@ export const collectionsSlice = createSlice({
       const collection = findCollectionByUid(state.collections, collectionUid);
 
       if (collection) {
-        const previousEnvironmentUid = collection.activeEnvironmentUid || null;
-
         if (environmentUid) {
           const environment = findEnvironmentInCollection(collection, environmentUid);
 
           if (environment) {
-            collection.activeEnvironmentUid = environmentUid;
+            setActiveEnvironment(collection, environmentUid);
           }
         } else {
-          collection.activeEnvironmentUid = null;
-        }
-
-        const activeEnvironmentUid = collection.activeEnvironmentUid || null;
-        if (previousEnvironmentUid !== activeEnvironmentUid) {
-          collection.runtimeVariables = {};
+          setActiveEnvironment(collection, null);
         }
 
         // Any explicit selection (including "No Environment") cancels a pending default
@@ -439,7 +442,7 @@ export const collectionsSlice = createSlice({
 
       const environment = (collection.environments || []).find((env) => env?.name === defaultEnvironmentName);
       if (environment) {
-        collection.activeEnvironmentUid = environment.uid;
+        setActiveEnvironment(collection, environment.uid);
         collection.pendingDefaultEnvironment = null;
       } else {
         // Environment files aren't loaded yet - remember to apply the default once the
@@ -3131,7 +3134,7 @@ export const collectionsSlice = createSlice({
           if (lastAction && lastAction.type === 'ADD_ENVIRONMENT') {
             collection.lastAction = null;
             if (lastAction.payload === environment.name) {
-              collection.activeEnvironmentUid = environment.uid;
+              setActiveEnvironment(collection, environment.uid);
             }
           }
         }
@@ -3143,7 +3146,7 @@ export const collectionsSlice = createSlice({
           && !collection.activeEnvironmentUid
           && environment.name === collection.pendingDefaultEnvironment
         ) {
-          collection.activeEnvironmentUid = environment.uid;
+          setActiveEnvironment(collection, environment.uid);
           collection.pendingDefaultEnvironment = null;
         }
       }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -407,6 +407,8 @@ export const collectionsSlice = createSlice({
       const collection = findCollectionByUid(state.collections, collectionUid);
 
       if (collection) {
+        const previousEnvironmentUid = collection.activeEnvironmentUid || null;
+
         if (environmentUid) {
           const environment = findEnvironmentInCollection(collection, environmentUid);
 
@@ -416,6 +418,12 @@ export const collectionsSlice = createSlice({
         } else {
           collection.activeEnvironmentUid = null;
         }
+
+        const activeEnvironmentUid = collection.activeEnvironmentUid || null;
+        if (previousEnvironmentUid !== activeEnvironmentUid) {
+          collection.runtimeVariables = {};
+        }
+
         // Any explicit selection (including "No Environment") cancels a pending default
         // so a late-loading environment file can't re-apply the default over this choice.
         collection.pendingDefaultEnvironment = null;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
@@ -5,6 +5,7 @@ const {
   setFolderVars,
   setCollectionVars,
   selectEnvironment,
+  runtimeVariablesUpdateEvent,
   updateFile,
   wsResponseReceived
 } = collectionsSlice.actions;
@@ -77,6 +78,40 @@ describe('selectEnvironment — isolates runtime variables by environment', () =
 
     expect(next.collections[0].activeEnvironmentUid).toBeNull();
     expect(next.collections[0].runtimeVariables).toEqual({});
+  });
+
+  it('ignores runtime variable updates from the previously active environment', () => {
+    const switchedState = reducer(
+      makeState(),
+      selectEnvironment({ collectionUid: 'col1', environmentUid: 'env-b' })
+    );
+    const next = reducer(
+      switchedState,
+      runtimeVariablesUpdateEvent({
+        collectionUid: 'col1',
+        environmentUid: 'env-a',
+        runtimeVariables: { title: 'stale-runtime-value' }
+      })
+    );
+
+    expect(next.collections[0].runtimeVariables).toEqual({});
+  });
+
+  it('applies runtime variable updates from the active environment', () => {
+    const switchedState = reducer(
+      makeState(),
+      selectEnvironment({ collectionUid: 'col1', environmentUid: 'env-b' })
+    );
+    const next = reducer(
+      switchedState,
+      runtimeVariablesUpdateEvent({
+        collectionUid: 'col1',
+        environmentUid: 'env-b',
+        runtimeVariables: { title: 'current-runtime-value' }
+      })
+    );
+
+    expect(next.collections[0].runtimeVariables).toEqual({ title: 'current-runtime-value' });
   });
 });
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
@@ -5,7 +5,9 @@ const {
   setFolderVars,
   setCollectionVars,
   selectEnvironment,
+  applyDefaultEnvironment,
   runtimeVariablesUpdateEvent,
+  collectionAddEnvFileEvent,
   updateFile,
   wsResponseReceived
 } = collectionsSlice.actions;
@@ -35,7 +37,7 @@ const assertGuardedVars = (vars) => {
   expect(vars[2].dataType).toBeUndefined();
 };
 
-describe('selectEnvironment — isolates runtime variables by environment', () => {
+describe('active environment changes — isolate runtime variables by environment', () => {
   const makeState = () => ({
     collections: [
       {
@@ -112,6 +114,52 @@ describe('selectEnvironment — isolates runtime variables by environment', () =
     );
 
     expect(next.collections[0].runtimeVariables).toEqual({ title: 'current-runtime-value' });
+  });
+
+  it('clears runtime variables when the default environment becomes active', () => {
+    const state = makeState();
+    state.collections[0].activeEnvironmentUid = null;
+
+    const next = reducer(
+      state,
+      applyDefaultEnvironment({ collectionUid: 'col1', defaultEnvironmentName: 'B' })
+    );
+
+    expect(next.collections[0].activeEnvironmentUid).toBe('env-b');
+    expect(next.collections[0].runtimeVariables).toEqual({});
+  });
+
+  it('clears runtime variables when a newly added environment becomes active', () => {
+    const state = makeState();
+    state.collections[0].lastAction = { type: 'ADD_ENVIRONMENT', payload: 'B' };
+
+    const next = reducer(
+      state,
+      collectionAddEnvFileEvent({
+        collectionUid: 'col1',
+        environment: { uid: 'env-c', name: 'B' }
+      })
+    );
+
+    expect(next.collections[0].activeEnvironmentUid).toBe('env-c');
+    expect(next.collections[0].runtimeVariables).toEqual({});
+  });
+
+  it('clears runtime variables when a pending default environment file loads', () => {
+    const state = makeState();
+    state.collections[0].activeEnvironmentUid = null;
+    state.collections[0].pendingDefaultEnvironment = 'C';
+
+    const next = reducer(
+      state,
+      collectionAddEnvFileEvent({
+        collectionUid: 'col1',
+        environment: { uid: 'env-c', name: 'C' }
+      })
+    );
+
+    expect(next.collections[0].activeEnvironmentUid).toBe('env-c');
+    expect(next.collections[0].runtimeVariables).toEqual({});
   });
 });
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js
@@ -4,6 +4,7 @@ const {
   setRequestVars,
   setFolderVars,
   setCollectionVars,
+  selectEnvironment,
   updateFile,
   wsResponseReceived
 } = collectionsSlice.actions;
@@ -32,6 +33,52 @@ const assertGuardedVars = (vars) => {
   expect(vars[2]).toMatchObject({ name: 'plain', value: 'hello' });
   expect(vars[2].dataType).toBeUndefined();
 };
+
+describe('selectEnvironment — isolates runtime variables by environment', () => {
+  const makeState = () => ({
+    collections: [
+      {
+        uid: 'col1',
+        activeEnvironmentUid: 'env-a',
+        environments: [
+          { uid: 'env-a', name: 'A' },
+          { uid: 'env-b', name: 'B' }
+        ],
+        runtimeVariables: { title: 'runtime-value' }
+      }
+    ]
+  });
+
+  it('clears runtime variables when the active environment changes', () => {
+    const next = reducer(
+      makeState(),
+      selectEnvironment({ collectionUid: 'col1', environmentUid: 'env-b' })
+    );
+
+    expect(next.collections[0].activeEnvironmentUid).toBe('env-b');
+    expect(next.collections[0].runtimeVariables).toEqual({});
+  });
+
+  it('keeps runtime variables when the active environment is selected again', () => {
+    const next = reducer(
+      makeState(),
+      selectEnvironment({ collectionUid: 'col1', environmentUid: 'env-a' })
+    );
+
+    expect(next.collections[0].activeEnvironmentUid).toBe('env-a');
+    expect(next.collections[0].runtimeVariables).toEqual({ title: 'runtime-value' });
+  });
+
+  it('clears runtime variables when no environment is selected', () => {
+    const next = reducer(
+      makeState(),
+      selectEnvironment({ collectionUid: 'col1', environmentUid: null })
+    );
+
+    expect(next.collections[0].activeEnvironmentUid).toBeNull();
+    expect(next.collections[0].runtimeVariables).toEqual({});
+  });
+});
 
 describe('setRequestVars — strips dataType: \'string\' (implicit default)', () => {
   it('drops a stray string-dataType on request vars and preserves typed datatypes', () => {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -523,7 +523,8 @@ const registerNetworkIpc = (mainWindow) => {
       mainWindow.webContents.send('main:runtime-variables-update', {
         runtimeVariables: result.runtimeVariables,
         requestUid,
-        collectionUid
+        collectionUid,
+        environmentUid: collection.activeEnvironmentUid || null
       });
     }
 

--- a/tests/interpolation/dynamic-variable/collection/environments/A.bru
+++ b/tests/interpolation/dynamic-variable/collection/environments/A.bru
@@ -1,0 +1,3 @@
+vars {
+  title: environment-a
+}

--- a/tests/interpolation/dynamic-variable/collection/environments/B.bru
+++ b/tests/interpolation/dynamic-variable/collection/environments/B.bru
@@ -1,0 +1,3 @@
+vars {
+  title: environment-b
+}

--- a/tests/interpolation/dynamic-variable/collection/read-environment-variable.bru
+++ b/tests/interpolation/dynamic-variable/collection/read-environment-variable.bru
@@ -1,0 +1,21 @@
+meta {
+  name: read-environment-variable
+  type: http
+  seq: 2
+}
+
+post {
+  url: https://echo.usebruno.com
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "title": "{{title}}"
+  }
+}

--- a/tests/interpolation/dynamic-variable/set-var-dynamic-variable.spec.ts
+++ b/tests/interpolation/dynamic-variable/set-var-dynamic-variable.spec.ts
@@ -3,7 +3,7 @@ import { closeAllCollections, openCollection, selectEnvironment, sendRequest } f
 import { buildCommonLocators } from '../../utils/page/locators';
 
 test.describe.serial('Dynamic Variable Interpolation', () => {
-  test.afterEach(async ({ pageWithUserData: page }) => {
+  test.afterAll(async ({ pageWithUserData: page }) => {
     await closeAllCollections(page);
   });
 
@@ -20,7 +20,7 @@ test.describe.serial('Dynamic Variable Interpolation', () => {
     await sendRequest(page, 200);
 
     // Verify response contains the title field and that it's not the literal interpolation string
-    const responsePane = page.locator('.response-pane');
+    const responsePane = locators.response.pane();
 
     // Check that the response contains a title field
     await expect(responsePane).toContainText('"title":');
@@ -46,7 +46,7 @@ test.describe.serial('Dynamic Variable Interpolation', () => {
 
   test('Runtime variables do not leak across collection environments', async ({ pageWithUserData: page }) => {
     const locators = buildCommonLocators(page);
-    const responsePane = page.locator('.response-pane');
+    const responsePane = locators.response.pane();
 
     await openCollection(page, 'dynamic-variable-interpolation');
     await selectEnvironment(page, 'A');

--- a/tests/interpolation/dynamic-variable/set-var-dynamic-variable.spec.ts
+++ b/tests/interpolation/dynamic-variable/set-var-dynamic-variable.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, openCollection, sendRequest } from '../../utils/page';
+import { closeAllCollections, openCollection, selectEnvironment, sendRequest } from '../../utils/page';
 import { buildCommonLocators } from '../../utils/page/locators';
 
 test.describe.serial('Dynamic Variable Interpolation', () => {
@@ -42,5 +42,24 @@ test.describe.serial('Dynamic Variable Interpolation', () => {
     expect(actualTitle).toBeDefined();
     expect(typeof actualTitle).toBe('string');
     expect(actualTitle.length).toBeGreaterThan(0);
+  });
+
+  test('Runtime variables do not leak across collection environments', async ({ pageWithUserData: page }) => {
+    const locators = buildCommonLocators(page);
+    const responsePane = page.locator('.response-pane');
+
+    await openCollection(page, 'dynamic-variable-interpolation');
+    await selectEnvironment(page, 'A');
+
+    await locators.sidebar.request('set-var-dynamic-variable').click();
+    await sendRequest(page, 200);
+
+    await expect(responsePane).not.toContainText('"title": "environment-a"');
+
+    await selectEnvironment(page, 'B');
+    await locators.sidebar.request('read-environment-variable').click();
+    await sendRequest(page, 200);
+
+    await expect(responsePane).toContainText('"title": "environment-b"');
   });
 });


### PR DESCRIPTION

### Description

Clear collection runtime variables when the active collection environment actually changes.

This prevents values created with `bru.setVar()` in one environment from overriding variables in another environment.

### Problem

Fixes #8825.

Runtime variables have the highest variable precedence. A runtime variable created while environment A was active remained in `collection.runtimeVariables` after switching to environment B, causing it to override B's environment variable with the same name.

### Fix

- Track the previously active collection environment in the `selectEnvironment` reducer.
- Clear `collection.runtimeVariables` only when the selected environment UID actually changes.
- Preserve runtime variables when the active environment is selected again.
- Clear runtime variables when switching to "No Environment".
- Add reducer and Playwright regression coverage for environment switching and variable interpolation.

This implementation treats changing the active collection environment as ending the previous runtime-variable context. The current documentation describes runtime variables as collection-scoped, so this behavior is called out for maintainer confirmation.

### Testing

- `npm test --workspace=packages/bruno-app -- --runInBand src/providers/ReduxStore/slices/collections/index.spec.js`
- `npx playwright test tests/interpolation/dynamic-variable/set-var-dynamic-variable.spec.ts --project=default --grep "Runtime variables do not leak"`
- `npm run lint -- packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js packages/bruno-app/src/providers/ReduxStore/slices/collections/index.spec.js tests/interpolation/dynamic-variable/set-var-dynamic-variable.spec.ts`
- `npm run build:web`

The targeted lint command completed with zero errors. It reports pre-existing warnings in the collections reducer outside the changed lines.

### Screenshots

Not applicable. The behavior is covered by the Playwright regression test.

| Before | After |
| --- | --- |
| Runtime variables from environment A override environment B variables. | Switching to environment B clears the previous runtime variables. |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Runtime variables are now cleared when switching collection environments or clearing the active environment.
- Prevented stale environment updates from modifying runtime variables.
- Ensured variables from one environment do not persist or affect requests in another environment.

## Tests

- Added coverage for environment switching, deselection, and runtime variable isolation.
- Added interpolation scenarios for reading variables from multiple environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->