### PR TITLE
feat(app): add select-all checkbox for query params

### DIFF
--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -76,6 +76,7 @@ const EditableTable = ({
   defaultRow,
   getRowError,
   showCheckbox = true,
+  showSelectAll = false,
   showDelete = true,
   disableCheckbox = false,
   checkboxLabel = '',
@@ -94,6 +95,7 @@ const EditableTable = ({
   const virtuosoRef = useRef(null);
   const emptyRowUidRef = useRef(null);
   const prevRowCountRef = useRef(0);
+  const selectAllRef = useRef(null);
   const [resizing, setResizing] = useState(null);
   const [tableHeight, setTableHeight] = useState(0);
   const [scrollParent, setScrollParent] = useState(null);
@@ -124,10 +126,19 @@ const EditableTable = ({
   const rows = sortable ? displayRows : rowsProp;
   const onChange = sortable ? handleChange : onChangeProp;
   const reorderable = reorderableProp && sortAllowsReorder;
+  const checkedRowCount = rows.filter((row) => row[checkboxKey] ?? true).length;
+  const allRowsChecked = rows.length > 0 && checkedRowCount === rows.length;
+  const someRowsChecked = checkedRowCount > 0 && !allRowsChecked;
 
   useLayoutEffect(() => {
     setScrollParent(findScrollParent(wrapperRef.current));
   }, []);
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someRowsChecked;
+    }
+  }, [someRowsChecked, scrollParent]);
 
   const handleTotalHeightChanged = useCallback((h) => {
     setTableHeight(h);
@@ -298,6 +309,13 @@ const EditableTable = ({
     handleValueChange(rowUid, checkboxKey, checked);
   }, [handleValueChange, checkboxKey]);
 
+  const handleSelectAllChange = useCallback((checked) => {
+    onChange(rows.map((row) => ({
+      ...row,
+      [checkboxKey]: checked
+    })));
+  }, [rows, checkboxKey, onChange]);
+
   const handleRemoveRow = useCallback((rowUid) => {
     const filteredRows = rows.filter((row) => row.uid !== rowUid);
     onChange(filteredRows);
@@ -393,7 +411,20 @@ const EditableTable = ({
     <tr>
       {!showCheckbox && reorderable && <td className="text-center" style={{ width: '32px' }}></td>}
       {showCheckbox && (
-        <td className="text-center">{checkboxLabel}</td>
+        <td className="text-center">
+          {showSelectAll ? (
+            <input
+              ref={selectAllRef}
+              type="checkbox"
+              className="mousetrap"
+              data-testid="select-all-checkbox"
+              aria-label={checkboxLabel || 'Toggle all rows'}
+              checked={allRowsChecked}
+              disabled={disableCheckbox || rows.length === 0}
+              onChange={(e) => handleSelectAllChange(e.target.checked)}
+            />
+          ) : checkboxLabel}
+        </td>
       )}
       {columns.map((column, colIndex) => {
         const isSortColumn = column === sortColumn;
@@ -430,7 +461,7 @@ const EditableTable = ({
         </td>
       )}
     </tr>
-  ), [showCheckbox, checkboxLabel, columns, getColumnWidth, resizing, tableHeight, handleResizeStart, showDelete, sortColumn, cycleSortMode, SortIcon, sortLabel, testId, reorderable]);
+  ), [showCheckbox, showSelectAll, checkboxLabel, allRowsChecked, disableCheckbox, rows.length, handleSelectAllChange, columns, getColumnWidth, resizing, tableHeight, handleResizeStart, showDelete, sortColumn, cycleSortMode, SortIcon, sortLabel, testId, reorderable]);
 
   const itemContent = useCallback((rowIndex, row) => {
     const isEmpty = isLastEmptyRow(row, rowIndex);

--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -138,7 +138,7 @@ const EditableTable = ({
     if (selectAllRef.current) {
       selectAllRef.current.indeterminate = someRowsChecked;
     }
-  }, [someRowsChecked, scrollParent]);
+  }, [someRowsChecked, showSelectAll, scrollParent]);
 
   const handleTotalHeightChanged = useCallback((h) => {
     setTableHeight(h);

--- a/packages/bruno-app/src/components/EditableTable/index.spec.js
+++ b/packages/bruno-app/src/components/EditableTable/index.spec.js
@@ -34,7 +34,7 @@ const columns = [
   }
 ];
 
-const ControlledTable = ({ initialRows }) => {
+const ControlledTable = ({ initialRows, showSelectAll = true }) => {
   const [rows, setRows] = useState(initialRows);
 
   return (
@@ -45,7 +45,7 @@ const ControlledTable = ({ initialRows }) => {
         rows={rows}
         onChange={setRows}
         defaultRow={{ name: '' }}
-        showSelectAll
+        showSelectAll={showSelectAll}
         checkboxLabel="Toggle all query parameters"
         showAddRow={false}
         showDelete={false}
@@ -105,6 +105,26 @@ describe('EditableTable select all checkbox', () => {
     screen.getAllByTestId('column-checkbox').forEach((checkbox) => {
       expect(checkbox).not.toBeChecked();
     });
+  });
+
+  it('shows an indeterminate state when select all becomes visible', () => {
+    const rows = [
+      { uid: 'first', name: 'First', enabled: true },
+      { uid: 'second', name: 'Second', enabled: false }
+    ];
+    const { rerender } = render(
+      <ControlledTable initialRows={rows} showSelectAll={false} />
+    );
+
+    expect(screen.queryByRole('checkbox', {
+      name: 'Toggle all query parameters'
+    })).not.toBeInTheDocument();
+
+    rerender(<ControlledTable initialRows={rows} showSelectAll />);
+
+    expect(screen.getByRole('checkbox', {
+      name: 'Toggle all query parameters'
+    })).toBePartiallyChecked();
   });
 
   it('disables the select all checkbox when there are no rows', () => {

--- a/packages/bruno-app/src/components/EditableTable/index.spec.js
+++ b/packages/bruno-app/src/components/EditableTable/index.spec.js
@@ -1,0 +1,117 @@
+import '@testing-library/jest-dom';
+import React, { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EditableTable from './index';
+
+jest.mock('react-virtuoso', () => ({
+  TableVirtuoso: ({ data, fixedHeaderContent, itemContent }) => (
+    <table>
+      <thead>{fixedHeaderContent()}</thead>
+      <tbody>
+        {data.map((row, index) => (
+          <tr key={row.uid}>{itemContent(index, row)}</tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}));
+
+jest.mock('./StyledWrapper', () => {
+  const { forwardRef } = jest.requireActual('react');
+
+  return forwardRef(({ children, ...props }, ref) => (
+    <div ref={ref} {...props}>
+      {children}
+    </div>
+  ));
+});
+
+const columns = [
+  {
+    key: 'name',
+    name: 'Name'
+  }
+];
+
+const ControlledTable = ({ initialRows }) => {
+  const [rows, setRows] = useState(initialRows);
+
+  return (
+    <div style={{ overflowY: 'auto' }}>
+      <EditableTable
+        tableId="query-params"
+        columns={columns}
+        rows={rows}
+        onChange={setRows}
+        defaultRow={{ name: '' }}
+        showSelectAll
+        checkboxLabel="Toggle all query parameters"
+        showAddRow={false}
+        showDelete={false}
+      />
+    </div>
+  );
+};
+
+describe('EditableTable select all checkbox', () => {
+  let user;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  it('shows an indeterminate state and enables every row when clicked', async () => {
+    render(
+      <ControlledTable
+        initialRows={[
+          { uid: 'first', name: 'First', enabled: true },
+          { uid: 'second', name: 'Second', enabled: false }
+        ]}
+      />
+    );
+
+    const selectAllCheckbox = screen.getByRole('checkbox', {
+      name: 'Toggle all query parameters'
+    });
+
+    expect(selectAllCheckbox).toBePartiallyChecked();
+
+    await user.click(selectAllCheckbox);
+
+    expect(selectAllCheckbox).toBeChecked();
+    screen.getAllByTestId('column-checkbox').forEach((checkbox) => {
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it('disables every row when all rows are enabled', async () => {
+    render(
+      <ControlledTable
+        initialRows={[
+          { uid: 'first', name: 'First', enabled: true },
+          { uid: 'second', name: 'Second', enabled: true }
+        ]}
+      />
+    );
+
+    const selectAllCheckbox = screen.getByRole('checkbox', {
+      name: 'Toggle all query parameters'
+    });
+
+    await user.click(selectAllCheckbox);
+
+    expect(selectAllCheckbox).not.toBeChecked();
+    screen.getAllByTestId('column-checkbox').forEach((checkbox) => {
+      expect(checkbox).not.toBeChecked();
+    });
+  });
+
+  it('disables the select all checkbox when there are no rows', () => {
+    render(<ControlledTable initialRows={[]} />);
+
+    expect(screen.getByRole('checkbox', {
+      name: 'Toggle all query parameters'
+    })).toBeDisabled();
+  });
+});

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -186,6 +186,8 @@ const QueryParams = ({ item, collection }) => {
           testId="query-params-table"
           columns={queryColumns}
           rows={queryParams || []}
+          showSelectAll
+          checkboxLabel="Toggle all query parameters"
           onChange={handleQueryParamsChange}
           defaultRow={defaultQueryRow}
           reorderable={true}


### PR DESCRIPTION
### Description

Adds a parent checkbox to the Query Parameters table so users can enable or disable all query parameters with one action.

### Problem

Requests with many query parameters currently require toggling each parameter individually.

Fixes #8799

### Fix

- Adds an opt-in select-all control to `EditableTable`.
- Reflects checked, unchecked, and indeterminate states.
- Enables the control only for request query parameters.
- Preserves the existing `onChange` flow so query parameters and the request URL stay in sync.
- Adds behavior-focused tests for selecting all, deselecting all, mixed selection, and empty tables.

### Screenshots

| Before | After |
| --- | --- |
| Not provided | Not provided |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

### Validation

- `npm test --workspace=packages/bruno-app -- --runInBand` (109 suites, 1732 tests)
- `npm run lint -- packages/bruno-app/src/components/EditableTable/index.js packages/bruno-app/src/components/EditableTable/index.spec.js packages/bruno-app/src/components/RequestPane/QueryParams/index.js`
- `npm run build:web`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “select all” checkbox to editable tables.
  * Users can select or deselect all rows at once, with partial selections clearly indicated.
  * Added a “Toggle all query parameters” control to the query-parameter table.
  * The control is disabled when selection is unavailable or no rows exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->