### PR TITLE
fix (transient-request): unable to create transient request when preset is websocket

### DIFF
--- a/packages/bruno-app/src/components/CreateTransientRequest/index.js
+++ b/packages/bruno-app/src/components/CreateTransientRequest/index.js
@@ -15,7 +15,7 @@ const REQUEST_TYPE = {
   HTTP: 'http',
   GRAPHQL: 'graphql',
   GRPC: 'grpc',
-  WEBSOCKET: 'websocket'
+  WEBSOCKET: 'ws'
 };
 
 /**
@@ -76,15 +76,6 @@ const CreateTransientRequest = ({ collectionUid }) => {
         }
       });
     }
-  };
-
-  const handleLeftClick = () => {
-    handleItemClick(collectionPresets.requestType);
-  };
-
-  const handleRightClick = (e) => {
-    e.preventDefault();
-    setDropdownVisible(true);
   };
 
   const handleCreateHttpRequest = useCallback(() => {
@@ -189,6 +180,15 @@ const CreateTransientRequest = ({ collectionUid }) => {
         handleCreateWebSocketRequest();
         break;
     }
+  };
+
+  const handleLeftClick = () => {
+    handleItemClick(collectionPresets.requestType);
+  };
+
+  const handleRightClick = (e) => {
+    e.preventDefault();
+    setDropdownVisible(true);
   };
 
   if (!collection) {

--- a/packages/bruno-app/src/components/CreateTransientRequest/index.js
+++ b/packages/bruno-app/src/components/CreateTransientRequest/index.js
@@ -6,17 +6,11 @@ import { newHttpRequest, newGrpcRequest, newWsRequest } from 'providers/ReduxSto
 import { sanitizeName } from 'utils/common/regex';
 import toast from 'react-hot-toast';
 import { useDispatch, useSelector } from 'react-redux';
-import { flattenItems, isItemARequest, isItemTransientRequest } from 'utils/collections';
+import { flattenItems, isItemTransientRequest } from 'utils/collections';
 import filter from 'lodash/filter';
 import { get } from 'lodash';
 import { formatIpcError } from 'utils/common/error';
-
-const REQUEST_TYPE = {
-  HTTP: 'http',
-  GRAPHQL: 'graphql',
-  GRPC: 'grpc',
-  WEBSOCKET: 'ws'
-};
+import { PRESET_REQUEST_TYPES as REQUEST_TYPE } from 'utils/common/constants';
 
 /**
  * Generate a request name for transient requests in the pattern "Untitled {Count}"
@@ -176,7 +170,7 @@ const CreateTransientRequest = ({ collectionUid }) => {
       case REQUEST_TYPE.GRPC:
         handleCreateGrpcRequest();
         break;
-      case REQUEST_TYPE.WEBSOCKET:
+      case REQUEST_TYPE.WS:
         handleCreateWebSocketRequest();
         break;
     }
@@ -233,7 +227,7 @@ const CreateTransientRequest = ({ collectionUid }) => {
         </div>
         <div className="dropdown-label">gRPC</div>
       </div>
-      <div className="dropdown-item" onClick={() => handleItemClick(REQUEST_TYPE.WEBSOCKET)}>
+      <div className="dropdown-item" onClick={() => handleItemClick(REQUEST_TYPE.WS)}>
         <div className="dropdown-icon">
           <IconPlugConnected size={16} strokeWidth={2} />
         </div>

--- a/tests/transient-requests/transient-request-preset-type.spec.ts
+++ b/tests/transient-requests/transient-request-preset-type.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  createTransientRequestFromPreset,
+  setRequestTypePreset,
+  PresetRequestType
+} from '../utils/page';
+
+const PRESET_CASES: { requestType: PresetRequestType; label: string; tabMethod: string }[] = [
+  { requestType: 'http', label: 'HTTP', tabMethod: 'GET' },
+  { requestType: 'graphql', label: 'GraphQL', tabMethod: 'GQL' },
+  { requestType: 'grpc', label: 'gRPC', tabMethod: 'gRPC' },
+  { requestType: 'ws', label: 'WebSocket', tabMethod: 'WS' }
+];
+
+test.describe.serial('Transient request type follows the collection preset', () => {
+  const collectionName = 'transient-preset-type';
+
+  test.beforeAll(async ({ page, createTmpDir }) => {
+    await createCollection(page, collectionName, await createTmpDir('transient-preset-type'));
+    await expect(buildCommonLocators(page).sidebar.collection(collectionName)).toBeVisible();
+  });
+
+  test.afterAll(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  for (const { requestType, label, tabMethod } of PRESET_CASES) {
+    test(`Left-clicking + opens a ${label} request when the ${label} preset is saved`, async ({ page }) => {
+      const locators = buildCommonLocators(page);
+
+      await test.step(`Save "${label}" as the default request type preset`, async () => {
+        await setRequestTypePreset(page, collectionName, requestType);
+      });
+
+      await test.step('Create a transient request with a left click on +', async () => {
+        await createTransientRequestFromPreset(page);
+      });
+
+      await test.step(`Verify the opened request is a ${label} request`, async () => {
+        await expect(locators.tabs.activeRequestTabMethod()).toHaveText(tabMethod);
+      });
+    });
+  }
+});

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -2,7 +2,7 @@ import { test, expect, Page, Locator, ElectronApplication, waitForReadyPage as w
 import process from 'node:process';
 import * as path from 'path';
 import * as fs from 'fs';
-import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators } from './locators';
+import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators, PresetRequestType } from './locators';
 import { waitForCollectionMount } from './mounting';
 import { buildPreferencesLocators, openPreferences, selectPreferencesTab } from './preferences';
 
@@ -296,6 +296,46 @@ const createTransientRequest = async (
     await page.locator('.request-tab.active').waitFor({ state: 'visible' });
     await expect(page.locator('.request-tab.active')).toContainText('Untitled');
     await page.waitForTimeout(300);
+  });
+};
+
+/**
+ * Create a transient request by left-clicking the + icon, which uses the
+ * collection's default request type preset instead of the dropdown
+ * @param page - The page object
+ * @returns void
+ */
+const createTransientRequestFromPreset = async (page: Page) => {
+  await test.step('Create transient request from the collection preset', async () => {
+    const createButton = page.getByRole('button', { name: 'New Transient Request' });
+    await createButton.waitFor({ state: 'visible', timeout: 5000 });
+    await createButton.click();
+
+    const activeTab = buildCommonLocators(page).tabs.activeRequestTab();
+    await expect(activeTab).toContainText('Untitled');
+  });
+};
+
+/**
+ * Set the collection's default request type preset and save it
+ * @param page - The page object
+ * @param collectionName - The name of the collection
+ * @param requestType - The preset request type to select
+ * @returns void
+ */
+const setRequestTypePreset = async (page: Page, collectionName: string, requestType: PresetRequestType) => {
+  await test.step(`Set the default request type preset to "${requestType}"`, async () => {
+    const locators = buildCommonLocators(page);
+
+    await openCollectionSettings(page, collectionName);
+    await selectCollectionPaneTab(page, 'presets');
+    await locators.presets.requestType(requestType).check();
+    await expect(locators.presets.requestType(requestType)).toBeChecked();
+
+    await locators.presets.saveBtn().click();
+
+    // the settings tab keeps a draft indicator until the presets are persisted
+    await expect(locators.tabs.tabDraftIndicator(locators.tabs.collectionSettingsTab())).toBeHidden();
   });
 };
 
