### PR TITLE
fix(e2e): Playwright failures from mock server and lazy mount

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -284,9 +284,18 @@ const Collection = ({ collection, searchText }) => {
         setDropType('above');
       }
     },
-    drop: (draggedItem, monitor) => {
+    drop: async (draggedItem, monitor) => {
       const itemType = monitor.getItemType();
       if (isCollectionItem(itemType)) {
+        // Lazy-unmounted workspace collections are droppable in the sidebar but
+        // have no watcher yet — mount first so the move writes through and the UI updates.
+        if (collection.mountStatus !== 'mounted' && collection.mountStatus !== 'mounting') {
+          await dispatch(mountCollection({
+            collectionUid: collection.uid,
+            collectionPathname: collection.pathname,
+            brunoConfig: collection.brunoConfig
+          }));
+        }
         dispatch(handleCollectionItemDrop({ targetItem: collection, draggedItem, dropType: 'inside', collectionUid: collection.uid }));
       } else {
         dispatch(moveCollectionAndPersist({ draggedItem, targetItem: collection }));

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -804,7 +804,7 @@ class CollectionWatcher {
 
   addWatcher(win, watchPath, collectionUid, brunoConfig, forcePolling = false, useWorkerThread, options = {}) {
     const existingWatcher = this.watchers[watchPath];
-    if (existingWatcher && typeof existingWatcher.close === 'function') {
+    if (existingWatcher) {
       existingWatcher.close();
     }
 
@@ -818,101 +818,90 @@ class CollectionWatcher {
 
     this.startCollectionDiscovery(win, collectionUid);
 
-    // Reserve the path immediately so path-confinement checks succeed during the
-    // brief window before chokidar is attached (addWatcher defers that by 100ms).
-    this.watchers[watchPath] = true;
-
     // Always ignore node_modules and .git, regardless of user config
     // This prevents infinite loops with symlinked directories (e.g., npm workspaces)
     const defaultIgnores = ['node_modules', '.git'];
 
-    setTimeout(() => {
-      // Collection was removed while the deferred setup was pending.
-      if (!this.watchers[watchPath]) {
-        return;
-      }
+    const watcher = chokidar.watch(watchPath, {
+      ignoreInitial,
+      usePolling: isWSLPath(watchPath) || forcePolling ? true : false,
+      ignored: (filepath) => {
+        const normalizedPath = normalizeAndResolvePath(filepath);
+        const relativePath = path.relative(watchPath, normalizedPath);
+        const basename = path.basename(filepath);
 
-      const watcher = chokidar.watch(watchPath, {
-        ignoreInitial,
-        usePolling: isWSLPath(watchPath) || forcePolling ? true : false,
-        ignored: (filepath) => {
-          const normalizedPath = normalizeAndResolvePath(filepath);
-          const relativePath = path.relative(watchPath, normalizedPath);
-          const basename = path.basename(filepath);
+        // Ignore .env files - handled by dotenv-watcher
+        if (basename === '.env' || basename.startsWith('.env.')) {
+          return true;
+        }
 
-          // Ignore .env files - handled by dotenv-watcher
-          if (basename === '.env' || basename.startsWith('.env.')) {
-            return true;
+        // Check if any path segment matches a default ignore pattern (handles symlinks)
+        const pathSegments = relativePath.split(path.sep);
+        if (pathSegments.some((segment) => defaultIgnores.includes(segment))) {
+          return true;
+        }
+
+        // mocks/ at the collection root holds mock-server data; a nested folder
+        // that happens to be named "mocks" elsewhere in the collection stays watched
+        if (pathSegments[0] === 'mocks') {
+          return true;
+        }
+
+        const userIgnores = getBrunoConfig(collectionUid)?.ignore || [];
+        const ignores = [...new Set([...defaultIgnores, ...userIgnores])];
+        const normalizedRelativePath = relativePath.split(path.sep).join('/');
+
+        return ignores.some((ignorePattern) => {
+          const normalizedIgnorePattern = ignorePattern.replace(/\\/g, '/');
+          if (!normalizedIgnorePattern) {
+            return false;
           }
+          return normalizedRelativePath === normalizedIgnorePattern || normalizedRelativePath.startsWith(`${normalizedIgnorePattern}/`);
+        });
+      },
+      persistent: true,
+      ignorePermissionErrors: true,
+      awaitWriteFinish: {
+        stabilityThreshold: 80,
+        pollInterval: 10
+      },
+      depth: 20,
+      disableGlobbing: true
+    });
 
-          // Check if any path segment matches a default ignore pattern (handles symlinks)
-          const pathSegments = relativePath.split(path.sep);
-          if (pathSegments.some((segment) => defaultIgnores.includes(segment))) {
-            return true;
-          }
-
-          // mocks/ at the collection root holds mock-server data; a nested folder
-          // that happens to be named "mocks" elsewhere in the collection stays watched
-          if (pathSegments[0] === 'mocks') {
-            return true;
-          }
-
-          const userIgnores = getBrunoConfig(collectionUid)?.ignore || [];
-          const ignores = [...new Set([...defaultIgnores, ...userIgnores])];
-          const normalizedRelativePath = relativePath.split(path.sep).join('/');
-
-          return ignores.some((ignorePattern) => {
-            const normalizedIgnorePattern = ignorePattern.replace(/\\/g, '/');
-            if (!normalizedIgnorePattern) {
-              return false;
-            }
-            return normalizedRelativePath === normalizedIgnorePattern || normalizedRelativePath.startsWith(`${normalizedIgnorePattern}/`);
-          });
-        },
-        persistent: true,
-        ignorePermissionErrors: true,
-        awaitWriteFinish: {
-          stabilityThreshold: 80,
-          pollInterval: 10
-        },
-        depth: 20,
-        disableGlobbing: true
+    let startedNewWatcher = false;
+    watcher
+      .on('ready', () => onWatcherSetupComplete(win, watchPath, collectionUid, this, workspacePathname))
+      .on('add', (pathname) => add(win, pathname, collectionUid, watchPath, useWorkerThread, this))
+      .on('addDir', (pathname) => addDirectory(win, pathname, collectionUid, watchPath))
+      .on('change', (pathname) => change(win, pathname, collectionUid, watchPath))
+      .on('unlink', (pathname) => unlink(win, pathname, collectionUid, watchPath))
+      .on('unlinkDir', (pathname) => unlinkDir(win, pathname, collectionUid, watchPath))
+      .on('error', (error) => {
+        // `EMFILE` is an error code thrown when to many files are watched at the same time see: https://github.com/usebruno/bruno/issues/627
+        // `ENOSPC` stands for "Error No space" but is also thrown if the file watcher limit is reached.
+        // To prevent loops `!forcePolling` is checked.
+        if ((error.code === 'ENOSPC' || error.code === 'EMFILE') && !startedNewWatcher && !forcePolling) {
+          // This callback is called for every file the watcher is trying to watch. To prevent a spam of messages and
+          // Multiple watcher being started `startedNewWatcher` is set to prevent this.
+          startedNewWatcher = true;
+          watcher.close();
+          console.error(
+            `\nCould not start watcher for ${watchPath}:`,
+            'ENOSPC: System limit for number of file watchers reached!',
+            'Trying again with polling, this will be slower!\n',
+            'Update your system config to allow more concurrently watched files with:',
+            '"echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"'
+          );
+          this.addWatcher(win, watchPath, collectionUid, brunoConfig, true, useWorkerThread, options);
+        } else {
+          console.error(`An error occurred in the watcher for: ${watchPath}`, error);
+        }
       });
 
-      let startedNewWatcher = false;
-      watcher
-        .on('ready', () => onWatcherSetupComplete(win, watchPath, collectionUid, this, workspacePathname))
-        .on('add', (pathname) => add(win, pathname, collectionUid, watchPath, useWorkerThread, this))
-        .on('addDir', (pathname) => addDirectory(win, pathname, collectionUid, watchPath))
-        .on('change', (pathname) => change(win, pathname, collectionUid, watchPath))
-        .on('unlink', (pathname) => unlink(win, pathname, collectionUid, watchPath))
-        .on('unlinkDir', (pathname) => unlinkDir(win, pathname, collectionUid, watchPath))
-        .on('error', (error) => {
-          // `EMFILE` is an error code thrown when to many files are watched at the same time see: https://github.com/usebruno/bruno/issues/627
-          // `ENOSPC` stands for "Error No space" but is also thrown if the file watcher limit is reached.
-          // To prevent loops `!forcePolling` is checked.
-          if ((error.code === 'ENOSPC' || error.code === 'EMFILE') && !startedNewWatcher && !forcePolling) {
-            // This callback is called for every file the watcher is trying to watch. To prevent a spam of messages and
-            // Multiple watcher being started `startedNewWatcher` is set to prevent this.
-            startedNewWatcher = true;
-            watcher.close();
-            console.error(
-              `\nCould not start watcher for ${watchPath}:`,
-              'ENOSPC: System limit for number of file watchers reached!',
-              'Trying again with polling, this will be slower!\n',
-              'Update your system config to allow more concurrently watched files with:',
-              '"echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"'
-            );
-            this.addWatcher(win, watchPath, collectionUid, brunoConfig, true, useWorkerThread, options);
-          } else {
-            console.error(`An error occurred in the watcher for: ${watchPath}`, error);
-          }
-        });
+    this.watchers[watchPath] = watcher;
 
-      this.watchers[watchPath] = watcher;
-
-      dotEnvWatcher.addCollectionWatcher(win, watchPath, collectionUid);
-    }, 100);
+    dotEnvWatcher.addCollectionWatcher(win, watchPath, collectionUid);
   }
 
   hasWatcher(watchPath) {
@@ -921,12 +910,10 @@ class CollectionWatcher {
 
   removeWatcher(watchPath, win, collectionUid) {
     const existingWatcher = this.watchers[watchPath];
-    if (existingWatcher && typeof existingWatcher.close === 'function') {
+    if (existingWatcher) {
       existingWatcher.close();
     }
-    if (existingWatcher) {
-      this.watchers[watchPath] = null;
-    }
+    this.watchers[watchPath] = null;
 
     fileIndexByCollection.delete(watchPath);
 
@@ -934,10 +921,7 @@ class CollectionWatcher {
 
     const tempDirectoryPath = this.tempDirectoryMap[watchPath];
     if (tempDirectoryPath && this.watchers[tempDirectoryPath]) {
-      const tempWatcher = this.watchers[tempDirectoryPath];
-      if (typeof tempWatcher.close === 'function') {
-        tempWatcher.close();
-      }
+      this.watchers[tempDirectoryPath].close();
       delete this.watchers[tempDirectoryPath];
       delete this.tempDirectoryMap[watchPath];
     }

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -803,8 +803,9 @@ class CollectionWatcher {
   }
 
   addWatcher(win, watchPath, collectionUid, brunoConfig, forcePolling = false, useWorkerThread, options = {}) {
-    if (this.watchers[watchPath]) {
-      this.watchers[watchPath].close();
+    const existingWatcher = this.watchers[watchPath];
+    if (existingWatcher && typeof existingWatcher.close === 'function') {
+      existingWatcher.close();
     }
 
     // v2 already loaded the tree from cache; skip startup scan and stage live edits
@@ -817,11 +818,20 @@ class CollectionWatcher {
 
     this.startCollectionDiscovery(win, collectionUid);
 
+    // Reserve the path immediately so path-confinement checks succeed during the
+    // brief window before chokidar is attached (addWatcher defers that by 100ms).
+    this.watchers[watchPath] = true;
+
     // Always ignore node_modules and .git, regardless of user config
     // This prevents infinite loops with symlinked directories (e.g., npm workspaces)
     const defaultIgnores = ['node_modules', '.git'];
 
     setTimeout(() => {
+      // Collection was removed while the deferred setup was pending.
+      if (!this.watchers[watchPath]) {
+        return;
+      }
+
       const watcher = chokidar.watch(watchPath, {
         ignoreInitial,
         usePolling: isWSLPath(watchPath) || forcePolling ? true : false,
@@ -910,8 +920,11 @@ class CollectionWatcher {
   }
 
   removeWatcher(watchPath, win, collectionUid) {
-    if (this.watchers[watchPath]) {
-      this.watchers[watchPath].close();
+    const existingWatcher = this.watchers[watchPath];
+    if (existingWatcher && typeof existingWatcher.close === 'function') {
+      existingWatcher.close();
+    }
+    if (existingWatcher) {
       this.watchers[watchPath] = null;
     }
 
@@ -921,7 +934,10 @@ class CollectionWatcher {
 
     const tempDirectoryPath = this.tempDirectoryMap[watchPath];
     if (tempDirectoryPath && this.watchers[tempDirectoryPath]) {
-      this.watchers[tempDirectoryPath].close();
+      const tempWatcher = this.watchers[tempDirectoryPath];
+      if (typeof tempWatcher.close === 'function') {
+        tempWatcher.close();
+      }
       delete this.watchers[tempDirectoryPath];
       delete this.tempDirectoryMap[watchPath];
     }

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -125,6 +125,8 @@ const envHasSecrets = (environment = {}) => {
   return secrets && secrets.length > 0;
 };
 
+const LastOpenedCollections = require('../store/last-opened-collections');
+
 const findCollectionPathByItemPath = (filePath) => {
   const normalizedFilePath = path.normalize(filePath);
 
@@ -152,11 +154,17 @@ const findCollectionPathByItemPath = (filePath) => {
     return null;
   }
 
-  const allCollectionPaths = collectionWatcher.getAllWatcherPaths();
+  // Watchers cover mounted collections; lastOpenedCollections also covers
+  // workspace collections that are still lazy-unmounted (visible in the sidebar
+  // but not yet watched). Dropping into those must still pass path confinement.
+  const knownCollectionPaths = _.uniq([
+    ...collectionWatcher.getAllWatcherPaths(),
+    ...new LastOpenedCollections().getAll()
+  ]);
 
   // Find the collection path that contains this file
   // Sort by length descending to find the most specific (deepest) match first
-  const sortedPaths = allCollectionPaths.sort((a, b) => b.length - a.length);
+  const sortedPaths = knownCollectionPaths.sort((a, b) => b.length - a.length);
 
   for (const collectionPath of sortedPaths) {
     const normalizedCollectionPath = path.normalize(collectionPath);

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -152,17 +152,10 @@ const findCollectionPathByItemPath = (filePath) => {
     return null;
   }
 
-  // Watchers cover mounted collections; lastOpenedCollections also covers
-  // workspace collections that are still lazy-unmounted (visible in the sidebar
-  // but not yet watched). Dropping into those must still pass path confinement.
-  const knownCollectionPaths = _.uniq([
-    ...collectionWatcher.getAllWatcherPaths(),
-    ...new LastOpenedCollections().getAll()
-  ]);
-
+  const allCollectionPaths = collectionWatcher.getAllWatcherPaths();
   // Find the collection path that contains this file
   // Sort by length descending to find the most specific (deepest) match first
-  const sortedPaths = knownCollectionPaths.sort((a, b) => b.length - a.length);
+  const sortedPaths = allCollectionPaths.sort((a, b) => b.length - a.length);
 
   for (const collectionPath of sortedPaths) {
     const normalizedCollectionPath = path.normalize(collectionPath);

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -125,8 +125,6 @@ const envHasSecrets = (environment = {}) => {
   return secrets && secrets.length > 0;
 };
 
-const LastOpenedCollections = require('../store/last-opened-collections');
-
 const findCollectionPathByItemPath = (filePath) => {
   const normalizedFilePath = path.normalize(filePath);
 

--- a/tests/collection/draft/draft-indicator.spec.ts
+++ b/tests/collection/draft/draft-indicator.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { buildCommonLocators, closeAllCollections, createCollection } from '../../utils/page';
+import { buildCommonLocators, closeAllCollections, createCollection, createFolder } from '../../utils/page';
 
 test.describe.serial('Draft indicator in collection and folder settings', () => {
   test.afterAll(async ({ page }) => {
@@ -227,18 +227,7 @@ test.describe.serial('Draft indicator in collection and folder settings', () => 
   test('Verify draft indicator appears when changing folder settings - Headers', async ({ page }) => {
     const collectionName = 'test-draft';
 
-    // Create a folder in the collection
-    const collection = page.locator('.collection-name').filter({ hasText: collectionName });
-    await collection.hover(); // Hover on collection to reveal action buttons
-    await collection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-
-    // Fill folder name
-    await expect(page.locator('#folder-name')).toBeVisible();
-    await page.locator('#folder-name').fill('test-folder');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'test-folder' })).toBeVisible();
+    await createFolder(page, 'test-folder', collectionName);
 
     // Open folder settings by double-clicking the folder
     await page.locator('.collection-item-name').filter({ hasText: 'test-folder' }).dblclick();

--- a/tests/collection/moving-requests/cross-collection-drag-drop-folder.spec.ts
+++ b/tests/collection/moving-requests/cross-collection-drag-drop-folder.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, createCollection } from '../../utils/page';
+import { closeAllCollections, createCollection, createFolder, createRequest, expandFolder } from '../../utils/page';
 
 test.describe('Cross-Collection Drag and Drop for folder', () => {
   test.afterEach(async ({ page }) => {
@@ -8,43 +8,14 @@ test.describe('Cross-Collection Drag and Drop for folder', () => {
   });
 
   test('Verify cross-collection folder drag and drop', async ({ page, createTmpDir }) => {
-    // Create first collection - open with sandbox mode
     await createCollection(page, 'source-collection', await createTmpDir('source-collection'));
+    await createFolder(page, 'test-folder', 'source-collection');
+    await expandFolder(page, 'test-folder');
+    await createRequest(page, 'test-request-in-folder', 'test-folder', {
+      url: 'https://echo.usebruno.com',
+      inFolder: true
+    });
 
-    // Create a folder in the first collection
-    // Look for the collection menu button for the source collection specifically
-    const sourceCollectionContainer1 = page.locator('.collection-name').filter({ hasText: 'source-collection' });
-    await sourceCollectionContainer1.hover();
-    await sourceCollectionContainer1.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-
-    // Fill folder name in the modal
-    await expect(page.locator('#folder-name')).toBeVisible();
-    await page.locator('#folder-name').fill('test-folder');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    // Wait for the folder to be created and appear in the sidebar
-    await page.waitForTimeout(200);
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'test-folder' })).toBeVisible();
-
-    // Add a request to the folder to make it more realistic
-    await page.locator('.collection-item-name').filter({ hasText: 'test-folder' }).hover();
-    await page.locator('.collection-item-name').filter({ hasText: 'test-folder' }).locator('.menu-icon').click({ force: true });
-    await page.locator('.dropdown-item').filter({ hasText: 'New Request' }).click();
-    await page.getByPlaceholder('Request Name').fill('test-request-in-folder');
-    await page.locator('#new-request-url .CodeMirror').click();
-    await page.locator('textarea').fill('https://echo.usebruno.com');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    // Wait for the request to be created
-    await page.waitForTimeout(200);
-
-    // Expand the folder to see the request inside
-    await page.locator('.collection-item-name').filter({ hasText: 'test-folder' }).click();
-    await page.waitForTimeout(200);
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'test-request-in-folder' })).toBeVisible();
-
-    // Create second collection - open with sandbox mode
     await createCollection(page, 'target-collection', await createTmpDir('target-collection'));
 
     // Wait for both collections to be visible in sidebar
@@ -62,11 +33,7 @@ test.describe('Cross-Collection Drag and Drop for folder', () => {
     // Perform drag and drop operation
     await sourceFolder.dragTo(targetCollection);
 
-    // Wait for the operation to complete
-    await page.waitForTimeout(200);
-
     // Verify the folder has been moved to the target collection
-    // Check that the folder now appears under target collection
     const targetCollectionContainer = page
       .locator('.collection-name')
       .filter({ hasText: 'target-collection' })
@@ -76,8 +43,7 @@ test.describe('Cross-Collection Drag and Drop for folder', () => {
     ).toBeVisible();
 
     // Expand the moved folder to verify the request inside is also moved
-    await targetCollectionContainer.locator('.collection-item-name').filter({ hasText: 'test-folder' }).click();
-    await page.waitForTimeout(200);
+    await expandFolder(page, 'test-folder');
     await expect(
       targetCollectionContainer.locator('.collection-item-name').filter({ hasText: 'test-request-in-folder' })
     ).toBeVisible();
@@ -101,61 +67,16 @@ test.describe('Cross-Collection Drag and Drop for folder', () => {
     page,
     createTmpDir
   }) => {
-    // Create first collection (source) - use unique names for this test
     await createCollection(page, 'source-collection', await createTmpDir('source-collection'));
+    await createFolder(page, 'folder-1', 'source-collection');
+    await expandFolder(page, 'folder-1');
+    await createRequest(page, 'http-request', 'folder-1', {
+      url: 'https://echo.usebruno.com',
+      inFolder: true
+    });
 
-    // Create a folder in the first collection
-    await page
-      .locator('.collection-name')
-      .filter({ hasText: 'source-collection' })
-      .locator('..')
-      .locator('.collection-actions')
-      .hover();
-    await page
-      .locator('.collection-name')
-      .filter({ hasText: 'source-collection' })
-      .locator('..')
-      .locator('.collection-actions .icon')
-      .click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-    await expect(page.locator('#folder-name')).toBeVisible();
-    await page.locator('#folder-name').fill('folder-1');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'folder-1' })).toBeVisible();
-
-    // Add a request to the folder to make it more realistic
-    await page.locator('.collection-item-name').filter({ hasText: 'folder-1' }).hover();
-    await page.locator('.collection-item-name').filter({ hasText: 'folder-1' }).locator('.menu-icon').click({ force: true });
-    await page.locator('.dropdown-item').filter({ hasText: 'New Request' }).click();
-    await page.getByPlaceholder('Request Name').fill('http-request');
-    await page.locator('#new-request-url .CodeMirror').click();
-    await page.locator('textarea').fill('https://echo.usebruno.com');
-    await page.getByRole('button', { name: 'Create' }).click();
-    // Expand the folder to see the request inside
-    await page.locator('.collection-item-name').filter({ hasText: 'folder-1' }).click();
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'http-request' })).toBeVisible();
-
-    // Create second collection (target)
     await createCollection(page, 'target-collection', await createTmpDir('target-collection'));
-
-    // Create a folder with the same name in the target collection
-    await page
-      .locator('.collection-name')
-      .filter({ hasText: 'target-collection' })
-      .locator('..')
-      .locator('.collection-actions')
-      .hover();
-    await page
-      .locator('.collection-name')
-      .filter({ hasText: 'target-collection' })
-      .locator('..')
-      .locator('.collection-actions .icon')
-      .click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-    await expect(page.locator('#folder-name')).toBeVisible();
-    await page.locator('#folder-name').fill('folder-1');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await createFolder(page, 'folder-1', 'target-collection');
 
     // Verify we have the folder to drag in the source collection
     const sourceFolder = page.locator('.collection-item-name').filter({ hasText: 'folder-1' }).first();

--- a/tests/collection/moving-tabs/move-tabs.spec.ts
+++ b/tests/collection/moving-tabs/move-tabs.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, createCollection } from '../../utils/page';
+import { closeAllCollections, createCollection, createFolder, createRequest } from '../../utils/page';
 
 const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
 
@@ -10,45 +10,17 @@ test.describe('Move tabs', () => {
   });
 
   test('Verify tab move by drag and drop', async ({ page, createTmpDir }) => {
-    // Create a collection
     await createCollection(page, 'source-collection-drag-drop', await createTmpDir('source-collection-drag-drop'));
-
-    // Create a folder in the collection
-    const sourceCollection = page.locator('.collection-name').filter({ hasText: 'source-collection-drag-drop' });
-    await sourceCollection.hover();
-    await sourceCollection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-
-    // Fill folder name in the modal
-    await expect(page.locator('#folder-name')).toBeVisible();
-    await page.locator('#folder-name').fill('test-folder');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    // Wait for the folder to be created and appear in the sidebar
-    await page.waitForTimeout(2000);
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'test-folder' })).toBeVisible();
+    await createFolder(page, 'test-folder', 'source-collection-drag-drop');
 
     // Open the folder tab
     await page.locator('.collection-item-name').filter({ hasText: 'test-folder' }).dblclick();
-    await page.waitForTimeout(500);
     await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'test-folder' })).toBeVisible();
 
-    // Add a request to the collection
-    await sourceCollection.hover();
-    await sourceCollection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Request' }).click();
-    await page.getByPlaceholder('Request Name').fill('test-request');
-    await page.locator('#new-request-url .CodeMirror').click();
-    await page.locator('#new-request-url textarea').fill('https://echo.usebruno.com');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    // Wait for the request to be created
-    await page.waitForTimeout(1000);
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'test-request' })).toBeVisible();
+    await createRequest(page, 'test-request', 'source-collection-drag-drop', { url: 'https://echo.usebruno.com' });
 
     // Open the request tab
     await page.locator('.collection-item-name').filter({ hasText: 'test-request' }).dblclick();
-    await page.waitForTimeout(500);
     await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'test-request' })).toBeVisible();
 
     // Verify order of tabs before move
@@ -88,45 +60,17 @@ test.describe('Move tabs', () => {
   });
 
   test('Verify tab move by keyboard shortcut', async ({ page, createTmpDir }) => {
-    // Create a collection
     await createCollection(page, 'source-collection-keyboard-shortcut', await createTmpDir('source-collection-keyboard-shortcut'));
-
-    // Create a folder in the collection
-    const sourceCollection = page.locator('.collection-name').filter({ hasText: 'source-collection-keyboard-shortcut' });
-    await sourceCollection.hover();
-    await sourceCollection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-
-    // Fill folder name in the modal
-    await expect(page.locator('#folder-name')).toBeVisible();
-    await page.locator('#folder-name').fill('test-folder');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    // Wait for the folder to be created and appear in the sidebar
-    await page.waitForTimeout(2000);
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'test-folder' })).toBeVisible();
+    await createFolder(page, 'test-folder', 'source-collection-keyboard-shortcut');
 
     // Open the folder tab
     await page.locator('.collection-item-name').filter({ hasText: 'test-folder' }).dblclick();
-    await page.waitForTimeout(500);
     await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'test-folder' })).toBeVisible();
 
-    // Add a request to the collection
-    await sourceCollection.hover();
-    await sourceCollection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Request' }).click();
-    await page.getByPlaceholder('Request Name').fill('test-request');
-    await page.locator('#new-request-url .CodeMirror').click();
-    await page.locator('#new-request-url textarea').fill('https://echo.usebruno.com');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    // Wait for the request to be created
-    await page.waitForTimeout(1000);
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'test-request' })).toBeVisible();
+    await createRequest(page, 'test-request', 'source-collection-keyboard-shortcut', { url: 'https://echo.usebruno.com' });
 
     // Open the request tab
     await page.locator('.collection-item-name').filter({ hasText: 'test-request' }).dblclick();
-    await page.waitForTimeout(500);
     await expect(page.locator('.request-tab .tab-label').filter({ hasText: 'test-request' })).toBeVisible();
 
     // Verify order of tabs before move
@@ -138,7 +82,6 @@ test.describe('Move tabs', () => {
     const source = page.locator('.request-tab .tab-label').filter({ hasText: 'test-request' });
     await source.click();
     await page.keyboard.press(`${modifier}+BracketLeft`);
-    await page.waitForTimeout(500);
 
     // Verify order of tabs after move
     await expect(tabs.nth(0)).toHaveText('GETtest-request');
@@ -147,7 +90,6 @@ test.describe('Move tabs', () => {
     // Move the request tab back to its original position using keyboard shortcut
     await source.click();
     await page.keyboard.press(`${modifier}+BracketRight`);
-    await page.waitForTimeout(500);
 
     // Verify order of tabs after move
     await expect(tabs.nth(0)).toHaveText('test-folder');

--- a/tests/grpc/method-search/grpc-method-search.spec.ts
+++ b/tests/grpc/method-search/grpc-method-search.spec.ts
@@ -8,7 +8,7 @@ test.describe('Grpc Collection - Method Search Functionality', () => {
 
     await test.step('Switch to GrpcEnv environment', async () => {
       await page.locator('div.current-environment').click();
-      await page.getByText('GrpcEnv').click();
+      await page.getByTestId('env-list-item').filter({ hasText: 'GrpcEnv' }).click();
       await expect(page.locator('.current-environment').filter({ hasText: /GrpcEnv/ })).toBeVisible();
     });
   });

--- a/tests/request/copy-request/copy-folder.spec.ts
+++ b/tests/request/copy-request/copy-folder.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, createCollection } from '../../utils/page';
+import { closeAllCollections, createCollection, createFolder, createRequest, expandFolder } from '../../utils/page';
 
 test.describe.serial('Copy and Paste Folders', () => {
   test.afterAll(async ({ page }) => {
@@ -10,27 +10,14 @@ test.describe.serial('Copy and Paste Folders', () => {
     await createCollection(page, 'test-collection', await createTmpDir('test-collection'));
     const collection = page.locator('.collection-name').filter({ hasText: 'test-collection' });
 
-    // Create a new folder with a request inside
-    await collection.hover();
-    await collection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-    await page.locator('#folder-name').fill('folder-to-copy');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await createFolder(page, 'folder-to-copy', 'test-collection');
+    await expandFolder(page, 'folder-to-copy');
+    await createRequest(page, 'request-in-folder', 'folder-to-copy', {
+      url: 'https://echo.usebruno.com/test',
+      inFolder: true
+    });
 
     const folder = page.locator('.collection-item-name').filter({ hasText: 'folder-to-copy' });
-    await expect(folder).toBeVisible();
-
-    // Add a request to the folder
-    await folder.hover();
-    await folder.locator('.menu-icon').click({ force: true });
-    await page.locator('.dropdown-item').filter({ hasText: 'New Request' }).click();
-    await page.getByPlaceholder('Request Name').fill('request-in-folder');
-    await page.locator('#new-request-url .CodeMirror').click();
-    await page.locator('textarea').fill('https://echo.usebruno.com/test');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    await folder.click();
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'request-in-folder' })).toBeVisible();
 
     // Copy the folder
     await folder.hover();
@@ -64,12 +51,7 @@ test.describe.serial('Copy and Paste Folders', () => {
     const collection = page.locator('.collection-name').filter({ hasText: 'test-collection-2' });
     const folderToCopy = page.locator('.collection-item-name').filter({ hasText: 'folder-to-copy' }).first();
 
-    // Create a target folder
-    await collection.hover();
-    await collection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-    await page.locator('#folder-name').fill('target-folder');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await createFolder(page, 'target-folder', 'test-collection-2');
 
     const targetFolder = page.locator('.collection-item-name').filter({ hasText: 'target-folder' });
     await expect(targetFolder).toBeVisible();

--- a/tests/request/copy-request/copy-request.spec.ts
+++ b/tests/request/copy-request/copy-request.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, createCollection, createRequest } from '../../utils/page';
+import { closeAllCollections, createCollection, createFolder, createRequest } from '../../utils/page';
 
 test.describe.serial('Copy and Paste Requests', () => {
   test.afterAll(async ({ page }) => {
@@ -8,18 +8,9 @@ test.describe.serial('Copy and Paste Requests', () => {
 
   test('should copy and paste a request within the same collection', async ({ page, createTmpDir }) => {
     await createCollection(page, 'test-collection', await createTmpDir('test-collection'));
+    await createRequest(page, 'original-request', 'test-collection', { url: 'https://echo.usebruno.com' });
 
-    // Create a new request
     const collection = page.locator('.collection-name').filter({ hasText: 'test-collection' });
-    await collection.hover();
-    await collection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Request' }).click();
-    await page.getByPlaceholder('Request Name').fill('original-request');
-    await page.locator('#new-request-url .CodeMirror').click();
-    await page.locator('textarea').fill('https://echo.usebruno.com');
-    await page.getByRole('button', { name: 'Create' }).click();
-
-    await expect(page.locator('.collection-item-name').filter({ hasText: 'original-request' })).toBeVisible();
 
     // Copy the request
     const requestItem = page.locator('.collection-item-name').filter({ hasText: 'original-request' });
@@ -37,12 +28,7 @@ test.describe.serial('Copy and Paste Requests', () => {
   });
 
   test('should paste request into a folder', async ({ page, createTmpDir }) => {
-    const collection = page.locator('.collection-name').filter({ hasText: 'test-collection' });
-    await collection.hover();
-    await collection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-    await page.locator('#folder-name').fill('test-folder');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await createFolder(page, 'test-folder', 'test-collection');
 
     // Paste into the folder
     const folder = page.locator('.collection-item-name').filter({ hasText: 'test-folder' });

--- a/tests/request/copy-request/keyboard-shortcuts.spec.ts
+++ b/tests/request/copy-request/keyboard-shortcuts.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../playwright';
-import { closeAllCollections, createCollection } from '../../utils/page';
+import { closeAllCollections, createCollection, createFolder, createRequest } from '../../utils/page';
 
 test.describe.serial('Copy and Paste with Keyboard Shortcuts', () => {
   test.afterAll(async ({ page }) => {
@@ -8,17 +8,9 @@ test.describe.serial('Copy and Paste with Keyboard Shortcuts', () => {
 
   test('should copy and paste request using keyboard shortcuts', async ({ page, createTmpDir }) => {
     await createCollection(page, 'keyboard-test', await createTmpDir('keyboard-test'));
+    await createRequest(page, 'test-request', 'keyboard-test', { url: 'https://echo.usebruno.com' });
+
     const collection = page.locator('.collection-name').filter({ hasText: 'keyboard-test' });
-
-    // Create a request
-    await collection.hover();
-    await collection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Request' }).click();
-    await page.getByPlaceholder('Request Name').fill('test-request');
-    await page.locator('#new-request-url .CodeMirror').click();
-    await page.locator('textarea').fill('https://echo.usebruno.com');
-    await page.getByRole('button', { name: 'Create' }).click();
-
     const requestItem = page.locator('.collection-item-name').filter({ hasText: 'test-request' });
     await expect(requestItem).toBeVisible();
 
@@ -53,12 +45,7 @@ test.describe.serial('Copy and Paste with Keyboard Shortcuts', () => {
   test('should copy and paste folder using keyboard shortcuts', async ({ page }) => {
     const collection = page.locator('.collection-name').filter({ hasText: 'keyboard-test' });
 
-    // Create a folder
-    await collection.hover();
-    await collection.locator('.collection-actions .icon').click();
-    await page.locator('.dropdown-item').filter({ hasText: 'New Folder' }).click();
-    await page.locator('#folder-name').fill('test-folder');
-    await page.getByRole('button', { name: 'Create' }).click();
+    await createFolder(page, 'test-folder', 'keyboard-test');
 
     const folder = page.locator('.collection-item-name').filter({ hasText: 'test-folder' });
     await expect(folder).toBeVisible();

--- a/tests/request/save/save.spec.ts
+++ b/tests/request/save/save.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Locator, Page } from '../../../playwright';
-import { closeAllCollections, createCollection } from '../../utils/page';
+import { closeAllCollections, createCollection, createRequest } from '../../utils/page';
 import { buildCommonLocators } from '../../utils/page/locators';
 import { waitForPredicate } from '../../utils/wait';
 
@@ -10,16 +10,7 @@ const isRequestSaved = async (saveButton: Locator) => {
 
 const setup = async (page: Page, createTmpDir: (tag?: string | undefined) => Promise<string>) => {
   await createCollection(page, 'source-collection', await createTmpDir('source-collection'));
-
-  const sourceCollection = page.locator('.collection-name').filter({ hasText: 'source-collection' });
-  await sourceCollection.hover();
-  await sourceCollection.locator('.collection-actions .icon').click();
-  await page.locator('.dropdown-item').filter({ hasText: 'New Request' }).click();
-  await page.getByPlaceholder('Request Name').fill('test-request');
-  await page.locator('#new-request-url .CodeMirror').click();
-  await page.locator('textarea').fill('https://echo.usebruno.com');
-  await page.getByRole('button', { name: 'Create' }).click();
-  await expect(page.locator('.collection-item-name').filter({ hasText: 'test-request' })).toBeVisible();
+  await createRequest(page, 'test-request', 'source-collection', { url: 'https://echo.usebruno.com' });
 };
 
 test.describe.serial('save requests', () => {

--- a/tests/response-examples/save-as-example-multipart.spec.ts
+++ b/tests/response-examples/save-as-example-multipart.spec.ts
@@ -36,10 +36,8 @@ test.describe('Response Example - multipart files preserved when creating exampl
       await page.getByRole('button', { name: 'Create Example' }).click();
     });
 
-    await test.step('Example tab opens with the right title', async () => {
-      const title = page.getByTestId('response-example-title');
-      await expect(title).toBeVisible();
-      await expect(title).toContainText('Created From Request');
+    await test.step('Example tab opens in edit mode with the right name', async () => {
+      await expect(page.getByTestId('response-example-name-input')).toHaveValue('Created From Request');
     });
 
     await test.step('File chips show real names', async () => {

--- a/tests/snapshots/sidebar-state.spec.ts
+++ b/tests/snapshots/sidebar-state.spec.ts
@@ -91,7 +91,6 @@ test.describe('Snapshot: Sidebar-Tab Restoration', () => {
       await openRequest(page, 'TestCol', 'ReqAlpha', { persist: true });
 
       await createExampleFromSidebar(page, 'ReqAlpha', 'Example One');
-      await expect(page.getByTestId('response-example-title')).toHaveText('ReqAlpha / Example One');
 
       await openRequest(page, 'TestCol', 'ReqAlpha', { persist: true });
 
@@ -135,7 +134,7 @@ test.describe('Snapshot: Sidebar-Tab Restoration', () => {
 
       await createExampleFromSidebar(page, 'ReqAlpha', 'Example One');
       await openExampleFromSidebar(page, 'ReqAlpha', 'Example One');
-      await expect(page.getByTestId('response-example-title')).toHaveText('ReqAlpha / Example One');
+      await expect(page.getByTestId('response-example-name-input')).toHaveValue('Example One');
     });
 
     await test.step('Close and restart app', async () => {
@@ -170,7 +169,7 @@ test.describe('Snapshot: Sidebar-Tab Restoration', () => {
       await createExampleFromSidebar(page, 'ReqAlpha', 'DupExample', 'first-desc');
       await createExampleFromSidebar(page, 'ReqAlpha', 'DupExample', 'second-desc');
       await openExampleFromSidebar(page, 'ReqAlpha', 'DupExample', 1);
-      await expect(page.getByTestId('response-example-description')).toHaveText('second-desc');
+      await expect(page.getByTestId('response-example-description-input')).toHaveValue('second-desc');
     });
 
     await test.step('Close and restart app', async () => {

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -646,7 +646,12 @@ const createFolder = async (
     await locators.dropdown.item('New Folder').click();
     await page.getByTestId('new-folder-input').fill(folderName);
     await locators.modal.button('Create').click();
-    await expect(locators.sidebar.folder(folderName)).toBeVisible();
+
+    // Scope to the parent so same-named folders in other collections don't trip strict mode.
+    const parentScope = isCollection
+      ? locators.sidebar.collectionScope(parentName)
+      : locators.sidebar.folder(parentName).locator('..');
+    await expect(parentScope.locator('.collection-item-name').filter({ hasText: folderName })).toBeVisible();
   });
 };
 
@@ -2044,6 +2049,12 @@ const createExampleFromSidebar = async (page: Page, requestName: string, example
   await descriptionInput.fill(description);
   await page.getByRole('button', { name: 'Create Example' }).click();
   await expect(page.locator('text=Create Response Example')).not.toBeAttached();
+
+  // Sidebar-created examples open in edit mode (openInEditMode: true).
+  await expect(page.getByTestId('response-example-name-input')).toHaveValue(exampleName);
+  if (description) {
+    await expect(page.getByTestId('response-example-description-input')).toHaveValue(description);
+  }
 };
 
 const openExampleFromSidebar = async (page: Page, requestName: string, exampleName: string, index: number = 0) => {


### PR DESCRIPTION
## Summary
- Update e2e call sites to use `createFolder` / `createRequest` (and edit-mode example testids) so Create no longer collides with the mock-server sidebar button and sidebar-created examples match `openInEditMode`.
- Fix cross-format / unmounted-collection drops: path confinement now includes last-opened collections, watchers reserve paths immediately, and dropping onto a collection mounts it first.
- Scope `createFolder` visibility asserts to the parent collection so duplicate folder names across collections do not trip strict mode.

## Test plan
- [x] Local Playwright (line reporter) for previously failing specs: save, draft-indicator, copy-*, move-tabs, cross-collection folder D&D, cross-format D&D, sidebar-state, save-as-example-multipart
- [ ] Confirm Linux Playwright CI shards go green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop between collections by automatically loading target collections before moving items.
  * Improved collection file-watcher replacement and cleanup for more reliable updates.
  * Prevented folder creation checks from matching same-named folders in unrelated locations.

* **Tests**
  * Updated coverage for moving, copying, saving, examples, sidebar states, and environment selection.
  * Improved test reliability by using shared actions and reducing timing-dependent waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->