### PR TITLE
fix(ws): disable message queuing when in intermediate connection states

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/SendButton/index.js
+++ b/packages/bruno-app/src/components/RequestPane/SendButton/index.js
@@ -2,11 +2,12 @@ import React from 'react';
 import Button from 'ui/Button';
 import StyledWrapper from './StyledWrapper';
 
-const SendButton = ({ isLoading = false, onSend, onCancel, testId = 'send-request-btn' }) => {
+const SendButton = ({ isLoading = false, disabled = false, onSend, onCancel, testId = 'send-request-btn' }) => {
   return (
     <StyledWrapper className="ml-2">
       <Button
         size="sm"
+        disabled={disabled}
         variant={isLoading ? 'outline' : 'filled'}
         color="primary"
         data-testid={testId}

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
@@ -114,7 +114,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
     if (connectionStatus !== CONNECTION_STATUS.CONNECTED) return;
     if (previousDeboundedInterpolatedURL.current === debouncedInterpolatedURL) return;
     if (debouncedInterpolatedURL === '') return;
-    closeWsConnection(item.uid).then(() => { }).catch(() => { });
+    closeWsConnection(item.uid).then(() => {}).catch(() => {});
   }, [debouncedInterpolatedURL, connectionStatus, item]);
 
   return (

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
@@ -9,12 +9,11 @@ import React, { useEffect, useState, useMemo, useRef } from 'react';
 import toast from 'react-hot-toast';
 import { useDispatch } from 'react-redux';
 import { isMacOS } from 'utils/common/platform';
-import { hasRequestChanges } from 'utils/collections';
+import { hasRequestChanges, getAllVariables } from 'utils/collections';
 import { closeWsConnection, getWsConnectionStatus } from 'utils/network/index';
 import StyledWrapper from './StyledWrapper';
 import ToolHint from 'components/ToolHint';
 import { interpolateUrl } from 'utils/url';
-import { getAllVariables } from 'utils/collections';
 import useDebounce from 'hooks/useDebounce';
 import get from 'lodash/get';
 
@@ -24,6 +23,8 @@ const CONNECTION_STATUS = {
   DISCONNECTING: 'disconnecting',
   DISCONNECTED: 'disconnected'
 };
+
+const UNINTERACTIVE_STATES = [CONNECTION_STATUS.CONNECTING, CONNECTION_STATUS.DISCONNECTING];
 
 const useWsConnectionStatus = (requestId) => {
   const [connectionStatus, setConnectionStatus] = useState(CONNECTION_STATUS.DISCONNECTED);
@@ -110,10 +111,10 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
 
   // Detect interpolated URL changes and attempt a disconnect
   useEffect(() => {
-    if (connectionStatus !== 'connected') return;
+    if (connectionStatus !== CONNECTION_STATUS.CONNECTED) return;
     if (previousDeboundedInterpolatedURL.current === debouncedInterpolatedURL) return;
     if (debouncedInterpolatedURL === '') return;
-    closeWsConnection(item.uid).then(() => {}).catch(() => {});
+    closeWsConnection(item.uid).then(() => { }).catch(() => { });
   }, [debouncedInterpolatedURL, connectionStatus, item]);
 
   return (
@@ -154,10 +155,10 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
               </div>
             </ToolHint>
 
-            {(connectionStatus === 'connected' || connectionStatus === 'disconnecting') && (
+            {(connectionStatus === CONNECTION_STATUS.CONNECTED || connectionStatus === CONNECTION_STATUS.DISCONNECTING) && (
               <div className="connection-controls relative flex items-center h-full">
-                <ToolHint text={connectionStatus === 'disconnecting' ? 'Disconnecting...' : 'Close Connection'} toolhintId="ws-close-connection" place="top" positionStrategy="fixed">
-                  <div className="flex items-center" onClick={(e) => connectionStatus === 'connected' ? handleDisconnect(e, true) : null} data-testid="ws-disconnect-button">
+                <ToolHint text={connectionStatus === CONNECTION_STATUS.DISCONNECTING ? 'Disconnecting...' : 'Close Connection'} toolhintId="ws-close-connection" place="top" positionStrategy="fixed">
+                  <div className="flex items-center" onClick={(e) => connectionStatus === CONNECTION_STATUS.CONNECTED ? handleDisconnect(e, true) : null} data-testid="ws-disconnect-button">
                     <IconPlugConnectedX
                       color={theme.colors.text.danger}
                       strokeWidth={1.5}
@@ -171,7 +172,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
               </div>
             )}
 
-            {(connectionStatus === 'connecting' || connectionStatus === 'disconnected') && (
+            {(connectionStatus === CONNECTION_STATUS.CONNECTING || connectionStatus === CONNECTION_STATUS.DISCONNECTED) && (
               <div className="connection-controls relative flex items-center h-full">
                 <ToolHint text="Connect" toolhintId="ws-connect" place="top" positionStrategy="fixed">
                   <div className="flex items-center" onClick={handleConnect} data-testid="ws-connect-button">
@@ -193,6 +194,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
         </div>
         <SendButton
           onSend={handleRunClick}
+          disabled={UNINTERACTIVE_STATES.includes(connectionStatus)}
           testId="run-button"
         />
       </div>

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
@@ -64,6 +64,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
   const previousDeboundedInterpolatedURL = useRef(debouncedInterpolatedURL);
 
   const handleConnect = async () => {
+    setConnectionStatus(CONNECTION_STATUS.CONNECTING);
     dispatch(wsConnectOnly(item, collection.uid));
     previousDeboundedInterpolatedURL.current = debouncedInterpolatedURL;
   };
@@ -86,8 +87,9 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
     }
   };
 
-  const handleRunClick = async (e) => {
-    e.stopPropagation();
+  const handleWsRun = (e) => {
+    e?.stopPropagation();
+    if (UNINTERACTIVE_STATES.includes(connectionStatus)) return;
     if (!url) {
       toast.error('Please enter a valid WebSocket URL');
       return;
@@ -114,6 +116,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
     if (connectionStatus !== CONNECTION_STATUS.CONNECTED) return;
     if (previousDeboundedInterpolatedURL.current === debouncedInterpolatedURL) return;
     if (debouncedInterpolatedURL === '') return;
+    setConnectionStatus(CONNECTION_STATUS.DISCONNECTING);
     closeWsConnection(item.uid).then(() => {}).catch(() => {});
   }, [debouncedInterpolatedURL, connectionStatus, item]);
 
@@ -131,7 +134,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
             placeholder="ws://localhost:8080 or wss://example.com"
             className="w-full"
             theme={displayedTheme}
-            onRun={handleRun}
+            onRun={handleWsRun}
             collection={collection}
             item={item}
           />
@@ -193,7 +196,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
           {connectionStatus === CONNECTION_STATUS.DISCONNECTING && <div className="connection-status-strip disconnecting" data-testid="ws-disconnecting-strip"></div>}
         </div>
         <SendButton
-          onSend={handleRunClick}
+          onSend={handleWsRun}
           disabled={UNINTERACTIVE_STATES.includes(connectionStatus)}
           testId="run-button"
         />


### PR DESCRIPTION
### Description

BRU-4133

Disables the Send button on websockets when in intermediatry states like `connecting` and `disconnecting` to avoid the network events from being dispatched. 

A simpler solution that complicating when to and when not to coalesce the connection requests

### Problem

Without the change, a user can click the Send button in websockets just after the user has clicked disconnect and that would add a ghost request in the trail till the disconnect finished, this allowed for quick re-connection but if multiple clicks are made on Send then you'd have multiple ghost requests that fill up the timeline while adding no value

### Screenshots

**Before:**

https://github.com/user-attachments/assets/4f992ae7-d3c8-48b0-bf41-6aa6abe6780f

**After:**

https://github.com/user-attachments/assets/58261c6e-e9ce-4234-bd82-e7fa5b32a1f3




#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for disabling the request Send button when actions are unavailable.
  * Run controls are now disabled while a WebSocket connection is connecting or disconnecting.
  * Send and cancel actions now provide clearer controls during request processing.

* **Bug Fixes**
  * Improved WebSocket connection-state handling for more consistent button behavior.
  * Prevented request actions from being triggered while connection state changes are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->