### PR TITLE
fix(mount): hydrate websocket message uids in the cached mount path

### DIFF
--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -21,7 +21,8 @@ const REQUEST_UID_PATHS = [
   ['request.assertions', 'assertions'],
   ['request.body.formUrlEncoded', 'body.formUrlEncoded'],
   ['request.body.multipartForm', 'body.multipartForm'],
-  ['request.body.file', 'body.file']
+  ['request.body.file', 'body.file'],
+  ['request.body.ws', 'body.ws']
 ];
 
 const EXAMPLE_UID_PATHS = [
@@ -241,4 +242,4 @@ const buildTree = (collectionPath, parserResults, options = {}) => {
   return tree;
 };
 
-module.exports = { buildTree };
+module.exports = { buildTree, REQUEST_UID_PATHS };

--- a/packages/bruno-electron/src/services/mount/tree-builder.spec.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.spec.js
@@ -1,0 +1,68 @@
+const path = require('node:path');
+const { get, set } = require('lodash');
+
+jest.mock('electron', () => ({
+  app: { getPath: jest.fn(() => require('node:os').tmpdir()) },
+  dialog: { showOpenDialog: jest.fn() }
+}));
+
+const { buildTree, REQUEST_UID_PATHS } = require('./tree-builder');
+
+const COLLECTION_PATH = path.join(path.sep === '\\' ? 'C:\\' : '/', 'collections', 'my-collection');
+
+const buildSingleRequest = (relativePath, data) =>
+  buildTree(COLLECTION_PATH, new Map([[relativePath, { data, raw: '' }]])).items[0];
+
+const REQUEST_LIST_PATHS = [
+  ['request.params', [{ name: 'q', value: '1' }, { name: 'page', value: '2' }]],
+  ['request.headers', [{ name: 'Accept', value: '*/*' }, { name: 'X-Trace', value: 'on' }]],
+  ['request.vars.req', [{ name: 'token' }, { name: 'userId' }]],
+  ['request.vars.res', [{ name: 'sessionId' }, { name: 'etag' }]],
+  ['request.assertions', [{ name: 'res.status', value: '200' }, { name: 'res.body.ok', value: 'true' }]],
+  ['request.body.formUrlEncoded', [{ name: 'field' }, { name: 'other' }]],
+  ['request.body.multipartForm', [{ name: 'file' }, { name: 'caption' }]],
+  ['request.body.file', [{ filePath: 'a.json' }, { filePath: 'b.json' }]],
+  ['request.body.ws', [{ name: 'ping', content: 'ping' }, { name: 'pong', content: 'pong' }]]
+];
+
+const requestWithEveryList = () => {
+  const data = { name: 'req', type: 'http-request', request: {} };
+  for (const [dotPath, entries] of REQUEST_LIST_PATHS) {
+    set(data, dotPath, entries.map((entry) => ({ ...entry })));
+  }
+  return data;
+};
+
+describe('buildTree — uid hydration', () => {
+  it('hydrates exactly the request lists this spec covers', () => {
+    expect(REQUEST_UID_PATHS.map(([dotPath]) => dotPath).sort()).toEqual(
+      REQUEST_LIST_PATHS.map(([dotPath]) => dotPath).sort()
+    );
+  });
+
+  it.each(REQUEST_LIST_PATHS)('gives every entry in %s a unique uid', (dotPath, fixture) => {
+    const node = buildSingleRequest('req.bru', requestWithEveryList());
+
+    const entries = get({ request: node.request }, dotPath);
+    expect(entries).toHaveLength(fixture.length);
+    const uids = entries.map((entry) => entry.uid);
+    expect(uids.filter((uid) => typeof uid !== 'string' || !uid.length)).toStrictEqual([]);
+    expect(new Set(uids).size).toBe(uids.length);
+  });
+
+  it('assigns the same websocket message uids across rebuilds so persisted per-message UI state survives a restart', () => {
+    const first = buildSingleRequest('req.bru', requestWithEveryList());
+    const second = buildSingleRequest('req.bru', requestWithEveryList());
+
+    expect(second.request.body.ws.map((message) => message.uid)).toEqual(
+      first.request.body.ws.map((message) => message.uid)
+    );
+  });
+
+  it('scopes websocket message uids to the request, so two requests never share one', () => {
+    const first = buildSingleRequest('chat.bru', requestWithEveryList());
+    const second = buildSingleRequest('echo.bru', requestWithEveryList());
+
+    expect(second.request.body.ws[0].uid).not.toEqual(first.request.body.ws[0].uid);
+  });
+});


### PR DESCRIPTION
### Problem

With **File Cache** (mount v2) enabled, WebSocket message bodies could not be expanded after reopening the app.

WS message expand/collapse is keyed by the message `uid`, and the toggle bails out on a falsy one:

```js
const toggleMessage = useCallback((uid) => {
  if (!uid) return;
```

The v1 mount path hydrates `request.body.ws` (`hydrateRequestWithUuid`), but mount v2's `REQUEST_UID_PATHS` omitted it. With the cache on, the tree is built from the cache on cold start, so every WS message arrived with `uid: undefined` — nothing expandable, and the whole list rendering with the same undefined React key.

It only reproduced after a restart because live edits during a session still flow through the collection watcher's v1 hydration.

### Fix

- Add `request.body.ws` to `REQUEST_UID_PATHS` in the mount v2 tree builder. Since v2 seeds uids deterministically from the file path, expanded-message state now also survives a restart instead of resetting.
- Add `tree-builder.spec.js` covering uid presence/uniqueness for every hydrated request list, plus WS-specific uid stability across rebuilds and no cross-request collisions. One test pins the spec's path list against `REQUEST_UID_PATHS` so adding or removing a path there can't silently go uncovered.

### Steps to verify

1. Open a collection with WS requests that have several messages, confirm the bodies expand.
2. Enable **Preferences → Cache → File cache**, close and reopen the app.
3. Expand the same message bodies — they now open as before.

### Notes

gRPC and GraphQL are unaffected: gRPC messages carry no uid in either mount path (`GrpcBody` addresses them by array index), and `body.graphql` is an object rather than a list. `EXAMPLE_UID_PATHS` needs no `ws` entry either — WS requests don't support examples at any layer (the UI gates "Create Example" to `http-request`, the yml parser hardcodes `examples: []`, and the `.bru` example grammar has no `body:ws`).

Ticket: BRU-4089