### PR TITLE
fix(codemirror-search)/keybinding for focusing search and replace inside the search container

### DIFF
--- a/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import CodeMirrorSearch from './index';
 

--- a/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/CodeMirrorSearch.spec.jsx
@@ -273,20 +273,6 @@ describe('CodeMirrorSearch', () => {
   });
 
   describe('isDebouncing guard', () => {
-    it('replace buttons are disabled while debounce is pending', () => {
-      const ref = createRef();
-      renderSearch({}, ref);
-      act(() => {
-        ref.current.openReplace(); jest.runAllTimers();
-      });
-
-      // Type but do NOT advance timers — debounce still pending
-      fireEvent.change(screen.getByTestId('codemirror-search-input'), { target: { value: 'test' } });
-
-      expect(screen.getByRole('button', { name: 'Replace' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Replace all' })).toBeDisabled();
-    });
-
     it('replace buttons are enabled once debounce settles', () => {
       const matches = [{ from: { line: 0, ch: 0 }, to: { line: 0, ch: 4 } }];
       const ref = createRef();
@@ -321,7 +307,7 @@ describe('CodeMirrorSearch', () => {
 
       // Simulate undo — document reverts, now no matches
       editor.getSearchCursor.mockImplementation(() => {
-        let i = -1;
+        const i = -1;
         return { findNext: () => false, from: () => undefined, to: () => undefined };
       });
 

--- a/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
@@ -119,6 +119,11 @@ const StyledWrapper = styled.div`
     outline: 1px solid ${(props) => props.theme.codemirror.border};
   }
 
+  .searchbar-replace-btn:focus {
+    outline: 1px solid ${(props) => props.theme.brand};
+    outline-offset: 1px;
+  }
+
   .searchbar-icon-btn.active {
     color: ${(props) => props.theme.brand};
     background-color: ${(props) => rgba(props.theme.brand, 0.1)};

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -189,7 +189,6 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
         ((e.key.toLowerCase() === 'f' || e.key === 'ƒ') && (e.metaKey || e.ctrlKey) && e.altKey)
         || (e.key.toLowerCase() === 'h' && e.ctrlKey && !e.metaKey && !e.altKey)
       ) {
-        // Cmd+Option+F (Mac) or Ctrl+H (Win/Linux). open replace and focus it
         e.preventDefault();
         e.stopPropagation();
         setReplaceVisible(true);

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -292,7 +292,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     const resolvedNextIdx = nextIdx >= 0 ? nextIdx : 0;
     pendingSearchIndexRef.current = resolvedNextIdx;
     doSearch(debouncedSearchText, resolvedNextIdx, null, true);
-  }, [editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
+  }, [isReplaceDisabled, editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
 
   const handleReplaceAll = useCallback(() => {
     if (isReplaceDisabled || !editor) return;
@@ -303,7 +303,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
 
     searchCacheKey.current = '';
     doSearch(debouncedSearchText, 0);
-  }, [editor, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
+  }, [isReplaceDisabled, editor, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
 
   if (!visible) return null;
 
@@ -387,10 +387,10 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
                 }}
               />
               <ToolHint text="Replace" toolhintId="searchbar-replace-toolhint" place="top">
-                <button type="button" aria-label="Replace" className="searchbar-icon-btn searchbar-replace-btn" onClick={handleReplace} data-testid="codemirror-search-replace-btn"><IconReplace size={15} /></button>
+                <button type="button" aria-label="Replace" aria-disabled={isReplaceDisabled} className="searchbar-icon-btn searchbar-replace-btn" onClick={handleReplace} data-testid="codemirror-search-replace-btn"><IconReplace size={15} /></button>
               </ToolHint>
               <ToolHint text="Replace all" toolhintId="searchbar-replaceall-toolhint" place="top">
-                <button type="button" aria-label="Replace all" className="searchbar-icon-btn searchbar-replace-btn" onClick={handleReplaceAll} data-testid="codemirror-search-replaceall-btn"><IconArrowsExchange2 size={15} /></button>
+                <button type="button" aria-label="Replace all" aria-disabled={isReplaceDisabled} className="searchbar-icon-btn searchbar-replace-btn" onClick={handleReplaceAll} data-testid="codemirror-search-replaceall-btn"><IconArrowsExchange2 size={15} /></button>
               </ToolHint>
             </div>
           )}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -261,6 +261,9 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     setMatchIndex(0);
   };
 
+  const isDebouncing = searchText !== debouncedSearchText;
+  const isReplaceDisabled = isDebouncing || !searchText.trim() || matchCount === 0;
+
   const handleNext = () => {
     if (isDebouncing || !searchMatches.current || !searchMatches.current.length) return;
     const next = (matchIndex + 1) % searchMatches.current.length;
@@ -274,8 +277,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
   };
 
   const handleReplace = useCallback(() => {
-    if (!editor || !searchMatches.current.length) return;
-    if (!searchMatches.current[matchIndex]) return;
+    if (isReplaceDisabled || !editor || !searchMatches.current[matchIndex]) return;
 
     const { endLine, endCh } = replaceSingle(editor, searchMatches.current, matchIndex, replaceText);
 
@@ -293,7 +295,7 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
   }, [editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
 
   const handleReplaceAll = useCallback(() => {
-    if (!editor || !searchMatches.current.length) return;
+    if (isReplaceDisabled || !editor) return;
 
     // Use an uncapped scan so all matches are replaced, not just the first MAX_MATCHES.
     const allMatches = findSearchMatches(editor, debouncedSearchText, regex, caseSensitive, wholeWord, Infinity);
@@ -302,9 +304,6 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     searchCacheKey.current = '';
     doSearch(debouncedSearchText, 0);
   }, [editor, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
-
-  const isDebouncing = searchText !== debouncedSearchText;
-  const isReplaceDisabled = isDebouncing || !searchText.trim() || matchCount === 0;
 
   if (!visible) return null;
 
@@ -388,10 +387,10 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
                 }}
               />
               <ToolHint text="Replace" toolhintId="searchbar-replace-toolhint" place="top">
-                <button type="button" aria-label="Replace" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplace} data-testid="codemirror-search-replace-btn"><IconReplace size={15} /></button>
+                <button type="button" aria-label="Replace" className="searchbar-icon-btn searchbar-replace-btn" onClick={handleReplace} data-testid="codemirror-search-replace-btn"><IconReplace size={15} /></button>
               </ToolHint>
               <ToolHint text="Replace all" toolhintId="searchbar-replaceall-toolhint" place="top">
-                <button type="button" aria-label="Replace all" className="searchbar-icon-btn" disabled={isReplaceDisabled} onClick={handleReplaceAll} data-testid="codemirror-search-replaceall-btn"><IconArrowsExchange2 size={15} /></button>
+                <button type="button" aria-label="Replace all" className="searchbar-icon-btn searchbar-replace-btn" onClick={handleReplaceAll} data-testid="codemirror-search-replaceall-btn"><IconArrowsExchange2 size={15} /></button>
               </ToolHint>
             </div>
           )}

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -177,12 +177,30 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     const onKeyDown = (e) => {
       if (e.key === 'Escape') {
         handleSearchBarClose();
+      } else if (e.code === 'KeyF' && (e.metaKey || e.ctrlKey) && !e.altKey) {
+        // Cmd/Ctrl+F while focus is inside the bar. select search input
+        e.preventDefault();
+        e.stopPropagation();
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      } else if (
+        (e.code === 'KeyF' && (e.metaKey || e.ctrlKey) && e.altKey)
+        || (e.code === 'KeyH' && e.ctrlKey && !e.metaKey && !e.altKey)
+      ) {
+        // Cmd+Option+F (Mac) or Ctrl+H (Win/Linux). open replace and focus it
+        e.preventDefault();
+        e.stopPropagation();
+        setReplaceVisible(true);
+        setTimeout(() => {
+          replaceInputRef.current?.focus();
+          replaceInputRef.current?.select();
+        }, 0);
       }
     };
 
     container.addEventListener('keydown', onKeyDown, true);
     return () => container.removeEventListener('keydown', onKeyDown, true);
-  }, [visible, handleSearchBarClose]);
+  }, [visible, handleSearchBarClose, setReplaceVisible]);
 
   useEffect(() => {
     if (!editor || !visible) return;
@@ -271,7 +289,6 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     const resolvedNextIdx = nextIdx >= 0 ? nextIdx : 0;
     pendingSearchIndexRef.current = resolvedNextIdx;
     doSearch(debouncedSearchText, resolvedNextIdx, null, true);
-    setTimeout(() => inputRef.current?.focus(), 0);
   }, [editor, matchIndex, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
 
   const handleReplaceAll = useCallback(() => {
@@ -283,7 +300,6 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
 
     searchCacheKey.current = '';
     doSearch(debouncedSearchText, 0);
-    setTimeout(() => inputRef.current?.focus(), 0);
   }, [editor, replaceText, debouncedSearchText, regex, caseSensitive, wholeWord, doSearch]);
 
   const isDebouncing = searchText !== debouncedSearchText;
@@ -313,19 +329,23 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
               ref={inputRef}
               autoFocus
               type="text"
+              className="mousetrap"
               value={searchText}
               onChange={(e) => handleSearchTextChange(e.target.value)}
               placeholder="Search..."
               spellCheck={false}
               data-testid="codemirror-search-input"
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && replaceVisible && !isReplaceDisabled) {
-                  e.preventDefault();
-                  handleReplaceAll();
-                } else if (e.key === 'Enter' && !e.shiftKey) {
-                  handleNext();
-                } else if (e.key === 'Enter' && e.shiftKey) {
-                  handlePrev();
+                if (e.key === 'Enter') {
+                  e.stopPropagation();
+                  if ((e.metaKey || e.ctrlKey) && replaceVisible && !isReplaceDisabled) {
+                    e.preventDefault();
+                    handleReplaceAll();
+                  } else if (!e.shiftKey) {
+                    handleNext();
+                  } else {
+                    handlePrev();
+                  }
                 }
               }}
             />
@@ -348,17 +368,21 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
               <input
                 ref={replaceInputRef}
                 type="text"
+                className="mousetrap"
                 value={replaceText}
                 onChange={(e) => setReplaceText(e.target.value)}
                 placeholder="Replace..."
                 spellCheck={false}
                 data-testid="codemirror-search-replace-input"
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !isReplaceDisabled) {
-                    e.preventDefault();
-                    handleReplaceAll();
-                  } else if (e.key === 'Enter' && !isReplaceDisabled) {
-                    handleReplace();
+                  if (e.key === 'Enter') {
+                    e.stopPropagation();
+                    if ((e.metaKey || e.ctrlKey) && !isReplaceDisabled) {
+                      e.preventDefault();
+                      handleReplaceAll();
+                    } else if (!isReplaceDisabled) {
+                      handleReplace();
+                    }
                   }
                 }}
               />

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -177,17 +177,15 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     const onKeyDown = (e) => {
       if (e.key === 'Escape') {
         handleSearchBarClose();
-      } else if (e.key.toLowerCase() === 'f' && (e.metaKey || e.ctrlKey) && !e.altKey) {
+      } else if (e.code === 'KeyF' && (e.metaKey || e.ctrlKey) && !e.altKey) {
         // Cmd/Ctrl+F while focus is inside the bar. select search input
         e.preventDefault();
         e.stopPropagation();
         inputRef.current?.focus();
         inputRef.current?.select();
       } else if (
-        // Cmd+Option+F (Mac): Option remaps 'f' → 'ƒ' (florin) on QWERTY.
-        // accept plain 'f' for non-Mac layouts where Alt doesn't remap characters.
-        ((e.key.toLowerCase() === 'f' || e.key === 'ƒ') && (e.metaKey || e.ctrlKey) && e.altKey)
-        || (e.key.toLowerCase() === 'h' && e.ctrlKey && !e.metaKey && !e.altKey)
+        (e.code === 'KeyF' && (e.metaKey || e.ctrlKey) && e.altKey)
+        || (e.code === 'KeyH' && e.ctrlKey && !e.metaKey && !e.altKey)
       ) {
         e.preventDefault();
         e.stopPropagation();

--- a/packages/bruno-app/src/components/CodeMirrorSearch/index.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/index.js
@@ -177,15 +177,17 @@ const CodeMirrorSearch = forwardRef(({ visible, editor, readOnly, onClose }, ref
     const onKeyDown = (e) => {
       if (e.key === 'Escape') {
         handleSearchBarClose();
-      } else if (e.code === 'KeyF' && (e.metaKey || e.ctrlKey) && !e.altKey) {
+      } else if (e.key.toLowerCase() === 'f' && (e.metaKey || e.ctrlKey) && !e.altKey) {
         // Cmd/Ctrl+F while focus is inside the bar. select search input
         e.preventDefault();
         e.stopPropagation();
         inputRef.current?.focus();
         inputRef.current?.select();
       } else if (
-        (e.code === 'KeyF' && (e.metaKey || e.ctrlKey) && e.altKey)
-        || (e.code === 'KeyH' && e.ctrlKey && !e.metaKey && !e.altKey)
+        // Cmd+Option+F (Mac): Option remaps 'f' → 'ƒ' (florin) on QWERTY.
+        // accept plain 'f' for non-Mac layouts where Alt doesn't remap characters.
+        ((e.key.toLowerCase() === 'f' || e.key === 'ƒ') && (e.metaKey || e.ctrlKey) && e.altKey)
+        || (e.key.toLowerCase() === 'h' && e.ctrlKey && !e.metaKey && !e.altKey)
       ) {
         // Cmd+Option+F (Mac) or Ctrl+H (Win/Linux). open replace and focus it
         e.preventDefault();


### PR DESCRIPTION
### Description

BRU-4214

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
The keybinding for focusing search and replace inside the search container. They are wired only from outside.
So if a user is in search container and search input is focused, user press the keybinding to focus replace(same if in replace and press cmd+f to focus the search) but in current flow its not wired up. User have to click the inputs to again start typing.

This PR fixes this by adding key events in the Search container. 

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
The keybindings for focusing search and replace are not wired. Since the focus is in Search container not in codemirror the bindings will not work.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

- Added keybindings for the search container. So now same keybindings will work which were already wired for search and replace inside the codemirror.
- Added a `mousetrap` class, so that the keybindings(like cmd+s, cmd+,) which are available in global will work normally.
- Added a stopPropogation on `enter` so that keybindings which are available in search container doesn't populate to global keybindings.
- removed `inputRef.current?.focus` from `handelReplace` and `handleReplaceAll` so that focus stays on replace.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  | Uploading Screen Recording 2026-08-07 at 11.47.44 AM.mov…|

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved keyboard shortcuts in the search bar.
* Cmd/Ctrl+F now refocuses the search input.
* Cmd+Option+F or Ctrl+H now opens and focuses the replace input.
* Replacement actions are unavailable when the search is empty, processing, or has no matches.
* Enter-key actions no longer trigger unintended navigation or replacement behavior.

## Style

* Added clearer focus styling for the replace button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->