### PR TITLE
feat: auto-save untitled request drafts

### DIFF
--- a/packages/bruno-app/src/components/SaveTransientRequest/index.js
+++ b/packages/bruno-app/src/components/SaveTransientRequest/index.js
@@ -201,15 +201,20 @@ const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOp
 
       const sanitizedFilename = sanitizeName(trimmedName);
 
-      const hasFileModeEdit = latestItem.draft?.raw != null && latestItem.draft.raw !== latestItem.raw;
+      let rawContent = null;
+      if (typeof latestItem.draft?.raw === 'string') {
+        rawContent = latestItem.draft.raw;
+      } else if (collection.fileMode && typeof latestItem.raw === 'string') {
+        rawContent = latestItem.raw;
+      }
       let baseItem;
-      if (hasFileModeEdit) {
+      if (rawContent !== null) {
         const rawSourceFormat = collection.format || DEFAULT_COLLECTION_FORMAT;
         try {
           const parsed = await ipcRenderer.invoke(
             'renderer:convert-to-json',
             latestItem,
-            latestItem.draft.raw,
+            rawContent,
             rawSourceFormat
           );
           baseItem = { ...latestItem, ...parsed, uid: latestItem.uid, pathname: latestItem.pathname };

--- a/packages/bruno-app/src/components/SaveTransientRequest/index.js
+++ b/packages/bruno-app/src/components/SaveTransientRequest/index.js
@@ -232,9 +232,8 @@ const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOp
       const targetFormat = targetCollection.format || DEFAULT_COLLECTION_FORMAT;
       const sourceFormat = collection.format || DEFAULT_COLLECTION_FORMAT;
       const targetFilename = resolveRequestFilename(sanitizedFilename, targetFormat);
-      const targetPathname = path.join(targetDirname, targetFilename);
 
-      await ipcRenderer.invoke('renderer:save-transient-request', {
+      const { newPathname } = await ipcRenderer.invoke('renderer:save-transient-request', {
         sourcePathname: item.pathname,
         targetDirname,
         targetFilename,
@@ -249,7 +248,7 @@ const SaveTransientRequest = ({ item: itemProp, collection: collectionProp, isOp
             uid: uuid(),
             type: 'OPEN_REQUEST',
             collectionUid: targetCollection.uid,
-            itemPathname: targetPathname,
+            itemPathname: newPathname,
             preview: false
           })
         );

--- a/packages/bruno-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
+++ b/packages/bruno-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
@@ -174,11 +174,9 @@ const SaveRequestsModal = ({ onClose, forceCloseTabs = false, tabUidsToClose = [
       if (transientRequestDrafts.length > 0) {
         await Promise.all(
           transientRequestDrafts.map((draft) =>
-            dispatch(saveRequest(draft.uid, draft.collectionUid, true)).catch(() => null)
+            dispatch(saveRequest(draft.uid, draft.collectionUid, true))
           )
         );
-        onClose();
-        return;
       }
 
       // Save environment drafts, skipping any with invalid variable names

--- a/packages/bruno-app/src/providers/App/ConfirmAppClose/index.js
+++ b/packages/bruno-app/src/providers/App/ConfirmAppClose/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import SaveRequestsModal from './SaveRequestsModal';
 import { isElectron } from 'utils/common/platform';
+import { persistTransientDraftsBeforeQuit } from 'providers/ReduxStore/slices/collections/actions';
 
 const ConfirmAppClose = () => {
   const { ipcRenderer } = window;
@@ -13,7 +14,12 @@ const ConfirmAppClose = () => {
       return;
     }
 
-    const clearListener = ipcRenderer.on('main:start-quit-flow', () => {
+    const clearListener = ipcRenderer.on('main:start-quit-flow', async () => {
+      try {
+        await dispatch(persistTransientDraftsBeforeQuit());
+      } catch (err) {
+        console.error('Failed to persist transient drafts before quit:', err);
+      }
       setShowConfirmClose(true);
     });
 

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/autosave/middleware.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/autosave/middleware.js
@@ -101,6 +101,7 @@ const actionsToIntercept = [
 
 // Simple object to track pending save timers
 const pendingTimers = {};
+const persistentTimerKeys = new Set();
 
 // Auto-save runs unattended, so a rejected save has nowhere to surface — the user would keep
 // editing believing their changes are on disk. A fixed toast id replaces the previous notice
@@ -109,14 +110,20 @@ const reportAutoSaveError = (err) =>
   toast.error(isEnvironmentValidationError(err) ? err.message : 'Auto-save failed', { id: 'autosave-error' });
 
 // Helper to schedule autosave for an item
-const scheduleAutoSave = (key, save, interval) => {
+const scheduleAutoSave = (key, save, interval, persistAlways = false) => {
   // Clear any existing timer for this entity
   clearTimeout(pendingTimers[key]);
+  if (persistAlways) {
+    persistentTimerKeys.add(key);
+  } else {
+    persistentTimerKeys.delete(key);
+  }
 
   // Schedule a new save
   pendingTimers[key] = setTimeout(() => {
     save();
     delete pendingTimers[key];
+    persistentTimerKeys.delete(key);
   }, interval);
 };
 
@@ -276,6 +283,9 @@ export const autosaveMiddleware = ({ dispatch, getState }) => (next) => (action)
 
   if (action.type === 'app/updatePreferences' && action.payload?.autoSave?.enabled === false) {
     Object.keys(pendingTimers).forEach((key) => {
+      if (persistentTimerKeys.has(key)) {
+        return;
+      }
       clearTimeout(pendingTimers[key]);
       delete pendingTimers[key];
     });
@@ -287,7 +297,7 @@ export const autosaveMiddleware = ({ dispatch, getState }) => (next) => (action)
 
   const handler = determineSaveHandler(action.type, action.payload, dispatch, getState);
   if (handler?.persistAlways) {
-    scheduleAutoSave(handler.key, handler.save, autoSave?.interval || 1000);
+    scheduleAutoSave(handler.key, handler.save, autoSave?.interval || 1000, true);
     return result;
   }
 

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/autosave/middleware.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/autosave/middleware.js
@@ -231,26 +231,23 @@ const determineSaveHandler = (actionType, payload, dispatch, getState) => {
 
   // Handle request actions
   if (itemUid) {
-    // Check if this is a transient request and skip auto-save
     const state = getState();
     const collection = findCollectionByUid(state.collections.collections, collectionUid);
-    if (collection) {
-      const item = findItemInCollection(collection, itemUid);
-      if (item && isItemTransientRequest(item)) {
-        return null; // Skip auto-save for transient requests
-      }
-    }
+    const item = collection ? findItemInCollection(collection, itemUid) : null;
+    const persistAlways = Boolean(item && isItemTransientRequest(item));
 
     if (actionType === 'collections/updateFileContent') {
       return {
         key: `file-${itemUid}`,
-        save: () => dispatch(saveFile(payload.content, itemUid, collectionUid, true))
+        save: () => dispatch(saveFile(payload.content, itemUid, collectionUid, true)),
+        persistAlways
       };
     }
 
     return {
       key: `request-${itemUid}`,
-      save: () => dispatch(saveRequest(itemUid, collectionUid, true))
+      save: () => dispatch(saveRequest(itemUid, collectionUid, true)),
+      persistAlways
     };
   }
 
@@ -269,9 +266,7 @@ export const autosaveMiddleware = ({ dispatch, getState }) => (next) => (action)
   // Let the action update the state first
   const result = next(action);
 
-  // Check if autosave is enabled
   const { autoSave } = getState().app.preferences;
-  if (!autoSave?.enabled) return result;
 
   // When autosave is enabled (or settings change), save any existing drafts
   if (action.type === 'app/updatePreferences' && action.payload?.autoSave?.enabled) {
@@ -291,6 +286,13 @@ export const autosaveMiddleware = ({ dispatch, getState }) => (next) => (action)
   if (!actionsToIntercept.includes(action.type)) return result;
 
   const handler = determineSaveHandler(action.type, action.payload, dispatch, getState);
+  if (handler?.persistAlways) {
+    scheduleAutoSave(handler.key, handler.save, autoSave?.interval || 1000);
+    return result;
+  }
+
+  if (!autoSave?.enabled) return result;
+
   if (handler) {
     scheduleAutoSave(handler.key, handler.save, autoSave.interval);
   }

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/autosave/middleware.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/autosave/middleware.spec.js
@@ -1,0 +1,82 @@
+const mockSaveRequest = jest.fn(() => ({ type: 'save-request' }));
+
+jest.mock('../../slices/collections/actions', () => ({
+  saveRequest: (...args) => mockSaveRequest(...args),
+  saveCollectionSettings: jest.fn(),
+  saveFolderRoot: jest.fn(),
+  saveFile: jest.fn(),
+  saveEnvironment: jest.fn()
+}));
+jest.mock('../../slices/global-environments', () => ({
+  saveGlobalEnvironment: jest.fn()
+}));
+jest.mock('utils/collections', () => ({
+  flattenItems: (items) => items,
+  isItemARequest: (item) => item?.type === 'http-request',
+  isItemAFolder: (item) => item?.type === 'folder',
+  findItemInCollection: (collection, itemUid) => collection.items.find((item) => item.uid === itemUid),
+  findCollectionByUid: (collections, collectionUid) => collections.find((collection) => collection.uid === collectionUid),
+  isItemTransientRequest: (item) => item?.isTransient === true
+}));
+jest.mock('utils/environments', () => ({
+  isEnvironmentValidationError: () => false
+}));
+jest.mock('react-hot-toast', () => ({
+  error: jest.fn()
+}));
+
+const { autosaveMiddleware } = require('./middleware');
+
+describe('autosaveMiddleware transient requests', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSaveRequest.mockClear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('keeps a pending transient save when autosave is disabled', () => {
+    const state = {
+      app: {
+        preferences: {
+          autoSave: {
+            enabled: true,
+            interval: 100
+          }
+        }
+      },
+      collections: {
+        collections: [
+          {
+            uid: 'collection-1',
+            items: [{ uid: 'request-1', type: 'http-request', isTransient: true }]
+          }
+        ]
+      }
+    };
+    const dispatch = jest.fn();
+    const next = jest.fn((action) => {
+      if (action.type === 'app/updatePreferences') {
+        state.app.preferences.autoSave.enabled = action.payload.autoSave.enabled;
+      }
+      return action;
+    });
+    const invoke = autosaveMiddleware({ dispatch, getState: () => state })(next);
+
+    invoke({
+      type: 'collections/requestUrlChanged',
+      payload: { itemUid: 'request-1', collectionUid: 'collection-1' }
+    });
+    invoke({
+      type: 'app/updatePreferences',
+      payload: { autoSave: { enabled: false } }
+    });
+    jest.advanceTimersByTime(100);
+
+    expect(mockSaveRequest).toHaveBeenCalledWith('request-1', 'collection-1', true);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'save-request' });
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.js
@@ -179,13 +179,14 @@ export const serializeSnapshot = async (state, options = {}) => {
   });
 
   (collections.collections || []).forEach((collection) => {
-    if (!collection.pathname || scratchCollectionUids.has(collection.uid)) {
+    if (!collection.pathname) {
       return;
     }
 
+    const isScratchCollection = scratchCollectionUids.has(collection.uid);
     const normalizedPath = normalizePath(collection.pathname);
 
-    if (activeWorkspace && !activeWorkspaceCollectionPaths.has(normalizedPath)) {
+    if (activeWorkspace && !isScratchCollection && !activeWorkspaceCollectionPaths.has(normalizedPath)) {
       return;
     }
 
@@ -198,14 +199,12 @@ export const serializeSnapshot = async (state, options = {}) => {
       serializedCollectionKeys.add(collectionSnapshotKey);
     }
 
-    const transientDirectory = collections.tempDirectories?.[collection.uid];
-
     const collectionTabs = (tabs.tabs || [])
-      .filter((t) => t.collectionUid === collection.uid && !shouldExcludeTab(t, transientDirectory))
+      .filter((t) => t.collectionUid === collection.uid && !shouldExcludeTab(t))
       .map((t) => serializeTab(t, collection));
 
     const activeTabInCollection = (tabs.tabs || []).find(
-      (t) => t.collectionUid === collection.uid && t.uid === tabs.activeTabUid && !shouldExcludeTab(t, transientDirectory)
+      (t) => t.collectionUid === collection.uid && t.uid === tabs.activeTabUid && !shouldExcludeTab(t)
     );
 
     const selectedEnvironment = (collection.environments || []).find((env) => env.uid === collection.activeEnvironmentUid);

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.js
@@ -186,8 +186,13 @@ export const serializeSnapshot = async (state, options = {}) => {
     const isScratchCollection = scratchCollectionUids.has(collection.uid);
     const normalizedPath = normalizePath(collection.pathname);
 
-    if (activeWorkspace && !isScratchCollection && !activeWorkspaceCollectionPaths.has(normalizedPath)) {
-      return;
+    if (activeWorkspace) {
+      if (isScratchCollection && collection.uid !== activeWorkspace.scratchCollectionUid) {
+        return;
+      }
+      if (!isScratchCollection && !activeWorkspaceCollectionPaths.has(normalizedPath)) {
+        return;
+      }
     }
 
     const workspacePathname = activeWorkspace?.pathname || '';

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.spec.js
@@ -126,6 +126,48 @@ describe('shouldPreserveCollectionEnvironmentInSnapshot', () => {
 });
 
 describe('serializeSnapshot workspace tab restoration', () => {
+  it('serializes only the active workspace scratch collection', async () => {
+    const state = makeState();
+    state.workspaces.workspaces = [
+      {
+        ...state.workspaces.workspaces[0],
+        scratchCollectionUid: 'scratch-1'
+      },
+      {
+        uid: 'ws-2',
+        pathname: '/tmp/workspace-2',
+        scratchCollectionUid: 'scratch-2',
+        collections: []
+      }
+    ];
+    state.collections.collections.push(
+      {
+        uid: 'scratch-1',
+        pathname: '/tmp/transient/scratch-1',
+        mountStatus: 'mounted',
+        environments: [],
+        activeEnvironmentUid: null,
+        items: []
+      },
+      {
+        uid: 'scratch-2',
+        pathname: '/tmp/transient/scratch-2',
+        mountStatus: 'mounted',
+        environments: [],
+        activeEnvironmentUid: null,
+        items: []
+      }
+    );
+
+    const snapshot = await serializeSnapshot(state, {
+      getExistingSnapshot: async () => null
+    });
+    const collectionPaths = snapshot.collections.map((collection) => collection.pathname);
+
+    expect(collectionPaths).toContain('/tmp/transient/scratch-1');
+    expect(collectionPaths).not.toContain('/tmp/transient/scratch-2');
+  });
+
   it('records the active workspace tab type when the scratch collection tab is focused', async () => {
     const scratchCollectionUid = 'scratch-1';
     const state = makeState();

--- a/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/middlewares/snapshot/serializeSnapshot.spec.js
@@ -1,4 +1,6 @@
 const { describe, it, expect } = require('@jest/globals');
+const os = require('node:os');
+const path = require('node:path');
 const {
   serializeSnapshot,
   shouldPreserveCollectionEnvironmentInSnapshot
@@ -127,6 +129,9 @@ describe('shouldPreserveCollectionEnvironmentInSnapshot', () => {
 
 describe('serializeSnapshot workspace tab restoration', () => {
   it('serializes only the active workspace scratch collection', async () => {
+    const inactiveWorkspacePath = path.join(os.tmpdir(), 'workspace-2');
+    const activeScratchPath = path.join(os.tmpdir(), 'transient', 'scratch-1');
+    const inactiveScratchPath = path.join(os.tmpdir(), 'transient', 'scratch-2');
     const state = makeState();
     state.workspaces.workspaces = [
       {
@@ -135,7 +140,7 @@ describe('serializeSnapshot workspace tab restoration', () => {
       },
       {
         uid: 'ws-2',
-        pathname: '/tmp/workspace-2',
+        pathname: inactiveWorkspacePath,
         scratchCollectionUid: 'scratch-2',
         collections: []
       }
@@ -143,7 +148,7 @@ describe('serializeSnapshot workspace tab restoration', () => {
     state.collections.collections.push(
       {
         uid: 'scratch-1',
-        pathname: '/tmp/transient/scratch-1',
+        pathname: activeScratchPath,
         mountStatus: 'mounted',
         environments: [],
         activeEnvironmentUid: null,
@@ -151,7 +156,7 @@ describe('serializeSnapshot workspace tab restoration', () => {
       },
       {
         uid: 'scratch-2',
-        pathname: '/tmp/transient/scratch-2',
+        pathname: inactiveScratchPath,
         mountStatus: 'mounted',
         environments: [],
         activeEnvironmentUid: null,
@@ -164,8 +169,8 @@ describe('serializeSnapshot workspace tab restoration', () => {
     });
     const collectionPaths = snapshot.collections.map((collection) => collection.pathname);
 
-    expect(collectionPaths).toContain('/tmp/transient/scratch-1');
-    expect(collectionPaths).not.toContain('/tmp/transient/scratch-2');
+    expect(collectionPaths).toContain(activeScratchPath);
+    expect(collectionPaths).not.toContain(inactiveScratchPath);
   });
 
   it('records the active workspace tab type when the scratch collection tab is focused', async () => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -289,7 +289,11 @@ export const persistTransientDraftsBeforeQuit = () => async (dispatch, getState)
   });
 
   try {
-    await Promise.all(saveOperations);
+    const results = await Promise.allSettled(saveOperations);
+    const rejected = results.find((result) => result.status === 'rejected');
+    if (rejected) {
+      throw rejected.reason;
+    }
   } finally {
     await flushSnapshotNow(getState);
   }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -24,7 +24,8 @@ import {
   getAllVariables,
   transformRequestToSaveToFilesystem,
   transformCollectionRootToSave,
-  flattenItems
+  flattenItems,
+  isItemTransientRequest
 } from 'utils/collections';
 import { uuid, waitForNextTick } from 'utils/common';
 import { cancelNetworkRequest, connectWS, sendGrpcRequest, sendNetworkRequest, sendWsRequest } from 'utils/network/index';
@@ -177,7 +178,7 @@ export const saveRequest = (itemUid, collectionUid, silent = false) => (dispatch
     }
 
     const isTransient = tempDirectory && item.pathname.startsWith(tempDirectory);
-    if (isTransient) {
+    if (isTransient && !silent) {
       dispatch(addSaveTransientRequestModal({ item, collection }));
       return reject();
     }
@@ -226,10 +227,8 @@ export const saveFile = (content, itemUid, collectionUid, silent = false) => asy
   }
 
   const isTransient = tempDirectory && item.pathname.startsWith(tempDirectory);
-  if (isTransient) {
-    if (!silent) {
-      dispatch(addSaveTransientRequestModal({ item, collection }));
-    }
+  if (isTransient && !silent) {
+    dispatch(addSaveTransientRequestModal({ item, collection }));
     throw new Error('Cannot save transient request');
   }
 
@@ -249,6 +248,14 @@ export const saveFile = (content, itemUid, collectionUid, silent = false) => asy
 
   try {
     await ipcRenderer.invoke('renderer:save-file', item.pathname, content);
+    if (isTransient && silent) {
+      dispatch(
+        _saveRequest({
+          itemUid,
+          collectionUid
+        })
+      );
+    }
     if (!silent) {
       toast.success('File saved successfully!');
     }
@@ -257,6 +264,34 @@ export const saveFile = (content, itemUid, collectionUid, silent = false) => asy
       toast.error('Failed to save file!');
     }
     throw err;
+  }
+};
+
+export const persistTransientDraftsBeforeQuit = () => async (dispatch, getState) => {
+  const state = getState();
+  const saveOperations = [];
+
+  state.collections.collections.forEach((collection) => {
+    flattenItems(collection.items || []).forEach((item) => {
+      if (!item.draft || !isItemTransientRequest(item)) {
+        return;
+      }
+
+      if (collection.fileMode && typeof item.draft.raw === 'string') {
+        saveOperations.push(dispatch(saveFile(item.draft.raw, item.uid, collection.uid, true)));
+        return;
+      }
+
+      if (isItemARequest(item)) {
+        saveOperations.push(dispatch(saveRequest(item.uid, collection.uid, true)));
+      }
+    });
+  });
+
+  try {
+    await Promise.all(saveOperations);
+  } finally {
+    await flushSnapshotNow(getState);
   }
 };
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -875,6 +875,9 @@ export const collectionsSlice = createSlice({
           if (item.draft.app) {
             item.app = item.draft.app;
           }
+          if (typeof item.draft.raw === 'string') {
+            item.raw = item.draft.raw;
+          }
           item.draft = null;
         }
       }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -680,6 +680,15 @@ export const switchWorkspace = (workspaceUid) => {
         }
       }
 
+      const activeScratchTab = scratchCollection
+        ? await getActiveTabFromSnapshot(
+            scratchCollection.pathname,
+            scratchCollection,
+            snapshotLookups,
+            workspace.pathname || null
+          )
+        : null;
+
       // Restore active collection from snapshot using lastActiveCollectionPathname
       const lastActiveCollectionPathname = workspaceSnapshot?.lastActiveCollectionPathname || null;
       const activeCollection = lastActiveCollectionPathname
@@ -710,9 +719,13 @@ export const switchWorkspace = (workspaceUid) => {
 
         if (activeTab) {
           dispatch(addTab(activeTab));
+        } else if (activeScratchTab && !requestedWorkspaceTabType) {
+          dispatch(addTab(activeScratchTab));
         } else if (scratchCollection?.uid && !requestedWorkspaceTabType) {
           dispatch(addTab({ uid: `${scratchCollection.uid}-overview`, collectionUid: scratchCollection.uid, type: 'workspaceOverview' }));
         }
+      } else if (activeScratchTab && !requestedWorkspaceTabType) {
+        dispatch(addTab(activeScratchTab));
       } else if (scratchCollection?.uid && !requestedWorkspaceTabType) {
         // No active collection, focus the workspace overview tab
         dispatch(addTab({ uid: `${scratchCollection.uid}-overview`, collectionUid: scratchCollection.uid, type: 'workspaceOverview' }));
@@ -1472,6 +1485,19 @@ export const mountScratchCollection = (workspaceUid) => {
       }
 
       await dispatch(openScratchCollectionEvent(scratchCollectionUid, tempDirectoryPath, brunoConfig));
+
+      const scratchCollection = getState().collections.collections.find(
+        (collection) => collection.uid === scratchCollectionUid
+      );
+      if (scratchCollection) {
+        await hydrateTabs(
+          [scratchCollection],
+          dispatch,
+          restoreTabs,
+          null,
+          workspace.pathname || null
+        );
+      }
 
       dispatch(setWorkspaceScratchCollection({
         workspaceUid,

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -98,9 +98,8 @@ const sanitizeSnapshotTabs = (tabsSnapshot) => {
   };
 };
 
-export const shouldExcludeTab = (tab, transientDirectory) => {
-  return IGNORED_TAB_TYPES.has(tab?.type)
-    || (transientDirectory && tab.pathname?.startsWith(transientDirectory));
+export const shouldExcludeTab = (tab) => {
+  return IGNORED_TAB_TYPES.has(tab?.type);
 };
 
 const normalizeSnapshotPathRef = (value) => {

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -988,7 +988,7 @@ class CollectionWatcher {
     };
 
     const watcher = chokidar.watch(tempDirectoryPath, {
-      ignoreInitial: true, // Don't process existing files
+      ignoreInitial: false,
       usePolling: isWSLPath(tempDirectoryPath) ? true : false,
       ignored,
       persistent: true,

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -83,6 +83,10 @@ const { cancelOAuth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress
 const { findUniqueFolderName } = require('../utils/collection-import');
 const { saveSpecAndUpdateMetadata, cleanupSpecFilesForCollection } = require('./openapi-sync');
 const {
+  ensureCollectionTransientDirectory,
+  ensureScratchTransientDirectory
+} = require('../utils/transient-directory');
+const {
   validateWorkspacePath,
   normalizeCollectionEntry,
   addCollectionToWorkspace,
@@ -105,11 +109,6 @@ const getTransientDirectoryBase = () => {
 // Get the prefix used for transient collection directories
 const getTransientCollectionPrefix = () => {
   return path.join(getTransientDirectoryBase(), 'bruno-');
-};
-
-// Get the prefix used for scratch collection directories
-const getTransientScratchPrefix = () => {
-  return path.join(getTransientDirectoryBase(), 'bruno-scratch-');
 };
 
 // Check if a path is within the transient directory
@@ -602,12 +601,23 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
       const filename = targetFilename || path.basename(sourcePathname);
       const filenameWithoutExt = filename.replace(/\.(bru|yml)$/, '');
-      const finalFilename = `${filenameWithoutExt}.${targetFormat}`;
-      const targetPathname = path.join(targetDirname, finalFilename);
+      let finalBaseName = filenameWithoutExt;
+      let finalFilename = `${finalBaseName}.${targetFormat}`;
+      let targetPathname = path.join(targetDirname, finalFilename);
+      let counter = 1;
 
-      if (fs.existsSync(targetPathname)) {
-        throw new Error(`A file with the name "${finalFilename}" already exists in the target location`);
+      while (fs.existsSync(targetPathname)) {
+        finalBaseName = `${filenameWithoutExt} (${counter})`;
+        finalFilename = `${finalBaseName}.${targetFormat}`;
+        targetPathname = path.join(targetDirname, finalFilename);
+        counter += 1;
       }
+
+      const requestToSave = {
+        ...request,
+        name: finalBaseName,
+        filename: finalFilename
+      };
 
       const actualSourceFormat = sourceFormat || 'yml';
       const needsConversion = actualSourceFormat !== targetFormat;
@@ -617,16 +627,20 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         const { parseRequest, stringifyRequest } = require('@usebruno/filestore');
         const sourceContent = await fs.promises.readFile(sourcePathname, 'utf8');
         const parsedRequest = parseRequest(sourceContent, { format: actualSourceFormat });
-        const mergedRequest = { ...parsedRequest, ...request };
+        const mergedRequest = { ...parsedRequest, ...requestToSave };
         syncExampleUidsCache(sourcePathname, mergedRequest.examples);
         finalContent = stringifyRequest(mergedRequest, { format: targetFormat });
       } else {
-        syncExampleUidsCache(sourcePathname, request.examples);
-        finalContent = await stringifyRequestViaWorker(request, { format: targetFormat });
+        syncExampleUidsCache(sourcePathname, requestToSave.examples);
+        finalContent = await stringifyRequestViaWorker(requestToSave, { format: targetFormat });
       }
 
       await writeFile(targetPathname, finalContent);
-      return { newPathname: targetPathname };
+      return {
+        newPathname: targetPathname,
+        name: finalBaseName,
+        filename: finalFilename
+      };
     } catch (error) {
       return Promise.reject(error);
     }
@@ -2269,16 +2283,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
   ipcMain.handle('renderer:mount-collection', async (event, { collectionUid, collectionPathname, brunoConfig, workspacePathname }) => {
     let tempDirectoryPath = null;
     try {
-      // Ensure the transient base directory exists
-      const transientBase = getTransientDirectoryBase();
-      if (!fs.existsSync(transientBase)) {
-        fs.mkdirSync(transientBase, { recursive: true });
-      }
-      tempDirectoryPath = fs.mkdtempSync(getTransientCollectionPrefix());
-      const metadata = {
-        collectionPath: collectionPathname
-      };
-      fs.writeFileSync(path.join(tempDirectoryPath, 'metadata.json'), JSON.stringify(metadata));
+      tempDirectoryPath = ensureCollectionTransientDirectory(collectionPathname);
     } catch (error) {
       throw error;
     }
@@ -2303,12 +2308,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
   ipcMain.handle('renderer:mount-workspace-scratch', async (event, { workspaceUid, workspacePath }) => {
     try {
-      // Ensure the transient base directory exists
-      const transientBase = getTransientDirectoryBase();
-      if (!fs.existsSync(transientBase)) {
-        fs.mkdirSync(transientBase, { recursive: true });
-      }
-      const tempDirectoryPath = fs.mkdtempSync(getTransientScratchPrefix());
+      const tempDirectoryPath = ensureScratchTransientDirectory({ workspaceUid, workspacePath });
       registerScratchCollectionPath(tempDirectoryPath);
 
       const collectionRoot = {
@@ -2326,13 +2326,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
       const content = stringifyCollection(collectionRoot, brunoConfig, { format: 'yml' });
       await writeFile(path.join(tempDirectoryPath, 'opencollection.yml'), content);
-
-      const metadata = {
-        workspaceUid,
-        workspacePath,
-        type: 'scratch'
-      };
-      fs.writeFileSync(path.join(tempDirectoryPath, 'metadata.json'), JSON.stringify(metadata));
 
       return tempDirectoryPath;
     } catch (error) {

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -86,6 +86,7 @@ const {
   ensureCollectionTransientDirectory,
   ensureScratchTransientDirectory
 } = require('../utils/transient-directory');
+const { writeFileWithSuffix } = require('../utils/write-file-with-suffix');
 const {
   validateWorkspacePath,
   normalizeCollectionEntry,
@@ -601,45 +602,39 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
       const filename = targetFilename || path.basename(sourcePathname);
       const filenameWithoutExt = filename.replace(/\.(bru|yml)$/, '');
-      let finalBaseName = filenameWithoutExt;
-      let finalFilename = `${finalBaseName}.${targetFormat}`;
-      let targetPathname = path.join(targetDirname, finalFilename);
-      let counter = 1;
-
-      while (fs.existsSync(targetPathname)) {
-        finalBaseName = `${filenameWithoutExt} (${counter})`;
-        finalFilename = `${finalBaseName}.${targetFormat}`;
-        targetPathname = path.join(targetDirname, finalFilename);
-        counter += 1;
-      }
-
-      const requestToSave = {
-        ...request,
-        name: finalBaseName,
-        filename: finalFilename
-      };
-
       const actualSourceFormat = sourceFormat || 'yml';
       const needsConversion = actualSourceFormat !== targetFormat;
+      let savedRequest;
 
-      let finalContent;
-      if (needsConversion) {
-        const { parseRequest, stringifyRequest } = require('@usebruno/filestore');
-        const sourceContent = await fs.promises.readFile(sourcePathname, 'utf8');
-        const parsedRequest = parseRequest(sourceContent, { format: actualSourceFormat });
-        const mergedRequest = { ...parsedRequest, ...requestToSave };
-        syncExampleUidsCache(sourcePathname, mergedRequest.examples);
-        finalContent = stringifyRequest(mergedRequest, { format: targetFormat });
-      } else {
-        syncExampleUidsCache(sourcePathname, requestToSave.examples);
-        finalContent = await stringifyRequestViaWorker(requestToSave, { format: targetFormat });
-      }
+      const result = await writeFileWithSuffix({
+        dirname: targetDirname,
+        basename: filenameWithoutExt,
+        extension: targetFormat,
+        createContent: async ({ name, filename }) => {
+          const requestToSave = {
+            ...request,
+            name,
+            filename
+          };
 
-      await writeFile(targetPathname, finalContent);
+          if (needsConversion) {
+            const { parseRequest, stringifyRequest } = require('@usebruno/filestore');
+            const sourceContent = await fs.promises.readFile(sourcePathname, 'utf8');
+            const parsedRequest = parseRequest(sourceContent, { format: actualSourceFormat });
+            savedRequest = { ...parsedRequest, ...requestToSave };
+            return stringifyRequest(savedRequest, { format: targetFormat });
+          }
+
+          savedRequest = requestToSave;
+          return stringifyRequestViaWorker(requestToSave, { format: targetFormat });
+        }
+      });
+
+      syncExampleUidsCache(result.pathname, savedRequest.examples);
       return {
-        newPathname: targetPathname,
-        name: finalBaseName,
-        filename: finalFilename
+        newPathname: result.pathname,
+        name: result.name,
+        filename: result.filename
       };
     } catch (error) {
       return Promise.reject(error);

--- a/packages/bruno-electron/src/services/mount/manager.js
+++ b/packages/bruno-electron/src/services/mount/manager.js
@@ -4,6 +4,7 @@ const { JobType, getPool, destroyPool } = require('../pool');
 const { FileIndex } = require('./file-index');
 const { buildTree } = require('./tree-builder');
 const { defaultClassify, uidForSeed } = require('../../utils/mount');
+const { ensureCollectionTransientDirectory } = require('../../utils/transient-directory');
 
 // cold start only — collection-watcher handles live changes and writes through to the cache
 
@@ -59,12 +60,6 @@ const sendTree = async (collectionUid, collectionPath, tree, emit) => {
   emit.tree(tree);
 };
 
-const ensureTransientDirectory = () => {
-  const base = path.join(require('electron').app.getPath('userData'), 'tmp', 'transient');
-  if (!fs.existsSync(base)) fs.mkdirSync(base, { recursive: true });
-  return fs.mkdtempSync(path.join(base, 'bruno-'));
-};
-
 class MountManager {
   #index = null;
   #mounts = new Map();
@@ -83,8 +78,7 @@ class MountManager {
       return existing.tempDirectoryPath;
     }
 
-    const tempDirectoryPath = ensureTransientDirectory();
-    fs.writeFileSync(path.join(tempDirectoryPath, 'metadata.json'), JSON.stringify({ collectionPath }));
+    const tempDirectoryPath = ensureCollectionTransientDirectory(collectionPath);
 
     const entry = {
       state: new Map(),

--- a/packages/bruno-electron/src/utils/transient-directory.js
+++ b/packages/bruno-electron/src/utils/transient-directory.js
@@ -1,0 +1,48 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { app } = require('electron');
+
+const getTransientDirectoryBase = () => {
+  return path.join(app.getPath('userData'), 'tmp', 'transient');
+};
+
+const hashIdentity = (identity) => {
+  return crypto.createHash('sha256').update(identity).digest('hex').slice(0, 16);
+};
+
+const ensureDirectory = (dirname, metadata) => {
+  fs.mkdirSync(dirname, { recursive: true });
+  fs.writeFileSync(path.join(dirname, 'metadata.json'), JSON.stringify(metadata));
+  return dirname;
+};
+
+const ensureCollectionTransientDirectory = (collectionPath) => {
+  const resolvedCollectionPath = path.resolve(collectionPath);
+  const dirname = path.join(
+    getTransientDirectoryBase(),
+    `bruno-${hashIdentity(resolvedCollectionPath)}`
+  );
+
+  return ensureDirectory(dirname, { collectionPath: resolvedCollectionPath });
+};
+
+const ensureScratchTransientDirectory = ({ workspaceUid, workspacePath }) => {
+  const identity = workspacePath || workspaceUid;
+  const dirname = path.join(
+    getTransientDirectoryBase(),
+    `bruno-scratch-${hashIdentity(identity)}`
+  );
+
+  return ensureDirectory(dirname, {
+    workspaceUid,
+    workspacePath,
+    type: 'scratch'
+  });
+};
+
+module.exports = {
+  ensureCollectionTransientDirectory,
+  ensureScratchTransientDirectory,
+  getTransientDirectoryBase
+};

--- a/packages/bruno-electron/src/utils/write-file-with-suffix.js
+++ b/packages/bruno-electron/src/utils/write-file-with-suffix.js
@@ -1,13 +1,35 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
+const validatePathSegment = (value, label) => {
+  const isInvalid = typeof value !== 'string'
+    || !value
+    || value === '.'
+    || value === '..'
+    || path.posix.isAbsolute(value)
+    || path.win32.isAbsolute(value)
+    || path.posix.basename(value) !== value
+    || path.win32.basename(value) !== value;
+
+  if (isInvalid) {
+    throw new Error(`Invalid ${label}`);
+  }
+};
+
 const writeFileWithSuffix = async ({ dirname, basename, extension, createContent }) => {
+  validatePathSegment(basename, 'basename');
+  validatePathSegment(extension, 'extension');
+
   let counter = 0;
 
   while (true) {
     const name = counter === 0 ? basename : `${basename} (${counter})`;
     const filename = `${name}.${extension}`;
     const pathname = path.join(dirname, filename);
+    const relativePathname = path.relative(path.resolve(dirname), path.resolve(pathname));
+    if (relativePathname === '..' || relativePathname.startsWith(`..${path.sep}`) || path.isAbsolute(relativePathname)) {
+      throw new Error('Generated pathname must remain inside dirname');
+    }
     const content = await createContent({ name, filename, pathname });
 
     try {

--- a/packages/bruno-electron/src/utils/write-file-with-suffix.js
+++ b/packages/bruno-electron/src/utils/write-file-with-suffix.js
@@ -1,0 +1,27 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const writeFileWithSuffix = async ({ dirname, basename, extension, createContent }) => {
+  let counter = 0;
+
+  while (true) {
+    const name = counter === 0 ? basename : `${basename} (${counter})`;
+    const filename = `${name}.${extension}`;
+    const pathname = path.join(dirname, filename);
+    const content = await createContent({ name, filename, pathname });
+
+    try {
+      await fs.promises.writeFile(pathname, content, { encoding: 'utf8', flag: 'wx' });
+      return { pathname, name, filename };
+    } catch (err) {
+      if (err.code !== 'EEXIST') {
+        throw err;
+      }
+      counter += 1;
+    }
+  }
+};
+
+module.exports = {
+  writeFileWithSuffix
+};

--- a/packages/bruno-electron/src/utils/write-file-with-suffix.spec.js
+++ b/packages/bruno-electron/src/utils/write-file-with-suffix.spec.js
@@ -1,0 +1,32 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { writeFileWithSuffix } = require('./write-file-with-suffix');
+
+describe('writeFileWithSuffix', () => {
+  let dirname;
+
+  beforeEach(async () => {
+    dirname = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bruno-suffix-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(dirname, { recursive: true, force: true });
+  });
+
+  it('creates distinct files when saves with the same name run concurrently', async () => {
+    const save = (content) => writeFileWithSuffix({
+      dirname,
+      basename: 'Login',
+      extension: 'bru',
+      createContent: async () => content
+    });
+
+    const results = await Promise.all([save('first'), save('second')]);
+    const filenames = results.map((result) => result.filename).sort();
+    const contents = await Promise.all(results.map((result) => fs.promises.readFile(result.pathname, 'utf8')));
+
+    expect(filenames).toEqual(['Login (1).bru', 'Login.bru']);
+    expect(contents.sort()).toEqual(['first', 'second']);
+  });
+});

--- a/packages/bruno-electron/src/utils/write-file-with-suffix.spec.js
+++ b/packages/bruno-electron/src/utils/write-file-with-suffix.spec.js
@@ -29,4 +29,24 @@ describe('writeFileWithSuffix', () => {
     expect(filenames).toEqual(['Login (1).bru', 'Login.bru']);
     expect(contents.sort()).toEqual(['first', 'second']);
   });
+
+  it.each([
+    ['basename', '../Login', 'bru'],
+    ['basename', '..\\Login', 'bru'],
+    ['basename', '/tmp/Login', 'bru'],
+    ['extension', 'Login', '../bru'],
+    ['extension', 'Login', '..\\bru']
+  ])('rejects an unsafe %s before creating content', async (label, basename, extension) => {
+    const createContent = jest.fn(async () => {
+      throw new Error('createContent should not run');
+    });
+
+    await expect(writeFileWithSuffix({
+      dirname,
+      basename,
+      extension,
+      createContent
+    })).rejects.toThrow(`Invalid ${label}`);
+    expect(createContent).not.toHaveBeenCalled();
+  });
 });

--- a/tests/snapshots/basic.spec.ts
+++ b/tests/snapshots/basic.spec.ts
@@ -4,8 +4,11 @@ import { test, expect, closeElectronApp, type Page } from '../../playwright';
 import {
   createCollection,
   createRequest,
+  createTransientRequest,
+  fillRequestUrl,
   openRequest,
   openCollection,
+  saveTransientViaModal,
   switchWorkspace,
   selectRequestPaneTab,
   waitForReadyPage
@@ -61,6 +64,63 @@ const expectSnapshotWorkspaceSortings = async (userDataPath: string, expectedSor
 // ─── Tab Persistence ────────────────────────────────────────────────────────
 
 test.describe('Snapshot: Tab Persistence', () => {
+  test('untitled request drafts are restored after app restart', async ({ launchElectronApp, createTmpDir }) => {
+    const userDataPath = await createTmpDir('untitled-draft-persistence');
+    const colPath = await createTmpDir('untitled-draft-collection');
+    const requestUrl = 'https://example.com/draft';
+
+    const app = await launchElectronApp({ userDataPath });
+    const page = await waitForReadyPage(app);
+    const locators = buildCommonLocators(page);
+
+    await createCollection(page, 'DraftCollection', colPath);
+    await locators.sidebar.collection('DraftCollection').click();
+    await createTransientRequest(page, { requestType: 'HTTP' });
+    await fillRequestUrl(page, requestUrl);
+
+    await expect(locators.tabs.activeRequestTab()).toContainText('Untitled 1');
+    await expect(locators.tabs.draftIndicator()).not.toBeVisible({ timeout: 5000 });
+
+    await closeElectronApp(app);
+
+    const restartedApp = await launchElectronApp({ userDataPath });
+    const restartedPage = await waitForReadyPage(restartedApp);
+    const restartedLocators = buildCommonLocators(restartedPage);
+
+    await expect(restartedLocators.tabs.requestTab('Untitled 1')).toBeVisible({ timeout: 15000 });
+    await restartedLocators.tabs.requestTab('Untitled 1').click();
+    await expect(restartedLocators.request.urlLine()).toContainText(requestUrl);
+
+    await closeElectronApp(restartedApp);
+  });
+
+  test('saving an untitled draft adds a numeric suffix on name collision', async ({ launchElectronApp, createTmpDir }) => {
+    const userDataPath = await createTmpDir('untitled-draft-name-collision');
+    const colPath = await createTmpDir('untitled-draft-collision-collection');
+    const app = await launchElectronApp({ userDataPath });
+    const page = await waitForReadyPage(app);
+    const locators = buildCommonLocators(page);
+    const saveShortcut = process.platform === 'darwin' ? 'Meta+s' : 'Control+s';
+
+    await createCollection(page, 'CollisionCollection', colPath);
+    await createRequest(page, 'Login', 'CollisionCollection', {
+      url: 'https://example.com/login',
+      method: 'GET'
+    });
+    await locators.sidebar.collection('CollisionCollection').click();
+    await createTransientRequest(page, { requestType: 'HTTP' });
+    await fillRequestUrl(page, 'https://example.com/draft-login');
+
+    await page.keyboard.press(saveShortcut);
+    await saveTransientViaModal(page, 'Login');
+
+    await expect(locators.sidebar.request('Login (1)')).toBeVisible({ timeout: 10000 });
+    await openRequest(page, 'CollisionCollection', 'Login (1)');
+    await expect(locators.request.urlLine()).toContainText('https://example.com/draft-login');
+
+    await closeElectronApp(app);
+  });
+
   test('open tabs are restored after app restart in the same order', async ({ launchElectronApp, createTmpDir }) => {
     const userDataPath = await createTmpDir('snap-tabs-order');
     const colPath = await createTmpDir('col');


### PR DESCRIPTION
### Description

Auto-saves new Untitled request drafts to stable application-managed transient storage and restores their tabs after Bruno restarts. Saving a draft whose requested name already exists now selects the next numeric suffix.

### Problem

Closing Bruno with unsaved Untitled requests currently prompts the user and the drafts are not restored on the next launch.

Fixes #8849

### Fix

- Use deterministic transient directories for collections and workspace scratch collections.
- Persist transient request edits regardless of the global auto-save preference and flush them before quit.
- Include transient and scratch request tabs in UI snapshots and hydrate them on startup.
- Resolve save-name collisions with suffixes such as `Login (1)` and use the resolved pathname in the renderer.
- Add end-to-end coverage for restart restoration and collision handling.

### Testing

- `npm run build:web` — passed.
- Targeted ESLint for all changed files — passed with 0 errors (existing warnings remain).
- `git diff --check` — passed.
- Targeted Jest could not start because the local `canvas` native module is missing `canvas.node`.
- Targeted Playwright could not run because the local dev server hit the `EMFILE` file-descriptor limit.

### Screenshots

Not applicable; this changes persistence behavior without changing the UI.

| Before | After |
| --- | --- |
| Untitled drafts prompt on quit and are lost after restart. | Untitled drafts auto-save and their tabs restore after restart. |

#### Contribution Checklist:

- [ ] **AI was used significantly to create this pull request.**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I have run the claude code review skill locally.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Untitled request drafts now autosave and persist when closing or restarting the app.
  * Drafts restore more reliably when switching workspaces or reopening scratch collections.
  * Saving a request with an existing name automatically creates a numbered filename.
* **Bug Fixes**
  * Improved transient request saving and close-flow handling, including saves when autosave is disabled.
  * Newly saved requests open from their actual saved location.
  * Scratch data is preserved only for the active workspace.
* **Tests**
  * Added coverage for draft persistence, autosave, workspace restoration, and filename conflict resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->