### PR TITLE
fix(app): global environment variables for apps

### DIFF
--- a/packages/bruno-app/src/components/AppPreviewKeepAlive/index.js
+++ b/packages/bruno-app/src/components/AppPreviewKeepAlive/index.js
@@ -1,8 +1,14 @@
 import React, { useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
+import { produce } from 'immer';
 import find from 'lodash/find';
 import get from 'lodash/get';
-import { findItemInCollection, findItemInCollectionByPathname } from 'utils/collections';
+import {
+  findItemInCollection,
+  findItemInCollectionByPathname,
+  getGlobalEnvironmentVariables,
+  getGlobalEnvironmentVariablesMasked
+} from 'utils/collections';
 import { ScopedPersistenceProvider } from 'hooks/usePersistedState/PersistedScopeProvider';
 import TabPanelErrorBoundary from 'components/RequestTabPanel/TabPanelErrorBoundary';
 import AppView from 'components/AppView';
@@ -21,7 +27,28 @@ const APP_CAPABLE_TAB_TYPES = new Set([
 const AppPreviewKeepAlive = () => {
   const tabs = useSelector((state) => state.tabs.tabs);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
-  const collections = useSelector((state) => state.collections.collections);
+  const _collections = useSelector((state) => state.collections.collections);
+  const globalEnvironments = useSelector((state) => state.globalEnvironments?.globalEnvironments);
+  const activeGlobalEnvironmentUid = useSelector(
+    (state) => state.globalEnvironments?.activeGlobalEnvironmentUid
+  );
+
+  const collections = useMemo(() => {
+    const globalEnvironmentVariables = getGlobalEnvironmentVariables({
+      globalEnvironments,
+      activeGlobalEnvironmentUid
+    });
+    const globalEnvSecrets = getGlobalEnvironmentVariablesMasked({
+      globalEnvironments,
+      activeGlobalEnvironmentUid
+    });
+    return produce(_collections, (draft) => {
+      for (const collection of draft) {
+        collection.globalEnvironmentVariables = globalEnvironmentVariables;
+        collection.globalEnvSecrets = globalEnvSecrets;
+      }
+    });
+  }, [_collections, globalEnvironments, activeGlobalEnvironmentUid]);
 
   const everActiveRef = useRef(new Set());
 

--- a/packages/bruno-app/src/components/AppPreviewKeepAlive/index.spec.js
+++ b/packages/bruno-app/src/components/AppPreviewKeepAlive/index.spec.js
@@ -5,18 +5,22 @@ import { Provider } from 'react-redux';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import AppPreviewKeepAlive from './index';
 
-jest.mock('components/AppView', () => ({ item }) => (
-  <div data-testid="mock-app-view">{item.name}</div>
-));
-jest.mock('components/CollectionApp', () => ({ item }) => (
-  <div data-testid="mock-collection-app">{item.name}</div>
-));
+const collectionSnapshots = { appView: null, collectionApp: null };
+
+jest.mock('components/AppView', () => ({ item, collection }) => {
+  collectionSnapshots.appView = collection;
+  return <div data-testid="mock-app-view">{item.name}</div>;
+});
+jest.mock('components/CollectionApp', () => ({ item, collection }) => {
+  collectionSnapshots.collectionApp = collection;
+  return <div data-testid="mock-collection-app">{item.name}</div>;
+});
 jest.mock('components/RequestTabPanel/TabPanelErrorBoundary', () => ({ children }) => children);
 jest.mock('hooks/usePersistedState/PersistedScopeProvider', () => ({
   ScopedPersistenceProvider: ({ children }) => children
 }));
 
-const makeStore = ({ tabs, activeTabUid, collections }) => {
+const makeStore = ({ tabs, activeTabUid, collections, globalEnvironments = [], activeGlobalEnvironmentUid = null }) => {
   const tabsSlice = createSlice({
     name: 'tabs',
     initialState: { tabs, activeTabUid },
@@ -34,9 +38,18 @@ const makeStore = ({ tabs, activeTabUid, collections }) => {
     initialState: { collections },
     reducers: {}
   });
+  const globalEnvironmentsSlice = createSlice({
+    name: 'globalEnvironments',
+    initialState: { globalEnvironments, activeGlobalEnvironmentUid },
+    reducers: {}
+  });
   return {
     store: configureStore({
-      reducer: { tabs: tabsSlice.reducer, collections: collectionsSlice.reducer }
+      reducer: {
+        tabs: tabsSlice.reducer,
+        collections: collectionsSlice.reducer,
+        globalEnvironments: globalEnvironmentsSlice.reducer
+      }
     }),
     actions: tabsSlice.actions
   };
@@ -71,6 +84,11 @@ const collection = {
 const tabFor = (item) => ({ uid: item.uid, collectionUid: 'coll-1', type: item.type, pathname: '' });
 
 describe('AppPreviewKeepAlive', () => {
+  beforeEach(() => {
+    collectionSnapshots.appView = null;
+    collectionSnapshots.collectionApp = null;
+  });
+
   it('renders nothing when no app tab has been activated', () => {
     const { store } = makeStore({
       tabs: [tabFor(plainRequestItem)],
@@ -150,6 +168,46 @@ describe('AppPreviewKeepAlive', () => {
     act(() => store.dispatch(actions.closeTab(requestAppItem.uid)));
 
     expect(screen.queryByTestId('mock-app-view')).not.toBeInTheDocument();
+  });
+
+  it('folds the active global environment into the collection reaching request apps', () => {
+    const { store } = makeStore({
+      tabs: [tabFor(requestAppItem)],
+      activeTabUid: requestAppItem.uid,
+      collections: [collection],
+      globalEnvironments: [
+        {
+          uid: 'g1',
+          variables: [
+            { name: 'base_url', value: 'https://httpbin.org', enabled: true },
+            { name: 'token', value: 't', enabled: true, secret: true }
+          ]
+        }
+      ],
+      activeGlobalEnvironmentUid: 'g1'
+    });
+    render(<Provider store={store}><AppPreviewKeepAlive /></Provider>);
+    expect(collectionSnapshots.appView.globalEnvironmentVariables).toEqual({
+      base_url: 'https://httpbin.org',
+      token: 't'
+    });
+    expect(collectionSnapshots.appView.globalEnvSecrets).toEqual(['token']);
+  });
+
+  it('folds the active global environment into the collection reaching standalone apps', () => {
+    const { store } = makeStore({
+      tabs: [tabFor(standaloneAppItem)],
+      activeTabUid: standaloneAppItem.uid,
+      collections: [collection],
+      globalEnvironments: [
+        { uid: 'g1', variables: [{ name: 'base_url', value: 'https://httpbin.org', enabled: true }] }
+      ],
+      activeGlobalEnvironmentUid: 'g1'
+    });
+    render(<Provider store={store}><AppPreviewKeepAlive /></Provider>);
+    expect(collectionSnapshots.collectionApp.globalEnvironmentVariables).toEqual({
+      base_url: 'https://httpbin.org'
+    });
   });
 
   it('ignores special tab types that resolve to app items via pathname', () => {


### PR DESCRIPTION
### Description

BRU-4151

- Added logic to fold active global environment variables and secrets into collections for both request and standalone apps.
- Updated tests to validate the integration of global environment data into the app views.

### Problem
Active global env variables were not getting resolved for request getting triggered through apps


### Screenshots
Before:

https://github.com/user-attachments/assets/805d6501-7525-4963-b043-1a636a17c6df

After:

https://github.com/user-attachments/assets/1d3f4129-b3c2-482c-a282-9802b2f20f3d



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App previews now reflect active global environment variables.
  * Secret values are tracked and masked when applied to preview collections.
  * Environment settings are consistently applied to both request-based and standalone app previews.

* **Tests**
  * Added coverage to verify global environment data is correctly passed to preview components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->