### PR TITLE
fix: handle ellipsis folder names during Postman import

### DIFF
--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -241,6 +241,7 @@ const searchForRequestFiles = (dir, collectionPath = null) => {
 
 const sanitizeName = (name) => {
   const invalidCharacters = /[<>:"/\\|?*\x00-\x1F]/g;
+  name = name.replace(/\.\.\./g, '_');
   name = name
     .replace(invalidCharacters, '-') // replace invalid characters with hyphens
     .replace(/^[\s\-]+/, '') // remove leading spaces and hyphens


### PR DESCRIPTION
### Description

This PR fixes the Postman import issue where folders named `...` (ellipsis) cause structural corruption in Bruno's collection tree. The fix replaces `...` with `_` during the sanitization process, ensuring proper folder naming and preserving the collection structure.
### Problem

When importing a Postman collection that contains folders named `...`, Bruno mishandles these folders, causing:
- Folders to appear in incorrect parent-child relationships
- Structural corruption in the collection tree
- Confusion for users migrating from Postman
### Fix #8845

The `sanitizeName` function in `filesystem.js` has been updated to replace `...` with `_` (underscore) during the import process:

### Screenshots

| Before
<img width="397" height="160" alt="brunofile" src="https://github.com/user-attachments/assets/c9ae5a09-2832-4a18-ba7a-3ce6264a960b" />


 | After |
![630227609-7d685c74-2484-4a43-80b7-0f6cf9813ae8.png](https://github.com/user-attachments/assets/0a32dfbe-7516-4588-96e9-50fe2d379336)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved name sanitization by safely handling sequences of consecutive periods.
  * Preserved existing cleanup for invalid characters, whitespace, hyphens, and trailing punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai 