### PR TITLE
fix(tests): jest mock for css imports and change paste timer

### DIFF
--- a/packages/bruno-app/jest.config.js
+++ b/packages/bruno-app/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '/node_modules/(?!strip-json-comments|nanoid|xml-formatter)/'
   ],
   moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': '<rootDir>/jest.cssMock.js',
     '^assets/(.*)$': '<rootDir>/src/assets/$1',
     '^components/(.*)$': '<rootDir>/src/components/$1',
     '^hooks/(.*)$': '<rootDir>/src/hooks/$1',

--- a/packages/bruno-app/jest.cssMock.js
+++ b/packages/bruno-app/jest.cssMock.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-undef
+module.exports = {};

--- a/packages/bruno-app/src/components/CodeEditor/index.spec.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.spec.js
@@ -8,6 +8,15 @@ jest.mock('codemirror', () => {
   return codemirror;
 });
 
+jest.mock('providers/ReduxStore', () => ({
+  __esModule: true,
+  default: {
+    dispatch: jest.fn(),
+    getState: jest.fn(() => ({})),
+    subscribe: jest.fn()
+  }
+}));
+
 const MOCK_THEME = {
   codemirror: {
     bg: '#1e1e1e',

--- a/packages/bruno-app/src/test-utils/mocks/codemirror.js
+++ b/packages/bruno-app/src/test-utils/mocks/codemirror.js
@@ -25,6 +25,8 @@ const CodeMirror = jest.fn((node, options) => {
   return editor;
 });
 
+Object.assign(CodeMirror, jest.requireActual('codemirror'));
+
 CodeMirror.commands = {
   autocomplete: jest.fn()
 };

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorCodeBlock/index.spec.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorCodeBlock/index.spec.js
@@ -58,7 +58,7 @@ describe('EditorCodeBlock', () => {
           ...nodeProps
         }}
         updateAttributes={updateAttributesMock}
-        editor={{ isEditable: true }}
+        editor={{ isEditable: true, on: jest.fn(), off: jest.fn() }}
         extension={{}}
       />
     );
@@ -73,7 +73,7 @@ describe('EditorCodeBlock', () => {
     }
     const pasteEvent = new Event('paste', { bubbles: true });
     preElement.dispatchEvent(pasteEvent);
-    jest.advanceTimersByTime(10);
+    jest.advanceTimersByTime(100);
   };
 
   it('should auto-detect language on paste with code content', () => {


### PR DESCRIPTION
### Description

- Paste timer was changed to 100 in the Rich Text Editor PR, so updating that. 
- Rich Text PR puts css imports in the setup module which isn't supported by jest so adding that in

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability for code and rich-text editors.
  * Added support for styling imports during test execution.
  * Enhanced editor mocks and Redux store behavior coverage.
  * Updated paste-event timing to better reflect real-world behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->