### PR TITLE
fixes: OpenAPI Spec Viewer: throws resolver errors for `$ref` schemas 

### DIFF
--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
@@ -660,6 +660,17 @@ const StyledWrapper = styled.div`
         border: 1px solid ${(props) => props.theme.status.danger.border};
         border-radius: 4px;
         background: ${(props) => props.theme.status.danger.background};
+        overflow-wrap: anywhere;
+        min-width: 0;
+        max-width: 100%;
+        overflow-x: auto;
+
+        .errors,
+        .error-wrapper,
+        .error-wrapper > div {
+          min-width: 0;
+          max-width: 100%;
+        }
 
         .errors__title {
           color: ${(props) => props.theme.status.danger.text};
@@ -671,12 +682,10 @@ const StyledWrapper = styled.div`
 
         .errors small {
           color: ${(props) => props.theme.colors.text.muted};
-          overflow-wrap: anywhere;
         }
 
         .errors .message {
           color: ${(props) => props.theme.text};
-          overflow-wrap: anywhere;
         }
       }
 

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/StyledWrapper.js
@@ -653,6 +653,33 @@ const StyledWrapper = styled.div`
         height: 14px;
       }
 
+      /* ── Errors panel ── */
+      .errors-wrapper {
+        margin: 16px 20px;
+        padding: 10px 16px;
+        border: 1px solid ${(props) => props.theme.status.danger.border};
+        border-radius: 4px;
+        background: ${(props) => props.theme.status.danger.background};
+
+        .errors__title {
+          color: ${(props) => props.theme.status.danger.text};
+        }
+
+        .errors h4 {
+          color: ${(props) => props.theme.text};
+        }
+
+        .errors small {
+          color: ${(props) => props.theme.colors.text.muted};
+          overflow-wrap: anywhere;
+        }
+
+        .errors .message {
+          color: ${(props) => props.theme.text};
+          overflow-wrap: anywhere;
+        }
+      }
+
       /* ── Misc / catch-all ── */
       .loading-container .loading::after {
         color: ${(props) => props.theme.colors.text.muted};

--- a/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
+++ b/packages/bruno-app/src/components/ApiSpecPanel/Renderers/Swagger/index.js
@@ -3,6 +3,24 @@ import SwaggerUI from 'swagger-ui-react';
 import StyledWrapper from './StyledWrapper';
 import { serializeBody } from './serializeBody';
 
+/*
+  OpenAPISec 3.1.0 resolver ignores to dereference "$refs" when document.baseURI is not http/https as the packaged app is loaded over "file:/", so every internal $ref fails with "Evaluation failed on URI".
+
+  All non-http bases have no path to resolution and the error is thrown.
+  https://github.com/swagger-api/swagger-js/blob/v3.36.1/src/resolver/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/visitors/dereference.js#L519
+
+  #HACK/tmp-workaround:
+  The fix: We fake the base URL so it just looks like an http address. Swagger never actually fetches it to verify, it only checks that it if its a valid URI.
+  "swagger-ui-react" pkg is the only in the app that reads this value, so faking it is safe.
+*/
+
+if (!/^https?:/.test(document.baseURI)) {
+  Object.defineProperty(document, 'baseURI', {
+    configurable: true,
+    get: () => 'http://localhost/'
+  });
+}
+
 const serializeHeaders = (headers) => {
   if (!headers) return {};
   if (typeof headers.entries === 'function') {


### PR DESCRIPTION
### Description
OpenAPI 3.1 specs were failing to render in the packaged app,  every internal $ref throws "Could not resolve reference: Evaluation failed on URI".  
In Dev mode and 3.0 specs are working fine.


### Problem
1. Resolver: swagger-client's 3.1 resolver checks the scheme of document.baseURI before dereferencing any refs. The packaged app loads over file:// so the check fails for every ref.
2. Error panel: the panel rendered with raw swagger-ui styles (unreadable heading colors in dark theme), and the long resolver URIs overflowed the panel. Also on window resize the panel was not responsive.


### Fix
1. Report an http base to swagger with a small override next to the SwaggerUI mount.

**Root cause (resolver):** 
https://github.com/swagger-api/swagger-js/blob/v3.36.1/src/resolver/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/visitors/dereference.js#L519
the condition is always true, the else branch meant to resolve unknown-scheme bases (like file://) vand the catch-block is isURL-gated, so non-http bases have no path to resolve and hence the error is thrown.

### Screenshots

https://github.com/user-attachments/assets/68f4e78e-10a4-4b1c-a4dd-f7d2141f35be

**Note**
The real fix needs to be done in swagger-js ,  I will raise a PR there for the resolver's scheme gate. Once that lands and swagger-ui-react picks it up, this overriding fix can be deleted.


2. Themed the panel with the app's danger tokens, long tokens now wraps and the panel is responsive

**How to replicate the error panel**:
```
openapi: 3.1.0
info:
  title: Long Error Test
  version: 1.0.0
paths:
  /pets:
    get:
      summary: List pets
      responses:
        '200':
          description: ok
          content:
            application/json:
              schema:
                $ref: 'file:///a/very/long/unresolvable/path/that/does/not/exist/index.html#/components/schemas/Pet'
```

1. Open this spec (API Specs → Open API Spec), 
2. then expand GET /pets . 


Before :
<img width="1345" height="898" alt="Screenshot 2026-08-07 at 12 52 42 PM" src="https://github.com/user-attachments/assets/9263b3cb-655e-477b-8d30-487ddf745551" />

After:
<img width="1139" height="754" alt="Screenshot 2026-08-07 at 1 09 50 PM" src="https://github.com/user-attachments/assets/10d7fc81-88fb-48a3-b024-4f018d60324c" />


REF: BRU-3939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Swagger error panel styling for clearer visibility and better readability across themes.
  * Fixed Swagger rendering in packaged applications by enabling internal OpenAPI references to resolve correctly.
  * Improved handling of long error messages and constrained content widths for more consistent layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->