### PR TITLE
feat: add migrate-to-YML pill to collection header

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/CollectionHeader/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionHeader/StyledWrapper.js
@@ -167,6 +167,61 @@ const StyledWrapper = styled.div`
     margin-left: 8px;
   }
 
+  .migrate-yml-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 4px 2px 8px;
+    border: 1px solid ${(props) => props.theme.input.border};
+    border-radius: 999px;
+    background: transparent;
+    color: ${(props) => props.theme.text};
+    font-size: 12px;
+    line-height: 1;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
+    }
+
+    .pill-main {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 0;
+      border: none;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    .pill-label {
+      font-weight: 500;
+    }
+
+    .pill-dismiss {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px;
+      height: 16px;
+      padding: 0;
+      border: none;
+      border-radius: 50%;
+      background: transparent;
+      color: inherit;
+      cursor: pointer;
+      opacity: 0.6;
+      transition: opacity 0.15s ease, background-color 0.15s ease;
+
+      &:hover {
+        opacity: 1;
+        background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
+      }
+    }
+  }
+
   .display-icon{
     padding: 4px;
     box-sizing: content-box;

--- a/packages/bruno-app/src/components/RequestTabs/CollectionHeader/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/CollectionHeader/index.js
@@ -17,7 +17,8 @@ import {
   IconFileCode,
   IconFileOff,
   IconCode,
-  IconAppWindow
+  IconAppWindow,
+  IconTransform
 } from '@tabler/icons';
 import IconSparkles from 'components/Icons/IconSparkles';
 import OpenAPISyncIcon from 'components/Icons/OpenAPISync';
@@ -26,6 +27,7 @@ import { updateWorkspace } from 'providers/ReduxStore/slices/workspaces';
 import { showInFolder } from 'providers/ReduxStore/slices/collections/actions';
 import { toggleCollectionFileMode } from 'providers/ReduxStore/slices/collections';
 import { toggleAiSidebar } from 'providers/ReduxStore/slices/chat';
+import { showMigrateToYmlModal } from 'providers/ReduxStore/slices/collection-migration';
 import { findItemInCollection, findItemInCollectionByPathname } from 'utils/collections';
 import find from 'lodash/find';
 import get from 'lodash/get';
@@ -48,6 +50,17 @@ import { useTheme } from 'providers/Theme';
 import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
 import CreateMockServerModal from 'components/MockServer/CreateMockServerModal';
 import { getMockServerInstances, openMockServerDashboard } from 'utils/mock-server/mock-server-instances';
+
+const readDismissedCollections = () => {
+  try {
+    const raw = localStorage.getItem('bruno.migrateToYmlPill.dismissed');
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
 
 const CollectionHeader = ({ collection, isScratchCollection }) => {
   const dispatch = useDispatch();
@@ -92,6 +105,36 @@ const CollectionHeader = ({ collection, isScratchCollection }) => {
   const [closeWorkspaceModalOpen, setCloseWorkspaceModalOpen] = useState(false);
   const [createWorkspaceModalOpen, setCreateWorkspaceModalOpen] = useState(false);
   const [showCreateMockServerModal, setShowCreateMockServerModal] = useState(false);
+
+  const [migratePillDismissed, setMigratePillDismissed] = useState(true);
+  useEffect(() => {
+    if (!collection?.pathname) return;
+    const dismissed = readDismissedCollections();
+    setMigratePillDismissed(dismissed.includes(collection.pathname));
+  }, [collection?.pathname]);
+
+  const dismissMigratePill = (e) => {
+    e?.stopPropagation();
+    if (!collection?.pathname) return;
+    const dismissed = readDismissedCollections();
+    if (!dismissed.includes(collection.pathname)) {
+      dismissed.push(collection.pathname);
+      try {
+        localStorage.setItem('bruno.migrateToYmlPill.dismissed', JSON.stringify(dismissed));
+      } catch { }
+    }
+    setMigratePillDismissed(true);
+  };
+
+  const openMigrateToYmlModal = () => {
+    dispatch(
+      showMigrateToYmlModal({
+        collectionUid: collection.uid,
+        collectionPathname: collection.pathname,
+        collectionName: collection.name
+      })
+    );
+  };
 
   const switcherRef = useRef();
   const workspaceActionsRef = useRef();
@@ -703,6 +746,31 @@ const CollectionHeader = ({ collection, isScratchCollection }) => {
                     <IconSparkles size={16} strokeWidth={1.5} />
                   </ActionIcon>
                 </ToolHint>
+              )}
+              {collection.format === 'bru' && !migratePillDismissed && (
+                <div
+                  className="migrate-yml-pill"
+                  data-testid="migrate-yml-pill"
+                  title="Migrate this collection to YML"
+                >
+                  <button
+                    type="button"
+                    className="pill-main"
+                    onClick={openMigrateToYmlModal}
+                  >
+                    <IconTransform size={13} strokeWidth={1.5} />
+                    <span className="pill-label">Migrate to YML</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="pill-dismiss"
+                    onClick={dismissMigratePill}
+                    aria-label="Dismiss"
+                    data-testid="migrate-yml-pill-dismiss"
+                  >
+                    <IconX size={12} strokeWidth={2} />
+                  </button>
+                </div>
               )}
               {/* OpenAPI Sync - standalone only when configured and beta enabled */}
               {hasOpenApiSyncConfigured && (

--- a/tests/collection/migrate-to-yml/migrate-to-yml-pill.spec.ts
+++ b/tests/collection/migrate-to-yml/migrate-to-yml-pill.spec.ts
@@ -3,7 +3,7 @@ import { closeAllCollections, openCollection } from '../../utils/page';
 
 const DISMISSED_LOCAL_STORAGE_KEY = 'bruno.migrateToYmlPill.dismissed';
 
-test.describe.skip('Migrate-to-YML pill in collection toolbar', () => {
+test.describe('Migrate-to-YML pill in collection toolbar', () => {
   test.afterAll(async ({ page }) => {
     await closeAllCollections(page);
   });


### PR DESCRIPTION
### Description

- Restored UI element for migrating collections to YML format.
- Implemented local storage handling for dismissed migration notifications.
- Added styles for the new migrate-to-YML pill.
- Updated tests to reflect the changes in the migration pill functionality.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->
<img width="641" height="228" alt="Screenshot 2026-08-05 at 4 00 55 PM" src="https://github.com/user-attachments/assets/d6e74ec1-7a09-4d62-b395-15807a670787" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Migrate to YML” option in eligible collection headers.
  * Added a migration action that opens the migration flow.
  * Added the ability to dismiss the migration prompt for individual collections.

* **Tests**
  * Enabled automated coverage for the migration prompt in the collection toolbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->