### PR TITLE
feat(path params): switch between candidate values for a path param

### DIFF
--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -478,6 +478,7 @@ const EditableTable = ({
                 className="mousetrap"
                 data-testid="column-radio"
                 name={`${testId}-${row[radioGroupKey]}`}
+                aria-label={`Use ${row[keyColumn?.key] ?? row[radioGroupKey]}: ${row.value ?? ''}`}
                 checked={row[checkboxKey] !== false}
                 disabled={disableCheckbox}
                 onChange={() => handleCheckboxChange(row.uid, true)}

--- a/packages/bruno-app/src/components/EditableTable/index.js
+++ b/packages/bruno-app/src/components/EditableTable/index.js
@@ -80,6 +80,9 @@ const EditableTable = ({
   disableCheckbox = false,
   checkboxLabel = '',
   checkboxKey = 'enabled',
+  radioGroupKey,
+  onCheckboxChange,
+  canDeleteRow,
   reorderable: reorderableProp = false,
   onReorder,
   showAddRow = true,
@@ -295,8 +298,20 @@ const EditableTable = ({
   }, [rowsWithEmpty, hasAnyValue, onChange, showAddRow]);
 
   const handleCheckboxChange = useCallback((rowUid, checked) => {
+    if (onCheckboxChange) {
+      onCheckboxChange(rowUid, checked);
+      return;
+    }
     handleValueChange(rowUid, checkboxKey, checked);
-  }, [handleValueChange, checkboxKey]);
+  }, [onCheckboxChange, handleValueChange, checkboxKey]);
+
+  const radioGroupCounts = useMemo(() => {
+    if (!radioGroupKey) {
+      return null;
+    }
+
+    return rows.reduce((counts, row) => counts.set(row[radioGroupKey], (counts.get(row[radioGroupKey]) || 0) + 1), new Map());
+  }, [radioGroupKey, rows]);
 
   const handleRemoveRow = useCallback((rowUid) => {
     const filteredRows = rows.filter((row) => row.uid !== rowUid);
@@ -455,7 +470,20 @@ const EditableTable = ({
                 />
               </div>
             )}
-            {!isEmpty && (
+            {/* A lone always-on row needs no control, but a lone row persisted as
+                disabled still needs the radio or it could never be re-enabled. */}
+            {!isEmpty && radioGroupCounts && (radioGroupCounts.get(row[radioGroupKey]) > 1 || row[checkboxKey] === false) && (
+              <input
+                type="radio"
+                className="mousetrap"
+                data-testid="column-radio"
+                name={`${testId}-${row[radioGroupKey]}`}
+                checked={row[checkboxKey] !== false}
+                disabled={disableCheckbox}
+                onChange={() => handleCheckboxChange(row.uid, true)}
+              />
+            )}
+            {!isEmpty && !radioGroupCounts && (
               <input
                 type="checkbox"
                 className="mousetrap"
@@ -486,7 +514,7 @@ const EditableTable = ({
             }
           }}
           >
-            {!isEmpty && (
+            {!isEmpty && (!canDeleteRow || canDeleteRow(row)) && (
               <button
                 data-testid="column-delete"
                 onClick={() => handleRemoveRow(row.uid)}
@@ -498,7 +526,7 @@ const EditableTable = ({
         )}
       </>
     );
-  }, [showCheckbox, reorderable, reorderableRowCount, isLastEmptyRow, keyColumn, handleDragHandleMouseDown, checkboxKey, disableCheckbox, handleCheckboxChange, columns, renderCell, showDelete, handleRemoveRow]);
+  }, [showCheckbox, reorderable, reorderableRowCount, isLastEmptyRow, keyColumn, handleDragHandleMouseDown, checkboxKey, radioGroupCounts, radioGroupKey, testId, disableCheckbox, handleCheckboxChange, columns, renderCell, showDelete, canDeleteRow, handleRemoveRow]);
 
   const initialTopMostItemIndex = useRef(Math.max(0, Math.floor(initialScroll / ROW_HEIGHT))).current;
 

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/StyledWrapper.js
@@ -58,10 +58,25 @@ const Wrapper = styled.div`
     }
   }
 
-  input[type='checkbox'] {
+  input[type='checkbox'],
+  input[type='radio'] {
     cursor: pointer;
     position: relative;
     top: 1px;
+  }
+
+  .add-alternate {
+    color: ${(props) => props.theme.colors.text.muted};
+    opacity: 0;
+
+    &:hover {
+      color: ${(props) => props.theme.colors.text.yellow};
+    }
+  }
+
+  tr:hover .add-alternate,
+  .add-alternate:focus-visible {
+    opacity: 1;
   }
 `;
 

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -1,12 +1,14 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useMemo, useRef } from 'react';
 import get from 'lodash/get';
+import { IconPlus } from '@tabler/icons';
 import InfoTip from 'components/InfoTip';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import {
   moveQueryParam,
   updatePathParam,
-  setQueryParams
+  setQueryParams,
+  setPathParams
 } from 'providers/ReduxStore/slices/collections';
 import { saveRequest, sendRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { updateTableColumnWidths } from 'providers/ReduxStore/slices/tabs';
@@ -68,6 +70,29 @@ const QueryParams = ({ item, collection }) => {
     },
     [dispatch, pathParams, item.uid, collection.uid]
   );
+
+  const handlePathParamsChange = useCallback((updatedParams) => {
+    dispatch(setPathParams({
+      collectionUid: collection.uid,
+      itemUid: item.uid,
+      params: updatedParams
+    }));
+  }, [dispatch, collection.uid, item.uid]);
+
+  const handlePathParamSelect = useCallback((rowUid) => {
+    handlePathParamChange(rowUid, 'enabled', true);
+  }, [handlePathParamChange]);
+
+  const addPathParamAlternate = useCallback((name) => {
+    handlePathParamsChange([...pathParams, { name, value: '', description: '', enabled: false }]);
+  }, [handlePathParamsChange, pathParams]);
+
+  const pathParamNameCounts = useMemo(
+    () => pathParams.reduce((counts, param) => counts.set(param.name, (counts.get(param.name) || 0) + 1), new Map()),
+    [pathParams]
+  );
+
+  const canDeletePathParam = useCallback((row) => pathParamNameCounts.get(row.name) > 1, [pathParamNameCounts]);
 
   const handleQueryParamDrag = useCallback(({ updateReorderedItem }) => {
     dispatch(moveQueryParam({
@@ -133,7 +158,19 @@ const QueryParams = ({ item, collection }) => {
       name: 'Name',
       isKeyField: true,
       width: '20%',
-      readOnly: true
+      render: ({ row, value }) => (
+        <div className="flex items-center justify-between gap-2 w-full">
+          <span className="truncate">{value}</span>
+          <button
+            className="add-alternate"
+            title={`Add another value for :${value}`}
+            data-testid="path-param-add-alternate"
+            onClick={() => addPathParamAlternate(row.name)}
+          >
+            <IconPlus strokeWidth={1.5} size={14} />
+          </button>
+        </div>
+      )
     },
     {
       key: 'value',
@@ -219,10 +256,11 @@ const QueryParams = ({ item, collection }) => {
             testId="path-params-table"
             columns={pathColumns}
             rows={pathParams}
-            onChange={() => {}}
+            onChange={handlePathParamsChange}
             defaultRow={{}}
-            showCheckbox={false}
-            showDelete={false}
+            radioGroupKey="name"
+            onCheckboxChange={handlePathParamSelect}
+            canDeleteRow={canDeletePathParam}
             showAddRow={false}
             columnWidths={pathParamsWidths}
             onColumnWidthsChange={(widths) => handleColumnWidthsChange('path-params', widths)}

--- a/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryParams/index.js
@@ -162,8 +162,10 @@ const QueryParams = ({ item, collection }) => {
         <div className="flex items-center justify-between gap-2 w-full">
           <span className="truncate">{value}</span>
           <button
+            type="button"
             className="add-alternate"
             title={`Add another value for :${value}`}
+            aria-label={`Add another value for :${value}`}
             data-testid="path-param-add-alternate"
             onClick={() => addPathParamAlternate(row.name)}
           >

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/autosave/middleware.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/autosave/middleware.js
@@ -14,6 +14,7 @@ const actionsToIntercept = [
   'collections/deleteQueryParam',
   'collections/setQueryParams',
   'collections/updatePathParam',
+  'collections/setPathParams',
   'collections/addRequestHeader',
   'collections/updateRequestHeader',
   'collections/deleteRequestHeader',

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2437,7 +2437,7 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
         case 'pathParam': {
           const { item } = data;
           const params = item.draft ? get(item, 'draft.request.params', []) : get(item, 'request.params', []);
-          const pathParam = params.find((p) => p.type === 'path' && p.name === variableName);
+          const pathParam = params.find((p) => p.type === 'path' && p.name === variableName && p.enabled !== false);
 
           if (pathParam) {
             const updatedParam = { ...pathParam, value: newValue };

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/exampleReducers.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/exampleReducers.js
@@ -605,7 +605,7 @@ export const updateResponseExampleRequestUrl = (state, action) => {
   const existingParams = example.request.params || [];
   const disabledQueryParams = filter(existingParams, (p) => !p.enabled && p.type === 'query');
   let enabledQueryParams = filter(existingParams, (p) => p.enabled && p.type === 'query');
-  let oldPathParams = filter(existingParams, (p) => p.enabled && p.type === 'path');
+  let oldPathParams = filter(existingParams, (p) => p.type === 'path');
   let newPathParams = [];
 
   each(urlQueryParams, (urlQueryParam) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/exampleReducers.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/exampleReducers.js
@@ -637,6 +637,18 @@ export const updateResponseExampleRequestUrl = (state, action) => {
   });
 
   example.request.params = concat(urlQueryParams, newPathParams, disabledQueryParams, oldPathParams);
+
+  // A path name whose retained rows are all disabled would never resolve;
+  // promote its first candidate so the URL placeholder stays functional.
+  const enabledPathNames = new Set(
+    filter(example.request.params, (p) => p.type === 'path' && p.enabled !== false).map((p) => p.name)
+  );
+  each(example.request.params, (p) => {
+    if (p.type === 'path' && !enabledPathNames.has(p.name)) {
+      p.enabled = true;
+      enabledPathNames.add(p.name);
+    }
+  });
 };
 
 export const updateResponseExampleResponse = (state, action) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1054,7 +1054,7 @@ export const collectionsSlice = createSlice({
 
           const disabledQueryParams = filter(item?.draft?.request?.params, (p) => !p.enabled && p.type === 'query');
           let enabledQueryParams = filter(item?.draft?.request?.params, (p) => p.enabled && p.type === 'query');
-          let oldPathParams = filter(item?.draft?.request?.params, (p) => p.enabled && p.type === 'path');
+          let oldPathParams = filter(item?.draft?.request?.params, (p) => p.type === 'path');
           let newPathParams = [];
 
           // try and connect as much as old params uid's as possible
@@ -1233,6 +1233,55 @@ export const collectionsSlice = createSlice({
         item.draft.request.url = parts[0];
       }
     },
+    setPathParams: (state, action) => {
+      const { collectionUid, itemUid, params } = action.payload;
+
+      const collection = findCollectionByUid(state.collections, collectionUid);
+      if (!collection) {
+        return;
+      }
+
+      const item = findItemInCollection(collection, itemUid);
+      if (!item || !isItemARequest(item)) {
+        return;
+      }
+
+      if (!item.draft) {
+        item.draft = cloneDeep(item);
+      }
+
+      const existingOtherParams = item.draft.request.params?.filter((p) => p.type !== 'path') || [];
+
+      const newPathParams = map(
+        params,
+        ({ uid, name = '', value = '', description = '', annotations = null, enabled = true }) => ({
+          uid: uid || uuid(),
+          name,
+          value,
+          description,
+          annotations,
+          type: 'path',
+          enabled
+        })
+      );
+
+      const namesWithSelection = new Set();
+      each(newPathParams, (param) => {
+        if (param.enabled && !namesWithSelection.has(param.name)) {
+          namesWithSelection.add(param.name);
+        } else {
+          param.enabled = false;
+        }
+      });
+      each(newPathParams, (param) => {
+        if (!namesWithSelection.has(param.name)) {
+          param.enabled = true;
+          namesWithSelection.add(param.name);
+        }
+      });
+
+      item.draft.request.params = [...existingOtherParams, ...newPathParams];
+    },
     moveQueryParam: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
 
@@ -1362,6 +1411,14 @@ export const collectionsSlice = createSlice({
             }
             if ('enabled' in action.payload.pathParam) {
               param.enabled = action.payload.pathParam.enabled;
+
+              if (param.enabled) {
+                each(item.draft.request.params, (p) => {
+                  if (p.type === 'path' && p.name === param.name && p.uid !== param.uid) {
+                    p.enabled = false;
+                  }
+                });
+              }
             }
           }
         }
@@ -4069,6 +4126,7 @@ export const {
   updateAuth,
   addQueryParam,
   setQueryParams,
+  setPathParams,
   moveQueryParam,
   updateQueryParam,
   deleteQueryParam,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1094,6 +1094,18 @@ export const collectionsSlice = createSlice({
           // the query params are the source of truth, the url in the queryurl input gets constructed using these params
           // we however are also storing the full url (with params) in the url itself
           item.draft.request.params = concat(urlQueryParams, newPathParams, disabledQueryParams, oldPathParams);
+
+          // A path name whose retained rows are all disabled would never resolve;
+          // promote its first candidate so the URL placeholder stays functional.
+          const enabledPathNames = new Set(
+            filter(item.draft.request.params, (p) => p.type === 'path' && p.enabled !== false).map((p) => p.name)
+          );
+          each(item.draft.request.params, (p) => {
+            if (p.type === 'path' && !enabledPathNames.has(p.name)) {
+              p.enabled = true;
+              enabledPathNames.add(p.name);
+            }
+          });
         }
       }
     },

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/path-params.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/path-params.spec.js
@@ -1,0 +1,142 @@
+jest.mock('nanoid', () => ({
+  customAlphabet: () => () => 'mock-uid'
+}));
+
+import reducer, { updatePathParam, setPathParams, requestUrlChanged } from 'providers/ReduxStore/slices/collections';
+
+const COLLECTION_UID = 'col-1';
+const ITEM_UID = 'item-1';
+const URL = '{{baseUrl}}/v1/images/:kind';
+
+const makeState = (params) => ({
+  collections: [
+    {
+      uid: COLLECTION_UID,
+      pathname: '/coll',
+      items: [
+        {
+          uid: ITEM_UID,
+          type: 'http-request',
+          name: 'Upload image',
+          request: { url: URL, method: 'PUT', params }
+        }
+      ],
+      environments: []
+    }
+  ]
+});
+
+const pathParamsOf = (state) => state.collections[0].items[0].draft.request.params.filter((p) => p.type === 'path');
+
+const candidates = () => [
+  { uid: 'p1', name: 'kind', value: 'Logo', type: 'path', enabled: true },
+  { uid: 'p2', name: 'kind', value: 'Signature', type: 'path', enabled: false }
+];
+
+describe('path params with several candidate values per name', () => {
+  it('updatePathParam disables the sibling sharing the enabled row name', () => {
+    const state = reducer(
+      makeState(candidates()),
+      updatePathParam({
+        collectionUid: COLLECTION_UID,
+        itemUid: ITEM_UID,
+        pathParam: { uid: 'p2', name: 'kind', value: 'Signature', enabled: true }
+      })
+    );
+
+    expect(pathParamsOf(state).map((p) => [p.uid, p.enabled])).toEqual([
+      ['p1', false],
+      ['p2', true]
+    ]);
+  });
+
+  it('updatePathParam leaves a different name untouched', () => {
+    const params = [...candidates(), { uid: 'p3', name: 'id', value: '7', type: 'path', enabled: true }];
+
+    const state = reducer(
+      makeState(params),
+      updatePathParam({
+        collectionUid: COLLECTION_UID,
+        itemUid: ITEM_UID,
+        pathParam: { uid: 'p2', name: 'kind', value: 'Signature', enabled: true }
+      })
+    );
+
+    expect(pathParamsOf(state).find((p) => p.uid === 'p3').enabled).toBe(true);
+  });
+
+  it('editing the url keeps disabled candidates instead of dropping them', () => {
+    const state = reducer(
+      makeState(candidates()),
+      requestUrlChanged({
+        collectionUid: COLLECTION_UID,
+        itemUid: ITEM_UID,
+        url: `${URL}?page=1`
+      })
+    );
+
+    expect(pathParamsOf(state).map((p) => p.value)).toEqual(['Logo', 'Signature']);
+  });
+
+  it('editing the url does not duplicate a name that only has disabled rows', () => {
+    const params = candidates().map((p) => ({ ...p, enabled: false }));
+
+    const state = reducer(
+      makeState(params),
+      requestUrlChanged({ collectionUid: COLLECTION_UID, itemUid: ITEM_UID, url: `${URL}?page=1` })
+    );
+
+    expect(pathParamsOf(state)).toHaveLength(2);
+  });
+
+  it('setPathParams promotes a remaining candidate when the selected row is deleted', () => {
+    const state = reducer(
+      makeState(candidates()),
+      setPathParams({
+        collectionUid: COLLECTION_UID,
+        itemUid: ITEM_UID,
+        params: [{ uid: 'p2', name: 'kind', value: 'Signature', type: 'path', enabled: false }]
+      })
+    );
+
+    expect(pathParamsOf(state)).toEqual([
+      expect.objectContaining({ uid: 'p2', name: 'kind', value: 'Signature', enabled: true })
+    ]);
+  });
+
+  it('setPathParams keeps the current selection when an alternate is added', () => {
+    const state = reducer(
+      makeState(candidates()),
+      setPathParams({
+        collectionUid: COLLECTION_UID,
+        itemUid: ITEM_UID,
+        params: [...candidates(), { name: 'kind', value: '', type: 'path', enabled: false }]
+      })
+    );
+
+    expect(pathParamsOf(state).map((p) => p.enabled)).toEqual([true, false, false]);
+  });
+
+  it('setPathParams keeps only the first enabled row of a name', () => {
+    const params = candidates().map((p) => ({ ...p, enabled: true }));
+
+    const state = reducer(
+      makeState(params),
+      setPathParams({ collectionUid: COLLECTION_UID, itemUid: ITEM_UID, params })
+    );
+
+    expect(pathParamsOf(state).map((p) => p.enabled)).toEqual([true, false]);
+  });
+
+  it('setPathParams leaves query params alone', () => {
+    const params = [...candidates(), { uid: 'q1', name: 'page', value: '1', type: 'query', enabled: true }];
+
+    const state = reducer(
+      makeState(params),
+      setPathParams({ collectionUid: COLLECTION_UID, itemUid: ITEM_UID, params: candidates() })
+    );
+
+    const queryParams = state.collections[0].items[0].draft.request.params.filter((p) => p.type === 'query');
+    expect(queryParams).toEqual([expect.objectContaining({ uid: 'q1', name: 'page', enabled: true })]);
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/path-params.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/path-params.spec.js
@@ -89,6 +89,17 @@ describe('path params with several candidate values per name', () => {
     expect(pathParamsOf(state)).toHaveLength(2);
   });
 
+  it('editing the url promotes a candidate when every row of a name is disabled', () => {
+    const params = candidates().map((p) => ({ ...p, enabled: false }));
+
+    const state = reducer(
+      makeState(params),
+      requestUrlChanged({ collectionUid: COLLECTION_UID, itemUid: ITEM_UID, url: `${URL}?page=1` })
+    );
+
+    expect(pathParamsOf(state).map((p) => p.enabled)).toEqual([true, false]);
+  });
+
   it('setPathParams promotes a remaining candidate when the selected row is deleted', () => {
     const state = reducer(
       makeState(candidates()),

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1273,8 +1273,10 @@ const getPathParams = (item) => {
   let pathParams = {};
   if (item && item.request && item.request.params) {
     item.request.params.forEach((param) => {
-      if (param.type === 'path' && param.name && param.value) {
-        pathParams[param.name] = param.value;
+      if (param.type === 'path' && param.enabled !== false && param.name && param.value) {
+        if (!Object.hasOwn(pathParams, param.name)) {
+          pathParams[param.name] = param.value;
+        }
       }
     });
   }

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
+import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts, getAllVariables } from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -130,5 +130,51 @@ describe('getCollectionItemCounts', () => {
   it('returns zero counts for empty or missing items', () => {
     expect(getCollectionItemCounts([])).toEqual({ folderCount: 0, requestCount: 0 });
     expect(getCollectionItemCounts(undefined)).toEqual({ folderCount: 0, requestCount: 0 });
+  });
+});
+
+describe('getAllVariables pathParams', () => {
+  const makeCollection = (item) => ({
+    uid: 'col-1',
+    pathname: '/coll',
+    items: [item],
+    environments: [],
+    root: {}
+  });
+
+  it('resolves the enabled row when a disabled row with the same name precedes it', () => {
+    const item = {
+      uid: 'item-1',
+      type: 'http-request',
+      request: {
+        url: '{{baseUrl}}/v1/images/:kind',
+        params: [
+          { uid: 'p1', name: 'kind', value: 'Logo', type: 'path', enabled: false },
+          { uid: 'p2', name: 'kind', value: 'Signature', type: 'path', enabled: true }
+        ]
+      }
+    };
+
+    const variables = getAllVariables(makeCollection(item), item);
+
+    expect(variables.pathParams).toEqual({ kind: 'Signature' });
+  });
+
+  it('returns no entry for a name whose rows are all disabled', () => {
+    const item = {
+      uid: 'item-1',
+      type: 'http-request',
+      request: {
+        url: '{{baseUrl}}/v1/images/:kind',
+        params: [
+          { uid: 'p1', name: 'kind', value: 'Logo', type: 'path', enabled: false },
+          { uid: 'p2', name: 'kind', value: 'Signature', type: 'path', enabled: false }
+        ]
+      }
+    };
+
+    const variables = getAllVariables(makeCollection(item), item);
+
+    expect(variables.pathParams).toEqual({});
   });
 });

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -22,6 +22,9 @@ const hasLength = (str) => {
   return str.length > 0;
 };
 
+const findActivePathParam = (params, name) =>
+  params.find((p) => p?.name === name && p?.type === 'path' && p?.enabled !== false);
+
 const hasResolvablePathParamValue = (pathParam) => {
   if (!pathParam || pathParam.enabled === false) {
     return false;
@@ -180,9 +183,8 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
         // traditional path parameters
         if (segment.startsWith(':')) {
           const name = segment.slice(1);
-          const pathParam = params.find((p) => p?.name === name && p?.type === 'path');
+          const pathParam = findActivePathParam(params, name);
           return hasResolvablePathParamValue(pathParam) ? substituteValue(pathParam.value) : segment;
-          // return pathParam ? substituteValue(pathParam.value) : segment;
         }
 
         // for OData-style parameters (parameters inside parentheses)
@@ -204,7 +206,7 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
           name = name.replace(/^[('"`]+/, '');
           if (!name) continue;
 
-          const pathParam = params.find((p) => p?.name === name && p?.type === 'path');
+          const pathParam = findActivePathParam(params, name);
           if (hasResolvablePathParamValue(pathParam)) {
             result = result.replace(':' + match[1], substituteValue(pathParam.value));
           }

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -23,7 +23,7 @@ const hasLength = (str) => {
 };
 
 const findActivePathParam = (params, name) =>
-  params.find((p) => p?.name === name && p?.type === 'path' && p?.enabled !== false);
+  (params || []).find((p) => p?.name === name && p?.type === 'path' && p?.enabled !== false);
 
 const hasResolvablePathParamValue = (pathParam) => {
   if (!pathParam || pathParam.enabled === false) {

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -453,6 +453,30 @@ describe('Url Utils - interpolateUrl, interpolateUrlPathParams', () => {
 
     expect(result).toEqual('https://example.com/v1/images/:kind');
   });
+
+  it('should skip a disabled row inside an OData segment and use the enabled sibling', () => {
+    const url = 'https://example.com/odata/Products(\':productId\')';
+    const params = [
+      { name: 'productId', type: 'path', enabled: false, value: 'OLD' },
+      { name: 'productId', type: 'path', enabled: true, value: 'NEW' }
+    ];
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual('https://example.com/odata/Products(\'NEW\')');
+  });
+
+  it('should keep an OData segment literal when every row sharing its name is disabled', () => {
+    const url = 'https://example.com/odata/Products(\':productId\')';
+    const params = [
+      { name: 'productId', type: 'path', enabled: false, value: 'OLD' },
+      { name: 'productId', type: 'path', enabled: false, value: 'NEW' }
+    ];
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual('https://example.com/odata/Products(\':productId\')');
+  });
 });
 
 describe('Url Utils - interpolateUrlPathParams with { raw: true }', () => {

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -429,6 +429,30 @@ describe('Url Utils - interpolateUrl, interpolateUrlPathParams', () => {
 
     expect(result).toEqual('https://httpbin.org/anything/:analyze-text');
   });
+
+  it('should skip a disabled row and use the enabled one sharing its name', () => {
+    const url = 'https://example.com/v1/images/:kind';
+    const params = [
+      { name: 'kind', type: 'path', enabled: false, value: 'Logo' },
+      { name: 'kind', type: 'path', enabled: true, value: 'Signature' }
+    ];
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual('https://example.com/v1/images/Signature');
+  });
+
+  it('should keep the colon segment when every row sharing a name is disabled', () => {
+    const url = 'https://example.com/v1/images/:kind';
+    const params = [
+      { name: 'kind', type: 'path', enabled: false, value: 'Logo' },
+      { name: 'kind', type: 'path', enabled: false, value: 'Signature' }
+    ];
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual('https://example.com/v1/images/:kind');
+  });
 });
 
 describe('Url Utils - interpolateUrlPathParams with { raw: true }', () => {

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -2,6 +2,9 @@ const { interpolate } = require('@usebruno/common');
 const { each, forOwn, cloneDeep, find } = require('lodash');
 const { isFormData } = require('@usebruno/common').utils;
 
+const findActivePathParam = (pathParams, name) =>
+  pathParams.find((param) => param.name === name && param.enabled !== false);
+
 const hasResolvablePathParamValue = (pathParam) => {
   if (!pathParam || pathParam.enabled === false) {
     return false;
@@ -159,7 +162,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         // traditional path parameters
         if (path.startsWith(':')) {
           const paramName = path.slice(1);
-          const existingPathParam = request.pathParams.find((param) => param.name === paramName);
+          const existingPathParam = findActivePathParam(request.pathParams, paramName);
           if (!hasResolvablePathParamValue(existingPathParam)) {
             return '/' + path;
           }
@@ -180,7 +183,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
               let name = match[1].replace(/[')"`]+$/, '');
               name = name.replace(/^[('"`]+/, '');
               if (name) {
-                const existingPathParam = request.pathParams.find((param) => param.name === name);
+                const existingPathParam = findActivePathParam(request.pathParams, name);
                 if (hasResolvablePathParamValue(existingPathParam)) {
                   result = result.replace(':' + match[1], existingPathParam.value);
                 }

--- a/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
+++ b/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
@@ -30,6 +30,34 @@ describe('interpolate-vars: interpolateVars', () => {
     expect(result.url).toBe('http://example.com/v1/images/:kind');
   });
 
+  it('skips a disabled row inside an OData segment and uses the enabled sibling', () => {
+    const request = {
+      method: 'GET',
+      url: 'http://example.com/odata/Products(\':productId\')',
+      pathParams: [
+        { type: 'path', name: 'productId', value: 'OLD', enabled: false },
+        { type: 'path', name: 'productId', value: 'NEW', enabled: true }
+      ]
+    };
+
+    const result = interpolateVars(request, {}, {}, {});
+    expect(result.url).toBe('http://example.com/odata/Products(\'NEW\')');
+  });
+
+  it('keeps an OData segment literal when every row sharing its name is disabled', () => {
+    const request = {
+      method: 'GET',
+      url: 'http://example.com/odata/Products(\':productId\')',
+      pathParams: [
+        { type: 'path', name: 'productId', value: 'OLD', enabled: false },
+        { type: 'path', name: 'productId', value: 'NEW', enabled: false }
+      ]
+    };
+
+    const result = interpolateVars(request, {}, {}, {});
+    expect(result.url).toBe('http://example.com/odata/Products(\':productId\')');
+  });
+
   it('keeps stream-backed JSON request bodies intact', () => {
     const streamPayload = {
       pipe: jest.fn(),

--- a/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
+++ b/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
@@ -2,6 +2,34 @@ const { describe, it, expect } = require('@jest/globals');
 const interpolateVars = require('../../src/runner/interpolate-vars');
 
 describe('interpolate-vars: interpolateVars', () => {
+  it('skips a disabled path param row and uses the enabled one sharing its name', () => {
+    const request = {
+      method: 'PUT',
+      url: 'http://example.com/v1/images/:kind',
+      pathParams: [
+        { type: 'path', name: 'kind', value: 'Logo', enabled: false },
+        { type: 'path', name: 'kind', value: 'Signature', enabled: true }
+      ]
+    };
+
+    const result = interpolateVars(request, {}, {}, {});
+    expect(result.url).toBe('http://example.com/v1/images/Signature');
+  });
+
+  it('keeps the colon segment when every path param row sharing a name is disabled', () => {
+    const request = {
+      method: 'PUT',
+      url: 'http://example.com/v1/images/:kind',
+      pathParams: [
+        { type: 'path', name: 'kind', value: 'Logo', enabled: false },
+        { type: 'path', name: 'kind', value: 'Signature', enabled: false }
+      ]
+    };
+
+    const result = interpolateVars(request, {}, {}, {});
+    expect(result.url).toBe('http://example.com/v1/images/:kind');
+  });
+
   it('keeps stream-backed JSON request bodies intact', () => {
     const streamPayload = {
       pipe: jest.fn(),

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -117,9 +117,10 @@ export const transformUrl = (url, params) => {
     .filter((param) => param.type === 'query')
     .map(({ name, value, description }) => ({ key: name, value, description }));
 
-  // Construct path params.
+  // Construct path params. A name can carry disabled alternate rows; exporting
+  // them would emit duplicate Postman variable keys.
   postmanUrl.variable = params
-    .filter((param) => param.type === 'path')
+    .filter((param) => param.type === 'path' && param.enabled !== false)
     .map(({ name, value, description }) => ({ key: name, value, description }));
 
   return postmanUrl;

--- a/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
+++ b/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
@@ -21,6 +21,18 @@ describe('transformUrl', () => {
     });
   });
 
+  it('should export only the enabled row when a path param has disabled alternates', () => {
+    const url = 'https://example.com/v1/images/:kind';
+    const params = [
+      { name: 'kind', value: 'Logo', type: 'path', enabled: true },
+      { name: 'kind', value: 'Signature', type: 'path', enabled: false }
+    ];
+
+    const result = transformUrl(url, params);
+
+    expect(result.variable).toEqual([{ key: 'kind', value: 'Logo' }]);
+  });
+
   it('should handle URL with query parameters', () => {
     const url = 'https://example.com/api/resource?limit=10&offset=20';
     const params = [

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -2,6 +2,9 @@ const { interpolate } = require('@usebruno/common');
 const { each, forOwn, cloneDeep } = require('lodash');
 const { isFormData } = require('@usebruno/common').utils;
 
+const findActivePathParam = (pathParams, name) =>
+  pathParams.find((param) => param.name === name && param.enabled !== false);
+
 const hasResolvablePathParamValue = (pathParam) => {
   if (!pathParam || pathParam.enabled === false) {
     return false;
@@ -197,7 +200,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
         // traditional path parameters
         if (path.startsWith(':')) {
           const paramName = path.slice(1);
-          const existingPathParam = request.pathParams.find((param) => param.name === paramName);
+          const existingPathParam = findActivePathParam(request.pathParams, paramName);
           if (!hasResolvablePathParamValue(existingPathParam)) {
             return '/' + path;
           }
@@ -218,7 +221,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
               let name = match[1].replace(/[')"`]+$/, '');
               name = name.replace(/^[('"`]+/, '');
               if (name) {
-                const existingPathParam = request.pathParams.find((param) => param.name === name);
+                const existingPathParam = findActivePathParam(request.pathParams, name);
                 if (hasResolvablePathParamValue(existingPathParam)) {
                   result = result.replace(':' + match[1], existingPathParam.value);
                 }

--- a/packages/bruno-electron/tests/network/interpolate-vars.spec.js
+++ b/packages/bruno-electron/tests/network/interpolate-vars.spec.js
@@ -83,6 +83,34 @@ describe('interpolate-vars: interpolateVars', () => {
         expect(result.url).toBe('http://example.com/v1/images/:kind');
       });
 
+      it('skips a disabled row inside an OData segment and uses the enabled sibling', async () => {
+        const request = {
+          method: 'GET',
+          url: 'http://example.com/odata/Products(\':productId\')',
+          pathParams: [
+            { type: 'path', name: 'productId', value: 'OLD', enabled: false },
+            { type: 'path', name: 'productId', value: 'NEW', enabled: true }
+          ]
+        };
+
+        const result = interpolateVars(request, null, null, null);
+        expect(result.url).toBe('http://example.com/odata/Products(\'NEW\')');
+      });
+
+      it('keeps an OData segment literal when every row sharing its name is disabled', async () => {
+        const request = {
+          method: 'GET',
+          url: 'http://example.com/odata/Products(\':productId\')',
+          pathParams: [
+            { type: 'path', name: 'productId', value: 'OLD', enabled: false },
+            { type: 'path', name: 'productId', value: 'NEW', enabled: false }
+          ]
+        };
+
+        const result = interpolateVars(request, null, null, null);
+        expect(result.url).toBe('http://example.com/odata/Products(\':productId\')');
+      });
+
       it('keeps the original url search params as is', async () => {
         const request = {
           method: 'GET',

--- a/packages/bruno-electron/tests/network/interpolate-vars.spec.js
+++ b/packages/bruno-electron/tests/network/interpolate-vars.spec.js
@@ -55,6 +55,34 @@ describe('interpolate-vars: interpolateVars', () => {
     });
 
     describe('With path params', () => {
+      it('skips a disabled row and uses the enabled one sharing its name', async () => {
+        const request = {
+          method: 'PUT',
+          url: 'http://example.com/v1/images/:kind',
+          pathParams: [
+            { type: 'path', name: 'kind', value: 'Logo', enabled: false },
+            { type: 'path', name: 'kind', value: 'Signature', enabled: true }
+          ]
+        };
+
+        const result = interpolateVars(request, null, null, null);
+        expect(result.url).toBe('http://example.com/v1/images/Signature');
+      });
+
+      it('keeps the colon segment when every row sharing a name is disabled', async () => {
+        const request = {
+          method: 'PUT',
+          url: 'http://example.com/v1/images/:kind',
+          pathParams: [
+            { type: 'path', name: 'kind', value: 'Logo', enabled: false },
+            { type: 'path', name: 'kind', value: 'Signature', enabled: false }
+          ]
+        };
+
+        const result = interpolateVars(request, null, null, null);
+        expect(result.url).toBe('http://example.com/v1/images/:kind');
+      });
+
       it('keeps the original url search params as is', async () => {
         const request = {
           method: 'GET',

--- a/packages/bruno-filestore/src/formats/yml/common/params.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/params.spec.ts
@@ -1,0 +1,30 @@
+import { toOpenCollectionParams, toBrunoParams } from './params';
+
+describe('path params with several candidate rows per name', () => {
+  it('round-trips duplicate-name path params with a disabled alternate', () => {
+    const brunoParams = [
+      { uid: 'u1', name: 'kind', value: 'Logo', type: 'path', enabled: true },
+      { uid: 'u2', name: 'kind', value: 'Signature', type: 'path', enabled: false }
+    ] as any;
+
+    const ocParams = toOpenCollectionParams(brunoParams);
+
+    expect(ocParams).toEqual([
+      { name: 'kind', value: 'Logo', type: 'path' },
+      { name: 'kind', value: 'Signature', type: 'path', disabled: true }
+    ]);
+
+    const roundTripped = toBrunoParams(ocParams);
+
+    expect(roundTripped).toEqual([
+      expect.objectContaining({ name: 'kind', value: 'Logo', type: 'path', enabled: true }),
+      expect.objectContaining({ name: 'kind', value: 'Signature', type: 'path', enabled: false })
+    ]);
+  });
+
+  it('parses a legacy row without the disabled flag as enabled', () => {
+    const out = toBrunoParams([{ name: 'id', value: '123', type: 'path' }] as any);
+
+    expect(out).toEqual([expect.objectContaining({ name: 'id', value: '123', type: 'path', enabled: true })]);
+  });
+});

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -67,7 +67,9 @@ class BrunoRequest {
           .map((segment) => {
             if (segment.startsWith(':')) {
               const paramName = segment.slice(1);
-              const pathParam = this.req.pathParams.find((param) => param.name === paramName);
+              // A name can carry disabled alternate rows; matching on name alone
+              // would let a disabled row shadow the enabled sibling.
+              const pathParam = this.req.pathParams.find((param) => param.name === paramName && param.enabled !== false);
               if (
                 pathParam
                 && pathParam.enabled !== false

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -146,7 +146,24 @@ const jsonToBru = (json) => {
     if (pathParams.length) {
       bru += 'params:path {';
 
-      bru += `\n${indentString(pathParams.map((item) => `${serializeAnnotations(buildAnnotationsFromKVItem(item))}${item.name}: ${getValueString(item.value)}`).join('\n'))}`;
+      if (enabled(pathParams).length) {
+        bru += `\n${indentString(
+          enabled(pathParams)
+            .map((item) => `${serializeAnnotations(buildAnnotationsFromKVItem(item))}${getKeyString(item.name)}: ${getValueString(item.value)}`)
+            .join('\n')
+        )}`;
+      }
+
+      // Enabled rows must precede disabled ones: older readers resolve a :segment
+      // with a first-match-by-name lookup, so a leading ~row would shadow the
+      // active value there.
+      if (disabled(pathParams).length) {
+        bru += `\n${indentString(
+          disabled(pathParams)
+            .map((item) => `${serializeAnnotations(buildAnnotationsFromKVItem(item))}~${getKeyString(item.name)}: ${getValueString(item.value)}`)
+            .join('\n')
+        )}`;
+      }
 
       bru += '\n}\n\n';
     }

--- a/packages/bruno-lang/v2/tests/params-path.spec.js
+++ b/packages/bruno-lang/v2/tests/params-path.spec.js
@@ -1,0 +1,54 @@
+const parse = require('../src/bruToJson');
+const stringify = require('../src/jsonToBru');
+
+describe('params:path', () => {
+  it('round-trips a disabled path param', () => {
+    const input = {
+      http: {
+        method: 'put',
+        url: 'http://example.com/v1/images/:kind'
+      },
+      params: [
+        { name: 'kind', value: 'Logo', type: 'path', enabled: true },
+        { name: 'kind', value: 'Signature', type: 'path', enabled: false }
+      ]
+    };
+
+    const output = stringify(input);
+
+    expect(output).toContain('kind: Logo');
+    expect(output).toContain('~kind: Signature');
+    expect(parse(output).params).toEqual(input.params);
+  });
+
+  it('writes enabled rows before disabled ones so older first-match readers resolve the active value', () => {
+    const input = {
+      http: {
+        method: 'put',
+        url: 'http://example.com/v1/images/:kind'
+      },
+      params: [
+        { name: 'kind', value: 'Logo', type: 'path', enabled: false },
+        { name: 'kind', value: 'Signature', type: 'path', enabled: true }
+      ]
+    };
+
+    expect(parse(stringify(input)).params).toEqual([
+      { name: 'kind', value: 'Signature', type: 'path', enabled: true },
+      { name: 'kind', value: 'Logo', type: 'path', enabled: false }
+    ]);
+  });
+
+  it('parses a legacy block written before disabled rows were persisted', () => {
+    const bru = `put {
+  url: http://example.com/v1/items/:id
+}
+
+params:path {
+  id: 123
+}
+`;
+
+    expect(parse(bru).params).toEqual([{ name: 'id', value: '123', type: 'path', enabled: true }]);
+  });
+});


### PR DESCRIPTION
Path params can hold several candidate rows per name - the OpenAPI importer emits one per enum value and enables only the default - but the Path table rendered no control, so the selection was unreachable.

- render a radio per name with 2+ rows, plus add-alternate and delete actions
- enforce one enabled row per name in updatePathParam/setPathParams
- resolve the first *enabled* row by name in app, electron and cli, so a disabled row no longer shadows the selected one
- stop requestUrlChanged discarding disabled rows on every keystroke
- persist disabled path params in .bru, which only ever wrote them enabled

### Description

Adds an enable/disable control to the Path params table so a path param with several candidate values can be switched between them. Closes #8843.

### Problem

The OpenAPI importer creates one path-param row per enum value (e.g. :kind → Logo, Signature) and enables only the default, but the Path table renders no control, so the selection is unreachable. Editing the URL also silently deletes the disabled rows, and .bru files never persist the disabled state. Details in #8843.

### Fix

- Path table renders a radio per param name with 2+ rows (selecting one disables its siblings), plus add-alternate and per-row delete actions; a lone param stays always-on with no control
- updatePathParam/setPathParams enforce one enabled row per name; deleting the selected row promotes a remaining candidate
- Resolvers (app URL preview, electron request, cli runner, code generation) pick the first enabled row, so a disabled row no longer shadows the selected one
- requestUrlChanged (and its response-example twin) keep disabled rows instead of dropping them on every keystroke
- .bru writer emits ~ for disabled path params, mirroring query params — enabled rows are written first so older first-match-by-name readers still resolve the active value
- Postman export skips disabled alternates to avoid duplicate variable keys

### Screenshots


| Before | After |
| --- | --- |
| <img width="796" alt="Path params without a selection control" src="https://github.com/user-attachments/assets/349a6b3b-6f03-4a67-b668-fb74a264cc4e" /> | <img width="785" alt="Path params with radio selection and add-alternate" src="https://github.com/user-attachments/assets/9b3fcade-ccdc-44bb-a0ae-21357cbcd7ea" /> |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating alternate path-parameter values directly in the request editor.
  - Added controls for selecting, enabling, disabling, and conditionally deleting path-parameter rows.

- **Bug Fixes**
  - Disabled path parameters are no longer substituted into request URLs.
  - Duplicate path-parameter names now consistently prioritize enabled values.
  - Exporting and saving requests no longer creates duplicate variables from disabled alternates.
  - Existing query parameters and disabled alternates are preserved during URL edits and format conversions.

- **Tests**
  - Added coverage for duplicate, disabled, serialized, and converted path parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->