### PR TITLE
fix (graphql): resolve inherited auth when loading schema from introspection

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -27,7 +27,7 @@ const { uuid, safeStringifyJSON, safeParseJSON, parseDataFromResponse, parseData
 const { chooseFileToSave, writeFile, getCollectionFormat, hasRequestExtension } = require('../../utils/filesystem');
 const { addCookieToJar, getDomainsWithCookies, getCookieStringForUrl } = require('../../utils/cookies');
 const { createFormData } = require('../../utils/form-data');
-const { findItemInCollectionByPathname, sortFolder, getAllRequestsInFolderRecursively, getEnvVars, getTreePathFromCollectionToItem, mergeVars, sortByNameThenSequence } = require('../../utils/collection');
+const { findItemInCollectionByPathname, sortFolder, getAllRequestsInFolderRecursively, getEnvVars, getTreePathFromCollectionToItem, mergeAuth, mergeVars, sortByNameThenSequence } = require('../../utils/collection');
 const { getOAuth2TokenUsingAuthorizationCode, getOAuth2TokenUsingClientCredentials, getOAuth2TokenUsingPasswordCredentials, getOAuth2TokenUsingImplicitGrant, updateCollectionOauth2Credentials, clearOauth2CredentialsByCredentialsId } = require('../../utils/oauth2');
 const { preferencesUtil } = require('../../store/preferences');
 const { getProcessEnvVars } = require('../../store/process-env');
@@ -382,6 +382,14 @@ const fetchGqlSchemaHandler = async (event, endpoint, environment, _request, col
     const resolvedRequest = cloneDeep(_request);
     // mergeVars modifies the request in place, but we'll assign it to ensure consistency
     mergeVars(collection, resolvedRequest, requestTreePath);
+    // Resolve `inherit` auth against the folder tree, the same way prepare-request
+    // and prepare-grpc-request do. Without this the request keeps `mode: 'inherit'`
+    // and setAuthHeaders can only fall back to collection auth, so folder-level auth
+    // is skipped and introspection goes out unauthenticated.
+    // `auth` is optional on a request, and mergeAuth reads `auth.mode` directly.
+    if (resolvedRequest.auth) {
+      mergeAuth(collection, resolvedRequest, requestTreePath);
+    }
     const envVars = getEnvVars(environment);
 
     const globalEnvironmentVars = collection.globalEnvironmentVariables;
@@ -410,7 +418,7 @@ const fetchGqlSchemaHandler = async (event, endpoint, environment, _request, col
     );
 
     const collectionRoot = collection?.draft?.root || collection?.root || {};
-    const request = prepareGqlIntrospectionRequest(endpoint, resolvedVars, _request, collectionRoot);
+    const request = prepareGqlIntrospectionRequest(endpoint, resolvedVars, resolvedRequest, collectionRoot);
 
     // Get timeout from request settings, resolve inheritance if needed
     const resolvedSettings = resolveInheritedSettings(request.settings || {});

--- a/packages/bruno-electron/tests/network/fetch-gql-schema-handler.spec.js
+++ b/packages/bruno-electron/tests/network/fetch-gql-schema-handler.spec.js
@@ -71,7 +71,7 @@ describe('fetchGqlSchemaHandler - variable precedence', () => {
       expect.objectContaining({
         SHARED_VAR: 'env-value'
       }),
-      request,
+      expect.objectContaining({ uid: request.uid }),
       collection.root
     );
   });
@@ -136,7 +136,7 @@ describe('fetchGqlSchemaHandler - variable precedence', () => {
       expect.objectContaining({
         SHARED_VAR: 'folder-value'
       }),
-      request,
+      expect.objectContaining({ uid: request.uid }),
       collection.root
     );
   });
@@ -203,7 +203,7 @@ describe('fetchGqlSchemaHandler - variable precedence', () => {
       expect.objectContaining({
         SHARED_VAR: 'request-value'
       }),
-      request,
+      expect.objectContaining({ uid: request.uid }),
       collection.root
     );
   });
@@ -255,7 +255,7 @@ describe('fetchGqlSchemaHandler - variable precedence', () => {
       expect.objectContaining({
         SHARED_VAR: 'collection-value'
       }),
-      request,
+      expect.objectContaining({ uid: request.uid }),
       collection.root
     );
   });
@@ -307,7 +307,7 @@ describe('fetchGqlSchemaHandler - variable precedence', () => {
       expect.objectContaining({
         SHARED_VAR: 'env-value'
       }),
-      request,
+      expect.objectContaining({ uid: request.uid }),
       collection.root
     );
   });
