### PR TITLE
feat(variables): adds variable scope selector with option to add as a secret

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Vars/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Vars/index.js
@@ -20,7 +20,7 @@ const Vars = ({ collection }) => {
   useTrackScroll({ ref: wrapperRef, selector: '.collection-settings-content', onChange: setScroll, initialValue: scroll });
 
   return (
-    <StyledWrapper className="w-full flex flex-col" ref={wrapperRef}>
+    <StyledWrapper className="w-full flex flex-col" ref={wrapperRef} data-testid="collection-vars-panel">
       <div className="flex-1">
         <div className="mb-3 title text-xs">Pre Request</div>
         <VarsTable collection={collection} vars={requestVars} varType="request" initialScroll={scroll} isDraft={isDraft} />

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState, useEffect, useMemo } from 'react'
 import { TableVirtuoso } from 'react-virtuoso';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
-import { IconTrash, IconAlertCircle, IconInfoCircle, IconGripVertical, IconMinusVertical } from '@tabler/icons';
+import { IconTrash, IconAlertCircle, IconGripVertical, IconMinusVertical } from '@tabler/icons';
 import { useTheme } from 'providers/Theme';
 import { useSelector, useDispatch } from 'react-redux';
 import { updateTableColumnWidths } from 'providers/ReduxStore/slices/tabs';
@@ -31,7 +31,7 @@ import { useSortCycle } from 'hooks/useSortCycle';
 import { sortRowsByName, reorderWithinSubset } from 'utils/sortableRows';
 import { useMouseRowDrag, DRAG_ROW_KEY_ATTR } from 'hooks/useMouseRowDrag';
 import ColumnSortHeader from 'components/EditableTable/ColumnSortHeader';
-import { reconcileSavedChange, findExternallyAddedVariables } from './reconcile';
+import { useReconcileSavedEnvironment } from './useReconcileSavedEnvironment';
 
 const MIN_H = 35 * 2;
 const MIN_COLUMN_WIDTH = 80;
@@ -477,50 +477,13 @@ const EnvironmentVariablesTable = ({
     return JSON.stringify((environment.variables || []).map(stripEnvVarUid));
   }, [environment.variables]);
 
-  // Controlled replacement for enableReinitialize. When the persisted snapshot
-  // changes (autosave echo, script env update, external file reload, or an edit
-  // made outside the table) adopt it ONLY if the form has no unsaved edits.
-  // If the user is typing ahead, keep their edits — the draft/autosave cycle
-  // persists them — so nothing typed during an async save is lost.
-  const prevSavedValuesJsonRef = useRef(savedValuesJson);
-  const prevRawSavedRef = useRef(environment.variables);
-  useEffect(() => {
-    const prevSaved = prevSavedValuesJsonRef.current;
-    const prevRawSaved = prevRawSavedRef.current;
-    prevSavedValuesJsonRef.current = savedValuesJson;
-    prevRawSavedRef.current = environment.variables;
-
-    const currentNamed = formik.values.filter((variable) => variable.name && variable.name.trim() !== '');
-    const currentJson = JSON.stringify(currentNamed.map(stripEnvVarUid));
-
-    const outcome = reconcileSavedChange({ prevSaved, nextSaved: savedValuesJson, current: currentJson });
-
-    if (outcome === 'adopt') {
-      formik.resetForm({ values: initialValues });
-      return;
-    }
-
-    if (outcome === 'skip') {
-      // find the subset of `environment.variables` that were added elsewhere(undefined variable tooltip's "Add to" switcher)
-      // while the form was dirty, and merge them back in.
-      const added = findExternallyAddedVariables({
-        prevRawSaved,
-        nextRawSaved: environment.variables,
-        currentValues: formik.values
-      });
-
-      if (added.length > 0) {
-        const values = formik.values;
-        const trailingRow = values[values.length - 1];
-        const restRows = values.slice(0, -1);
-        formik.setValues([
-          ...restRows,
-          ...added.map((v) => ({ ...v, description: v.description ?? '' })),
-          trailingRow
-        ]);
-      }
-    }
-  }, [savedValuesJson]);
+  // Controlled replacement for Formik's `enableReinitialize`.
+  useReconcileSavedEnvironment({
+    formik,
+    savedValuesJson,
+    savedVariables: environment.variables,
+    initialValues
+  });
 
   useEffect(() => {
     setPinnedData({ query: '', uids: new Set() });

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -18,7 +18,7 @@ import { BRUNO_VARIABLE_DATATYPES, valueToString } from '@usebruno/common/utils'
 import { variableNameRegex } from 'utils/common/regex';
 import toast from 'react-hot-toast';
 import { Tooltip } from 'react-tooltip';
-import { getGlobalEnvironmentVariables } from 'utils/collections';
+import { getGlobalEnvironmentVariables, getGlobalEnvironmentVariablesMasked } from 'utils/collections';
 import {
   stripEnvVarUid,
   getDuplicateSecretNames,
@@ -31,7 +31,7 @@ import { useSortCycle } from 'hooks/useSortCycle';
 import { sortRowsByName, reorderWithinSubset } from 'utils/sortableRows';
 import { useMouseRowDrag, DRAG_ROW_KEY_ATTR } from 'hooks/useMouseRowDrag';
 import ColumnSortHeader from 'components/EditableTable/ColumnSortHeader';
-import { reconcileSavedChange } from './reconcile';
+import { reconcileSavedChange, findExternallyAddedVariables } from './reconcile';
 
 const MIN_H = 35 * 2;
 const MIN_COLUMN_WIDTH = 80;
@@ -301,6 +301,7 @@ const EnvironmentVariablesTable = ({
   const pendingDraftRestoreRef = useRef(false);
 
   const globalEnvironmentVariables = getGlobalEnvironmentVariables({ globalEnvironments, activeGlobalEnvironmentUid });
+  const globalEnvSecrets = getGlobalEnvironmentVariablesMasked({ globalEnvironments, activeGlobalEnvironmentUid });
   const workspaceProcessEnvVariables = activeWorkspace?.processEnvVariables;
   // `_collection` flows into every row's MultiLineEditor as the variable-resolution
   // context. Without memoization, `cloneDeep(collection)` runs on every render —
@@ -310,12 +311,13 @@ const EnvironmentVariablesTable = ({
   const _collection = useMemo(() => {
     const c = collection ? cloneDeep(collection) : {};
     c.globalEnvironmentVariables = globalEnvironmentVariables;
+    c.globalEnvSecrets = globalEnvSecrets;
     c.activeEnvironmentUid = environment.uid;
     if (!collection && workspaceProcessEnvVariables) {
       c.workspaceProcessEnvVariables = workspaceProcessEnvVariables;
     }
     return c;
-  }, [collection, globalEnvironmentVariables, workspaceProcessEnvVariables, environment.uid]);
+  }, [collection, globalEnvironmentVariables, globalEnvSecrets, workspaceProcessEnvVariables, environment.uid]);
 
   // Reuse the previous initialValues when only uids changed but the content is
   // identical.
@@ -481,15 +483,42 @@ const EnvironmentVariablesTable = ({
   // If the user is typing ahead, keep their edits — the draft/autosave cycle
   // persists them — so nothing typed during an async save is lost.
   const prevSavedValuesJsonRef = useRef(savedValuesJson);
+  const prevRawSavedRef = useRef(environment.variables);
   useEffect(() => {
     const prevSaved = prevSavedValuesJsonRef.current;
+    const prevRawSaved = prevRawSavedRef.current;
     prevSavedValuesJsonRef.current = savedValuesJson;
+    prevRawSavedRef.current = environment.variables;
 
     const currentNamed = formik.values.filter((variable) => variable.name && variable.name.trim() !== '');
     const currentJson = JSON.stringify(currentNamed.map(stripEnvVarUid));
 
-    if (reconcileSavedChange({ prevSaved, nextSaved: savedValuesJson, current: currentJson }) === 'adopt') {
+    const outcome = reconcileSavedChange({ prevSaved, nextSaved: savedValuesJson, current: currentJson });
+
+    if (outcome === 'adopt') {
       formik.resetForm({ values: initialValues });
+      return;
+    }
+
+    if (outcome === 'skip') {
+      // find the subset of `environment.variables` that were added elsewhere(undefined variable tooltip's "Add to" switcher)
+      // while the form was dirty, and merge them back in.
+      const added = findExternallyAddedVariables({
+        prevRawSaved,
+        nextRawSaved: environment.variables,
+        currentValues: formik.values
+      });
+
+      if (added.length > 0) {
+        const values = formik.values;
+        const trailingRow = values[values.length - 1];
+        const restRows = values.slice(0, -1);
+        formik.setValues([
+          ...restRows,
+          ...added.map((v) => ({ ...v, description: v.description ?? '' })),
+          trailingRow
+        ]);
+      }
     }
   }, [savedValuesJson]);
 

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/reconcile.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/reconcile.js
@@ -16,3 +16,18 @@ export const reconcileSavedChange = ({ prevSaved, nextSaved, current }) => {
   // the save. Keep their edits and let the draft/autosave cycle catch up.
   return 'skip';
 };
+
+/*
+  when reconcileSavedChange returns 'skip', find the subset of `nextRawSaved` that were
+  added elsewhere (e.g. via the undefined-variable tooltip's "Add to" switcher) while the form was dirty,
+  and merge them back in.
+ */
+export const findExternallyAddedVariables = ({ prevRawSaved, nextRawSaved, currentValues }) => {
+  const prevNames = new Set((prevRawSaved || []).map((v) => v.name));
+  const currentNames = new Set((currentValues || []).map((v) => v.name).filter(Boolean));
+  const currentUids = new Set((currentValues || []).map((v) => v.uid).filter(Boolean));
+
+  return (nextRawSaved || []).filter(
+    (v) => v.name && !prevNames.has(v.name) && !currentNames.has(v.name) && !currentUids.has(v.uid)
+  );
+};

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/reconcile.spec.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/reconcile.spec.js
@@ -1,4 +1,4 @@
-import { reconcileSavedChange } from './reconcile';
+import { reconcileSavedChange, findExternallyAddedVariables } from './reconcile';
 
 // Serialized snapshots stand in for the JSON the component compares. The
 // concrete strings don't matter; only the equality relationships between
@@ -38,5 +38,71 @@ describe('reconcileSavedChange', () => {
   it('skips a script env update while the user has unsaved edits', () => {
     // script rewrote the value to 'ax' but the user is mid-edit at 'abc'
     expect(reconcileSavedChange({ prevSaved: baselineValue, nextSaved: scriptWrittenValue, current: userEditedValue })).toBe('skip');
+  });
+});
+
+describe('findExternallyAddedVariables', () => {
+  it('finds a variable added purely externally, absent from both baselines', () => {
+    const added = findExternallyAddedVariables({
+      prevRawSaved: [{ uid: 'u1', name: 'token' }],
+      nextRawSaved: [{ uid: 'u1', name: 'token' }, { uid: 'u2', name: 'newVar' }],
+      currentValues: [{ uid: 'u1', name: 'token' }, { uid: 'draft', name: '' }]
+    });
+
+    expect(added).toEqual([{ uid: 'u2', name: 'newVar' }]);
+  });
+
+  it('excludes a name that already existed in the previous saved snapshot (a modification, not an addition)', () => {
+    const added = findExternallyAddedVariables({
+      prevRawSaved: [{ uid: 'u1', name: 'token' }],
+      nextRawSaved: [{ uid: 'u1-new', name: 'token' }],
+      currentValues: [{ uid: 'u1', name: 'token' }]
+    });
+
+    expect(added).toEqual([]);
+  });
+
+  it('excludes a name that collides with something the user is currently editing', () => {
+    const added = findExternallyAddedVariables({
+      prevRawSaved: [],
+      nextRawSaved: [{ uid: 'u2', name: 'newVar' }],
+      currentValues: [{ uid: 'u1', name: 'newVar' }, { uid: 'draft', name: '' }]
+    });
+
+    expect(added).toEqual([]);
+  });
+
+  it('ignores the trailing empty "add new" row when checking for name collisions', () => {
+    const added = findExternallyAddedVariables({
+      prevRawSaved: [],
+      nextRawSaved: [{ uid: 'u2', name: 'newVar' }],
+      currentValues: [{ uid: 'draft', name: '' }]
+    });
+
+    expect(added).toEqual([{ uid: 'u2', name: 'newVar' }]);
+  });
+
+  it('returns an empty array when there is nothing additive', () => {
+    const added = findExternallyAddedVariables({
+      prevRawSaved: [{ uid: 'u1', name: 'token' }],
+      nextRawSaved: [{ uid: 'u1', name: 'token' }],
+      currentValues: [{ uid: 'u1', name: 'token' }]
+    });
+
+    expect(added).toEqual([]);
+  });
+
+  it('handles missing arguments gracefully', () => {
+    expect(findExternallyAddedVariables({})).toEqual([]);
+  });
+
+  it('excludes a same-uid row even when its name differs — the fast-typing/autosave-echo race', () => {
+    const added = findExternallyAddedVariables({
+      prevRawSaved: [],
+      nextRawSaved: [{ uid: 'u1', name: 'hellll' }],
+      currentValues: [{ uid: 'u1', name: 'hellllllloooooo' }, { uid: 'draft', name: '' }]
+    });
+
+    expect(added).toEqual([]);
   });
 });

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/useReconcileSavedEnvironment.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/useReconcileSavedEnvironment.js
@@ -40,8 +40,6 @@ export const useReconcileSavedEnvironment = ({ formik, savedValuesJson, savedVar
     }
 
     if (outcome === 'skip') {
-      // find the subset of `savedVariables` that were added elsewhere (undefined variable tooltip's "Add to" switcher)
-      // while the form was dirty, and merge them back in.
       const added = findExternallyAddedVariables({
         prevRawSaved,
         nextRawSaved: savedVariables,

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/useReconcileSavedEnvironment.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/useReconcileSavedEnvironment.js
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import { stripEnvVarUid } from 'utils/environments';
+import { reconcileSavedChange, findExternallyAddedVariables } from './reconcile';
+
+/**
+ * Reconcile changes coming from outside the form, such as an autosave echo,
+ * script update, external file reload, or the "Add to" switcher.
+ *
+ * - If the form has no unsaved edits, replace its values with the persisted
+ *   values.
+ * - If the form has unsaved edits, keep the user's changes to prevent async
+     saves from overwriting text while the user is typing quickly.
+ * - Even when the form is dirty, merge variables that were added externally
+ *   so those new variables are still shown in the form.
+ * @param {Object} params
+ * @param {Object} params.formik - The table's Formik instance.
+ * @param {string} params.savedValuesJson - Serialized (JSON, uid-stripped, named-rows-only)
+ *   snapshot of the currently persisted variables.
+ * @param {Array} params.savedVariables - The raw persisted variables (`environment.variables`).
+ * @param {Array} params.initialValues - The values to reset the form to when adopting.
+ */
+export const useReconcileSavedEnvironment = ({ formik, savedValuesJson, savedVariables, initialValues }) => {
+  const prevSavedValuesJsonRef = useRef(savedValuesJson);
+  const prevRawSavedRef = useRef(savedVariables);
+
+  useEffect(() => {
+    const prevSaved = prevSavedValuesJsonRef.current;
+    const prevRawSaved = prevRawSavedRef.current;
+    prevSavedValuesJsonRef.current = savedValuesJson;
+    prevRawSavedRef.current = savedVariables;
+
+    const currentNamed = formik.values.filter((variable) => variable.name && variable.name.trim() !== '');
+    const currentJson = JSON.stringify(currentNamed.map(stripEnvVarUid));
+
+    const outcome = reconcileSavedChange({ prevSaved, nextSaved: savedValuesJson, current: currentJson });
+
+    if (outcome === 'adopt') {
+      formik.resetForm({ values: initialValues });
+      return;
+    }
+
+    if (outcome === 'skip') {
+      // find the subset of `savedVariables` that were added elsewhere (undefined variable tooltip's "Add to" switcher)
+      // while the form was dirty, and merge them back in.
+      const added = findExternallyAddedVariables({
+        prevRawSaved,
+        nextRawSaved: savedVariables,
+        currentValues: formik.values
+      });
+
+      if (added.length > 0) {
+        const values = formik.values;
+        const trailingRow = values[values.length - 1];
+        const restRows = values.slice(0, -1);
+        formik.setValues([
+          ...restRows,
+          ...added.map((v) => ({ ...v, description: v.description ?? '' })),
+          trailingRow
+        ]);
+      }
+    }
+  }, [savedValuesJson]);
+};

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/useReconcileSavedEnvironment.spec.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/useReconcileSavedEnvironment.spec.js
@@ -1,0 +1,86 @@
+import { renderHook } from '@testing-library/react';
+import { useReconcileSavedEnvironment } from './useReconcileSavedEnvironment';
+import { stripEnvVarUid } from 'utils/environments';
+
+const toSavedJson = (vars) => JSON.stringify(vars.map(stripEnvVarUid));
+
+describe('useReconcileSavedEnvironment', () => {
+  it('adopts the incoming snapshot when the form has no unsaved edits', () => {
+    const savedA = [{ uid: 'u1', name: 'a', value: '1', type: 'text', enabled: true, secret: false }];
+    const formik = {
+      values: [{ uid: 'u1', name: 'a', value: '1', type: 'text', enabled: true, secret: false }],
+      resetForm: jest.fn(),
+      setValues: jest.fn()
+    };
+    const initialValues = [{ uid: 'new', name: '', value: '', type: 'text', enabled: true, secret: false }];
+
+    const { rerender } = renderHook(
+      ({ savedValuesJson, savedVariables }) => useReconcileSavedEnvironment({ formik, savedValuesJson, savedVariables, initialValues }),
+      { initialProps: { savedValuesJson: toSavedJson(savedA), savedVariables: savedA } }
+    );
+
+    expect(formik.resetForm).not.toHaveBeenCalled();
+
+    // Saved snapshot changes externally (e.g. file reload) while the form still matches the old baseline.
+    const savedB = [{ uid: 'u2', name: 'a', value: '2', type: 'text', enabled: true, secret: false }];
+    rerender({ savedValuesJson: toSavedJson(savedB), savedVariables: savedB });
+
+    expect(formik.resetForm).toHaveBeenCalledWith({ values: initialValues });
+    expect(formik.setValues).not.toHaveBeenCalled();
+  });
+
+  it('merges in externally added variables while keeping unsaved edits, without touching the trailing empty row', () => {
+    const savedA = [{ uid: 'u1', name: 'a', value: '1', type: 'text', enabled: true, secret: false }];
+    const trailingRow = { uid: 'trailing', name: '', value: '', type: 'text', enabled: true, secret: false };
+    const formik = {
+      // User has an unsaved edit to "a" (value 999) from the very start.
+      values: [{ uid: 'u1', name: 'a', value: '999', type: 'text', enabled: true, secret: false }, trailingRow],
+      resetForm: jest.fn(),
+      setValues: jest.fn()
+    };
+    const initialValues = [];
+
+    const { rerender } = renderHook(
+      ({ savedValuesJson, savedVariables }) => useReconcileSavedEnvironment({ formik, savedValuesJson, savedVariables, initialValues }),
+      { initialProps: { savedValuesJson: toSavedJson(savedA), savedVariables: savedA } }
+    );
+
+    // A new variable "b" is added externally (e.g. the undefined-variable tooltip's "Add to" switcher)
+    // while the form is still dirty from the user's edit to "a".
+    const savedB = [
+      { uid: 'u1', name: 'a', value: '1', type: 'text', enabled: true, secret: false },
+      { uid: 'u2', name: 'b', value: '2', type: 'text', enabled: true, secret: false }
+    ];
+    rerender({ savedValuesJson: toSavedJson(savedB), savedVariables: savedB });
+
+    expect(formik.resetForm).not.toHaveBeenCalled();
+    expect(formik.setValues).toHaveBeenCalledWith([
+      { uid: 'u1', name: 'a', value: '999', type: 'text', enabled: true, secret: false },
+      { uid: 'u2', name: 'b', value: '2', type: 'text', enabled: true, secret: false, description: '' },
+      trailingRow
+    ]);
+  });
+
+  it('does nothing when the form already matches the incoming snapshot (its own save landing)', () => {
+    const savedA = [{ uid: 'u1', name: 'a', value: '1', type: 'text', enabled: true, secret: false }];
+    const formik = {
+      values: savedA,
+      resetForm: jest.fn(),
+      setValues: jest.fn()
+    };
+    const initialValues = [];
+
+    const { rerender } = renderHook(
+      ({ savedValuesJson, savedVariables }) => useReconcileSavedEnvironment({ formik, savedValuesJson, savedVariables, initialValues }),
+      { initialProps: { savedValuesJson: toSavedJson(savedA), savedVariables: savedA } }
+    );
+
+    const savedB = [{ uid: 'u1', name: 'a', value: '2', type: 'text', enabled: true, secret: false }];
+    // Simulate the form having already been reset to match the new snapshot (e.g. by handleSave itself).
+    formik.values = savedB;
+    rerender({ savedValuesJson: toSavedJson(savedB), savedVariables: savedB });
+
+    expect(formik.resetForm).not.toHaveBeenCalled();
+    expect(formik.setValues).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-app/src/components/FolderSettings/Vars/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Vars/index.js
@@ -20,7 +20,7 @@ const Vars = ({ collection, folder }) => {
   useTrackScroll({ ref: wrapperRef, selector: '.folder-settings-content', onChange: setScroll, initialValue: scroll });
 
   return (
-    <StyledWrapper className="w-full flex flex-col" ref={wrapperRef}>
+    <StyledWrapper className="w-full flex flex-col" ref={wrapperRef} data-testid="folder-vars-panel">
       <div>
         <div className="mb-3 title text-xs">Pre Request</div>
         <VarsTable folder={folder} collection={collection} vars={requestVars} varType="request" initialScroll={scroll} isDraft={isDraft} />

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import toast from 'react-hot-toast';
 import { IconCopy } from '@tabler/icons';
-import { findCollectionByItemUid, getGlobalEnvironmentVariables } from 'utils/collections/index';
+import { findCollectionByItemUid, getGlobalEnvironmentVariables, getGlobalEnvironmentVariablesMasked } from 'utils/collections/index';
 import { cloneDeep } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { generateSnippet } from '../utils/snippet-generator';
@@ -28,6 +28,7 @@ const CodeView = ({ language, item }) => {
       activeGlobalEnvironmentUid
     });
     c.globalEnvironmentVariables = globalEnvironmentVariables;
+    c.globalEnvSecrets = getGlobalEnvironmentVariablesMasked({ globalEnvironments, activeGlobalEnvironmentUid });
     return c;
   }, [collectionOriginal, globalEnvironments, activeGlobalEnvironmentUid]);
 

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -720,10 +720,10 @@ const GlobalStyle = createGlobalStyle`
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: 1.125rem;
-    height: 1.125rem;
+    width: 0.875rem;
+    height: 0.875rem;
     border-radius: ${(props) => props.theme.border.radius.sm || props.theme.border.radius.base};
-    font-size: 0.625rem;
+    font-size: 0.5rem;
     font-weight: 600;
     line-height: 1;
   }

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -409,12 +409,13 @@ const GlobalStyle = createGlobalStyle`
 
   .CodeMirror-brunoVarInfo .var-name-link {
     cursor: pointer;
-    text-decoration: underline;
-    text-underline-offset: 0.125rem;
+    color: ${(props) => props.theme.textLink};
+    text-decoration: none;
   }
 
   .CodeMirror-brunoVarInfo .var-name-link:hover {
-    color: ${(props) => props.theme.brand};
+    text-decoration: underline;
+    text-underline-offset: 0.125rem;
   }
 
   /* Scope Badge */
@@ -619,6 +620,7 @@ const GlobalStyle = createGlobalStyle`
   /* "Add to" scope switcher (shown below the value editor for brand new variables) */
   .CodeMirror-brunoVarInfo .var-add-to-switcher {
     margin-top: 0.5rem;
+    max-width: 18rem;
   }
 
   /* Toggle and Secret checkbox sit in one row. */
@@ -701,6 +703,7 @@ const GlobalStyle = createGlobalStyle`
     gap: 0.2rem;
     width: 100%;
     height: 1.5rem;
+    min-width: 0;
     box-sizing: border-box;
     background: transparent;
     border: none;
@@ -776,6 +779,10 @@ const GlobalStyle = createGlobalStyle`
 
   .CodeMirror-brunoVarInfo .var-add-to-option-label {
     flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .CodeMirror-brunoVarInfo .var-add-to-option-note {

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -715,6 +715,50 @@ const GlobalStyle = createGlobalStyle`
     background: ${(props) => props.theme.dropdown.hoverBg};
   }
 
+  .CodeMirror-brunoVarInfo .var-add-to-option-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 1.125rem;
+    height: 1.125rem;
+    border-radius: ${(props) => props.theme.border.radius.sm || props.theme.border.radius.base};
+    font-size: 0.625rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-icon-request {
+    color: ${(props) => props.theme.colors.text.purple};
+    background: ${(props) => rgba(props.theme.colors.text.purple, 0.14)};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-icon-folder {
+    color: ${(props) => props.theme.colors.text.yellow};
+    background: ${(props) => rgba(props.theme.colors.text.yellow, 0.14)};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-icon-collection {
+    color: ${(props) => props.theme.colors.text.subtext1};
+    background: ${(props) => rgba(props.theme.colors.text.subtext1, 0.14)};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-icon-environment {
+    color: ${(props) => props.theme.colors.text.green};
+    background: ${(props) => rgba(props.theme.colors.text.green, 0.14)};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-icon-global {
+    color: ${(props) => props.theme.textLink};
+    background: ${(props) => rgba(props.theme.textLink, 0.14)};
+  }
+
+  /* Disabled row badge */
+  .CodeMirror-brunoVarInfo .var-add-to-option-icon-muted {
+    color: ${(props) => props.theme.dropdown.mutedText};
+    background: ${(props) => rgba(props.theme.dropdown.mutedText, 0.14)};
+  }
+
   /* Currently selected scope in the "Add to" list — matches the selected-item treatment used by
      the app's other dropdowns (see components/Dropdown, StatusBar/ThemeDropdown). */
   .CodeMirror-brunoVarInfo .var-add-to-option-active {

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -623,6 +623,187 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.25rem;
   }
 
+  /* "Add to" scope switcher (shown below the value editor for brand new variables) */
+  .CodeMirror-brunoVarInfo .var-add-to-switcher {
+    margin-top: 0.5rem;
+  }
+
+  /* Toggle and Secret checkbox sit in one row. */
+  .CodeMirror-brunoVarInfo .var-add-to-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    width: auto;
+    max-width: max-content;
+    background: transparent;
+    border: none;
+    border-radius: ${(props) => props.theme.border.radius.base};
+    padding: 0.25rem 0.375rem;
+    font-size: ${(props) => props.theme.font.size.sm};
+    color: ${(props) => props.theme.dropdown.color};
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-toggle:hover {
+    background: ${(props) => props.theme.dropdown.hoverBg};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-secret-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: auto;
+    font-size: ${(props) => props.theme.font.size.sm};
+    color: ${(props) => props.theme.dropdown.color};
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-secret-checkbox {
+    margin: 0;
+    cursor: pointer;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-toggle-chevron {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: ${(props) => props.theme.dropdown.mutedText};
+    line-height: 0;
+    transition: transform 0.15s;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-toggle-chevron-open {
+    transform: rotate(180deg);
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.0625rem 0.25rem 0.0625rem 0.5rem;
+    box-sizing: border-box;
+    border-radius: ${(props) => props.theme.border.radius.base};
+    margin-top: 0.125rem;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-trigger {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+    width: 100%;
+    height: 1.5rem;
+    box-sizing: border-box;
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-size: ${(props) => props.theme.font.size.sm};
+    color: ${(props) => props.theme.dropdown.color};
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option:has(.var-add-to-option-trigger:hover) {
+    background: ${(props) => props.theme.dropdown.hoverBg};
+  }
+
+  /* Currently selected scope in the "Add to" list — matches the selected-item treatment used by
+     the app's other dropdowns (see components/Dropdown, StatusBar/ThemeDropdown). */
+  .CodeMirror-brunoVarInfo .var-add-to-option-active {
+    background: ${(props) => rgba(props.theme.dropdown.selectedColor, 0.07)};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-active .var-add-to-option-trigger,
+  .CodeMirror-brunoVarInfo .var-add-to-option-active .var-add-to-option-label {
+    color: ${(props) => props.theme.dropdown.selectedColor};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-active:has(.var-add-to-option-trigger:hover) {
+    background: ${(props) => rgba(props.theme.dropdown.selectedColor, 0.12)};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-label {
+    flex: 1;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-note {
+    flex: 1;
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.dropdown.mutedText};
+    line-height: 1.25rem;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-link-button {
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.dropdown.color};
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-link-button:hover {
+    color: ${(props) => props.theme.textLink};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-inline-env-name-input {
+    flex: 1;
+    min-width: 0;
+    height: 1.5rem;
+    box-sizing: border-box;
+    padding: 0 0.375rem;
+    font-size: ${(props) => props.theme.font.size.xs};
+    border: 1px solid ${(props) => props.theme.input.focusBorder};
+    border-radius: ${(props) => props.theme.border.radius.base};
+    background: ${(props) => props.theme.input.bg};
+    color: ${(props) => props.theme.dropdown.color};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-inline-env-name-input:focus {
+    outline: none;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-inline-create-button {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 1.5rem;
+    box-sizing: border-box;
+    background: transparent;
+    border: 1px solid ${(props) => props.theme.border.border2};
+    border-radius: ${(props) => props.theme.border.radius.base};
+    padding: 0 0.5rem;
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.dropdown.color};
+    cursor: pointer;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-inline-create-button:hover {
+    background: ${(props) => props.theme.dropdown.hoverBg};
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-inline-create-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
   // Active/selected hint - using theme colors instead of hardcoded blue
   .CodeMirror-hint-active {
     background: ${(props) => props.theme.dropdown.hoverBg} !important;

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -722,7 +722,7 @@ const GlobalStyle = createGlobalStyle`
     flex-shrink: 0;
     width: 0.875rem;
     height: 0.875rem;
-    border-radius: ${(props) => props.theme.border.radius.sm || props.theme.border.radius.base};
+    border-radius: ${(props) => props.theme.border.radius.sm};
     font-size: 0.5rem;
     font-weight: 600;
     line-height: 1;

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -407,10 +407,18 @@ const GlobalStyle = createGlobalStyle`
     white-space: nowrap;
   }
 
+  .CodeMirror-brunoVarInfo .var-name-link {
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 0.125rem;
+  }
+
+  .CodeMirror-brunoVarInfo .var-name-link:hover {
+    color: ${(props) => props.theme.brand};
+  }
+
   /* Scope Badge */
-  .CodeMirror-brunoVarInfo .var-scope-badge,
-  .CodeMirror-brunoVarInfo .var-scope-select,
-  .CodeMirror-brunoVarInfo .var-definition-button {
+  .CodeMirror-brunoVarInfo .var-scope-badge {
     display: inline-block;
     padding: 0.125rem 0.375rem;
     background: ${(props) => rgba(props.theme.brand, 0.07)};
@@ -420,21 +428,6 @@ const GlobalStyle = createGlobalStyle`
     color: ${(props) => props.theme.brand};
     letter-spacing: 0.03125rem;
     flex-shrink: 0;
-  }
-
-  .CodeMirror-brunoVarInfo .var-scope-select,
-  .CodeMirror-brunoVarInfo .var-definition-button {
-    cursor: pointer;
-  }
-
-  .CodeMirror-brunoVarInfo .var-scope-select {
-    min-width: 7rem;
-    max-width: min(32rem, calc(100vw - 8rem));
-    text-overflow: ellipsis;
-  }
-
-  .CodeMirror-brunoVarInfo .var-definition-button {
-    background: transparent;
   }
 
   .bruno-var-definition-target {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -24,7 +24,8 @@ import {
   getAllVariables,
   transformRequestToSaveToFilesystem,
   transformCollectionRootToSave,
-  flattenItems
+  flattenItems,
+  resolveEnabledVariable
 } from 'utils/collections';
 import { uuid, waitForNextTick } from 'utils/common';
 import { cancelNetworkRequest, connectWS, sendGrpcRequest, sendNetworkRequest, sendWsRequest } from 'utils/network/index';
@@ -2299,7 +2300,8 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
             return reject(new Error('Environment not found'));
           }
 
-          const variable = environment.variables.find((v) => v.name === variableName && v.enabled);
+          const variable = resolveEnabledVariable(environment.variables, variableName);
+          const newVariable = { uid: uuid(), name: variableName, value: newValue, type: 'text', enabled: true, secret: !!data.secret };
 
           // Match script variable behavior: preserve disabled entries and create a separate enabled slot.
           const updatedVariables = variable
@@ -2309,12 +2311,9 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
                 }
                 return v;
               })
-            : [
-                ...(environment.variables || []),
-                { uid: uuid(), name: variableName, value: newValue, type: 'text', enabled: true, secret: !!data.secret }
-              ];
+            : [...(environment.variables || []), newVariable];
 
-          const resolvedVariables = resolveSecretNameCollision(updatedVariables, variable);
+          const resolvedVariables = resolveSecretNameCollision(updatedVariables, variable || newVariable);
 
           return dispatch(saveEnvironment(resolvedVariables, environment.uid, collectionUid))
             .then(() => {
@@ -2418,7 +2417,8 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
           }
 
           // Match script variable behavior: preserve disabled entries and create a separate enabled slot.
-          const variable = environment.variables.find((v) => v.name === variableName && v.enabled);
+          const variable = resolveEnabledVariable(environment.variables, variableName);
+          const newVariable = { uid: uuid(), name: variableName, value: newValue, type: 'text', enabled: true, secret: !!data.secret };
 
           const updatedVariables = variable
             ? environment.variables.map((v) => {
@@ -2427,12 +2427,9 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
                 }
                 return v;
               })
-            : [
-                ...(environment.variables || []),
-                { uid: uuid(), name: variableName, value: newValue, type: 'text', enabled: true, secret: !!data.secret }
-              ];
+            : [...(environment.variables || []), newVariable];
 
-          const resolvedVariables = resolveSecretNameCollision(updatedVariables, variable);
+          const resolvedVariables = resolveSecretNameCollision(updatedVariables, variable || newVariable);
 
           return dispatch(saveGlobalEnvironment({
             variables: resolvedVariables,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -95,7 +95,7 @@ import {
   isPathOrDescendant
 } from 'utils/collections/index';
 import { sanitizeName } from 'utils/common/regex';
-import { applyScriptEnvVars, getScriptModifiedKeys, writesCollidingSecrets, resolveSecretNameCollision, DUPLICATE_SECRET_NAMES_ERROR } from 'utils/environments';
+import { applyScriptEnvVars, getScriptModifiedKeys, writesCollidingSecrets, DUPLICATE_SECRET_NAMES_ERROR } from 'utils/environments';
 import { getInvalidVariableNames, invalidVariableNamesError } from 'utils/common/variables';
 import { safeParseJSON, safeStringifyJSON } from 'utils/common/index';
 import { resolveInheritedAuth } from 'utils/auth';
@@ -2313,9 +2313,7 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
               })
             : [...(environment.variables || []), newVariable];
 
-          const resolvedVariables = resolveSecretNameCollision(updatedVariables, variable || newVariable);
-
-          return dispatch(saveEnvironment(resolvedVariables, environment.uid, collectionUid))
+          return dispatch(saveEnvironment(updatedVariables, environment.uid, collectionUid))
             .then(() => {
               toast.success(`Variable "${variableName}" ${variable ? 'updated' : 'created'}`);
             })
@@ -2429,10 +2427,8 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
               })
             : [...(environment.variables || []), newVariable];
 
-          const resolvedVariables = resolveSecretNameCollision(updatedVariables, variable || newVariable);
-
           return dispatch(saveGlobalEnvironment({
-            variables: resolvedVariables,
+            variables: updatedVariables,
             environmentUid: activeGlobalEnvUid
           }))
             .then(() => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -2311,7 +2311,7 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
               })
             : [
                 ...(environment.variables || []),
-                { uid: uuid(), name: variableName, value: newValue, enabled: true, secret: false }
+                { uid: uuid(), name: variableName, value: newValue, type: 'text', enabled: true, secret: !!data.secret }
               ];
 
           const resolvedVariables = resolveSecretNameCollision(updatedVariables, variable);
@@ -2429,7 +2429,7 @@ export const updateVariableInScope = (variableName, newValue, scopeInfo, collect
               })
             : [
                 ...(environment.variables || []),
-                { uid: uuid(), name: variableName, value: newValue, enabled: true, secret: false }
+                { uid: uuid(), name: variableName, value: newValue, type: 'text', enabled: true, secret: !!data.secret }
               ];
 
           const resolvedVariables = resolveSecretNameCollision(updatedVariables, variable);

--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -6,10 +6,6 @@ const CHEVRON_ICON_SVG_TEXT = `
 </svg>
 `;
 
-const isEnvironmentScope = (scope) =>
-  scope.type === VARIABLE_ADD_SCOPES.GLOBAL
-  || scope.type === VARIABLE_ADD_SCOPES.ENVIRONMENT;
-
 const SCOPE_ICON_LETTER = {
   [VARIABLE_ADD_SCOPES.REQUEST]: 'R',
   [VARIABLE_ADD_SCOPES.FOLDER]: 'F',
@@ -193,6 +189,10 @@ const renderNoEnvironmentInline = (row, scope, actions) => {
 const buildScopeRow = (scope, actions) => {
   const row = document.createElement('div');
   row.className = 'var-add-to-option';
+
+  const isEnvironmentScope = (scope) =>
+    scope.type === VARIABLE_ADD_SCOPES.GLOBAL
+    || scope.type === VARIABLE_ADD_SCOPES.ENVIRONMENT;
 
   // If the scope is an environment and it's not enabled,
   // show the "No Environment" message with a "Create One" link.
@@ -443,7 +443,7 @@ function createSecretController({ secretLabel, secretCheckbox, onSecretChange })
  *
  * @param {Array<{type: string, label: string, enabled: boolean, supportsSecret: boolean}>} scopes
  * @param {{type: string, label: string, enabled: boolean, supportsSecret: boolean}} initialScope -
- *   The scope currently active before any switch (the guessed scope) — used to set the secret
+ *   The scope currently active before any switch (the guessed scope). used to set the secret
  *   checkbox's initial visibility.
  * @param {(scope: Object, options?: {immediate?: boolean}) => void} onSwitchScope - Repoints the
  *   pending target scope. When `immediate` is true (after creating a brand new environment),

--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -10,6 +10,24 @@ const isEnvironmentScope = (scope) =>
   scope.type === VARIABLE_ADD_SCOPES.GLOBAL
   || scope.type === VARIABLE_ADD_SCOPES.ENVIRONMENT;
 
+const SCOPE_ICON_LETTER = {
+  [VARIABLE_ADD_SCOPES.REQUEST]: 'R',
+  [VARIABLE_ADD_SCOPES.FOLDER]: 'F',
+  [VARIABLE_ADD_SCOPES.COLLECTION]: 'C',
+  [VARIABLE_ADD_SCOPES.ENVIRONMENT]: 'E',
+  [VARIABLE_ADD_SCOPES.GLOBAL]: 'G'
+};
+
+const createScopeIcon = (scope, { muted = false } = {}) => {
+  const icon = document.createElement('span');
+  icon.className = `var-add-to-option-icon var-add-to-option-icon-${scope.type}`;
+  if (muted) {
+    icon.classList.add('var-add-to-option-icon-muted');
+  }
+  icon.textContent = SCOPE_ICON_LETTER[scope.type] || scope.label?.charAt(0)?.toUpperCase() || '?';
+  return icon;
+};
+
 const clearRow = (row) => {
   row.innerHTML = '';
 };
@@ -21,6 +39,8 @@ const renderScopeOption = (row, scope, { handleScopeSwitch, clearError }) => {
   trigger.type = 'button';
   trigger.className = 'var-add-to-option-trigger';
   trigger.setAttribute('data-testid', `var-info-add-to-option-${scope.type}`);
+
+  trigger.appendChild(createScopeIcon(scope));
 
   const label = document.createElement('span');
   label.className = 'var-add-to-option-label';
@@ -146,6 +166,8 @@ const renderCreateEnvironment = (row, scope, actions) => {
 
 const renderNoEnvironmentInline = (row, scope, actions) => {
   clearRow(row);
+
+  row.appendChild(createScopeIcon(scope, { muted: true }));
 
   const note = document.createElement('span');
   note.className = 'var-add-to-option-note';
@@ -357,10 +379,6 @@ function renderScopeRows({ list, scopes, rowActions }) {
   const rowsByType = {};
 
   for (const scope of scopes) {
-    if (scope.type === VARIABLE_ADD_SCOPES.FOLDER) {
-      continue;
-    }
-
     const row = buildScopeRow(scope, rowActions);
     rowsByType[scope.type] = row;
     fragment.appendChild(row);

--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -1,0 +1,473 @@
+import { VARIABLE_ADD_SCOPES } from 'utils/common/constants';
+
+const CHEVRON_ICON_SVG_TEXT = `
+<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="6,9 12,15 18,9"></polyline>
+</svg>
+`;
+
+const isEnvironmentScope = (scope) =>
+  scope.type === VARIABLE_ADD_SCOPES.GLOBAL
+  || scope.type === VARIABLE_ADD_SCOPES.ENVIRONMENT;
+
+const clearRow = (row) => {
+  row.innerHTML = '';
+};
+
+const renderScopeOption = (row, scope, { handleScopeSwitch, clearError }) => {
+  clearRow(row);
+
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.className = 'var-add-to-option-trigger';
+  trigger.setAttribute('data-testid', `var-info-add-to-option-${scope.type}`);
+
+  const label = document.createElement('span');
+  label.className = 'var-add-to-option-label';
+  label.textContent = scope.label;
+  trigger.appendChild(label);
+
+  trigger.addEventListener('click', () => {
+    clearError();
+    handleScopeSwitch(scope);
+  });
+
+  row.appendChild(trigger);
+};
+
+const submitCreateEnvironment = ({
+  scope,
+  nameInput,
+  createButton,
+  actions,
+  revert
+}) => {
+  const {
+    handleScopeSwitch,
+    onCreateEnvironment,
+    showError,
+    clearError,
+    unregisterActiveCreateForm
+  } = actions;
+
+  const name = nameInput.value.trim();
+
+  if (!name) {
+    showError('Environment name is required');
+    return;
+  }
+
+  clearError();
+
+  createButton.disabled = true;
+  createButton.textContent = 'Creating…';
+  nameInput.disabled = true;
+
+  onCreateEnvironment(scope, name)
+    .then(() => {
+      unregisterActiveCreateForm(revert);
+      // once new env is created, add the variable to it and save immediately
+      handleScopeSwitch(scope, { immediate: true });
+    })
+    .catch((err) => {
+      showError(err?.message || 'Failed to create environment');
+
+      createButton.disabled = false;
+      createButton.textContent = 'Create';
+      nameInput.disabled = false;
+    });
+};
+
+const renderCreateEnvironment = (row, scope, actions) => {
+  clearRow(row);
+
+  const {
+    registerActiveCreateForm,
+    unregisterActiveCreateForm
+  } = actions;
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'var-add-to-inline-env-name-input';
+  nameInput.placeholder = 'Enter environment name';
+  nameInput.setAttribute(
+    'data-testid',
+    'var-info-add-to-create-env-name-input'
+  );
+
+  const createButton = document.createElement('button');
+  createButton.type = 'button';
+  createButton.className = 'var-add-to-inline-create-button';
+  createButton.textContent = 'Create';
+  createButton.setAttribute(
+    'data-testid',
+    'var-info-add-to-create-env-submit'
+  );
+
+  row.append(nameInput, createButton);
+
+  // Restores this row back to the "No Environment" state.
+  const revert = () => {
+    unregisterActiveCreateForm(revert);
+    renderNoEnvironmentInline(row, scope, actions);
+  };
+
+  // Register this form so any previously open form is closed and outside clicks
+  // can restore this row via `revert`.
+  registerActiveCreateForm(revert, row);
+
+  const submit = () =>
+    submitCreateEnvironment({
+      scope,
+      nameInput,
+      createButton,
+      actions,
+      revert
+    });
+
+  createButton.addEventListener('click', (e) => {
+    e.stopPropagation();
+    submit();
+  });
+
+  nameInput.addEventListener('click', (e) => e.stopPropagation());
+
+  nameInput.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter') {
+      return;
+    }
+
+    e.preventDefault();
+    submit();
+  });
+
+  nameInput.focus();
+};
+
+const renderNoEnvironmentInline = (row, scope, actions) => {
+  clearRow(row);
+
+  const note = document.createElement('span');
+  note.className = 'var-add-to-option-note';
+  note.setAttribute('data-testid', 'var-info-add-to-no-env-note');
+
+  note.appendChild(document.createTextNode(`No ${scope.label} selected. `));
+
+  const createLink = document.createElement('button');
+  createLink.type = 'button';
+  createLink.className = 'var-add-to-link-button';
+  createLink.setAttribute('data-testid', 'var-info-add-to-create-env-button');
+  createLink.textContent = 'Create One';
+
+  createLink.addEventListener('click', (e) => {
+    e.stopPropagation();
+    renderCreateEnvironment(row, scope, actions);
+  });
+
+  note.appendChild(createLink);
+  row.appendChild(note);
+};
+
+const buildScopeRow = (scope, actions) => {
+  const row = document.createElement('div');
+  row.className = 'var-add-to-option';
+
+  // If the scope is an environment and it's not enabled,
+  // show the "No Environment" message with a "Create One" link.
+  if (isEnvironmentScope(scope) && !scope.enabled) {
+    renderNoEnvironmentInline(row, scope, actions);
+  } else {
+    renderScopeOption(row, scope, actions);
+  }
+
+  return row;
+};
+
+function createAddToScopeSwitcherDOM() {
+  const container = document.createElement('div');
+  container.className = 'var-add-to-switcher';
+  container.setAttribute('data-testid', 'var-info-add-to');
+
+  const controlsRow = document.createElement('div');
+  controlsRow.className = 'var-add-to-controls';
+  container.appendChild(controlsRow);
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'var-add-to-toggle';
+  toggle.setAttribute('data-testid', 'var-info-add-to-toggle');
+  controlsRow.appendChild(toggle);
+
+  const toggleLabel = document.createElement('span');
+  toggleLabel.className = 'var-add-to-toggle-label';
+  toggleLabel.textContent = 'Add to';
+  toggle.appendChild(toggleLabel);
+
+  const toggleChevron = document.createElement('span');
+  toggleChevron.className = 'var-add-to-toggle-chevron';
+  toggleChevron.innerHTML = CHEVRON_ICON_SVG_TEXT;
+  toggle.appendChild(toggleChevron);
+
+  // Only shown when the currently active scope (Global/Environment) supports secrets.
+  const secretLabel = document.createElement('label');
+  secretLabel.className = 'var-add-to-secret-label';
+  secretLabel.style.display = 'none';
+  controlsRow.appendChild(secretLabel);
+
+  const secretCheckbox = document.createElement('input');
+  secretCheckbox.type = 'checkbox';
+  secretCheckbox.className = 'var-add-to-secret-checkbox';
+  secretCheckbox.setAttribute('data-testid', 'var-info-add-to-secret-checkbox');
+  secretLabel.appendChild(secretCheckbox);
+
+  const secretLabelText = document.createElement('span');
+  secretLabelText.textContent = 'Secret';
+  secretLabel.appendChild(secretLabelText);
+
+  const list = document.createElement('div');
+  list.className = 'var-add-to-list';
+  list.setAttribute('data-testid', 'var-info-add-to-list');
+  list.style.display = 'none';
+  container.appendChild(list);
+
+  const errorNote = document.createElement('div');
+  errorNote.className = 'var-warning-note';
+  errorNote.setAttribute('data-testid', 'var-info-add-to-error');
+  errorNote.style.display = 'none';
+  container.appendChild(errorNote);
+
+  return {
+    container,
+    controlsRow,
+    toggle,
+    toggleChevron,
+    secretLabel,
+    secretCheckbox,
+    list,
+    errorNote
+  };
+}
+
+function createDropdownController({ toggle, list, toggleChevron }) {
+  const open = () => {
+    list.style.display = 'block';
+    toggleChevron.classList.add('var-add-to-toggle-chevron-open');
+  };
+
+  const close = () => {
+    list.style.display = 'none';
+    toggleChevron.classList.remove('var-add-to-toggle-chevron-open');
+  };
+
+  toggle.addEventListener('click', () => {
+    if (list.style.display === 'none') {
+      open();
+    } else {
+      close();
+    }
+  });
+
+  return {
+    open,
+    close
+  };
+}
+
+function createErrorController(errorNote) {
+  const show = (message) => {
+    errorNote.textContent = message;
+    errorNote.style.display = 'block';
+  };
+
+  const clear = () => {
+    errorNote.textContent = '';
+    errorNote.style.display = 'none';
+  };
+
+  return {
+    show,
+    clear
+  };
+}
+
+// Ensures only one inline "Create Environment" form is open at a time and
+// closes it when the user clicks outside.
+function createInlineCreateFormManager() {
+  let activeRevert = null;
+  let activeRow = null;
+
+  // Closes the active inline create form when clicking outside its row.
+  const handleOutsideClick = (e) => {
+    if (!activeRevert || !activeRow || activeRow.contains(e.target)) {
+      return;
+    }
+
+    const revert = activeRevert;
+
+    activeRevert = null;
+    activeRow = null;
+    document.removeEventListener('mousedown', handleOutsideClick);
+
+    revert();
+  };
+
+  const register = (revert, row) => {
+    // Only one inline create form can be active at a time.
+    if (activeRevert && activeRevert !== revert) {
+      const previousRevert = activeRevert;
+
+      activeRevert = null;
+      activeRow = null;
+
+      previousRevert();
+    }
+
+    activeRevert = revert;
+    activeRow = row;
+
+    document.addEventListener('mousedown', handleOutsideClick);
+  };
+
+  const unregister = (revert) => {
+    if (activeRevert !== revert) {
+      return;
+    }
+
+    activeRevert = null;
+    activeRow = null;
+
+    document.removeEventListener('mousedown', handleOutsideClick);
+  };
+
+  const destroy = () => {
+    activeRevert = null;
+    activeRow = null;
+    document.removeEventListener('mousedown', handleOutsideClick);
+  };
+
+  return {
+    register,
+    unregister,
+    destroy
+  };
+}
+
+function renderScopeRows({ list, scopes, rowActions }) {
+  const fragment = document.createDocumentFragment();
+  const rowsByType = {};
+
+  for (const scope of scopes) {
+    if (scope.type === VARIABLE_ADD_SCOPES.FOLDER) {
+      continue;
+    }
+
+    const row = buildScopeRow(scope, rowActions);
+    rowsByType[scope.type] = row;
+    fragment.appendChild(row);
+  }
+
+  list.appendChild(fragment);
+
+  return rowsByType;
+}
+
+function createActiveRowTracker(rowsByType) {
+  let activeRow = null;
+
+  const setActiveScope = (scope) => {
+    if (activeRow) {
+      activeRow.classList.remove('var-add-to-option-active');
+      activeRow = null;
+    }
+
+    const row = scope && rowsByType[scope.type];
+    if (row) {
+      row.classList.add('var-add-to-option-active');
+      activeRow = row;
+    }
+  };
+
+  return { setActiveScope };
+}
+
+function createSecretController({ secretLabel, secretCheckbox }) {
+  let currentScope = null;
+
+  const setCurrentScope = (scope) => {
+    currentScope = scope;
+    const supportsSecret = !!(scope && scope.supportsSecret);
+    secretLabel.style.display = supportsSecret ? 'inline-flex' : 'none';
+    if (!supportsSecret) {
+      secretCheckbox.checked = false;
+    }
+  };
+
+  const getSecret = () => !!(currentScope && currentScope.supportsSecret) && secretCheckbox.checked;
+
+  return { setCurrentScope, getSecret };
+}
+
+/**
+ * Builds the "Add to" toggle + scope list dropdown, plus a Secret checkbox that appears once
+ * a secret-capable scope is selected.
+ *
+ * @param {Array<{type: string, label: string, enabled: boolean, supportsSecret: boolean}>} scopes
+ * @param {{type: string, label: string, enabled: boolean, supportsSecret: boolean}} initialScope -
+ *   The scope currently active before any switch (the guessed scope) — used to set the secret
+ *   checkbox's initial visibility.
+ * @param {(scope: Object, options?: {immediate?: boolean}) => void} onSwitchScope - Repoints the
+ *   pending target scope. When `immediate` is true (after creating a brand new environment),
+ *   the caller should save right away rather than waiting for the next blur.
+ * @param {(scope: Object, name: string) => Promise<void>} onCreateEnvironment
+ */
+export const createAddToScopeSwitcher = ({
+  scopes,
+  initialScope,
+  onSwitchScope,
+  onCreateEnvironment
+}) => {
+  const switcherElements = createAddToScopeSwitcherDOM();
+
+  const dropdown = createDropdownController(switcherElements);
+  const error = createErrorController(switcherElements.errorNote);
+  const createFormManager = createInlineCreateFormManager();
+  const secretController = createSecretController({
+    secretLabel: switcherElements.secretLabel,
+    secretCheckbox: switcherElements.secretCheckbox
+  });
+
+  secretController.setCurrentScope(initialScope);
+
+  let activeRowTracker = null;
+
+  const handleScopeSwitch = (scope, options) => {
+    dropdown.close();
+    error.clear();
+    secretController.setCurrentScope(scope);
+    if (activeRowTracker) {
+      activeRowTracker.setActiveScope(scope);
+    }
+    onSwitchScope(scope, options);
+  };
+
+  const rowsByType = renderScopeRows({
+    list: switcherElements.list,
+    scopes,
+    rowActions: {
+      handleScopeSwitch,
+      onCreateEnvironment,
+      showError: error.show,
+      clearError: error.clear,
+      registerActiveCreateForm: createFormManager.register,
+      unregisterActiveCreateForm: createFormManager.unregister
+    }
+  });
+
+  activeRowTracker = createActiveRowTracker(rowsByType);
+  activeRowTracker.setActiveScope(initialScope);
+
+  switcherElements.container._destroy = createFormManager.destroy;
+  switcherElements.container._getPendingSecret = secretController.getSecret;
+
+  return switcherElements.container;
+};

--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -41,6 +41,7 @@ const renderScopeOption = (row, scope, { handleScopeSwitch, clearError }) => {
   const label = document.createElement('span');
   label.className = 'var-add-to-option-label';
   label.textContent = scope.label;
+  label.title = scope.label;
   trigger.appendChild(label);
 
   trigger.addEventListener('click', () => {

--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -390,8 +390,16 @@ function createActiveRowTracker(rowsByType) {
   return { setActiveScope };
 }
 
-function createSecretController({ secretLabel, secretCheckbox }) {
+function createSecretController({ secretLabel, secretCheckbox, onSecretChange }) {
   let currentScope = null;
+
+  const getSecret = () => !!(currentScope && currentScope.supportsSecret) && secretCheckbox.checked;
+
+  const notifyChange = () => {
+    if (typeof onSecretChange === 'function') {
+      onSecretChange(getSecret());
+    }
+  };
 
   const setCurrentScope = (scope) => {
     currentScope = scope;
@@ -400,9 +408,13 @@ function createSecretController({ secretLabel, secretCheckbox }) {
     if (!supportsSecret) {
       secretCheckbox.checked = false;
     }
+    notifyChange();
   };
 
-  const getSecret = () => !!(currentScope && currentScope.supportsSecret) && secretCheckbox.checked;
+  secretCheckbox.addEventListener('change', (e) => {
+    e.stopPropagation();
+    notifyChange();
+  });
 
   return { setCurrentScope, getSecret };
 }
@@ -419,12 +431,14 @@ function createSecretController({ secretLabel, secretCheckbox }) {
  *   pending target scope. When `immediate` is true (after creating a brand new environment),
  *   the caller should save right away rather than waiting for the next blur.
  * @param {(scope: Object, name: string) => Promise<void>} onCreateEnvironment
+ * @param {(secret: boolean) => void} [onSecretChange] - Called whenever the Secret checkbox is toggled or the active scope changes.
  */
 export const createAddToScopeSwitcher = ({
   scopes,
   initialScope,
   onSwitchScope,
-  onCreateEnvironment
+  onCreateEnvironment,
+  onSecretChange
 }) => {
   const switcherElements = createAddToScopeSwitcherDOM();
 
@@ -433,7 +447,8 @@ export const createAddToScopeSwitcher = ({
   const createFormManager = createInlineCreateFormManager();
   const secretController = createSecretController({
     secretLabel: switcherElements.secretLabel,
-    secretCheckbox: switcherElements.secretCheckbox
+    secretCheckbox: switcherElements.secretCheckbox,
+    onSecretChange
   });
 
   secretController.setCurrentScope(initialScope);

--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -260,7 +260,6 @@ function createAddToScopeSwitcherDOM() {
 
   return {
     container,
-    controlsRow,
     toggle,
     toggleChevron,
     secretLabel,

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -733,12 +733,16 @@ export const renderVarInfo = (token, options) => {
       updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
     };
 
-    // Only the request/folder's direct containing folder is offered as a creatable scope — not
-    // any ancestor further up the tree. Doesn't apply when the tooltip itself was opened from
-    // folder settings (that folder is already the guessed default in that case).
-    const parentFolder = item && item.type !== 'folder' && collection
+    // Only the request/folder's direct containing folder is offered as a creatable scope. not
+    // any ancestor further up the tree.
+    const isInFolderSettings = !!(item && item.type === 'folder');
+    const parentFolder = item && !isInFolderSettings && collection
       ? findParentItemInCollection(collection, item.uid)
       : null;
+
+    // When the tooltip is opened from folder settings itself, the "Folder" scope should target
+    // that folder directly (labeled "Folder"), not an ancestor.
+    const folderScopeTarget = isInFolderSettings ? item : parentFolder;
 
     // for new variables, add a switcher to select the scope to add the variable to (collection, request, folder, environment, global)
     if (isNewVariable) {
@@ -749,7 +753,7 @@ export const renderVarInfo = (token, options) => {
           case VARIABLE_ADD_SCOPES.REQUEST:
             return { type: 'request', value: '', data: { item, variable: null } };
           case VARIABLE_ADD_SCOPES.FOLDER:
-            return { type: 'folder', value: '', data: { folder: parentFolder, variable: null } };
+            return { type: 'folder', value: '', data: { folder: folderScopeTarget, variable: null } };
           case VARIABLE_ADD_SCOPES.ENVIRONMENT: {
             const freshState = store.getState();
             const freshCollection = findCollectionByUid(freshState.collections.collections, collection.uid);
@@ -782,7 +786,8 @@ export const renderVarInfo = (token, options) => {
         activeEnvironmentUid: freshCollectionForScopes?.activeEnvironmentUid,
         activeGlobalEnvironmentUid: globalEnvironmentsState.activeGlobalEnvironmentUid,
         item,
-        parentFolder,
+        parentFolder: folderScopeTarget,
+        isSelfFolder: isInFolderSettings,
         hasCollection: !!collection?.uid
       });
 

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -661,7 +661,8 @@ export const renderVarInfo = (token, options) => {
       const interpolatedValue = interpolate(newValue, allVariables);
       currentInterpolatedValue = interpolatedValue ?? '';
       const newHasSecretRefs = containsSecretVariableReferences(newValue, collection, item);
-      currentShouldMaskValue = isSecret || newHasSecretRefs;
+
+      currentShouldMaskValue = currentShouldMaskValue || newHasSecretRefs;
       updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
 
       // new variables are saved via the Add-to switcher, not on blur. so don't dispatch an update action here.
@@ -813,7 +814,8 @@ export const renderVarInfo = (token, options) => {
             const interpolatedValue = interpolate(value, allVariables);
             currentInterpolatedValue = interpolatedValue ?? '';
             const newHasSecretRefs = containsSecretVariableReferences(value, collection, item);
-            currentShouldMaskValue = isSecret || newHasSecretRefs;
+            // Use the secret flag actually being persisted (from the Secret checkbox).
+            currentShouldMaskValue = secret || newHasSecretRefs;
             updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
 
             removeAddToSwitcher();
@@ -832,7 +834,12 @@ export const renderVarInfo = (token, options) => {
         // If immediate is true, persist the new variable immediately after switching scope.
         // for inline create environment flow, the new variable is persisted immediately after the environment is created and selected.
         if (immediate) {
-          persistNewVariable(false).catch((err) => {
+          // Read the user's pending Secret checkbox state.
+          const pendingSecret = valueContainer._addToSwitcher && typeof valueContainer._addToSwitcher._getPendingSecret === 'function'
+            ? valueContainer._addToSwitcher._getPendingSecret()
+            : false;
+
+          persistNewVariable(pendingSecret).catch((err) => {
             toast.error(err?.message || 'Failed to save variable');
           });
         }

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -19,13 +19,10 @@ import {
   getAvailableAddToScopes
 } from 'utils/collections';
 import {
-  openCollectionSettings,
   updateVariableInScope,
   addEnvironment,
   selectEnvironment
 } from 'providers/ReduxStore/slices/collections/actions';
-import { updatedFolderSettingsSelectedTab } from 'providers/ReduxStore/slices/collections';
-import { addTab, focusTab, updateRequestPaneTab } from 'providers/ReduxStore/slices/tabs';
 import { addGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import store from 'providers/ReduxStore';
 import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
@@ -34,6 +31,7 @@ import { setupAutoComplete } from 'utils/codemirror/autocomplete';
 import { variableNameRegex } from 'utils/common/regex';
 import { VARIABLE_ADD_SCOPES } from 'utils/common/constants';
 import { createAddToScopeSwitcher } from 'utils/codemirror/addToScopeSwitcher';
+import { goToVariableDefinition } from 'utils/codemirror/goToVariableDefinition';
 
 let CodeMirror;
 const SERVER_RENDERED = typeof window === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
@@ -134,100 +132,6 @@ const waitForEnvironmentByName = (
   });
 };
 
-const scrollDefinitionIntoView = (scopeType, variableName) => {
-  const selectorByScope = {
-    request: `[data-testid="request-vars-req"] [data-row-name="${variableName}"]`,
-    folder: `[data-testid="folder-vars-req"] [data-row-name="${variableName}"]`,
-    collection: `[data-testid="collection-vars-req"] [data-row-name="${variableName}"]`,
-    environment: `[data-testid="env-var-row-${variableName}"]`,
-    global: `[data-testid="env-var-row-${variableName}"]`
-  };
-
-  const selector = selectorByScope[scopeType];
-  if (!selector || typeof document === 'undefined') {
-    return;
-  }
-
-  let attempts = 0;
-  const maxAttempts = 12;
-
-  const tryScroll = () => {
-    const definitionRow = document.querySelector(selector);
-    if (definitionRow) {
-      definitionRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      definitionRow.classList.add('bruno-var-definition-target');
-      window.setTimeout(() => definitionRow.classList.remove('bruno-var-definition-target'), 1500);
-      return;
-    }
-
-    attempts += 1;
-    if (attempts < maxAttempts) {
-      window.setTimeout(tryScroll, 100);
-    }
-  };
-
-  window.setTimeout(tryScroll, 50);
-};
-
-const goToVariableDefinition = (scopeInfo, collection, item, variableName) => {
-  if (!scopeInfo || !collection || !variableName) {
-    return;
-  }
-
-  const dispatch = store.dispatch;
-
-  switch (scopeInfo.type) {
-    case 'request': {
-      const targetItem = scopeInfo.data?.item || item;
-      if (!targetItem?.uid) {
-        return;
-      }
-
-      dispatch(addTab({
-        uid: targetItem.uid,
-        collectionUid: collection.uid,
-        type: targetItem.type,
-        pathname: targetItem.pathname,
-        requestPaneTab: 'vars'
-      }));
-      dispatch(updateRequestPaneTab({ uid: targetItem.uid, requestPaneTab: 'vars' }));
-      dispatch(focusTab({ uid: targetItem.uid }));
-      break;
-    }
-
-    case 'folder': {
-      const folder = scopeInfo.data?.folder;
-      if (!folder?.uid) {
-        return;
-      }
-
-      dispatch(updatedFolderSettingsSelectedTab({ collectionUid: collection.uid, folderUid: folder.uid, tab: 'vars' }));
-      dispatch(addTab({ uid: folder.uid, collectionUid: collection.uid, type: 'folder-settings', pathname: folder.pathname }));
-      break;
-    }
-
-    case 'collection': {
-      dispatch(openCollectionSettings(collection.uid, 'vars'));
-      break;
-    }
-
-    case 'environment': {
-      dispatch(addTab({ uid: `${collection.uid}-environment-settings`, collectionUid: collection.uid, type: 'environment-settings' }));
-      break;
-    }
-
-    case 'global': {
-      dispatch(addTab({ uid: `${collection.uid}-global-environment-settings`, collectionUid: collection.uid, type: 'global-environment-settings' }));
-      break;
-    }
-
-    default:
-      return;
-  }
-
-  scrollDefinitionIntoView(scopeInfo.type, variableName);
-};
-
 // Get the masked display text based on the value length
 const getMaskedDisplay = (value) => {
   const contentLength = (value === undefined || value === null ? '' : String(value)).length;
@@ -288,6 +192,11 @@ const getCopyButton = (getVariableValue, onCopyCallback) => {
   copyButton.type = 'button';
 
   let isCopied = false;
+
+  copyButton.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
 
   copyButton.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -639,6 +548,11 @@ export const renderVarInfo = (token, options) => {
       toggleButton.innerHTML = EYE_ICON_SVG;
       toggleButton.type = 'button';
       toggleButton.style.display = (shouldMaskValue || isMasked) ? '' : 'none';
+
+      toggleButton.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      });
 
       toggleButton.addEventListener('click', (e) => {
         e.stopPropagation();

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -15,6 +15,7 @@ import {
   getAllVariables,
   findCollectionByUid,
   findItemInCollectionByItemUid,
+  findParentItemInCollection,
   getAvailableAddToScopes
 } from 'utils/collections';
 import {
@@ -466,6 +467,12 @@ export const renderVarInfo = (token, options) => {
       e.stopPropagation();
       e.preventDefault();
       goToVariableDefinition(scopeInfo, collection, item, variableName);
+
+      // Close the tooltip once we've navigated to the definition.
+      const popup = varName.closest('.CodeMirror-brunoVarInfo');
+      if (popup && typeof popup._hidePopup === 'function') {
+        popup._hidePopup({ immediate: true });
+      }
     });
   }
 
@@ -788,7 +795,14 @@ export const renderVarInfo = (token, options) => {
       updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
     };
 
-    // for new variables, add a switcher to select the scope to add the variable to (collection, request, environment, global)
+    // Only the request/folder's direct containing folder is offered as a creatable scope — not
+    // any ancestor further up the tree. Doesn't apply when the tooltip itself was opened from
+    // folder settings (that folder is already the guessed default in that case).
+    const parentFolder = item && item.type !== 'folder' && collection
+      ? findParentItemInCollection(collection, item.uid)
+      : null;
+
+    // for new variables, add a switcher to select the scope to add the variable to (collection, request, folder, environment, global)
     if (isNewVariable) {
       const buildScopeInfoForSwitch = (scope) => {
         switch (scope.type) {
@@ -796,6 +810,8 @@ export const renderVarInfo = (token, options) => {
             return { type: 'collection', value: '', data: { collection, variable: null } };
           case VARIABLE_ADD_SCOPES.REQUEST:
             return { type: 'request', value: '', data: { item, variable: null } };
+          case VARIABLE_ADD_SCOPES.FOLDER:
+            return { type: 'folder', value: '', data: { folder: parentFolder, variable: null } };
           case VARIABLE_ADD_SCOPES.ENVIRONMENT: {
             const freshState = store.getState();
             const freshCollection = findCollectionByUid(freshState.collections.collections, collection.uid);
@@ -821,7 +837,8 @@ export const renderVarInfo = (token, options) => {
       const addToScopes = getAvailableAddToScopes(
         collection?.activeEnvironmentUid,
         globalEnvironmentsState.activeGlobalEnvironmentUid,
-        item
+        item,
+        parentFolder
       );
 
       // The guessed scope is selected by default (if it's in the addToScopes list).
@@ -909,8 +926,12 @@ export const renderVarInfo = (token, options) => {
       valueContainer._addToSwitcher = addToSwitcher;
 
       // Called from `onDocumentClick` in showPopup when the tooltip is dismissed via an
-      // outside click.
+      // outside click. update only if user has changed the value, otherwise do nothing.
       valueContainer._persistNewVariable = () => {
+        if (cmEditor.getValue() === originalValue) {
+          return Promise.resolve();
+        }
+
         const pendingSecret = valueContainer._addToSwitcher && typeof valueContainer._addToSwitcher._getPendingSecret === 'function'
           ? valueContainer._addToSwitcher._getPendingSecret()
           : false;

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -94,6 +94,7 @@ const getScopeLabel = (scopeType) => {
     'dynamic': 'Dynamic',
     'oauth2': 'OAuth2',
     'undefined': 'Undefined',
+    'unresolved': 'New',
     'pathParam': 'Path Param'
   };
   return labels[scopeType] || scopeType;
@@ -319,15 +320,23 @@ export const renderVarInfo = (token, options) => {
             data: { item, variable: null } // variable is null since it doesn't exist yet
           };
         }
-      } else if (collection) {
-        // No item context but we have collection - create as collection variable
+      } else if (collection?.uid) {
         scopeInfo = {
           type: 'collection',
           value: '',
           data: { collection, variable: null }
         };
+      } else if (collection) {
+        // We're in the Global Environment table (no collection context).
+        // for global env colelction is {} without uid.
+        // Pass as "unresolved" so that the Add-to switcher can resolve to the first available scope.
+        scopeInfo = {
+          type: 'unresolved',
+          value: '',
+          data: { variable: null }
+        };
       } else {
-        // No context at all, show as undefined
+        // No context at all (no collection, no item) - nothing to add to, show as undefined.
         scopeInfo = {
           type: 'undefined',
           value: '',
@@ -753,15 +762,24 @@ export const renderVarInfo = (token, options) => {
 
       const addToScopesState = store.getState();
       const globalEnvironmentsState = (addToScopesState && addToScopesState.globalEnvironments) || {};
-      const addToScopes = getAvailableAddToScopes(
-        collection?.activeEnvironmentUid,
-        globalEnvironmentsState.activeGlobalEnvironmentUid,
+      const addToScopes = getAvailableAddToScopes({
+        activeEnvironmentUid: collection?.activeEnvironmentUid,
+        activeGlobalEnvironmentUid: globalEnvironmentsState.activeGlobalEnvironmentUid,
         item,
-        parentFolder
-      );
+        parentFolder,
+        hasCollection: !!collection?.uid
+      });
 
-      // The guessed scope is selected by default (if it's in the addToScopes list).
-      const initialScope = addToScopes.find((s) => s.type === scopeInfo.type) || null;
+      // If there's only one available scope, select it by default. Otherwise, use the detected scope if it's available.
+      const initialScope = addToScopes.find((s) => s.type === scopeInfo.type)
+        || (addToScopes.length === 1 ? addToScopes[0] : null);
+
+      // If the initial scope is different from the detected scope, rebuild the scopeInfo for the initial scope and update the badge.
+      // This can happen if adding variable in Global Table where collection is not available.
+      if (initialScope && initialScope.type !== scopeInfo.type) {
+        scopeInfo = buildScopeInfoForSwitch(initialScope);
+        scopeBadge.textContent = getScopeLabel(initialScope.type);
+      }
 
       const removeAddToSwitcher = () => {
         if (valueContainer._addToSwitcher) {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -8,23 +8,31 @@
 
 import { interpolate, mockDataFunctions, timeBasedDynamicVars } from '@usebruno/common';
 import { toDisplayString } from '@usebruno/common/utils';
+import toast from 'react-hot-toast';
 import {
   getVariableScope,
   isVariableSecret,
   getAllVariables,
   findCollectionByUid,
-  findEnvironmentInCollection,
   findItemInCollectionByItemUid,
-  getTreePathFromCollectionToItem
+  getAvailableAddToScopes
 } from 'utils/collections';
-import { openCollectionSettings, updateVariableInScope } from 'providers/ReduxStore/slices/collections/actions';
+import {
+  openCollectionSettings,
+  updateVariableInScope,
+  addEnvironment,
+  selectEnvironment
+} from 'providers/ReduxStore/slices/collections/actions';
 import { updatedFolderSettingsSelectedTab } from 'providers/ReduxStore/slices/collections';
 import { addTab, focusTab, updateRequestPaneTab } from 'providers/ReduxStore/slices/tabs';
+import { addGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import store from 'providers/ReduxStore';
 import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
 import { MaskedEditor } from 'utils/common/masked-editor';
 import { setupAutoComplete } from 'utils/codemirror/autocomplete';
 import { variableNameRegex } from 'utils/common/regex';
+import { VARIABLE_ADD_SCOPES } from 'utils/common/constants';
+import { createAddToScopeSwitcher } from 'utils/codemirror/addToScopeSwitcher';
 
 let CodeMirror;
 const SERVER_RENDERED = typeof window === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true;
@@ -92,106 +100,37 @@ const getScopeLabel = (scopeType) => {
   return labels[scopeType] || scopeType;
 };
 
-const getActiveGlobalEnvironment = () => {
-  const state = store.getState();
-  const globalEnvironments = state.globalEnvironments?.globalEnvironments || [];
-  const activeGlobalEnvironmentUid = state.globalEnvironments?.activeGlobalEnvironmentUid;
+const NEW_ENVIRONMENT_POLL_INTERVAL_MS = 50;
+const NEW_ENVIRONMENT_POLL_TIMEOUT_MS = 3000;
 
-  if (!activeGlobalEnvironmentUid) {
-    return null;
-  }
+// `addEnvironment` only writes the file through IPC. The store is updated later, after the filesystem watcher picks up the change.
+// So, poll for the environment here instead of assuming it’s available immediately.
+const waitForEnvironmentByName = (
+  collectionUid,
+  name,
+  { intervalMs = NEW_ENVIRONMENT_POLL_INTERVAL_MS, timeoutMs = NEW_ENVIRONMENT_POLL_TIMEOUT_MS } = {}
+) => {
+  const deadline = Date.now() + timeoutMs;
 
-  return globalEnvironments.find((env) => env.uid === activeGlobalEnvironmentUid) || null;
-};
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      const state = store.getState();
+      const freshCollection = findCollectionByUid(state.collections.collections, collectionUid);
+      const found = (freshCollection?.environments || []).find((env) => env.name === name);
 
-const getCreatableScopeOptions = (collection, item) => {
-  if (!collection) {
-    return [];
-  }
+      if (found) {
+        return resolve(found);
+      }
 
-  const options = [];
+      if (Date.now() >= deadline) {
+        return reject(new Error(`Timed out waiting for environment "${name}" to be created`));
+      }
 
-  if (item?.uid) {
-    if (item.type !== 'folder') {
-      options.push({
-        key: `request:${item.uid}`,
-        type: 'request',
-        label: getScopeLabel('request'),
-        scopeInfo: {
-          type: 'request',
-          value: '',
-          data: { item, variable: null }
-        }
-      });
-    }
+      setTimeout(check, intervalMs);
+    };
 
-    const folderPath = getTreePathFromCollectionToItem(collection, item)
-      .filter((pathItem) => pathItem?.type === 'folder');
-
-    if (item.type === 'folder' && !folderPath.some((folder) => folder.uid === item.uid)) {
-      folderPath.push(item);
-    }
-
-    folderPath.forEach((folder, index) => {
-      const nestedLabel = folderPath
-        .slice(0, index + 1)
-        .map((pathItem) => pathItem.name)
-        .filter(Boolean)
-        .join(' / ');
-
-      options.push({
-        key: `folder:${folder.uid}`,
-        type: 'folder',
-        label: nestedLabel ? `Folder: ${nestedLabel}` : getScopeLabel('folder'),
-        scopeInfo: {
-          type: 'folder',
-          value: '',
-          data: { folder, variable: null }
-        }
-      });
-    });
-  }
-
-  options.push({
-    key: 'collection',
-    type: 'collection',
-    label: getScopeLabel('collection'),
-    scopeInfo: {
-      type: 'collection',
-      value: '',
-      data: { collection, variable: null }
-    }
+    check();
   });
-
-  const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
-  if (environment) {
-    options.push({
-      key: `environment:${environment.uid}`,
-      type: 'environment',
-      label: getScopeLabel('environment'),
-      scopeInfo: {
-        type: 'environment',
-        value: '',
-        data: { environment, variable: null }
-      }
-    });
-  }
-
-  const globalEnvironment = getActiveGlobalEnvironment();
-  if (globalEnvironment) {
-    options.push({
-      key: `global:${globalEnvironment.uid}`,
-      type: 'global',
-      label: getScopeLabel('global'),
-      scopeInfo: {
-        type: 'global',
-        value: '',
-        data: { environment: globalEnvironment, variable: null }
-      }
-    });
-  }
-
-  return options;
 };
 
 const scrollDefinitionIntoView = (scopeType, variableName) => {
@@ -520,82 +459,20 @@ export const renderVarInfo = (token, options) => {
   const isNewVariable = scopeInfo && scopeInfo.data && scopeInfo.data.variable === null;
   const canGoToDefinition = !!collection && !isNewVariable && !hasRuntimeVariable && ['request', 'folder', 'collection', 'environment', 'global'].includes(scopeInfo?.type);
 
+  // If the variable is not new and has a valid scope, make the variable name clickable to go to its definition
+  if (canGoToDefinition) {
+    varName.classList.add('var-name-link');
+    varName.addEventListener('click', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      goToVariableDefinition(scopeInfo, collection, item, variableName);
+    });
+  }
+
   header.appendChild(varName);
 
-  if (isNewVariable) {
-    const scopeSelect = document.createElement('select');
-    scopeSelect.className = 'var-scope-select';
-
-    const scopeOptions = getCreatableScopeOptions(collection, item);
-    scopeOptions.forEach(({ key, label }) => {
-      const option = document.createElement('option');
-      option.value = key;
-      option.textContent = label;
-      scopeSelect.appendChild(option);
-    });
-
-    const selectedScope = scopeOptions.find(({ type, scopeInfo: optionScopeInfo }) => {
-      if (type !== scopeInfo.type) {
-        return false;
-      }
-
-      if (type === 'folder') {
-        return optionScopeInfo.data?.folder?.uid === scopeInfo.data?.folder?.uid;
-      }
-
-      if (type === 'request') {
-        return optionScopeInfo.data?.item?.uid === scopeInfo.data?.item?.uid;
-      }
-
-      if (type === 'environment') {
-        return optionScopeInfo.data?.environment?.uid === scopeInfo.data?.environment?.uid;
-      }
-
-      if (type === 'global') {
-        return optionScopeInfo.data?.environment?.uid === scopeInfo.data?.environment?.uid;
-      }
-
-      return true;
-    }) || scopeOptions[0];
-
-    const resizeScopeSelect = (scopeOption) => {
-      const labelLength = scopeOption?.label?.length || getScopeLabel('request').length;
-      const widthInCharacters = Math.min(Math.max(labelLength + 4, 14), 48);
-      scopeSelect.style.width = `${widthInCharacters}ch`;
-      into.style.width = `calc(${widthInCharacters}ch + 8rem)`;
-    };
-
-    if (selectedScope) {
-      scopeSelect.value = selectedScope.key;
-      resizeScopeSelect(selectedScope);
-    }
-
-    scopeSelect.addEventListener('change', (event) => {
-      const nextScope = scopeOptions.find(({ key }) => key === event.target.value);
-      if (nextScope) {
-        scopeInfo = nextScope.scopeInfo;
-        resizeScopeSelect(nextScope);
-      }
-    });
-
-    header.appendChild(scopeSelect);
-  } else {
-    scopeBadge.textContent = scopeLabel;
-    header.appendChild(scopeBadge);
-
-    if (canGoToDefinition) {
-      const definitionButton = document.createElement('button');
-      definitionButton.className = 'var-definition-button';
-      definitionButton.type = 'button';
-      definitionButton.textContent = 'Go to definition';
-      definitionButton.addEventListener('click', (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        goToVariableDefinition(scopeInfo, collection, item, variableName);
-      });
-      header.appendChild(definitionButton);
-    }
-  }
+  scopeBadge.textContent = scopeLabel;
+  header.appendChild(scopeBadge);
 
   into.appendChild(header);
 
@@ -747,13 +624,14 @@ export const renderVarInfo = (token, options) => {
     const iconsContainer = document.createElement('div');
     iconsContainer.className = 'var-icons';
 
-    // Eye toggle button (show if the displayed value is masked)
-    if (shouldMaskValue || isMasked) {
-      const toggleButton = document.createElement('button');
+    let toggleButton = null;
+    if (shouldMaskValue || isMasked || isNewVariable) {
+      toggleButton = document.createElement('button');
       toggleButton.className = 'secret-toggle-button';
       toggleButton.setAttribute('data-testid', 'var-info-secret-toggle');
       toggleButton.innerHTML = EYE_ICON_SVG;
       toggleButton.type = 'button';
+      toggleButton.style.display = (shouldMaskValue || isMasked) ? '' : 'none';
 
       toggleButton.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -840,48 +718,206 @@ export const renderVarInfo = (token, options) => {
       valueDisplay.style.display = 'block';
       isEditing = false;
 
-      if (newValue !== originalValue) {
-        // Dispatch Redux action to update variable
-        const dispatch = store.dispatch;
-        dispatch(updateVariableInScope(variableName, newValue, scopeInfo, collection.uid))
-          .then(() => {
-            originalValue = newValue;
-
-            // Re-fetch scopeInfo to get the updated variable reference after save
-            const state = store.getState();
-            const freshCollection = findCollectionByUid(state.collections.collections, collection.uid);
-            if (collection) {
-              const freshItem = item ? findItemInCollectionByItemUid(freshCollection, item.uid) : null;
-              const updatedScopeInfo = getVariableScope(variableName, freshCollection, freshItem);
-              if (updatedScopeInfo) {
-                scopeInfo = updatedScopeInfo;
-              }
-            }
-
-            // Re-interpolate the new value to show the resolved value in display.
-            // Use `??` so falsy-but-valid values (0 / false / '') survive the assignment.
-            const interpolatedValue = interpolate(newValue, allVariables);
-            currentInterpolatedValue = interpolatedValue ?? '';
-            // Check if the NEW value contains secret references and update live mask state
-            const newHasSecretRefs = containsSecretVariableReferences(newValue, collection, item);
-            currentShouldMaskValue = isSecret || newHasSecretRefs;
-            updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
-          })
-          .catch((err) => {
-            console.error('Failed to update variable:', err);
-            // Revert on error to the last good state — currentInterpolatedValue and
-            // currentShouldMaskValue still hold pre-attempt values since the success
-            // block above never ran.
-            cmEditor.setValue(originalValue);
-            updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
-          });
+      if (newValue === originalValue) {
+        return;
       }
+
+      // Sync the displayed value with the new value (interpolated and masked if needed).
+      const interpolatedValue = interpolate(newValue, allVariables);
+      currentInterpolatedValue = interpolatedValue ?? '';
+      const newHasSecretRefs = containsSecretVariableReferences(newValue, collection, item);
+      currentShouldMaskValue = isSecret || newHasSecretRefs;
+      updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
+
+      // new variables are saved via the Add-to switcher, not on blur. so don't dispatch an update action here.
+      if (isNewVariable) {
+        return;
+      }
+
+      const dispatch = store.dispatch;
+      dispatch(updateVariableInScope(variableName, newValue, scopeInfo, collection.uid))
+        .then(() => {
+          originalValue = newValue;
+
+          // Re-fetch scopeInfo to get the updated variable reference after save
+          const state = store.getState();
+          const freshCollection = findCollectionByUid(state.collections.collections, collection.uid);
+          if (collection) {
+            const freshItem = item ? findItemInCollectionByItemUid(freshCollection, item.uid) : null;
+            const updatedScopeInfo = getVariableScope(variableName, freshCollection, freshItem);
+            if (updatedScopeInfo) {
+              scopeInfo = updatedScopeInfo;
+            }
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to update variable:', err);
+          cmEditor.setValue(originalValue);
+          updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
+        });
     });
 
     // Store references for cleanup
     valueContainer._cmEditor = cmEditor;
     valueContainer._maskedEditor = maskedEditor;
     valueContainer._autoCompleteCleanup = autoCompleteCleanup;
+
+    const applySecretMasking = (secretSelected) => {
+      const hasSecretRefs = containsSecretVariableReferences(cmEditor.getValue(), collection, item);
+      currentShouldMaskValue = secretSelected || hasSecretRefs;
+
+      if (!currentShouldMaskValue) {
+        isRevealed = false;
+      }
+
+      if (toggleButton) {
+        toggleButton.style.display = currentShouldMaskValue ? '' : 'none';
+        toggleButton.innerHTML = isRevealed ? EYE_OFF_ICON_SVG : EYE_ICON_SVG;
+      }
+
+      if (currentShouldMaskValue) {
+        if (!maskedEditor) {
+          maskedEditor = new MaskedEditor(cmEditor);
+          valueContainer._maskedEditor = maskedEditor;
+        }
+        isRevealed ? maskedEditor.disable() : maskedEditor.enable();
+      } else if (maskedEditor) {
+        maskedEditor.disable();
+      }
+
+      updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
+    };
+
+    // for new variables, add a switcher to select the scope to add the variable to (collection, request, environment, global)
+    if (isNewVariable) {
+      const buildScopeInfoForSwitch = (scope) => {
+        switch (scope.type) {
+          case VARIABLE_ADD_SCOPES.COLLECTION:
+            return { type: 'collection', value: '', data: { collection, variable: null } };
+          case VARIABLE_ADD_SCOPES.REQUEST:
+            return { type: 'request', value: '', data: { item, variable: null } };
+          case VARIABLE_ADD_SCOPES.ENVIRONMENT: {
+            const freshState = store.getState();
+            const freshCollection = findCollectionByUid(freshState.collections.collections, collection.uid);
+            const environment = (freshCollection?.environments || []).find(
+              (env) => env.uid === freshCollection?.activeEnvironmentUid
+            );
+            return { type: 'environment', value: '', data: { environment, variable: null, secret: false } };
+          }
+          case VARIABLE_ADD_SCOPES.GLOBAL: {
+            const freshGlobalState = store.getState();
+            const globalEnvironments = freshGlobalState.globalEnvironments?.globalEnvironments || [];
+            const activeGlobalEnvironmentUid = freshGlobalState.globalEnvironments?.activeGlobalEnvironmentUid;
+            const globalEnvironment = globalEnvironments.find((env) => env.uid === activeGlobalEnvironmentUid);
+            return { type: 'global', value: '', data: { environment: globalEnvironment, variable: null, secret: false } };
+          }
+          default:
+            return null;
+        }
+      };
+
+      const addToScopesState = store.getState();
+      const globalEnvironmentsState = (addToScopesState && addToScopesState.globalEnvironments) || {};
+      const addToScopes = getAvailableAddToScopes(
+        collection?.activeEnvironmentUid,
+        globalEnvironmentsState.activeGlobalEnvironmentUid,
+        item
+      );
+
+      // The guessed scope is selected by default (if it's in the addToScopes list).
+      const initialScope = addToScopes.find((s) => s.type === scopeInfo.type) || null;
+
+      const removeAddToSwitcher = () => {
+        if (valueContainer._addToSwitcher) {
+          if (typeof valueContainer._addToSwitcher._destroy === 'function') {
+            valueContainer._addToSwitcher._destroy();
+          }
+          valueContainer._addToSwitcher.remove();
+          valueContainer._addToSwitcher = null;
+        }
+      };
+
+      const persistNewVariable = (secret) => {
+        const value = cmEditor.getValue();
+        const scopeInfoToSave = scopeInfo && scopeInfo.data
+          ? { ...scopeInfo, data: { ...scopeInfo.data, secret } }
+          : scopeInfo;
+
+        return store.dispatch(updateVariableInScope(variableName, value, scopeInfoToSave, collection.uid))
+          .then(() => {
+            originalValue = value;
+
+            const state = store.getState();
+            const freshCollection = findCollectionByUid(state.collections.collections, collection.uid);
+            const freshItem = item ? findItemInCollectionByItemUid(freshCollection, item.uid) : null;
+            const updatedScopeInfo = getVariableScope(variableName, freshCollection, freshItem);
+            if (updatedScopeInfo) {
+              scopeInfo = updatedScopeInfo;
+              scopeBadge.textContent = getScopeLabel(updatedScopeInfo.type);
+            }
+
+            const interpolatedValue = interpolate(value, allVariables);
+            currentInterpolatedValue = interpolatedValue ?? '';
+            const newHasSecretRefs = containsSecretVariableReferences(value, collection, item);
+            currentShouldMaskValue = isSecret || newHasSecretRefs;
+            updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
+
+            removeAddToSwitcher();
+          });
+      };
+
+      const onSwitchScope = (scope, { immediate = false } = {}) => {
+        const newScopeInfo = buildScopeInfoForSwitch(scope);
+        if (!newScopeInfo) {
+          return;
+        }
+        scopeInfo = newScopeInfo;
+        scopeBadge.textContent = getScopeLabel(newScopeInfo.type);
+
+        // If immediate is true, persist the new variable immediately after switching scope.
+        // for create environment flow, the new variable is persisted immediately after the environment is created and selected.
+        if (immediate) {
+          persistNewVariable(false).catch((err) => {
+            toast.error(err?.message || 'Failed to save variable');
+          });
+        }
+      };
+
+      const onCreateEnvironment = (scope, name) => {
+        const dispatch = store.dispatch;
+
+        if (scope.type === VARIABLE_ADD_SCOPES.GLOBAL) {
+          return dispatch(addGlobalEnvironment({ name, variables: [] }));
+        }
+
+        if (scope.type === VARIABLE_ADD_SCOPES.ENVIRONMENT) {
+          return dispatch(addEnvironment(name, collection.uid))
+            .then(() => waitForEnvironmentByName(collection.uid, name))
+            .then((newEnvironment) => dispatch(selectEnvironment(newEnvironment.uid, collection.uid)));
+        }
+
+        return Promise.reject(new Error(`"${scope.label}" does not support creating a new one`));
+      };
+
+      const addToSwitcher = createAddToScopeSwitcher({
+        scopes: addToScopes,
+        initialScope,
+        onSwitchScope,
+        onCreateEnvironment,
+        onSecretChange: applySecretMasking
+      });
+      valueContainer._addToSwitcher = addToSwitcher;
+
+      // Called from `onDocumentClick` in showPopup when the tooltip is dismissed via an
+      // outside click.
+      valueContainer._persistNewVariable = () => {
+        const pendingSecret = valueContainer._addToSwitcher && typeof valueContainer._addToSwitcher._getPendingSecret === 'function'
+          ? valueContainer._addToSwitcher._getPendingSecret()
+          : false;
+
+        return persistNewVariable(pendingSecret);
+      };
+    }
   } else {
     // Read-only display (for runtime, process.env, undefined variables)
     let isRevealed = false;
@@ -952,6 +988,10 @@ export const renderVarInfo = (token, options) => {
   }
 
   into.appendChild(valueContainer);
+
+  if (valueContainer._addToSwitcher) {
+    into.appendChild(valueContainer._addToSwitcher);
+  }
 
   return into;
 };
@@ -1221,6 +1261,14 @@ if (!SERVER_RENDERED) {
 
       if (!popup.contains(e.target)) {
         isPinned = false;
+
+        const valueContainer = popup.querySelector('.var-value-container');
+        if (valueContainer && typeof valueContainer._persistNewVariable === 'function') {
+          valueContainer._persistNewVariable().catch((err) => {
+            toast.error(err?.message || 'Failed to save variable');
+          });
+        }
+
         hidePopup();
       }
     };
@@ -1259,6 +1307,12 @@ if (!SERVER_RENDERED) {
         if (valueContainer._cmEditor) {
           valueContainer._cmEditor.getWrapperElement().remove();
           valueContainer._cmEditor = null;
+        }
+
+        // Cleanup the "Add to" switcher (outside-click listener for its inline create form, etc.)
+        if (valueContainer._addToSwitcher && typeof valueContainer._addToSwitcher._destroy === 'function') {
+          valueContainer._addToSwitcher._destroy();
+          valueContainer._addToSwitcher = null;
         }
       }
 

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -104,12 +104,8 @@ const NEW_ENVIRONMENT_WAIT_TIMEOUT_MS = 3000;
 
 // `addEnvironment` only writes the file through IPC. The store is updated later, once the
 // filesystem watcher picks up the new file and dispatches it in.
-//  subscribe to the store and resolve on the exact dispatch that adds it
-const waitForEnvironmentByName = (
-  collectionUid,
-  name,
-  { timeoutMs = NEW_ENVIRONMENT_WAIT_TIMEOUT_MS } = {}
-) => {
+// subscribe to the store and resolve on the exact dispatch that adds it
+const waitForEnvironmentByName = (collectionUid, name) => {
   const findEnvironment = () => {
     const freshCollection = findCollectionByUid(store.getState().collections.collections, collectionUid);
     return (freshCollection?.environments || []).find((env) => env.name === name);
@@ -125,7 +121,7 @@ const waitForEnvironmentByName = (
     const timeoutId = setTimeout(() => {
       unsubscribe();
       reject(new Error(`Failed to create environment "${name}"`));
-    }, timeoutMs);
+    }, NEW_ENVIRONMENT_WAIT_TIMEOUT_MS);
 
     const unsubscribe = store.subscribe(() => {
       const found = findEnvironment();

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -28,7 +28,7 @@ import store from 'providers/ReduxStore';
 import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
 import { MaskedEditor } from 'utils/common/masked-editor';
 import { setupAutoComplete } from 'utils/codemirror/autocomplete';
-import { variableNameRegex } from 'utils/common/regex';
+import { variableNameRegex, validateName, validateNameError } from 'utils/common/regex';
 import { VARIABLE_ADD_SCOPES } from 'utils/common/constants';
 import { createAddToScopeSwitcher } from 'utils/codemirror/addToScopeSwitcher';
 import { goToVariableDefinition } from 'utils/codemirror/goToVariableDefinition';
@@ -457,6 +457,13 @@ export const renderVarInfo = (token, options) => {
   const valueContainer = document.createElement('div');
   valueContainer.className = 'var-value-container';
 
+  // Reads the Add-to switcher's pending Secret checkbox state, if a switcher is mounted.
+  const getPendingSecret = () => (
+    valueContainer._addToSwitcher && typeof valueContainer._addToSwitcher._getPendingSecret === 'function'
+      ? valueContainer._addToSwitcher._getPendingSecret()
+      : false
+  );
+
   // Create editable value display/editor (if editable)
   if (!isReadOnly && scopeInfo) {
     // Handle secret/masked variables state
@@ -662,7 +669,9 @@ export const renderVarInfo = (token, options) => {
       currentInterpolatedValue = interpolatedValue ?? '';
       const newHasSecretRefs = containsSecretVariableReferences(newValue, collection, item);
 
-      currentShouldMaskValue = currentShouldMaskValue || newHasSecretRefs;
+      // for new variable get the secret state from the switcher
+      const ownSecret = isNewVariable ? getPendingSecret() : isSecret;
+      currentShouldMaskValue = ownSecret || newHasSecretRefs;
       updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
 
       // new variables are saved via the Add-to switcher, not on blur. so don't dispatch an update action here.
@@ -763,8 +772,14 @@ export const renderVarInfo = (token, options) => {
 
       const addToScopesState = store.getState();
       const globalEnvironmentsState = (addToScopesState && addToScopesState.globalEnvironments) || {};
+
+      // Use the latest collection state so "Add to Environment" targets the real
+      // active environment, not the environment currently being viewed in environment settings.
+      const freshCollectionForScopes = collection?.uid
+        ? findCollectionByUid(addToScopesState?.collections?.collections, collection.uid)
+        : null;
       const addToScopes = getAvailableAddToScopes({
-        activeEnvironmentUid: collection?.activeEnvironmentUid,
+        activeEnvironmentUid: freshCollectionForScopes?.activeEnvironmentUid,
         activeGlobalEnvironmentUid: globalEnvironmentsState.activeGlobalEnvironmentUid,
         item,
         parentFolder,
@@ -834,12 +849,7 @@ export const renderVarInfo = (token, options) => {
         // If immediate is true, persist the new variable immediately after switching scope.
         // for inline create environment flow, the new variable is persisted immediately after the environment is created and selected.
         if (immediate) {
-          // Read the user's pending Secret checkbox state.
-          const pendingSecret = valueContainer._addToSwitcher && typeof valueContainer._addToSwitcher._getPendingSecret === 'function'
-            ? valueContainer._addToSwitcher._getPendingSecret()
-            : false;
-
-          persistNewVariable(pendingSecret).catch((err) => {
+          persistNewVariable(getPendingSecret()).catch((err) => {
             toast.error(err?.message || 'Failed to save variable');
           });
         }
@@ -847,14 +857,38 @@ export const renderVarInfo = (token, options) => {
 
       const onCreateEnvironment = (scope, name) => {
         const dispatch = store.dispatch;
+        const trimmedName = (name || '').trim();
+
+        if (!validateName(trimmedName)) {
+          return Promise.reject(new Error(validateNameError(trimmedName)));
+        }
+
+        const freshState = store.getState();
 
         if (scope.type === VARIABLE_ADD_SCOPES.GLOBAL) {
-          return dispatch(addGlobalEnvironment({ name, variables: [] }));
+          const globalEnvironments = freshState.globalEnvironments?.globalEnvironments || [];
+          const isDuplicate = globalEnvironments.some(
+            (env) => env?.name?.toLowerCase().trim() === trimmedName.toLowerCase()
+          );
+          if (isDuplicate) {
+            return Promise.reject(new Error('Environment already exists'));
+          }
+
+          return dispatch(addGlobalEnvironment({ name: trimmedName, variables: [] }));
         }
 
         if (scope.type === VARIABLE_ADD_SCOPES.ENVIRONMENT) {
-          return dispatch(addEnvironment(name, collection.uid))
-            .then(() => waitForEnvironmentByName(collection.uid, name))
+          const freshCollection = findCollectionByUid(freshState.collections.collections, collection.uid);
+
+          const isDuplicate = (freshCollection?.environments || []).some(
+            (env) => env?.name?.toLowerCase().trim() === trimmedName.toLowerCase()
+          );
+          if (isDuplicate) {
+            return Promise.reject(new Error('Environment already exists'));
+          }
+
+          return dispatch(addEnvironment(trimmedName, collection.uid))
+            .then(() => waitForEnvironmentByName(collection.uid, trimmedName))
             .then((newEnvironment) => dispatch(selectEnvironment(newEnvironment.uid, collection.uid)));
         }
 
@@ -877,11 +911,7 @@ export const renderVarInfo = (token, options) => {
           return Promise.resolve();
         }
 
-        const pendingSecret = valueContainer._addToSwitcher && typeof valueContainer._addToSwitcher._getPendingSecret === 'function'
-          ? valueContainer._addToSwitcher._getPendingSecret()
-          : false;
-
-        return persistNewVariable(pendingSecret);
+        return persistNewVariable(getPendingSecret());
       };
     }
   } else {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -798,6 +798,7 @@ export const renderVarInfo = (token, options) => {
       };
 
       const onSwitchScope = (scope, { immediate = false } = {}) => {
+        // on scope switch, rebuild the scopeInfo based on the new scope and update the scope badge.
         const newScopeInfo = buildScopeInfoForSwitch(scope);
         if (!newScopeInfo) {
           return;
@@ -806,7 +807,7 @@ export const renderVarInfo = (token, options) => {
         scopeBadge.textContent = getScopeLabel(newScopeInfo.type);
 
         // If immediate is true, persist the new variable immediately after switching scope.
-        // for create environment flow, the new variable is persisted immediately after the environment is created and selected.
+        // for inline create environment flow, the new variable is persisted immediately after the environment is created and selected.
         if (immediate) {
           persistNewVariable(false).catch((err) => {
             toast.error(err?.message || 'Failed to save variable');

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -376,8 +376,8 @@ export const renderVarInfo = (token, options) => {
   // Check if a runtime variable exists - if so, show Runtime scope (even if detected as collection/folder/environment)
   const displayScopeType = hasRuntimeVariable ? 'runtime' : (scopeInfo ? scopeInfo.type : 'Unknown');
   const scopeLabel = getScopeLabel(displayScopeType);
-  const isNewVariable = scopeInfo && scopeInfo.data && scopeInfo.data.variable === null;
-  const canGoToDefinition = !!collection && !isNewVariable && !hasRuntimeVariable && ['request', 'folder', 'collection', 'environment', 'global'].includes(scopeInfo?.type);
+  const isNewVariable = scopeInfo.data && scopeInfo.data.variable === null;
+  const canGoToDefinition = !!collection && !isNewVariable && !hasRuntimeVariable && ['request', 'folder', 'collection', 'environment', 'global'].includes(scopeInfo.type);
 
   // If the variable is not new and has a valid scope, make the variable name clickable to go to its definition
   if (canGoToDefinition) {
@@ -461,7 +461,7 @@ export const renderVarInfo = (token, options) => {
   );
 
   // Create editable value display/editor (if editable)
-  if (!isReadOnly && scopeInfo) {
+  if (!isReadOnly) {
     // Handle secret/masked variables state
     let isRevealed = false;
 
@@ -693,6 +693,7 @@ export const renderVarInfo = (token, options) => {
         })
         .catch((err) => {
           console.error('Failed to update variable:', err);
+          toast.error(err?.message || 'Failed to update variable');
           cmEditor.setValue(originalValue);
           updateValueDisplay(valueDisplay, currentInterpolatedValue, currentShouldMaskValue, isMasked, isRevealed);
         });
@@ -771,16 +772,24 @@ export const renderVarInfo = (token, options) => {
       };
 
       const addToScopesState = store.getState();
-      const globalEnvironmentsState = (addToScopesState && addToScopesState.globalEnvironments) || {};
+      const globalEnvironmentsState = addToScopesState.globalEnvironments || {};
 
       // Use the latest collection state so "Add to Environment" targets the real
       // active environment, not the environment currently being viewed in environment settings.
       const freshCollectionForScopes = collection?.uid
-        ? findCollectionByUid(addToScopesState?.collections?.collections, collection.uid)
+        ? findCollectionByUid(addToScopesState.collections?.collections, collection.uid)
         : null;
+      const activeEnvironmentName = (freshCollectionForScopes?.environments || []).find(
+        (env) => env.uid === freshCollectionForScopes?.activeEnvironmentUid
+      )?.name;
+      const activeGlobalEnvironmentName = (globalEnvironmentsState.globalEnvironments || []).find(
+        (env) => env.uid === globalEnvironmentsState.activeGlobalEnvironmentUid
+      )?.name;
       const addToScopes = getAvailableAddToScopes({
         activeEnvironmentUid: freshCollectionForScopes?.activeEnvironmentUid,
+        activeEnvironmentName,
         activeGlobalEnvironmentUid: globalEnvironmentsState.activeGlobalEnvironmentUid,
+        activeGlobalEnvironmentName,
         item,
         parentFolder: folderScopeTarget,
         isSelfFolder: isInFolderSettings,
@@ -839,7 +848,6 @@ export const renderVarInfo = (token, options) => {
       };
 
       const onSwitchScope = (scope, { immediate = false } = {}) => {
-        // on scope switch, rebuild the scopeInfo based on the new scope and update the scope badge.
         const newScopeInfo = buildScopeInfoForSwitch(scope);
         if (!newScopeInfo) {
           return;
@@ -847,7 +855,6 @@ export const renderVarInfo = (token, options) => {
         scopeInfo = newScopeInfo;
         scopeBadge.textContent = getScopeLabel(newScopeInfo.type);
 
-        // If immediate is true, persist the new variable immediately after switching scope.
         // for inline create environment flow, the new variable is persisted immediately after the environment is created and selected.
         if (immediate) {
           persistNewVariable(getPendingSecret()).catch((err) => {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -99,36 +99,41 @@ const getScopeLabel = (scopeType) => {
   return labels[scopeType] || scopeType;
 };
 
-const NEW_ENVIRONMENT_POLL_INTERVAL_MS = 50;
-const NEW_ENVIRONMENT_POLL_TIMEOUT_MS = 3000;
+const NEW_ENVIRONMENT_WAIT_TIMEOUT_MS = 3000;
 
-// `addEnvironment` only writes the file through IPC. The store is updated later, after the filesystem watcher picks up the change.
-// So, poll for the environment here instead of assuming it’s available immediately.
+// `addEnvironment` only writes the file through IPC. The store is updated later, once the
+// filesystem watcher picks up the new file and dispatches it in.
+//  subscribe to the store and resolve on the exact dispatch that adds it
 const waitForEnvironmentByName = (
   collectionUid,
   name,
-  { intervalMs = NEW_ENVIRONMENT_POLL_INTERVAL_MS, timeoutMs = NEW_ENVIRONMENT_POLL_TIMEOUT_MS } = {}
+  { timeoutMs = NEW_ENVIRONMENT_WAIT_TIMEOUT_MS } = {}
 ) => {
-  const deadline = Date.now() + timeoutMs;
+  const findEnvironment = () => {
+    const freshCollection = findCollectionByUid(store.getState().collections.collections, collectionUid);
+    return (freshCollection?.environments || []).find((env) => env.name === name);
+  };
 
   return new Promise((resolve, reject) => {
-    const check = () => {
-      const state = store.getState();
-      const freshCollection = findCollectionByUid(state.collections.collections, collectionUid);
-      const found = (freshCollection?.environments || []).find((env) => env.name === name);
+  // check if the environment already exists in the store (in case it was created before this function was called)
+    const existing = findEnvironment();
+    if (existing) {
+      return resolve(existing);
+    }
 
+    const timeoutId = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`Failed to create environment "${name}"`));
+    }, timeoutMs);
+
+    const unsubscribe = store.subscribe(() => {
+      const found = findEnvironment();
       if (found) {
-        return resolve(found);
+        clearTimeout(timeoutId);
+        unsubscribe();
+        resolve(found);
       }
-
-      if (Date.now() >= deadline) {
-        return reject(new Error(`Timed out waiting for environment "${name}" to be created`));
-      }
-
-      setTimeout(check, intervalMs);
-    };
-
-    check();
+    });
   });
 };
 

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -1,6 +1,15 @@
 import { interpolate } from '@usebruno/common';
+import RealCodeMirror from 'codemirror';
 import store from 'providers/ReduxStore';
-import { getVariableScope, findEnvironmentInCollection, getTreePathFromCollectionToItem } from 'utils/collections';
+import {
+  getVariableScope,
+  findEnvironmentInCollection,
+  getTreePathFromCollectionToItem,
+  findCollectionByUid,
+  findItemInCollectionByItemUid,
+  getAvailableAddToScopes
+} from 'utils/collections';
+import { updateVariableInScope, addEnvironment, selectEnvironment } from 'providers/ReduxStore/slices/collections/actions';
 import { COPY_SUCCESS_TIMEOUT, extractVariableInfo, renderVarInfo } from './brunoVarInfo';
 
 // Mock the dependencies
@@ -27,7 +36,13 @@ jest.mock('providers/ReduxStore', () => ({
 
 jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
   updateVariableInScope: jest.fn(),
-  openCollectionSettings: jest.fn()
+  openCollectionSettings: jest.fn(),
+  addEnvironment: jest.fn(),
+  selectEnvironment: jest.fn()
+}));
+
+jest.mock('providers/ReduxStore/slices/global-environments', () => ({
+  addGlobalEnvironment: jest.fn()
 }));
 
 jest.mock('utils/collections', () => ({
@@ -35,7 +50,11 @@ jest.mock('utils/collections', () => ({
   isVariableSecret: jest.fn(),
   getAllVariables: jest.fn(),
   findEnvironmentInCollection: jest.fn(),
-  getTreePathFromCollectionToItem: jest.fn()
+  getTreePathFromCollectionToItem: jest.fn(),
+  findCollectionByUid: jest.fn(),
+  findItemInCollectionByItemUid: jest.fn(),
+  getAvailableAddToScopes: jest.fn(() => []),
+  isItemARequest: jest.fn((item) => !!item && item.type !== 'folder')
 }));
 
 jest.mock('utils/common/codemirror', () => ({
@@ -340,6 +359,9 @@ describe('renderVarInfo', () => {
 
     findEnvironmentInCollection.mockReturnValue(null);
     getTreePathFromCollectionToItem.mockReturnValue([]);
+    getAvailableAddToScopes.mockReturnValue([]);
+    findCollectionByUid.mockImplementation((collections, uid) => (collections || []).find((c) => c.uid === uid) || null);
+    findItemInCollectionByItemUid.mockReturnValue(null);
     getVariableScope.mockReturnValue({
       type: 'request',
       value: 'test-value',
@@ -540,21 +562,15 @@ describe('renderVarInfo', () => {
     });
   });
 
-  describe('new variable scope selection', () => {
-    it('should show scope selector for undefined variables with available scopes', () => {
+  describe('new variable — Add to switcher', () => {
+    it('shows the Add-to switcher with the guessed scope pre-selected, excluding Folder', () => {
       getVariableScope.mockReturnValue(null);
-      getTreePathFromCollectionToItem.mockReturnValue([
-        { uid: 'folder-1', type: 'folder', name: 'parent' },
-        { uid: 'folder-2', type: 'folder', name: 'child' },
-        { uid: 'req-1', type: 'http-request' }
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'request', label: 'Request Variable', enabled: true, supportsSecret: false },
+        { type: 'collection', label: 'Collection Variables', enabled: true, supportsSecret: false },
+        { type: 'environment', label: 'Collection Environment', enabled: true, supportsSecret: true },
+        { type: 'global', label: 'Global Environment', enabled: true, supportsSecret: true }
       ]);
-      findEnvironmentInCollection.mockReturnValue({ uid: 'env-1', name: 'Dev', variables: [] });
-      store.getState.mockReturnValue({
-        globalEnvironments: {
-          globalEnvironments: [{ uid: 'global-1', name: 'Global', variables: [] }],
-          activeGlobalEnvironmentUid: 'global-1'
-        }
-      });
 
       const result = renderVarInfo(
         { string: '{{missingVar}}' },
@@ -565,59 +581,173 @@ describe('renderVarInfo', () => {
         }
       );
 
-      const scopeSelect = result.querySelector('.var-scope-select');
-      expect(scopeSelect).not.toBeNull();
-      expect(Array.from(scopeSelect.options).map((option) => option.textContent)).toEqual([
-        'Request',
-        'Folder: parent',
-        'Folder: parent / child',
-        'Collection',
-        'Environment',
-        'Global'
-      ]);
-      expect(scopeSelect.value).toBe('request:req-1');
-      expect(scopeSelect.style.width).toBe('14ch');
-      expect(result.style.width).toBe('calc(14ch + 8rem)');
+      // Guessed scope shows up as the header badge, same as any other variable.
+      const scopeBadge = result.querySelector('.var-scope-badge');
+      expect(scopeBadge.textContent).toBe('Request');
 
-      scopeSelect.value = 'folder:folder-2';
-      scopeSelect.dispatchEvent(new Event('change'));
+      const switcher = result.querySelector('.var-add-to-switcher');
+      expect(switcher).not.toBeNull();
 
-      expect(scopeSelect.style.width).toBe('26ch');
-      expect(result.style.width).toBe('calc(26ch + 8rem)');
+      switcher.querySelector('.var-add-to-toggle').click();
+
+      expect(switcher.querySelector('[data-testid="var-info-add-to-option-request"]')).not.toBeNull();
+      expect(switcher.querySelector('[data-testid="var-info-add-to-option-collection"]')).not.toBeNull();
+      expect(switcher.querySelector('[data-testid="var-info-add-to-option-environment"]')).not.toBeNull();
+      expect(switcher.querySelector('[data-testid="var-info-add-to-option-global"]')).not.toBeNull();
+      // Folder is not offered as a creatable scope yet.
+      expect(switcher.querySelector('[data-testid="var-info-add-to-option-folder"]')).toBeNull();
+
+      const activeRow = switcher.querySelector('.var-add-to-option-active');
+      expect(activeRow.querySelector('[data-testid="var-info-add-to-option-request"]')).not.toBeNull();
     });
 
-    it('should show every ancestor folder when creating from nested folder settings', () => {
-      const parentFolder = { uid: 'folder-1', type: 'folder', name: 'parent' };
-      const childFolder = { uid: 'folder-2', type: 'folder', name: 'child' };
+    it('repoints the scope badge when a different scope is picked, without saving immediately', () => {
       getVariableScope.mockReturnValue(null);
-      getTreePathFromCollectionToItem.mockReturnValue([parentFolder, childFolder]);
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'request', label: 'Request Variable', enabled: true, supportsSecret: false },
+        { type: 'collection', label: 'Collection Variables', enabled: true, supportsSecret: false }
+      ]);
 
       const result = renderVarInfo(
         { string: '{{missingVar}}' },
         {
           variables: {},
           collection: { uid: 'col-1' },
-          item: childFolder
+          item: { uid: 'req-1', type: 'http-request' }
         }
       );
 
-      const scopeSelect = result.querySelector('.var-scope-select');
-      expect(Array.from(scopeSelect.options).map((option) => option.textContent)).toEqual([
-        'Folder: parent',
-        'Folder: parent / child',
-        'Collection'
+      const scopeBadge = result.querySelector('.var-scope-badge');
+      expect(scopeBadge.textContent).toBe('Request');
+
+      const switcher = result.querySelector('.var-add-to-switcher');
+      switcher.querySelector('.var-add-to-toggle').click();
+      switcher.querySelector('[data-testid="var-info-add-to-option-collection"]').click();
+
+      expect(scopeBadge.textContent).toBe('Collection');
+      // Picking an existing scope only repoints where the next blur-save writes to.
+      expect(updateVariableInScope).not.toHaveBeenCalled();
+    });
+
+    it('shows "Create One" when no environment exists, and saves the variable immediately once it is created', async () => {
+      getVariableScope.mockReturnValue(null);
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'collection', label: 'Collection Variables', enabled: true, supportsSecret: false },
+        { type: 'environment', label: 'Collection Environment', enabled: false, supportsSecret: true }
       ]);
-      expect(scopeSelect.value).toBe('folder:folder-2');
+
+      const collectionAfterCreate = {
+        uid: 'col-1',
+        activeEnvironmentUid: 'env-new',
+        environments: [{ uid: 'env-new', name: 'Dev', variables: [] }]
+      };
+
+      store.getState.mockReturnValue({
+        globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
+        collections: { collections: [collectionAfterCreate] }
+      });
+      findCollectionByUid.mockReturnValue(collectionAfterCreate);
+      addEnvironment.mockReturnValue(() => Promise.resolve());
+      selectEnvironment.mockReturnValue(() => Promise.resolve());
+      getVariableScope.mockReturnValue(null);
+      store.dispatch.mockImplementation(() => Promise.resolve());
+
+      const result = renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1' },
+          item: null
+        }
+      );
+
+      const switcher = result.querySelector('.var-add-to-switcher');
+      switcher.querySelector('.var-add-to-toggle').click();
+
+      const createLink = switcher.querySelector('[data-testid="var-info-add-to-create-env-button"]');
+      expect(createLink).not.toBeNull();
+      createLink.click();
+
+      const nameInput = switcher.querySelector('[data-testid="var-info-add-to-create-env-name-input"]');
+      nameInput.value = 'Dev';
+      switcher.querySelector('[data-testid="var-info-add-to-create-env-submit"]').click();
+
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(addEnvironment).toHaveBeenCalledWith('Dev', 'col-1');
+      expect(updateVariableInScope).toHaveBeenCalled();
+    });
+
+    it('does not save on blur for a brand new variable, even if the value changed', () => {
+      getVariableScope.mockReturnValue(null);
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'request', label: 'Request Variable', enabled: true, supportsSecret: false }
+      ]);
+
+      const result = renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1' },
+          item: { uid: 'req-1', type: 'http-request' }
+        }
+      );
+
+      // brunoVarInfo.js uses the real `codemirror` package (not the `global.CodeMirror` mock
+      // defined above, which nothing in the source references) — grab the real editor instance
+      // it stashed on the value container and fire its registered blur handler directly via
+      // CodeMirror's own signal API instead of simulating real DOM focus/blur.
+      const cmEditor = result.querySelector('.var-value-container')._cmEditor;
+      cmEditor.getValue = () => 'a-new-value';
+      RealCodeMirror.signal(cmEditor, 'blur');
+
+      expect(updateVariableInScope).not.toHaveBeenCalled();
+    });
+
+    it('saves the pending value via _persistNewVariable when the tooltip is dismissed with an outside click', async () => {
+      getVariableScope.mockReturnValue(null);
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'request', label: 'Request Variable', enabled: true, supportsSecret: false }
+      ]);
+      store.dispatch.mockImplementation(() => Promise.resolve());
+      store.getState.mockReturnValue({
+        globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
+        collections: { collections: [{ uid: 'col-1' }] }
+      });
+      findCollectionByUid.mockReturnValue({ uid: 'col-1' });
+
+      const result = renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1' },
+          item: { uid: 'req-1', type: 'http-request' }
+        }
+      );
+
+      const valueContainer = result.querySelector('.var-value-container');
+      expect(typeof valueContainer._persistNewVariable).toBe('function');
+
+      await valueContainer._persistNewVariable();
+
+      expect(updateVariableInScope).toHaveBeenCalledWith(
+        'missingVar',
+        expect.any(String),
+        expect.objectContaining({ type: 'request' }),
+        'col-1'
+      );
     });
   });
 
   describe('go to definition', () => {
-    it('should show go to definition button for persisted variables', () => {
+    it('should render the variable name as the go-to-definition link for persisted variables', () => {
       const { containerDiv } = setupRender({ apiKey: 'test-value' }, { uid: 'col-1' }, { uid: 'req-1' });
-      const definitionButton = containerDiv.querySelector('.var-definition-button');
+      const varName = containerDiv.querySelector('.var-name');
 
-      expect(definitionButton).not.toBeNull();
-      expect(definitionButton.textContent).toBe('Go to definition');
+      expect(varName.classList.contains('var-name-link')).toBe(true);
+      expect(containerDiv.querySelector('.var-definition-button')).toBeNull();
     });
 
     it('should open the target request before navigating to its variable definition', () => {
@@ -630,9 +760,9 @@ describe('renderVarInfo', () => {
       });
 
       const { containerDiv } = setupRender({ apiKey: 'test-value' }, { uid: 'col-1' }, renderedItem);
-      const definitionButton = containerDiv.querySelector('.var-definition-button');
+      const varName = containerDiv.querySelector('.var-name-link');
 
-      definitionButton.click();
+      varName.click();
 
       expect(store.dispatch).toHaveBeenCalledWith(expect.objectContaining({
         payload: {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -628,6 +628,36 @@ describe('renderVarInfo', () => {
       );
     });
 
+    it('targets the folder itself (not its parent) when opened from that folder\'s own settings, and pre-selects it', () => {
+      getVariableScope.mockReturnValue(null);
+      const folderItem = { uid: 'folder-1', type: 'folder', name: 'Auth' };
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'collection', label: 'Collection Variables', enabled: true, supportsSecret: false },
+        { type: 'environment', label: 'Collection Environment', enabled: true, supportsSecret: true },
+        { type: 'folder', label: 'Folder', enabled: true, supportsSecret: false }
+      ]);
+
+      const result = renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1', activeEnvironmentUid: 'env-1' },
+          item: folderItem
+        }
+      );
+
+      // The folder scope targets the folder being edited itself (labeled "Folder"), not a parent.
+      expect(getAvailableAddToScopes).toHaveBeenCalledWith(
+        expect.objectContaining({ parentFolder: folderItem, isSelfFolder: true })
+      );
+
+      const switcher = result.querySelector('.var-add-to-switcher');
+      switcher.querySelector('.var-add-to-toggle').click();
+
+      const activeRow = switcher.querySelector('.var-add-to-option-active');
+      expect(activeRow.querySelector('[data-testid="var-info-add-to-option-folder"]')).not.toBeNull();
+    });
+
     it('repoints the scope badge when a different scope is picked, without saving immediately', () => {
       getVariableScope.mockReturnValue(null);
       getAvailableAddToScopes.mockReturnValue([

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -1016,7 +1016,6 @@ describe('renderVarInfo', () => {
       const varName = containerDiv.querySelector('.var-name');
 
       expect(varName.classList.contains('var-name-link')).toBe(true);
-      expect(containerDiv.querySelector('.var-definition-button')).toBeNull();
     });
 
     it('should open the target request before navigating to its variable definition', () => {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -3,6 +3,7 @@ import RealCodeMirror from 'codemirror';
 import store from 'providers/ReduxStore';
 import {
   getVariableScope,
+  isVariableSecret,
   findEnvironmentInCollection,
   getTreePathFromCollectionToItem,
   findCollectionByUid,
@@ -602,6 +603,31 @@ describe('renderVarInfo', () => {
       expect(activeRow.querySelector('[data-testid="var-info-add-to-option-request"]')).not.toBeNull();
     });
 
+    it('resolves the Environment scope against the real active environment, not whichever environment is merely being displayed', () => {
+      getVariableScope.mockReturnValue(null);
+      getAvailableAddToScopes.mockReturnValue([]);
+      store.getState.mockReturnValue({
+        globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
+        collections: {
+          collections: [{ uid: 'col-1', activeEnvironmentUid: 'env-prod' }]
+        }
+      });
+      findCollectionByUid.mockReturnValue({ uid: 'col-1', activeEnvironmentUid: 'env-prod' });
+
+      renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1', activeEnvironmentUid: 'env-stage' },
+          item: null
+        }
+      );
+
+      expect(getAvailableAddToScopes).toHaveBeenCalledWith(
+        expect.objectContaining({ activeEnvironmentUid: 'env-prod' })
+      );
+    });
+
     it('repoints the scope badge when a different scope is picked, without saving immediately', () => {
       getVariableScope.mockReturnValue(null);
       getAvailableAddToScopes.mockReturnValue([
@@ -637,6 +663,7 @@ describe('renderVarInfo', () => {
         { type: 'environment', label: 'Collection Environment', enabled: false, supportsSecret: true }
       ]);
 
+      const collectionBeforeCreate = { uid: 'col-1', activeEnvironmentUid: null, environments: [] };
       const collectionAfterCreate = {
         uid: 'col-1',
         activeEnvironmentUid: 'env-new',
@@ -647,7 +674,13 @@ describe('renderVarInfo', () => {
         globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
         collections: { collections: [collectionAfterCreate] }
       });
-      findCollectionByUid.mockReturnValue(collectionAfterCreate);
+      // No "Dev" exists yet for the initial render's lookup and the duplicate-name check inside
+      // onCreateEnvironment; once addEnvironment resolves, later lookups (waitForEnvironmentByName)
+      // see it created.
+      findCollectionByUid
+        .mockReturnValueOnce(collectionBeforeCreate)
+        .mockReturnValueOnce(collectionBeforeCreate)
+        .mockReturnValue(collectionAfterCreate);
       addEnvironment.mockReturnValue(() => Promise.resolve());
       selectEnvironment.mockReturnValue(() => Promise.resolve());
       getVariableScope.mockReturnValue(null);
@@ -688,6 +721,7 @@ describe('renderVarInfo', () => {
         { type: 'environment', label: 'Collection Environment', enabled: false, supportsSecret: true }
       ]);
 
+      const collectionBeforeCreate = { uid: 'col-1', activeEnvironmentUid: null, environments: [] };
       const collectionAfterCreate = {
         uid: 'col-1',
         activeEnvironmentUid: 'env-new',
@@ -698,7 +732,10 @@ describe('renderVarInfo', () => {
         globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
         collections: { collections: [collectionAfterCreate] }
       });
-      findCollectionByUid.mockReturnValue(collectionAfterCreate);
+      findCollectionByUid
+        .mockReturnValueOnce(collectionBeforeCreate)
+        .mockReturnValueOnce(collectionBeforeCreate)
+        .mockReturnValue(collectionAfterCreate);
       addEnvironment.mockReturnValue(() => Promise.resolve());
       selectEnvironment.mockReturnValue(() => Promise.resolve());
       getVariableScope.mockReturnValue(null);
@@ -740,6 +777,94 @@ describe('renderVarInfo', () => {
       );
     });
 
+    it('rejects an environment name that would be rewritten by the main process, instead of risking a false "failed to create" report', async () => {
+      // Regression: `sanitizeName` (main process) strips characters like ':' before writing the
+      // file. Without this check, the create would actually succeed under a different, sanitized
+      // name, but `waitForEnvironmentByName` (which polls by the originally-typed name) would
+      // never find a match and time out, falsely reporting a failure.
+      getVariableScope.mockReturnValue(null);
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'collection', label: 'Collection Variables', enabled: true, supportsSecret: false },
+        { type: 'environment', label: 'Collection Environment', enabled: false, supportsSecret: true }
+      ]);
+
+      findCollectionByUid.mockReturnValue({ uid: 'col-1', activeEnvironmentUid: null, environments: [] });
+      store.getState.mockReturnValue({
+        globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
+        collections: { collections: [{ uid: 'col-1', activeEnvironmentUid: null, environments: [] }] }
+      });
+
+      const result = renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1' },
+          item: null
+        }
+      );
+
+      const switcher = result.querySelector('.var-add-to-switcher');
+      switcher.querySelector('.var-add-to-toggle').click();
+      switcher.querySelector('[data-testid="var-info-add-to-create-env-button"]').click();
+
+      const nameInput = switcher.querySelector('[data-testid="var-info-add-to-create-env-name-input"]');
+      nameInput.value = 'Prod:Env';
+      switcher.querySelector('[data-testid="var-info-add-to-create-env-submit"]').click();
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(addEnvironment).not.toHaveBeenCalled();
+      const errorNote = switcher.querySelector('[data-testid="var-info-add-to-error"]');
+      expect(errorNote.textContent).not.toBe('');
+    });
+
+    it('rejects a name that only differs in case from an existing environment, instead of risking a same-file overwrite', async () => {
+      // Regression: `generateUniqueName` (main process) compares names case-sensitively, so
+      // "Dev" would be considered unique even with "dev" already on disk. On a case-insensitive
+      // filesystem that write silently overwrites the existing "dev" environment's file.
+      getVariableScope.mockReturnValue(null);
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'collection', label: 'Collection Variables', enabled: true, supportsSecret: false },
+        { type: 'environment', label: 'Collection Environment', enabled: false, supportsSecret: true }
+      ]);
+
+      const collectionWithDev = {
+        uid: 'col-1',
+        activeEnvironmentUid: 'env-existing',
+        environments: [{ uid: 'env-existing', name: 'dev', variables: [] }]
+      };
+      findCollectionByUid.mockReturnValue(collectionWithDev);
+      store.getState.mockReturnValue({
+        globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
+        collections: { collections: [collectionWithDev] }
+      });
+
+      const result = renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1' },
+          item: null
+        }
+      );
+
+      const switcher = result.querySelector('.var-add-to-switcher');
+      switcher.querySelector('.var-add-to-toggle').click();
+      switcher.querySelector('[data-testid="var-info-add-to-create-env-button"]').click();
+
+      const nameInput = switcher.querySelector('[data-testid="var-info-add-to-create-env-name-input"]');
+      nameInput.value = 'Dev';
+      switcher.querySelector('[data-testid="var-info-add-to-create-env-submit"]').click();
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(addEnvironment).not.toHaveBeenCalled();
+      const errorNote = switcher.querySelector('[data-testid="var-info-add-to-error"]');
+      expect(errorNote.textContent).toBe('Environment already exists');
+    });
+
     it('does not save on blur for a brand new variable, even if the value changed', () => {
       getVariableScope.mockReturnValue(null);
       getAvailableAddToScopes.mockReturnValue([
@@ -764,6 +889,56 @@ describe('renderVarInfo', () => {
       RealCodeMirror.signal(cmEditor, 'blur');
 
       expect(updateVariableInScope).not.toHaveBeenCalled();
+    });
+
+    it('recomputes masking fresh on each blur, so removing a secret reference actually un-masks the value', () => {
+      // Regression: masking used to be computed as `currentShouldMaskValue || newHasSecretRefs`,
+      // which is sticky — once a value referenced a secret, masking could never turn back off
+      // within the same tooltip session, even after the reference was removed.
+      getVariableScope.mockImplementation((name) => {
+        if (name === 'secretVar') {
+          return { type: 'environment', data: { variable: { secret: true } } };
+        }
+        return null;
+      });
+      isVariableSecret.mockImplementation((scopeInfo) => !!scopeInfo?.data?.variable?.secret);
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'environment', label: 'Collection Environment', enabled: true, supportsSecret: true }
+      ]);
+      interpolate.mockImplementation((value) => value);
+
+      const activeCollection = {
+        uid: 'col-1',
+        activeEnvironmentUid: 'env-1',
+        environments: [{ uid: 'env-1', name: 'Dev', variables: [] }]
+      };
+      findCollectionByUid.mockReturnValue(activeCollection);
+      store.getState.mockReturnValue({
+        globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
+        collections: { collections: [activeCollection] }
+      });
+
+      const result = renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1' },
+          item: null
+        }
+      );
+
+      const cmEditor = result.querySelector('.var-value-container')._cmEditor;
+      const valueDisplay = result.querySelector('[data-testid="var-info-value-editable"]');
+
+      // Reference a secret variable — masking should turn on.
+      cmEditor.getValue = () => '{{secretVar}}';
+      RealCodeMirror.signal(cmEditor, 'blur');
+      expect(valueDisplay.textContent).toBe('*'.repeat('{{secretVar}}'.length));
+
+      // Remove the secret reference — masking should turn back off, not stay stuck on.
+      cmEditor.getValue = () => 'plainvalue';
+      RealCodeMirror.signal(cmEditor, 'blur');
+      expect(valueDisplay.textContent).toBe('plainvalue');
     });
 
     it('saves the pending value via _persistNewVariable when the tooltip is dismissed with an outside click', async () => {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -53,6 +53,7 @@ jest.mock('utils/collections', () => ({
   getTreePathFromCollectionToItem: jest.fn(),
   findCollectionByUid: jest.fn(),
   findItemInCollectionByItemUid: jest.fn(),
+  findParentItemInCollection: jest.fn(),
   getAvailableAddToScopes: jest.fn(() => []),
   isItemARequest: jest.fn((item) => !!item && item.type !== 'folder')
 }));
@@ -680,6 +681,65 @@ describe('renderVarInfo', () => {
       expect(updateVariableInScope).toHaveBeenCalled();
     });
 
+    it('adds variable as a secret if secret is selected when creating the environment, instead of always saving as a plain variable', async () => {
+      getVariableScope.mockReturnValue(null);
+      getAvailableAddToScopes.mockReturnValue([
+        { type: 'collection', label: 'Collection Variables', enabled: true, supportsSecret: false },
+        { type: 'environment', label: 'Collection Environment', enabled: false, supportsSecret: true }
+      ]);
+
+      const collectionAfterCreate = {
+        uid: 'col-1',
+        activeEnvironmentUid: 'env-new',
+        environments: [{ uid: 'env-new', name: 'Dev', variables: [] }]
+      };
+
+      store.getState.mockReturnValue({
+        globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
+        collections: { collections: [collectionAfterCreate] }
+      });
+      findCollectionByUid.mockReturnValue(collectionAfterCreate);
+      addEnvironment.mockReturnValue(() => Promise.resolve());
+      selectEnvironment.mockReturnValue(() => Promise.resolve());
+      getVariableScope.mockReturnValue(null);
+      store.dispatch.mockImplementation(() => Promise.resolve());
+
+      const result = renderVarInfo(
+        { string: '{{missingVar}}' },
+        {
+          variables: {},
+          collection: { uid: 'col-1' },
+          item: null
+        }
+      );
+
+      const switcher = result.querySelector('.var-add-to-switcher');
+      switcher.querySelector('.var-add-to-toggle').click();
+
+      const createLink = switcher.querySelector('[data-testid="var-info-add-to-create-env-button"]');
+      createLink.click();
+
+      // Tick Secret before creating the environment.
+      const secretCheckbox = switcher.querySelector('[data-testid="var-info-add-to-secret-checkbox"]');
+      secretCheckbox.checked = true;
+      secretCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+      const nameInput = switcher.querySelector('[data-testid="var-info-add-to-create-env-name-input"]');
+      nameInput.value = 'Dev';
+      switcher.querySelector('[data-testid="var-info-add-to-create-env-submit"]').click();
+
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(updateVariableInScope).toHaveBeenCalledWith(
+        'missingVar',
+        expect.any(String),
+        expect.objectContaining({ data: expect.objectContaining({ secret: true }) }),
+        'col-1'
+      );
+    });
+
     it('does not save on blur for a brand new variable, even if the value changed', () => {
       getVariableScope.mockReturnValue(null);
       getAvailableAddToScopes.mockReturnValue([
@@ -729,6 +789,10 @@ describe('renderVarInfo', () => {
 
       const valueContainer = result.querySelector('.var-value-container');
       expect(typeof valueContainer._persistNewVariable).toBe('function');
+
+      // _persistNewVariable is a no-op unless the value actually changed from what the
+      // editor was initialized with (see brunoVarInfo.js), so simulate an edit first.
+      valueContainer._cmEditor.getValue = () => 'a-new-value';
 
       await valueContainer._persistNewVariable();
 

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
@@ -122,9 +122,24 @@ export const goToVariableDefinition = (scopeInfo, collection, item, variableName
     }
 
     case 'global': {
-      const globalEnvironmentTabUid = `${collection.uid}-global-environment-settings`;
-      const environmentUid = store.getState().globalEnvironments?.activeGlobalEnvironmentUid;
-      dispatch(addTab({ uid: globalEnvironmentTabUid, collectionUid: collection.uid, type: 'global-environment-settings' }));
+      const state = store.getState();
+      const tabsState = state.tabs || {};
+      const activeTab = (tabsState.tabs || []).find((t) => t.uid === tabsState.activeTabUid);
+
+      // instead of creating a new global environment tab, check if one already exists and reuse it.
+      const existingGlobalTab = activeTab?.type === 'global-environment-settings'
+        ? activeTab
+        : (tabsState.tabs || []).find((t) => t.type === 'global-environment-settings');
+
+      const fallbackCollectionUid = collection?.uid || activeTab?.collectionUid;
+      const globalEnvironmentTabUid = existingGlobalTab?.uid || `${fallbackCollectionUid}-global-environment-settings`;
+      const environmentUid = state.globalEnvironments?.activeGlobalEnvironmentUid;
+
+      dispatch(addTab({
+        uid: globalEnvironmentTabUid,
+        collectionUid: existingGlobalTab?.collectionUid || fallbackCollectionUid,
+        type: 'global-environment-settings'
+      }));
 
       // pin the environment and the sub-tab(variables or secrets) to tab state.
       dispatch(updateTabState({

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
@@ -107,29 +107,33 @@ export const goToVariableDefinition = (scopeInfo, collection, item, variableName
 
     case 'environment': {
       const environmentTabUid = `${collection.uid}-environment-settings`;
+      const environmentUid = scopeInfo.data?.environment?.uid;
       dispatch(addTab({ uid: environmentTabUid, collectionUid: collection.uid, type: 'environment-settings' }));
 
-      // If the variable is a secret, switch to the 'secrets' tab in the environment settings.
-      if (scopeInfo.data?.variable?.secret) {
-        dispatch(updateTabState({
-          uid: environmentTabUid,
-          tabState: { environment: { tab: 'secrets' } }
-        }));
-      }
+      // pin the environment and the sub-tab(variables or secrets) to tab state.
+      dispatch(updateTabState({
+        uid: environmentTabUid,
+        tabState: {
+          ...(environmentUid ? { envUid: environmentUid } : {}),
+          environment: { tab: scopeInfo.data?.variable?.secret ? 'secrets' : 'variables' }
+        }
+      }));
       break;
     }
 
     case 'global': {
       const globalEnvironmentTabUid = `${collection.uid}-global-environment-settings`;
+      const environmentUid = store.getState().globalEnvironments?.activeGlobalEnvironmentUid;
       dispatch(addTab({ uid: globalEnvironmentTabUid, collectionUid: collection.uid, type: 'global-environment-settings' }));
 
-      // If the variable is a secret, switch to the 'secrets' tab in the environment settings.
-      if (scopeInfo.data?.variable?.secret) {
-        dispatch(updateTabState({
-          uid: globalEnvironmentTabUid,
-          tabState: { environment: { tab: 'secrets' } }
-        }));
-      }
+      // pin the environment and the sub-tab(variables or secrets) to tab state.
+      dispatch(updateTabState({
+        uid: globalEnvironmentTabUid,
+        tabState: {
+          ...(environmentUid ? { envUid: environmentUid } : {}),
+          environment: { tab: scopeInfo.data?.variable?.secret ? 'secrets' : 'variables' }
+        }
+      }));
       break;
     }
 

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
@@ -131,7 +131,7 @@ export const goToVariableDefinition = (scopeInfo, collection, item, variableName
         ? activeTab
         : (tabsState.tabs || []).find((t) => t.type === 'global-environment-settings');
 
-      const fallbackCollectionUid = collection?.uid || activeTab?.collectionUid;
+      const fallbackCollectionUid = collection.uid || activeTab?.collectionUid;
       const globalEnvironmentTabUid = existingGlobalTab?.uid || `${fallbackCollectionUid}-global-environment-settings`;
       const environmentUid = state.globalEnvironments?.activeGlobalEnvironmentUid;
 

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
@@ -1,0 +1,141 @@
+import store from 'providers/ReduxStore';
+import { openCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
+import { updatedFolderSettingsSelectedTab } from 'providers/ReduxStore/slices/collections';
+import { addTab, focusTab, updateRequestPaneTab, updateTabState } from 'providers/ReduxStore/slices/tabs';
+
+const SELECTOR_BY_SCOPE = {
+  request: (variableName) =>
+    `[data-testid="request-vars-req"] [data-row-name="${CSS.escape(variableName)}"]`,
+
+  folder: (variableName) =>
+    `[data-testid="folder-vars-req"] [data-row-name="${CSS.escape(variableName)}"]`,
+
+  collection: (variableName) =>
+    `[data-testid="collection-vars-req"] [data-row-name="${CSS.escape(variableName)}"]`,
+
+  environment: (variableName) =>
+    `[data-testid="env-var-row-${CSS.escape(variableName)}"]`,
+
+  global: (variableName) =>
+    `[data-testid="env-var-row-${CSS.escape(variableName)}"]`
+};
+
+const scrollDefinitionIntoView = (scopeType, variableName) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const getSelector = SELECTOR_BY_SCOPE[scopeType];
+
+  if (!getSelector) {
+    return;
+  }
+
+  const selector = getSelector(variableName);
+  const deadline = performance.now() + 1500;
+
+  // scroll the definition row into view, if it exists. If it doesn't exist yet, keep trying until the deadline is reached.
+  const tryScroll = () => {
+    const definitionRow = document.querySelector(selector);
+
+    if (definitionRow) {
+      definitionRow.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'
+      });
+
+      definitionRow.classList.add('bruno-var-definition-target');
+
+      window.setTimeout(() => {
+        definitionRow.classList.remove('bruno-var-definition-target');
+      }, 1500);
+
+      return;
+    }
+
+    if (performance.now() < deadline) {
+      window.requestAnimationFrame(tryScroll);
+    }
+  };
+
+  window.requestAnimationFrame(tryScroll);
+};
+
+// Navigate to the definition of a variable based on its scope and name.
+// for Environment also send the tab state to select the right sub-tab (Variables or Secrets).
+export const goToVariableDefinition = (scopeInfo, collection, item, variableName) => {
+  if (!scopeInfo || !collection || !variableName) {
+    return;
+  }
+
+  const dispatch = store.dispatch;
+
+  switch (scopeInfo.type) {
+    case 'request': {
+      const targetItem = scopeInfo.data?.item || item;
+      if (!targetItem?.uid) {
+        return;
+      }
+
+      dispatch(addTab({
+        uid: targetItem.uid,
+        collectionUid: collection.uid,
+        type: targetItem.type,
+        pathname: targetItem.pathname,
+        requestPaneTab: 'vars'
+      }));
+      dispatch(updateRequestPaneTab({ uid: targetItem.uid, requestPaneTab: 'vars' }));
+      dispatch(focusTab({ uid: targetItem.uid }));
+      break;
+    }
+
+    case 'folder': {
+      const folder = scopeInfo.data?.folder;
+      if (!folder?.uid) {
+        return;
+      }
+
+      dispatch(updatedFolderSettingsSelectedTab({ collectionUid: collection.uid, folderUid: folder.uid, tab: 'vars' }));
+      dispatch(addTab({ uid: folder.uid, collectionUid: collection.uid, type: 'folder-settings', pathname: folder.pathname }));
+      break;
+    }
+
+    case 'collection': {
+      dispatch(openCollectionSettings(collection.uid, 'vars'));
+      break;
+    }
+
+    case 'environment': {
+      const environmentTabUid = `${collection.uid}-environment-settings`;
+      dispatch(addTab({ uid: environmentTabUid, collectionUid: collection.uid, type: 'environment-settings' }));
+
+      // If the variable is a secret, switch to the 'secrets' tab in the environment settings.
+      if (scopeInfo.data?.variable?.secret) {
+        dispatch(updateTabState({
+          uid: environmentTabUid,
+          tabState: { environment: { tab: 'secrets' } }
+        }));
+      }
+      break;
+    }
+
+    case 'global': {
+      const globalEnvironmentTabUid = `${collection.uid}-global-environment-settings`;
+      dispatch(addTab({ uid: globalEnvironmentTabUid, collectionUid: collection.uid, type: 'global-environment-settings' }));
+
+      // If the variable is a secret, switch to the 'secrets' tab in the environment settings.
+      if (scopeInfo.data?.variable?.secret) {
+        dispatch(updateTabState({
+          uid: globalEnvironmentTabUid,
+          tabState: { environment: { tab: 'secrets' } }
+        }));
+      }
+      break;
+    }
+
+    default:
+      return;
+  }
+
+  scrollDefinitionIntoView(scopeInfo.type, variableName);
+};

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.spec.js
@@ -149,4 +149,52 @@ describe('goToVariableDefinition', () => {
       tabState: { envUid: 'genv-1', environment: { tab: 'variables' } }
     });
   });
+
+  it('reuses the already-active Global Environment Settings tab instead of minting a new one from a collection-less context', () => {
+    // Simulates clicking go-to-definition from inside the Global Environment table itself,
+    // where `collection` is a synthetic `{}` with no uid.
+    const syntheticCollection = {};
+    store.getState.mockReturnValueOnce({
+      globalEnvironments: { activeGlobalEnvironmentUid: undefined },
+      tabs: {
+        activeTabUid: 'col-1-global-environment-settings',
+        tabs: [
+          { uid: 'col-1-global-environment-settings', collectionUid: 'col-1', type: 'global-environment-settings' }
+        ]
+      }
+    });
+    const scopeInfo = { type: 'global', data: { variable: { name: 'apiToken', secret: true } } };
+
+    goToVariableDefinition(scopeInfo, syntheticCollection, null, 'apiToken');
+
+    // Reuses the, already-open global tab uid
+    expect(addTab).toHaveBeenCalledWith(expect.objectContaining({
+      uid: 'col-1-global-environment-settings',
+      collectionUid: 'col-1',
+      type: 'global-environment-settings'
+    }));
+    expect(updateTabState).toHaveBeenCalledWith({
+      uid: 'col-1-global-environment-settings',
+      tabState: { environment: { tab: 'secrets' } }
+    });
+  });
+
+  it('finds an already-open Global tab even when it is not the currently active tab', () => {
+    const syntheticCollection = {};
+    store.getState.mockReturnValueOnce({
+      globalEnvironments: { activeGlobalEnvironmentUid: undefined },
+      tabs: {
+        activeTabUid: 'req-current',
+        tabs: [
+          { uid: 'req-current', collectionUid: 'col-1', type: 'http-request' },
+          { uid: 'col-1-global-environment-settings', collectionUid: 'col-1', type: 'global-environment-settings' }
+        ]
+      }
+    });
+    const scopeInfo = { type: 'global', data: { variable: { name: 'apiToken', secret: false } } };
+
+    goToVariableDefinition(scopeInfo, syntheticCollection, null, 'apiToken');
+
+    expect(addTab).toHaveBeenCalledWith(expect.objectContaining({ uid: 'col-1-global-environment-settings' }));
+  });
 });

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.spec.js
@@ -7,7 +7,8 @@ import { goToVariableDefinition } from './goToVariableDefinition';
 jest.mock('providers/ReduxStore', () => ({
   __esModule: true,
   default: {
-    dispatch: jest.fn()
+    dispatch: jest.fn(),
+    getState: jest.fn(() => ({ globalEnvironments: { activeGlobalEnvironmentUid: undefined } }))
   }
 }));
 
@@ -68,13 +69,16 @@ describe('goToVariableDefinition', () => {
     expect(openCollectionSettings).toHaveBeenCalledWith('col-1', 'vars');
   });
 
-  it('does not dispatch updateTabState for a plain (non-secret) environment variable', () => {
+  it('selects the Variables sub-tab for a plain (non-secret) environment variable', () => {
     const scopeInfo = { type: 'environment', data: { variable: { name: 'apiKey', secret: false } } };
 
     goToVariableDefinition(scopeInfo, collection, null, 'apiKey');
 
     expect(addTab).toHaveBeenCalledWith(expect.objectContaining({ uid: 'col-1-environment-settings', type: 'environment-settings' }));
-    expect(updateTabState).not.toHaveBeenCalled();
+    expect(updateTabState).toHaveBeenCalledWith({
+      uid: 'col-1-environment-settings',
+      tabState: { environment: { tab: 'variables' } }
+    });
   });
 
   it('selects the Secrets sub-tab for a secret environment variable', () => {
@@ -86,6 +90,27 @@ describe('goToVariableDefinition', () => {
       uid: 'col-1-environment-settings',
       tabState: { environment: { tab: 'secrets' } }
     });
+  });
+
+  it('pins the tab to the environment the variable actually lives in, overriding any stale selection', () => {
+    const environment = { uid: 'env-prod', name: 'Prod' };
+    const scopeInfo = { type: 'environment', data: { environment, variable: { name: 'apiKey', secret: true } } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiKey');
+
+    expect(updateTabState).toHaveBeenCalledWith({
+      uid: 'col-1-environment-settings',
+      tabState: { envUid: 'env-prod', environment: { tab: 'secrets' } }
+    });
+  });
+
+  it('does not set envUid when scopeInfo has no environment data', () => {
+    const scopeInfo = { type: 'environment', data: { variable: { name: 'apiKey', secret: true } } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiKey');
+
+    const [{ tabState }] = updateTabState.mock.calls[0];
+    expect(tabState).not.toHaveProperty('envUid');
   });
 
   it('dispatches updateTabState after addTab so the tab already exists when it runs', () => {
@@ -110,6 +135,18 @@ describe('goToVariableDefinition', () => {
     expect(updateTabState).toHaveBeenCalledWith({
       uid: 'col-1-global-environment-settings',
       tabState: { environment: { tab: 'secrets' } }
+    });
+  });
+
+  it('pins the tab to the active global environment, overriding any stale selection', () => {
+    store.getState.mockReturnValueOnce({ globalEnvironments: { activeGlobalEnvironmentUid: 'genv-1' } });
+    const scopeInfo = { type: 'global', data: { variable: { name: 'apiToken', secret: false } } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiToken');
+
+    expect(updateTabState).toHaveBeenCalledWith({
+      uid: 'col-1-global-environment-settings',
+      tabState: { envUid: 'genv-1', environment: { tab: 'variables' } }
     });
   });
 });

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.spec.js
@@ -1,0 +1,115 @@
+import store from 'providers/ReduxStore';
+import { addTab, focusTab, updateRequestPaneTab, updateTabState } from 'providers/ReduxStore/slices/tabs';
+import { openCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
+import { updatedFolderSettingsSelectedTab } from 'providers/ReduxStore/slices/collections';
+import { goToVariableDefinition } from './goToVariableDefinition';
+
+jest.mock('providers/ReduxStore', () => ({
+  __esModule: true,
+  default: {
+    dispatch: jest.fn()
+  }
+}));
+
+jest.mock('providers/ReduxStore/slices/tabs', () => ({
+  addTab: jest.fn((payload) => ({ type: 'tabs/addTab', payload })),
+  focusTab: jest.fn((payload) => ({ type: 'tabs/focusTab', payload })),
+  updateRequestPaneTab: jest.fn((payload) => ({ type: 'tabs/updateRequestPaneTab', payload })),
+  updateTabState: jest.fn((payload) => ({ type: 'tabs/updateTabState', payload }))
+}));
+
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  openCollectionSettings: jest.fn((collectionUid, tab) => ({ type: 'collections/openCollectionSettings', payload: { collectionUid, tab } }))
+}));
+
+jest.mock('providers/ReduxStore/slices/collections', () => ({
+  updatedFolderSettingsSelectedTab: jest.fn((payload) => ({ type: 'collections/updatedFolderSettingsSelectedTab', payload }))
+}));
+
+describe('goToVariableDefinition', () => {
+  const collection = { uid: 'col-1' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does nothing when scopeInfo, collection, or variableName is missing', () => {
+    goToVariableDefinition(null, collection, null, 'apiKey');
+    goToVariableDefinition({ type: 'collection' }, null, null, 'apiKey');
+    goToVariableDefinition({ type: 'collection' }, collection, null, '');
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('opens the target request on its Variables tab for a request-scoped variable', () => {
+    const targetItem = { uid: 'req-target', type: 'http-request', pathname: '/target.bru' };
+    const scopeInfo = { type: 'request', data: { item: targetItem } };
+
+    goToVariableDefinition(scopeInfo, collection, { uid: 'req-current' }, 'apiKey');
+
+    expect(addTab).toHaveBeenCalledWith(expect.objectContaining({ uid: 'req-target', requestPaneTab: 'vars' }));
+    expect(updateRequestPaneTab).toHaveBeenCalledWith({ uid: 'req-target', requestPaneTab: 'vars' });
+    expect(focusTab).toHaveBeenCalledWith({ uid: 'req-target' });
+  });
+
+  it('opens folder settings on its Variables tab for a folder-scoped variable', () => {
+    const folder = { uid: 'folder-1', pathname: '/folder' };
+    const scopeInfo = { type: 'folder', data: { folder } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiKey');
+
+    expect(updatedFolderSettingsSelectedTab).toHaveBeenCalledWith({ collectionUid: 'col-1', folderUid: 'folder-1', tab: 'vars' });
+    expect(addTab).toHaveBeenCalledWith(expect.objectContaining({ uid: 'folder-1', type: 'folder-settings' }));
+  });
+
+  it('opens collection settings on the Variables tab for a collection-scoped variable', () => {
+    goToVariableDefinition({ type: 'collection', data: {} }, collection, null, 'apiKey');
+
+    expect(openCollectionSettings).toHaveBeenCalledWith('col-1', 'vars');
+  });
+
+  it('does not dispatch updateTabState for a plain (non-secret) environment variable', () => {
+    const scopeInfo = { type: 'environment', data: { variable: { name: 'apiKey', secret: false } } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiKey');
+
+    expect(addTab).toHaveBeenCalledWith(expect.objectContaining({ uid: 'col-1-environment-settings', type: 'environment-settings' }));
+    expect(updateTabState).not.toHaveBeenCalled();
+  });
+
+  it('selects the Secrets sub-tab for a secret environment variable', () => {
+    const scopeInfo = { type: 'environment', data: { variable: { name: 'apiKey', secret: true } } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiKey');
+
+    expect(updateTabState).toHaveBeenCalledWith({
+      uid: 'col-1-environment-settings',
+      tabState: { environment: { tab: 'secrets' } }
+    });
+  });
+
+  it('dispatches updateTabState after addTab so the tab already exists when it runs', () => {
+    const scopeInfo = { type: 'environment', data: { variable: { name: 'apiKey', secret: true } } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiKey');
+
+    const dispatchCalls = store.dispatch.mock.calls.map(([action]) => action.type);
+    const addTabIndex = dispatchCalls.indexOf('tabs/addTab');
+    const updateTabStateIndex = dispatchCalls.indexOf('tabs/updateTabState');
+
+    expect(addTabIndex).toBeGreaterThanOrEqual(0);
+    expect(updateTabStateIndex).toBeGreaterThan(addTabIndex);
+  });
+
+  it('selects the correct sub-tab for a global-scoped secret variable', () => {
+    const scopeInfo = { type: 'global', data: { variable: { name: 'apiToken', secret: true } } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiToken');
+
+    expect(addTab).toHaveBeenCalledWith(expect.objectContaining({ uid: 'col-1-global-environment-settings', type: 'global-environment-settings' }));
+    expect(updateTabState).toHaveBeenCalledWith({
+      uid: 'col-1-global-environment-settings',
+      tabState: { environment: { tab: 'secrets' } }
+    });
+  });
+});

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1741,6 +1741,19 @@ export const getInitialExampleName = (item) => {
   }
 };
 
+/**
+ * A name can exist as both a plain variable and a secret. The secret takes
+ * precedence (matching interpolation), so the resolved value and the secret
+ * flag stay in sync instead of coming from different entries.
+ * @param {Array} variables - `environment.variables`
+ * @param {string} variableName - Name of the variable to resolve
+ * @returns {Object|undefined} The matching variable, preferring a secret entry over a plain one
+ */
+export const resolveEnabledVariable = (variables, variableName) => {
+  const matches = (variables || []).filter((v) => v.name === variableName && v.enabled);
+  return matches.find((v) => v.secret) || matches[0];
+};
+
 // Get the scope and raw value of a variable by checking all scopes in priority order
 export const getVariableScope = (variableName, collection, item) => {
   if (!variableName || !collection) {
@@ -1787,11 +1800,7 @@ export const getVariableScope = (variableName, collection, item) => {
   if (collection.activeEnvironmentUid) {
     const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
     if (environment && environment.variables) {
-      // A name can exist as both a plain variable and a secret. The secret takes
-      // precedence (matching interpolation), so the resolved value and the secret
-      // flag stay in sync instead of coming from different entries.
-      const envVars = environment.variables.filter((v) => v.name === variableName && v.enabled);
-      const envVar = envVars.find((v) => v.secret) || envVars[0];
+      const envVar = resolveEnabledVariable(environment.variables, variableName);
       if (envVar) {
         return {
           type: 'environment',

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1960,13 +1960,17 @@ export const isScratchCollection = (collection, workspaces) => {
 const SCOPE_CONFIG = [
   {
     type: VARIABLE_ADD_SCOPES.GLOBAL,
-    label: 'Global Environment',
+    label: ({ activeGlobalEnvironmentName }) => (
+      activeGlobalEnvironmentName ? `Global Environment (${activeGlobalEnvironmentName})` : 'Global Environment'
+    ),
     supportsSecret: true,
     enabled: ({ activeGlobalEnvironmentUid }) => !!activeGlobalEnvironmentUid
   },
   {
     type: VARIABLE_ADD_SCOPES.ENVIRONMENT,
-    label: 'Collection Environment',
+    label: ({ activeEnvironmentName }) => (
+      activeEnvironmentName ? `Collection Environment (${activeEnvironmentName})` : 'Collection Environment'
+    ),
     supportsSecret: true,
     isAvailable: ({ hasCollection }) => hasCollection,
     enabled: ({ activeEnvironmentUid }) => !!activeEnvironmentUid
@@ -2000,7 +2004,9 @@ const SCOPE_CONFIG = [
  * Resolves which scopes an undefined `{{variable}}` can be added to.
  * @param {Object} options
  * @param {string} [options.activeEnvironmentUid] - The collection's active environment uid, if any.
+ * @param {string} [options.activeEnvironmentName] - The collection's active environment name, if any.
  * @param {string} [options.activeGlobalEnvironmentUid] - The active global environment uid, if any.
+ * @param {string} [options.activeGlobalEnvironmentName] - The active global environment name, if any.
  * @param {Object} [options.item] - The request/folder item the tooltip was opened from, if any.
  *   Request Variable is only added when this is a request (see isItemARequest).
  * @param {Object} [options.parentFolder] - The folder variables should be added to, if any: either
@@ -2015,7 +2021,9 @@ const SCOPE_CONFIG = [
  */
 export const getAvailableAddToScopes = ({
   activeEnvironmentUid,
+  activeEnvironmentName,
   activeGlobalEnvironmentUid,
+  activeGlobalEnvironmentName,
   item,
   parentFolder,
   isSelfFolder = false,
@@ -2023,7 +2031,9 @@ export const getAvailableAddToScopes = ({
 } = {}) => {
   const context = {
     activeEnvironmentUid,
+    activeEnvironmentName,
     activeGlobalEnvironmentUid,
+    activeGlobalEnvironmentName,
     item,
     parentFolder,
     isSelfFolder,

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -2011,7 +2011,7 @@ const SCOPE_CONFIG = [
  *   Only affects the Folder scope's label ("Folder" vs "Parent Folder(...)").
  * @param {boolean} [options.hasCollection] - when we are in Global Environment table, there is no collection context,
  * so we don't show collection/environment scopes
- * @returns {Array<{type: string, label: string, enabled: boolean, disabledReason?: string, supportsSecret: boolean}>}
+ * @returns {Array<{type: string, label: string, enabled: boolean, supportsSecret: boolean}>}
  */
 export const getAvailableAddToScopes = ({
   activeEnvironmentUid,

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -3,6 +3,7 @@ import { uuid } from 'utils/common';
 import { sortByNameThenSequence } from 'utils/common/index';
 import path, { normalizePath } from 'utils/common/path';
 import { isRequestTagsIncluded } from '@usebruno/common';
+import { VARIABLE_ADD_SCOPES } from 'utils/common/constants';
 
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
   if (!str || !str.length || !isString(str)) {
@@ -1945,4 +1946,67 @@ export const filterTransientItems = (items) => {
 export const isScratchCollection = (collection, workspaces) => {
   if (!collection || !workspaces) return false;
   return workspaces.some((w) => w.scratchCollectionUid === collection.uid);
+};
+
+const SCOPE_CONFIG = [
+  {
+    type: VARIABLE_ADD_SCOPES.GLOBAL,
+    label: 'Global Environment',
+    supportsSecret: true,
+    enabled: ({ activeGlobalEnvironmentUid }) => !!activeGlobalEnvironmentUid
+  },
+  {
+    type: VARIABLE_ADD_SCOPES.ENVIRONMENT,
+    label: 'Collection Environment',
+    supportsSecret: true,
+    enabled: ({ activeEnvironmentUid }) => !!activeEnvironmentUid
+  },
+  {
+    type: VARIABLE_ADD_SCOPES.COLLECTION,
+    label: 'Collection Variables',
+    supportsSecret: false,
+    enabled: () => true
+  },
+  {
+    type: VARIABLE_ADD_SCOPES.REQUEST,
+    label: 'Request Variable',
+    supportsSecret: false,
+    include: ({ item }) => item && isItemARequest(item),
+    enabled: () => true
+  },
+  {
+    type: VARIABLE_ADD_SCOPES.FOLDER,
+    label: 'Immediate Parent Folder',
+    supportsSecret: false,
+    enabled: () => false,
+    disabledReason: 'Not yet supported'
+  }
+];
+
+/**
+ * Resolves which scopes an undefined `{{variable}}` can be added to.
+ * @param {string} [activeEnvironmentUid] - The collection's active environment uid, if any.
+ * @param {string} [activeGlobalEnvironmentUid] - The active global environment uid, if any.
+ * @param {Object} [item] - The request/folder item the tooltip was opened from, if any. Request
+ *   Variable is only included when this is a request (see isItemARequest).
+ * @returns {Array<{type: string, label: string, enabled: boolean, disabledReason?: string, supportsSecret: boolean}>}
+ */
+export const getAvailableAddToScopes = (
+  activeEnvironmentUid,
+  activeGlobalEnvironmentUid,
+  item
+) => {
+  const context = {
+    activeEnvironmentUid,
+    activeGlobalEnvironmentUid,
+    item
+  };
+
+  const filteredScopes = SCOPE_CONFIG.filter((scope) => !scope.include || scope.include(context));
+
+  return filteredScopes
+    .map(({ enabled, include, ...scope }) => ({
+      ...scope,
+      enabled: enabled(context)
+    }));
 };

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1987,9 +1987,10 @@ const SCOPE_CONFIG = [
   },
   {
     type: VARIABLE_ADD_SCOPES.FOLDER,
-    label: ({ parentFolder }) => `Parent Folder(${parentFolder?.name || ''})`,
+    label: ({ parentFolder, isSelfFolder }) => (isSelfFolder ? 'Folder' : `Parent Folder(${parentFolder?.name || ''})`),
     supportsSecret: false,
-    // Only the request/folder's direct containing folder is added.
+    // Only the request/folder's direct containing folder is added. unless we're already in
+    // that folder's own settings, in which case the folder itself is the target.
     isAvailable: ({ parentFolder }) => !!parentFolder,
     enabled: () => true
   }
@@ -2002,8 +2003,12 @@ const SCOPE_CONFIG = [
  * @param {string} [options.activeGlobalEnvironmentUid] - The active global environment uid, if any.
  * @param {Object} [options.item] - The request/folder item the tooltip was opened from, if any.
  *   Request Variable is only added when this is a request (see isItemARequest).
- * @param {Object} [options.parentFolder] - The immediate containing folder of `item`, if any.
+ * @param {Object} [options.parentFolder] - The folder variables should be added to, if any: either
+ *   the immediate containing folder of `item`, or `item` itself when already in folder settings.
  *   Folder Variable is only added when this is present.
+ * @param {boolean} [options.isSelfFolder] - True when `parentFolder` is the folder currently being
+ *   edited (tooltip opened from within that folder's own settings), rather than an actual parent.
+ *   Only affects the Folder scope's label ("Folder" vs "Parent Folder(...)").
  * @param {boolean} [options.hasCollection] - when we are in Global Environment table, there is no collection context,
  * so we don't show collection/environment scopes
  * @returns {Array<{type: string, label: string, enabled: boolean, disabledReason?: string, supportsSecret: boolean}>}
@@ -2013,6 +2018,7 @@ export const getAvailableAddToScopes = ({
   activeGlobalEnvironmentUid,
   item,
   parentFolder,
+  isSelfFolder = false,
   hasCollection = true
 } = {}) => {
   const context = {
@@ -2020,6 +2026,7 @@ export const getAvailableAddToScopes = ({
     activeGlobalEnvironmentUid,
     item,
     parentFolder,
+    isSelfFolder,
     hasCollection
   };
 

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1816,12 +1816,17 @@ export const getVariableScope = (variableName, collection, item) => {
   }
 
   // 5. Check Global Environment Variables
-  const { globalEnvironmentVariables = {} } = collection;
+  const { globalEnvironmentVariables = {}, globalEnvSecrets = [] } = collection;
   if (variableName in globalEnvironmentVariables) {
+    const isSecret = globalEnvSecrets.includes(variableName);
     return {
       type: 'global',
       value: globalEnvironmentVariables[variableName],
-      data: { variableName, value: globalEnvironmentVariables[variableName] }
+      data: {
+        variableName,
+        value: globalEnvironmentVariables[variableName],
+        variable: { name: variableName, secret: isSecret }
+      }
     };
   }
 
@@ -1846,14 +1851,9 @@ export const isVariableSecret = (scopeInfo) => {
     return false;
   }
 
-  // Only environment variables can be marked as secret
-  if (scopeInfo.type === 'environment') {
+  // Environment and global environment variables can be marked as secret
+  if (scopeInfo.type === 'environment' || scopeInfo.type === 'global') {
     return !!scopeInfo.data.variable?.secret;
-  }
-
-  // Global variables are not checked here
-  if (scopeInfo.type === 'global') {
-    return false;
   }
 
   return false;

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1959,19 +1959,21 @@ const SCOPE_CONFIG = [
     type: VARIABLE_ADD_SCOPES.ENVIRONMENT,
     label: 'Collection Environment',
     supportsSecret: true,
+    isAvailable: ({ hasCollection }) => hasCollection,
     enabled: ({ activeEnvironmentUid }) => !!activeEnvironmentUid
   },
   {
     type: VARIABLE_ADD_SCOPES.COLLECTION,
     label: 'Collection Variables',
     supportsSecret: false,
+    isAvailable: ({ hasCollection }) => hasCollection,
     enabled: () => true
   },
   {
     type: VARIABLE_ADD_SCOPES.REQUEST,
     label: 'Request Variable',
     supportsSecret: false,
-    include: ({ item }) => item && isItemARequest(item),
+    isAvailable: ({ item }) => item && isItemARequest(item),
     enabled: () => true
   },
   {
@@ -1979,38 +1981,43 @@ const SCOPE_CONFIG = [
     label: ({ parentFolder }) => `Parent Folder(${parentFolder?.name || ''})`,
     supportsSecret: false,
     // Only the request/folder's direct containing folder is added.
-    include: ({ parentFolder }) => !!parentFolder,
+    isAvailable: ({ parentFolder }) => !!parentFolder,
     enabled: () => true
   }
 ];
 
 /**
  * Resolves which scopes an undefined `{{variable}}` can be added to.
- * @param {string} [activeEnvironmentUid] - The collection's active environment uid, if any.
- * @param {string} [activeGlobalEnvironmentUid] - The active global environment uid, if any.
- * @param {Object} [item] - The request/folder item the tooltip was opened from, if any. Request
- *   Variable is only included when this is a request (see isItemARequest).
- * @param {Object} [parentFolder] - The immediate containing folder of `item`, if any. Folder
- *   Variable is only included when this is present.
+ * @param {Object} options
+ * @param {string} [options.activeEnvironmentUid] - The collection's active environment uid, if any.
+ * @param {string} [options.activeGlobalEnvironmentUid] - The active global environment uid, if any.
+ * @param {Object} [options.item] - The request/folder item the tooltip was opened from, if any.
+ *   Request Variable is only added when this is a request (see isItemARequest).
+ * @param {Object} [options.parentFolder] - The immediate containing folder of `item`, if any.
+ *   Folder Variable is only added when this is present.
+ * @param {boolean} [options.hasCollection] - when we are in Global Environment table, there is no collection context,
+ * so we don't show collection/environment scopes
  * @returns {Array<{type: string, label: string, enabled: boolean, disabledReason?: string, supportsSecret: boolean}>}
  */
-export const getAvailableAddToScopes = (
+export const getAvailableAddToScopes = ({
   activeEnvironmentUid,
   activeGlobalEnvironmentUid,
   item,
-  parentFolder
-) => {
+  parentFolder,
+  hasCollection = true
+} = {}) => {
   const context = {
     activeEnvironmentUid,
     activeGlobalEnvironmentUid,
     item,
-    parentFolder
+    parentFolder,
+    hasCollection
   };
 
-  const filteredScopes = SCOPE_CONFIG.filter((scope) => !scope.include || scope.include(context));
+  const filteredScopes = SCOPE_CONFIG.filter((scope) => !scope.isAvailable || scope.isAvailable(context));
 
   return filteredScopes
-    .map(({ enabled, include, label, ...scope }) => ({
+    .map(({ enabled, isAvailable, label, ...scope }) => ({
       ...scope,
       label: typeof label === 'function' ? label(context) : label,
       enabled: enabled(context)

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1,4 +1,4 @@
-import { cloneDeep, isEqual, sortBy, filter, map, isString, findIndex, find, each, get } from 'lodash';
+import { cloneDeep, isEqual, sortBy, filter, map, isString, find, each, get } from 'lodash';
 import { uuid } from 'utils/common';
 import { sortByNameThenSequence } from 'utils/common/index';
 import path, { normalizePath } from 'utils/common/path';
@@ -1976,10 +1976,11 @@ const SCOPE_CONFIG = [
   },
   {
     type: VARIABLE_ADD_SCOPES.FOLDER,
-    label: 'Immediate Parent Folder',
+    label: ({ parentFolder }) => `Parent Folder(${parentFolder?.name || ''})`,
     supportsSecret: false,
-    enabled: () => false,
-    disabledReason: 'Not yet supported'
+    // Only the request/folder's direct containing folder is added.
+    include: ({ parentFolder }) => !!parentFolder,
+    enabled: () => true
   }
 ];
 
@@ -1989,24 +1990,29 @@ const SCOPE_CONFIG = [
  * @param {string} [activeGlobalEnvironmentUid] - The active global environment uid, if any.
  * @param {Object} [item] - The request/folder item the tooltip was opened from, if any. Request
  *   Variable is only included when this is a request (see isItemARequest).
+ * @param {Object} [parentFolder] - The immediate containing folder of `item`, if any. Folder
+ *   Variable is only included when this is present.
  * @returns {Array<{type: string, label: string, enabled: boolean, disabledReason?: string, supportsSecret: boolean}>}
  */
 export const getAvailableAddToScopes = (
   activeEnvironmentUid,
   activeGlobalEnvironmentUid,
-  item
+  item,
+  parentFolder
 ) => {
   const context = {
     activeEnvironmentUid,
     activeGlobalEnvironmentUid,
-    item
+    item,
+    parentFolder
   };
 
   const filteredScopes = SCOPE_CONFIG.filter((scope) => !scope.include || scope.include(context));
 
   return filteredScopes
-    .map(({ enabled, include, ...scope }) => ({
+    .map(({ enabled, include, label, ...scope }) => ({
       ...scope,
+      label: typeof label === 'function' ? label(context) : label,
       enabled: enabled(context)
     }));
 };

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -163,6 +163,43 @@ describe('getVariableScope — global environment secrets', () => {
   });
 });
 
+describe('getAvailableAddToScopes — Environment scope labels name the target environment', () => {
+  it('names the active environment in the Collection Environment label, so the user can see which file a new variable would land in', () => {
+    const scopes = getAvailableAddToScopes({
+      activeEnvironmentUid: 'env-1',
+      activeEnvironmentName: 'Staging',
+      hasCollection: true
+    });
+
+    const environmentScope = scopes.find((s) => s.type === 'environment');
+    expect(environmentScope.label).toBe('Collection Environment (Staging)');
+  });
+
+  it('falls back to the plain "Collection Environment" label when no active environment name is known', () => {
+    const scopes = getAvailableAddToScopes({ hasCollection: true });
+
+    const environmentScope = scopes.find((s) => s.type === 'environment');
+    expect(environmentScope.label).toBe('Collection Environment');
+  });
+
+  it('names the active global environment in the Global Environment label', () => {
+    const scopes = getAvailableAddToScopes({
+      activeGlobalEnvironmentUid: 'genv-1',
+      activeGlobalEnvironmentName: 'Personal'
+    });
+
+    const globalScope = scopes.find((s) => s.type === 'global');
+    expect(globalScope.label).toBe('Global Environment (Personal)');
+  });
+
+  it('falls back to the plain "Global Environment" label when no active global environment name is known', () => {
+    const scopes = getAvailableAddToScopes({});
+
+    const globalScope = scopes.find((s) => s.type === 'global');
+    expect(globalScope.label).toBe('Global Environment');
+  });
+});
+
 describe('getAvailableAddToScopes — Folder scope label', () => {
   it('labels the Folder scope "Parent Folder(name)" for a normal ancestor folder', () => {
     const scopes = getAvailableAddToScopes({

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts, getVariableScope, isVariableSecret } from './index';
+import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts, getVariableScope, isVariableSecret, getAvailableAddToScopes } from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -160,5 +160,30 @@ describe('getVariableScope — global environment secrets', () => {
 
     expect(scopeInfo.data.variable).toEqual({ name: 'baseUrl', secret: false });
     expect(isVariableSecret(scopeInfo)).toBe(false);
+  });
+});
+
+describe('getAvailableAddToScopes — Folder scope label', () => {
+  it('labels the Folder scope "Parent Folder(name)" for a normal ancestor folder', () => {
+    const scopes = getAvailableAddToScopes({
+      item: { uid: 'req-1', type: 'http-request' },
+      parentFolder: { uid: 'folder-1', name: 'Auth' },
+      hasCollection: true
+    });
+
+    const folderScope = scopes.find((s) => s.type === 'folder');
+    expect(folderScope.label).toBe('Parent Folder(Auth)');
+  });
+
+  it('labels the Folder scope plainly "Folder" when it is the folder currently being edited', () => {
+    const scopes = getAvailableAddToScopes({
+      item: { uid: 'folder-1', type: 'folder', name: 'Auth' },
+      parentFolder: { uid: 'folder-1', type: 'folder', name: 'Auth' },
+      isSelfFolder: true,
+      hasCollection: true
+    });
+
+    const folderScope = scopes.find((s) => s.type === 'folder');
+    expect(folderScope.label).toBe('Folder');
   });
 });

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
+import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts, getVariableScope, isVariableSecret } from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -130,5 +130,35 @@ describe('getCollectionItemCounts', () => {
   it('returns zero counts for empty or missing items', () => {
     expect(getCollectionItemCounts([])).toEqual({ folderCount: 0, requestCount: 0 });
     expect(getCollectionItemCounts(undefined)).toEqual({ folderCount: 0, requestCount: 0 });
+  });
+});
+
+describe('getVariableScope — global environment secrets', () => {
+  it('flags a global-scoped variable as secret when its name is in globalEnvSecrets', () => {
+    const collection = {
+      globalEnvironmentVariables: { apiToken: 'super-secret' },
+      globalEnvSecrets: ['apiToken']
+    };
+
+    const scopeInfo = getVariableScope('apiToken', collection, null);
+
+    expect(scopeInfo).toEqual({
+      type: 'global',
+      value: 'super-secret',
+      data: { variableName: 'apiToken', value: 'super-secret', variable: { name: 'apiToken', secret: true } }
+    });
+    expect(isVariableSecret(scopeInfo)).toBe(true);
+  });
+
+  it('does not flag a global-scoped variable as secret when its name is not in globalEnvSecrets', () => {
+    const collection = {
+      globalEnvironmentVariables: { baseUrl: 'https://api.example.com' },
+      globalEnvSecrets: ['apiToken']
+    };
+
+    const scopeInfo = getVariableScope('baseUrl', collection, null);
+
+    expect(scopeInfo.data.variable).toEqual({ name: 'baseUrl', secret: false });
+    expect(isVariableSecret(scopeInfo)).toBe(false);
   });
 });

--- a/packages/bruno-app/src/utils/common/constants.js
+++ b/packages/bruno-app/src/utils/common/constants.js
@@ -14,6 +14,14 @@ export const PRESET_REQUEST_TYPES = {
 
 export const DEFAULT_PRESET_REQUEST_TYPE = PRESET_REQUEST_TYPES.HTTP;
 
+export const VARIABLE_ADD_SCOPES = {
+  GLOBAL: 'global',
+  ENVIRONMENT: 'environment',
+  COLLECTION: 'collection',
+  REQUEST: 'request',
+  FOLDER: 'folder'
+};
+
 export const AUTH_MODES = {
   AWSV4: 'awsv4',
   BASIC: 'basic',

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -2569,6 +2569,34 @@ const openUrlVarTooltip = async (
 };
 
 /**
+ * Hover a `{{var}}` token inside another row's Value cell in the (collection or global)
+ * environment table itself, and return its (visible) info tooltip. Use this for the
+ * "go to definition from inside the environment table it would target" scenario, as opposed
+ * to `openUrlVarTooltip` which hovers a token in a request's URL bar.
+ * @param page - The page object
+ * @param rowName - The name of the environment row whose Value cell contains the token
+ * @param tokenName - The variable name inside the braces to hover
+ * @param state - Highlight class to match: 'valid' (known) or 'invalid' (unknown); omit to match either
+ * @returns The tooltip popup locator
+ */
+const openEnvValueVarTooltip = async (
+  page: Page,
+  rowName: string,
+  tokenName: string,
+  state?: 'valid' | 'invalid'
+): Promise<Locator> => {
+  const { environment, varInfoPopup } = buildCommonLocators(page);
+  const selector = state ? `.cm-variable-${state}` : '.cm-variable-valid, .cm-variable-invalid';
+  // Dismiss any previously-open tooltip first.
+  await page.mouse.move(0, 0);
+  await environment.varRowValueEditor(rowName).locator(selector).filter({ hasText: tokenName }).first().hover();
+
+  const tooltip = varInfoPopup.all().first();
+  await expect(tooltip).toBeVisible();
+  return tooltip;
+};
+
+/**
  * Returns true if the element is on top at its centre (not hidden behind a header),
  * i.e. the topmost element at its centre is inside a dropdown/tippy container.
  * @param locator - The dropdown item locator
@@ -2603,6 +2631,7 @@ export {
   waitForReadyPage,
   setRequestUrlAndSave,
   openUrlVarTooltip,
+  openEnvValueVarTooltip,
   scrollVirtuosoRowIntoView,
   dismissImportIssuesToasts,
   closeAllCollections,

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -59,6 +59,7 @@ export const buildEnvironmentLocators = (page: Page) => ({
   variableValue: (name: string) =>
     page.locator('tbody tr').filter({ has: page.locator(`input[value="${name}"]`) }).getByTestId(/^test-multiline-editor-\d+\.value$/).locator('.CodeMirror').first(),
   settingsListItem: (name: string) => page.locator('.environment-item').filter({ hasText: name }),
+  activatedCheckmark: (name: string) => page.locator('.environment-item').filter({ hasText: name }).locator('.activated-checkmark'),
   createEnvButton: () => page.locator('button[id="create-env"]'),
   settingsCreateButton: () =>
     page.locator('.environments-container .sidebar button[title="Create environment"]'),

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -59,8 +59,6 @@ export const buildEnvironmentLocators = (page: Page) => ({
   variableValue: (name: string) =>
     page.locator('tbody tr').filter({ has: page.locator(`input[value="${name}"]`) }).getByTestId(/^test-multiline-editor-\d+\.value$/).locator('.CodeMirror').first(),
   settingsListItem: (name: string) => page.locator('.environment-item').filter({ hasText: name }),
-  activateButton: (name: string) =>
-    page.locator('.environment-item').filter({ hasText: name }).locator('button.activate-btn'),
   createEnvButton: () => page.locator('button[id="create-env"]'),
   settingsCreateButton: () =>
     page.locator('.environments-container .sidebar button[title="Create environment"]'),

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -58,6 +58,9 @@ export const buildEnvironmentLocators = (page: Page) => ({
   // matching on the wrapper is the only way to get the full concatenated text.
   variableValue: (name: string) =>
     page.locator('tbody tr').filter({ has: page.locator(`input[value="${name}"]`) }).getByTestId(/^test-multiline-editor-\d+\.value$/).locator('.CodeMirror').first(),
+  settingsListItem: (name: string) => page.locator('.environment-item').filter({ hasText: name }),
+  activateButton: (name: string) =>
+    page.locator('.environment-item').filter({ hasText: name }).locator('button.activate-btn'),
   createEnvButton: () => page.locator('button[id="create-env"]'),
   settingsCreateButton: () =>
     page.locator('.environments-container .sidebar button[title="Create environment"]'),

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -136,7 +136,24 @@ export const buildCommonLocators = (page: Page) => ({
     warningNote: (popup: Locator) => popup.getByTestId('var-info-warning-note'),
     // The editor container itself (hidden until the value display is clicked).
     editorContainer: (popup: Locator) => popup.getByTestId('var-info-value-editor'),
-    editor: (popup: Locator) => popup.getByTestId('var-info-value-editor').locator('.CodeMirror')
+    editor: (popup: Locator) => popup.getByTestId('var-info-value-editor').locator('.CodeMirror'),
+    // The "Add to" switcher, shown in place of an editable value for undefined variables.
+    addToSwitcher: (popup: Locator) => popup.getByTestId('var-info-add-to'),
+    addToToggle: (popup: Locator) => popup.getByTestId('var-info-add-to-toggle'),
+    addToOption: (popup: Locator, scopeType: string) => popup.getByTestId(`var-info-add-to-option-${scopeType}`),
+    // The currently-active scope row (guessed default, or whichever was last picked).
+    addToActiveOption: (popup: Locator) => popup.locator('.var-add-to-option-active'),
+    addToSecretCheckbox: (popup: Locator) => popup.getByTestId('var-info-add-to-secret-checkbox'),
+    addToNoEnvNote: (popup: Locator, scopeType: 'environment' | 'global') =>
+      popup.getByTestId('var-info-add-to-no-env-note')
+        .filter({ hasText: scopeType === 'global' ? 'Global Environment' : 'Collection Environment' }),
+    addToCreateEnvButton: (popup: Locator, scopeType: 'environment' | 'global') =>
+      popup.getByTestId('var-info-add-to-no-env-note')
+        .filter({ hasText: scopeType === 'global' ? 'Global Environment' : 'Collection Environment' })
+        .getByTestId('var-info-add-to-create-env-button'),
+    addToCreateEnvNameInput: (popup: Locator) => popup.getByTestId('var-info-add-to-create-env-name-input'),
+    addToCreateEnvSubmit: (popup: Locator) => popup.getByTestId('var-info-add-to-create-env-submit'),
+    addToError: (popup: Locator) => popup.getByTestId('var-info-add-to-error')
   },
   auth: {
     apiKey: {

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -663,7 +663,7 @@ test.describe('Variable Tooltip', () => {
 
   test('should go to definition into Environment Settings, landing on Variables or Secrets depending on type(var or secret)', async ({ page, createTmpDir }) => {
     const collectionName = 'go-to-definition-env-test';
-    const { sidebar, request, varInfoPopup, environment } = buildCommonLocators(page);
+    const { sidebar, varInfoPopup, environment } = buildCommonLocators(page);
 
     await test.step('Setup collection, environment with a plain and a secret variable, and a request referencing both', async () => {
       await createCollection(page, collectionName, await createTmpDir('go-to-definition-env-collection'));
@@ -1034,7 +1034,7 @@ test.describe('Variable Tooltip', () => {
   test('should go to definition into Folder Settings for a folder variable, and Collection Settings for a collection variable', async ({ page, createTmpDir }) => {
     const collectionName = 'go-to-definition-folder-collection-test';
     const folderName = 'goToDefFolder';
-    const { sidebar, request, paneTabs, varInfoPopup, table } = buildCommonLocators(page);
+    const { sidebar, paneTabs, varInfoPopup, table } = buildCommonLocators(page);
 
     await test.step('Add a folder variable', async () => {
       await createCollection(page, collectionName, await createTmpDir('go-to-definition-folder-collection'));
@@ -1043,36 +1043,38 @@ test.describe('Variable Tooltip', () => {
       await sidebar.folder(folderName).dblclick();
       await paneTabs.folderSettingsTab('vars').click();
 
-      const tableContainer = page.getByTestId('folder-vars-req').first();
-      const lastRow = tableContainer.locator('tbody tr').last();
+      const folderVarsTable = table('folder-vars-req');
+      const lastRow = folderVarsTable.allRows().last();
       await lastRow.locator('input[type="text"]').first().click();
       await page.keyboard.type('goToFolderVar');
 
-      const namedRow = tableContainer.locator('tbody tr[data-row-name="goToFolderVar"]');
+      const namedRow = folderVarsTable.rowByName('goToFolderVar');
       await expect(namedRow).toBeVisible();
       const valueEditor = namedRow.locator('[data-testid="column-value"] .CodeMirror').first();
       await valueEditor.click({ force: true });
+      await expect(valueEditor).toHaveClass(/CodeMirror-focused/);
       await page.keyboard.type('folder-def-value');
 
-      await page.getByRole('button', { name: 'Save', exact: true }).first().click();
+      await page.getByTestId('folder-vars-panel').getByRole('button', { name: 'Save', exact: true }).click();
     });
 
     await test.step('Add a collection variable', async () => {
       await openCollectionSettings(page, collectionName);
       await selectCollectionPaneTab(page, 'vars');
 
-      const tableContainer = page.getByTestId('collection-vars-req').first();
-      const lastRow = tableContainer.locator('tbody tr').last();
+      const collectionVarsTable = table('collection-vars-req');
+      const lastRow = collectionVarsTable.allRows().last();
       await lastRow.locator('input[type="text"]').first().click();
       await page.keyboard.type('goToCollectionVar');
 
-      const namedRow = tableContainer.locator('tbody tr[data-row-name="goToCollectionVar"]');
+      const namedRow = collectionVarsTable.rowByName('goToCollectionVar');
       await expect(namedRow).toBeVisible();
       const valueEditor = namedRow.locator('[data-testid="column-value"] .CodeMirror').first();
       await valueEditor.click({ force: true });
+      await expect(valueEditor).toHaveClass(/CodeMirror-focused/);
       await page.keyboard.type('collection-def-value');
 
-      await page.getByRole('button', { name: 'Save', exact: true }).first().click();
+      await page.getByTestId('collection-vars-panel').getByRole('button', { name: 'Save', exact: true }).click();
     });
 
     await test.step('Create a request inside the folder referencing both variables', async () => {
@@ -1134,7 +1136,7 @@ test.describe('Variable Tooltip', () => {
       await environment.variablesTab().click();
       await expect(environment.varRow('stageOnlyVar')).toBeVisible();
       // Prod is still the active environment. Stage was only selected for viewing.
-      await expect(environment.settingsListItem('EnvProd').locator('.activated-checkmark')).toBeVisible();
+      await expect(environment.activatedCheckmark('EnvProd')).toBeVisible();
 
       await closeEnvironmentPanel(page);
     });

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -13,7 +13,10 @@ import {
   closeEnvironmentPanel,
   deleteAllGlobalEnvironments,
   setRequestUrlAndSave,
-  openUrlVarTooltip
+  openUrlVarTooltip,
+  openCollectionSettings,
+  selectCollectionPaneTab,
+  openEnvironmentConfigTab
 } from '../utils/page';
 import { buildCommonLocators } from '../utils/page/locators';
 import { SECRET_DATATYPE_CASES } from '../utils/constants';
@@ -281,6 +284,370 @@ test.describe('Variable Tooltip', () => {
       await expect(varValue).toBeVisible();
       const varValueContent = await varValue.locator('.CodeMirror-line').textContent();
       expect(varValueContent).toContain('secret-key-123');
+    });
+  });
+
+  test('should pre-select the guessed scope in the Add-to switcher for an undefined variable', async ({ page, createTmpDir }) => {
+    const collectionName = 'add-to-guessed-scope-test';
+    const { sidebar, request, varInfoPopup } = buildCommonLocators(page);
+
+    await test.step('Setup collection and request', async () => {
+      await createCollection(page, collectionName, await createTmpDir('add-to-guessed-scope-collection'));
+
+      await createRequest(page, 'Guessed Scope Request', collectionName);
+      await sidebar.request('Guessed Scope Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
+    });
+
+    await test.step('Type an undefined variable into the URL', async () => {
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('?key={{newApiKey}}');
+    });
+
+    await test.step('Hover the undefined variable and open the Add-to switcher', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'newApiKey', 'invalid');
+      await expect(varInfoPopup.name(tooltip)).toContainText('newApiKey');
+      // The header badge reflects the same guessed scope shown in the switcher below.
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Request');
+
+      await expect(varInfoPopup.addToSwitcher(tooltip)).toBeVisible();
+      await varInfoPopup.addToToggle(tooltip).click();
+    });
+
+    await test.step('Request is shown as the pre-selected (guessed) scope', async () => {
+      const tooltip = varInfoPopup.all().first();
+
+      // Request is the guessed scope and is pre-selected in the Add-to switcher.
+      const activeOption = varInfoPopup.addToActiveOption(tooltip);
+      await expect(activeOption).toHaveCount(1);
+      await expect(activeOption.getByTestId('var-info-add-to-option-request')).toBeVisible();
+
+      await expect(varInfoPopup.addToOption(tooltip, 'collection')).toBeVisible();
+    });
+  });
+
+  test('should repoint the scope badge on switch without saving, then save into the newly picked scope', async ({ page, createTmpDir }) => {
+    const collectionName = 'add-to-switch-scope-test';
+    const { sidebar, request, varInfoPopup } = buildCommonLocators(page);
+
+    await test.step('Setup collection and request', async () => {
+      await createCollection(page, collectionName, await createTmpDir('add-to-switch-scope-collection'));
+
+      await createRequest(page, 'Switch Scope Request', collectionName);
+      await sidebar.request('Switch Scope Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
+    });
+
+    await test.step('Type an undefined variable into the URL', async () => {
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('?key={{scopeSwitchVar}}');
+    });
+
+    await test.step('Switch the guessed scope from Request to Collection without entering a value', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'scopeSwitchVar', 'invalid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Request');
+
+      await varInfoPopup.addToToggle(tooltip).click();
+      await varInfoPopup.addToOption(tooltip, 'collection').click();
+
+      // The badge repoints immediately — this only decides where the next save writes to.
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Collection');
+
+      await page.locator('body').click();
+    });
+
+    await test.step('Re-hovering shows it is still undefined — the scope pick alone saved nothing', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'scopeSwitchVar', 'invalid');
+      // Guessed back to Request — proof the earlier Collection pick never persisted.
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Request');
+      await expect(varInfoPopup.addToSwitcher(tooltip)).toBeVisible();
+
+      await page.mouse.move(0, 0);
+    });
+
+    await test.step('Switching scope again and entering a value saves into the newly picked scope', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'scopeSwitchVar', 'invalid');
+      await varInfoPopup.addToToggle(tooltip).click();
+      await varInfoPopup.addToOption(tooltip, 'collection').click();
+
+      await varInfoPopup.editableValue(tooltip).click();
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
+      await page.keyboard.type('collection-value');
+      await page.locator('body').click();
+    });
+
+    await test.step('Variable now resolves as a Collection variable', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'scopeSwitchVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Collection');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('collection-value');
+
+      await page.mouse.move(0, 0);
+    });
+
+    await test.step('Confirm it lives in Collection Variables, not Request Variables', async () => {
+      await selectRequestPaneTab(page, 'Vars');
+      await expect(page.getByTestId('request-vars-req').locator('tbody tr[data-row-name="scopeSwitchVar"]')).toHaveCount(0);
+
+      await openCollectionSettings(page, collectionName);
+      await selectCollectionPaneTab(page, 'vars');
+      await expect(page.getByTestId('collection-vars-req').locator('tbody tr[data-row-name="scopeSwitchVar"]')).toBeVisible();
+    });
+  });
+
+  test('should offer Folder scope only when there is an immediate parent folder, and save into it', async ({ page, createTmpDir }) => {
+    const collectionName = 'add-to-folder-scope-test';
+    const folderName = 'parentFolder';
+    const { sidebar, request, paneTabs, varInfoPopup } = buildCommonLocators(page);
+
+    await test.step('Setup collection with a root-level request and a folder request', async () => {
+      await createCollection(page, collectionName, await createTmpDir('add-to-folder-scope-collection'));
+      await createFolder(page, folderName, collectionName);
+
+      await createRequest(page, 'Root Request', collectionName);
+      await sidebar.request('Root Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
+
+      await expandFolder(page, folderName);
+      await createRequest(page, 'Folder Request', folderName, { inFolder: true });
+      await sidebar.folderRequest(folderName, 'Folder Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
+    });
+
+    await test.step('Root-level request: Folder scope is not offered (no parent folder)', async () => {
+      await sidebar.request('Root Request').click();
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('?key={{rootVar}}');
+
+      const tooltip = await openUrlVarTooltip(page, 'rootVar', 'invalid');
+      await varInfoPopup.addToToggle(tooltip).click();
+      await expect(varInfoPopup.addToOption(tooltip, 'folder')).toHaveCount(0);
+
+      await page.mouse.move(0, 0);
+    });
+
+    await test.step('Request inside a folder: Folder scope is offered', async () => {
+      await sidebar.folderRequest(folderName, 'Folder Request').click();
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('?key={{folderVar}}');
+
+      const tooltip = await openUrlVarTooltip(page, 'folderVar', 'invalid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Request');
+
+      await varInfoPopup.addToToggle(tooltip).click();
+      const folderOption = varInfoPopup.addToOption(tooltip, 'folder');
+      await expect(folderOption).toBeVisible();
+      await folderOption.click();
+
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Folder');
+
+      await varInfoPopup.editableValue(tooltip).click();
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
+      await page.keyboard.type('folder-value');
+      await page.locator('body').click();
+    });
+
+    await test.step('Variable now resolves as a Folder variable', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'folderVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Folder');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('folder-value');
+
+      await page.mouse.move(0, 0);
+    });
+
+    await test.step('Confirm it lives in the folder\'s Variables, not the request\'s', async () => {
+      await selectRequestPaneTab(page, 'Vars');
+      await expect(page.getByTestId('request-vars-req').locator('tbody tr[data-row-name="folderVar"]')).toHaveCount(0);
+
+      await sidebar.folder(folderName).dblclick();
+      await paneTabs.folderSettingsTab('vars').click();
+      await expect(page.getByTestId('folder-vars-req').locator('tbody tr[data-row-name="folderVar"]')).toBeVisible();
+    });
+  });
+
+  test('should route to the Secrets tab when the Secret checkbox is checked, and to Variables when it is not', async ({ page, createTmpDir }) => {
+    const collectionName = 'add-to-secret-checkbox-test';
+    const { sidebar, request, varInfoPopup, environment } = buildCommonLocators(page);
+
+    await test.step('Setup collection, environment, and request', async () => {
+      await createCollection(page, collectionName, await createTmpDir('add-to-secret-checkbox-collection'));
+
+      await createEnvironment(page, 'Secret Checkbox Env', 'collection');
+      await saveEnvironment(page);
+      await closeEnvironmentPanel(page);
+
+      await createRequest(page, 'Secret Checkbox Request', collectionName);
+      await sidebar.request('Secret Checkbox Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
+    });
+
+    await test.step('Add-to Environment with the Secret checkbox left unchecked', async () => {
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('?a={{plainEnvVar}}');
+
+      const tooltip = await openUrlVarTooltip(page, 'plainEnvVar', 'invalid');
+      await varInfoPopup.addToToggle(tooltip).click();
+      await varInfoPopup.addToOption(tooltip, 'environment').click();
+
+      const secretCheckbox = varInfoPopup.addToSecretCheckbox(tooltip);
+      await expect(secretCheckbox).toBeVisible();
+      await expect(secretCheckbox).not.toBeChecked();
+
+      await varInfoPopup.editableValue(tooltip).click();
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
+      await page.keyboard.type('plain-value');
+      await page.locator('body').click();
+    });
+
+    await test.step('Confirm the plain variable finished saving before continuing', async () => {
+      // The save is async (dispatch -> file write -> watcher -> redux update); re-hovering
+      // and waiting for the saved value is a real synchronization point, not a fixed sleep.
+      const tooltip = await openUrlVarTooltip(page, 'plainEnvVar', 'valid');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('plain-value');
+      await page.mouse.move(0, 0);
+    });
+
+    await test.step('Add-to Environment with the Secret checkbox checked', async () => {
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('&b={{secretEnvVar}}');
+
+      const tooltip = await openUrlVarTooltip(page, 'secretEnvVar', 'invalid');
+      await varInfoPopup.addToToggle(tooltip).click();
+      await varInfoPopup.addToOption(tooltip, 'environment').click();
+
+      const secretCheckbox = varInfoPopup.addToSecretCheckbox(tooltip);
+      await expect(secretCheckbox).toBeVisible();
+      await secretCheckbox.check();
+
+      await varInfoPopup.editableValue(tooltip).click();
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
+      await page.keyboard.type('secret-value');
+      await page.locator('body').click();
+    });
+
+    await test.step('Plain variable is under Variables; secret variable is under Secrets', async () => {
+      await openEnvironmentConfigTab(page, 'collection');
+
+      await environment.variablesTab().click();
+      await expect(environment.varRow('plainEnvVar')).toBeVisible();
+      await expect(environment.varRow('secretEnvVar')).toHaveCount(0);
+
+      await environment.secretsTab().click();
+      await expect(environment.varRow('secretEnvVar')).toBeVisible();
+      await expect(environment.varRow('plainEnvVar')).toHaveCount(0);
+    });
+  });
+
+  test('should create an environment inline via "Create One" and save the variable into it immediately', async ({ page, createTmpDir }) => {
+    const collectionName = 'add-to-create-env-test';
+    const envName = 'Freshly Created Env';
+    const { sidebar, request, varInfoPopup, environment } = buildCommonLocators(page);
+
+    await test.step('Setup collection and request (no environment exists yet)', async () => {
+      await createCollection(page, collectionName, await createTmpDir('add-to-create-env-collection'));
+
+      await createRequest(page, 'Create Env Request', collectionName);
+      await sidebar.request('Create Env Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
+    });
+
+    await test.step('Type an undefined variable and enter its value', async () => {
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('?key={{freshEnvVar}}');
+
+      const tooltip = await openUrlVarTooltip(page, 'freshEnvVar', 'invalid');
+      await varInfoPopup.editableValue(tooltip).click();
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
+      await page.keyboard.type('fresh-value');
+    });
+
+    await test.step('Pick Environment scope, see "No Environment", and create one inline', async () => {
+      const tooltip = varInfoPopup.all().first();
+
+      await varInfoPopup.addToToggle(tooltip).click();
+      // Not enabled yet (no environment exists) — shown as an inline note, not a pickable option.
+      await expect(varInfoPopup.addToOption(tooltip, 'environment')).toHaveCount(0);
+      await expect(varInfoPopup.addToNoEnvNote(tooltip, 'environment')).toContainText('No Collection Environment selected.');
+
+      await varInfoPopup.addToCreateEnvButton(tooltip, 'environment').click();
+      await varInfoPopup.addToCreateEnvNameInput(tooltip).fill(envName);
+      await varInfoPopup.addToCreateEnvSubmit(tooltip).click();
+    });
+
+    await test.step('The variable is saved into the newly created environment immediately', async () => {
+      const tooltip = varInfoPopup.all().first();
+
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('fresh-value');
+      await expect(varInfoPopup.addToSwitcher(tooltip)).toHaveCount(0);
+
+      await page.locator('body').click();
+    });
+
+    await test.step('Environment now exists with this variable under Variables', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'freshEnvVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
+      await page.mouse.move(0, 0);
+
+      await openEnvironmentConfigTab(page, 'collection');
+      await expect(page.locator('.current-environment')).toContainText(envName);
+
+      await environment.variablesTab().click();
+      await expect(environment.varRow('freshEnvVar')).toBeVisible();
+    });
+  });
+
+  test('should go to definition into Environment Settings, landing on Variables or Secrets depending on type(var or secret)', async ({ page, createTmpDir }) => {
+    const collectionName = 'go-to-definition-env-test';
+    const { sidebar, request, varInfoPopup, environment } = buildCommonLocators(page);
+
+    await test.step('Setup collection, environment with a plain and a secret variable, and a request referencing both', async () => {
+      await createCollection(page, collectionName, await createTmpDir('go-to-definition-env-collection'));
+
+      await createEnvironment(page, 'GoToDef Env', 'collection');
+      await addEnvironmentVariables(page, [
+        { name: 'goToPlainVar', value: 'plain-val' },
+        { name: 'goToSecretVar', value: 'secret-val', isSecret: true }
+      ]);
+      await saveEnvironment(page);
+      await closeEnvironmentPanel(page);
+
+      await createRequest(page, 'GoToDef Request', collectionName);
+      await sidebar.request('GoToDef Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?a={{goToPlainVar}}&b={{goToSecretVar}}');
+    });
+
+    await test.step('Go to definition on the plain variable lands on the Variables sub-tab', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'goToPlainVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
+
+      await varInfoPopup.name(tooltip).click();
+
+      // The tooltip closes immediately once navigation happens.
+      await expect(varInfoPopup.all()).toHaveCount(0);
+
+      await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+      await expect(environment.variablesTab()).toHaveClass(/active/);
+      await expect(environment.varRow('goToPlainVar')).toBeVisible();
+    });
+
+    await test.step('Go to definition on the secret variable lands on the Secrets sub-tab', async () => {
+      await sidebar.request('GoToDef Request').click();
+
+      const tooltip = await openUrlVarTooltip(page, 'goToSecretVar', 'valid');
+      await varInfoPopup.name(tooltip).click();
+
+      await expect(varInfoPopup.all()).toHaveCount(0);
+
+      await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+      await expect(environment.secretsTab()).toHaveClass(/active/);
+      await expect(environment.varRow('goToSecretVar')).toBeVisible();
     });
   });
 
@@ -605,6 +972,218 @@ test.describe('Variable Tooltip', () => {
       expect(clipboardText.replace(/\r\n/g, '\n')).toBe(expectedJson);
     });
   });
+
+  test('should go to definition into Folder Settings for a folder variable, and Collection Settings for a collection variable', async ({ page, createTmpDir }) => {
+    const collectionName = 'go-to-definition-folder-collection-test';
+    const folderName = 'goToDefFolder';
+    const { sidebar, request, paneTabs, varInfoPopup } = buildCommonLocators(page);
+
+    await test.step('Add a folder variable', async () => {
+      await createCollection(page, collectionName, await createTmpDir('go-to-definition-folder-collection'));
+      await createFolder(page, folderName, collectionName);
+
+      await sidebar.folder(folderName).dblclick();
+      await paneTabs.folderSettingsTab('vars').click();
+
+      const tableContainer = page.getByTestId('folder-vars-req').first();
+      const lastRow = tableContainer.locator('tbody tr').last();
+      await lastRow.locator('input[type="text"]').first().click();
+      await page.keyboard.type('goToFolderVar');
+
+      const namedRow = tableContainer.locator('tbody tr[data-row-name="goToFolderVar"]');
+      await expect(namedRow).toBeVisible();
+      const valueEditor = namedRow.locator('[data-testid="column-value"] .CodeMirror').first();
+      await valueEditor.click({ force: true });
+      await page.keyboard.type('folder-def-value');
+
+      await page.getByRole('button', { name: 'Save', exact: true }).first().click();
+    });
+
+    await test.step('Add a collection variable', async () => {
+      await openCollectionSettings(page, collectionName);
+      await selectCollectionPaneTab(page, 'vars');
+
+      const tableContainer = page.getByTestId('collection-vars-req').first();
+      const lastRow = tableContainer.locator('tbody tr').last();
+      await lastRow.locator('input[type="text"]').first().click();
+      await page.keyboard.type('goToCollectionVar');
+
+      const namedRow = tableContainer.locator('tbody tr[data-row-name="goToCollectionVar"]');
+      await expect(namedRow).toBeVisible();
+      const valueEditor = namedRow.locator('[data-testid="column-value"] .CodeMirror').first();
+      await valueEditor.click({ force: true });
+      await page.keyboard.type('collection-def-value');
+
+      await page.getByRole('button', { name: 'Save', exact: true }).first().click();
+    });
+
+    await test.step('Create a request inside the folder referencing both variables', async () => {
+      await expandFolder(page, folderName);
+      await createRequest(page, 'GoToDef Folder Request', folderName, { inFolder: true });
+      await sidebar.folderRequest(folderName, 'GoToDef Folder Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?a={{goToFolderVar}}&b={{goToCollectionVar}}');
+    });
+
+    await test.step('Go to definition on the folder variable opens Folder Settings > Vars', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'goToFolderVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Folder');
+
+      await varInfoPopup.name(tooltip).click();
+
+      await expect(varInfoPopup.all()).toHaveCount(0);
+      await expect(paneTabs.folderSettingsTab('vars')).toHaveClass(/active/);
+      await expect(page.getByTestId('folder-vars-req').locator('tbody tr[data-row-name="goToFolderVar"]')).toBeVisible();
+    });
+
+    await test.step('Go to definition on the collection variable opens Collection Settings > Vars', async () => {
+      await sidebar.folderRequest(folderName, 'GoToDef Folder Request').click();
+
+      const tooltip = await openUrlVarTooltip(page, 'goToCollectionVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Collection');
+
+      await varInfoPopup.name(tooltip).click();
+
+      await expect(varInfoPopup.all()).toHaveCount(0);
+      await expect(paneTabs.collectionSettingsTab('vars')).toHaveClass(/active/);
+      await expect(page.getByTestId('collection-vars-req').locator('tbody tr[data-row-name="goToCollectionVar"]')).toBeVisible();
+    });
+  });
+
+  test('should go to definition into the environment the variable actually lives in, not a previously-browsed one, and reset the correct sub-tab', async ({ page, createTmpDir }) => {
+    const collectionName = 'go-to-definition-stale-env-test';
+    const { sidebar, varInfoPopup, environment } = buildCommonLocators(page);
+
+    await test.step('Create two environments — Stage (inactive) and Prod (active, with a plain and a secret var)', async () => {
+      await createCollection(page, collectionName, await createTmpDir('go-to-definition-stale-env-collection'));
+
+      // Created first, so it's briefly active, then superseded by prod below.
+      await createEnvironment(page, 'EnvStage', 'collection');
+      await addEnvironmentVariable(page, { name: 'stageOnlyVar', value: 'stage-value' });
+      await saveEnvironment(page);
+
+      // createEnvironment always selects the environment it just created, so prod becomes the active one.
+      await createEnvironment(page, 'EnvProd', 'collection');
+      await addEnvironmentVariables(page, [
+        { name: 'prodPlainVar', value: 'prod-plain-value' },
+        { name: 'prodSecretVar', value: 'prod-secret-value', isSecret: true }
+      ]);
+      await saveEnvironment(page);
+    });
+
+    await test.step('Manually browse to Stage in the settings sidebar (view only — does not activate it), then leave', async () => {
+      await environment.settingsListItem('EnvStage').click();
+      await expect(environment.varRow('stageOnlyVar')).toBeVisible();
+      // Prod is still the active environment. Stage was only selected for viewing.
+      await expect(environment.settingsListItem('EnvProd').locator('.activated-checkmark')).toBeVisible();
+
+      await closeEnvironmentPanel(page);
+    });
+
+    await test.step('Create a request referencing both Prod variables', async () => {
+      await createRequest(page, 'Stale Env Request', collectionName);
+      await sidebar.request('Stale Env Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?a={{prodPlainVar}}&b={{prodSecretVar}}');
+    });
+
+    await test.step('Go to definition on the secret variable lands on Prod (not the previously-browsed Stage) and the Secrets sub-tab', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'prodSecretVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
+
+      await varInfoPopup.name(tooltip).click();
+      await expect(varInfoPopup.all()).toHaveCount(0);
+
+      await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+      await expect(environment.secretsTab()).toHaveClass(/active/);
+      // Only visible if Prod (not the stale, previously-viewed Stage) is the environment on screen.
+      await expect(environment.varRow('prodSecretVar')).toBeVisible();
+    });
+
+    await test.step('Browse back to Stage again, then go to definition on the plain variable still lands on Prod and resets to the Variables sub-tab', async () => {
+      await environment.settingsListItem('EnvStage').click();
+      await expect(environment.varRow('stageOnlyVar')).toBeVisible();
+
+      await closeEnvironmentPanel(page);
+      await sidebar.request('Stale Env Request').click();
+
+      const tooltip = await openUrlVarTooltip(page, 'prodPlainVar', 'valid');
+      await varInfoPopup.name(tooltip).click();
+      await expect(varInfoPopup.all()).toHaveCount(0);
+
+      await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+      await expect(environment.variablesTab()).toHaveClass(/active/);
+      await expect(environment.varRow('prodPlainVar')).toBeVisible();
+    });
+  });
+
+  test('should not steal focus (and cancel an in-progress edit) when clicking the eye or copy icon', async ({ page, createTmpDir }) => {
+    const collectionName = 'icon-mousedown-test';
+    const { sidebar, varInfoPopup } = buildCommonLocators(page);
+
+    await test.step('Setup collection, environment secret variable, and request', async () => {
+      await createCollection(page, collectionName, await createTmpDir('icon-mousedown-collection'));
+
+      await createEnvironment(page, 'Icon Mousedown Env', 'collection');
+      await addEnvironmentVariable(page, { name: 'iconMousedownVar', value: 'original-secret', isSecret: true });
+      await saveEnvironment(page);
+      await closeEnvironmentPanel(page);
+
+      await createRequest(page, 'Icon Mousedown Request', collectionName);
+      await sidebar.request('Icon Mousedown Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?key={{iconMousedownVar}}');
+    });
+
+    await test.step('Clicking the eye icon mid-edit does not blur the editor', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'iconMousedownVar', 'valid');
+      await varInfoPopup.editableValue(tooltip).click();
+      const editor = varInfoPopup.editor(tooltip);
+      await expect(editor).toBeVisible();
+      await expect(editor).toHaveClass(/CodeMirror-focused/);
+
+      await page.keyboard.press('End');
+      await page.keyboard.type('-eye');
+
+      await varInfoPopup.secretToggle(tooltip).click();
+
+      await expect(editor).toBeVisible();
+      await expect(editor).toHaveClass(/CodeMirror-focused/);
+
+      // The click also revealed the real (unmasked) text
+      await expect(editor.locator('.CodeMirror-line')).toContainText('original-secret-eye');
+
+      await page.locator('body').click();
+    });
+
+    await test.step('The eye-icon interaction did not lose or corrupt the edit', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'iconMousedownVar', 'valid');
+      await varInfoPopup.secretToggle(tooltip).click();
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('original-secret-eye');
+      await page.mouse.move(0, 0);
+    });
+
+    await test.step('Clicking the copy icon mid-edit does not blur the editor', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'iconMousedownVar', 'valid');
+      await varInfoPopup.editableValue(tooltip).click();
+      const editor = varInfoPopup.editor(tooltip);
+      await expect(editor).toBeVisible();
+      await expect(editor).toHaveClass(/CodeMirror-focused/);
+
+      await page.keyboard.press('End');
+      await page.keyboard.type('-copy');
+
+      await varInfoPopup.copyButton(tooltip).click();
+
+      await expect(editor).toBeVisible();
+      await expect(editor).toHaveClass(/CodeMirror-focused/);
+
+      await page.locator('body').click();
+    });
+
+    await test.step('The copy-icon interaction did not lose or corrupt the edit', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'iconMousedownVar', 'valid');
+      await varInfoPopup.secretToggle(tooltip).click();
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('original-secret-eye-copy');
+    });
+  });
 });
 
 test.describe('Variable Tooltip - Global Secret Variables', () => {
@@ -670,4 +1249,37 @@ test.describe('Variable Tooltip - Global Secret Variables', () => {
       });
     });
   }
+
+  test('should go to definition into Global Environment Settings, landing on the Secrets sub-tab', async ({ page, createTmpDir }) => {
+    const collectionName = 'go-to-definition-global-secret-test';
+    const envName = 'GoToDef Global Env';
+    const { sidebar, varInfoPopup, environment } = buildCommonLocators(page);
+
+    await test.step('Create a global env with a secret variable, and a request referencing it', async () => {
+      await createCollection(page, collectionName, await createTmpDir('go-to-definition-global-secret-collection'));
+
+      await createEnvironment(page, envName, 'global');
+      await addEnvironmentVariable(page, { name: 'goToGlobalSecretVar', value: 'global-secret-value', isSecret: true });
+      await saveEnvironment(page);
+      await closeEnvironmentPanel(page);
+
+      await createRequest(page, 'GoToDef Global Request', collectionName);
+      await sidebar.request('GoToDef Global Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com?v={{goToGlobalSecretVar}}');
+    });
+
+    await test.step('Go to definition lands on Global Environment Settings > Secrets', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'goToGlobalSecretVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Global');
+
+      await varInfoPopup.name(tooltip).click();
+
+      // The tooltip closes immediately once navigation happens.
+      await expect(varInfoPopup.all()).toHaveCount(0);
+
+      await expect(page.locator('.request-tab').filter({ hasText: 'Global Environments' })).toBeVisible();
+      await expect(environment.secretsTab()).toHaveClass(/active/);
+      await expect(environment.varRow('goToGlobalSecretVar')).toBeVisible();
+    });
+  });
 });

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -330,7 +330,7 @@ test.describe('Variable Tooltip', () => {
 
   test('should repoint the scope badge on switch without saving, then save into the newly picked scope', async ({ page, createTmpDir }) => {
     const collectionName = 'add-to-switch-scope-test';
-    const { sidebar, request, varInfoPopup } = buildCommonLocators(page);
+    const { sidebar, request, varInfoPopup, table } = buildCommonLocators(page);
 
     await test.step('Setup collection and request', async () => {
       await createCollection(page, collectionName, await createTmpDir('add-to-switch-scope-collection'));
@@ -389,18 +389,18 @@ test.describe('Variable Tooltip', () => {
 
     await test.step('Confirm it lives in Collection Variables, not Request Variables', async () => {
       await selectRequestPaneTab(page, 'Vars');
-      await expect(page.getByTestId('request-vars-req').locator('tbody tr[data-row-name="scopeSwitchVar"]')).toHaveCount(0);
+      await expect(table('request-vars-req').rowByName('scopeSwitchVar')).toHaveCount(0);
 
       await openCollectionSettings(page, collectionName);
       await selectCollectionPaneTab(page, 'vars');
-      await expect(page.getByTestId('collection-vars-req').locator('tbody tr[data-row-name="scopeSwitchVar"]')).toBeVisible();
+      await expect(table('collection-vars-req').rowByName('scopeSwitchVar')).toBeVisible();
     });
   });
 
   test('should offer Folder scope only when there is an immediate parent folder, and save into it', async ({ page, createTmpDir }) => {
     const collectionName = 'add-to-folder-scope-test';
     const folderName = 'parentFolder';
-    const { sidebar, request, paneTabs, varInfoPopup } = buildCommonLocators(page);
+    const { sidebar, request, paneTabs, varInfoPopup, table } = buildCommonLocators(page);
 
     await test.step('Setup collection with a root-level request and a folder request', async () => {
       await createCollection(page, collectionName, await createTmpDir('add-to-folder-scope-collection'));
@@ -461,11 +461,11 @@ test.describe('Variable Tooltip', () => {
 
     await test.step('Confirm it lives in the folder\'s Variables, not the request\'s', async () => {
       await selectRequestPaneTab(page, 'Vars');
-      await expect(page.getByTestId('request-vars-req').locator('tbody tr[data-row-name="folderVar"]')).toHaveCount(0);
+      await expect(table('request-vars-req').rowByName('folderVar')).toHaveCount(0);
 
       await sidebar.folder(folderName).dblclick();
       await paneTabs.folderSettingsTab('vars').click();
-      await expect(page.getByTestId('folder-vars-req').locator('tbody tr[data-row-name="folderVar"]')).toBeVisible();
+      await expect(table('folder-vars-req').rowByName('folderVar')).toBeVisible();
     });
   });
 
@@ -597,10 +597,67 @@ test.describe('Variable Tooltip', () => {
       await page.mouse.move(0, 0);
 
       await openEnvironmentConfigTab(page, 'collection');
-      await expect(page.locator('.current-environment')).toContainText(envName);
+      await expect(environment.currentEnvironment()).toContainText(envName);
 
       await environment.variablesTab().click();
       await expect(environment.varRow('freshEnvVar')).toBeVisible();
+    });
+  });
+
+  test('should show an inline error when creating an environment inline fails, and allow retrying', async ({ page, createTmpDir }) => {
+    const collectionName = 'add-to-create-env-error-test';
+    const { sidebar, request, varInfoPopup } = buildCommonLocators(page);
+
+    await test.step('Setup collection and request (no environment exists yet)', async () => {
+      await createCollection(page, collectionName, await createTmpDir('add-to-create-env-error-collection'));
+
+      await createRequest(page, 'Create Env Error Request', collectionName);
+      await sidebar.request('Create Env Error Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
+    });
+
+    await test.step('Type an undefined variable and enter its value', async () => {
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('?key={{errEnvVar}}');
+
+      const tooltip = await openUrlVarTooltip(page, 'errEnvVar', 'invalid');
+      await varInfoPopup.editableValue(tooltip).click();
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
+      await page.keyboard.type('err-value');
+    });
+
+    await test.step('Submitting with an empty name shows an inline error and keeps the create form open', async () => {
+      const tooltip = varInfoPopup.all().first();
+
+      await varInfoPopup.addToToggle(tooltip).click();
+      await varInfoPopup.addToCreateEnvButton(tooltip, 'environment').click();
+      await varInfoPopup.addToCreateEnvSubmit(tooltip).click();
+
+      await expect(varInfoPopup.addToError(tooltip)).toContainText('Environment name is required');
+      // Nothing was dispatched and the form is still open, ready to retry.
+      await expect(varInfoPopup.addToCreateEnvNameInput(tooltip)).toBeVisible();
+    });
+
+    await test.step('Submitting a name with characters the main process would rewrite shows the failure and keeps the form open', async () => {
+      const tooltip = varInfoPopup.all().first();
+
+      await varInfoPopup.addToCreateEnvNameInput(tooltip).fill('Bad:Name');
+      await varInfoPopup.addToCreateEnvSubmit(tooltip).click();
+
+      await expect(varInfoPopup.addToError(tooltip)).toContainText('Special characters aren\'t allowed');
+      await expect(varInfoPopup.addToCreateEnvNameInput(tooltip)).toBeVisible();
+    });
+
+    await test.step('Fixing the name and resubmitting succeeds, saving the pending value', async () => {
+      const tooltip = varInfoPopup.all().first();
+
+      await varInfoPopup.addToCreateEnvNameInput(tooltip).fill('Recovered Env');
+      await varInfoPopup.addToCreateEnvSubmit(tooltip).click();
+
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('err-value');
+      await expect(varInfoPopup.addToSwitcher(tooltip)).toHaveCount(0);
     });
   });
 
@@ -633,7 +690,7 @@ test.describe('Variable Tooltip', () => {
       // The tooltip closes immediately once navigation happens.
       await expect(varInfoPopup.all()).toHaveCount(0);
 
-      await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+      await expect(environment.collectionEnvTab()).toBeVisible();
       await expect(environment.variablesTab()).toHaveClass(/active/);
       await expect(environment.varRow('goToPlainVar')).toBeVisible();
     });
@@ -646,7 +703,7 @@ test.describe('Variable Tooltip', () => {
 
       await expect(varInfoPopup.all()).toHaveCount(0);
 
-      await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+      await expect(environment.collectionEnvTab()).toBeVisible();
       await expect(environment.secretsTab()).toHaveClass(/active/);
       await expect(environment.varRow('goToSecretVar')).toBeVisible();
     });
@@ -864,7 +921,7 @@ test.describe('Variable Tooltip', () => {
         await environment.createEnvButton().click();
         await environment.envNameInput().fill(envName);
         await page.getByRole('button', { name: 'Create', exact: true }).click();
-        await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+        await expect(environment.collectionEnvTab()).toBeVisible();
 
         // `isSecret` routes the row to the Secrets tab; `dataType` sets its type.
         await addEnvironmentVariable(page, {
@@ -977,7 +1034,7 @@ test.describe('Variable Tooltip', () => {
   test('should go to definition into Folder Settings for a folder variable, and Collection Settings for a collection variable', async ({ page, createTmpDir }) => {
     const collectionName = 'go-to-definition-folder-collection-test';
     const folderName = 'goToDefFolder';
-    const { sidebar, request, paneTabs, varInfoPopup } = buildCommonLocators(page);
+    const { sidebar, request, paneTabs, varInfoPopup, table } = buildCommonLocators(page);
 
     await test.step('Add a folder variable', async () => {
       await createCollection(page, collectionName, await createTmpDir('go-to-definition-folder-collection'));
@@ -1033,7 +1090,7 @@ test.describe('Variable Tooltip', () => {
 
       await expect(varInfoPopup.all()).toHaveCount(0);
       await expect(paneTabs.folderSettingsTab('vars')).toHaveClass(/active/);
-      await expect(page.getByTestId('folder-vars-req').locator('tbody tr[data-row-name="goToFolderVar"]')).toBeVisible();
+      await expect(table('folder-vars-req').rowByName('goToFolderVar')).toBeVisible();
     });
 
     await test.step('Go to definition on the collection variable opens Collection Settings > Vars', async () => {
@@ -1046,7 +1103,7 @@ test.describe('Variable Tooltip', () => {
 
       await expect(varInfoPopup.all()).toHaveCount(0);
       await expect(paneTabs.collectionSettingsTab('vars')).toHaveClass(/active/);
-      await expect(page.getByTestId('collection-vars-req').locator('tbody tr[data-row-name="goToCollectionVar"]')).toBeVisible();
+      await expect(table('collection-vars-req').rowByName('goToCollectionVar')).toBeVisible();
     });
   });
 
@@ -1073,6 +1130,8 @@ test.describe('Variable Tooltip', () => {
 
     await test.step('Manually browse to Stage in the settings sidebar (view only — does not activate it), then leave', async () => {
       await environment.settingsListItem('EnvStage').click();
+
+      await environment.variablesTab().click();
       await expect(environment.varRow('stageOnlyVar')).toBeVisible();
       // Prod is still the active environment. Stage was only selected for viewing.
       await expect(environment.settingsListItem('EnvProd').locator('.activated-checkmark')).toBeVisible();
@@ -1093,7 +1152,7 @@ test.describe('Variable Tooltip', () => {
       await varInfoPopup.name(tooltip).click();
       await expect(varInfoPopup.all()).toHaveCount(0);
 
-      await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+      await expect(environment.collectionEnvTab()).toBeVisible();
       await expect(environment.secretsTab()).toHaveClass(/active/);
       // Only visible if Prod (not the stale, previously-viewed Stage) is the environment on screen.
       await expect(environment.varRow('prodSecretVar')).toBeVisible();
@@ -1101,6 +1160,8 @@ test.describe('Variable Tooltip', () => {
 
     await test.step('Browse back to Stage again, then go to definition on the plain variable still lands on Prod and resets to the Variables sub-tab', async () => {
       await environment.settingsListItem('EnvStage').click();
+
+      await environment.variablesTab().click();
       await expect(environment.varRow('stageOnlyVar')).toBeVisible();
 
       await closeEnvironmentPanel(page);
@@ -1110,7 +1171,7 @@ test.describe('Variable Tooltip', () => {
       await varInfoPopup.name(tooltip).click();
       await expect(varInfoPopup.all()).toHaveCount(0);
 
-      await expect(page.locator('.request-tab').filter({ hasText: 'Environments' })).toBeVisible();
+      await expect(environment.collectionEnvTab()).toBeVisible();
       await expect(environment.variablesTab()).toHaveClass(/active/);
       await expect(environment.varRow('prodPlainVar')).toBeVisible();
     });
@@ -1278,7 +1339,7 @@ test.describe('Variable Tooltip - Global Secret Variables', () => {
       // The tooltip closes immediately once navigation happens.
       await expect(varInfoPopup.all()).toHaveCount(0);
 
-      await expect(page.locator('.request-tab').filter({ hasText: 'Global Environments' })).toBeVisible();
+      await expect(environment.globalEnvTab()).toBeVisible();
       await expect(environment.secretsTab()).toHaveClass(/active/);
       await expect(environment.varRow('goToGlobalSecretVar')).toBeVisible();
     });
@@ -1287,7 +1348,7 @@ test.describe('Variable Tooltip - Global Secret Variables', () => {
   test('should go to definition on a global secret referenced from inside the Global Environment table itself, without closing other tabs', async ({ page, createTmpDir }) => {
     const collectionName = 'go-to-definition-global-secret-self-test';
     const envName = 'GoToDef Global Self Env';
-    const { sidebar, varInfoPopup, environment } = buildCommonLocators(page);
+    const { sidebar, varInfoPopup, environment, tabs } = buildCommonLocators(page);
 
     await test.step('Create a global env with a secret variable, and a plain variable referencing it', async () => {
       await createCollection(page, collectionName, await createTmpDir('go-to-definition-global-secret-self-collection'));
@@ -1318,8 +1379,8 @@ test.describe('Variable Tooltip - Global Secret Variables', () => {
     });
 
     await test.step('The same Global Environments tab is reused, no other tab was closed, and it lands on Secrets', async () => {
-      await expect(page.locator('.request-tab').filter({ hasText: 'Global Environments' })).toHaveCount(1);
-      await expect(page.locator('.request-tab').filter({ hasText: 'GoToDef Self Persist Request' })).toHaveCount(1);
+      await expect(environment.globalEnvTab()).toHaveCount(1);
+      await expect(tabs.requestTab('GoToDef Self Persist Request')).toHaveCount(1);
 
       await expect(environment.secretsTab()).toHaveClass(/active/);
       await expect(environment.varRow('goToGlobalSecretVar')).toBeVisible();

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -14,6 +14,7 @@ import {
   deleteAllGlobalEnvironments,
   setRequestUrlAndSave,
   openUrlVarTooltip,
+  openEnvValueVarTooltip,
   openCollectionSettings,
   selectCollectionPaneTab,
   openEnvironmentConfigTab
@@ -1278,6 +1279,48 @@ test.describe('Variable Tooltip - Global Secret Variables', () => {
       await expect(varInfoPopup.all()).toHaveCount(0);
 
       await expect(page.locator('.request-tab').filter({ hasText: 'Global Environments' })).toBeVisible();
+      await expect(environment.secretsTab()).toHaveClass(/active/);
+      await expect(environment.varRow('goToGlobalSecretVar')).toBeVisible();
+    });
+  });
+
+  test('should go to definition on a global secret referenced from inside the Global Environment table itself, without closing other tabs', async ({ page, createTmpDir }) => {
+    const collectionName = 'go-to-definition-global-secret-self-test';
+    const envName = 'GoToDef Global Self Env';
+    const { sidebar, varInfoPopup, environment } = buildCommonLocators(page);
+
+    await test.step('Create a global env with a secret variable, and a plain variable referencing it', async () => {
+      await createCollection(page, collectionName, await createTmpDir('go-to-definition-global-secret-self-collection'));
+
+      await createEnvironment(page, envName, 'global');
+      await addEnvironmentVariable(page, { name: 'goToGlobalSecretVar', value: 'global-secret-value', isSecret: true });
+      // Added last so the Variables tab (where this row lives) ends up active.
+      await addEnvironmentVariable(page, { name: 'goToGlobalRefVar', value: '{{goToGlobalSecretVar}}' });
+      await environment.saveAll().click();
+    });
+
+    await test.step('Open an unrelated request tab, then switch back to the Global Environment table', async () => {
+      await createRequest(page, 'GoToDef Self Persist Request', collectionName);
+      await sidebar.request('GoToDef Self Persist Request').click();
+
+      await environment.globalEnvTab().click();
+      await expect(environment.varRow('goToGlobalRefVar')).toBeVisible();
+    });
+
+    await test.step('Go to definition on the reference, from inside the table it targets', async () => {
+      const tooltip = await openEnvValueVarTooltip(page, 'goToGlobalRefVar', 'goToGlobalSecretVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Global');
+
+      await varInfoPopup.name(tooltip).click();
+
+      // The tooltip closes immediately once navigation happens.
+      await expect(varInfoPopup.all()).toHaveCount(0);
+    });
+
+    await test.step('The same Global Environments tab is reused, no other tab was closed, and it lands on Secrets', async () => {
+      await expect(page.locator('.request-tab').filter({ hasText: 'Global Environments' })).toHaveCount(1);
+      await expect(page.locator('.request-tab').filter({ hasText: 'GoToDef Self Persist Request' })).toHaveCount(1);
+
       await expect(environment.secretsTab()).toHaveClass(/active/);
       await expect(environment.varRow('goToGlobalSecretVar')).toBeVisible();
     });


### PR DESCRIPTION
### Description

Closes https://github.com/usebruno/bruno/issues/7382
Adopted from - https://github.com/usebruno/bruno/pull/8665

BRU-3763

- Add support for undefined variable addition to a Environment(Golbal/Collection), Request, Collection var, Parent Folder.
- Provide support for adding var as a secret.
- For defined variable user can click on var name and go to the defined scope.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Problem

When a user types an undefined variable placeholder like {{currency_id}} in the request editor, there is no way to create that variable in the correct scope without leaving the editor. Users must manually navigate to environment or collection settings to define the variable before it resolves. This breaks flow, especially for users migrating from Postman who expect inline variable creation.

<!-- What issue does this PR solve? Link the related issue if one exists. -->

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

- Extended `updateVariableInScope` in `providers/ReduxStore/slices/collections/actions.js` to support creating new variables in **Environment** and **Global** scopes.

- Added `getAvailableAddToScopes` in `utils/collections/index.js` to determine which scopes are currently available when adding a new variable:
  - **Request** — available when inside a request
  - **Collection** — always available
  - **Environment / Global** — available when an active environment exists
  - **Folder** — intentionally excluded for now

- Added `addToScopeSwitcher.js`, for scope selector with a toggle and dropdown. For Environment and Global scopes, it also provides a **Secret** checkbox and an inline **Create One** flow for creating a new Environment/Global Environment when active environment is not present without leaving the variable tooltip.

- Integrated the scope switcher into `brunoVarInfo.js`. The initially guessed scope is shown as the default badge. Changing the scope only changes where the variable will be saved next.

- Added secret handling: checking **Secret** immediately masks the variable value and shows the eye toggle, even before the variable is saved.

- Newly created variables are saved through an outside-click or immediately after creating the required scope.

- When a variable already has a definition, its **name itself becomes an underlined link**. Clicking it takes the user directly to the scope where that variable is defined.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="426" height="162" alt="image" src="https://github.com/user-attachments/assets/ed7644aa-77d3-4098-b122-5c2b55cb7e89" /> | <img width="446" height="389" alt="image" src="https://github.com/user-attachments/assets/4ca8a362-6ea1-45ac-a8b2-df8111180081" /> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
