### PR TITLE
fix(proxy): update timestamp label format 

### DIFF
--- a/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
+++ b/packages/bruno-app/src/components/Preferences/ProxySettings/SystemProxy/index.js
@@ -111,7 +111,7 @@ const SystemProxy = () => {
               data-testid="system-proxy-last-refreshed"
               data-refreshed-at={lastRefreshedAt}
             >
-              Last refreshed at {formatProxyTimestamp(lastRefreshedAt)}
+              Last refreshed: {formatProxyTimestamp(lastRefreshedAt)}
             </small>
           )}
         </div>

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -556,12 +556,14 @@ export function isHexFormat(str) {
 }
 
 export const formatProxyTimestamp = (timestamp) => {
-  return new Date(timestamp).toLocaleString('en-GB', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: true
-  });
+  return new Date(timestamp)
+    .toLocaleString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true
+    })
+    .replace(/\b(a|p)m\b/gi, (match) => match.toUpperCase());
 };

--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -565,5 +565,6 @@ export const formatProxyTimestamp = (timestamp) => {
       minute: '2-digit',
       hour12: true
     })
+    .replace(/[\u00A0\u202F]/g, ' ')
     .replace(/\b(a|p)m\b/gi, (match) => match.toUpperCase());
 };

--- a/tests/preferences/system-proxy-timestamp.spec.ts
+++ b/tests/preferences/system-proxy-timestamp.spec.ts
@@ -9,7 +9,7 @@ import { buildPreferencesLocators, openSystemProxyPanel } from '../utils/page';
 // year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true })` with the day
 // period uppercased, e.g.
 //   "15 Jul 2026, 04:30 PM"
-const TIMESTAMP_REGEX = /^Last refreshed: \d{2} [A-Z][a-z]{2,3} \d{4},\s+\d{2}:\d{2}\s?(am|pm)$/i;
+const TIMESTAMP_REGEX = /^Last refreshed: \d{2} [A-Z][a-z]{2,3} \d{4},\s+\d{2}:\d{2}\s?(AM|PM)$/;
 
 test.describe('System Proxy - last refreshed timestamp', () => {
   test('does not show a timestamp before the user forces a refresh', async ({ page }) => {

--- a/tests/preferences/system-proxy-timestamp.spec.ts
+++ b/tests/preferences/system-proxy-timestamp.spec.ts
@@ -1,14 +1,15 @@
 import { expect, test } from '../../playwright';
 import { buildPreferencesLocators, openSystemProxyPanel } from '../utils/page';
 
-// The System Proxy panel renders a "Last refreshed at <timestamp>" label that is
+// The System Proxy panel renders a "Last refreshed: <timestamp>" label that is
 // produced by the `formatProxyTimestamp` util. The label is created only when the user
 // explicitly clicks "Refresh" (a forced refresh), not on the initial auto-fetch.
 //
 // formatProxyTimestamp uses `toLocaleString('en-GB', { day: '2-digit', month: 'short',
-// year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true })`, e.g.
-//   "15 Jul 2026, 04:30 pm"
-const TIMESTAMP_REGEX = /^Last refreshed at \d{2} [A-Z][a-z]{2} \d{4},\s+\d{2}:\d{2}\s?(am|pm)$/i;
+// year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true })` with the day
+// period uppercased, e.g.
+//   "15 Jul 2026, 04:30 PM"
+const TIMESTAMP_REGEX = /^Last refreshed: \d{2} [A-Z][a-z]{2,3} \d{4},\s+\d{2}:\d{2}\s?(am|pm)$/i;
 
 test.describe('System Proxy - last refreshed timestamp', () => {
   test('does not show a timestamp before the user forces a refresh', async ({ page }) => {

--- a/tests/preferences/system-proxy-timestamp.spec.ts
+++ b/tests/preferences/system-proxy-timestamp.spec.ts
@@ -9,7 +9,7 @@ import { buildPreferencesLocators, openSystemProxyPanel } from '../utils/page';
 // year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true })` with the day
 // period uppercased, e.g.
 //   "15 Jul 2026, 04:30 PM"
-const TIMESTAMP_REGEX = /^Last refreshed: \d{2} [A-Z][a-z]{2,3} \d{4},\s+\d{2}:\d{2}\s?(AM|PM)$/;
+const TIMESTAMP_REGEX = /^Last refreshed: \d{2} [A-Z][a-z]{2,3} \d{4}, \d{2}:\d{2} (AM|PM)$/;
 
 test.describe('System Proxy - last refreshed timestamp', () => {
   test('does not show a timestamp before the user forces a refresh', async ({ page }) => {


### PR DESCRIPTION
BRU-3978

### Description

Fix the "last refreshed" text in the System Proxy preferences panel

### Fix

Reworded the label from Last refreshed at <timestamp> to Last refreshed: <timestamp>.
Uppercased the AM/PM in the formatted timestamp, so it now reads 04 Aug 2026, 02:30 PM instead of 04 Aug 2026, 02:30 pm.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="558" height="258" alt="image" src="https://github.com/user-attachments/assets/942941e9-a1cb-43ae-be52-f29fa28fec13" /> | <img width="356" height="169" alt="image" src="https://github.com/user-attachments/assets/c27435c4-d71b-4ca8-a33e-35ceafa67412" />|

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the system proxy refresh timestamp label to display “Last refreshed:”.
  * Standardized localized timestamps to use uppercase AM/PM indicators.
  * Improved timestamp formatting consistency across supported locales.
  * Updated supported timestamp displays to accommodate varying month abbreviation lengths across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->