### PR TITLE
feat(migrate): enhance migration modal to handle collection drafts

### DIFF
--- a/packages/bruno-app/src/components/MigrateCollectionToYmlModal/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MigrateCollectionToYmlModal/StyledWrapper.js
@@ -60,6 +60,16 @@ const StyledWrapper = styled.div`
     font-size: ${(props) => props.theme.font.size.sm};
     color: ${(props) => props.theme.colors.text.muted};
   }
+
+  .warning-text {
+    color: ${(props) => props.theme.status.warning.text};
+  }
+
+  .transient-item {
+    background-color: ${(props) => props.theme.background.surface0};
+    border: 1px solid ${(props) => props.theme.border.border0};
+    border-radius: 4px;
+  }
 `;
 
 export default StyledWrapper;

--- a/packages/bruno-app/src/components/MigrateCollectionToYmlModal/index.js
+++ b/packages/bruno-app/src/components/MigrateCollectionToYmlModal/index.js
@@ -256,7 +256,7 @@ const MigrateCollectionToYmlModal = () => {
   };
 
   const handleSaveTransient = (draft) => {
-    dispatch(saveRequest(draft.uid, draft.collectionUid));
+    dispatch(saveRequest(draft.uid, draft.collectionUid)).catch(() => {});
   };
 
   const transientRequestDrafts = collectionDrafts.filter((d) => isItemARequest(d) && d.isTransient);
