### PR TITLE
fix(grpc-e2e): reflection cache & ordering across environment switches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8407,6 +8407,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/@grpc/reflection": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@grpc/reflection/-/reflection-1.0.4.tgz",
+      "integrity": "sha512-znA8v4AviOD3OPOxy11pxrtP8k8DanpefeTymS8iGW1fVr1U2cHuzfhYqDPHnVNDf4qvF9E25KtSihPy2DBWfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "protobufjs": "^7.2.5"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "^1.8.21"
+      }
+    },
     "node_modules/@headlessui/react": {
       "version": "1.7.19",
       "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
@@ -39209,6 +39222,9 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@grpc/grpc-js": "^1.14.4",
+        "@grpc/proto-loader": "^0.7.15",
+        "@grpc/reflection": "^1.0.4",
         "axios": "1.16.0",
         "body-parser": "2.2.0",
         "cookie-parser": "^1.4.6",
@@ -39224,6 +39240,37 @@
         "lodash": "4.18.1",
         "multer": "^1.4.5-lts.1",
         "ws": "^8.18.3"
+      }
+    },
+    "packages/bruno-tests/node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "packages/bruno-tests/node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "packages/bruno-tests/node_modules/cookie": {

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -57,10 +57,8 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   const protoDropdownRef = useRef(null);
   const haveFetchedMethodsRef = useRef(false);
   const latestReflectionRequestIdRef = useRef(0);
-  // Records the (url, envUid) pair the mount-effect last dispatched a reflection for.
-  // Used to short-circuit repeat runs of the same effect (React 18 StrictMode fires
-  // effects twice in dev, and the ref persists across the fake unmount/remount) so we
-  // don't fire two network reflections + toasts for the same environment.
+  // Dedupes the mount-effect against React 18 StrictMode's dev double-invoke: the ref
+  // survives the fake unmount, so the second run sees the same (url, envUid) and bails.
   const lastReflectionKeyRef = useRef(null);
 
   const protoFileManagement = useProtoFileManagement(collection, protoFilePath);
@@ -95,12 +93,8 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
     dispatch(saveRequest(item.uid, collection.uid));
   };
 
-  // Debounce reflection so rapid URL edits don't spam the network. The debounce
-  // instance is created once per component instance via `useState`'s lazy
-  // initializer, and routed through a ref to the latest `handleReflection`
-  // closure (set below, after `handleReflection` is declared) so it always calls
-  // the current version. Cancel on unmount so a pending timer can't fire against
-  // a dead component.
+  // Debounce URL edits; route through a ref so the timer always calls the current
+  // `handleReflection` closure. Cancel on unmount so a pending fire can't hit a dead component.
   const handleReflectionRef = useRef(null);
   const [debouncedReflection] = useState(() =>
     debounce((value) => handleReflectionRef.current?.(value), 3000)
@@ -137,8 +131,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   };
 
   const handleReflection = async (url, isManualRefresh = false) => {
-    // Concurrent reflection calls (e.g. from rapid env switches) can resolve out of order;
-    // drop any result that isn't from the most recent call so older methods can't clobber newer.
+    // Drop stale results so an out-of-order response can't clobber a newer one.
     const requestId = ++latestReflectionRequestIdRef.current;
     const { methods, error, fromCache } = await reflectionManagement.loadMethodsFromReflection(url, isManualRefresh);
     if (requestId !== latestReflectionRequestIdRef.current) return;
@@ -301,11 +294,8 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
     }
   };
 
