### PR TITLE
feat: add sorting to the secrets tab as well

### DIFF
--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -228,8 +228,10 @@ const EnvironmentVariablesTable = ({
   const [pinnedData, setPinnedData] = useState({ query: '', uids: new Set() });
   const isSearchActive = !!searchQuery?.trim();
 
-  const { sortMode, cycleSortMode, SortIcon, sortLabel } = useSortCycle({ storageKey: `env-var-sort::${environment.uid}` });
-  const dragEnabled = sortMode === 'default' && !isSecretTab && !isSearchActive;
+  const variablesSort = useSortCycle({ storageKey: `persisted::${activeTabUid}::env-var-sort::${environment.uid}::variables` });
+  const secretsSort = useSortCycle({ storageKey: `persisted::${activeTabUid}::env-var-sort::${environment.uid}::secrets` });
+  const { sortMode, cycleSortMode, SortIcon, sortLabel } = isSecretTab ? secretsSort : variablesSort;
+  const dragEnabled = sortMode === 'default' && !isSearchActive;
 
   const handleColumnWidthsChange = (id, widths) => {
     dispatch(updateTableColumnWidths({ uid: activeTabUid, tableId: id, widths }));
@@ -410,13 +412,16 @@ const EnvironmentVariablesTable = ({
 
   const sortOrderRef = useRef(null);
   const prevSortModeRef = useRef();
+  const prevIsSecretTabRef = useRef(isSecretTab);
   const prevIsDraftRef = useRef(hasDraftForThisEnv);
   const prevEnvironmentVariablesRef = useRef(environment.variables);
   const justCommitted = prevIsDraftRef.current === true && hasDraftForThisEnv === false;
   const savedVariablesChanged = prevEnvironmentVariablesRef.current !== environment.variables;
+  const tabChanged = prevIsSecretTabRef.current !== isSecretTab;
+  prevIsSecretTabRef.current = isSecretTab;
   prevIsDraftRef.current = hasDraftForThisEnv;
   prevEnvironmentVariablesRef.current = environment.variables;
-  if (prevSortModeRef.current !== sortMode || justCommitted || savedVariablesChanged) {
+  if (prevSortModeRef.current !== sortMode || tabChanged || justCommitted || savedVariablesChanged) {
     prevSortModeRef.current = sortMode;
     // After a save/reparse, `environment.variables` gets new uids; `initialValues` keeps stable ones for reorder.
     sortOrderRef.current = buildSortOrder(savedVariablesChanged ? initialValues : formik.values, sortMode);
@@ -881,7 +886,7 @@ const EnvironmentVariablesTable = ({
   }, [formik.values, searchQuery, pinnedData, isSecretTab]);
 
   const displayedVariables = (() => {
-    if (isSecretTab || sortMode === 'default' || !sortOrderRef.current) {
+    if (sortMode === 'default' || !sortOrderRef.current) {
       return filteredVariables;
     }
 
@@ -920,14 +925,12 @@ const EnvironmentVariablesTable = ({
               <td className="text-center"></td>
               <td
                 style={{ width: columnWidths.name }}
-                className={!isSecretTab ? 'sortable-header' : ''}
-                onClick={!isSecretTab ? (e) => {
+                className="sortable-header"
+                onClick={(e) => {
                   if (!e.target.closest('.resize-handle')) cycleSortMode();
-                } : undefined}
+                }}
               >
-                {isSecretTab ? 'Name' : (
-                  <ColumnSortHeader label="Name" SortIcon={SortIcon} sortLabel={sortLabel} />
-                )}
+                <ColumnSortHeader label="Name" SortIcon={SortIcon} sortLabel={sortLabel} />
                 <div
                   className={`resize-handle ${resizing === 'name' ? 'resizing' : ''}`}
                   style={{ height: tableHeight > 0 ? `${tableHeight}px` : undefined }}

--- a/tests/environments/variable-sort-drag/variable-sort-drag.spec.ts
+++ b/tests/environments/variable-sort-drag/variable-sort-drag.spec.ts
@@ -222,4 +222,113 @@ test.describe('Variable sort + drag-and-drop (Environment vars)', () => {
       expect(secretIndices).toEqual([...secretIndices].sort((a, b) => a - b));
     });
   });
+
+  test('secrets sort A-Z / Z-A without rewriting the file', async ({ page, createTmpDir }) => {
+    const tmpDir = await createTmpDir('sort-secrets-view-only');
+    await importCollection(page, collectionFile, tmpDir, { expectedCollectionName: COLLECTION_NAME });
+    await createEnvironment(page, 'SortSecretsEnv', 'collection');
+
+    await secretsTab(page).click();
+    await addRowToActiveTab(page, 'zulu', '1');
+    await addRowToActiveTab(page, 'alpha', '2');
+    await addRowToActiveTab(page, 'mike', '3');
+    await saveTab(page).click();
+    await expect(savedToast(page)).toBeVisible();
+
+    await test.step('A-Z then Z-A sort the secrets view', async () => {
+      await cycleVariableSort(page);
+      await expect.poll(() => getVisibleVariableNames(page)).toEqual(['alpha', 'mike', 'zulu']);
+      await cycleVariableSort(page);
+      await expect.poll(() => getVisibleVariableNames(page)).toEqual(['zulu', 'mike', 'alpha']);
+    });
+
+    await test.step('Cycling back to Manual reveals the untouched real order', async () => {
+      await cycleVariableSort(page);
+      await expect.poll(() => getVisibleVariableNames(page)).toEqual(['zulu', 'alpha', 'mike']);
+    });
+
+    await test.step('The on-disk file was never rewritten by viewing A-Z/Z-A', async () => {
+      const content = readEnvironmentFile(tmpDir, 'SortSecretsEnv');
+      const indices = ['zulu', 'alpha', 'mike'].map((name) => content.indexOf(name));
+      expect(indices.every((i) => i !== -1)).toBe(true);
+      expect(indices).toEqual([...indices].sort((a, b) => a - b));
+    });
+  });
+
+  test('dragging a secret never crosses into the variables group', async ({ page, createTmpDir }) => {
+    const tmpDir = await createTmpDir('sort-drag-variable-isolation');
+    await importCollection(page, collectionFile, tmpDir, { expectedCollectionName: COLLECTION_NAME });
+    await createEnvironment(page, 'DragVariableIsolationEnv', 'collection');
+
+    await test.step('Add two variables and two secrets, saving each tab independently', async () => {
+      await addRowToActiveTab(page, 'v1', 'one');
+      await addRowToActiveTab(page, 'v2', 'two');
+      await saveTab(page).click();
+      await expect(savedToast(page)).toBeVisible();
+
+      await secretsTab(page).click();
+      await addRowToActiveTab(page, 's1', 'secret-one');
+      await addRowToActiveTab(page, 's2', 'secret-two');
+      await saveTab(page).click();
+      await expect(savedToast(page)).toBeVisible();
+    });
+
+    await test.step('Drag s2 before s1, then save', async () => {
+      await expect(dragHandle(page, 's2')).toHaveCount(1);
+      await dragVariableRow(page, 's2', 's1');
+      await expect.poll(() => getVisibleVariableNames(page)).toEqual(['s2', 's1']);
+      await saveTab(page).click();
+      await expect(savedToast(page)).toBeVisible();
+    });
+
+    await test.step('On disk, secrets were reordered but variables kept their original order', async () => {
+      const content = readEnvironmentFile(tmpDir, 'DragVariableIsolationEnv');
+      const secretIndices = ['s2', 's1'].map((name) => content.indexOf(name));
+      expect(secretIndices.every((i) => i !== -1)).toBe(true);
+      expect(secretIndices).toEqual([...secretIndices].sort((a, b) => a - b));
+
+      const varIndices = ['v1', 'v2'].map((name) => content.indexOf(name));
+      expect(varIndices.every((i) => i !== -1)).toBe(true);
+      expect(varIndices).toEqual([...varIndices].sort((a, b) => a - b));
+    });
+  });
+
+  test('each tab remembers its own sort mode', async ({ page, createTmpDir }) => {
+    await importCollection(page, collectionFile, await createTmpDir('sort-per-tab-mode'), {
+      expectedCollectionName: COLLECTION_NAME
+    });
+    await createEnvironment(page, 'PerTabSortEnv', 'collection');
+
+    await test.step('Seed both tabs with deliberately unsorted rows', async () => {
+      await addRowToActiveTab(page, 'vzulu', '1');
+      await addRowToActiveTab(page, 'valpha', '2');
+      await saveTab(page).click();
+      await expect(savedToast(page)).toBeVisible();
+
+      await secretsTab(page).click();
+      await addRowToActiveTab(page, 'szulu', '1');
+      await addRowToActiveTab(page, 'salpha', '2');
+      await saveTab(page).click();
+      await expect(savedToast(page)).toBeVisible();
+
+      await variablesTab(page).click();
+    });
+
+    await test.step('Sorting variables A-Z leaves secrets in Manual order', async () => {
+      await cycleVariableSort(page);
+      await expect.poll(() => getVisibleVariableNames(page)).toEqual(['valpha', 'vzulu']);
+
+      await secretsTab(page).click();
+      await expect.poll(() => getVisibleVariableNames(page)).toEqual(['szulu', 'salpha']);
+      await expect(dragHandle(page, 'szulu')).toHaveCount(1);
+    });
+
+    await test.step('Sorting secrets A-Z does not disturb the variables tab', async () => {
+      await cycleVariableSort(page);
+      await expect.poll(() => getVisibleVariableNames(page)).toEqual(['salpha', 'szulu']);
+
+      await variablesTab(page).click();
+      await expect.poll(() => getVisibleVariableNames(page)).toEqual(['valpha', 'vzulu']);
+    });
+  });
 });


### PR DESCRIPTION
### Description
REF:4129
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Problem

Variables in an environment could be sorted A–Z and reordered by dragging. Secrets couldn't — even though a secret is just a variable with the "secret" flag on, so there was no real reason for the difference.

<!-- What issue does this PR solve? Link the related issue if one exists. -->

### Fix
1)Enabled sorting and drag-and-drop on the Secrets tab.
Each tab now keeps its own sort setting, and the display order is rebuilt when you switch tabs so one tab's ordering never leaks into the other.
2)Moved the sort setting onto the app's standard persisted:: storage keys, so it's cleaned up with the tab like scroll position and every other table.
<!-- How does this PR fix the problem? Briefly describe your approach. -->

### Screenshots

https://github.com/user-attachments/assets/52f7e52b-6c7c-4edd-b8fc-63f41a9578f4


<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting behavior for environment variables and secrets.
  * Each tab now preserves its own sorting state when switching between variables and secrets.
  * Drag-and-drop ordering works correctly for both tabs when using the default order.
  * Searching or applying an explicit sort now consistently disables drag reordering.
  * Secret sorting no longer affects the order of regular variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->