@@ -278,10 +278,11 @@ const MigrateCollectionToYmlModal = () => {
   if (showDraftsStep && migration.status === 'confirming') {
     const totalDraftsCount = collectionDrafts.length;
     return (
-      <StyledWrapper data-testid="migration-drafts-step">
+      <StyledWrapper>
         <Modal
           size="md"
           title="Unsaved changes"
+          dataTestId="migration-drafts-step"
           handleCancel={handleBackToConfirm}
           disableEscapeKey={true}
           disableCloseOnOutsideClick={true}

--- a/packages/bruno-app/src/components/MigrateCollectionToYmlModal/index.js
+++ b/packages/bruno-app/src/components/MigrateCollectionToYmlModal/index.js
@@ -1,11 +1,36 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import filter from 'lodash/filter';
+import each from 'lodash/each';
 import { useDispatch, useSelector } from 'react-redux';
+import { IconAlertTriangle, IconDeviceFloppy } from '@tabler/icons';
 import toast from 'react-hot-toast';
-import { migrateCollectionToYml, cancelMigrateCollectionToYml } from 'providers/ReduxStore/slices/collections/actions';
+import {
+  migrateCollectionToYml,
+  cancelMigrateCollectionToYml,
+  saveRequest,
+  saveMultipleRequests,
+  saveMultipleCollections,
+  saveMultipleFolders,
+  saveEnvironment
+} from 'providers/ReduxStore/slices/collections/actions';
+import {
+  deleteRequestDraft,
+  deleteCollectionDraft,
+  deleteFolderDraft,
+  clearEnvironmentsDraft
+} from 'providers/ReduxStore/slices/collections';
 import { hideMigrateToYmlModal } from 'providers/ReduxStore/slices/collection-migration';
-import { findCollectionByUid } from 'utils/collections';
+import {
+  findCollectionByUid,
+  findEnvironmentInCollection,
+  flattenItems,
+  hasRequestChanges,
+  isItemARequest
+} from 'utils/collections';
+import { pluralizeWord } from 'utils/common';
+import { getInvalidVariableNames } from 'utils/common/variables';
+import { isEnvironmentValidationError } from 'utils/environments';
 import Modal from 'components/Modal';
-import Portal from 'components/Portal';
 import Button from 'ui/Button';
 import StyledWrapper from './StyledWrapper';
 
@@ -13,6 +38,58 @@ const PHASE_LABELS = {
   parsing: 'Converting files',
   writing: 'Writing yml files',
   finalizing: 'Removing bru files'
+};
+
+const MAX_UNSAVED_ITEMS_TO_SHOW = 5;
+
+const collectCollectionDrafts = (collection) => {
+  if (!collection) {
+    return [];
+  }
+
+  const drafts = [];
+
+  if (collection.draft) {
+    drafts.push({
+      type: 'collection',
+      name: collection.name,
+      collectionUid: collection.uid
+    });
+  }
+
+  if (collection.environmentsDraft) {
+    const { environmentUid, variables } = collection.environmentsDraft;
+    const environment = findEnvironmentInCollection(collection, environmentUid);
+    if (environment && variables) {
+      drafts.push({
+        type: 'collection-environment',
+        name: environment.name,
+        environmentUid,
+        variables,
+        collectionUid: collection.uid
+      });
+    }
+  }
+
+  const items = flattenItems(collection.items);
+
+  each(filter(items, (item) => item.type === 'folder' && item.draft), (folder) => {
+    drafts.push({
+      type: 'folder',
+      name: folder.name,
+      folderUid: folder.uid,
+      collectionUid: collection.uid
+    });
+  });
+
+  each(filter(items, (item) => isItemARequest(item) && hasRequestChanges(item)), (item) => {
+    drafts.push({
+      ...item,
+      collectionUid: collection.uid
+    });
+  });
+
+  return drafts;
 };
 
 // Rendered at app level (AppProvider) and driven by the collectionMigration slice: the
@@ -26,6 +103,10 @@ const MigrateCollectionToYmlModal = () => {
     findCollectionByUid(state.collections.collections, migration.collectionUid)
   );
   const [isExporting, setIsExporting] = useState(false);
+  const [isResolvingDrafts, setIsResolvingDrafts] = useState(false);
+  const [showDraftsStep, setShowDraftsStep] = useState(false);
+
+  const collectionDrafts = useMemo(() => collectCollectionDrafts(collection), [collection]);
 
   if (migration.status === 'idle') {
     return null;
@@ -37,8 +118,16 @@ const MigrateCollectionToYmlModal = () => {
   // finishes races with the watcher's initial scan and can leave the tree half-loaded.
   const isCollectionMounted = collection?.mountStatus === 'mounted';
 
-  const handleMigrate = () => {
+  const startMigration = () => {
     dispatch(migrateCollectionToYml(migration.collectionUid)).catch(() => {});
+  };
+
+  const handleMigrateClick = () => {
+    if (collectionDrafts.length > 0) {
+      setShowDraftsStep(true);
+      return;
+    }
+    startMigration();
   };
 
   const handleCancelMigration = () => {
@@ -46,7 +135,14 @@ const MigrateCollectionToYmlModal = () => {
   };
 
   const handleClose = () => {
+    setShowDraftsStep(false);
+    setIsResolvingDrafts(false);
     dispatch(hideMigrateToYmlModal());
+  };
+
+  const handleBackToConfirm = () => {
+    if (isResolvingDrafts) return;
+    setShowDraftsStep(false);
   };
 
   const handleExportBackup = async () => {
@@ -69,6 +165,201 @@ const MigrateCollectionToYmlModal = () => {
     }
   };
 
+  const handleDiscardAllDrafts = () => {
+    if (isResolvingDrafts) return;
+    collectionDrafts.forEach((draft) => {
+      switch (draft.type) {
+        case 'collection':
+          dispatch(deleteCollectionDraft({ collectionUid: draft.collectionUid }));
+          break;
+        case 'folder':
+          dispatch(deleteFolderDraft({ collectionUid: draft.collectionUid, folderUid: draft.folderUid }));
+          break;
+        case 'collection-environment':
+          dispatch(clearEnvironmentsDraft({ collectionUid: draft.collectionUid }));
+          break;
+        default:
+          dispatch(deleteRequestDraft({ collectionUid: draft.collectionUid, itemUid: draft.uid }));
+          break;
+      }
+    });
+    setShowDraftsStep(false);
+    startMigration();
+  };
+
+  const handleSaveAllDrafts = async () => {
+    if (isResolvingDrafts) return;
+    setIsResolvingDrafts(true);
+    try {
+      const collectionLevelDrafts = collectionDrafts.filter((d) => d.type === 'collection');
+      const folderDrafts = collectionDrafts.filter((d) => d.type === 'folder');
+      const requestDrafts = collectionDrafts.filter((d) => isItemARequest(d));
+      const transientRequestDrafts = requestDrafts.filter((d) => d.isTransient);
+      const nonTransientRequestDrafts = requestDrafts.filter((d) => !d.isTransient);
+      const environmentDrafts = collectionDrafts.filter((d) => d.type === 'collection-environment');
+
+      if (collectionLevelDrafts.length > 0) {
+        await dispatch(saveMultipleCollections(collectionLevelDrafts));
+      }
+
+      if (folderDrafts.length > 0) {
+        await dispatch(saveMultipleFolders(folderDrafts));
+      }
+
+      if (nonTransientRequestDrafts.length > 0) {
+        await dispatch(saveMultipleRequests(nonTransientRequestDrafts));
+      }
+
+      if (transientRequestDrafts.length > 0) {
+        // Transient requests have no on-disk file yet; each must be saved individually
+        // (Save As dialog). Keep the drafts step open so the user can finish them.
+        await Promise.all(
+          transientRequestDrafts.map((draft) =>
+            dispatch(saveRequest(draft.uid, draft.collectionUid, true)).catch(() => null)
+          )
+        );
+        return;
+      }
+
+      let hasSkippedEnvs = false;
+      for (const draft of environmentDrafts) {
+        const invalidNames = getInvalidVariableNames(draft.variables);
+        if (invalidNames.length > 0) {
+          hasSkippedEnvs = true;
+          toast.error(`Cannot save environment "${draft.name}": invalid variable name(s) — ${invalidNames.join(', ')}`);
+          continue;
+        }
+
+        try {
+          await dispatch(saveEnvironment(draft.variables, draft.environmentUid, draft.collectionUid));
+        } catch (err) {
+          hasSkippedEnvs = true;
+          toast.error(
+            isEnvironmentValidationError(err)
+              ? `Cannot save environment "${draft.name}": ${err.message}`
+              : `Failed to save environment "${draft.name}"`
+          );
+        }
+      }
+
+      if (hasSkippedEnvs) {
+        return;
+      }
+
+      setShowDraftsStep(false);
+      startMigration();
+    } catch (error) {
+      toast.error('Failed to save changes');
+    } finally {
+      setIsResolvingDrafts(false);
+    }
+  };
+
+  const handleSaveTransient = (draft) => {
+    dispatch(saveRequest(draft.uid, draft.collectionUid));
+  };
+
+  const transientRequestDrafts = collectionDrafts.filter((d) => isItemARequest(d) && d.isTransient);
+  const hasBlockingTransients = transientRequestDrafts.length > 0;
+
+  const renderDraftLabel = (draft) => {
+    switch (draft.type) {
+      case 'collection':
+        return `Collection: ${draft.name}`;
+      case 'folder':
+        return `Folder: ${draft.name}`;
+      case 'collection-environment':
+        return `Environment: ${draft.name}`;
+      default:
+        return `Request: ${draft.filename || draft.name}`;
+    }
+  };
+
+  if (showDraftsStep && migration.status === 'confirming') {
+    const totalDraftsCount = collectionDrafts.length;
+    return (
+      <StyledWrapper>
+        <Modal
+          size="md"
+          title="Unsaved changes"
+          handleCancel={handleBackToConfirm}
+          disableEscapeKey={true}
+          disableCloseOnOutsideClick={true}
+          closeModalFadeTimeout={150}
+          hideFooter={true}
+        >
+          <div className="flex items-center">
+            <IconAlertTriangle size={32} strokeWidth={1.5} className="warning-text" />
+            <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
+          </div>
+          <p className="mt-4">
+            You have unsaved changes in <span className="font-medium">{totalDraftsCount}</span>{' '}
+            {pluralizeWord('item', totalDraftsCount)}. Save or discard them before migrating.
+          </p>
+
+          <ul className="mt-4 ml-2">
+            {collectionDrafts.slice(0, MAX_UNSAVED_ITEMS_TO_SHOW).map((draft, index) => (
+              <li key={`${draft.type || 'request'}-${draft.uid || draft.folderUid || draft.environmentUid || draft.collectionUid}-${index}`} className="mt-1 text-xs">
+                • {renderDraftLabel(draft)}
+              </li>
+            ))}
+          </ul>
+
+          {totalDraftsCount > MAX_UNSAVED_ITEMS_TO_SHOW && (
+            <p className="ml-2 mt-1 text-xs">
+              ...{totalDraftsCount - MAX_UNSAVED_ITEMS_TO_SHOW} additional{' '}
+              {pluralizeWord('item', totalDraftsCount - MAX_UNSAVED_ITEMS_TO_SHOW)} not shown
+            </p>
+          )}
+
+          {hasBlockingTransients && (
+            <div className="mt-4">
+              <p className="text-xs mb-2">
+                Transient requests need to be saved individually before migrating.
+              </p>
+              <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
+                {transientRequestDrafts.map((item) => (
+                  <div key={item.uid} className="flex items-center justify-between py-2 px-3 transient-item">
+                    <span className="text-sm truncate mr-3">{item.name}</span>
+                    <Button
+                      color="primary"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleSaveTransient(item)}
+                      icon={<IconDeviceFloppy size={14} strokeWidth={1.5} />}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-between mt-6">
+            <div>
+              <Button color="danger" onClick={handleDiscardAllDrafts} disabled={isResolvingDrafts}>
+                Discard All
+              </Button>
+            </div>
+            <div className="flex gap-2">
+              <Button color="secondary" variant="ghost" onClick={handleBackToConfirm} disabled={isResolvingDrafts}>
+                Back
+              </Button>
+              <Button
+                onClick={handleSaveAllDrafts}
+                disabled={isResolvingDrafts || hasBlockingTransients}
+                title={hasBlockingTransients ? 'Save transient requests individually first' : ''}
+              >
+                {isResolvingDrafts ? 'Saving…' : totalDraftsCount > 1 ? 'Save All and Migrate' : 'Save and Migrate'}
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      </StyledWrapper>
+    );
+  }
+
   const confirmDisabled = isMigrating ? isCancelling : isExporting || !isCollectionMounted;
   const progressPercent = migration.total ? Math.round((migration.current / migration.total) * 100) : 0;
   const progressLabel = migration.phase
@@ -76,86 +367,84 @@ const MigrateCollectionToYmlModal = () => {
     : 'Preparing…';
 
   return (
-    <Portal>
-      <StyledWrapper>
-        <Modal
-          size="md"
-          title="Migrate to YML format"
-          confirmText={isMigrating ? (isCancelling ? 'Cancelling…' : 'Cancel') : 'Migrate'}
-          confirmButtonColor={isMigrating ? 'danger' : 'primary'}
-          confirmDisabled={confirmDisabled}
-          handleConfirm={isMigrating ? handleCancelMigration : handleMigrate}
-          handleCancel={handleClose}
-          hideCancel={isMigrating}
-          hideClose={isMigrating}
-          disableCloseOnOutsideClick={isMigrating}
-          disableEscapeKey={isMigrating}
-        >
-          <div>
-            <p>
-              This will convert all files in <strong>{migration.collectionName}</strong> from <code>.bru</code> format to <code>.yml</code> format.
-            </p>
-            {isMigrating ? (
-              <div
-                className="migration-progress mt-4"
-                data-testid="migration-progress"
-                role="progressbar"
-                aria-valuenow={progressPercent}
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-label={isCancelling ? 'Cancelling and restoring the collection' : progressLabel}
-              >
-                <div className="migration-progress-track">
-                  <div
-                    className="migration-progress-fill"
-                    data-testid="migration-progress-bar"
-                    style={{ width: `${progressPercent}%` }}
-                  />
+    <StyledWrapper>
+      <Modal
+        size="md"
+        title="Migrate to YML format"
+        confirmText={isMigrating ? (isCancelling ? 'Cancelling…' : 'Cancel') : 'Migrate'}
+        confirmButtonColor={isMigrating ? 'danger' : 'primary'}
+        confirmDisabled={confirmDisabled}
+        handleConfirm={isMigrating ? handleCancelMigration : handleMigrateClick}
+        handleCancel={handleClose}
+        hideCancel={isMigrating}
+        hideClose={isMigrating}
+        disableCloseOnOutsideClick={isMigrating}
+        disableEscapeKey={isMigrating}
+      >
+        <div>
+          <p>
+            This will convert all files in <strong>{migration.collectionName}</strong> from <code>.bru</code> format to <code>.yml</code> format.
+          </p>
+          {isMigrating ? (
+            <div
+              className="migration-progress mt-4"
+              data-testid="migration-progress"
+              role="progressbar"
+              aria-valuenow={progressPercent}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={isCancelling ? 'Cancelling and restoring the collection' : progressLabel}
+            >
+              <div className="migration-progress-track">
+                <div
+                  className="migration-progress-fill"
+                  data-testid="migration-progress-bar"
+                  style={{ width: `${progressPercent}%` }}
+                />
+              </div>
+              <div className="migration-progress-label" data-testid="migration-progress-label">
+                {isCancelling ? 'Cancelling and restoring the collection…' : progressLabel}
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="mt-4 text-sm text-muted">
+                <p className="font-medium mb-2">What will happen:</p>
+                <ul className="list-disc ml-5 flex flex-col gap-1">
+                  <li>All <code>.bru</code> request files will be converted to <code>.yml</code></li>
+                  <li>Environment files will be converted to YML format</li>
+                  <li><code>bruno.json</code> will be replaced with <code>opencollection.yml</code></li>
+                  <li>Open tabs will be closed and the collection will be reloaded</li>
+                </ul>
+                {!isCollectionMounted && (
+                  <p className="mt-3">Waiting for the collection to finish loading before migration can start…</p>
+                )}
+              </div>
+              <div className="backup-section mt-4">
+                <div className="backup-section-head">
+                  <span className="backup-section-title">Backup</span>
                 </div>
-                <div className="migration-progress-label" data-testid="migration-progress-label">
-                  {isCancelling ? 'Cancelling and restoring the collection…' : progressLabel}
+                <p className="backup-section-help">
+                  Export this collection as a ZIP archive before migrating, in case you want to restore it later.
+                </p>
+                <div className="backup-section-action">
+                  <Button
+                    data-testid="export-collection-backup-button"
+                    size="sm"
+                    color="secondary"
+                    variant="outline"
+                    onClick={handleExportBackup}
+                    disabled={isExporting}
+                  >
+                    {isExporting ? 'Exporting…' : 'Export Collection'}
+                  </Button>
                 </div>
               </div>
-            ) : (
-              <>
-                <div className="mt-4 text-sm text-muted">
-                  <p className="font-medium mb-2">What will happen:</p>
-                  <ul className="list-disc ml-5 flex flex-col gap-1">
-                    <li>All <code>.bru</code> request files will be converted to <code>.yml</code></li>
-                    <li>Environment files will be converted to YML format</li>
-                    <li><code>bruno.json</code> will be replaced with <code>opencollection.yml</code></li>
-                    <li>Open tabs will be closed and the collection will be reloaded</li>
-                  </ul>
-                  {!isCollectionMounted && (
-                    <p className="mt-3">Waiting for the collection to finish loading before migration can start…</p>
-                  )}
-                </div>
-                <div className="backup-section mt-4">
-                  <div className="backup-section-head">
-                    <span className="backup-section-title">Backup</span>
-                  </div>
-                  <p className="backup-section-help">
-                    Export this collection as a ZIP archive before migrating, in case you want to restore it later.
-                  </p>
-                  <div className="backup-section-action">
-                    <Button
-                      data-testid="export-collection-backup-button"
-                      size="sm"
-                      color="secondary"
-                      variant="outline"
-                      onClick={handleExportBackup}
-                      disabled={isExporting}
-                    >
-                      {isExporting ? 'Exporting…' : 'Export Collection'}
-                    </Button>
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
-        </Modal>
-      </StyledWrapper>
-    </Portal>
+            </>
+          )}
+        </div>
+      </Modal>
+    </StyledWrapper>
   );
 };
 

--- a/packages/bruno-app/src/components/MigrateCollectionToYmlModal/index.js
+++ b/packages/bruno-app/src/components/MigrateCollectionToYmlModal/index.js
@@ -278,7 +278,7 @@ const MigrateCollectionToYmlModal = () => {
   if (showDraftsStep && migration.status === 'confirming') {
     const totalDraftsCount = collectionDrafts.length;
     return (
-      <StyledWrapper>
+      <StyledWrapper data-testid="migration-drafts-step">
         <Modal
           size="md"
           title="Unsaved changes"
@@ -319,9 +319,15 @@ const MigrateCollectionToYmlModal = () => {
               </p>
               <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
                 {transientRequestDrafts.map((item) => (
-                  <div key={item.uid} className="flex items-center justify-between py-2 px-3 transient-item">
+                  <div
+                    key={item.uid}
+                    className="flex items-center justify-between py-2 px-3 transient-item"
+                    data-testid="migration-drafts-transient-row"
+                    data-transient-name={item.name}
+                  >
                     <span className="text-sm truncate mr-3">{item.name}</span>
                     <Button
+                      data-testid="migration-drafts-transient-save"
                       color="primary"
                       variant="ghost"
                       size="sm"
@@ -338,15 +344,27 @@ const MigrateCollectionToYmlModal = () => {
 
           <div className="flex justify-between mt-6">
             <div>
-              <Button color="danger" onClick={handleDiscardAllDrafts} disabled={isResolvingDrafts}>
+              <Button
+                data-testid="migration-drafts-discard-all"
+                color="danger"
+                onClick={handleDiscardAllDrafts}
+                disabled={isResolvingDrafts}
+              >
                 Discard All
               </Button>
             </div>
             <div className="flex gap-2">
-              <Button color="secondary" variant="ghost" onClick={handleBackToConfirm} disabled={isResolvingDrafts}>
+              <Button
+                data-testid="migration-drafts-back"
+                color="secondary"
+                variant="ghost"
+                onClick={handleBackToConfirm}
+                disabled={isResolvingDrafts}
+              >
                 Back
               </Button>
               <Button
+                data-testid="migration-drafts-save-all"
                 onClick={handleSaveAllDrafts}
                 disabled={isResolvingDrafts || hasBlockingTransients}
                 title={hasBlockingTransients ? 'Save transient requests individually first' : ''}

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -415,27 +415,24 @@ export const saveMultipleCollections = (collectionDrafts) => (dispatch, getState
         const collectionRootToSave = transformCollectionRootToSave(collectionCopy);
         const { ipcRenderer } = window;
 
-        let savePromises = [];
-
-        savePromises.push(ipcRenderer.invoke('renderer:save-collection-root', collectionCopy.pathname, collectionRootToSave, collectionCopy.brunoConfig));
+        const collectionSavePromises = [
+          ipcRenderer.invoke('renderer:save-collection-root', collectionCopy.pathname, collectionRootToSave, collectionCopy.brunoConfig)
+        ];
 
         if (collectionCopy.draft?.brunoConfig) {
-          savePromises.push(ipcRenderer.invoke('renderer:update-bruno-config', collectionCopy.draft.brunoConfig, collectionCopy.pathname, collectionCopy.root));
+          collectionSavePromises.push(ipcRenderer.invoke('renderer:update-bruno-config', collectionCopy.draft.brunoConfig, collectionCopy.pathname, collectionCopy.root));
         }
 
-        Promise.all(savePromises)
-          .then(() => {
+        savePromises.push(
+          Promise.all(collectionSavePromises).then(() => {
             dispatch(saveCollectionDraft({ collectionUid: collectionDraft.collectionUid }));
           })
-          .catch((err) => {
-            toast.error('Failed to save collection settings!');
-            reject(err);
-          });
+        );
       }
     });
 
     Promise.all(savePromises)
-      .then(resolve)
+      .then(() => resolve())
       .catch((err) => {
         toast.error('Failed to save collection settings!');
         reject(err);

--- a/tests/collection/migrate-to-yml-drafts/collection-settings-draft.spec.ts
+++ b/tests/collection/migrate-to-yml-drafts/collection-settings-draft.spec.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  createRequest,
+  openCollectionSettings,
+  selectCollectionPaneTab,
+  editCodeMirrorEditor,
+  openMigrateToYmlModalFromOverview,
+  openMigrateDraftsStep,
+  saveAllDraftsAndMigrate
+} from '../../utils/page';
+
+const firstDirIn = (dir: string) =>
+  path.join(dir, fs.readdirSync(dir).find((entry) => fs.statSync(path.join(dir, entry)).isDirectory())!);
+
+test.describe('Migrate to YML — collection-settings draft is persisted before migration', () => {
+  test('saving a collection-settings draft in the drafts step preserves the change on disk after migration', async ({ page, createTmpDir }) => {
+    const loc = buildCommonLocators(page);
+    const parentDir = await createTmpDir('migrate-drafts-collection-settings');
+    const collectionName = 'migrate-drafts-collsettings';
+    const markerScript = 'bru.setVar(\'collectionMigrationMarker\', \'draft-survives-migrate\');';
+
+    await test.step('Create a bru collection with one saved request', async () => {
+      await createCollection(page, collectionName, parentDir, 'bru');
+      await createRequest(page, 'ping', collectionName, { method: 'GET', url: 'http://localhost:8081/ping' });
+    });
+
+    await test.step('Leave an unsaved pre-request script on the collection', async () => {
+      await openCollectionSettings(page, collectionName, { persist: true });
+      await selectCollectionPaneTab(page, 'script');
+      await loc.paneTabs.tabTrigger('pre-request').click();
+      await editCodeMirrorEditor(page, 'collection-pre-request-script-editor', markerScript);
+      await expect(loc.tabs.tabDraftIndicator(loc.tabs.collectionSettingsTab())).toBeVisible();
+    });
+
+    await test.step('Open the migrate modal from the overview tab', async () => {
+      await openMigrateToYmlModalFromOverview(page, collectionName);
+    });
+
+    await test.step('Migrate button routes to the drafts step; save resolves it and starts migration', async () => {
+      await openMigrateDraftsStep(page);
+      await saveAllDraftsAndMigrate(page);
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('opencollection.yml contains the pre-request marker (proves save finished before migrate)', async () => {
+      const collectionDir = firstDirIn(parentDir);
+      const yml = fs.readFileSync(path.join(collectionDir, 'opencollection.yml'), 'utf8');
+      expect(yml).toContain('collectionMigrationMarker');
+      expect(yml).toContain('draft-survives-migrate');
+    });
+
+    await test.step('Cleanup', async () => {
+      await closeAllCollections(page);
+    });
+  });
+});

--- a/tests/collection/migrate-to-yml-drafts/collection-settings-draft.spec.ts
+++ b/tests/collection/migrate-to-yml-drafts/collection-settings-draft.spec.ts
@@ -18,6 +18,12 @@ const firstDirIn = (dir: string) =>
   path.join(dir, fs.readdirSync(dir).find((entry) => fs.statSync(path.join(dir, entry)).isDirectory())!);
 
 test.describe('Migrate to YML — collection-settings draft is persisted before migration', () => {
+  test.afterEach(async ({ page }) => {
+    if (!page.isClosed()) {
+      await closeAllCollections(page);
+    }
+  });
+
   test('saving a collection-settings draft in the drafts step preserves the change on disk after migration', async ({ page, createTmpDir }) => {
     const loc = buildCommonLocators(page);
     const parentDir = await createTmpDir('migrate-drafts-collection-settings');
@@ -52,10 +58,6 @@ test.describe('Migrate to YML — collection-settings draft is persisted before 
       const yml = fs.readFileSync(path.join(collectionDir, 'opencollection.yml'), 'utf8');
       expect(yml).toContain('collectionMigrationMarker');
       expect(yml).toContain('draft-survives-migrate');
-    });
-
-    await test.step('Cleanup', async () => {
-      await closeAllCollections(page);
     });
   });
 });

--- a/tests/collection/migrate-to-yml-drafts/invalid-env-blocks-migrate.spec.ts
+++ b/tests/collection/migrate-to-yml-drafts/invalid-env-blocks-migrate.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '../../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  createRequest,
+  createEnvironment,
+  addEnvironmentVariable,
+  openMigrateToYmlModalFromOverview,
+  openMigrateDraftsStep,
+  discardAllDraftsAndMigrate
+} from '../../utils/page';
+
+test.describe('Migrate to YML — invalid environment draft blocks migrate', () => {
+  test('Save All surfaces the invalid-name error and keeps the drafts step; Discard All then unblocks migrate', async ({ page, createTmpDir }) => {
+    const loc = buildCommonLocators(page);
+    const migrate = loc.migrateToYml;
+    const parentDir = await createTmpDir('migrate-drafts-invalid-env');
+    const collectionName = 'migrate-drafts-invalid-env';
+    const invalidVarName = 'bad name!';
+
+    await createCollection(page, collectionName, parentDir, 'bru');
+    await createRequest(page, 'req', collectionName, { method: 'GET', url: 'http://localhost:8081/ping' });
+
+    await test.step('Leave an environment draft with an invalid variable name', async () => {
+      await createEnvironment(page, 'MigrateEnv', 'collection');
+      await addEnvironmentVariable(page, { name: invalidVarName, value: 'v1' });
+      // Do not save — the env stays as a draft in `collection.environmentsDraft`.
+    });
+
+    await openMigrateToYmlModalFromOverview(page, collectionName);
+    await openMigrateDraftsStep(page);
+
+    await test.step('Save All shows the invalid-name toast and keeps the drafts step open', async () => {
+      await migrate.draftsSaveAll().click();
+      await expect(loc.toast.byMessage(/invalid variable name/i)).toBeVisible({ timeout: 10000 });
+      await expect(migrate.draftsStep()).toBeVisible();
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeHidden();
+    });
+
+    await test.step('Discard All resolves the draft and lets migration complete', async () => {
+      await discardAllDraftsAndMigrate(page);
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('Cleanup', async () => {
+      await closeAllCollections(page);
+    });
+  });
+});

--- a/tests/collection/migrate-to-yml-drafts/invalid-env-blocks-migrate.spec.ts
+++ b/tests/collection/migrate-to-yml-drafts/invalid-env-blocks-migrate.spec.ts
@@ -12,6 +12,12 @@ import {
 } from '../../utils/page';
 
 test.describe('Migrate to YML — invalid environment draft blocks migrate', () => {
+  test.afterEach(async ({ page }) => {
+    if (!page.isClosed()) {
+      await closeAllCollections(page);
+    }
+  });
+
   test('Save All surfaces the invalid-name error and keeps the drafts step; Discard All then unblocks migrate', async ({ page, createTmpDir }) => {
     const loc = buildCommonLocators(page);
     const migrate = loc.migrateToYml;
@@ -25,7 +31,8 @@ test.describe('Migrate to YML — invalid environment draft blocks migrate', () 
     await test.step('Leave an environment draft with an invalid variable name', async () => {
       await createEnvironment(page, 'MigrateEnv', 'collection');
       await addEnvironmentVariable(page, { name: invalidVarName, value: 'v1' });
-      // Do not save — the env stays as a draft in `collection.environmentsDraft`.
+      const envTab = page.locator('.request-tab').filter({ hasText: 'Environments' });
+      await expect(loc.tabs.tabDraftIndicator(envTab)).toBeVisible({ timeout: 5000 });
     });
 
     await openMigrateToYmlModalFromOverview(page, collectionName);
@@ -35,16 +42,11 @@ test.describe('Migrate to YML — invalid environment draft blocks migrate', () 
       await migrate.draftsSaveAll().click();
       await expect(loc.toast.byMessage(/invalid variable name/i)).toBeVisible({ timeout: 10000 });
       await expect(migrate.draftsStep()).toBeVisible();
-      await expect(page.getByText('Collection migrated to YML format successfully')).toBeHidden();
     });
 
     await test.step('Discard All resolves the draft and lets migration complete', async () => {
       await discardAllDraftsAndMigrate(page);
       await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
-    });
-
-    await test.step('Cleanup', async () => {
-      await closeAllCollections(page);
     });
   });
 });

--- a/tests/collection/migrate-to-yml-drafts/request-draft-save-discard-back.spec.ts
+++ b/tests/collection/migrate-to-yml-drafts/request-draft-save-discard-back.spec.ts
@@ -102,11 +102,13 @@ test.describe('Migrate to YML — request draft happy paths', () => {
       await returnFromDraftsStep(page);
       await expect(migrate.modal()).toBeVisible();
       await expect(migrate.migrateButton()).toBeVisible();
-      await expect(page.getByText('Collection migrated to YML format successfully')).toBeHidden();
     });
 
     await test.step('Close the migrate modal and confirm the draft is still dirty', async () => {
       await migrate.modal().getByTestId('modal-close-button').click();
+      // Focus the request tab (openMigrateToYmlModalFromOverview switched the active tab
+      // to Collection Settings), then check its draft indicator.
+      await loc.sidebar.request('req').click();
       await expect(loc.tabs.tabDraftIndicator(loc.tabs.activeRequestTab())).toBeVisible();
       const collectionDir = firstDirIn(parentDir);
       // On-disk file still has the pre-edit URL; edit lives only in the draft.

--- a/tests/collection/migrate-to-yml-drafts/request-draft-save-discard-back.spec.ts
+++ b/tests/collection/migrate-to-yml-drafts/request-draft-save-discard-back.spec.ts
@@ -1,0 +1,118 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  createRequest,
+  fillRequestUrl,
+  openMigrateToYmlModalFromOverview,
+  openMigrateDraftsStep,
+  saveAllDraftsAndMigrate,
+  discardAllDraftsAndMigrate,
+  returnFromDraftsStep
+} from '../../utils/page';
+
+const firstDirIn = (dir: string) =>
+  path.join(dir, fs.readdirSync(dir).find((entry) => fs.statSync(path.join(dir, entry)).isDirectory())!);
+
+const SAVED_URL = 'http://localhost:8081/original';
+const EDITED_SUFFIX = '/edited-in-draft';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Migrate to YML — request draft happy paths', () => {
+  test.afterEach(async ({ page }) => {
+    if (!page.isClosed()) {
+      await closeAllCollections(page);
+    }
+  });
+
+  test('Save and Migrate persists the edited request into the migrated .yml', async ({ page, createTmpDir }) => {
+    const loc = buildCommonLocators(page);
+    const parentDir = await createTmpDir('migrate-drafts-req-save');
+    const collectionName = 'migrate-drafts-req-save';
+
+    await createCollection(page, collectionName, parentDir, 'bru');
+    await createRequest(page, 'req', collectionName, { method: 'GET', url: SAVED_URL });
+    await loc.sidebar.request('req').click();
+
+    await test.step('Edit the URL without saving so the request is dirty', async () => {
+      await fillRequestUrl(page, EDITED_SUFFIX);
+      await expect(loc.tabs.tabDraftIndicator(loc.tabs.activeRequestTab())).toBeVisible();
+    });
+
+    await test.step('Migrate → drafts step → Save and Migrate', async () => {
+      await openMigrateToYmlModalFromOverview(page, collectionName);
+      await openMigrateDraftsStep(page);
+      await saveAllDraftsAndMigrate(page);
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('Migrated req.yml contains the edited URL', async () => {
+      const collectionDir = firstDirIn(parentDir);
+      const yml = fs.readFileSync(path.join(collectionDir, 'req.yml'), 'utf8');
+      expect(yml).toContain(EDITED_SUFFIX);
+    });
+  });
+
+  test('Discard All skips the edit and migrates from the on-disk state', async ({ page, createTmpDir }) => {
+    const loc = buildCommonLocators(page);
+    const parentDir = await createTmpDir('migrate-drafts-req-discard');
+    const collectionName = 'migrate-drafts-req-discard';
+
+    await createCollection(page, collectionName, parentDir, 'bru');
+    await createRequest(page, 'req', collectionName, { method: 'GET', url: SAVED_URL });
+    await loc.sidebar.request('req').click();
+    await fillRequestUrl(page, EDITED_SUFFIX);
+    await expect(loc.tabs.tabDraftIndicator(loc.tabs.activeRequestTab())).toBeVisible();
+
+    await test.step('Migrate → drafts step → Discard All', async () => {
+      await openMigrateToYmlModalFromOverview(page, collectionName);
+      await openMigrateDraftsStep(page);
+      await discardAllDraftsAndMigrate(page);
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('Migrated req.yml keeps the originally saved URL, not the discarded edit', async () => {
+      const collectionDir = firstDirIn(parentDir);
+      const yml = fs.readFileSync(path.join(collectionDir, 'req.yml'), 'utf8');
+      expect(yml).toContain(SAVED_URL);
+      expect(yml).not.toContain(EDITED_SUFFIX);
+    });
+  });
+
+  test('Back returns to the migrate confirmation and leaves the draft intact', async ({ page, createTmpDir }) => {
+    const loc = buildCommonLocators(page);
+    const migrate = loc.migrateToYml;
+    const parentDir = await createTmpDir('migrate-drafts-req-back');
+    const collectionName = 'migrate-drafts-req-back';
+
+    await createCollection(page, collectionName, parentDir, 'bru');
+    await createRequest(page, 'req', collectionName, { method: 'GET', url: SAVED_URL });
+    await loc.sidebar.request('req').click();
+    await fillRequestUrl(page, EDITED_SUFFIX);
+    await expect(loc.tabs.tabDraftIndicator(loc.tabs.activeRequestTab())).toBeVisible();
+
+    await openMigrateToYmlModalFromOverview(page, collectionName);
+    await openMigrateDraftsStep(page);
+
+    await test.step('Back returns to migrate confirm; nothing migrates', async () => {
+      await returnFromDraftsStep(page);
+      await expect(migrate.modal()).toBeVisible();
+      await expect(migrate.migrateButton()).toBeVisible();
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeHidden();
+    });
+
+    await test.step('Close the migrate modal and confirm the draft is still dirty', async () => {
+      await migrate.modal().getByTestId('modal-close-button').click();
+      await expect(loc.tabs.tabDraftIndicator(loc.tabs.activeRequestTab())).toBeVisible();
+      const collectionDir = firstDirIn(parentDir);
+      // On-disk file still has the pre-edit URL; edit lives only in the draft.
+      const bru = fs.readFileSync(path.join(collectionDir, 'req.bru'), 'utf8');
+      expect(bru).toContain(SAVED_URL);
+      expect(bru).not.toContain(EDITED_SUFFIX);
+    });
+  });
+});

--- a/tests/collection/migrate-to-yml-drafts/transient-blocks-save-all.spec.ts
+++ b/tests/collection/migrate-to-yml-drafts/transient-blocks-save-all.spec.ts
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  createTransientRequest,
+  fillRequestUrl,
+  openMigrateToYmlModalFromOverview,
+  openMigrateDraftsStep,
+  saveAllDraftsAndMigrate
+} from '../../utils/page';
+
+const firstDirIn = (dir: string) =>
+  path.join(dir, fs.readdirSync(dir).find((entry) => fs.statSync(path.join(dir, entry)).isDirectory())!);
+
+test.describe('Migrate to YML — a transient request blocks Save All until it is saved', () => {
+  test('save the transient via its per-item Save button, then Save All completes migration', async ({ page, createTmpDir }) => {
+    const loc = buildCommonLocators(page);
+    const migrate = loc.migrateToYml;
+    const parentDir = await createTmpDir('migrate-drafts-transient');
+    const collectionName = 'migrate-drafts-transient';
+    const savedName = 'saved-from-transient';
+
+    await createCollection(page, collectionName, parentDir, 'bru');
+
+    await test.step('Create a transient request with a URL so it counts as unsaved', async () => {
+      await createTransientRequest(page, { requestType: 'HTTP' });
+      await fillRequestUrl(page, 'http://localhost:8081/transient-migrate');
+    });
+
+    await openMigrateToYmlModalFromOverview(page, collectionName);
+    await openMigrateDraftsStep(page);
+
+    const transientName = await loc.tabs.activeRequestTab().locator('.tab-label').innerText();
+
+    await test.step('Save All is disabled and the transient row is listed', async () => {
+      await expect(migrate.draftsTransientRow(transientName)).toBeVisible();
+      await expect(migrate.draftsSaveAll()).toBeDisabled();
+    });
+
+    await test.step('Save the transient via its per-item Save button', async () => {
+      await migrate.draftsTransientSave(transientName).click();
+
+      const saveTransientModal = page.locator('.bruno-modal-card').filter({ hasText: 'Save Request' });
+      await expect(saveTransientModal).toBeVisible({ timeout: 10000 });
+
+      const nameInput = saveTransientModal.locator('#request-name');
+      await nameInput.clear();
+      await nameInput.fill(savedName);
+
+      await saveTransientModal.getByRole('button', { name: 'Save' }).click();
+      await expect(saveTransientModal).toBeHidden({ timeout: 10000 });
+      await expect(page.getByText('Request saved successfully').last()).toBeVisible({ timeout: 10000 });
+    });
+
+    await test.step('Drafts step now has no transients and Save All is enabled', async () => {
+      await expect(migrate.draftsTransientRow(transientName)).toHaveCount(0);
+      await expect(migrate.draftsSaveAll()).toBeEnabled();
+    });
+
+    await test.step('Save All completes migration', async () => {
+      await saveAllDraftsAndMigrate(page);
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('The saved request survives as a .yml on disk', async () => {
+      const collectionDir = firstDirIn(parentDir);
+      expect(fs.existsSync(path.join(collectionDir, `${savedName}.yml`))).toBe(true);
+    });
+
+    await test.step('Cleanup', async () => {
+      await closeAllCollections(page);
+    });
+  });
+});

--- a/tests/collection/migrate-to-yml-drafts/transient-blocks-save-all.spec.ts
+++ b/tests/collection/migrate-to-yml-drafts/transient-blocks-save-all.spec.ts
@@ -16,6 +16,12 @@ const firstDirIn = (dir: string) =>
   path.join(dir, fs.readdirSync(dir).find((entry) => fs.statSync(path.join(dir, entry)).isDirectory())!);
 
 test.describe('Migrate to YML — a transient request blocks Save All until it is saved', () => {
+  test.afterEach(async ({ page }) => {
+    if (!page.isClosed()) {
+      await closeAllCollections(page);
+    }
+  });
+
   test('save the transient via its per-item Save button, then Save All completes migration', async ({ page, createTmpDir }) => {
     const loc = buildCommonLocators(page);
     const migrate = loc.migrateToYml;
@@ -25,15 +31,15 @@ test.describe('Migrate to YML — a transient request blocks Save All until it i
 
     await createCollection(page, collectionName, parentDir, 'bru');
 
+    let transientName = '';
     await test.step('Create a transient request with a URL so it counts as unsaved', async () => {
       await createTransientRequest(page, { requestType: 'HTTP' });
+      transientName = (await loc.tabs.activeRequestTab().locator('.tab-name').innerText()).trim();
       await fillRequestUrl(page, 'http://localhost:8081/transient-migrate');
     });
 
     await openMigrateToYmlModalFromOverview(page, collectionName);
     await openMigrateDraftsStep(page);
-
-    const transientName = await loc.tabs.activeRequestTab().locator('.tab-label').innerText();
 
     await test.step('Save All is disabled and the transient row is listed', async () => {
       await expect(migrate.draftsTransientRow(transientName)).toBeVisible();
@@ -68,10 +74,6 @@ test.describe('Migrate to YML — a transient request blocks Save All until it i
     await test.step('The saved request survives as a .yml on disk', async () => {
       const collectionDir = firstDirIn(parentDir);
       expect(fs.existsSync(path.join(collectionDir, `${savedName}.yml`))).toBe(true);
-    });
-
-    await test.step('Cleanup', async () => {
-      await closeAllCollections(page);
     });
   });
 });

--- a/tests/utils/page/collection/migrate-to-yml.ts
+++ b/tests/utils/page/collection/migrate-to-yml.ts
@@ -1,12 +1,17 @@
-import { Page } from '../../../../playwright';
+import { Locator, Page, expect, test } from '../../../../playwright';
 import { buildSidebarLocators } from '../sidebar';
 
 /**
- * Migrate-to-yml UI: the "Convert to YML" entry points and the app-level migration
- * modal (confirm view + locked progress view with a Cancel button).
+ * Migrate-to-yml UI: the "Convert to YML" entry points, the app-level migration
+ * modal (confirm view + locked progress view with a Cancel button), and the
+ * "Unsaved changes" drafts-resolution step that gates migration on any collection
+ * draft (request, folder, collection settings, environments, transient requests).
  */
 export const buildMigrateToYmlLocators = (page: Page) => {
   const modal = () => page.getByRole('dialog').filter({ hasText: 'Migrate to YML format' });
+  const draftsStep = () => page.getByTestId('migration-drafts-step');
+  const draftsTransientRow = (name: string) =>
+    page.getByTestId('migration-drafts-transient-row').filter({ has: page.locator(`[data-transient-name="${name}"]`) });
 
   return {
     modal,
@@ -18,7 +23,14 @@ export const buildMigrateToYmlLocators = (page: Page) => {
     progressLabel: () => page.getByTestId('migration-progress-label'),
     convertButton: () => page.getByTestId('migrate-collection-to-yml-button'),
     cancelledMessage: () => page.getByText('Migration cancelled'),
-    missingRequestMessage: () => page.getByText('Request no longer exists')
+    missingRequestMessage: () => page.getByText('Request no longer exists'),
+    draftsStep,
+    draftsSaveAll: () => page.getByTestId('migration-drafts-save-all'),
+    draftsDiscardAll: () => page.getByTestId('migration-drafts-discard-all'),
+    draftsBack: () => page.getByTestId('migration-drafts-back'),
+    draftsTransientRow,
+    draftsTransientSave: (name: string) =>
+      draftsTransientRow(name).getByTestId('migration-drafts-transient-save')
   };
 };
 
@@ -42,4 +54,49 @@ export const openCollectionOverview = async (page: Page, collectionName: string)
 export const confirmMigration = async (page: Page) => {
   const locators = buildMigrateToYmlLocators(page);
   await locators.migrateButton().click();
+};
+
+/**
+ * Click Migrate and wait for the "Unsaved changes" drafts step to appear. Use when
+ * the collection is expected to have drafts so the migrate button routes to the
+ * drafts-resolution view instead of starting migration.
+ */
+export const openMigrateDraftsStep = async (page: Page): Promise<Locator> => {
+  const locators = buildMigrateToYmlLocators(page);
+  await locators.migrateButton().click();
+  await expect(locators.draftsStep()).toBeVisible({ timeout: 5000 });
+  return locators.draftsStep();
+};
+
+/**
+ * From the drafts step, resolve every draft by clicking "Save All / Save and
+ * Migrate". Waits for the drafts step to close (i.e. migration has been kicked off).
+ */
+export const saveAllDraftsAndMigrate = async (page: Page) => {
+  await test.step('Save all drafts and migrate', async () => {
+    const locators = buildMigrateToYmlLocators(page);
+    await locators.draftsSaveAll().click();
+    await expect(locators.draftsStep()).toBeHidden({ timeout: 10000 });
+  });
+};
+
+/**
+ * From the drafts step, discard every draft and continue with migration. Waits for
+ * the drafts step to close.
+ */
+export const discardAllDraftsAndMigrate = async (page: Page) => {
+  await test.step('Discard all drafts and migrate', async () => {
+    const locators = buildMigrateToYmlLocators(page);
+    await locators.draftsDiscardAll().click();
+    await expect(locators.draftsStep()).toBeHidden({ timeout: 10000 });
+  });
+};
+
+/**
+ * Return to the migrate confirmation view from the drafts step.
+ */
+export const returnFromDraftsStep = async (page: Page) => {
+  const locators = buildMigrateToYmlLocators(page);
+  await locators.draftsBack().click();
+  await expect(locators.draftsStep()).toBeHidden({ timeout: 5000 });
 };

--- a/tests/utils/page/collection/migrate-to-yml.ts
+++ b/tests/utils/page/collection/migrate-to-yml.ts
@@ -11,7 +11,7 @@ export const buildMigrateToYmlLocators = (page: Page) => {
   const modal = () => page.getByRole('dialog').filter({ hasText: 'Migrate to YML format' });
   const draftsStep = () => page.getByTestId('migration-drafts-step');
   const draftsTransientRow = (name: string) =>
-    page.getByTestId('migration-drafts-transient-row').filter({ has: page.locator(`[data-transient-name="${name}"]`) });
+    page.locator(`[data-testid="migration-drafts-transient-row"][data-transient-name=${JSON.stringify(name)}]`);
 
   return {
     modal,


### PR DESCRIPTION
### Description

BRU-4178

- Added functionality to collect and manage drafts for collections, folders, and environments during migration.
- Implemented UI updates to display draft items and allow users to save or discard them before proceeding with migration.
- Introduced new state management for handling draft resolution and improved user experience with toast notifications for invalid variable names.
- Updated styles for transient items in the modal to improve visual feedback.

### Problem

If a user has a draft or transient request in a Bruno collection and initiates a migration, the migration proceeds without warning, causing any unsaved changes to be lost.

### Fix

Before starting the migration, display the same confirmation modal used when closing app with draft. This prompts the user to either save or discard their unsaved changes before the migration continues.
<!-- How does this PR fix the problem? Briefly describe your approach. -->

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a draft-resolution step before migrating collections to YML.
* Users can save eligible drafts, save transient requests individually, or discard all drafts.
* Added validation feedback for invalid environment drafts.
* Added options to return to migration confirmation or preserve drafts without migrating.

## UI Improvements
* Added clearer warning and transient-item styling.
* Limited the number of displayed draft items.
* Prevented duplicate draft-resolution actions.
* Save All remains unavailable until required transient requests are saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->