-  // Fire reflection on mount and re-fetch when the active environment changes. We key on
-  // `(url, envUid)` and short-circuit if the same pair has already been dispatched — this
-  // both dedupes React 18 StrictMode's dev double-effect (refs persist across the fake
-  // remount, so the second invocation sees the same key and bails) and prevents redundant
-  // env-change re-fires when the dep evaluates to the same UID.
+  // Fetch on mount and on env switch, keyed on `(url, envUid)` to dedupe StrictMode's
+  // dev double-effect and skip re-fires when the env UID hasn't actually changed.
   useEffect(() => {
     if (protoFilePath) {
       if (haveFetchedMethodsRef.current) return;
@@ -321,9 +311,6 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
     lastReflectionKeyRef.current = { url, envUid };
     haveFetchedMethodsRef.current = true;
     setIsReflectionMode(true);
-    // The interpolated URL is the ultimate decider for whether to fetch: the cache is
-    // keyed on it, so a hit is always the right result. Only the explicit refresh
-    // button should bypass the cache.
     handleReflection(url);
   }, [collection.activeEnvironmentUid]);
 

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -120,10 +120,8 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   };
 
   const handleReflection = async (url, isManualRefresh = false) => {
-    // Guard against out-of-order completion: rapid env switches (or URL edits) can queue
-    // multiple in-flight reflection calls, and the older one resolving last would clobber
-    // the newer one's methods, selection, and toasts. Each call takes a monotonic id and
-    // bails after the await if a newer call has since started.
+    // Concurrent reflection calls (e.g. from rapid env switches) can resolve out of order;
+    // drop any result that isn't from the most recent call so older methods can't clobber newer.
     const requestId = ++latestReflectionRequestIdRef.current;
     const { methods, error, fromCache } = await reflectionManagement.loadMethodsFromReflection(url, isManualRefresh);
     if (requestId !== latestReflectionRequestIdRef.current) return;
@@ -287,13 +285,8 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
 
   const debouncedOnUrlChange = debounce(onUrlChange, 1000);
 
-  // Reflection fetch on mount, and re-fetch whenever the active environment changes.
-  // The URL may contain `{{var}}` placeholders (e.g. `{{host}}`) that only resolve
-  // once the env is active in Redux — if the pane mounts before the env has landed,
-  // the mount-time call reaches electron with un-interpolated placeholders and
-  // gRPC-js reports "Name resolution failed for target dns:{{host}}". Env changes
-  // also mean the same `{{host}}` may now point at a different endpoint, so the
-  // env-change re-fetch bypasses the URL-keyed reflection cache.
+  // Re-fetch on env change because a `{{host}}` in the URL may now resolve to a different
+  // endpoint; bypass the URL-keyed cache in that case so the new endpoint isn't served stale.
   useEffect(() => {
     if (protoFilePath) {
       if (haveFetchedMethodsRef.current) return;

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -281,12 +281,11 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
 
   useEffect(() => {
     if (protoFilePath) {
-      if (!protoFileManagement.claimProtoFileLoad(protoFilePath)) return;
       setIsReflectionMode(false);
       handleProtoFileLoad(protoFilePath);
       return;
     }
-    if (!reflectionManagement.claimReflection(url)) return;
+    if (!url) return;
     setIsReflectionMode(true);
     handleReflection(url);
   }, [collection.activeEnvironmentUid]);

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -57,8 +57,6 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   const protoDropdownRef = useRef(null);
   const haveFetchedMethodsRef = useRef(false);
   const latestReflectionRequestIdRef = useRef(0);
-  // Dedupes the mount-effect against React 18 StrictMode's dev double-invoke: the ref
-  // survives the fake unmount, so the second run sees the same (url, envUid) and bails.
   const lastReflectionKeyRef = useRef(null);
 
   const protoFileManagement = useProtoFileManagement(collection, protoFilePath);
@@ -93,8 +91,6 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
     dispatch(saveRequest(item.uid, collection.uid));
   };
 
-  // Debounce URL edits; route through a ref so the timer always calls the current
-  // `handleReflection` closure. Cancel on unmount so a pending fire can't hit a dead component.
   const handleReflectionRef = useRef(null);
   const [debouncedReflection] = useState(() =>
     debounce((value) => handleReflectionRef.current?.(value), 3000)
@@ -131,7 +127,6 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   };
 
   const handleReflection = async (url, isManualRefresh = false) => {
-    // Drop stale results so an out-of-order response can't clobber a newer one.
     const requestId = ++latestReflectionRequestIdRef.current;
     const { methods, error, fromCache } = await reflectionManagement.loadMethodsFromReflection(url, isManualRefresh);
     if (requestId !== latestReflectionRequestIdRef.current) return;
@@ -294,8 +289,6 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
     }
   };
 
-  // Fetch on mount and on env switch, keyed on `(url, envUid)` to dedupe StrictMode's
-  // dev double-effect and skip re-fires when the env UID hasn't actually changed.
   useEffect(() => {
     if (protoFilePath) {
       if (haveFetchedMethodsRef.current) return;

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -58,7 +58,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   const haveFetchedMethodsRef = useRef(false);
 
   const protoFileManagement = useProtoFileManagement(collection, protoFilePath);
-  const reflectionManagement = useReflectionManagement(item, collection.uid);
+  const reflectionManagement = useReflectionManagement(item, collection);
 
   const onMethodSelect = ({ path, type }) => {
     if (isConnectionActive) {
@@ -280,21 +280,27 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
 
   const debouncedOnUrlChange = debounce(onUrlChange, 1000);
 
+  // Reflection fetch on mount, and re-fetch whenever the active environment changes.
+  // The URL may contain `{{var}}` placeholders (e.g. `{{host}}`) that only resolve
+  // once the env is active in Redux — if the pane mounts before the env has landed,
+  // the mount-time call reaches electron with un-interpolated placeholders and
+  // gRPC-js reports "Name resolution failed for target dns:{{host}}". Env changes
+  // also mean the same `{{host}}` may now point at a different endpoint, so the
+  // env-change re-fetch bypasses the URL-keyed reflection cache.
   useEffect(() => {
-    if (haveFetchedMethodsRef.current) {
-      return;
-    }
-    haveFetchedMethodsRef.current = true;
-
     if (protoFilePath) {
+      if (haveFetchedMethodsRef.current) return;
+      haveFetchedMethodsRef.current = true;
       setIsReflectionMode(false);
       handleProtoFileLoad(protoFilePath);
       return;
     }
     if (!url) return;
+    const isEnvChange = haveFetchedMethodsRef.current;
+    haveFetchedMethodsRef.current = true;
     setIsReflectionMode(true);
-    handleReflection(url);
-  }, []);
+    handleReflection(url, isEnvChange);
+  }, [collection.activeEnvironmentUid]);
 
   return (
     <StyledWrapper className="flex items-center relative" data-testid="grpc-query-url-container">

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -20,7 +20,6 @@ import {
   endGrpcConnection
 } from 'utils/network/index';
 import GrpcurlModal from './GrpcurlModal';
-import { debounce } from 'lodash';
 import { getPropertyFromDraftOrRequest } from 'utils/collections';
 import useReflectionManagement from 'hooks/useReflectionManagement/index';
 import useProtoFileManagement from 'hooks/useProtoFileManagement/index';
@@ -55,9 +54,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
 
   const methodDropdownRef = useRef(null);
   const protoDropdownRef = useRef(null);
-  const haveFetchedMethodsRef = useRef(false);
   const latestReflectionRequestIdRef = useRef(0);
-  const lastReflectionKeyRef = useRef(null);
 
   const protoFileManagement = useProtoFileManagement(collection, protoFilePath);
   const reflectionManagement = useReflectionManagement(item, collection);
@@ -89,41 +86,6 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
 
   const onSave = () => {
     dispatch(saveRequest(item.uid, collection.uid));
-  };
-
-  const handleReflectionRef = useRef(null);
-  const [debouncedReflection] = useState(() =>
-    debounce((value) => handleReflectionRef.current?.(value), 3000)
-  );
-  useEffect(() => () => debouncedReflection.cancel(), [debouncedReflection]);
-
-  const onUrlChange = (value) => {
-    if (!editorRef.current?.editor) return;
-    const editor = editorRef.current.editor;
-    const cursor = editor.getCursor();
-
-    const finalUrl = value?.trim() || value;
-
-    dispatch(
-      requestUrlChanged({
-        itemUid: item.uid,
-        collectionUid: collection.uid,
-        url: finalUrl
-      })
-    );
-
-    if (finalUrl !== value) {
-      setTimeout(() => {
-        if (editor) {
-          editor.setCursor(cursor);
-        }
-      }, 0);
-    }
-
-    if (!protoFilePath && value) {
-      setIsReflectionMode(true);
-      debouncedReflection(finalUrl);
-    }
   };
 
   const handleReflection = async (url, isManualRefresh = false) => {
@@ -170,7 +132,35 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
       }
     }
   };
-  handleReflectionRef.current = handleReflection;
+
+  const onUrlChange = (value) => {
+    if (!editorRef.current?.editor) return;
+    const editor = editorRef.current.editor;
+    const cursor = editor.getCursor();
+
+    const finalUrl = value?.trim() || value;
+
+    dispatch(
+      requestUrlChanged({
+        itemUid: item.uid,
+        collectionUid: collection.uid,
+        url: finalUrl
+      })
+    );
+
+    if (finalUrl !== value) {
+      setTimeout(() => {
+        if (editor) {
+          editor.setCursor(cursor);
+        }
+      }, 0);
+    }
+
+    if (!protoFilePath && value) {
+      setIsReflectionMode(true);
+      reflectionManagement.scheduleReflection(finalUrl, handleReflection);
+    }
+  };
 
   const handleProtoFileLoad = async (filePath, isManualRefresh = false) => {
     const { methods, error, fromCache } = await protoFileManagement.loadMethodsFromProtoFile(filePath, isManualRefresh);
@@ -291,18 +281,12 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
 
   useEffect(() => {
     if (protoFilePath) {
-      if (haveFetchedMethodsRef.current) return;
-      haveFetchedMethodsRef.current = true;
+      if (!protoFileManagement.claimProtoFileLoad(protoFilePath)) return;
       setIsReflectionMode(false);
       handleProtoFileLoad(protoFilePath);
       return;
     }
-    if (!url) return;
-    const envUid = collection.activeEnvironmentUid ?? null;
-    const last = lastReflectionKeyRef.current;
-    if (last && last.url === url && last.envUid === envUid) return;
-    lastReflectionKeyRef.current = { url, envUid };
-    haveFetchedMethodsRef.current = true;
+    if (!reflectionManagement.claimReflection(url)) return;
     setIsReflectionMode(true);
     handleReflection(url);
   }, [collection.activeEnvironmentUid]);

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -57,6 +57,11 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   const protoDropdownRef = useRef(null);
   const haveFetchedMethodsRef = useRef(false);
   const latestReflectionRequestIdRef = useRef(0);
+  // Records the (url, envUid) pair the mount-effect last dispatched a reflection for.
+  // Used to short-circuit repeat runs of the same effect (React 18 StrictMode fires
+  // effects twice in dev, and the ref persists across the fake unmount/remount) so we
+  // don't fire two network reflections + toasts for the same environment.
+  const lastReflectionKeyRef = useRef(null);
 
   const protoFileManagement = useProtoFileManagement(collection, protoFilePath);
   const reflectionManagement = useReflectionManagement(item, collection);
@@ -90,6 +95,18 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
     dispatch(saveRequest(item.uid, collection.uid));
   };
 
+  // Debounce reflection so rapid URL edits don't spam the network. The debounce
+  // instance is created once per component instance via `useState`'s lazy
+  // initializer, and routed through a ref to the latest `handleReflection`
+  // closure (set below, after `handleReflection` is declared) so it always calls
+  // the current version. Cancel on unmount so a pending timer can't fire against
+  // a dead component.
+  const handleReflectionRef = useRef(null);
+  const [debouncedReflection] = useState(() =>
+    debounce((value) => handleReflectionRef.current?.(value), 3000)
+  );
+  useEffect(() => () => debouncedReflection.cancel(), [debouncedReflection]);
+
   const onUrlChange = (value) => {
     if (!editorRef.current?.editor) return;
     const editor = editorRef.current.editor;
@@ -115,7 +132,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
 
     if (!protoFilePath && value) {
       setIsReflectionMode(true);
-      handleReflection(finalUrl);
+      debouncedReflection(finalUrl);
     }
   };
 
@@ -165,6 +182,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
       }
     }
   };
+  handleReflectionRef.current = handleReflection;
 
   const handleProtoFileLoad = async (filePath, isManualRefresh = false) => {
     const { methods, error, fromCache } = await protoFileManagement.loadMethodsFromProtoFile(filePath, isManualRefresh);
@@ -283,10 +301,11 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
     }
   };
 
