### PR TITLE
feat(timeline): add copy action for network logs

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/StyledWrapper.js
@@ -1,6 +1,42 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  .network-logs-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 8px;
+
+    h4 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 500;
+    }
+  }
+
+  .copy-button {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 6px;
+    background: transparent;
+    border: 1px solid ${(props) => props.theme.border.border1};
+    border-radius: 4px;
+    color: ${(props) => props.theme.colors.text.muted};
+    cursor: pointer;
+    font-size: 12px;
+
+    &:hover:not(:disabled) {
+      color: ${(props) => props.theme.text};
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+
   .network-logs-container {
     color: ${(props) => props.theme.text};
   }

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.js
@@ -1,28 +1,7 @@
+import React from 'react';
+import { IconCopy } from '@tabler/icons';
+import toast from 'react-hot-toast';
 import StyledWrapper from './StyledWrapper';
-
-const Network = ({ logs }) => {
-  return (
-    <StyledWrapper>
-      <div className="network-logs-container">
-        <pre className="network-logs-pre">
-          {logs.map((currentLog, index) => {
-            if (index > 0 && currentLog?.type === 'separator') {
-              return <div className="network-logs-separator" key={index} />;
-            }
-            const nextLog = logs[index + 1];
-            const isSameLogType = nextLog?.type === currentLog?.type;
-            return (
-              <div key={index}>
-                <NetworkLogsEntry entry={currentLog} />
-                {!isSameLogType && <div className="network-logs-spacing" />}
-              </div>
-            );
-          })}
-        </pre>
-      </div>
-    </StyledWrapper>
-  );
-};
 
 const NetworkLogsEntry = ({ entry }) => {
   const { type, message } = entry;
@@ -53,6 +32,56 @@ const NetworkLogsEntry = ({ entry }) => {
     <div className={className}>
       <div>{message}</div>
     </div>
+  );
+};
+
+const Network = ({ logs, showCopy = false }) => {
+  const networkLogs = Array.isArray(logs) ? logs : [];
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(networkLogs
+        .map((entry) => (entry?.type === 'separator' ? '' : entry?.message ?? String(entry)))
+        .join('\n'));
+      toast.success('Network logs copied to clipboard');
+    } catch (error) {
+      toast.error('Failed to copy network logs');
+    }
+  };
+
+  return (
+    <StyledWrapper>
+      {showCopy && (
+        <div className="network-logs-header">
+          <h4>Network Logs</h4>
+          <button
+            className="copy-button"
+            type="button"
+            onClick={handleCopy}
+            disabled={networkLogs.length === 0}
+          >
+            <IconCopy size={16} strokeWidth={2} />
+            Copy
+          </button>
+        </div>
+      )}
+      <div className="network-logs-container">
+        <pre className="network-logs-pre">
+          {networkLogs.map((currentLog, index) => {
+            if (index > 0 && currentLog?.type === 'separator') {
+              return <div className="network-logs-separator" key={index} />;
+            }
+            const nextLog = networkLogs[index + 1];
+            const isSameLogType = nextLog?.type === currentLog?.type;
+            return (
+              <div key={index}>
+                <NetworkLogsEntry entry={currentLog} />
+                {!isSameLogType && <div className="network-logs-spacing" />}
+              </div>
+            );
+          })}
+        </pre>
+      </div>
+    </StyledWrapper>
   );
 };
 

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/Network/index.spec.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import toast from 'react-hot-toast';
+import Network from './index';
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+const theme = {
+  text: '#fff',
+  textLink: '#fff',
+  border: { border1: '#333' },
+  colors: { text: { muted: '#aaa', green: '#0f0', danger: '#f00', purple: '#a0f', yellow: '#ff0' } }
+};
+
+describe('Timeline Network', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render a Copy action by default', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <Network logs={[{ type: 'request', message: 'GET https://api.example.com/users' }]} />
+      </ThemeProvider>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+  });
+
+  it('copies the raw displayed network logs', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const logs = [
+      { type: 'request', message: 'GET https://api.example.com/users' },
+      { type: 'requestHeader', message: 'Authorization: Basic real-token' },
+      { type: 'separator' },
+      { type: 'response', message: 'HTTP/1.1 200 OK' }
+    ];
+
+    render(
+      <ThemeProvider theme={theme}>
+        <Network logs={logs} showCopy={true} />
+      </ThemeProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith([
+      'GET https://api.example.com/users',
+      'Authorization: Basic real-token',
+      '',
+      'HTTP/1.1 200 OK'
+    ].join('\n')));
+    expect(toast.success).toHaveBeenCalledWith('Network logs copied to clipboard');
+  });
+
+  it('shows an error when clipboard copy fails', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('Clipboard unavailable'));
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <Network logs={[{ type: 'error', message: 'there was an error executing the request!' }]} showCopy={true} />
+      </ThemeProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to copy network logs'));
+  });
+
+  it('disables the Copy action when there are no logs', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <Network logs={[]} showCopy={true} />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeDisabled();
+  });
+
+  it('disables the Copy action when logs is not an array', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <Network logs={null} showCopy={true} />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeDisabled();
+  });
+});

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -214,7 +214,7 @@ const TimelineItem = ({
               )}
               {showNetworkLogs && visitedTabs.network && (
                 <div style={{ display: activeTab === 'network' ? 'block' : 'none' }}>
-                  <Network logs={response?.timeline} />
+                  <Network logs={response?.timeline} showCopy={true} />
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Motivation

Timeline network logs are useful when diagnosing redirects, TLS failures, and connection issues, but currently have to be selected manually.

## Summary

- add an opt-in Copy action to the Timeline Network panel
- copy the displayed log entries in their original order
- preserve multiline messages and separator spacing

The copied text mirrors the network log content already visible to the user.

## Tests

- verify the Copy action is disabled for empty logs
- verify successful clipboard writes and success feedback
- verify clipboard failures show an error
- verify multiline messages and separators are preserved

## Test command

`npm test -- --runInBand src/components/ResponsePane/Timeline/TimelineItem/Network/index.spec.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Copy button to network logs for copying log content as formatted text.
  * Copy actions provide success or failure notifications and are disabled when no logs are available.
  * Network logs now handle missing or invalid log data gracefully.

* **Tests**
  * Added coverage for copying logs, empty states, and copy failure notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->