### PR TITLE
fix(generate-code): encode a literal colon in the path when the toggl…

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -1239,15 +1239,22 @@ describe('generateSnippet – encodeUrl setting', () => {
     expect(result).not.toContain('localhost%3A6000');
   });
 
-  it.each([false, true])('preserves a colon inside a path segment when encodeUrl is %s', async (encodeUrl) => {
-    const item = makeItem('http://localhost:6000/values:colon', { encodeUrl });
+  it('preserves a colon inside a path segment when encodeUrl is false', async () => {
+    const item = makeItem('http://localhost:6000/values:colon', { encodeUrl: false });
 
     const result = await generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
     expect(result).toContain('http://localhost:6000/values:colon');
     expect(result).not.toContain('%3A');
   });
 
-  it('preserves a colon path segment alongside a declared path param', async () => {
+  it('encodes a colon inside a path segment when encodeUrl is true', async () => {
+    const item = makeItem('http://localhost:6000/values:colon', { encodeUrl: true });
+
+    const result = await generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: false });
+    expect(result).toContain('http://localhost:6000/values%3Acolon');
+  });
+
+  it('encodes a colon path segment while substituting a declared path param', async () => {
     const item = {
       ...makeItem('http://localhost:6000/users/:userId/values:colon', { encodeUrl: true }),
       request: {
@@ -1261,8 +1268,7 @@ describe('generateSnippet – encodeUrl setting', () => {
     };
 
     const result = await generateSnippet({ language, item, collection: baseCollection, shouldInterpolate: true });
-    expect(result).toContain('/users/123/values:colon');
-    expect(result).not.toContain('%3A');
+    expect(result).toContain('/users/123/values%3Acolon');
   });
 });
 

--- a/packages/bruno-common/src/generate-code/har/index.spec.ts
+++ b/packages/bruno-common/src/generate-code/har/index.spec.ts
@@ -903,6 +903,18 @@ describe('buildHar — regression: known issues map to single fixes', () => {
     });
     expect(rawUrl).toBe('https://example.com/odata/Products(ABC123)');
   });
+
+  it('literal colon in a path segment is encoded when the toggle is ON and there are no path params', async () => {
+    const { rawUrl, encodedUrl } = await buildHar({
+      request: baseRequest({
+        url: 'https://example.com/values:colon',
+        settings: { encodeUrl: true }
+      }),
+      shouldInterpolate: false
+    });
+    expect(rawUrl).toBe('https://example.com/values:colon');
+    expect(encodedUrl).toBe('https://example.com/values%3Acolon');
+  });
 });
 
 describe('buildHar — does not mutate caller inputs', () => {

--- a/packages/bruno-common/src/generate-code/har/index.ts
+++ b/packages/bruno-common/src/generate-code/har/index.ts
@@ -277,14 +277,9 @@ const hashPathParamPositions = (
   pathParams: BrunoKV[] | undefined
 ): { url: string; restore: (input: string, opts: { encode: boolean }) => string } => {
   const noopRestore = (input: string) => input;
-  if (!url) {
+  if (!url || !Array.isArray(pathParams) || pathParams.length === 0) {
     return { url, restore: noopRestore };
   }
-  // Hash `:id` positions even with no path params to substitute: `encodePathSegments`
-  // runs `encodeURIComponent` per segment, so an unhashed `:id` would reach the
-  // snippet as `%3Aid`. With no matching param, `restore` puts the `:id` literal
-  // back — which is what a caller preserving templates wants.
-  const enabledPathParams = Array.isArray(pathParams) ? pathParams : [];
 
   let prefix = '';
   let working = url;
@@ -303,7 +298,7 @@ const hashPathParamPositions = (
   const path = authorityMatch?.[2] ?? pathPart;
 
   const enabledByName = new Map<string, string>(
-    enabledPathParams
+    pathParams
       .filter((p) => p && p.enabled !== false && (p.type === undefined || p.type === 'path'))
       .map((p) => [p.name, p.value == null ? '' : String(p.value)])
   );

--- a/tests/request/generate-code/collection/requests/path-literal-colon.bru
+++ b/tests/request/generate-code/collection/requests/path-literal-colon.bru
@@ -1,0 +1,15 @@
+meta {
+  name: path-literal-colon
+  type: http
+  seq: 52
+}
+
+get {
+  url: http://localhost:8081/api/echo/anything/values:colon
+  body: none
+  auth: none
+}
+
+settings {
+  encodeUrl: false
+}

--- a/tests/request/generate-code/url-encoding-off.spec.ts
+++ b/tests/request/generate-code/url-encoding-off.spec.ts
@@ -207,6 +207,18 @@ test.describe('Generate Code – URL Encoding OFF', () => {
       await closeGenerateCodeDialog(page);
     });
 
+    test('preserves a literal colon inside a path segment (issue #8771)', async ({ pageWithUserData: page }) => {
+      await openCollection(page, COLLECTION);
+      await openRequestInFolder(page, FOLDER, 'path-literal-colon');
+      await setUrlEncoding(page, false);
+
+      const snippet = await getGeneratedSnippet(page);
+      expect(snippet).toContain('http://localhost:8081/api/echo/anything/values:colon');
+      expect(snippet).not.toContain('%3A');
+
+      await closeGenerateCodeDialog(page);
+    });
+
     test('preserves URL fragment in snippet (intentional asymmetry vs ON)', async ({ pageWithUserData: page }) => {
       // Raw mode honors user intent — fragment is kept verbatim. ON mode
       // encodes `#` to %23 as data. See snippet-generator.spec.js for the

--- a/tests/request/generate-code/url-encoding-on.spec.ts
+++ b/tests/request/generate-code/url-encoding-on.spec.ts
@@ -279,6 +279,7 @@ test.describe('Generate Code – URL Encoding ON', () => {
 
       const snippet = await getGeneratedSnippet(page);
       expect(snippet).toContain('http://localhost:8081/api/echo/anything/values%3Acolon');
+      expect(snippet).not.toContain('http://localhost:8081/api/echo/anything/values:colon');
 
       await closeGenerateCodeDialog(page);
     });

--- a/tests/request/generate-code/url-encoding-on.spec.ts
+++ b/tests/request/generate-code/url-encoding-on.spec.ts
@@ -272,6 +272,17 @@ test.describe('Generate Code – URL Encoding ON', () => {
       await closeGenerateCodeDialog(page);
     });
 
+    test('encodes a literal colon inside a path segment (: → %3A)', async ({ pageWithUserData: page }) => {
+      await openCollection(page, COLLECTION);
+      await openRequestInFolder(page, FOLDER, 'path-literal-colon');
+      await setUrlEncoding(page, true);
+
+      const snippet = await getGeneratedSnippet(page);
+      expect(snippet).toContain('http://localhost:8081/api/echo/anything/values%3Acolon');
+
+      await closeGenerateCodeDialog(page);
+    });
+
     test('encodes # and reserved chars in an OAuth callback fragment', async ({ pageWithUserData: page }) => {
       // Scenario 8: OAuth implicit-flow callback URL with token data in the
       // fragment. In ON mode the entire segment after the last `/` is encoded


### PR DESCRIPTION
### Description


With the URL Encoding setting turned on, Generate Code was leaving a literal colon in the path unencoded, so the snippet no longer matched what Bruno actually sends on the wire.

### Problem

Regression from #7308. That PR removed the `pathParams.length === 0` early-return in hashPathParamPositions, so every `:word` in the path is now hashed behind a placeholder before `encodeUrl` run

### Fix

Restore the guard: no path params to protect means nothing to hide, so the encoder sees the URL as typed. 

### Screenshots

Before
<img width="782" height="374" alt="image" src="https://github.com/user-attachments/assets/7e921740-23ad-4aa3-8732-ef1d7ac3ea6f" />


After

<img width="782" height="374" alt="image" src="https://github.com/user-attachments/assets/482cd9e1-c80d-4368-b573-ee1c2b702c6d" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated code handling for URLs containing literal colons in path segments.
  - Colons now remain readable when URL encoding is disabled and are correctly percent-encoded when enabled.
  - Fixed path-parameter processing so unmatched parameter patterns are not altered unexpectedly.
  - Improved consistency between raw and encoded URL representations in generated HAR output.
  - Added coverage for URL encoding behavior across generated snippets and requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->