-  const debouncedOnUrlChange = debounce(onUrlChange, 1000);
-
-  // Re-fetch on env change because a `{{host}}` in the URL may now resolve to a different
-  // endpoint; bypass the URL-keyed cache in that case so the new endpoint isn't served stale.
+  // Fire reflection on mount and re-fetch when the active environment changes. We key on
+  // `(url, envUid)` and short-circuit if the same pair has already been dispatched — this
+  // both dedupes React 18 StrictMode's dev double-effect (refs persist across the fake
+  // remount, so the second invocation sees the same key and bails) and prevents redundant
+  // env-change re-fires when the dep evaluates to the same UID.
   useEffect(() => {
     if (protoFilePath) {
       if (haveFetchedMethodsRef.current) return;
@@ -296,10 +315,16 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
       return;
     }
     if (!url) return;
-    const isEnvChange = haveFetchedMethodsRef.current;
+    const envUid = collection.activeEnvironmentUid ?? null;
+    const last = lastReflectionKeyRef.current;
+    if (last && last.url === url && last.envUid === envUid) return;
+    lastReflectionKeyRef.current = { url, envUid };
     haveFetchedMethodsRef.current = true;
     setIsReflectionMode(true);
-    handleReflection(url, isEnvChange);
+    // The interpolated URL is the ultimate decider for whether to fetch: the cache is
+    // keyed on it, so a hit is always the right result. Only the explicit refresh
+    // button should bypass the cache.
+    handleReflection(url);
   }, [collection.activeEnvironmentUid]);
 
   return (
@@ -315,7 +340,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
           value={url}
           onSave={(finalValue) => onSave(finalValue)}
           theme={storedTheme}
-          onChange={(newValue) => debouncedOnUrlChange(newValue)}
+          onChange={onUrlChange}
           onRun={handleRun}
           collection={collection}
           highlightPathParams={true}

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -56,6 +56,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   const methodDropdownRef = useRef(null);
   const protoDropdownRef = useRef(null);
   const haveFetchedMethodsRef = useRef(false);
+  const latestReflectionRequestIdRef = useRef(0);
 
   const protoFileManagement = useProtoFileManagement(collection, protoFilePath);
   const reflectionManagement = useReflectionManagement(item, collection);
@@ -119,7 +120,13 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
   };
 
   const handleReflection = async (url, isManualRefresh = false) => {
+    // Guard against out-of-order completion: rapid env switches (or URL edits) can queue
+    // multiple in-flight reflection calls, and the older one resolving last would clobber
+    // the newer one's methods, selection, and toasts. Each call takes a monotonic id and
+    // bails after the await if a newer call has since started.
+    const requestId = ++latestReflectionRequestIdRef.current;
     const { methods, error, fromCache } = await reflectionManagement.loadMethodsFromReflection(url, isManualRefresh);
+    if (requestId !== latestReflectionRequestIdRef.current) return;
 
     if (error) {
       toast.error(`Failed to load gRPC methods: ${error.message || 'Unknown error'}`);

--- a/packages/bruno-app/src/hooks/useProtoFileManagement/index.js
+++ b/packages/bruno-app/src/hooks/useProtoFileManagement/index.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { browseFiles, updateBrunoConfig } from 'providers/ReduxStore/slices/collections/actions';
 import { updateCollectionProtobuf } from 'providers/ReduxStore/slices/collections';
@@ -389,29 +389,11 @@ export default function useProtoFileManagement(collection) {
     }
   };
 
-  const claimedProtoFileRef = useRef(null);
-
-  /**
-   * Marks a filePath as loaded and returns whether this filePath is new (i.e.
-   * the caller should run the proto-file-load side-effect chain). Callers that
-   * want to skip re-running side effects for a filePath they've already handled
-   * should gate on the return value.
-   * @param {string} filePath
-   * @returns {boolean} true if the filePath was new (and is now marked), false if already seen
-   */
-  const claimProtoFileLoad = (filePath) => {
-    if (!filePath) return false;
-    if (claimedProtoFileRef.current === filePath) return false;
-    claimedProtoFileRef.current = filePath;
-    return true;
-  };
-
   return {
     protoFiles: protoFilesWithExistence,
     importPaths: importPathsWithExistence,
     isLoadingMethods,
     loadMethodsFromProtoFile,
-    claimProtoFileLoad,
     addProtoFileToCollection,
     addImportPathToCollection,
     addImportPathFromRequest,

--- a/packages/bruno-app/src/hooks/useProtoFileManagement/index.js
+++ b/packages/bruno-app/src/hooks/useProtoFileManagement/index.js
@@ -389,11 +389,29 @@ export default function useProtoFileManagement(collection) {
     }
   };
 
+  const claimedProtoFileRef = useRef(null);
+
+  /**
+   * Marks a filePath as loaded and returns whether this filePath is new (i.e.
+   * the caller should run the proto-file-load side-effect chain). Callers that
+   * want to skip re-running side effects for a filePath they've already handled
+   * should gate on the return value.
+   * @param {string} filePath
+   * @returns {boolean} true if the filePath was new (and is now marked), false if already seen
+   */
+  const claimProtoFileLoad = (filePath) => {
+    if (!filePath) return false;
+    if (claimedProtoFileRef.current === filePath) return false;
+    claimedProtoFileRef.current = filePath;
+    return true;
+  };
+
   return {
     protoFiles: protoFilesWithExistence,
     importPaths: importPathsWithExistence,
     isLoadingMethods,
     loadMethodsFromProtoFile,
+    claimProtoFileLoad,
     addProtoFileToCollection,
     addImportPathToCollection,
     addImportPathFromRequest,

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.js
@@ -47,7 +47,7 @@ export default function useReflectionManagement(item, collection) {
 
     setIsLoadingMethods(true);
     try {
-      const { methods, error } = await dispatch(loadGrpcMethodsFromReflection(item, collection.uid, url));
+      const { methods, error } = await dispatch(loadGrpcMethodsFromReflection(item, collection.uid, cacheKey));
 
       if (error) {
         console.error('Error loading gRPC methods:', error);

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.js
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { debounce } from 'lodash';
 import { interpolate } from '@usebruno/common';
 import { loadGrpcMethodsFromReflection } from 'providers/ReduxStore/slices/collections/actions';
 import useLocalStorage from 'hooks/useLocalStorage/index';
 import { getAllVariables } from 'utils/collections';
+
+const REFLECTION_DEBOUNCE_MS = 3000;
 
 /**
  * Custom hook for managing reflection data and server discovery
@@ -105,10 +108,53 @@ export default function useReflectionManagement(item, collection) {
     setReflectionCache({});
   };
 
+  // Keep a ref to the latest loader so the debounced closure isn't stale after
+  // renders (item / collection changes). Same ref-to-latest pattern applies to
+  // the reflection key predicate below.
+  const loadRef = useRef(loadMethodsFromReflection);
+  loadRef.current = loadMethodsFromReflection;
+
+  const [debouncedLoad] = useState(() =>
+    debounce((url, onDone) => {
+      loadRef.current(url, false).then((result) => onDone?.(result));
+    }, REFLECTION_DEBOUNCE_MS)
+  );
+  useEffect(() => () => debouncedLoad.cancel(), [debouncedLoad]);
+
+  /**
+   * Debounced reflection call. Cancels on unmount.
+   * @param {string} url
+   * @param {(result: {methods, error, fromCache}) => void} onDone
+   */
+  const scheduleReflection = (url, onDone) => {
+    debouncedLoad(url, onDone);
+  };
+
+  const lastReflectionKeyRef = useRef(null);
+
+  /**
+   * Marks (url, activeEnvironmentUid) as reflected and returns whether this
+   * key is new (i.e. the caller should run the reflection side-effect chain).
+   * Callers that want to skip re-running side effects for a URL they've already
+   * reflected in this env should gate on the return value.
+   * @param {string} url
+   * @returns {boolean} true if the key was new (and is now marked), false if already seen
+   */
+  const claimReflection = (url) => {
+    if (!url) return false;
+    const envUid = collection.activeEnvironmentUid ?? null;
+    const last = lastReflectionKeyRef.current;
+    if (last && last.url === url && last.envUid === envUid) return false;
+    lastReflectionKeyRef.current = { url, envUid };
+    return true;
+  };
+
   return {
     isLoadingMethods,
     reflectionCache,
     loadMethodsFromReflection,
+    scheduleReflection,
+    claimReflection,
     hasCachedMethods,
     getCachedMethods,
     clearCacheForUrl,

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.js
@@ -130,31 +130,11 @@ export default function useReflectionManagement(item, collection) {
     debouncedLoad(url, onDone);
   };
 
-  const lastReflectionKeyRef = useRef(null);
-
-  /**
-   * Marks (url, activeEnvironmentUid) as reflected and returns whether this
-   * key is new (i.e. the caller should run the reflection side-effect chain).
-   * Callers that want to skip re-running side effects for a URL they've already
-   * reflected in this env should gate on the return value.
-   * @param {string} url
-   * @returns {boolean} true if the key was new (and is now marked), false if already seen
-   */
-  const claimReflection = (url) => {
-    if (!url) return false;
-    const envUid = collection.activeEnvironmentUid ?? null;
-    const last = lastReflectionKeyRef.current;
-    if (last && last.url === url && last.envUid === envUid) return false;
-    lastReflectionKeyRef.current = { url, envUid };
-    return true;
-  };
-
   return {
     isLoadingMethods,
     reflectionCache,
     loadMethodsFromReflection,
     scheduleReflection,
-    claimReflection,
     hasCachedMethods,
     getCachedMethods,
     clearCacheForUrl,

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.js
@@ -1,18 +1,32 @@
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { interpolate } from '@usebruno/common';
 import { loadGrpcMethodsFromReflection } from 'providers/ReduxStore/slices/collections/actions';
 import useLocalStorage from 'hooks/useLocalStorage/index';
+import { getAllVariables } from 'utils/collections';
 
 /**
  * Custom hook for managing reflection data and server discovery
  * @param {Object} item - The request item
- * @param {string} collectionUid - Collection UID
+ * @param {Object} collection - The collection the item belongs to
  */
-export default function useReflectionManagement(item, collectionUid) {
+export default function useReflectionManagement(item, collection) {
   const dispatch = useDispatch();
 
   const [reflectionCache, setReflectionCache] = useLocalStorage('bruno.grpc.reflectionCache', {});
   const [isLoadingMethods, setIsLoadingMethods] = useState(false);
+
+  // Cache keys use the *interpolated* URL, not the raw one. The same template
+  // (e.g. `{{host}}`) resolves to different endpoints under different envs;
+  // keying on the raw string would let a cache hit serve methods for the wrong
+  // server. If interpolation leaves `{{...}}` behind (var not found in scope),
+  // the key falls back to that partially-resolved string — reflection will fail
+  // anyway, but distinct unresolved keys stay distinct.
+  const resolveCacheKey = (url) => {
+    if (!url) return null;
+    const vars = getAllVariables(collection, item);
+    return interpolate(url, vars) || url;
+  };
 
   /**
    * Load gRPC methods from server reflection
@@ -25,24 +39,27 @@ export default function useReflectionManagement(item, collectionUid) {
       return { methods: [], error: new Error('No URL provided') };
     }
 
-    const cachedMethods = reflectionCache[url];
+    const cacheKey = resolveCacheKey(url);
+    const cachedMethods = cacheKey ? reflectionCache[cacheKey] : null;
     if (!isManualRefresh && cachedMethods && !isLoadingMethods) {
       return { methods: cachedMethods, error: null, fromCache: true };
     }
 
     setIsLoadingMethods(true);
     try {
-      const { methods, error } = await dispatch(loadGrpcMethodsFromReflection(item, collectionUid, url));
+      const { methods, error } = await dispatch(loadGrpcMethodsFromReflection(item, collection.uid, url));
 
       if (error) {
         console.error('Error loading gRPC methods:', error);
         return { methods: [], error };
       }
 
-      setReflectionCache((prevCache) => ({
-        ...prevCache,
-        [url]: methods
-      }));
+      if (cacheKey) {
+        setReflectionCache((prevCache) => ({
+          ...prevCache,
+          [cacheKey]: methods
+        }));
+      }
 
       return { methods, error: null, fromCache: false };
     } catch (error) {
@@ -59,7 +76,8 @@ export default function useReflectionManagement(item, collectionUid) {
    * @returns {boolean}
    */
   const hasCachedMethods = (url) => {
-    return !!(reflectionCache[url] && reflectionCache[url].length > 0);
+    const cacheKey = resolveCacheKey(url);
+    return !!(cacheKey && reflectionCache[cacheKey] && reflectionCache[cacheKey].length > 0);
   };
 
   /**
@@ -68,7 +86,8 @@ export default function useReflectionManagement(item, collectionUid) {
    * @returns {Array}
    */
   const getCachedMethods = (url) => {
-    return reflectionCache[url] || [];
+    const cacheKey = resolveCacheKey(url);
+    return (cacheKey && reflectionCache[cacheKey]) || [];
   };
 
   /**
@@ -76,9 +95,11 @@ export default function useReflectionManagement(item, collectionUid) {
    * @param {string} url - The gRPC server URL
    */
   const clearCacheForUrl = (url) => {
+    const cacheKey = resolveCacheKey(url);
+    if (!cacheKey) return;
     setReflectionCache((prevCache) => {
       const newCache = { ...prevCache };
-      delete newCache[url];
+      delete newCache[cacheKey];
       return newCache;
     });
   };

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.js
@@ -16,8 +16,6 @@ export default function useReflectionManagement(item, collection) {
   const [reflectionCache, setReflectionCache] = useLocalStorage('bruno.grpc.reflectionCache', {});
   const [isLoadingMethods, setIsLoadingMethods] = useState(false);
 
-  // Interpolated URL is the cache key so distinct envs get distinct slots;
-  // falls back to the raw string when placeholders can't resolve.
   const resolveUrl = (url) => {
     if (!url) return null;
     const vars = getAllVariables(collection, item);

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.js
@@ -16,10 +16,8 @@ export default function useReflectionManagement(item, collection) {
   const [reflectionCache, setReflectionCache] = useLocalStorage('bruno.grpc.reflectionCache', {});
   const [isLoadingMethods, setIsLoadingMethods] = useState(false);
 
-  // The URL template (e.g. `{{host}}`) resolves to different endpoints under
-  // different envs, so the interpolated form is both what reflection dials and
-  // what the cache is keyed on. Falls back to the raw string if interpolation
-  // leaves placeholders behind — distinct unresolved templates stay distinct.
+  // Interpolated URL is the cache key so distinct envs get distinct slots;
+  // falls back to the raw string when placeholders can't resolve.
   const resolveUrl = (url) => {
     if (!url) return null;
     const vars = getAllVariables(collection, item);

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.js
@@ -16,13 +16,11 @@ export default function useReflectionManagement(item, collection) {
   const [reflectionCache, setReflectionCache] = useLocalStorage('bruno.grpc.reflectionCache', {});
   const [isLoadingMethods, setIsLoadingMethods] = useState(false);
 
-  // Cache keys use the *interpolated* URL, not the raw one. The same template
-  // (e.g. `{{host}}`) resolves to different endpoints under different envs;
-  // keying on the raw string would let a cache hit serve methods for the wrong
-  // server. If interpolation leaves `{{...}}` behind (var not found in scope),
-  // the key falls back to that partially-resolved string — reflection will fail
-  // anyway, but distinct unresolved keys stay distinct.
-  const resolveCacheKey = (url) => {
+  // The URL template (e.g. `{{host}}`) resolves to different endpoints under
+  // different envs, so the interpolated form is both what reflection dials and
+  // what the cache is keyed on. Falls back to the raw string if interpolation
+  // leaves placeholders behind — distinct unresolved templates stay distinct.
+  const resolveUrl = (url) => {
     if (!url) return null;
     const vars = getAllVariables(collection, item);
     return interpolate(url, vars) || url;
@@ -39,25 +37,25 @@ export default function useReflectionManagement(item, collection) {
       return { methods: [], error: new Error('No URL provided') };
     }
 
-    const cacheKey = resolveCacheKey(url);
-    const cachedMethods = cacheKey ? reflectionCache[cacheKey] : null;
+    const resolvedUrl = resolveUrl(url);
+    const cachedMethods = resolvedUrl ? reflectionCache[resolvedUrl] : null;
     if (!isManualRefresh && cachedMethods && !isLoadingMethods) {
       return { methods: cachedMethods, error: null, fromCache: true };
     }
 
     setIsLoadingMethods(true);
     try {
-      const { methods, error } = await dispatch(loadGrpcMethodsFromReflection(item, collection.uid, cacheKey));
+      const { methods, error } = await dispatch(loadGrpcMethodsFromReflection(item, collection.uid, resolvedUrl));
 
       if (error) {
         console.error('Error loading gRPC methods:', error);
         return { methods: [], error };
       }
 
-      if (cacheKey) {
+      if (resolvedUrl) {
         setReflectionCache((prevCache) => ({
           ...prevCache,
-          [cacheKey]: methods
+          [resolvedUrl]: methods
         }));
       }
 
@@ -76,8 +74,8 @@ export default function useReflectionManagement(item, collection) {
    * @returns {boolean}
    */
   const hasCachedMethods = (url) => {
-    const cacheKey = resolveCacheKey(url);
-    return !!(cacheKey && reflectionCache[cacheKey] && reflectionCache[cacheKey].length > 0);
+    const resolvedUrl = resolveUrl(url);
+    return !!(resolvedUrl && reflectionCache[resolvedUrl] && reflectionCache[resolvedUrl].length > 0);
   };
 
   /**
@@ -86,8 +84,8 @@ export default function useReflectionManagement(item, collection) {
    * @returns {Array}
    */
   const getCachedMethods = (url) => {
-    const cacheKey = resolveCacheKey(url);
-    return (cacheKey && reflectionCache[cacheKey]) || [];
+    const resolvedUrl = resolveUrl(url);
+    return (resolvedUrl && reflectionCache[resolvedUrl]) || [];
   };
 
   /**
@@ -95,11 +93,11 @@ export default function useReflectionManagement(item, collection) {
    * @param {string} url - The gRPC server URL
    */
   const clearCacheForUrl = (url) => {
-    const cacheKey = resolveCacheKey(url);
-    if (!cacheKey) return;
+    const resolvedUrl = resolveUrl(url);
+    if (!resolvedUrl) return;
     setReflectionCache((prevCache) => {
       const newCache = { ...prevCache };
-      delete newCache[cacheKey];
+      delete newCache[resolvedUrl];
       return newCache;
     });
   };

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.spec.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.spec.js
@@ -1,12 +1,10 @@
 import { renderHook, act } from '@testing-library/react';
 
-// Stub `dispatch` so we can assert both the action dispatched and the resolved result.
 let mockDispatch;
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch
 }));
 
-// Stub the action creator to inspect the URL passed through to IPC.
 jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
   loadGrpcMethodsFromReflection: jest.fn((item, uid, url) => ({
     type: 'MOCK/loadGrpcMethodsFromReflection',
@@ -85,7 +83,6 @@ describe('useReflectionManagement', () => {
       envWithHost('env-b', 'grpc://server-b:9000')
     ];
 
-    // Populate the cache under env A.
     let collection = makeCollection({ activeEnvUid: 'env-a', envs });
     mockDispatch.mockResolvedValue({ methods: [{ path: '/A/Only' }], error: null });
     const { result, rerender } = renderHook(({ coll }) => useReflectionManagement(item, coll), {
@@ -95,7 +92,6 @@ describe('useReflectionManagement', () => {
       await result.current.loadMethodsFromReflection('{{host}}');
     });
 
-    // Switch to env B — env-A's cache entry must not be served to env B.
     collection = makeCollection({ activeEnvUid: 'env-b', envs });
     mockDispatch.mockResolvedValue({ methods: [{ path: '/B/Only' }], error: null });
     rerender({ coll: collection });
@@ -104,13 +100,11 @@ describe('useReflectionManagement', () => {
       envBResult = await result.current.loadMethodsFromReflection('{{host}}');
     });
 
-    // Two distinct dispatches, one per env, each with its own resolved URL.
     expect(loadGrpcMethodsFromReflection).toHaveBeenNthCalledWith(1, item, 'coll-1', 'grpc://server-a:9000');
     expect(loadGrpcMethodsFromReflection).toHaveBeenNthCalledWith(2, item, 'coll-1', 'grpc://server-b:9000');
     expect(envBResult.fromCache).toBe(false);
     expect(envBResult.methods).toEqual([{ path: '/B/Only' }]);
 
-    // Both cache slots should now exist, keyed on the interpolated URLs.
     const cache = JSON.parse(localStorage.getItem(CACHE_KEY));
     expect(cache['grpc://server-a:9000']).toEqual([{ path: '/A/Only' }]);
     expect(cache['grpc://server-b:9000']).toEqual([{ path: '/B/Only' }]);
@@ -160,14 +154,12 @@ describe('useReflectionManagement', () => {
     });
 
     expect(loadGrpcMethodsFromReflection).toHaveBeenCalledTimes(2);
-    // Manual refresh bypasses the cache but still dispatches the interpolated URL.
     expect(loadGrpcMethodsFromReflection).toHaveBeenNthCalledWith(2, item, 'coll-1', 'grpc://server-a:9000');
     expect(refreshed.fromCache).toBe(false);
   });
 
   it('keys on the un-interpolated string when a variable is missing from scope', async () => {
     const item = makeItem('{{host}}');
-    // No env active — `{{host}}` has no resolver.
     const collection = makeCollection({ activeEnvUid: null, envs: [] });
     mockDispatch.mockResolvedValue({ methods: [], error: null });
 
@@ -177,8 +169,6 @@ describe('useReflectionManagement', () => {
       await result.current.loadMethodsFromReflection('{{host}}');
     });
 
-    // Missing var: raw `{{host}}` is dispatched and cached as-is; reflection fails on the
-    // electron side rather than us silently substituting something else.
     expect(loadGrpcMethodsFromReflection).toHaveBeenCalledWith(item, 'coll-1', '{{host}}');
     const cache = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
     expect(Object.keys(cache)).toEqual(['{{host}}']);

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.spec.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.spec.js
@@ -1,0 +1,192 @@
+import { renderHook, act } from '@testing-library/react';
+
+// react-redux's `useDispatch` is the only hook boundary we need to stub. We
+// resolve `dispatch(...)` ourselves so we can assert both what was dispatched
+// (the action creator's return) and what came back (the reflection result).
+let mockDispatch;
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch
+}));
+
+// Mock the action creator so we can inspect exactly which URL the hook hands
+// off to the electron IPC. Its real body wires up an IPC roundtrip we don't
+// care about here.
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  loadGrpcMethodsFromReflection: jest.fn((item, uid, url) => ({
+    type: 'MOCK/loadGrpcMethodsFromReflection',
+    item,
+    uid,
+    url
+  }))
+}));
+
+const { loadGrpcMethodsFromReflection } = require('providers/ReduxStore/slices/collections/actions');
+const useReflectionManagement = require('./index').default;
+
+const CACHE_KEY = 'bruno.grpc.reflectionCache';
+
+const makeItem = (url) => ({
+  uid: 'item-1',
+  type: 'grpc-request',
+  request: {
+    url,
+    method: '',
+    methodType: '',
+    params: [],
+    headers: [],
+    body: { mode: 'grpc', grpc: [] },
+    vars: { req: [], res: [] }
+  }
+});
+
+const makeCollection = ({ activeEnvUid, envs = [] } = {}) => ({
+  uid: 'coll-1',
+  activeEnvironmentUid: activeEnvUid,
+  environments: envs,
+  items: [makeItem('{{host}}')],
+  globalEnvironmentVariables: {},
+  processEnvVariables: {},
+  runtimeVariables: {},
+  promptVariables: {},
+  workspaceProcessEnvVariables: {},
+  globalEnvSecrets: []
+});
+
+const envWithHost = (uid, hostValue) => ({
+  uid,
+  name: uid,
+  variables: [{ name: 'host', value: hostValue, enabled: true }]
+});
+
+describe('useReflectionManagement', () => {
+  beforeEach(() => {
+    mockDispatch = jest.fn();
+    localStorage.clear();
+  });
+
+  it('dispatches the interpolated URL, not the raw template', async () => {
+    const item = makeItem('{{host}}');
+    const collection = makeCollection({
+      activeEnvUid: 'env-a',
+      envs: [envWithHost('env-a', 'grpc://server-a:9000')]
+    });
+    mockDispatch.mockResolvedValue({ methods: [{ path: '/A/M' }], error: null });
+
+    const { result } = renderHook(() => useReflectionManagement(item, collection));
+
+    await act(async () => {
+      await result.current.loadMethodsFromReflection('{{host}}');
+    });
+
+    expect(loadGrpcMethodsFromReflection).toHaveBeenCalledTimes(1);
+    expect(loadGrpcMethodsFromReflection).toHaveBeenCalledWith(item, 'coll-1', 'grpc://server-a:9000');
+  });
+
+  it('keeps the same raw URL in separate cache slots per environment', async () => {
+    const item = makeItem('{{host}}');
+    const envs = [
+      envWithHost('env-a', 'grpc://server-a:9000'),
+      envWithHost('env-b', 'grpc://server-b:9000')
+    ];
+
+    // Populate the cache under env A.
+    let collection = makeCollection({ activeEnvUid: 'env-a', envs });
+    mockDispatch.mockResolvedValue({ methods: [{ path: '/A/Only' }], error: null });
+    const { result, rerender } = renderHook(({ coll }) => useReflectionManagement(item, coll), {
+      initialProps: { coll: collection }
+    });
+    await act(async () => {
+      await result.current.loadMethodsFromReflection('{{host}}');
+    });
+
+    // Switch to env B — env-A's cache entry must not be served to env B.
+    collection = makeCollection({ activeEnvUid: 'env-b', envs });
+    mockDispatch.mockResolvedValue({ methods: [{ path: '/B/Only' }], error: null });
+    rerender({ coll: collection });
+    let envBResult;
+    await act(async () => {
+      envBResult = await result.current.loadMethodsFromReflection('{{host}}');
+    });
+
+    // Two distinct dispatches, one per env, each with its own resolved URL.
+    expect(loadGrpcMethodsFromReflection).toHaveBeenNthCalledWith(1, item, 'coll-1', 'grpc://server-a:9000');
+    expect(loadGrpcMethodsFromReflection).toHaveBeenNthCalledWith(2, item, 'coll-1', 'grpc://server-b:9000');
+    expect(envBResult.fromCache).toBe(false);
+    expect(envBResult.methods).toEqual([{ path: '/B/Only' }]);
+
+    // Both cache slots should now exist, keyed on the interpolated URLs.
+    const cache = JSON.parse(localStorage.getItem(CACHE_KEY));
+    expect(cache['grpc://server-a:9000']).toEqual([{ path: '/A/Only' }]);
+    expect(cache['grpc://server-b:9000']).toEqual([{ path: '/B/Only' }]);
+  });
+
+  it('serves the cached result on the second call for the same env (no re-dispatch)', async () => {
+    const item = makeItem('{{host}}');
+    const collection = makeCollection({
+      activeEnvUid: 'env-a',
+      envs: [envWithHost('env-a', 'grpc://server-a:9000')]
+    });
+    mockDispatch.mockResolvedValue({ methods: [{ path: '/A/M' }], error: null });
+
+    const { result } = renderHook(() => useReflectionManagement(item, collection));
+
+    await act(async () => {
+      await result.current.loadMethodsFromReflection('{{host}}');
+    });
+
+    let second;
+    await act(async () => {
+      second = await result.current.loadMethodsFromReflection('{{host}}');
+    });
+
+    expect(loadGrpcMethodsFromReflection).toHaveBeenCalledTimes(1);
+    expect(second.fromCache).toBe(true);
+    expect(second.methods).toEqual([{ path: '/A/M' }]);
+  });
+
+  it('bypasses the cache when isManualRefresh is true', async () => {
+    const item = makeItem('{{host}}');
+    const collection = makeCollection({
+      activeEnvUid: 'env-a',
+      envs: [envWithHost('env-a', 'grpc://server-a:9000')]
+    });
+    mockDispatch.mockResolvedValue({ methods: [{ path: '/A/M' }], error: null });
+
+    const { result } = renderHook(() => useReflectionManagement(item, collection));
+
+    await act(async () => {
+      await result.current.loadMethodsFromReflection('{{host}}');
+    });
+
+    let refreshed;
+    await act(async () => {
+      refreshed = await result.current.loadMethodsFromReflection('{{host}}', true);
+    });
+
+    expect(loadGrpcMethodsFromReflection).toHaveBeenCalledTimes(2);
+    // Second call is also under the interpolated URL — manual refresh doesn't
+    // change the endpoint, only whether we trust the cache.
+    expect(loadGrpcMethodsFromReflection).toHaveBeenNthCalledWith(2, item, 'coll-1', 'grpc://server-a:9000');
+    expect(refreshed.fromCache).toBe(false);
+  });
+
+  it('keys on the un-interpolated string when a variable is missing from scope', async () => {
+    const item = makeItem('{{host}}');
+    // No env active — `{{host}}` has no resolver.
+    const collection = makeCollection({ activeEnvUid: null, envs: [] });
+    mockDispatch.mockResolvedValue({ methods: [], error: null });
+
+    const { result } = renderHook(() => useReflectionManagement(item, collection));
+
+    await act(async () => {
+      await result.current.loadMethodsFromReflection('{{host}}');
+    });
+
+    // The raw `{{host}}` is what gets dispatched *and* what the cache is keyed
+    // on — reflection will fail on the electron side, but we don't mask the
+    // failure by turning the missing var into something else.
+    expect(loadGrpcMethodsFromReflection).toHaveBeenCalledWith(item, 'coll-1', '{{host}}');
+    const cache = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
+    expect(Object.keys(cache)).toEqual(['{{host}}']);
+  });
+});

--- a/packages/bruno-app/src/hooks/useReflectionManagement/index.spec.js
+++ b/packages/bruno-app/src/hooks/useReflectionManagement/index.spec.js
@@ -1,16 +1,12 @@
 import { renderHook, act } from '@testing-library/react';
 
-// react-redux's `useDispatch` is the only hook boundary we need to stub. We
-// resolve `dispatch(...)` ourselves so we can assert both what was dispatched
-// (the action creator's return) and what came back (the reflection result).
+// Stub `dispatch` so we can assert both the action dispatched and the resolved result.
 let mockDispatch;
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch
 }));
 
-// Mock the action creator so we can inspect exactly which URL the hook hands
-// off to the electron IPC. Its real body wires up an IPC roundtrip we don't
-// care about here.
+// Stub the action creator to inspect the URL passed through to IPC.
 jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
   loadGrpcMethodsFromReflection: jest.fn((item, uid, url) => ({
     type: 'MOCK/loadGrpcMethodsFromReflection',
@@ -164,8 +160,7 @@ describe('useReflectionManagement', () => {
     });
 
     expect(loadGrpcMethodsFromReflection).toHaveBeenCalledTimes(2);
-    // Second call is also under the interpolated URL — manual refresh doesn't
-    // change the endpoint, only whether we trust the cache.
+    // Manual refresh bypasses the cache but still dispatches the interpolated URL.
     expect(loadGrpcMethodsFromReflection).toHaveBeenNthCalledWith(2, item, 'coll-1', 'grpc://server-a:9000');
     expect(refreshed.fromCache).toBe(false);
   });
@@ -182,9 +177,8 @@ describe('useReflectionManagement', () => {
       await result.current.loadMethodsFromReflection('{{host}}');
     });
 
-    // The raw `{{host}}` is what gets dispatched *and* what the cache is keyed
-    // on — reflection will fail on the electron side, but we don't mask the
-    // failure by turning the missing var into something else.
+    // Missing var: raw `{{host}}` is dispatched and cached as-is; reflection fails on the
+    // electron side rather than us silently substituting something else.
     expect(loadGrpcMethodsFromReflection).toHaveBeenCalledWith(item, 'coll-1', '{{host}}');
     const cache = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
     expect(Object.keys(cache)).toEqual(['{{host}}']);

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1969,18 +1969,24 @@ export const collectionsSlice = createSlice({
     },
     updateRequestMethod: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
+      if (!collection) return;
 
-      if (collection) {
-        const item = findItemInCollection(collection, action.payload.itemUid);
+      const item = findItemInCollection(collection, action.payload.itemUid);
+      if (!item || !isItemARequest(item)) return;
 
-        if (item && isItemARequest(item)) {
-          if (!item.draft) {
-            item.draft = cloneDeep(item);
-          }
-          item.draft.request.method = action.payload.method;
-          item.draft.request.methodType = action.payload.methodType;
-        }
+      const source = item.draft ? item.draft : item;
+      if (
+        source.request.method === action.payload.method
+        && source.request.methodType === action.payload.methodType
+      ) {
+        return;
       }
+
+      if (!item.draft) {
+        item.draft = cloneDeep(item);
+      }
+      item.draft.request.method = action.payload.method;
+      item.draft.request.methodType = action.payload.methodType;
     },
     updateRequestProtoPath: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);

--- a/packages/bruno-tests/package.json
+++ b/packages/bruno-tests/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "start": "node ."
+    "start": "node .",
+    "start:grpc": "node ./src/grpc/index.js"
   },
   "repository": {
     "type": "git",
@@ -18,6 +19,9 @@
   },
   "homepage": "https://github.com/usebruno/bruno-testbench#readme",
   "dependencies": {
+    "@grpc/grpc-js": "^1.14.4",
+    "@grpc/proto-loader": "^0.7.15",
+    "@grpc/reflection": "^1.0.4",
     "axios": "1.16.0",
     "body-parser": "2.2.0",
     "cookie-parser": "^1.4.6",

--- a/packages/bruno-tests/src/grpc/hello.proto
+++ b/packages/bruno-tests/src/grpc/hello.proto
@@ -1,0 +1,44 @@
+/*
+ * Sourced from https://github.com/moul/pb — MIT License:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017-2022 Manfred Touron
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+syntax = "proto2";
+
+package hello;
+
+service HelloService {
+  rpc SayHello(HelloRequest) returns (HelloResponse);
+  rpc LotsOfReplies(HelloRequest) returns (stream HelloResponse);
+  rpc LotsOfGreetings(stream HelloRequest) returns (HelloResponse);
+  rpc BidiHello(stream HelloRequest) returns (stream HelloResponse);
+}
+
+message HelloRequest {
+  optional string greeting = 1;
+}
+
+message HelloResponse {
+  required string reply = 1;
+}

--- a/packages/bruno-tests/src/grpc/index.js
+++ b/packages/bruno-tests/src/grpc/index.js
@@ -1,0 +1,116 @@
+/**
+ * Local gRPC testbench — mirrors the historical grpcb.in HelloService the
+ * Playwright fixtures were written against.
+ *
+ *   50051  insecure  — plaintext (env: GRPC_PORT)
+ *
+ * Service (see ./hello.proto) — hello.HelloService:
+ *   SayHello         unary          → echoes greeting back as reply
+ *   LotsOfReplies    server stream  → emits 10 replies
+ *   LotsOfGreetings  client stream  → aggregates greetings into one reply
+ *   BidiHello        bidi stream    → echoes each incoming greeting
+ *
+ * Reflection is registered via `@grpc/reflection` so Bruno's reflection-based
+ * method discovery works without a client-side proto file.
+ *
+ * Usage:
+ *   node ./src/grpc/index.js                 # standalone
+ *   const grpc = require('./grpc');          # imported (see ../index.js)
+ *   grpc.start().catch(err => { ... });
+ */
+
+const path = require('path');
+const grpc = require('@grpc/grpc-js');
+const protoLoader = require('@grpc/proto-loader');
+const { ReflectionService } = require('@grpc/reflection');
+
+const PROTO_PATH = path.join(__dirname, 'hello.proto');
+const STREAM_REPLY_COUNT = 10;
+
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+});
+
+const proto = grpc.loadPackageDefinition(packageDefinition);
+const helloService = proto.hello.HelloService.service;
+
+const buildReply = (greeting, suffix = '') =>
+  ({ reply: `hello ${greeting || 'world'}${suffix}` });
+
+const handlers = {
+  SayHello(call, callback) {
+    const greeting = call.request && call.request.greeting;
+    callback(null, buildReply(greeting));
+  },
+
+  LotsOfReplies(call) {
+    const greeting = call.request && call.request.greeting;
+    for (let i = 0; i < STREAM_REPLY_COUNT; i++) {
+      if (call.cancelled) return;
+      call.write(buildReply(greeting, ` #${i + 1}`));
+    }
+    call.end();
+  },
+
+  LotsOfGreetings(call, callback) {
+    const greetings = [];
+    call.on('data', (msg) => {
+      if (msg && typeof msg.greeting === 'string') greetings.push(msg.greeting);
+    });
+    call.on('end', () => {
+      callback(null, buildReply(greetings.join(', ')));
+    });
+    call.on('error', (err) => {
+      console.error('LotsOfGreetings stream error', err);
+    });
+  },
+
+  BidiHello(call) {
+    call.on('data', (msg) => {
+      const greeting = msg && typeof msg.greeting === 'string' ? msg.greeting : '';
+      call.write(buildReply(greeting));
+    });
+    call.on('end', () => call.end());
+    call.on('error', (err) => {
+      console.error('BidiHello stream error', err);
+    });
+  }
+};
+
+const bind = (server, address, credentials) =>
+  new Promise((resolve, reject) => {
+    server.bindAsync(address, credentials, (err, boundPort) => {
+      if (err) return reject(err);
+      console.log(`gRPC testbench started on port: ${boundPort}`);
+      resolve(boundPort);
+    });
+  });
+
+const start = async () => {
+  const port = process.env.GRPC_PORT || 50051;
+
+  const server = new grpc.Server();
+  server.addService(helloService, handlers);
+
+  // Register reflection so Bruno's reflection-based method discovery works
+  // against this server without needing the proto file client-side.
+  const reflection = new ReflectionService(packageDefinition);
+  reflection.addToServer(server);
+
+  try {
+    await bind(server, `0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure());
+  } catch (err) {
+    console.error('Failed to bind gRPC server', err);
+    process.exit(1);
+  }
+};
+
+if (require.main === module) {
+  start();
+}
+
+module.exports = { start };

--- a/packages/bruno-tests/src/index.js
+++ b/packages/bruno-tests/src/index.js
@@ -13,6 +13,7 @@ const setupGraphQL = require('./graphql');
 const sseRouter = require('./sse');
 const fileBinaryRouter = require('./file-binary');
 const waitForRouter = require('./wait-for');
+const grpcServer = require('./grpc');
 
 const app = new express();
 const port = process.env.PORT || 8081;
@@ -105,6 +106,11 @@ app.use((err, req, res, next) => {
 const server = require('http').createServer(app);
 
 server.on('upgrade', wsRouter);
+
+grpcServer.start().catch((err) => {
+  console.error('Failed to start gRPC testbench', err);
+  process.exit(1);
+});
 
 setupGraphQL(app).then(() => {
   server.listen(port, function () {

--- a/tests/grpc/make-request/fixtures/collection/environments/Env.bru
+++ b/tests/grpc/make-request/fixtures/collection/environments/Env.bru
@@ -1,3 +1,3 @@
 vars {
-  host: grpc://grpcb.in:9000
+  host: grpc://localhost:50051
 }

--- a/tests/grpc/metadata/fixtures/collection/sayHello.bru
+++ b/tests/grpc/metadata/fixtures/collection/sayHello.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 grpc {
-  url: grpc://grpcb.in:9000
+  url: grpc://localhost:50051
   method: /hello.HelloService/SayHello
   body: grpc
   auth: inherit

--- a/tests/grpc/method-search/fixtures/grpc-collection/environments/GrpcEnv.bru
+++ b/tests/grpc/method-search/fixtures/grpc-collection/environments/GrpcEnv.bru
@@ -1,3 +1,3 @@
 vars {
-  host: grpc://grpcb.in:9000
+  host: grpc://localhost:50051
 }

--- a/tests/grpc/method-search/grpc-method-search.spec.ts
+++ b/tests/grpc/method-search/grpc-method-search.spec.ts
@@ -33,15 +33,15 @@ test.describe('Grpc Collection - Method Search Functionality', () => {
       await grpcMethodsDropdown.click();
     });
 
-    await test.step('Search the term "Loojup" and verify the "Lookup" grpc method is visible and select it', async () => {
-      await page.getByTestId('grpc-methods-search-input').fill('loojup');
-      const method = page.getByTestId('grpc-method-item').filter({ hasText: 'Lookup' });
+    await test.step('Search the term "bdiHelo" and verify the "BidiHello" grpc method is visible and select it', async () => {
+      await page.getByTestId('grpc-methods-search-input').fill('bdiHelo');
+      const method = page.getByTestId('grpc-method-item').filter({ hasText: 'BidiHello' });
       await expect(method).toBeVisible();
       await method.click();
     });
 
-    await test.step('Verify the "Lookup" grpc method is selected', async () => {
-      const method = page.getByTestId('selected-grpc-method-name').filter({ hasText: 'Lookup' });
+    await test.step('Verify the "BidiHello" grpc method is selected', async () => {
+      const method = page.getByTestId('selected-grpc-method-name').filter({ hasText: 'BidiHello' });
       await expect(method).toBeVisible();
     });
   });
@@ -62,13 +62,14 @@ test.describe('Grpc Collection - Method Search Functionality', () => {
       await grpcMethodsDropdown.click();
     });
 
-    await test.step('Use keyboard to navigate to "Sum" method and select it', async () => {
+    await test.step('Use keyboard to navigate to "LotsOfReplies" method and select it', async () => {
+      await page.keyboard.press('ArrowDown');
       await page.keyboard.press('ArrowDown');
       await page.keyboard.press('Enter');
     });
 
-    await test.step('Verify the "Sum" grpc method is selected', async () => {
-      const method = page.getByTestId('selected-grpc-method-name').filter({ hasText: 'Add/Sum' });
+    await test.step('Verify the "LotsOfReplies" grpc method is selected', async () => {
+      const method = page.getByTestId('selected-grpc-method-name').filter({ hasText: 'HelloService/LotsOfReplies' });
       await expect(method).toBeVisible();
     });
   });

--- a/tests/grpc/method-search/grpc-method-search.spec.ts
+++ b/tests/grpc/method-search/grpc-method-search.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../../playwright';
+import { selectEnvironment } from '../../utils/page/actions';
 
 test.describe('Grpc Collection - Method Search Functionality', () => {
   test.beforeAll(async ({ pageWithUserData: page }) => {
@@ -6,11 +7,7 @@ test.describe('Grpc Collection - Method Search Functionality', () => {
       await page.locator('#sidebar-collection-name').filter({ hasText: 'grpc-collection' }).click();
     });
 
-    await test.step('Switch to GrpcEnv environment', async () => {
-      await page.locator('div.current-environment').click();
-      await page.getByTestId('env-list-item').filter({ hasText: 'GrpcEnv' }).click();
-      await expect(page.locator('.current-environment').filter({ hasText: /GrpcEnv/ })).toBeVisible();
-    });
+    await selectEnvironment(page, 'GrpcEnv');
   });
 
   test.afterEach(async ({ pageWithUserData: page }) => {

--- a/tests/grpc/multi-message-yml/multi-message.spec.ts
+++ b/tests/grpc/multi-message-yml/multi-message.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '../../utils/page/actions';
 
 const REQUEST_NAME = 'grpc-multi-msg';
-const GRPC_URL = 'grpcb.in:9000';
+const GRPC_URL = 'localhost:50051';
 const GRPC_METHOD = 'BidiHello';
 
 type GrpcRequestYml = {

--- a/tests/protobuf/fixtures/collection/environments/GrpcEnv.bru
+++ b/tests/protobuf/fixtures/collection/environments/GrpcEnv.bru
@@ -1,3 +1,3 @@
 vars {
-  host: grpc://grpcb.in:9000
+  host: grpc://localhost:50051
 }

--- a/tests/protobuf/manage-protofile.spec.ts
+++ b/tests/protobuf/manage-protofile.spec.ts
@@ -1,7 +1,13 @@
 import { test, expect } from '../../playwright';
 import { closeAllCollections } from '../utils/page';
+import { selectEnvironment } from '../utils/page/actions';
 
 test.describe('manage protofile', () => {
+  test.beforeAll(async ({ pageWithUserData: page }) => {
+    await page.locator('#sidebar-collection-name').filter({ hasText: 'Grpcbin' }).click();
+    await selectEnvironment(page, 'GrpcEnv');
+  });
+
   test.afterAll(async ({ pageWithUserData: page }) => {
     await closeAllCollections(page);
   });
@@ -115,7 +121,7 @@ test.describe('manage protofile', () => {
     await page.locator('div').filter({ hasText: /^product\.proto\.\/protos\/services\/product\.proto$/ }).first().click();
 
     // Verify the error message is visible (auto-retrying)
-    await expect(page.getByText('Failed to load gRPC methods: Unknown error').first()).toBeVisible();
+    await expect(page.getByText(/^Failed to load gRPC methods/).first()).toBeVisible();
 
     // Check that methods dropdown is not visible when loading fails
     const methodsDropdown = page.getByTestId('grpc-methods-dropdown');

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1718,7 +1718,10 @@ const saveRequest = async (page: Page) => {
 const addGrpcMessage = async (page: Page) => {
   await test.step('Add gRPC message', async () => {
     const locators = buildGrpcCommonLocators(page);
+    const containers = locators.request.messagesContainer().locator('.message-container');
+    const before = await containers.count();
     await locators.request.addMessageButton().click();
+    await expect(containers).toHaveCount(before + 1);
   });
 };
 

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1718,10 +1718,10 @@ const saveRequest = async (page: Page) => {
 const addGrpcMessage = async (page: Page) => {
   await test.step('Add gRPC message', async () => {
     const locators = buildGrpcCommonLocators(page);
-    const containers = locators.request.messagesContainer().locator('.message-container');
-    const before = await containers.count();
+    const messages = locators.request.messages();
+    const before = await messages.count();
     await locators.request.addMessageButton().click();
-    await expect(containers).toHaveCount(before + 1);
+    await expect(messages).toHaveCount(before + 1);
   });
 };
 

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -346,6 +346,7 @@ export const buildGrpcCommonLocators = (page: Page) => ({
     queryUrlContainer: () => page.getByTestId('grpc-query-url-container'),
     sendButton: () => page.getByTestId('grpc-send-request-button'),
     messagesContainer: () => page.getByTestId('grpc-messages-container'),
+    messages: () => page.getByTestId('grpc-messages-container').locator('.message-container'),
     addMessageButton: () => page.getByTestId('grpc-add-message-button'),
     regenerateMessage: (index: number) => page.getByTestId(`grpc-regenerate-message-${index}`),
     sendMessage: (index: number) => page.getByTestId(`grpc-send-message-${index}`),


### PR DESCRIPTION
BRU-4088

### Description

Fixes gRPC reflection when the active environment changes:

- Key the reflection cache by the resolved URL, so `{{host}}` doesn't share a slot across envs.
- Guard against out-of-order reflection responses with a request ID.
- Debounce the reflection fetch (3s) so rapid URL edits don't spam the network — URL dispatch stays immediate.
- Stabilize the flaky method-search e2e specs.
- Adds unit coverage for \`useReflectionManagement\` (URL dispatch + per-env cache keying).
- Added gRPC server testbench

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gRPC reflection when switching environments, preventing outdated results from replacing current data.
  * Updated gRPC method loading to use the appropriate proto-file or reflection results.
  * Improved reflection caching for environment-based URLs and refreshed methods when connection settings change.
  * Added debounced reflection requests to reduce unnecessary loading while editing request URLs.

* **Tests**
  * Strengthened checks for gRPC method search and message creation to verify expected UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->