### PR TITLE
chore(flaky-test)/fix grpc flaky test

### DIFF
--- a/tests/grpc/make-request/make-request.spec.ts
+++ b/tests/grpc/make-request/make-request.spec.ts
@@ -65,7 +65,7 @@ test.describe('make grpc requests', () => {
 
     await test.step('select server streaming method', async () => {
       await locators.sidebar.request('LotOfReplies').click();
-      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/LotsOfReplies');
+      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/LotsOfReplies', { timeout: 30000 });
     });
 
     await test.step('verify gRPC server streaming request is opened successfully', async () => {
@@ -106,7 +106,7 @@ test.describe('make grpc requests', () => {
 
     await test.step('select client streaming method', async () => {
       await locators.sidebar.request('LotOfGreetings').click();
-      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/LotsOfGreetings');
+      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/LotsOfGreetings', { timeout: 30000 });
     });
 
     await test.step('verify gRPC client streaming request is opened successfully', async () => {
@@ -163,7 +163,7 @@ test.describe('make grpc requests', () => {
 
     await test.step('select bidirectional streaming method', async () => {
       await locators.sidebar.request('BidiHello').click();
-      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/BidiHello');
+      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/BidiHello', { timeout: 30000 });
     });
 
     await test.step('verify gRPC bidi streaming request is opened successfully', async () => {
@@ -222,7 +222,7 @@ test.describe('make grpc requests', () => {
 
     await test.step('select client streaming method', async () => {
       await locators.sidebar.request('LotOfGreetings').click();
-      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/LotsOfGreetings');
+      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/LotsOfGreetings', { timeout: 30000 });
     });
 
     await test.step('start client streaming connection', async () => {
@@ -260,7 +260,7 @@ test.describe('make grpc requests', () => {
 
     await test.step('select bidirectional streaming method', async () => {
       await locators.sidebar.request('BidiHello').click();
-      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/BidiHello');
+      await expect(locators.method.dropdownTrigger()).toContainText('HelloService/BidiHello', { timeout: 30000 });
     });
 
     await test.step('start bidirectional streaming connection', async () => {


### PR DESCRIPTION
### Description

Fixes an intermittent CI-only failure in the gRPC "make request" E2E tests, where method-selection assertions time out waiting for the method dropdown trigger to update.

### Problem

`MethodDropdown` doesn't render its trigger element (`data-testid="grpc-method-dropdown-trigger"`) until gRPC reflection has finished populating `grpcMethods`. This fetch is async and its duration varies with system load. On CI runners (parallel workers, shared/contended resources), reflection can take longer than Playwright's default 5000ms expect timeout.

### Fix

Applied the same `{ timeout: 30000 }` override to the remaining five `expect(locators.method.dropdownTrigger()).toContainText(...)` assertions, so all six method-selection checks in the file are consistent and tolerant of slower reflection loads on CI.
 
No application code changes — test-only fix.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved streaming request test reliability by allowing additional time for the gRPC method selection to appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->