@@ -2611,6 +2651,8 @@ export {
   createRequest,
   createUntitledRequest,
   createTransientRequest,
+  createTransientRequestFromPreset,
+  setRequestTypePreset,
   fillRequestUrl,
   deleteRequest,
   deleteCollectionFromOverview,

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -16,6 +16,8 @@ import { buildRequestLocators } from '../request';
 import { buildCollectionHeaderLocators } from './collection/collection-header';
 import { buildEnvironmentLocators } from './environments';
 
+export type PresetRequestType = 'http' | 'graphql' | 'grpc' | 'ws';
+
 export const buildCommonLocators = (page: Page) => ({
   collectionHeader: buildCollectionHeaderLocators(page),
   runner: () => page.getByTestId('run-button'),
@@ -58,8 +60,10 @@ export const buildCommonLocators = (page: Page) => ({
     collectionSettingsTab: () =>
       page.locator('.request-tab').filter({ has: page.locator('.tab-label', { hasText: 'Collection' }) }),
     activeRequestTab: () => page.locator('.request-tab.active'),
+    activeRequestTabMethod: () => page.locator('.request-tab.active .tab-method'),
     closeTab: (requestName: string) => page.locator('.request-tab').filter({ hasText: requestName }).getByTestId('request-tab-close-icon'),
-    draftIndicator: () => page.locator('.request-tab.active .has-changes-icon')
+    draftIndicator: () => page.locator('.request-tab.active .has-changes-icon'),
+    tabDraftIndicator: (tab: Locator) => tab.locator('.has-changes-icon')
   },
   paneTabs: {
     responsiveTab: (key: string) => page.getByTestId(`responsive-tab-${key}`),
@@ -154,7 +158,7 @@ export const buildCommonLocators = (page: Page) => ({
     dropdownItem: (id: string) => page.getByTestId(`auth-mode-dropdown-${id}`)
   },
   presets: {
-    requestType: (type: 'http' | 'graphql' | 'grpc' | 'ws') =>
+    requestType: (type: PresetRequestType) =>
       page.getByTestId(`presets-request-type-${type}`),
     requestUrl: () => page.getByTestId('presets-request-url'),
     saveBtn: () => page.getByTestId('presets-save-btn'),


### PR DESCRIPTION
### Problem
When `websocket` is the selected preset in collection settings, creating a transient request by `left-click` on the `+` icon does not work.

### Cause
The preset setting used the key `ws` for `websocket` and the `CreateTransientRequest` component was switching on the type with `case 'websocket': `. This would fail as no branch would satisfy the case and the function returns without dispatching any action.

### Fix
Change the key from `websocket` to `ws` in `CreateTransientRequest`

Ticket - BRU-4064


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Creating a transient request now follows the collection’s saved request-type preset.
  - Supported presets include HTTP, GraphQL, gRPC, and WebSocket requests.

- **Bug Fixes**
  - WebSocket transient requests now open with the correct request type and method label.
  - Existing request creation and interaction behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->