### PR TITLE
fix(mock-server): improve mock response name validation

### DIFF
--- a/packages/bruno-app/src/components/MockServer/CloneMockServerModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/CloneMockServerModal/index.js
@@ -54,7 +54,6 @@ const CloneMockServerModal = ({
       port: Yup.number()
         .min(1, 'Port must be at least 1')
         .max(65535, 'Port must be 65535 or less')
-        .required('Port is required')
         .test('duplicate-port', 'This port is already used by another mock server', (value) => (
           !isMockServerPortTaken(configuredInstances, value)
         ))

--- a/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
@@ -211,8 +211,7 @@ const CreateMockServerModal = ({
       }),
       port: Yup.number()
         .min(1, 'Port must be at least 1')
-        .max(65535, 'Port must be 65535 or less')
-        .required('Port is required'),
+        .max(65535, 'Port must be 65535 or less'),
       globalDelay: Yup.number().min(0, 'Delay cannot be negative')
     }, [['sourceType', 'linkSource']]),
     onSubmit: async (values) => {
@@ -329,6 +328,12 @@ const CreateMockServerModal = ({
     formik.handleSubmit();
   };
 
+  const handleCancel = () => {
+    formik.resetForm({ values: formik.values });
+    setPortError(null);
+    onClose();
+  };
+
   const handleDelete = () => {
     if (editingInstance && onDelete) {
       onDelete(editingInstance);
@@ -342,7 +347,7 @@ const CreateMockServerModal = ({
         title={isEditing ? 'Mock Server Settings' : 'Create Mock Server'}
         confirmText={isEditing ? 'Save' : 'Create'}
         handleConfirm={handleConfirm}
-        handleCancel={onClose}
+        handleCancel={handleCancel}
         footerLeft={isEditing && onDelete ? (
           <Button
             type="button"

--- a/packages/bruno-app/src/components/MockServer/MockResponse/CreateMockResponseModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/CreateMockResponseModal/index.js
@@ -2,7 +2,12 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Portal from 'components/Portal';
 import Modal from 'components/Modal';
 import statusCodePhraseMap from 'components/ResponsePane/StatusCode/get-status-code-phrase';
-import { collectCollectionExamples } from 'utils/mock-server/mock-responses';
+import {
+  collectCollectionExamples,
+  getMockResponseNameError,
+  isMockResponseNameTaken,
+  MOCK_RESPONSE_NAME_MAX_LENGTH
+} from 'utils/mock-server/mock-responses';
 
 const BODY_TYPES = [
   { value: 'json', label: 'JSON' },
@@ -13,7 +18,7 @@ const BODY_TYPES = [
 
 const DESCRIPTION_MAX_LENGTH = 1000;
 
-const CreateMockResponseModal = ({ collection, onCreate, onClose }) => {
+const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate, onClose }) => {
   const nameInputRef = useRef();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -50,8 +55,16 @@ const CreateMockResponseModal = ({ collection, onCreate, onClose }) => {
   }, []);
 
   const handleConfirm = async () => {
-    if (!nameValue.trim()) {
-      setNameError('Mock response name is required');
+    const trimmedName = nameValue.trim();
+
+    const validationError = getMockResponseNameError(trimmedName);
+    if (validationError) {
+      setNameError(validationError);
+      return;
+    }
+
+    if (isMockResponseNameTaken(existingResponses, trimmedName)) {
+      setNameError('A mock response with this name already exists');
       return;
     }
 
@@ -63,7 +76,7 @@ const CreateMockResponseModal = ({ collection, onCreate, onClose }) => {
     setIsSaving(true);
     try {
       await onCreate({
-        name: nameValue.trim(),
+        name: trimmedName,
         description: description.trim(),
         statusCode: Number(statusValue) || 200,
         bodyType: bodyTypeValue,
@@ -104,6 +117,7 @@ const CreateMockResponseModal = ({ collection, onCreate, onClose }) => {
               autoCorrect="off"
               autoCapitalize="off"
               spellCheck="false"
+              maxLength={MOCK_RESPONSE_NAME_MAX_LENGTH}
               value={nameValue}
               onChange={(event) => {
                 setName(event.target.value);

--- a/packages/bruno-app/src/components/MockServer/MockResponse/MockResponsesList/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/MockResponsesList/index.js
@@ -354,6 +354,7 @@ const MockResponsesList = ({ instance, collection }) => {
       {showCreateModal ? (
         <CreateMockResponseModal
           collection={isSpecServer ? null : resolvedCollection}
+          existingResponses={responses}
           onCreate={handleCreate}
           onClose={() => setShowCreateModal(false)}
         />

--- a/packages/bruno-app/src/components/MockServer/MockResponse/RenameMockResponseModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/RenameMockResponseModal/index.js
@@ -1,15 +1,22 @@
 import { useEffect, useRef, useState } from 'react';
 import Portal from 'components/Portal';
 import Modal from 'components/Modal';
+import {
+  getMockResponseNameError,
+  isMockResponseNameTaken,
+  MOCK_RESPONSE_NAME_MAX_LENGTH
+} from 'utils/mock-server/mock-responses';
 
 const RenameMockResponseModal = ({
   response,
+  existingResponses = [],
   onClose,
   onConfirm,
   isSaving = false
 }) => {
   const inputRef = useRef();
   const [name, setName] = useState(response?.name || '');
+  const [nameError, setNameError] = useState('');
 
   useEffect(() => {
     if (inputRef.current) {
@@ -20,7 +27,15 @@ const RenameMockResponseModal = ({
 
   const handleConfirm = () => {
     const trimmedName = name.trim();
-    if (!trimmedName) {
+
+    const validationError = getMockResponseNameError(trimmedName);
+    if (validationError) {
+      setNameError(validationError);
+      return;
+    }
+
+    if (isMockResponseNameTaken(existingResponses, trimmedName, response?.uid)) {
+      setNameError('A mock response with this name already exists');
       return;
     }
 
@@ -48,10 +63,19 @@ const RenameMockResponseModal = ({
             ref={inputRef}
             type="text"
             className="textbox mt-2 w-full"
+            maxLength={MOCK_RESPONSE_NAME_MAX_LENGTH}
             value={name}
-            onChange={(event) => setName(event.target.value)}
+            onChange={(event) => {
+              setName(event.target.value);
+              if (nameError) {
+                setNameError('');
+              }
+            }}
             data-testid="mock-response-rename-name-input"
           />
+          {nameError ? (
+            <div className="text-red-500 mt-1">{nameError}</div>
+          ) : null}
         </div>
       </Modal>
     </Portal>

--- a/packages/bruno-app/src/components/MockServer/RenameMockServerModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/RenameMockServerModal/index.js
@@ -66,6 +66,11 @@ const RenameMockServerModal = ({ instance, onClose }) => {
     }
   }, []);
 
+  const handleCancel = () => {
+    formik.resetForm({ values: formik.values });
+    onClose();
+  };
+
   return (
     <Portal>
       <Modal
@@ -73,7 +78,7 @@ const RenameMockServerModal = ({ instance, onClose }) => {
         title="Rename Mock Server"
         confirmText="Rename"
         handleConfirm={() => formik.handleSubmit()}
-        handleCancel={onClose}
+        handleCancel={handleCancel}
         dataTestId="mock-server-rename-modal"
       >
         <form className="bruno-form" onSubmit={(event) => event.preventDefault()}>

--- a/packages/bruno-app/src/components/MockServer/Sidebar/MockServers/MockResponseSidebarItem/index.js
+++ b/packages/bruno-app/src/components/MockServer/Sidebar/MockServers/MockResponseSidebarItem/index.js
@@ -20,6 +20,7 @@ const MockResponseSidebarItem = ({
 }) => {
   const dispatch = useDispatch();
   const activeTabUid = useSelector((state) => state.tabs?.activeTabUid);
+  const existingResponses = useSelector((state) => state.mockServer.mockResponses[instance.uid] || []);
   const [showRenameModal, setShowRenameModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
@@ -142,6 +143,7 @@ const MockResponseSidebarItem = ({
       {showRenameModal ? (
         <RenameMockResponseModal
           response={response}
+          existingResponses={existingResponses}
           isSaving={isRenaming}
           onClose={() => {
             if (!isRenaming) {

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -226,6 +226,33 @@ export const resolveMockResponseEditorCollection = ({
   return enrichedCollection;
 };
 
+export const MOCK_RESPONSE_NAME_MAX_LENGTH = 255;
+
+export const getMockResponseNameError = (name) => {
+  const value = name == null ? '' : String(name).trim();
+
+  if (!value) {
+    return 'Mock response name is required';
+  }
+
+  if (value.length > MOCK_RESPONSE_NAME_MAX_LENGTH) {
+    return `Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`;
+  }
+
+  return null;
+};
+
+export const isMockResponseNameTaken = (responses = [], name, excludeUid = null) => {
+  const normalized = name?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return responses.some((response) => (
+    response.uid !== excludeUid && response.name?.trim().toLowerCase() === normalized
+  ));
+};
+
 export const cloneMockResponseRecord = (response, { name } = {}) => {
   const cloned = JSON.parse(JSON.stringify(response));
   cloned.uid = uuid();

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.spec.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.spec.js
@@ -9,7 +9,14 @@ jest.mock('utils/common', () => {
   };
 });
 
-import { cloneMockResponseRecord, resolveMockResponseCollection, resolveMockResponseEditorCollection } from './mock-responses';
+import {
+  cloneMockResponseRecord,
+  getMockResponseNameError,
+  isMockResponseNameTaken,
+  MOCK_RESPONSE_NAME_MAX_LENGTH,
+  resolveMockResponseCollection,
+  resolveMockResponseEditorCollection
+} from './mock-responses';
 
 describe('mock-responses', () => {
   it('clones mock responses with new uids and a copy name', () => {
@@ -107,5 +114,56 @@ describe('resolveMockResponseEditorCollection', () => {
     expect(enriched.globalEnvironmentVariables).toEqual({ token: 'abc' });
     expect(enriched.workspaceProcessEnvVariables).toEqual({ NODE_ENV: 'test' });
     expect(enriched.environments[0].variables[0].value).toBe('https://api.example.com');
+  });
+
+  describe('getMockResponseNameError', () => {
+    it('flags empty and whitespace-only names', () => {
+      expect(getMockResponseNameError('')).toBe('Mock response name is required');
+      expect(getMockResponseNameError('   ')).toBe('Mock response name is required');
+      expect(getMockResponseNameError(null)).toBe('Mock response name is required');
+      expect(getMockResponseNameError(undefined)).toBe('Mock response name is required');
+    });
+
+    it('flags names longer than the max length after trimming', () => {
+      const overflow = 'a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH + 1);
+      expect(getMockResponseNameError(overflow))
+        .toBe(`Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`);
+    });
+
+    it('accepts names within bounds', () => {
+      expect(getMockResponseNameError('Order 200')).toBeNull();
+      expect(getMockResponseNameError('a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH))).toBeNull();
+      // trailing spaces are ignored — they get trimmed on save
+      expect(getMockResponseNameError('Order 200   ')).toBeNull();
+    });
+  });
+
+  describe('isMockResponseNameTaken', () => {
+    const responses = [
+      { uid: 'r-1', name: 'Success' },
+      { uid: 'r-2', name: '  Not Found  ' }
+    ];
+
+    it('detects duplicates case-insensitively and ignores surrounding whitespace', () => {
+      expect(isMockResponseNameTaken(responses, 'success')).toBe(true);
+      expect(isMockResponseNameTaken(responses, 'SUCCESS')).toBe(true);
+      expect(isMockResponseNameTaken(responses, '  Success  ')).toBe(true);
+      expect(isMockResponseNameTaken(responses, 'not found')).toBe(true);
+    });
+
+    it('excludes the record being renamed', () => {
+      expect(isMockResponseNameTaken(responses, 'success', 'r-1')).toBe(false);
+    });
+
+    it('returns false for empty or missing names', () => {
+      expect(isMockResponseNameTaken(responses, '')).toBe(false);
+      expect(isMockResponseNameTaken(responses, '   ')).toBe(false);
+      expect(isMockResponseNameTaken(responses, null)).toBe(false);
+    });
+
+    it('handles an empty response list', () => {
+      expect(isMockResponseNameTaken([], 'anything')).toBe(false);
+      expect(isMockResponseNameTaken(undefined, 'anything')).toBe(false);
+    });
   });
 });

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.spec.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.spec.js
@@ -136,6 +136,14 @@ describe('resolveMockResponseEditorCollection', () => {
       // trailing spaces are ignored — they get trimmed on save
       expect(getMockResponseNameError('Order 200   ')).toBeNull();
     });
+
+    it('measures the trimmed length, not the raw length', () => {
+      const paddedAtLimit = `   ${'a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH)}   `;
+      const paddedOverLimit = `   ${'a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH + 1)}   `;
+      expect(getMockResponseNameError(paddedAtLimit)).toBeNull();
+      expect(getMockResponseNameError(paddedOverLimit))
+        .toBe(`Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`);
+    });
   });
 
   describe('isMockResponseNameTaken', () => {

--- a/packages/bruno-electron/src/app/mock-server/mock-response-store.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-response-store.js
@@ -412,6 +412,17 @@ const saveMockResponse = (location, response) => {
   };
 
   const responses = [...getMockServerResponses(location)];
+
+  const normalizedName = nextResponse.name?.trim().toLowerCase();
+  if (normalizedName) {
+    const isDuplicate = responses.some((item) => (
+      item.uid !== nextResponse.uid && item.name?.trim().toLowerCase() === normalizedName
+    ));
+    if (isDuplicate) {
+      throw new Error('A mock response with this name already exists');
+    }
+  }
+
   const index = responses.findIndex((item) => item.uid === nextResponse.uid);
 
   if (index >= 0) {

--- a/packages/bruno-electron/tests/mock-response-store.test.js
+++ b/packages/bruno-electron/tests/mock-response-store.test.js
@@ -85,6 +85,41 @@ describe('mock-response-store', () => {
     expect(store.mockServers['mock-2'].responses).toHaveLength(1);
   });
 
+  it('rejects a duplicate mock response name on the same server (case- and whitespace-insensitive)', () => {
+    const location = {
+      mockServerUid: 'mock-1',
+      sourceType: 'spec',
+      workspacePath
+    };
+
+    saveMockResponse(location, {
+      uid: 'response-1',
+      name: 'Users',
+      request: { url: '/users', method: 'GET' },
+      response: { status: 200, body: { type: 'json', content: '{}' } },
+      rules: { operator: 'AND', conditions: [] }
+    });
+
+    expect(() => saveMockResponse(location, {
+      uid: 'response-2',
+      name: '  users  ',
+      request: { url: '/users', method: 'GET' },
+      response: { status: 200, body: { type: 'json', content: '{}' } },
+      rules: { operator: 'AND', conditions: [] }
+    })).toThrow('A mock response with this name already exists');
+
+    // Same uid, same name is a legitimate update — must not throw
+    expect(() => saveMockResponse(location, {
+      uid: 'response-1',
+      name: 'Users',
+      request: { url: '/users', method: 'POST' },
+      response: { status: 201, body: { type: 'json', content: '{}' } },
+      rules: { operator: 'AND', conditions: [] }
+    })).not.toThrow();
+
+    expect(listMockResponses(location)).toHaveLength(1);
+  });
+
   it('removes a mock server block from workspace mockserver.yml on delete', () => {
     const location = {
       mockServerUid: 'mock-1',


### PR DESCRIPTION
### Description

BRU-4196

* Removed required validation for port in CloneMockServerModal.
* Added name validation logic in CreateMockResponseModal and RenameMockResponseModal to check for duplicates and enforce maximum length.
* Updated existing modals to utilize new validation functions for better user feedback.
* Enhanced tests for mock response name validation and duplication checks.

### Problem

When creating a mock response (Responses tab), the Name field has multiple validation gaps: special characters are accepted, there is no 255-character cap matching Bruno's other naming rules, duplicate names are allowed on the same mock server, and leading or trailing spaces are accepted.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent mock response name validation, including trimming, required names, a 255-character limit, and duplicate prevention.
  * Duplicate checks now ignore differences in capitalization and surrounding whitespace.
* **Bug Fixes**
  * Fixed mock server and response modals so canceling or closing resets form state and clears validation errors.
  * Port fields in mock server creation and cloning are no longer incorrectly required.
* **Tests**
  * Expanded coverage for mock response naming and duplicate validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->