@@ -362,8 +362,125 @@ describe('fetchGqlSchemaHandler - variable precedence', () => {
       expect.objectContaining({
         SHARED_VAR: 'runtime-value'
       }),
-      request,
+      expect.objectContaining({ uid: request.uid }),
       collection.root
     );
+  });
+});
+
+// https://github.com/usebruno/bruno/issues/8813
+describe('fetchGqlSchemaHandler - auth inheritance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const buildCollection = (folderAuth, collectionAuth) => ({
+    uid: 'test-collection',
+    pathname: '/test',
+    runtimeVariables: {},
+    globalEnvironmentVariables: {},
+    items: [
+      {
+        uid: 'test-folder',
+        type: 'folder',
+        root: {
+          request: {
+            auth: folderAuth
+          }
+        },
+        items: [
+          {
+            uid: 'test-request',
+            request: {
+              vars: { req: [] }
+            }
+          }
+        ]
+      }
+    ],
+    root: {
+      request: {
+        headers: [],
+        auth: collectionAuth,
+        vars: { req: [] }
+      }
+    }
+  });
+
+  it('should resolve inherited auth from the closest folder', async () => {
+    const request = {
+      uid: 'test-request',
+      auth: { mode: 'inherit' },
+      vars: { req: [] }
+    };
+    const folderAuth = {
+      mode: 'bearer',
+      bearer: { token: 'folder-token' }
+    };
+
+    await fetchGqlSchemaHandler(null, 'https://example.com/', { variables: [] }, request, buildCollection(folderAuth));
+
+    const resolved = prepareGqlIntrospectionRequest.mock.calls[0][2];
+    expect(resolved.auth).toEqual(folderAuth);
+  });
+
+  it('should prefer folder auth over collection auth', async () => {
+    const request = {
+      uid: 'test-request',
+      auth: { mode: 'inherit' },
+      vars: { req: [] }
+    };
+    const folderAuth = {
+      mode: 'bearer',
+      bearer: { token: 'folder-token' }
+    };
+    const collectionAuth = {
+      mode: 'bearer',
+      bearer: { token: 'collection-token' }
+    };
+
+    await fetchGqlSchemaHandler(
+      null,
+      'https://example.com/',
+      { variables: [] },
+      request,
+      buildCollection(folderAuth, collectionAuth)
+    );
+
+    const resolved = prepareGqlIntrospectionRequest.mock.calls[0][2];
+    expect(resolved.auth).toEqual(folderAuth);
+  });
+
+  it('should not mutate the request passed in by the caller', async () => {
+    const request = {
+      uid: 'test-request',
+      auth: { mode: 'inherit' },
+      vars: { req: [] }
+    };
+    const folderAuth = {
+      mode: 'bearer',
+      bearer: { token: 'folder-token' }
+    };
+
+    await fetchGqlSchemaHandler(null, 'https://example.com/', { variables: [] }, request, buildCollection(folderAuth));
+
+    expect(request.auth).toEqual({ mode: 'inherit' });
+  });
+
+  it('should leave an explicit request auth untouched', async () => {
+    const request = {
+      uid: 'test-request',
+      auth: { mode: 'bearer', bearer: { token: 'request-token' } },
+      vars: { req: [] }
+    };
+    const folderAuth = {
+      mode: 'bearer',
+      bearer: { token: 'folder-token' }
+    };
+
+    await fetchGqlSchemaHandler(null, 'https://example.com/', { variables: [] }, request, buildCollection(folderAuth));
+
+    const resolved = prepareGqlIntrospectionRequest.mock.calls[0][2];
+    expect(resolved.auth).toEqual({ mode: 'bearer', bearer: { token: 'request-token' } });
   });
 });


### PR DESCRIPTION
### Description

`fetchGqlSchemaHandler` merges variables against the folder tree but never merges auth, so
"load schema from introspection" ignores folder-level auth that a normal request honours.

### Problem

Fixes #8813.

The handler already works out the folder path and uses it for variables:

```js
const requestTreePath = getTreePathFromCollectionToItem(collection, _request);
const resolvedRequest = cloneDeep(_request);
mergeVars(collection, resolvedRequest, requestTreePath);
```

`mergeAuth` is never called with it. The request keeps `auth.mode === 'inherit'` all the way
into `prepareGqlIntrospectionRequest`, and `setAuthHeaders` only resolves `'inherit'` against
`collectionRoot`:

```js
const collectionAuth = get(collectionRoot, 'request.auth');
if (collectionAuth && request.auth.mode === 'inherit') {
```

So a folder auth block is never consulted. With auth set on a folder and nothing at the
collection root, the introspection request goes out unauthenticated and the server answers
401, while sending the same request normally works.

`prepare-request.js` and `prepare-grpc-request.js` both call `mergeAuth` right after
`mergeVars`. This path is the one that does not.

### Fix

Call `mergeAuth` alongside the existing `mergeVars`, and pass `resolvedRequest` rather than
`_request` to `prepareGqlIntrospectionRequest` so the merged auth is actually used. The clone
was already there "to avoid mutating the original", and passing it keeps that true.

The call is guarded on `resolvedRequest.auth` because `auth` is not required on a request in
`bruno-schema` (unlike `headers` and `params`) while `mergeAuth` reads `request.auth.mode`
directly.

Six existing assertions in `fetch-gql-schema-handler.spec.js` compared the third argument to
the caller's `request` object by deep equality. Now that the resolved clone is passed, and
that clone carries the merged variables, they check `expect.objectContaining({ uid })`
instead. They still pass without the source change, so they are not hiding anything.

### Testing

Four tests added to the existing spec: inherited auth resolves from the closest folder, folder
auth wins over collection auth, the caller's request is not mutated, and an explicit request
auth is left alone. The first two fail without this change.

```
node --experimental-vm-modules ../../node_modules/jest/bin/jest.js
Test Suites: 51 passed, 51 total
Tests:       1 skipped, 737 passed, 738 total
```

### Screenshots

Not applicable, this changes which auth headers are attached to a build-time introspection
request rather than anything rendered.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL schema introspection now correctly inherits authentication from the nearest folder or collection when not explicitly configured.
  * Explicit request authentication is preserved, and request data remains unchanged during processing.
* **Tests**
  * Added coverage for authentication inheritance, precedence, immutability, and expected request identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->