### PR TITLE
fix(editor): allow app keybindings if that keybindings is not present in rich text editor

### DIFF
--- a/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
+++ b/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
@@ -71,17 +71,13 @@ const DocsEditor = ({
         lastEmittedDocsRef.current = markdown;
         onEdit(markdown);
       },
-      editorProps: {
-        handleKeyDown: (_view, event) => {
-          if (event.key === 's' && (event.ctrlKey || event.metaKey)) {
-            event.preventDefault();
-            onSave();
-            return true;
-          }
-          return false;
-        }
-      },
       onCreate: ({ editor: createdEditor }) => {
+        // `mousetrap` bypasses Mousetrap's default "ignore all contentEditable"
+        // rule, so shortcuts Tiptap doesn't bind still reach
+        // the global handlers instead of being silently swallowed.
+        createdEditor.view.dom.classList.add('mousetrap');
+
+        // Prevent keydown events which are bind to TipTap from bubbling up to the global Mousetrap handlers
         createdEditor.view.dom.addEventListener('keydown', (event) => {
           if (event.defaultPrevented) {
             event.stopPropagation();

--- a/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
+++ b/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
@@ -80,6 +80,13 @@ const DocsEditor = ({
           }
           return false;
         }
+      },
+      onCreate: ({ editor: createdEditor }) => {
+        createdEditor.view.dom.addEventListener('keydown', (event) => {
+          if (event.defaultPrevented) {
+            event.stopPropagation();
+          }
+        });
       }
     },
     [collectionPath]

--- a/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
+++ b/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
@@ -71,6 +71,16 @@ const DocsEditor = ({
         lastEmittedDocsRef.current = markdown;
         onEdit(markdown);
       },
+      editorProps: {
+        handleKeyDown: (_view, event) => {
+          if (event.key === 's' && (event.ctrlKey || event.metaKey)) {
+            event.preventDefault();
+            onSave();
+            return true;
+          }
+          return false;
+        }
+      },
       onCreate: ({ editor: createdEditor }) => {
         // `HACK`: `mousetrap` bypasses Mousetrap's default "ignore all contentEditable"
         // rule, so shortcuts Tiptap doesn't bind still reach

--- a/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
+++ b/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
@@ -82,9 +82,8 @@ const DocsEditor = ({
         }
       },
       onCreate: ({ editor: createdEditor }) => {
-        // `HACK`: `mousetrap` bypasses Mousetrap's default "ignore all contentEditable"
-        // rule, so shortcuts Tiptap doesn't bind still reach
-        // the global handlers instead of being silently swallowed.
+        // by default Mousetrap ignores key events that originates from contenteditable elements (like TipTap's editor),
+        // adding mousetrap class to the editor's dom element will make Mousetrap listen to key events from TipTap's editor
         createdEditor.view.dom.classList.add('mousetrap');
 
         // Prevent keydown events which are bind to TipTap from bubbling up to the global Mousetrap handlers

--- a/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
+++ b/packages/bruno-app/src/components/Documentation/DocsEditor/index.js
@@ -72,7 +72,7 @@ const DocsEditor = ({
         onEdit(markdown);
       },
       onCreate: ({ editor: createdEditor }) => {
-        // `mousetrap` bypasses Mousetrap's default "ignore all contentEditable"
+        // `HACK`: `mousetrap` bypasses Mousetrap's default "ignore all contentEditable"
         // rule, so shortcuts Tiptap doesn't bind still reach
         // the global handlers instead of being silently swallowed.
         createdEditor.view.dom.classList.add('mousetrap');

--- a/tests/richtext-editor/init-user-data/preferences.json
+++ b/tests/richtext-editor/init-user-data/preferences.json
@@ -1,0 +1,8 @@
+{
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/richtext-editor/shortcut-passthrough.spec.ts
+++ b/tests/richtext-editor/shortcut-passthrough.spec.ts
@@ -26,7 +26,7 @@ test.describe('Rich Text Editor - Keyboard Shortcut Interop with Global Hotkeys'
 
     await test.step('Open Preferences (Cmd/Ctrl+,) still fires — no Tiptap binding for it', async () => {
       await pressShortcut(page, modifier, 'Comma');
-      await expect(page.locator('.request-tab').filter({ has: page.getByText('Preferences', { exact: true }) })).toBeVisible();
+      await expect(locators.tabs.requestTab('Preferences')).toBeVisible();
     });
   });
 
@@ -42,9 +42,9 @@ test.describe('Rich Text Editor - Keyboard Shortcut Interop with Global Hotkeys'
 
     await test.step('Cmd/Ctrl+N still opens the New Request modal', async () => {
       await pressShortcut(page, modifier, 'KeyN');
-      const newRequestModal = page.locator('.bruno-modal').filter({ has: page.getByText('New Request', { exact: true }) });
+      const newRequestModal = locators.modal.byTitle('New Request');
       await expect(newRequestModal).toBeVisible();
-      await page.getByTestId('modal-close-button').click();
+      await locators.modal.closeButton().click();
     });
   });
 
@@ -60,12 +60,11 @@ test.describe('Rich Text Editor - Keyboard Shortcut Interop with Global Hotkeys'
     await test.step('Cmd/Ctrl+Enter inserts a hard break (Tiptap\'s HardBreak binding)', async () => {
       await prosemirror.click();
       await page.keyboard.type('Line one');
-      // Mod-Enter is Tiptap's HardBreak binding and Bruno's global "Send
-      // Request" shortcut.
+      // Mod-Enter is Tiptap's HardBreak binding and Bruno's global "Send Request" shortcut.
       await pressShortcut(page, modifier, 'Enter');
       await page.keyboard.type('Line two');
 
-      // A hard break keeps both lines in the same paragraph and a real Enter
+      // A hard break keeps both lines in the same paragraph. a real Enter
       // (new paragraph) would split them into two separate <p> elements.
       await expect(prosemirror.locator('p')).toHaveCount(1);
       await expect(prosemirror.locator('p br')).toHaveCount(1);
@@ -73,11 +72,11 @@ test.describe('Rich Text Editor - Keyboard Shortcut Interop with Global Hotkeys'
     });
 
     await test.step('The global Send Request shortcut did not also fire', async () => {
-      await expect(page.getByTestId('send-arrow-icon')).toHaveAttribute('data-action', 'send');
-
-      await expect(page.getByTestId('response-status-code')).toHaveCount(0);
-      await page.waitForTimeout(3000);
-      await expect(page.getByTestId('response-status-code')).toHaveCount(0);
+      // The Send Request shortcut would have changed button text from Send to Cancel
+      await expect(locators.request.sendButton()).toBeVisible();
+      await expect(locators.request.sendButton()).not.toHaveAttribute('data-action', 'cancel');
+      // check for response status code which will present if the request was sent
+      await expect(locators.response.statusCode()).toHaveCount(0);
     });
   });
 
@@ -108,7 +107,7 @@ test.describe('Rich Text Editor - Keyboard Shortcut with Global Hotkeys (remappe
     await closeAllCollections(page);
   });
 
-  test('a shortcut Tiptap DOES bind only runs the editor action, not a colliding global shortcut', async ({ pageWithUserData: page, createTmpDir }) => {
+  test('a shortcut Tiptap does bind only runs the editor action, not a colliding global shortcut', async ({ pageWithUserData: page, createTmpDir }) => {
     await test.step('Remap Open Preferences shortcut to Cmd/Ctrl+B which is same combo Tiptap Bold binds', async () => {
       await remapKeybinding(page, 'openPreferences', modifier, 'KeyB');
     });
@@ -130,7 +129,7 @@ test.describe('Rich Text Editor - Keyboard Shortcut with Global Hotkeys (remappe
     await test.step('Cmd/Ctrl+B only bolds the selection. it does not open Preferences', async () => {
       await pressShortcut(page, modifier, 'KeyB');
       await expect(prosemirror.locator('strong')).toHaveText('World');
-      await expect(page.locator('.request-tab').filter({ has: page.getByText('Preferences', { exact: true }) })).not.toBeVisible();
+      await expect(locators.tabs.requestTab('Preferences')).not.toBeVisible();
     });
   });
 });

--- a/tests/richtext-editor/shortcut-passthrough.spec.ts
+++ b/tests/richtext-editor/shortcut-passthrough.spec.ts
@@ -72,7 +72,11 @@ test.describe('Rich Text Editor - Keyboard Shortcut Interop with Global Hotkeys'
       await expect(prosemirror.locator('p')).toContainText('Line oneLine two');
     });
 
-    await test.step('The global Send Request shortcut did not fire', async () => {
+    await test.step('The global Send Request shortcut did not also fire', async () => {
+      await expect(page.getByTestId('send-arrow-icon')).toHaveAttribute('data-action', 'send');
+
+      await expect(page.getByTestId('response-status-code')).toHaveCount(0);
+      await page.waitForTimeout(3000);
       await expect(page.getByTestId('response-status-code')).toHaveCount(0);
     });
   });

--- a/tests/richtext-editor/shortcut-passthrough.spec.ts
+++ b/tests/richtext-editor/shortcut-passthrough.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '../../playwright';
+import { closeAllCollections, setRequestUrlAndSave } from '../utils/page/actions';
+import { setupRequestDocs } from './actions';
+import { modifier, pressShortcut, remapKeybinding, resetKeybindings } from '../shortcuts/helpers';
+
+// keybinding which is bound in Tiptap and also has a global handler (Cmd/Ctrl+B) should not trigger the global handler when docs is focused.
+// keybinding which is not bound in Tiptap (Cmd/Ctrl+,) should still trigger the global handler when docs is focused.
+test.describe('Rich Text Editor - Keyboard Shortcut Interop with Global Hotkeys', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('a shortcut Tiptap does not bind still reaches the global handler while docs is focused', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-docs-shortcut-passthrough');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Type into docs', async () => {
+      await expect(prosemirror).toBeVisible();
+      await prosemirror.click();
+      await page.keyboard.type('Some docs content');
+    });
+
+    await test.step('Open Preferences (Cmd/Ctrl+,) still fires — no Tiptap binding for it', async () => {
+      await pressShortcut(page, modifier, 'Comma');
+      await expect(page.locator('.request-tab').filter({ has: page.getByText('Preferences', { exact: true }) })).toBeVisible();
+    });
+  });
+
+  test('Cmd/Ctrl+N (no Tiptap binding) opens the New Request modal while docs is focused', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-docs-shortcut-new-request');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Type into docs', async () => {
+      await expect(prosemirror).toBeVisible();
+      await prosemirror.click();
+      await page.keyboard.type('Some docs content');
+    });
+
+    await test.step('Cmd/Ctrl+N still opens the New Request modal', async () => {
+      await pressShortcut(page, modifier, 'KeyN');
+      const newRequestModal = page.locator('.bruno-modal').filter({ has: page.getByText('New Request', { exact: true }) });
+      await expect(newRequestModal).toBeVisible();
+      await page.getByTestId('modal-close-button').click();
+    });
+  });
+
+  test('Cmd/Ctrl+Enter inside docs inserts a hard break, not the global Send Request shortcut', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-docs-shortcut-send-request');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Give the request a real URL, so a regression (Send Request also firing) would be unambiguous', async () => {
+      await setRequestUrlAndSave(page, 'https://echo.usebruno.com');
+      await expect(prosemirror).toBeVisible();
+    });
+
+    await test.step('Cmd/Ctrl+Enter inserts a hard break (Tiptap\'s HardBreak binding)', async () => {
+      await prosemirror.click();
+      await page.keyboard.type('Line one');
+      // Mod-Enter is Tiptap's HardBreak binding and Bruno's global "Send
+      // Request" shortcut.
+      await pressShortcut(page, modifier, 'Enter');
+      await page.keyboard.type('Line two');
+
+      // A hard break keeps both lines in the same paragraph and a real Enter
+      // (new paragraph) would split them into two separate <p> elements.
+      await expect(prosemirror.locator('p')).toHaveCount(1);
+      await expect(prosemirror.locator('p br')).toHaveCount(1);
+      await expect(prosemirror.locator('p')).toContainText('Line oneLine two');
+    });
+
+    await test.step('The global Send Request shortcut did not fire', async () => {
+      await expect(page.getByTestId('response-status-code')).toHaveCount(0);
+    });
+  });
+
+  test('typing the bare "b" key (no modifier) just inserts text', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-docs-shortcut-bare-key');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Type a bare "b"', async () => {
+      await expect(prosemirror).toBeVisible();
+      await prosemirror.click();
+      await page.keyboard.type('b');
+    });
+
+    await test.step('It is inserted as plain text, not bolded', async () => {
+      await expect(prosemirror).toContainText('b');
+      await expect(prosemirror.locator('strong')).toHaveCount(0);
+    });
+  });
+});
+
+test.describe('Rich Text Editor - Keyboard Shortcut with Global Hotkeys (remapped)', () => {
+  test.beforeEach(async ({ pageWithUserData: page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+  });
+
+  test.afterEach(async ({ pageWithUserData: page }) => {
+    await resetKeybindings(page);
+    await closeAllCollections(page);
+  });
+
+  test('a shortcut Tiptap DOES bind only runs the editor action, not a colliding global shortcut', async ({ pageWithUserData: page, createTmpDir }) => {
+    await test.step('Remap Open Preferences shortcut to Cmd/Ctrl+B which is same combo Tiptap Bold binds', async () => {
+      await remapKeybinding(page, 'openPreferences', modifier, 'KeyB');
+    });
+
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-docs-shortcut-collision');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Select text in docs', async () => {
+      await expect(prosemirror).toBeVisible();
+      await prosemirror.click();
+      await page.keyboard.type('Hello World');
+      await page.keyboard.down('Shift');
+      for (let i = 0; i < 5; i++) {
+        await page.keyboard.press('ArrowLeft');
+      }
+      await page.keyboard.up('Shift');
+    });
+
+    await test.step('Cmd/Ctrl+B only bolds the selection. it does not open Preferences', async () => {
+      await pressShortcut(page, modifier, 'KeyB');
+      await expect(prosemirror.locator('strong')).toHaveText('World');
+      await expect(page.locator('.request-tab').filter({ has: page.getByText('Preferences', { exact: true }) })).not.toBeVisible();
+    });
+  });
+});

