### PR TITLE
Add copy action to timeline network logs

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/StyledWrapper.js
@@ -1,6 +1,42 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  .network-logs-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 8px;
+
+    h4 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 500;
+    }
+  }
+
+  .copy-button {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 6px;
+    background: transparent;
+    border: 1px solid ${(props) => props.theme.border.border1};
+    border-radius: 4px;
+    color: ${(props) => props.theme.colors.text.muted};
+    cursor: pointer;
+    font-size: 12px;
+
+    &:hover:not(:disabled) {
+      color: ${(props) => props.theme.text};
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+
   .network-logs-container {
     color: ${(props) => props.theme.text};
   }

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.js
@@ -1,28 +1,7 @@
+import React from 'react';
+import { IconCopy } from '@tabler/icons';
+import toast from 'react-hot-toast';
 import StyledWrapper from './StyledWrapper';
-
-const Network = ({ logs }) => {
-  return (
-    <StyledWrapper>
-      <div className="network-logs-container">
-        <pre className="network-logs-pre">
-          {logs.map((currentLog, index) => {
-            if (index > 0 && currentLog?.type === 'separator') {
-              return <div className="network-logs-separator" key={index} />;
-            }
-            const nextLog = logs[index + 1];
-            const isSameLogType = nextLog?.type === currentLog?.type;
-            return (
-              <div key={index}>
-                <NetworkLogsEntry entry={currentLog} />
-                {!isSameLogType && <div className="network-logs-spacing" />}
-              </div>
-            );
-          })}
-        </pre>
-      </div>
-    </StyledWrapper>
-  );
-};
 
 const NetworkLogsEntry = ({ entry }) => {
   const { type, message } = entry;
@@ -53,6 +32,56 @@ const NetworkLogsEntry = ({ entry }) => {
     <div className={className}>
       <div>{message}</div>
     </div>
+  );
+};
+
+const Network = ({ logs, showCopy = false }) => {
+  const networkLogs = Array.isArray(logs) ? logs : [];
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(networkLogs
+        .map((entry) => (entry?.type === 'separator' ? '' : entry?.message ?? String(entry)))
+        .join('\n'));
+      toast.success('Network logs copied to clipboard');
+    } catch (error) {
+      toast.error('Failed to copy network logs');
+    }
+  };
+
+  return (
+    <StyledWrapper>
+      {showCopy && (
+        <div className="network-logs-header">
+          <h4>Network Logs</h4>
+          <button
+            className="copy-button"
+            type="button"
+            onClick={handleCopy}
+            disabled={networkLogs.length === 0}
+          >
+            <IconCopy size={16} strokeWidth={2} />
+            Copy
+          </button>
+        </div>
+      )}
+      <div className="network-logs-container">
+        <pre className="network-logs-pre">
+          {networkLogs.map((currentLog, index) => {
+            if (index > 0 && currentLog?.type === 'separator') {
+              return <div className="network-logs-separator" key={index} />;
+            }
+            const nextLog = logs[index + 1];
+            const isSameLogType = nextLog?.type === currentLog?.type;
+            return (
+              <div key={index}>
+                <NetworkLogsEntry entry={currentLog} />
+                {!isSameLogType && <div className="network-logs-spacing" />}
+              </div>
+            );
+          })}
+        </pre>
+      </div>
+    </StyledWrapper>
   );
 };
 

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.spec.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import Network from './index';
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+const theme = {
+  text: '#fff',
+  textLink: '#fff',
+  border: { border1: '#333' },
+  colors: { text: { muted: '#aaa', green: '#0f0', danger: '#f00', purple: '#a0f', yellow: '#ff0' } }
+};
+
+describe('Timeline Network', () => {
+  it('does not render a Copy action by default', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <Network logs={[{ type: 'request', message: 'GET https://api.example.com/users' }]} />
+      </ThemeProvider>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+  });
+
+  it('copies the raw displayed network logs', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const logs = [
+      { type: 'request', message: 'GET https://api.example.com/users' },
+      { type: 'requestHeader', message: 'Authorization: Basic real-token' },
+      { type: 'separator' },
+      { type: 'response', message: 'HTTP/1.1 200 OK' }
+    ];
+
+    render(
+      <ThemeProvider theme={theme}>
+        <Network logs={logs} showCopy={true} />
+      </ThemeProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith([
+      'GET https://api.example.com/users',
+      'Authorization: Basic real-token',
+      '',
+      'HTTP/1.1 200 OK'
+    ].join('\n')));
+    expect(writeText.mock.calls[0][0]).toContain('Authorization: Basic real-token');
+    expect(writeText.mock.calls[0][0]).not.toContain('[REDACTED]');
+    expect(writeText.mock.calls[0][0]).not.toContain('# API 调试上下文');
+  });
+});

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -214,7 +214,7 @@ const TimelineItem = ({
               )}
               {showNetworkLogs && visitedTabs.network && (
                 <div style={{ display: activeTab === 'network' ? 'block' : 'none' }}>
-                  <Network logs={response?.timeline} />
+                  <Network logs={response?.timeline} showCopy={true} />
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- add a raw Copy action to the Timeline Network panel
- preserve displayed log order and separator spacing in copied output
- keep the copy UI opt-in for Timeline

## Tests
- npm test -- --runInBand src/components/ResponsePane/Timeline/TimelineItem/Network/index.spec.js