### PR TITLE
feat(bruno-js): enable TypeScript for local modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15708,7 +15708,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -20985,6 +20984,23 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/file/-/file-0.2.2.tgz",
@@ -26243,7 +26259,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -32380,18 +32395,17 @@
       }
     },
     "node_modules/sucrase": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
-        "glob": "^10.3.10",
         "lines-and-columns": "^1.1.6",
         "mz": "^2.7.0",
         "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
         "ts-interface-checker": "^0.1.9"
       },
       "bin": {
@@ -32406,57 +32420,9 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/sucrase/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/sucrase/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/sucrase/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/sumchecker": {
@@ -33215,7 +33181,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -33225,7 +33190,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -33284,6 +33248,34 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
@@ -33624,7 +33616,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
@@ -38719,6 +38710,7 @@
         "node-fetch": "^2.7.0",
         "path": "^0.12.7",
         "quickjs-emscripten": "^0.32.0",
+        "sucrase": "3.35.1",
         "tv4": "^1.3.0",
         "uuid": "^10.0.0",
         "xml-formatter": "^3.5.0",

--- a/packages/bruno-js/package.json
+++ b/packages/bruno-js/package.json
@@ -32,6 +32,7 @@
     "node-fetch": "^2.7.0",
     "path": "^0.12.7",
     "quickjs-emscripten": "^0.32.0",
+    "sucrase": "3.35.1",
     "tv4": "^1.3.0",
     "uuid": "^10.0.0",
     "xml-formatter": "^3.5.0",

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -3,60 +3,65 @@ const fs = require('node:fs');
 const path = require('node:path');
 const nodeModule = require('node:module');
 
-const { isBuiltinModule, isPathWithinAllowedRoots } = require('./utils');
+const { isBuiltinModule } = require('./utils');
+const { isPathWithinAllowedRoots, isPathWithinRoot } = require('../../utils/path-security');
+const { isTypeScriptFile, transpileTypeScript } = require('../../utils/typescript');
+const { isFile, resolveModuleFile, resolveDirectoryIndex } = require('../../utils/module-resolution');
 
 /**
- * Resolve a local module path, handling files and directories
- * Follows Node.js resolution algorithm:
- * 1. Exact path (with extension)
- * 2. Path + .js extension
- * 3. Directory with package.json (main field)
- * 4. Directory with index.js
- * @param {string} fromDir - Directory to resolve from
- * @param {string} moduleName - Module name/path
- * @returns {string} Resolved absolute path
+ * Resolve a directory module through its package.json main field.
+ * Only a main that stays inside the package directory is honored: this runs
+ * on sandboxed collection content, and probing an escaping main would leak
+ * file existence outside the allowed roots.
+ * @param {string} dirPath - Absolute path of the directory
+ * @returns {string|null} Path of the main file, or null
  */
-function resolveLocalModulePath(fromDir, moduleName) {
-  const basePath = path.resolve(fromDir, moduleName);
-
-  // 1. If has extension, use as-is
-  if (path.extname(moduleName)) {
-    return path.normalize(basePath);
+function resolvePackageJsonMain(dirPath) {
+  const pkgPath = path.join(dirPath, 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    return null;
   }
 
-  // 2. Try with .js extension
-  const withJs = basePath + '.js';
-  if (fs.existsSync(withJs)) {
-    return path.normalize(withJs);
-  }
-
-  // 3. Check if it's a directory
-  if (fs.existsSync(basePath) && fs.statSync(basePath).isDirectory()) {
-    // 3a. Check for package.json with main field
-    const pkgPath = path.join(basePath, 'package.json');
-    if (fs.existsSync(pkgPath)) {
-      try {
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-        if (pkg.main) {
-          const mainPath = path.resolve(basePath, pkg.main);
-          if (fs.existsSync(mainPath)) {
-            return path.normalize(mainPath);
-          }
-        }
-      } catch {
-        // Ignore JSON parse errors, fall through to index.js
-      }
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    if (!pkg.main) {
+      return null;
     }
 
-    // 3b. Check for index.js
-    const indexPath = path.join(basePath, 'index.js');
-    if (fs.existsSync(indexPath)) {
-      return path.normalize(indexPath);
+    const mainPath = path.resolve(dirPath, pkg.main);
+    if (isPathWithinRoot(dirPath, mainPath) && isFile(mainPath)) {
+      return mainPath;
     }
+  } catch {
+    // Ignore JSON parse errors, the caller falls through to index files
   }
 
-  // 4. Fall back to original path (will likely fail with file not found)
-  return path.normalize(basePath);
+  return null;
+}
+
+/**
+ * Read a module's source, transpiling TypeScript to JavaScript
+ * @param {string} filePath - Absolute path of the module file
+ * @returns {string} JavaScript source ready for compilation
+ */
+function readModuleSource(filePath) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  return isTypeScriptFile(filePath) ? transpileTypeScript(source, filePath) : source;
+}
+
+/**
+ * Compile a module's code in the VM context and run it against moduleObj,
+ * wrapping it in a function that receives the CJS parameters
+ * @param {Object} options - Configuration options
+ */
+function runModuleInContext({ moduleCode, filePath, isolatedContext, moduleObj, moduleRequire }) {
+  const moduleDir = path.dirname(filePath);
+  const wrappedCode = `(function(module, exports, require, __filename, __dirname) {\n${moduleCode}\n})`;
+  // lineOffset compensates for the wrapper's leading line so stack traces
+  // report the module's real line numbers
+  const compiledScript = new vm.Script(wrappedCode, { filename: filePath, lineOffset: -1 });
+  const moduleFunction = compiledScript.runInContext(isolatedContext);
+  moduleFunction(moduleObj, moduleObj.exports, moduleRequire, filePath, moduleDir);
 }
 
 /**
@@ -137,8 +142,8 @@ function loadLocalModule({
   additionalContextRootsAbsolute = []
 }) {
   // Validate the raw module name doesn't try to escape allowed roots
-  const preliminaryPath = path.resolve(currentModuleDir, moduleName);
-  if (!isPathWithinAllowedRoots(path.normalize(preliminaryPath), additionalContextRootsAbsolute)) {
+  const preliminaryPath = path.normalize(path.resolve(currentModuleDir, moduleName));
+  if (!isPathWithinAllowedRoots(preliminaryPath, additionalContextRootsAbsolute)) {
     const allowedRootsDisplay = additionalContextRootsAbsolute.map((root) => `  - ${root}`).join('\n');
     throw new Error(
       `Access to files outside of the allowed context roots is not allowed: ${moduleName}\n\n`
@@ -146,8 +151,13 @@ function loadLocalModule({
     );
   }
 
-  // Resolve the module path, handling files and directories
-  const normalizedFilePath = resolveLocalModulePath(currentModuleDir, moduleName);
+  // Resolve to a file (extension candidates, then directory via package.json
+  // main and index files), falling back to the raw path so the not-found
+  // error below names it
+  const normalizedFilePath = resolveModuleFile(preliminaryPath)
+    || resolvePackageJsonMain(preliminaryPath)
+    || resolveDirectoryIndex(preliminaryPath)
+    || preliminaryPath;
 
   // Final security check after resolution
   if (!isPathWithinAllowedRoots(normalizedFilePath, additionalContextRootsAbsolute)) {
@@ -163,13 +173,12 @@ function loadLocalModule({
     return localModuleCache.get(normalizedFilePath).exports;
   }
 
-  if (!fs.existsSync(normalizedFilePath)) {
+  if (!fs.existsSync(normalizedFilePath) || !fs.statSync(normalizedFilePath).isFile()) {
     throw new Error(`Cannot find module ${moduleName}`);
   }
 
-  const moduleCode = fs.readFileSync(normalizedFilePath, 'utf8');
+  const moduleCode = readModuleSource(normalizedFilePath);
   const moduleObj = { exports: {} };
-  const moduleDir = path.dirname(normalizedFilePath);
 
   // Pre-populate cache with moduleObj BEFORE execution to handle circular dependencies
   // This allows re-entrant requires to get partial exports (Node.js behavior)
@@ -180,17 +189,19 @@ function loadLocalModule({
   const moduleRequire = createCustomRequire({
     collectionPath,
     isolatedContext,
-    currentModuleDir: moduleDir,
+    currentModuleDir: path.dirname(normalizedFilePath),
     localModuleCache,
     additionalContextRootsAbsolute
   });
 
   try {
-    // Wrap module code in a function that receives CJS parameters
-    const wrappedCode = `(function(module, exports, require, __filename, __dirname) {\n${moduleCode}\n})`;
-    const compiledScript = new vm.Script(wrappedCode, { filename: normalizedFilePath });
-    const moduleFunction = compiledScript.runInContext(isolatedContext);
-    moduleFunction(moduleObj, moduleObj.exports, moduleRequire, normalizedFilePath, moduleDir);
+    runModuleInContext({
+      moduleCode,
+      filePath: normalizedFilePath,
+      isolatedContext,
+      moduleObj,
+      moduleRequire
+    });
     return moduleObj.exports;
   } catch (error) {
     // Remove failed module from cache to allow retry
@@ -236,9 +247,8 @@ function executeModuleInVmContext({
     return result;
   }
 
-  // JavaScript files
-  const moduleSource = fs.readFileSync(resolvedPath, 'utf8');
-  const moduleDir = path.dirname(resolvedPath);
+  // JavaScript / TypeScript files
+  const moduleSource = readModuleSource(resolvedPath);
   const moduleObj = { exports: {} };
 
   // Pre-populate cache with moduleObj BEFORE execution to handle circular dependencies
@@ -249,16 +259,18 @@ function executeModuleInVmContext({
   const moduleRequire = createNpmModuleRequire({
     collectionPath,
     isolatedContext,
-    currentModuleDir: moduleDir,
+    currentModuleDir: path.dirname(resolvedPath),
     localModuleCache
   });
 
   try {
-    // Wrap module code in a function that receives CJS parameters
-    const wrappedCode = `(function(module, exports, require, __filename, __dirname) {\n${moduleSource}\n})`;
-    const compiledScript = new vm.Script(wrappedCode, { filename: resolvedPath });
-    const moduleFunction = compiledScript.runInContext(isolatedContext);
-    moduleFunction(moduleObj, moduleObj.exports, moduleRequire, resolvedPath, moduleDir);
+    runModuleInContext({
+      moduleCode: moduleSource,
+      filePath: resolvedPath,
+      isolatedContext,
+      moduleObj,
+      moduleRequire
+    });
   } catch (error) {
     // Remove failed module from cache to allow retry
     localModuleCache.delete(resolvedPath);

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -175,6 +175,262 @@ describe('node-vm sandbox', () => {
     });
   });
 
+  describe('createCustomRequire - TypeScript modules', () => {
+    const makeContext = () => ({
+      bru: { setVar: jest.fn() },
+      console: console
+    });
+
+    it('should load a TypeScript module with explicit .ts extension', async () => {
+      fs.writeFileSync(
+        path.join(collectionPath, 'helper.ts'),
+        `
+          interface Payload {
+            value: number;
+          }
+          const payload: Payload = { value: 42 };
+          module.exports = { getValue: (): number => payload.value };
+        `
+      );
+
+      const script = `
+        const helper = require('./helper.ts');
+        bru.setVar('result', helper.getValue());
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 42);
+    });
+
+    it('should resolve extensionless require to a .ts file', async () => {
+      fs.writeFileSync(
+        path.join(collectionPath, 'helper.ts'),
+        'export const value: number = 7;'
+      );
+
+      const script = `
+        const helper = require('./helper');
+        bru.setVar('result', helper.value);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 7);
+    });
+
+    it('should prefer .js over .ts when both exist', async () => {
+      fs.writeFileSync(path.join(collectionPath, 'dual.js'), 'module.exports = { source: "js" };');
+      fs.writeFileSync(path.join(collectionPath, 'dual.ts'), 'export const source: string = "ts";');
+
+      const script = `
+        const dual = require('./dual');
+        bru.setVar('result', dual.source);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 'js');
+    });
+
+    it('should map a .js require onto the TypeScript source when no .js file exists', async () => {
+      fs.writeFileSync(
+        path.join(collectionPath, 'esm-style.ts'),
+        'export const loaded: boolean = true;'
+      );
+
+      const script = `
+        const mod = require('./esm-style.js');
+        bru.setVar('result', mod.loaded);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', true);
+    });
+
+    it('should append extensions to a request whose basename contains a dot', async () => {
+      fs.writeFileSync(
+        path.join(collectionPath, 'config.helper.ts'),
+        'export const value: string = "dotted";'
+      );
+
+      const script = `
+        const helper = require('./config.helper');
+        bru.setVar('result', helper.value);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 'dotted');
+    });
+
+    it('should resolve a directory with index.ts', async () => {
+      const libDir = path.join(collectionPath, 'lib');
+      fs.mkdirSync(libDir);
+      fs.writeFileSync(path.join(libDir, 'index.ts'), 'export const name: string = "lib-index";');
+
+      const script = `
+        const lib = require('./lib');
+        bru.setVar('result', lib.name);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 'lib-index');
+    });
+
+    it('should handle ESM import/export between TypeScript modules', async () => {
+      fs.writeFileSync(
+        path.join(collectionPath, 'math.ts'),
+        'export const double = (n: number): number => n * 2;'
+      );
+      fs.writeFileSync(
+        path.join(collectionPath, 'consumer.ts'),
+        `
+          import { double } from './math';
+          export const result: number = double(21);
+        `
+      );
+
+      const script = `
+        const consumer = require('./consumer.ts');
+        bru.setVar('result', consumer.result);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 42);
+    });
+
+    it('should expose export default via .default', async () => {
+      fs.writeFileSync(
+        path.join(collectionPath, 'default-export.ts'),
+        'export default { kind: "default" };'
+      );
+
+      const script = `
+        const mod = require('./default-export.ts');
+        bru.setVar('result', mod.default.kind);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 'default');
+    });
+
+    it('should strip TypeScript-only syntax (enums, generics, type assertions)', async () => {
+      fs.writeFileSync(
+        path.join(collectionPath, 'typed.ts'),
+        `
+          enum Status {
+            Active = 'active',
+            Inactive = 'inactive'
+          }
+          const pick = <T>(items: T[]): T => items[0];
+          export const status = Status.Active;
+          export const first = pick<string>(['a', 'b']) as string;
+        `
+      );
+
+      const script = `
+        const typed = require('./typed.ts');
+        bru.setVar('status', typed.status);
+        bru.setVar('first', typed.first);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('status', 'active');
+      expect(context.bru.setVar).toHaveBeenCalledWith('first', 'a');
+    });
+
+    it('should resolve a local directory through its package.json main field', async () => {
+      const pkgDir = path.join(collectionPath, 'pkg');
+      fs.mkdirSync(pkgDir);
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ main: './entry.js' }));
+      fs.writeFileSync(path.join(pkgDir, 'entry.js'), 'module.exports = { from: "main" };');
+
+      const script = `
+        const pkg = require('./pkg');
+        bru.setVar('result', pkg.from);
+      `;
+      const context = makeContext();
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 'main');
+    });
+
+    it('should ignore a package.json main that escapes the package directory', async () => {
+      const pkgDir = path.join(collectionPath, 'probe');
+      fs.mkdirSync(pkgDir);
+      fs.writeFileSync(path.join(collectionPath, 'target.js'), 'module.exports = { reached: true };');
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ main: '../target.js' }));
+
+      const script = `
+        require('./probe');
+      `;
+      const context = makeContext();
+
+      await expect(
+        runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} })
+      ).rejects.toThrow(/Cannot find module/);
+    });
+
+    it('should report Cannot find module for a directory without an index file', async () => {
+      fs.mkdirSync(path.join(collectionPath, 'no-index'));
+      fs.writeFileSync(path.join(collectionPath, 'no-index', 'other.txt'), 'not a module');
+
+      const script = `
+        require('./no-index');
+      `;
+      const context = makeContext();
+
+      await expect(
+        runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} })
+      ).rejects.toThrow(/Cannot find module/);
+    });
+
+    it('should report a clear error for invalid TypeScript syntax', async () => {
+      fs.writeFileSync(
+        path.join(collectionPath, 'broken.ts'),
+        'const x: = 5;'
+      );
+
+      const script = `
+        require('./broken.ts');
+      `;
+      const context = makeContext();
+
+      await expect(
+        runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} })
+      ).rejects.toThrow(/Failed to transpile TypeScript file/);
+    });
+
+    it('should enforce allowed context roots for TypeScript modules', async () => {
+      fs.writeFileSync(path.join(testDir, 'outside.ts'), 'export const secret: string = "nope";');
+
+      const script = `
+        require('../outside.ts');
+      `;
+      const context = makeContext();
+
+      await expect(
+        runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} })
+      ).rejects.toThrow('Access to files outside of the allowed context roots is not allowed');
+    });
+  });
+
   describe('createCustomRequire - additionalContextRoots', () => {
     it('should allow module access from additionalContextRoots', async () => {
       // Create an additional context root at same level as collection
@@ -1356,6 +1612,25 @@ describe('node-vm sandbox', () => {
         await expect(
           runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} })
         ).rejects.toThrow('Module initialization failed');
+      });
+
+      it('should report the module source line in stack traces (wrapper line offset)', async () => {
+        const nodeModulesDir = path.join(collectionPath, 'node_modules', 'line-offset-module');
+        fs.mkdirSync(nodeModulesDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(nodeModulesDir, 'index.js'),
+          'const noop = 1;\nthrow new Error("boom at line two");'
+        );
+
+        const script = `
+          require('line-offset-module');
+        `;
+
+        const context = { console: console };
+
+        await expect(
+          runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} })
+        ).rejects.toThrow(/index\.js:2/);
       });
     });
   });

--- a/packages/bruno-js/src/sandbox/node-vm/utils.js
+++ b/packages/bruno-js/src/sandbox/node-vm/utils.js
@@ -12,20 +12,6 @@ function isBuiltinModule(moduleName) {
 }
 
 /**
- * Validate that a path is within allowed context roots
- * @param {string} normalizedPath - Normalized file path
- * @param {Array<string>} additionalContextRootsAbsolute - Allowed roots
- * @returns {boolean} True if path is within allowed roots
- */
-function isPathWithinAllowedRoots(normalizedPath, additionalContextRootsAbsolute) {
-  return additionalContextRootsAbsolute.some((allowedRoot) => {
-    const normalizedAllowedRoot = path.normalize(allowedRoot);
-    const relativePath = path.relative(normalizedAllowedRoot, normalizedPath);
-    return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
-  });
-}
-
-/**
  * Resolve the VM filename for the script
  * @param {string|null} scriptPath - Path to the source file
  * @param {string} collectionPath - Path to the collection directory
@@ -51,7 +37,6 @@ class ScriptError extends Error {
 
 module.exports = {
   isBuiltinModule,
-  isPathWithinAllowedRoots,
   resolveVmFilename,
   ScriptError
 };

--- a/packages/bruno-js/src/sandbox/quickjs/shims/local-module.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/local-module.js
@@ -1,31 +1,41 @@
 const path = require('path');
 const fs = require('fs');
 const { marshallToVm } = require('../utils');
+const { isPathWithinRoot } = require('../../../utils/path-security');
+const { isTypeScriptFile, transpileTypeScript } = require('../../../utils/typescript');
+const { resolveModuleFile, resolveDirectoryIndex } = require('../../../utils/module-resolution');
 
 const addLocalModuleLoaderShimToContext = (vm, collectionPath) => {
-  let loadLocalModuleHandle = vm.newFunction('loadLocalModule', function (module) {
+  const loadLocalModuleHandle = vm.newFunction('loadLocalModule', function (module) {
     const filename = vm.dump(module);
 
-    // Check if the filename has an extension
-    const hasExtension = path.extname(filename) !== '';
-    const resolvedFilename = hasExtension ? filename : `${filename}.js`;
-
-    // Resolve the file path and check if it's within the collectionPath
-    const filePath = path.resolve(collectionPath, resolvedFilename);
-    const relativePath = path.relative(collectionPath, filePath);
-
-    // Ensure the resolved file path is inside the collectionPath
-    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    // Ensure the requested path is inside the collectionPath before probing
+    // the filesystem for extension candidates
+    const basePath = path.resolve(collectionPath, filename);
+    if (!isPathWithinRoot(collectionPath, basePath)) {
       throw new Error('Access to files outside of the collectionPath is not allowed.');
     }
 
-    if (!fs.existsSync(filePath)) {
+    // The safe sandbox does not honor package.json main — directory imports
+    // resolve only through index files. Falls back to the raw path so the
+    // not-found error below names it
+    const filePath = resolveModuleFile(basePath) || resolveDirectoryIndex(basePath) || basePath;
+
+    // Re-check after resolution: extension fallbacks must not escape either
+    if (!isPathWithinRoot(collectionPath, filePath)) {
+      throw new Error('Access to files outside of the collectionPath is not allowed.');
+    }
+
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
       throw new Error(`Cannot find module ${filename}`);
     }
 
-    let code = fs.readFileSync(filePath).toString();
+    let code = fs.readFileSync(filePath, 'utf8');
+    if (isTypeScriptFile(filePath)) {
+      code = transpileTypeScript(code, filePath);
+    }
 
-    return marshallToVm(code, vm);
+    return marshallToVm({ code, resolvedPath: filePath }, vm);
   });
 
   vm.setProp(vm.global, '__brunoLoadLocalModule', loadLocalModuleHandle);

--- a/packages/bruno-js/src/sandbox/quickjs/shims/require.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/require.js
@@ -9,30 +9,66 @@
  */
 function getRequireCode() {
   return `
+    globalThis.__brunoResolvedModulePaths = {};
+
     globalThis.require = (mod) => {
       let lib = globalThis.requireObject[mod];
       let isModuleAPath = (module) => (module?.startsWith('.') || (typeof bru !== 'undefined' && module?.startsWith(bru.cwd())))
+      let isModuleLoaded = (key) => Object.prototype.hasOwnProperty.call(globalThis.requireObject, key);
       if (lib) {
         return lib;
       }
       else if (isModuleAPath(mod)) {
-        // fetch local module
-        let localModuleCode = globalThis.__brunoLoadLocalModule(mod);
+        // a specifier always resolves against the same base (the collection root
+        // for relative ones, since nested requires are made absolute below), so
+        // remembering its resolved path lets a repeated require skip the host
+        // round-trip: another read and TypeScript transpile of the same file
+        const knownPath = globalThis.__brunoResolvedModulePaths[mod];
+        if (knownPath && isModuleLoaded(knownPath)) {
+          return globalThis.requireObject[knownPath];
+        }
+
+        // fetch local module (source code + canonical resolved path)
+        const localModule = globalThis.__brunoLoadLocalModule(mod);
+        const resolvedPath = localModule.resolvedPath;
+        globalThis.__brunoResolvedModulePaths[mod] = resolvedPath;
+
+        // the same file can be requested through different specifiers
+        // ('./helper', './helper.ts', a directory resolving to its index) —
+        // cache under the resolved path so it is only evaluated once
+        if (isModuleLoaded(resolvedPath)) {
+          return globalThis.requireObject[resolvedPath];
+        }
 
         // compile local module as iife
-        (function (){
-          const initModuleExportsCode = "const module = { exports: {} };"
-          const copyModuleExportsCode = "\\n;globalThis.requireObject[mod] = module.exports;";
-          const patchedRequire = ${`
-            "\\n;" +
-            "let require = (subModule) => isModuleAPath(subModule) ? globalThis.require(path.resolve(bru.cwd(), mod, '..', subModule)) : globalThis.require(subModule)" +
-            "\\n;"
-          `}
-          eval(initModuleExportsCode + patchedRequire + localModuleCode + copyModuleExportsCode);
-        })();
+        try {
+          (function (){
+            // the exports object is published before the body runs, so a module
+            // required again while it is still loading (a cycle) gets the partial
+            // exports instead of re-entering the loader forever
+            const initModuleExportsCode = "const module = { exports: {} };"
+              + "\\n;globalThis.requireObject[resolvedPath] = module.exports;";
+            const copyModuleExportsCode = "\\n;globalThis.requireObject[resolvedPath] = module.exports;";
+            // nested imports resolve relative to the resolved file — not the requested
+            // specifier, which may name a directory ('./lib' -> lib/index.ts)
+            const patchedRequire = "\\n;"
+              + "let require = (subModule) => isModuleAPath(subModule) ? globalThis.require(path.resolve(resolvedPath, '..', subModule)) : globalThis.require(subModule)"
+              + "\\n;";
+            // the module body runs inside a function wrapper (like Node's CJS wrapper)
+            // so its own top-level 'var module' / 'var exports' declarations (UMD-style
+            // output) don't clash with the bindings above
+            const moduleWrapperStart = "\\n;(function (module, exports) {\\n";
+            const moduleWrapperEnd = "\\n})(module, module.exports);";
+            eval(initModuleExportsCode + patchedRequire + moduleWrapperStart + localModule.code + moduleWrapperEnd + copyModuleExportsCode);
+          })();
+        } catch (error) {
+          // a module whose body threw must not stay cached as partial exports
+          delete globalThis.requireObject[resolvedPath];
+          throw error;
+        }
 
         // resolve module
-        return globalThis.requireObject[mod];
+        return globalThis.requireObject[resolvedPath];
       }
       else {
         throw new Error("Cannot find module " + mod);

--- a/packages/bruno-js/src/utils/module-resolution.js
+++ b/packages/bruno-js/src/utils/module-resolution.js
@@ -1,0 +1,94 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+// .js listed first so a compiled JS artifact wins over its TypeScript source.
+// .tsx/.jsx are deliberately absent: collection scripts have no JSX runtime.
+// .cts/.mts are reachable through an explicit extension or the .cjs/.mjs
+// mapping below.
+const MODULE_FILE_EXTENSIONS = ['.js', '.ts'];
+const INDEX_FILES = ['index.js', 'index.ts'];
+
+// TypeScript sources are commonly imported with their output extension
+// (ESM/TS convention: `import './helper.js'` for helper.ts)
+const JS_TO_TS_EXTENSIONS = {
+  '.js': ['.ts'],
+  '.cjs': ['.cts'],
+  '.mjs': ['.mts']
+};
+
+const isFile = (candidatePath) => {
+  try {
+    return fs.statSync(candidatePath).isFile();
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Resolve an absolute module base path to an existing file, extending the
+ * Node.js file-resolution steps with TypeScript sources:
+ * 1. Exact path (with extension), falling back to the matching TypeScript
+ *    file when a .js/.cjs/.mjs request has no JS file on disk
+ * 2. Path + known extension (.js, .ts)
+ * Directory handling (package.json main, index files) is the caller's
+ * responsibility — each sandbox composes the directory steps it supports.
+ * @param {string} basePath - Absolute path, with or without extension
+ * @returns {string|null} Path of the first existing file candidate, or null
+ */
+function resolveModuleFile(basePath) {
+  const extension = path.extname(basePath);
+
+  // 1. Exact path with TypeScript fallbacks
+  if (extension) {
+    if (isFile(basePath)) {
+      return basePath;
+    }
+
+    const tsExtensions = JS_TO_TS_EXTENSIONS[extension.toLowerCase()] || [];
+    const stem = basePath.slice(0, -extension.length);
+    for (const tsExtension of tsExtensions) {
+      if (isFile(stem + tsExtension)) {
+        return stem + tsExtension;
+      }
+    }
+
+    // A dot in the basename is not necessarily an extension ('./config.helper'),
+    // so Node.js still appends its known extensions — fall through
+  }
+
+  // 2. Try known extensions
+  for (const candidateExtension of MODULE_FILE_EXTENSIONS) {
+    const fullFilePath = basePath + candidateExtension;
+    if (isFile(fullFilePath)) {
+      return fullFilePath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a directory module through its index file (index.js, index.ts)
+ * @param {string} basePath - Absolute path of the directory
+ * @returns {string|null} Path of the first existing index file, or null
+ */
+function resolveDirectoryIndex(basePath) {
+  if (!fs.existsSync(basePath) || !fs.statSync(basePath).isDirectory()) {
+    return null;
+  }
+
+  for (const indexFile of INDEX_FILES) {
+    const indexPath = path.join(basePath, indexFile);
+    if (isFile(indexPath)) {
+      return indexPath;
+    }
+  }
+
+  return null;
+}
+
+module.exports = {
+  isFile,
+  resolveModuleFile,
+  resolveDirectoryIndex
+};

--- a/packages/bruno-js/src/utils/path-security.js
+++ b/packages/bruno-js/src/utils/path-security.js
@@ -1,0 +1,28 @@
+const path = require('node:path');
+
+/**
+ * Check that a path is inside a root directory (lexically — symlinks are not
+ * resolved, matching how allowed roots such as npm-linked packages are declared)
+ * @param {string} root - Root directory
+ * @param {string} candidatePath - Path to validate
+ * @returns {boolean} True if candidatePath is within root
+ */
+function isPathWithinRoot(root, candidatePath) {
+  const relativePath = path.relative(path.normalize(root), candidatePath);
+  return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+}
+
+/**
+ * Validate that a path is within at least one allowed root
+ * @param {string} normalizedPath - Normalized file path
+ * @param {Array<string>} allowedRoots - Allowed root directories
+ * @returns {boolean} True if path is within an allowed root
+ */
+function isPathWithinAllowedRoots(normalizedPath, allowedRoots) {
+  return allowedRoots.some((allowedRoot) => isPathWithinRoot(allowedRoot, normalizedPath));
+}
+
+module.exports = {
+  isPathWithinRoot,
+  isPathWithinAllowedRoots
+};

--- a/packages/bruno-js/src/utils/typescript.js
+++ b/packages/bruno-js/src/utils/typescript.js
@@ -1,0 +1,49 @@
+const path = require('node:path');
+
+const TYPESCRIPT_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'];
+
+let sucraseTransform;
+
+/**
+ * Check if a file is a TypeScript source file
+ * @param {string} filePath - File path to check
+ * @returns {boolean} True if the file has a TypeScript extension
+ */
+function isTypeScriptFile(filePath) {
+  return TYPESCRIPT_EXTENSIONS.includes(path.extname(filePath).toLowerCase());
+}
+
+/**
+ * Transpile TypeScript source to CommonJS JavaScript.
+ *
+ * Uses sucrase: pure JS and synchronous (no native binary to repackage in
+ * Electron), and it preserves line numbers so stack traces map back to the
+ * original TypeScript source without source maps. This is type *stripping*
+ * only — no type checking is performed.
+ *
+ * @param {string} source - TypeScript source code
+ * @param {string} filePath - Absolute path of the source file (for error messages)
+ * @returns {string} Transpiled CommonJS JavaScript
+ * @throws {Error} When the source cannot be parsed
+ */
+function transpileTypeScript(source, filePath) {
+  if (!sucraseTransform) {
+    // Lazy-load so pure-JS collections never pay the cost of loading sucrase
+    sucraseTransform = require('sucrase').transform;
+  }
+
+  try {
+    return sucraseTransform(source, {
+      transforms: ['typescript', 'imports'],
+      filePath,
+      disableESTransforms: true
+    }).code;
+  } catch (error) {
+    throw new Error(`Failed to transpile TypeScript file ${filePath}: ${error.message}`);
+  }
+}
+
+module.exports = {
+  isTypeScriptFile,
+  transpileTypeScript
+};

--- a/packages/bruno-js/tests/quickjs-local-modules.spec.js
+++ b/packages/bruno-js/tests/quickjs-local-modules.spec.js
@@ -1,0 +1,304 @@
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const ScriptRuntime = require('../src/runtime/script-runtime');
+
+describe('quickjs - local modules', () => {
+  let testDir;
+  let collectionPath;
+
+  const baseRequest = {
+    method: 'GET',
+    url: 'http://localhost:3000/',
+    headers: {}
+  };
+
+  const runScript = (script) => {
+    const runtime = new ScriptRuntime({ runtime: 'quickjs' });
+    // The bundled libraries evaluated inside the VM at startup (chai, jwt shim)
+    // reference `console`, and the console shim is only installed when an
+    // onConsoleLog callback is provided
+    const onConsoleLog = () => {};
+    return runtime.runRequestScript(script, { ...baseRequest }, {}, {}, collectionPath, onConsoleLog, process.env);
+  };
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-quickjs-test-'));
+    collectionPath = path.join(testDir, 'collection');
+    fs.mkdirSync(collectionPath);
+  });
+
+  afterEach(() => {
+    // maxRetries/retryDelay: Windows can hold transient locks (antivirus, indexing)
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  });
+
+  it('should load a local JS module', async () => {
+    fs.writeFileSync(path.join(collectionPath, 'helper.js'), 'module.exports = { value: 42 };');
+
+    const result = await runScript(`
+      const helper = require('./helper');
+      bru.setVar('result', helper.value);
+    `);
+
+    expect(result.runtimeVariables.result).toBe(42);
+  });
+
+  it('should load a local JS module using the exports binding', async () => {
+    fs.writeFileSync(path.join(collectionPath, 'named.js'), 'exports.value = "named";');
+
+    const result = await runScript(`
+      const named = require('./named.js');
+      bru.setVar('result', named.value);
+    `);
+
+    expect(result.runtimeVariables.result).toBe('named');
+  });
+
+  it('should load a TypeScript module with explicit .ts extension', async () => {
+    fs.writeFileSync(
+      path.join(collectionPath, 'helper.ts'),
+      `
+        interface Payload {
+          value: number;
+        }
+        const payload: Payload = { value: 42 };
+        module.exports = { getValue: (): number => payload.value };
+      `
+    );
+
+    const result = await runScript(`
+      const helper = require('./helper.ts');
+      bru.setVar('result', helper.getValue());
+    `);
+
+    expect(result.runtimeVariables.result).toBe(42);
+  });
+
+  it('should resolve extensionless require to a .ts file', async () => {
+    fs.writeFileSync(path.join(collectionPath, 'helper.ts'), 'export const value: number = 7;');
+
+    const result = await runScript(`
+      const helper = require('./helper');
+      bru.setVar('result', helper.value);
+    `);
+
+    expect(result.runtimeVariables.result).toBe(7);
+  });
+
+  it('should prefer .js over .ts when both exist', async () => {
+    fs.writeFileSync(path.join(collectionPath, 'dual.js'), 'module.exports = { source: "js" };');
+    fs.writeFileSync(path.join(collectionPath, 'dual.ts'), 'export const source: string = "ts";');
+
+    const result = await runScript(`
+      const dual = require('./dual');
+      bru.setVar('result', dual.source);
+    `);
+
+    expect(result.runtimeVariables.result).toBe('js');
+  });
+
+  it('should append extensions to a require whose basename contains a dot', async () => {
+    fs.writeFileSync(path.join(collectionPath, 'config.helper.ts'), 'export const value: string = "dotted";');
+
+    const result = await runScript(`
+      const helper = require('./config.helper');
+      bru.setVar('result', helper.value);
+    `);
+
+    expect(result.runtimeVariables.result).toBe('dotted');
+  });
+
+  it('should evaluate a module once across repeated requires', async () => {
+    fs.writeFileSync(
+      path.join(collectionPath, 'once.js'),
+      'globalThis.__loadCount = (globalThis.__loadCount || 0) + 1; module.exports = { loads: globalThis.__loadCount };'
+    );
+
+    const result = await runScript(`
+      const first = require('./once');
+      const second = require('./once');
+      const third = require('./once.js');
+      bru.setVar('result', [first === second, first === third, third.loads].join(','));
+    `);
+
+    expect(result.runtimeVariables.result).toBe('true,true,1');
+  });
+
+  it('should resolve circular requires with partial exports', async () => {
+    fs.writeFileSync(
+      path.join(collectionPath, 'circular-a.js'),
+      `
+        exports.name = 'a';
+        const b = require('./circular-b');
+        exports.fromB = b.name;
+      `
+    );
+    fs.writeFileSync(
+      path.join(collectionPath, 'circular-b.js'),
+      `
+        const a = require('./circular-a');
+        exports.name = 'b';
+        exports.fromA = a.name;
+      `
+    );
+
+    const result = await runScript(`
+      const a = require('./circular-a');
+      const b = require('./circular-b');
+      bru.setVar('result', a.fromB + ':' + b.fromA);
+    `);
+
+    expect(result.runtimeVariables.result).toBe('b:a');
+  });
+
+  it('should allow a module to be required again after its body threw', async () => {
+    fs.writeFileSync(
+      path.join(collectionPath, 'throws-once.js'),
+      `
+        exports.partial = true;
+        if (!globalThis.__attempted) {
+          globalThis.__attempted = true;
+          throw new Error('first load fails');
+        }
+        exports.loaded = true;
+      `
+    );
+
+    const result = await runScript(`
+      try {
+        require('./throws-once');
+      } catch (error) {
+        // the failed module must not stay cached with its partial exports
+      }
+      const retried = require('./throws-once');
+      bru.setVar('result', retried.loaded === true);
+    `);
+
+    expect(result.runtimeVariables.result).toBe(true);
+  });
+
+  it('should resolve a directory with index.ts', async () => {
+    const libDir = path.join(collectionPath, 'lib');
+    fs.mkdirSync(libDir);
+    fs.writeFileSync(path.join(libDir, 'index.ts'), 'export const name: string = "lib-index";');
+
+    const result = await runScript(`
+      const lib = require('./lib');
+      bru.setVar('result', lib.name);
+    `);
+
+    expect(result.runtimeVariables.result).toBe('lib-index');
+  });
+
+  it('should resolve nested imports relative to a directory-index module', async () => {
+    const libDir = path.join(collectionPath, 'lib');
+    fs.mkdirSync(libDir);
+    fs.writeFileSync(path.join(libDir, 'util.ts'), 'export const value: number = 99;');
+    fs.writeFileSync(
+      path.join(libDir, 'index.ts'),
+      `
+        import { value } from './util';
+        export const result: number = value;
+      `
+    );
+
+    const result = await runScript(`
+      const lib = require('./lib');
+      bru.setVar('result', lib.result);
+    `);
+
+    expect(result.runtimeVariables.result).toBe(99);
+  });
+
+  it('should load a module that redeclares var exports (UMD-style)', async () => {
+    fs.writeFileSync(
+      path.join(collectionPath, 'umd.js'),
+      'var exports = module.exports; exports.kind = "umd";'
+    );
+
+    const result = await runScript(`
+      const umd = require('./umd');
+      bru.setVar('result', umd.kind);
+    `);
+
+    expect(result.runtimeVariables.result).toBe('umd');
+  });
+
+  it('should not honor package.json main in the safe sandbox', async () => {
+    const pkgDir = path.join(collectionPath, 'pkg');
+    fs.mkdirSync(pkgDir);
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ main: './entry.js' }));
+    fs.writeFileSync(path.join(pkgDir, 'entry.js'), 'module.exports = { from: "main" };');
+
+    await expect(
+      runScript(`
+        require('./pkg');
+      `)
+    ).rejects.toThrow(/Cannot find module/);
+  });
+
+  it('should report Cannot find module for a directory without an index file', async () => {
+    fs.mkdirSync(path.join(collectionPath, 'no-index'));
+    fs.writeFileSync(path.join(collectionPath, 'no-index', 'other.txt'), 'not a module');
+
+    await expect(
+      runScript(`
+        require('./no-index');
+      `)
+    ).rejects.toThrow(/Cannot find module/);
+  });
+
+  it('should handle ESM import/export between TypeScript modules', async () => {
+    fs.writeFileSync(
+      path.join(collectionPath, 'math.ts'),
+      'export const double = (n: number): number => n * 2;'
+    );
+    fs.writeFileSync(
+      path.join(collectionPath, 'consumer.ts'),
+      `
+        import { double } from './math';
+        export const result: number = double(21);
+      `
+    );
+
+    const result = await runScript(`
+      const consumer = require('./consumer.ts');
+      bru.setVar('result', consumer.result);
+    `);
+
+    expect(result.runtimeVariables.result).toBe(42);
+  });
+
+  it('should expose export default via .default', async () => {
+    fs.writeFileSync(path.join(collectionPath, 'default-export.ts'), 'export default { kind: "default" };');
+
+    const result = await runScript(`
+      const mod = require('./default-export.ts');
+      bru.setVar('result', mod.default.kind);
+    `);
+
+    expect(result.runtimeVariables.result).toBe('default');
+  });
+
+  it('should report a clear error for invalid TypeScript syntax', async () => {
+    fs.writeFileSync(path.join(collectionPath, 'broken.ts'), 'const x: = 5;');
+
+    await expect(
+      runScript(`
+        require('./broken.ts');
+      `)
+    ).rejects.toThrow(/Failed to transpile TypeScript file/);
+  });
+
+  it('should block TypeScript modules outside the collection path', async () => {
+    fs.writeFileSync(path.join(testDir, 'outside.ts'), 'export const secret: string = "nope";');
+
+    await expect(
+      runScript(`
+        require('../outside.ts');
+      `)
+    ).rejects.toThrow(/Access to files outside of the collectionPath is not allowed/);
+  });
+});


### PR DESCRIPTION
Allow users to write local utility modules in TypeScript within both Node.js VM and QuickJS scripting environments. This improves code organization and type safety for pre-request and post-response scripts.

Includes custom module resolution to locate `.ts` files and on-the-fly transpilation to JavaScript using Sucrase.

### Description

This PR adds TypeScript support for local modules loaded via `require()` in collection scripts, in **both** scripting runtimes (developer mode / Node VM and safe mode / QuickJS).

**Example** — given a collection with:

```ts
// helper.ts
interface User {
  id: number;
  name: string;
}

export const buildAuthHeader = (token: string): string => `Bearer ${token}`;

export const pickUser = (users: User[]): User => users[0];
```

any pre-request / post-response / test script can now do:

```js
const { buildAuthHeader, pickUser } = require('./helper.ts');
// or extensionless — resolves helper.ts when no helper.js exists:
// const { buildAuthHeader } = require('./helper');

req.setHeader('Authorization', buildAuthHeader(bru.getEnvVar('token')));

const user = pickUser(res.getBody());
bru.setVar('userId', user.id);
```

Resolution follows the Node.js algorithm, extended with TypeScript sources:
- explicit extension: `require('./helper.ts')`, plus the ESM/TS convention `require('./helper.js')` → `helper.ts` when no JS file exists on disk (`.cjs` → `.cts`, `.mjs` → `.mts`)
- extensionless: tries `.js` then `.ts` — a compiled `.js` artifact always wins over its TypeScript source
- directories: `package.json#main` (confined to the package directory), then `index.js` / `index.ts` — in developer mode; the safe (QuickJS) sandbox resolves directories through index files only, since `package.json#main` is a Node/developer-mode convention
- nested `require()`/`import` between TypeScript files works in both runtimes

Notes / limitations (by design):
- This is type **stripping** only (Sucrase) — no type checking, no `tsconfig.json` `paths` aliases
- `export default` is exposed as `.default` (standard CJS interop); named exports are recommended
- Sucrase is pure JS and synchronous, and preserves line numbers, so stack traces map back to the original `.ts` source without source maps (module scripts are compiled with `lineOffset: -1` so reported lines match the file exactly)


### Problem

Users writing helpers for their collection scripts are limited to plain JavaScript. `require('./helper.ts')` fails today with a `SyntaxError` on the first type annotation

### Fix

- **Shared utils (`@usebruno/js`)**
  - `src/utils/module-resolution.js` — `resolveModuleFile()` (exact path + TS fallbacks + extension candidates) and `resolveDirectoryIndex()`; each sandbox composes the directory steps it supports
  - `src/utils/typescript.js` — `isTypeScriptFile()` + `transpileTypeScript()` (Sucrase, lazy-loaded so pure-JS collections pay no cost; `transforms: ['typescript', 'imports']`)
  - `src/utils/path-security.js` — shared lexical path-containment helpers used by both loaders
- **Node VM** (`sandbox/node-vm/cjs-loader.js`) — resolves through `resolveModuleFile()` → `resolvePackageJsonMain()` (loader-side, honored only when `main` stays inside the package directory) → `resolveDirectoryIndex()`; TS sources are transpiled before `vm.Script`, also in `executeModuleInVmContext` so uncompiled TS in `file:`/`npm link`ed packages works. `additionalContextRoots` checks are enforced both before and after resolution, unchanged
- **QuickJS** (`sandbox/quickjs/shims/local-module.js`) — same file resolution + transpilation host-side before the code is marshalled into the VM; directories resolve through index files only. The shim returns the resolved path alongside the code so the in-VM `require` resolves nested imports relative to the resolved file (a specifier like `./lib` may name a directory) and caches modules under one canonical key
  - `shims/require.js` — the module body now runs inside a CJS-style function wrapper with `module`/`exports` bindings; required for Sucrase output (`exports.foo = ...`) and fixes a latent safe-mode bug where `exports.foo = ...` or UMD-style `var exports = module.exports` modules threw
- **Dependency**: `sucrase` added to `@usebruno/js` (pure JS, no native binary to repackage in Electron)
- **Tests**: 14 new Node VM cases (`sandbox/node-vm/index.spec.js`) and a dedicated QuickJS suite (14 cases)


### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

<img width="1552" height="982" alt="Capture d’écran 2026-08-07 à 16 25 21" src="https://github.com/user-attachments/assets/a5262300-4973-4b1d-8a49-1cef1670b2a8" />


| Before | After |
| --- | --- |
| <img width="1552" height="982" alt="Capture d’écran 2026-08-07 à 16 23 44" src="https://github.com/user-attachments/assets/ee2bb320-fa44-4592-9ea5-ab8d8e405723" /> | <img width="1552" height="982" alt="Capture d’écran 2026-08-07 à 16 24 51" src="https://github.com/user-attachments/assets/9e2c1804-ce94-41a7-bb02-1181e6fffa0c" /> |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading and executing TypeScript modules in sandboxed scripts.
  * Improved module resolution for file extensions, directory indexes, nested imports, and package entry points.
  * Enhanced CommonJS and ES module interoperability, including default exports and circular dependencies.

* **Bug Fixes**
  * Strengthened protections against path traversal and out-of-scope module access.
  * Corrected stack traces to reference original source lines.
  * Improved handling of missing modules and invalid TypeScript syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->