--- a/tests/richtext-editor/shortcut-passthrough.spec.ts
+++ b/tests/richtext-editor/shortcut-passthrough.spec.ts
@@ -98,6 +98,8 @@ test.describe('Rich Text Editor - Keyboard Shortcut Interop with Global Hotkeys'
 });
 
 test.describe('Rich Text Editor - Keyboard Shortcut with Global Hotkeys (remapped)', () => {
+  // we are remapping the preferences shortcuts which will store in keybindings.json.
+  // now we need to use pageWithUserData so that other tests don't get affected by the remapping.
   test.beforeEach(async ({ pageWithUserData: page }) => {
     await page.setViewportSize({ width: 1920, height: 1080 });
   });


### PR DESCRIPTION
### Description

BRU-4216

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
In Rich doc editor the keybindings which are not bind but have binding in global keybindings are getting ignores. 
Eg, cmd+N is for creating a new request. Since this keybinding is not there in doc editor, this should open the new request. 

This PR targets the keybindings to flow and add a `mousetrap` class so that the Global keybinding which uses MouseTrap do not ignore and perform the action tied to that keybind.

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->

- If a keybind is not in Titptaps keyBind then that keybind if present in global, it should get executed.
- `Mousetrap` by default "ignore all contentEditable" events. So even it gets a keybind event from Tiptap  editor (editable element) those keybinds are getting rejected.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

- added `mousetrap` classlist to editor so that Mousetrap doesn't ignore the keybind if its there.
- added stopPropogation for Titap key events so that prevent keydown events which are bind to TipTap from bubbling up to the global Mousetrap handlers.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved keyboard shortcut handling in the documentation editor.
* Prevented save shortcuts from triggering duplicate or unintended actions.
* Ensured global shortcuts continue working while the editor is focused, while editor-specific shortcuts take precedence.
* Preserved rich-text behaviors such as bold formatting and hard breaks without triggering unintended requests.

## Tests

* Added coverage for keyboard shortcut interactions and editor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->